### PR TITLE
fix(apollo-wind): radix wrapper components now properly forward refs

### DIFF
--- a/packages/apollo-wind/src/components/ui/dialog.tsx
+++ b/packages/apollo-wind/src/components/ui/dialog.tsx
@@ -10,22 +10,28 @@ function Dialog({ ...props }: React.ComponentProps<typeof DialogPrimitive.Root>)
   return <DialogPrimitive.Root data-slot="dialog" {...props} />;
 }
 
-function DialogTrigger({ ...props }: React.ComponentProps<typeof DialogPrimitive.Trigger>) {
-  return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />;
-}
+const DialogTrigger = React.forwardRef<
+  React.ComponentRef<typeof DialogPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Trigger>
+>(function DialogTrigger(props, ref) {
+  return <DialogPrimitive.Trigger data-slot="dialog-trigger" ref={ref} {...props} />;
+});
 
 function DialogPortal({ ...props }: React.ComponentProps<typeof DialogPrimitive.Portal>) {
   return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />;
 }
 
-function DialogClose({ ...props }: React.ComponentProps<typeof DialogPrimitive.Close>) {
-  return <DialogPrimitive.Close data-slot="dialog-close" {...props} />;
-}
+const DialogClose = React.forwardRef<
+  React.ComponentRef<typeof DialogPrimitive.Close>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Close>
+>(function DialogClose(props, ref) {
+  return <DialogPrimitive.Close data-slot="dialog-close" ref={ref} {...props} />;
+});
 
-function DialogOverlay({
-  className,
-  ...props
-}: React.ComponentProps<typeof DialogPrimitive.Overlay>) {
+const DialogOverlay = React.forwardRef<
+  React.ComponentRef<typeof DialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(function DialogOverlay({ className, ...props }, ref) {
   return (
     <DialogPrimitive.Overlay
       data-slot="dialog-overlay"
@@ -33,19 +39,18 @@ function DialogOverlay({
         "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
         className,
       )}
+      ref={ref}
       {...props}
     />
   );
-}
+});
 
-function DialogContent({
-  className,
-  children,
-  showCloseButton = true,
-  ...props
-}: React.ComponentProps<typeof DialogPrimitive.Content> & {
-  showCloseButton?: boolean;
-}) {
+const DialogContent = React.forwardRef<
+  React.ComponentRef<typeof DialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content> & {
+    showCloseButton?: boolean;
+  }
+>(function DialogContent({ className, children, showCloseButton = true, ...props }, ref) {
   return (
     <DialogPortal data-slot="dialog-portal">
       <DialogOverlay />
@@ -55,6 +60,7 @@ function DialogContent({
           "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
           className,
         )}
+        ref={ref}
         {...props}
       >
         {children}
@@ -70,7 +76,7 @@ function DialogContent({
       </DialogPrimitive.Content>
     </DialogPortal>
   );
-}
+});
 
 function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
   return (
@@ -92,28 +98,33 @@ function DialogFooter({ className, ...props }: React.ComponentProps<"div">) {
   );
 }
 
-function DialogTitle({ className, ...props }: React.ComponentProps<typeof DialogPrimitive.Title>) {
+const DialogTitle = React.forwardRef<
+  React.ComponentRef<typeof DialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+>(function DialogTitle({ className, ...props }, ref) {
   return (
     <DialogPrimitive.Title
       data-slot="dialog-title"
       className={cn("text-lg leading-none font-semibold", className)}
+      ref={ref}
       {...props}
     />
   );
-}
+});
 
-function DialogDescription({
-  className,
-  ...props
-}: React.ComponentProps<typeof DialogPrimitive.Description>) {
+const DialogDescription = React.forwardRef<
+  React.ComponentRef<typeof DialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+>(function DialogDescription({ className, ...props }, ref) {
   return (
     <DialogPrimitive.Description
       data-slot="dialog-description"
       className={cn("text-muted-foreground text-sm", className)}
+      ref={ref}
       {...props}
     />
   );
-}
+});
 
 export {
   Dialog,


### PR DESCRIPTION
# Bug Report: DialogOverlay missing forwardRef

##  Issue
React warning in console when using Dialog component:
Warning: Function components cannot be given refs. Attempts to access this ref will fail. Did you mean to use React.forwardRef()?

##  Check the render method of `Primitive.div.SlotClone`.

###  Stack Trace
```
  at DialogOverlay (dialog.js:31:26)
  at slot.tsx:68:13
  at slot.tsx:15:13
  at primitive.tsx:40:13
  at portal.tsx:22:22
  at Presence (presence.tsx:12:11)
  at DialogPortal (dialog.tsx:146:11)
  at DialogContent (dialog.js:38:26)
```
### Root Cause
The DialogOverlay component at dialog.js:31 is a function component that doesn't use React.forwardRef(). Radix UI's internal Slot component tries to pass a ref to it via SlotClone, but since DialogOverlay doesn't forward refs, React throws this warning.

### Fix

  Wrap DialogOverlay with forwardRef:

  Before:
```
  function DialogOverlay(props) {
    return <RadixDialog.Overlay {...props} />;
  }
```
  After:
```
  import { forwardRef } from 'react';

  const DialogOverlay = forwardRef<HTMLDivElement, DialogOverlayProps>(
    function DialogOverlay(props, ref) {
      return <RadixDialog.Overlay {...props} ref={ref} />;
    }
  );
```
###  Why This Matters

  - Radix UI's composition pattern uses Slot to merge props and refs between components
  - When a component doesn't support forwardRef, the ref chain breaks
  - This causes React warnings in development and may prevent certain accessibility features from working correctly

  Affected Components

  You may want to audit other Dialog-related components for the same issue:
  - DialogOverlay
  - DialogContent
  - DialogPortal
  - Any other components that wrap Radix primitives