### PR TITLE
feat(apollo-react): add ApButton and also new width variant PLT-90042 PLT-94605

### DIFF
--- a/apps/react-playground/src/App.tsx
+++ b/apps/react-playground/src/App.tsx
@@ -12,6 +12,7 @@ import { CssVariables } from "./pages/CssVariables";
 import { AlertBarShowcase } from "./pages/components/AlertBarShowcase";
 import { ApChatShowcase } from "./pages/components/ApChatShowcase";
 import { BadgeShowcase } from "./pages/components/BadgeShowcase";
+import { ButtonShowcase } from "./pages/components/ButtonShowcase";
 import { ChipShowcase } from "./pages/components/ChipShowcase";
 import { LinkShowcase } from "./pages/components/LinkShowcase";
 import { SkeletonShowcase } from "./pages/components/SkeletonShowcase";
@@ -138,6 +139,7 @@ function App() {
 								element={<AlertBarShowcase />}
 							/>
 							<Route path="/components/badge" element={<BadgeShowcase />} />
+							<Route path="/components/button" element={<ButtonShowcase />} />
 							<Route path="/components/chat" element={<ApChatShowcase />} />
 							<Route path="/components/chip" element={<ChipShowcase />} />
 							<Route path="/components/link" element={<LinkShowcase />} />

--- a/apps/react-playground/src/components/Breadcrumb.tsx
+++ b/apps/react-playground/src/components/Breadcrumb.tsx
@@ -58,6 +58,7 @@ export function Breadcrumb() {
 		// Apollo component routes
 		"alert-bar": "Alert Bar",
 		badge: "Badge",
+		button: "Button",
 		chat: "Chat",
 		"text-area": "Text Area",
 		"tool-call": "Tool Call",

--- a/apps/react-playground/src/components/Sidebar.tsx
+++ b/apps/react-playground/src/components/Sidebar.tsx
@@ -49,6 +49,7 @@ export function Sidebar() {
 			children: [
 				{ label: "Alert Bar", path: "/components/alert-bar" },
 				{ label: "Badge", path: "/components/badge" },
+				{ label: "Button", path: "/components/button" },
 				{ label: "Chat", path: "/components/chat" },
 				{ label: "Chip", path: "/components/chip" },
 				{ label: "Link", path: "/components/link" },

--- a/apps/react-playground/src/pages/ComponentsHome.tsx
+++ b/apps/react-playground/src/pages/ComponentsHome.tsx
@@ -17,6 +17,7 @@ export function ComponentsHome() {
 	const components = [
 		{ label: "Alert Bar", path: "/components/alert-bar", icon: "⚠️" },
 		{ label: "Badge", path: "/components/badge", icon: "🏷️" },
+		{ label: "Button", path: "/components/button", icon: "🔘" },
 		{ label: "Chat", path: "/components/chat", icon: "💬" },
 		{ label: "Chip", path: "/components/chip", icon: "🔖" },
 		{ label: "Link", path: "/components/link", icon: "🔗" },

--- a/apps/react-playground/src/pages/components/ButtonShowcase.tsx
+++ b/apps/react-playground/src/pages/components/ButtonShowcase.tsx
@@ -1,0 +1,300 @@
+import { ArrowDropDown, Search } from "@uipath/apollo-react/icons";
+import { ApButton } from "@uipath/apollo-react/material/components";
+import styled from "styled-components";
+
+import {
+	PageContainer,
+	PageDescription,
+	PageTitle,
+} from "../../components/SharedStyles";
+
+const ShowcaseSection = styled.div`
+	margin-top: 48px;
+	display: flex;
+	flex-direction: column;
+	gap: 24px;
+`;
+
+const SectionTitle = styled.h3`
+	font-size: 20px;
+	color: var(--color-primary);
+	margin-bottom: 16px;
+	border-bottom: 2px solid var(--color-border);
+	padding-bottom: 8px;
+`;
+
+const ComponentRow = styled.div`
+	display: flex;
+	flex-wrap: wrap;
+	gap: 16px;
+	padding: 24px;
+	background: var(--color-background);
+	border-radius: 12px;
+	border: 2px solid var(--color-border);
+`;
+
+const Label = styled.div`
+	font-size: 14px;
+	color: var(--color-foreground-de-emp);
+	font-weight: 600;
+	width: 100%;
+	margin-bottom: 8px;
+`;
+
+const showClickAlert = (buttonType: string) => {
+	alert(`You clicked the ${buttonType} button!`);
+};
+
+const variants = [
+	"primary",
+	"secondary",
+	"destructive",
+	"tertiary",
+	"text",
+	"text-foreground",
+] as const;
+
+export function ButtonShowcase() {
+	return (
+		<PageContainer>
+			<PageTitle>Button</PageTitle>
+			<PageDescription>
+				Interactive elements that trigger actions or events when clicked,
+			</PageDescription>
+
+			<ShowcaseSection>
+				<SectionTitle>Button Variants</SectionTitle>
+				<ComponentRow>
+					<ApButton
+						label="Primary"
+						variant="primary"
+						onClick={() => showClickAlert("Primary")}
+					/>
+					<ApButton
+						label="Secondary"
+						variant="secondary"
+						onClick={() => showClickAlert("Secondary")}
+					/>
+					<ApButton
+						label="Destructive"
+						variant="destructive"
+						onClick={() => showClickAlert("Destructive")}
+					/>
+					<ApButton
+						label="Tertiary"
+						variant="tertiary"
+						onClick={() => showClickAlert("Tertiary")}
+					/>
+					<ApButton
+						label="Text"
+						variant="text"
+						onClick={() => showClickAlert("Text")}
+					/>
+					<ApButton
+						label="Text Foreground"
+						variant="text-foreground"
+						onClick={() => showClickAlert("Text Foreground")}
+					/>
+				</ComponentRow>
+			</ShowcaseSection>
+
+			<ShowcaseSection>
+				<SectionTitle>Sizes (Height) </SectionTitle>
+				<ComponentRow>
+					<ApButton
+						label="Tall Button"
+						size="tall"
+						onClick={() => showClickAlert("Tall Button")}
+					/>
+					<ApButton
+						label="Small Button"
+						size="small"
+						onClick={() => showClickAlert("Small Button")}
+					/>
+				</ComponentRow>
+			</ShowcaseSection>
+
+			<ShowcaseSection>
+				<SectionTitle>Width Modes </SectionTitle>
+				<ComponentRow>
+					<ApButton label="Default" onClick={() => showClickAlert("Default")} />
+					<ApButton
+						label="Hug"
+						widthMode="fit-content"
+						onClick={() => showClickAlert("Hug")}
+					/>
+				</ComponentRow>
+			</ShowcaseSection>
+
+			<ShowcaseSection>
+				<SectionTitle>Button States </SectionTitle>
+				<ComponentRow>
+					<ApButton label="Disabled" disabled />
+					<ApButton label="Loading" loading />
+				</ComponentRow>
+			</ShowcaseSection>
+
+			<ShowcaseSection>
+				<SectionTitle>Button Types </SectionTitle>
+				<ComponentRow>
+					<ApButton
+						label="button"
+						type="button"
+						onClick={() => showClickAlert("button")}
+					/>
+					<ApButton
+						label="submit"
+						type="submit"
+						onClick={() => showClickAlert("submit")}
+					/>
+					<ApButton
+						label="reset"
+						type="reset"
+						onClick={() => showClickAlert("reset")}
+					/>
+				</ComponentRow>
+			</ShowcaseSection>
+
+			<ShowcaseSection>
+				<SectionTitle>With Icons </SectionTitle>
+				<ComponentRow>
+					<Label>Buttons with Icons</Label>
+					<ApButton
+						label="Start Icon"
+						startIcon={<Search />}
+						onClick={() => showClickAlert("Start Icon")}
+					/>
+					<ApButton
+						label="End Icon"
+						endIcon={<ArrowDropDown />}
+						onClick={() => showClickAlert("End Icon")}
+					/>
+					<ApButton
+						label="Both Icons"
+						startIcon={<Search />}
+						endIcon={<ArrowDropDown />}
+						onClick={() => showClickAlert("Both Icons")}
+					/>
+					<Label>Buttons With Icons with Loading State</Label>
+					<ApButton label="Start Icon" startIcon={<Search />} loading />
+					<ApButton label="End Icon" endIcon={<ArrowDropDown />} loading />
+					<ApButton
+						label="Both Icons"
+						startIcon={<Search />}
+						endIcon={<ArrowDropDown />}
+						loading
+					/>
+				</ComponentRow>
+			</ShowcaseSection>
+
+			<ShowcaseSection>
+				<SectionTitle>Custom Content </SectionTitle>
+				<ComponentRow>
+					<ApButton
+						label="Custom Content"
+						customContent={
+							<span>
+								<b>Custom</b> <i style={{ fontWeight: 200 }}>Content</i>
+							</span>
+						}
+						type="button"
+						onClick={() => showClickAlert("Custom Content")}
+					/>
+				</ComponentRow>
+			</ShowcaseSection>
+
+			<ShowcaseSection>
+				<SectionTitle>All Variants and Decorations</SectionTitle>
+				<ComponentRow>
+					{variants.map((variant) => (
+						<div
+							key={variant}
+							style={{ display: "flex", flexDirection: "column", gap: "8px" }}
+						>
+							<ApButton
+								key={variant}
+								label={variant.charAt(0).toUpperCase() + variant.slice(1)}
+								variant={variant}
+								onClick={() => showClickAlert(variant)}
+							/>
+							<ApButton
+								label="Small Button"
+								size="small"
+								variant={variant}
+								onClick={() => showClickAlert(`Small`)}
+							/>
+							<ApButton
+								label="Fit"
+								widthMode="fit-content"
+								variant={variant}
+								onClick={() => showClickAlert(`Fit`)}
+							/>
+							<ApButton
+								label="Loading"
+								loading
+								variant={variant}
+								onClick={() => showClickAlert(`Loading`)}
+							/>
+							<ApButton
+								label="Disabled"
+								disabled
+								variant={variant}
+								onClick={() => showClickAlert(`Disabled`)}
+							/>
+							<ApButton
+								variant={variant}
+								label="Start Icon"
+								startIcon={<Search />}
+								onClick={() => showClickAlert("Start Icon")}
+							/>
+							<ApButton
+								variant={variant}
+								label="End Icon"
+								endIcon={<ArrowDropDown />}
+								onClick={() => showClickAlert("End Icon")}
+							/>
+							<ApButton
+								variant={variant}
+								label="Both Icons"
+								startIcon={<Search />}
+								endIcon={<ArrowDropDown />}
+								onClick={() => showClickAlert("Both Icons")}
+							/>
+							<ApButton
+								variant={variant}
+								label="Start Icon"
+								startIcon={<Search />}
+								loading
+							/>
+							<ApButton
+								variant={variant}
+								label="End Icon"
+								endIcon={<ArrowDropDown />}
+								loading
+							/>
+							<ApButton
+								variant={variant}
+								label="Both Icons"
+								startIcon={<Search />}
+								endIcon={<ArrowDropDown />}
+								loading
+							/>
+
+							<ApButton
+								variant={variant}
+								label="Custom Content"
+								customContent={
+									<span>
+										<b>Custom</b> <i style={{ fontWeight: 200 }}>Content</i>
+									</span>
+								}
+								type="button"
+								onClick={() => showClickAlert("Custom Content")}
+							/>
+						</div>
+					))}
+				</ComponentRow>
+			</ShowcaseSection>
+		</PageContainer>
+	);
+}

--- a/packages/apollo-react/src/material/components/ap-button/ApButton.test.tsx
+++ b/packages/apollo-react/src/material/components/ap-button/ApButton.test.tsx
@@ -1,0 +1,228 @@
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { ApButton } from './ApButton';
+import { ButtonVariants } from './ApButton.types';
+
+describe('ApButton', () => {
+    describe('Basic Rendering', () => {
+        it('renders the button with label default', () => {
+            render(<ApButton label="Click Me" />);
+            expect(screen.getByText('Click Me')).toBeInTheDocument();
+            expect(screen.getByRole('button')).toBeInTheDocument();
+        });
+
+        it('renders button with specific variant', () => {
+            render(<ApButton label="Primary" variant="primary" />);
+            expect(screen.getByText('Primary')).toBeInTheDocument();
+        });
+
+        it('renders the button as disabled', () => {
+            render(<ApButton label="Disabled" disabled />);
+            expect(screen.getByText('Disabled')).toBeInTheDocument();
+        });
+
+        it('renders the button in loading state with loading indicator as label', () => {
+            render(<ApButton label="Loading" loading />);
+            expect(screen.getByLabelText('Loading')).toBeInTheDocument();
+        });
+
+        it('renders the button with start and end icons', () => {
+            const StartIcon = () => <span data-testid="start-icon">S</span>;
+            const EndIcon = () => <span data-testid="end-icon">E</span>;
+            render(<ApButton label="With Icons" startIcon={<StartIcon />} endIcon={<EndIcon />} />);
+            expect(screen.getByTestId('start-icon')).toBeInTheDocument();
+            expect(screen.getByTestId('end-icon')).toBeInTheDocument();
+        });
+
+        it('renders the button with custom content', () => {
+            render(<ApButton label="Custom" customContent={<span data-testid="custom-content">Custom Content</span>} />);
+            expect(screen.getByTestId('custom-content')).toBeInTheDocument();
+        });
+    });
+
+    describe('Button Variants', () => {
+        const variants = ['primary', 'secondary', 'tertiary', 'destructive', 'text', 'text-foreground'] as ButtonVariants[];
+
+        variants.forEach((variant) => {
+            it(`renders the button with ${variant} variant`, () => {
+                render(<ApButton label={`${variant} Button`} variant={variant} />);
+                const button = screen.getByRole('button');
+                expect(button).toBeInTheDocument();
+                expect(button.tagName).toBe('BUTTON');
+                expect(screen.getByText(`${variant} Button`)).toBeInTheDocument();
+            });
+        });
+    });
+
+    describe('Button Sizes and Width Modes', () => {
+        it('renders the button with small size', () => {
+            render(<ApButton label="Small Button" size="small" />);
+            const button = screen.getByRole('button');
+            expect(button).toBeInTheDocument();
+        });
+
+        it('renders the button with tall size', () => {
+            render(<ApButton label="Tall Button" size="tall" />);
+            const button = screen.getByRole('button');
+            expect(button).toBeInTheDocument();
+        });
+
+        it('renders the button with fit-content width mode', () => {
+            render(<ApButton label="Fit Content" widthMode="fit-content" />);
+            const button = screen.getByRole('button');
+            expect(button).toBeInTheDocument();
+        });
+
+        it('renders the button with default width mode', () => {
+            render(<ApButton label="Default Width" widthMode="default" />);
+            const button = screen.getByRole('button');
+            expect(button).toBeInTheDocument();
+        });
+    });
+
+    describe('Disabled and Loading States', () => {
+        it('renders the button as disabled', () => {
+            render(<ApButton label="Disabled Button" disabled />);
+            const button = screen.getByRole('button');
+            expect(button).toBeDisabled();
+
+            const handleClick = vi.fn();
+            render(<ApButton label="Disabled Button" disabled onClick={handleClick} />);
+            button.click();
+            expect(handleClick).not.toHaveBeenCalled();
+        });
+
+        it('renders the button in loading state', () => {
+            render(<ApButton label="Loading Button" loading />);
+            const button = screen.getByRole('button');
+            expect(button).toHaveAttribute('aria-disabled', 'true');
+            expect(screen.getByLabelText('Loading Button')).toBeInTheDocument();
+
+            const handleClick = vi.fn();
+            render(<ApButton label="Loading Button" loading onClick={handleClick} />);
+            button.click();
+            expect(handleClick).not.toHaveBeenCalled();
+        });
+
+        it('renders the loading incidator in place of label', () => {
+           const { container } = render(<ApButton label="Loading Button" loading />);
+            expect(screen.getByLabelText('Loading Button')).toBeInTheDocument();
+            expect(screen.queryByText('Loading Button')).toHaveStyle('opacity: 0');
+            expect(container.querySelector('.MuiCircularProgress-root')).toBeInTheDocument();
+        });
+
+        it('renders the loading indicator as start icon', () => {
+            const StartIcon = () => <span data-testid="start-icon">S</span>;
+            const { container } = render(<ApButton label="Loading Button" loading startIcon={<StartIcon />} />);
+            expect(screen.getByLabelText('Loading Button')).toBeInTheDocument();
+            expect(screen.queryByTestId('start-icon')).not.toBeInTheDocument();
+            expect(container.querySelector('.MuiCircularProgress-root')).toBeInTheDocument();
+        });
+
+        it('renders the loading indicator as end icon', () => {
+            const EndIcon = () => <span data-testid="end-icon">E</span>;
+            const { container } = render(<ApButton label="Loading Button" loading endIcon={<EndIcon />} />);
+            expect(screen.getByLabelText('Loading Button')).toBeInTheDocument();
+            expect(screen.queryByTestId('end-icon')).not.toBeInTheDocument();
+            expect(container.querySelector('.MuiCircularProgress-root')).toBeInTheDocument();
+        });
+
+        it('renders loading indicator as start icon when both icons are provided', () => {
+            const StartIcon = () => <span data-testid="start-icon">S</span>;
+            const EndIcon = () => <span data-testid="end-icon">E</span>;
+            const { container } = render(<ApButton label="Loading Button" loading startIcon={<StartIcon />} endIcon={<EndIcon />} />);
+            expect(screen.getByLabelText('Loading Button')).toBeInTheDocument();
+            expect(screen.queryByTestId('start-icon')).not.toBeInTheDocument();
+            expect(screen.queryByTestId('end-icon')).toBeInTheDocument();
+            expect(container.querySelector('.MuiCircularProgress-root')).toBeInTheDocument();
+        });
+    });
+
+    describe('Id, Type, href, tabIndex, and Event Handlers', () => {
+        it('sets the id of the button', () => {
+            render(<ApButton label="With ID" id="test-button" />);
+            const button = screen.getByRole('button');
+            expect(button).toHaveAttribute('id', 'test-button');
+        });
+
+        it('sets the type of the button', () => {
+            render(<ApButton label="Submit Button" type="submit" />);
+            const button = screen.getByRole('button');
+            expect(button).toHaveAttribute('type', 'submit');
+        });
+
+        it('sets the href of the button when provided', () => {
+            render(<ApButton label="Link Button" href="https://example.com" />);
+            const button = screen.getByRole('link');
+            expect(button).toHaveAttribute('href', 'https://example.com');
+        });
+
+        it('sets the tabIndex of the button', () => {
+            render(<ApButton label="Tabbable Button" tabIndex={3} />);
+            const button = screen.getByRole('button');
+            expect(button).toHaveAttribute('tabindex', '3');
+        });
+
+        it('calls onClick handler when clicked', async () => {
+            const handleClick = vi.fn();
+            render(<ApButton label="Clickable" onClick={handleClick} />);
+            const button = screen.getByRole('button');
+            await button.click();
+            expect(handleClick).toHaveBeenCalled();
+        });
+
+        it('calls onMouseEnter and onMouseLeave handlers', () => {
+            const handleMouseEnter = vi.fn();
+            const handleMouseLeave = vi.fn();
+
+            render(
+            <ApButton
+                label="Hoverable"
+                onMouseEnter={handleMouseEnter}
+                onMouseLeave={handleMouseLeave}
+            />
+            );
+
+            const button = screen.getByRole('button');
+
+            fireEvent.mouseEnter(button);
+            expect(handleMouseEnter).toHaveBeenCalledTimes(1);
+
+            fireEvent.mouseLeave(button);
+            expect(handleMouseLeave).toHaveBeenCalledTimes(1);
+        });
+
+        it('calls onFocus and onBlur handlers', async () => {
+            const handleFocus = vi.fn();
+            const handleBlur = vi.fn();
+            render(<ApButton label="Focusable" onFocus={handleFocus} onBlur={handleBlur} />);
+            const button = screen.getByRole('button');
+            await button.focus();
+            expect(handleFocus).toHaveBeenCalled();
+            await button.blur();
+            expect(handleBlur).toHaveBeenCalled();
+        });
+
+        it('calls onKeyDown handler', async () => {
+            const handleKeyDown = vi.fn();
+            render(<ApButton label="Keyable" onKeyDown={handleKeyDown} />);
+            const button = screen.getByRole('button');
+            await button.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+            expect(handleKeyDown).toHaveBeenCalled();
+        }); 
+    });
+
+    describe('Accessibility', () => {
+        it('has appropriate aria attributes when expanded', () => {
+            render(<ApButton label="Expandable" expanded />);
+            const button = screen.getByRole('button');
+            expect(button).toHaveAttribute('aria-expanded', 'true');
+        });
+
+        it('sets the title attribute when provided', () => {
+            render(<ApButton label="With Title" title="Button Title" />);
+            const button = screen.getByRole('button');
+            expect(button).toHaveAttribute('title', 'Button Title');
+        });
+    });
+});

--- a/packages/apollo-react/src/material/components/ap-button/ApButton.tsx
+++ b/packages/apollo-react/src/material/components/ap-button/ApButton.tsx
@@ -1,0 +1,192 @@
+import { CircularProgress } from '@mui/material';
+import Button, { ButtonProps } from '@mui/material/Button';
+import { styled } from '@mui/material/styles';
+import React from 'react';
+
+import { ApButtonProps, ButtonVariants } from './ApButton.types';
+
+const variantToProps: Record<ButtonVariants, Partial<ButtonProps>> = {
+    primary: { variant: 'contained' },
+    secondary: {
+        variant: 'outlined',
+        sx: { background: 'transparent' },
+    },
+
+    destructive: { className: 'warning' },
+    tertiary: {},
+    text: {
+        variant: 'text',
+        sx: { background: 'transparent' },
+    },
+    'text-foreground': {
+        variant: 'text',
+        sx: {
+            color: 'var(--color-foreground)',
+            '&&:hover': { backgroundColor: 'var(--color-background-hover)' },
+            '&&:focus': { backgroundColor: 'var(--color-background-hover)' },
+            '&&:focus-visible': { backgroundColor: 'var(--color-background-hover)' },
+            '&&:active': { backgroundColor: 'var(--color-background-pressed)' },
+        },
+    },
+};
+
+function joinClasses(...classes: Array<string | boolean | undefined>) {
+    return classes.filter(Boolean).join(' ');
+}
+
+const LoadingMouseInteractionBlocker = styled('div')({
+    position: 'absolute',
+    inset: 0,
+    cursor: 'not-allowed',
+});
+
+const LabelLoadingIndicatorContainer = styled('div')({
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+});
+
+export const ApButton = React.forwardRef<HTMLButtonElement, ApButtonProps>((props, ref) => {
+    const {
+        startIcon,
+        endIcon,
+        id,
+        variant = 'primary',
+        size = 'tall',
+        widthMode = 'default',
+        label,
+        customContent,
+        type = 'button',
+        disabled = false,
+        loading = false,
+        onClick,
+        href,
+        tabIndex,
+        expanded,
+        title,
+        onMouseEnter,
+        onMouseLeave,
+        onMouseDown,
+        onMouseUp,
+        onFocus,
+        onBlur,
+        onKeyDown,
+    } = props;
+
+    const hasStartIcon = !!startIcon;
+    const hasEndIcon = !!endIcon;
+    const shouldShowLoadingAsStartIcon = loading && hasStartIcon;
+    const shouldShowLoadingAsEndIcon = loading && !hasStartIcon && hasEndIcon;
+    const shouldShowLoadingAsLabel = loading && !hasStartIcon && !hasEndIcon;
+    const variantProps = variantToProps[variant];
+
+    const loadingIndicator = loading ? <ButtonLoadingIndicator aria-label={label} /> : null;
+
+    return (
+        <div style={{ position: 'relative' }}>
+            <StyledButton
+                ref={ref}
+                type={type}
+                id={id}
+                color="secondary"
+                {...(disabled ? { disabled: true } : {})}
+                disableElevation={true}
+                onClick={!loading ? onClick : undefined}
+                onKeyDown={onKeyDown}
+                onMouseEnter={onMouseEnter}
+                onMouseLeave={onMouseLeave}
+                onMouseDown={onMouseDown}
+                onMouseUp={onMouseUp}
+                onFocus={onFocus}
+                onBlur={onBlur}
+                startIcon={(loading && shouldShowLoadingAsStartIcon) ? loadingIndicator : startIcon}
+                endIcon={(loading && shouldShowLoadingAsEndIcon) ? loadingIndicator : endIcon}
+                {...variantProps}
+                tabIndex={tabIndex ?? (loading ? -1 : undefined)}
+                aria-disabled={(disabled || loading) ? 'true' : undefined}
+                aria-expanded={expanded}
+                title={title}
+                className={joinClasses(variantProps?.className, loading && 'loading')}
+                href={href}
+                customSize={size}
+                customWidth={widthMode}
+            >
+                <span
+                style={{
+                    opacity: shouldShowLoadingAsLabel ? 0 : 1,
+                }}
+                >
+                    {customContent ?? label}
+                </span>
+
+                {shouldShowLoadingAsLabel && (
+                    <LabelLoadingIndicatorContainer>
+                        {loadingIndicator}
+                    </LabelLoadingIndicatorContainer>
+                )}
+            </StyledButton>
+            {loading && <LoadingMouseInteractionBlocker/>}
+        </div>
+    );
+});
+
+const StyledButton = styled(Button, { shouldForwardProp: (prop) => prop !== 'customSize' && prop !== 'customWidth' })<ButtonProps & {
+    customSize: string; customWidth: string;
+}>(({
+    customSize, customWidth,
+}) => ({
+    '--border-radius': `3px`,
+    '--focus-border-offset': `1px`,
+    '--focus-border-width': `2px`,
+    // Automatically calculate the outer focus border radius and position
+    '--focus-border-radius': `calc( var(--border-radius) + var(--focus-border-offset) + var(--focus-border-width) )`,
+    '--focus-border-inset': `calc( -1 * (var(--focus-border-offset) + var(--focus-border-width) + 1px))`,
+
+    position: 'relative',
+    borderRadius: 'var(--border-radius)',
+    minWidth: customWidth === 'fit-content' ? undefined : '120px',
+    height: customSize === 'tall' ? '40px' : '32px',
+
+    '&.loading': { pointerEvents: 'none' },
+
+    ':before': {
+        content: `''`,
+        boxSizing: 'border-box',
+        position: 'absolute',
+        inset: `var(--focus-border-inset)`,
+        border: `var(--focus-border-width) solid var(--color-focus-indicator)`,
+        borderRadius: 'var(--focus-border-radius)',
+        pointerEvents: 'none',
+        display: 'none',
+    },
+
+    ':focus-visible': {
+        outline: 'none',
+
+        ':before': { display: 'block' },
+    },
+
+}));
+
+const StyledCircularProgress = styled(CircularProgress)({
+    color: 'inherit !important',
+    stroke: 'currentColor !important',
+});
+
+function ButtonLoadingIndicator(props: Readonly<React.ComponentProps<typeof CircularProgress>>) {
+
+    return (
+        <StyledCircularProgress
+            size={16}
+            {...props}
+            className={props.className}
+        />
+    );
+}
+
+ApButton.displayName = 'ApButton';

--- a/packages/apollo-react/src/material/components/ap-button/ApButton.types.ts
+++ b/packages/apollo-react/src/material/components/ap-button/ApButton.types.ts
@@ -1,0 +1,48 @@
+import { FocusEventHandler, KeyboardEventHandler, MouseEventHandler, ReactNode } from 'react';
+import { ButtonProps } from "@mui/material";
+
+export type ButtonVariants = 'primary' | 'secondary' | 'tertiary' | 'destructive' | 'text' | 'text-foreground';
+export type ButtonTypes = 'button' | 'submit' | 'reset';
+export type ButtonSizes = 'tall' | 'small';
+export type ButtonWidthModes = 'default' | 'fit-content';
+
+export interface ApButtonProps extends Omit<ButtonProps, 'size' | 'variant' | 'type'> {
+    /** Sets the label of the button */
+    label: string;
+    /** Sets the id of the button */
+    id?: string;
+    /** Sets the type of the button */
+    type?: ButtonTypes;
+    /** If `true`, the button will be disabled. */
+    disabled?: boolean;
+    /** If `true`, the button will be disabled and show a loading indicator. */
+    loading?: boolean;
+    /** Sets the variant of the button */
+    variant?: ButtonVariants;
+    /** Sets the height of the button */
+    size?: ButtonSizes;
+    /** Sets the width of the button default has min width 120px */
+    widthMode?: ButtonWidthModes;
+    /** Sets the start icon of the button */
+    startIcon?: ReactNode;
+    /** Sets the end icon of the button */
+    endIcon?: ReactNode;
+    /** Sets the custom content of the button, replacing the label value */
+    customContent?: ReactNode;
+    onClick?: MouseEventHandler;
+    /** Sets the href of the button */
+    href?: string;
+    /** Sets the tab index of the button */
+    tabIndex?: number;
+    /** If `true`, sets `aria-expanded` to true */
+    expanded?: boolean;
+    /** Sets the title attribute of the button */
+    title?: string;
+    onMouseEnter?: MouseEventHandler;
+    onMouseLeave?: MouseEventHandler;
+    onMouseDown?: MouseEventHandler;
+    onMouseUp?: MouseEventHandler;
+    onFocus?: FocusEventHandler;
+    onBlur?: FocusEventHandler;
+    onKeyDown?: KeyboardEventHandler;
+}

--- a/packages/apollo-react/src/material/components/ap-button/index.ts
+++ b/packages/apollo-react/src/material/components/ap-button/index.ts
@@ -1,0 +1,3 @@
+export {ApButton} from './ApButton';
+export type {ApButtonProps} from './ApButton.types';
+export type {ButtonSizes, ButtonTypes, ButtonVariants, ButtonWidthModes} from './ApButton.types';

--- a/packages/apollo-react/src/material/components/index.ts
+++ b/packages/apollo-react/src/material/components/index.ts
@@ -1,5 +1,6 @@
 export * from './ap-alert-bar'
 export * from './ap-badge'
+export * from './ap-button'
 export * from './ap-chat'
 export * from './ap-chip'
 export * from './ap-link'


### PR DESCRIPTION
- Migrated ApButton from Apollo Design System over 
- Added A fit content width variant so button min width is not 120px
- Added Tests for ApButton
- Added a Button Showcase to the React-playground for ApButton 


https://github.com/user-attachments/assets/891ca3d4-3ffa-4aee-9a76-bec4b6406af9



