### PR TITLE
refactor(apollo-vertex): update install cmd for components

### DIFF
--- a/apps/apollo-vertex/app/components/accordion/page.mdx
+++ b/apps/apollo-vertex/app/components/accordion/page.mdx
@@ -30,7 +30,7 @@ A vertically stacked set of interactive headings that each reveal a section of c
 ## Installation
 
 ```bash
-npx shadcn@latest add https://apollo-vertex.vercel.app/r/accordion.json
+npx shadcn@latest add @uipath/accordion
 ```
 
 ## Usage

--- a/apps/apollo-vertex/app/components/alert-dialog/page.mdx
+++ b/apps/apollo-vertex/app/components/alert-dialog/page.mdx
@@ -29,7 +29,7 @@ A modal dialog that interrupts the user with important content and expects a res
 ## Installation
 
 ```bash
-npx shadcn@latest add https://apollo-vertex.vercel.app/r/alert-dialog.json
+npx shadcn@latest add @uipath/alert-dialog
 ```
 
 ## Usage

--- a/apps/apollo-vertex/app/components/alert/page.mdx
+++ b/apps/apollo-vertex/app/components/alert/page.mdx
@@ -26,7 +26,7 @@ Displays a callout for user attention.
 ## Installation
 
 ```bash
-npx shadcn@latest add https://apollo-vertex.vercel.app/r/alert.json
+npx shadcn@latest add @uipath/alert
 ```
 
 ## Usage

--- a/apps/apollo-vertex/app/components/aspect-ratio/page.mdx
+++ b/apps/apollo-vertex/app/components/aspect-ratio/page.mdx
@@ -19,7 +19,7 @@ Displays content within a desired ratio.
 ## Installation
 
 ```bash
-npx shadcn@latest add https://apollo-vertex.vercel.app/r/aspect-ratio.json
+npx shadcn@latest add @uipath/aspect-ratio
 ```
 
 ## Usage

--- a/apps/apollo-vertex/app/components/avatar/page.mdx
+++ b/apps/apollo-vertex/app/components/avatar/page.mdx
@@ -37,7 +37,7 @@ An image element with a fallback for representing the user.
 ## Installation
 
 ```bash
-npx shadcn@latest add https://apollo-vertex.vercel.app/r/avatar.json
+npx shadcn@latest add @uipath/avatar
 ```
 
 ## Usage

--- a/apps/apollo-vertex/app/components/badge/page.mdx
+++ b/apps/apollo-vertex/app/components/badge/page.mdx
@@ -14,7 +14,7 @@ Displays a badge or a component that looks like a badge.
 ## Installation
 
 ```bash
-npx shadcn@latest add https://apollo-vertex.vercel.app/r/badge.json
+npx shadcn@latest add @uipath/badge
 ```
 
 ## Usage

--- a/apps/apollo-vertex/app/components/breadcrumb/page.mdx
+++ b/apps/apollo-vertex/app/components/breadcrumb/page.mdx
@@ -25,7 +25,7 @@ Displays the path to the current resource using a hierarchy of links.
 ## Installation
 
 ```bash
-npx shadcn@latest add https://apollo-vertex.vercel.app/r/breadcrumb.json
+npx shadcn@latest add @uipath/breadcrumb
 ```
 
 ## Usage

--- a/apps/apollo-vertex/app/components/button-group/page.mdx
+++ b/apps/apollo-vertex/app/components/button-group/page.mdx
@@ -28,7 +28,7 @@ Groups multiple buttons together with proper styling and spacing.
 ## Installation
 
 ```bash
-npx shadcn@latest add https://apollo-vertex.vercel.app/r/button-group.json
+npx shadcn@latest add @uipath/button-group
 ```
 
 ## Usage

--- a/apps/apollo-vertex/app/components/button/page.mdx
+++ b/apps/apollo-vertex/app/components/button/page.mdx
@@ -46,7 +46,7 @@ Displays a button or a component that looks like a button.
 ## Installation
 
 ```bash
-npx shadcn@latest add https://apollo-vertex.vercel.app/r/button.json
+npx shadcn@latest add @uipath/button
 ```
 
 ## Usage

--- a/apps/apollo-vertex/app/components/calendar/page.mdx
+++ b/apps/apollo-vertex/app/components/calendar/page.mdx
@@ -16,7 +16,7 @@ A date field component that allows users to enter and edit dates.
 ## Installation
 
 ```bash
-npx shadcn@latest add https://apollo-vertex.vercel.app/r/calendar.json
+npx shadcn@latest add @uipath/calendar
 ```
 
 ## Usage

--- a/apps/apollo-vertex/app/components/card/page.mdx
+++ b/apps/apollo-vertex/app/components/card/page.mdx
@@ -33,7 +33,7 @@ Displays a card with header, content, and footer.
 ## Installation
 
 ```bash
-npx shadcn@latest add https://apollo-vertex.vercel.app/r/card.json
+npx shadcn@latest add @uipath/card
 ```
 
 ## Usage

--- a/apps/apollo-vertex/app/components/carousel/page.mdx
+++ b/apps/apollo-vertex/app/components/carousel/page.mdx
@@ -28,7 +28,7 @@ A carousel with motion and swipe built using Embla.
 ## Installation
 
 ```bash
-npx shadcn@latest add https://apollo-vertex.vercel.app/r/carousel.json
+npx shadcn@latest add @uipath/carousel
 ```
 
 ## Usage

--- a/apps/apollo-vertex/app/components/chart/page.mdx
+++ b/apps/apollo-vertex/app/components/chart/page.mdx
@@ -11,7 +11,7 @@ Beautiful charts using Recharts with consistent theming and styling.
 ## Installation
 
 ```bash
-npx shadcn@latest add https://apollo-vertex.vercel.app/r/chart.json
+npx shadcn@latest add @uipath/chart
 ```
 
 ## Usage

--- a/apps/apollo-vertex/app/components/checkbox/page.mdx
+++ b/apps/apollo-vertex/app/components/checkbox/page.mdx
@@ -25,7 +25,7 @@ A control that allows the user to toggle between checked and not checked.
 ## Installation
 
 ```bash
-npx shadcn@latest add https://apollo-vertex.vercel.app/r/checkbox.json
+npx shadcn@latest add @uipath/checkbox
 ```
 
 ## Usage

--- a/apps/apollo-vertex/app/components/collapsible/page.mdx
+++ b/apps/apollo-vertex/app/components/collapsible/page.mdx
@@ -36,7 +36,7 @@ An interactive component which expands/collapses a panel.
 ## Installation
 
 ```bash
-npx shadcn@latest add https://apollo-vertex.vercel.app/r/collapsible.json
+npx shadcn@latest add @uipath/collapsible
 ```
 
 ## Usage

--- a/apps/apollo-vertex/app/components/command/page.mdx
+++ b/apps/apollo-vertex/app/components/command/page.mdx
@@ -49,7 +49,7 @@ Fast, composable, unstyled command menu for React.
 ## Installation
 
 ```bash
-npx shadcn@latest add https://apollo-vertex.vercel.app/r/command.json
+npx shadcn@latest add @uipath/command
 ```
 
 ## Usage

--- a/apps/apollo-vertex/app/components/context-menu/page.mdx
+++ b/apps/apollo-vertex/app/components/context-menu/page.mdx
@@ -33,7 +33,7 @@ Displays a menu to the user triggered by a right-click or long-press.
 ## Installation
 
 ```bash
-npx shadcn@latest add https://apollo-vertex.vercel.app/r/context-menu.json
+npx shadcn@latest add @uipath/context-menu
 ```
 
 ## Usage

--- a/apps/apollo-vertex/app/components/dialog/page.mdx
+++ b/apps/apollo-vertex/app/components/dialog/page.mdx
@@ -42,7 +42,7 @@ A modal dialog that appears in front of app content to provide critical informat
 ## Installation
 
 ```bash
-npx shadcn@latest add https://apollo-vertex.vercel.app/r/dialog.json
+npx shadcn@latest add @uipath/dialog
 ```
 
 ## Usage

--- a/apps/apollo-vertex/app/components/drawer/page.mdx
+++ b/apps/apollo-vertex/app/components/drawer/page.mdx
@@ -40,7 +40,7 @@ A drawer component that slides in from the edge of the screen.
 ## Installation
 
 ```bash
-npx shadcn@latest add https://apollo-vertex.vercel.app/r/drawer.json
+npx shadcn@latest add @uipath/drawer
 ```
 
 ## Usage

--- a/apps/apollo-vertex/app/components/dropdown-menu/page.mdx
+++ b/apps/apollo-vertex/app/components/dropdown-menu/page.mdx
@@ -44,7 +44,7 @@ Displays a menu to the user triggered by a button.
 ## Installation
 
 ```bash
-npx shadcn@latest add https://apollo-vertex.vercel.app/r/dropdown-menu.json
+npx shadcn@latest add @uipath/dropdown-menu
 ```
 
 ## Usage

--- a/apps/apollo-vertex/app/components/empty/page.mdx
+++ b/apps/apollo-vertex/app/components/empty/page.mdx
@@ -44,7 +44,7 @@ An empty state component for when there is no data to display.
 ## Installation
 
 ```bash
-npx shadcn@latest add https://apollo-vertex.vercel.app/r/empty.json
+npx shadcn@latest add @uipath/empty
 ```
 
 ## Usage

--- a/apps/apollo-vertex/app/components/field/page.mdx
+++ b/apps/apollo-vertex/app/components/field/page.mdx
@@ -27,7 +27,7 @@ A form field component with label, input, and description.
 ## Installation
 
 ```bash
-npx shadcn@latest add https://apollo-vertex.vercel.app/r/field.json
+npx shadcn@latest add @uipath/field
 ```
 
 ## Usage

--- a/apps/apollo-vertex/app/components/form/page.mdx
+++ b/apps/apollo-vertex/app/components/form/page.mdx
@@ -11,7 +11,7 @@ Building forms with React Hook Form and Zod validation.
 ## Installation
 
 ```bash
-npx shadcn@latest add https://apollo-vertex.vercel.app/r/form.json
+npx shadcn@latest add @uipath/form
 ```
 
 ## Usage

--- a/apps/apollo-vertex/app/components/hover-card/page.mdx
+++ b/apps/apollo-vertex/app/components/hover-card/page.mdx
@@ -38,7 +38,7 @@ For sighted users to preview content available behind a link.
 ## Installation
 
 ```bash
-npx shadcn@latest add https://apollo-vertex.vercel.app/r/hover-card.json
+npx shadcn@latest add @uipath/hover-card
 ```
 
 ## Usage

--- a/apps/apollo-vertex/app/components/input-group/page.mdx
+++ b/apps/apollo-vertex/app/components/input-group/page.mdx
@@ -34,7 +34,7 @@ Groups input elements with addons and buttons.
 ## Installation
 
 ```bash
-npx shadcn@latest add https://apollo-vertex.vercel.app/r/input-group.json
+npx shadcn@latest add @uipath/input-group
 ```
 
 ## Usage

--- a/apps/apollo-vertex/app/components/input-otp/page.mdx
+++ b/apps/apollo-vertex/app/components/input-otp/page.mdx
@@ -23,7 +23,7 @@ Accessible one-time password component with copy paste functionality.
 ## Installation
 
 ```bash
-npx shadcn@latest add https://apollo-vertex.vercel.app/r/input-otp.json
+npx shadcn@latest add @uipath/input-otp
 ```
 
 ## Usage

--- a/apps/apollo-vertex/app/components/input/page.mdx
+++ b/apps/apollo-vertex/app/components/input/page.mdx
@@ -37,7 +37,7 @@ Displays a form input field or a component that looks like an input field.
 ## Installation
 
 ```bash
-npx shadcn@latest add https://apollo-vertex.vercel.app/r/input.json
+npx shadcn@latest add @uipath/input
 ```
 
 ## Usage

--- a/apps/apollo-vertex/app/components/item/page.mdx
+++ b/apps/apollo-vertex/app/components/item/page.mdx
@@ -44,7 +44,7 @@ A versatile list item component for displaying content in lists.
 ## Installation
 
 ```bash
-npx shadcn@latest add https://apollo-vertex.vercel.app/r/item.json
+npx shadcn@latest add @uipath/item
 ```
 
 ## Usage

--- a/apps/apollo-vertex/app/components/kbd/page.mdx
+++ b/apps/apollo-vertex/app/components/kbd/page.mdx
@@ -36,7 +36,7 @@ The keyboard key component is used to display keyboard shortcuts.
 ## Installation
 
 ```bash
-npx shadcn@latest add https://apollo-vertex.vercel.app/r/kbd.json
+npx shadcn@latest add @uipath/kbd
 ```
 
 ## Usage

--- a/apps/apollo-vertex/app/components/label/page.mdx
+++ b/apps/apollo-vertex/app/components/label/page.mdx
@@ -21,7 +21,7 @@ Renders an accessible label associated with controls.
 ## Installation
 
 ```bash
-npx shadcn@latest add https://apollo-vertex.vercel.app/r/label.json
+npx shadcn@latest add @uipath/label
 ```
 
 ## Usage

--- a/apps/apollo-vertex/app/components/menubar/page.mdx
+++ b/apps/apollo-vertex/app/components/menubar/page.mdx
@@ -59,7 +59,7 @@ A visually persistent menu common in desktop applications.
 ## Installation
 
 ```bash
-npx shadcn@latest add https://apollo-vertex.vercel.app/r/menubar.json
+npx shadcn@latest add @uipath/menubar
 ```
 
 ## Usage

--- a/apps/apollo-vertex/app/components/native-select/page.mdx
+++ b/apps/apollo-vertex/app/components/native-select/page.mdx
@@ -33,7 +33,7 @@ A native HTML select element with consistent styling.
 ## Installation
 
 ```bash
-npx shadcn@latest add https://apollo-vertex.vercel.app/r/native-select.json
+npx shadcn@latest add @uipath/native-select
 ```
 
 ## Usage

--- a/apps/apollo-vertex/app/components/navigation-menu/page.mdx
+++ b/apps/apollo-vertex/app/components/navigation-menu/page.mdx
@@ -11,7 +11,7 @@ A collection of links for navigating websites.
 ## Installation
 
 ```bash
-npx shadcn@latest add https://apollo-vertex.vercel.app/r/navigation-menu.json
+npx shadcn@latest add @uipath/navigation-menu
 ```
 
 ## Usage

--- a/apps/apollo-vertex/app/components/pagination/page.mdx
+++ b/apps/apollo-vertex/app/components/pagination/page.mdx
@@ -34,7 +34,7 @@ Pagination with page navigation, next and previous links.
 ## Installation
 
 ```bash
-npx shadcn@latest add https://apollo-vertex.vercel.app/r/pagination.json
+npx shadcn@latest add @uipath/pagination
 ```
 
 ## Usage

--- a/apps/apollo-vertex/app/components/popover/page.mdx
+++ b/apps/apollo-vertex/app/components/popover/page.mdx
@@ -38,7 +38,7 @@ Displays rich content in a portal, triggered by a button.
 ## Installation
 
 ```bash
-npx shadcn@latest add https://apollo-vertex.vercel.app/r/popover.json
+npx shadcn@latest add @uipath/popover
 ```
 
 ## Usage

--- a/apps/apollo-vertex/app/components/progress/page.mdx
+++ b/apps/apollo-vertex/app/components/progress/page.mdx
@@ -13,7 +13,7 @@ Displays an indicator showing the completion progress of a task.
 ## Installation
 
 ```bash
-npx shadcn@latest add https://apollo-vertex.vercel.app/r/progress.json
+npx shadcn@latest add @uipath/progress
 ```
 
 ## Usage

--- a/apps/apollo-vertex/app/components/radio-group/page.mdx
+++ b/apps/apollo-vertex/app/components/radio-group/page.mdx
@@ -25,7 +25,7 @@ A set of checkable buttons—known as radio buttons—where no more than one can
 ## Installation
 
 ```bash
-npx shadcn@latest add https://apollo-vertex.vercel.app/r/radio-group.json
+npx shadcn@latest add @uipath/radio-group
 ```
 
 ## Usage

--- a/apps/apollo-vertex/app/components/resizable/page.mdx
+++ b/apps/apollo-vertex/app/components/resizable/page.mdx
@@ -36,7 +36,7 @@ Accessible resizable panel groups and layouts with keyboard support.
 ## Installation
 
 ```bash
-npx shadcn@latest add https://apollo-vertex.vercel.app/r/resizable.json
+npx shadcn@latest add @uipath/resizable
 ```
 
 ## Usage

--- a/apps/apollo-vertex/app/components/scroll-area/page.mdx
+++ b/apps/apollo-vertex/app/components/scroll-area/page.mdx
@@ -24,7 +24,7 @@ export const tags = Array.from({ length: 50 }).map((_, i, a) => `v1.2.0-beta.${a
 ## Installation
 
 ```bash
-npx shadcn@latest add https://apollo-vertex.vercel.app/r/scroll-area.json
+npx shadcn@latest add @uipath/scroll-area
 ```
 
 ## Usage

--- a/apps/apollo-vertex/app/components/select/page.mdx
+++ b/apps/apollo-vertex/app/components/select/page.mdx
@@ -25,7 +25,7 @@ Displays a list of options for the user to pick from—triggered by a button.
 ## Installation
 
 ```bash
-npx shadcn@latest add https://apollo-vertex.vercel.app/r/select.json
+npx shadcn@latest add @uipath/select
 ```
 
 ## Usage

--- a/apps/apollo-vertex/app/components/separator/page.mdx
+++ b/apps/apollo-vertex/app/components/separator/page.mdx
@@ -26,7 +26,7 @@ Visually or semantically separates content.
 ## Installation
 
 ```bash
-npx shadcn@latest add https://apollo-vertex.vercel.app/r/separator.json
+npx shadcn@latest add @uipath/separator
 ```
 
 ## Usage

--- a/apps/apollo-vertex/app/components/sheet/page.mdx
+++ b/apps/apollo-vertex/app/components/sheet/page.mdx
@@ -41,7 +41,7 @@ Extends the Dialog component to display content that complements the main conten
 ## Installation
 
 ```bash
-npx shadcn@latest add https://apollo-vertex.vercel.app/r/sheet.json
+npx shadcn@latest add @uipath/sheet
 ```
 
 ## Usage

--- a/apps/apollo-vertex/app/components/sidebar/page.mdx
+++ b/apps/apollo-vertex/app/components/sidebar/page.mdx
@@ -11,7 +11,7 @@ A composable, themeable and customizable sidebar component.
 ## Installation
 
 ```bash
-npx shadcn@latest add https://apollo-vertex.vercel.app/r/sidebar.json
+npx shadcn@latest add @uipath/sidebar
 ```
 
 ## Usage

--- a/apps/apollo-vertex/app/components/skeleton/page.mdx
+++ b/apps/apollo-vertex/app/components/skeleton/page.mdx
@@ -25,7 +25,7 @@ Use to show a placeholder while content is loading.
 ## Installation
 
 ```bash
-npx shadcn@latest add https://apollo-vertex.vercel.app/r/skeleton.json
+npx shadcn@latest add @uipath/skeleton
 ```
 
 ## Usage

--- a/apps/apollo-vertex/app/components/slider/page.mdx
+++ b/apps/apollo-vertex/app/components/slider/page.mdx
@@ -22,7 +22,7 @@ An input where the user selects a value from within a given range.
 ## Installation
 
 ```bash
-npx shadcn@latest add https://apollo-vertex.vercel.app/r/slider.json
+npx shadcn@latest add @uipath/slider
 ```
 
 ## Usage

--- a/apps/apollo-vertex/app/components/sonner/page.mdx
+++ b/apps/apollo-vertex/app/components/sonner/page.mdx
@@ -14,7 +14,7 @@ An opinionated toast component for React.
 ## Installation
 
 ```bash
-npx shadcn@latest add https://apollo-vertex.vercel.app/r/sonner.json
+npx shadcn@latest add @uipath/sonner
 ```
 
 Add the `<Toaster />` component to your app:

--- a/apps/apollo-vertex/app/components/spinner/page.mdx
+++ b/apps/apollo-vertex/app/components/spinner/page.mdx
@@ -23,7 +23,7 @@ A loading spinner component to indicate loading state.
 ## Installation
 
 ```bash
-npx shadcn@latest add https://apollo-vertex.vercel.app/r/spinner.json
+npx shadcn@latest add @uipath/spinner
 ```
 
 ## Usage

--- a/apps/apollo-vertex/app/components/switch/page.mdx
+++ b/apps/apollo-vertex/app/components/switch/page.mdx
@@ -25,7 +25,7 @@ A control that allows the user to toggle between on and off.
 ## Installation
 
 ```bash
-npx shadcn@latest add https://apollo-vertex.vercel.app/r/switch.json
+npx shadcn@latest add @uipath/switch
 ```
 
 ## Usage

--- a/apps/apollo-vertex/app/components/table/page.mdx
+++ b/apps/apollo-vertex/app/components/table/page.mdx
@@ -45,7 +45,7 @@ export const invoices = [
 ## Installation
 
 ```bash
-npx shadcn@latest add https://apollo-vertex.vercel.app/r/table.json
+npx shadcn@latest add @uipath/table
 ```
 
 ## Usage

--- a/apps/apollo-vertex/app/components/tabs/page.mdx
+++ b/apps/apollo-vertex/app/components/tabs/page.mdx
@@ -66,7 +66,7 @@ A set of layered sections of content—known as tab panels—that are displayed 
 ## Installation
 
 ```bash
-npx shadcn@latest add https://apollo-vertex.vercel.app/r/tabs.json
+npx shadcn@latest add @uipath/tabs
 ```
 
 ## Usage

--- a/apps/apollo-vertex/app/components/textarea/page.mdx
+++ b/apps/apollo-vertex/app/components/textarea/page.mdx
@@ -36,7 +36,7 @@ Displays a form textarea or a component that looks like a textarea.
 ## Installation
 
 ```bash
-npx shadcn@latest add https://apollo-vertex.vercel.app/r/textarea.json
+npx shadcn@latest add @uipath/textarea
 ```
 
 ## Usage

--- a/apps/apollo-vertex/app/components/toggle-group/page.mdx
+++ b/apps/apollo-vertex/app/components/toggle-group/page.mdx
@@ -50,7 +50,7 @@ A set of two-state buttons that can be toggled on or off.
 ## Installation
 
 ```bash
-npx shadcn@latest add https://apollo-vertex.vercel.app/r/toggle-group.json
+npx shadcn@latest add @uipath/toggle-group
 ```
 
 ## Usage

--- a/apps/apollo-vertex/app/components/toggle/page.mdx
+++ b/apps/apollo-vertex/app/components/toggle/page.mdx
@@ -41,7 +41,7 @@ A two-state button that can be either on or off.
 ## Installation
 
 ```bash
-npx shadcn@latest add https://apollo-vertex.vercel.app/r/toggle.json
+npx shadcn@latest add @uipath/toggle
 ```
 
 ## Usage

--- a/apps/apollo-vertex/app/components/tooltip/page.mdx
+++ b/apps/apollo-vertex/app/components/tooltip/page.mdx
@@ -83,7 +83,7 @@ A popup that displays information related to an element when the element receive
 ## Installation
 
 ```bash
-npx shadcn@latest add https://apollo-vertex.vercel.app/r/tooltip.json
+npx shadcn@latest add @uipath/tooltip
 ```
 
 ## Usage


### PR DESCRIPTION
Since we define the registry by default in the repo now - this removes the long URL and just relies on the registry name