### PR TITLE
fix(apollo-wind): honor grid.span on fields and custom components

### DIFF
--- a/packages/apollo-wind/src/components/forms/field-renderer.test.tsx
+++ b/packages/apollo-wind/src/components/forms/field-renderer.test.tsx
@@ -306,7 +306,7 @@ describe('FormFieldRenderer', () => {
   });
 
   describe('grid layout', () => {
-    it('applies grid span class', () => {
+    it('applies grid span style', () => {
       const field: FieldMetadata = {
         name: 'wide_field',
         type: 'text',
@@ -321,7 +321,24 @@ describe('FormFieldRenderer', () => {
       );
 
       const wrapper = container.firstChild as HTMLElement;
-      expect(wrapper).toHaveClass('col-span-2');
+      expect(wrapper).toHaveStyle({ gridColumn: 'span 2' });
+    });
+
+    it('defaults to span 1 when grid config is not provided', () => {
+      const field: FieldMetadata = {
+        name: 'default_field',
+        type: 'text',
+        label: 'Default Field',
+      };
+
+      const { container } = render(
+        <FormWrapper>
+          <FormFieldRenderer field={field} context={createMockContext()} customComponents={{}} />
+        </FormWrapper>
+      );
+
+      const wrapper = container.firstChild as HTMLElement;
+      expect(wrapper).toHaveStyle({ gridColumn: 'span 1' });
     });
   });
 

--- a/packages/apollo-wind/src/components/forms/field-renderer.tsx
+++ b/packages/apollo-wind/src/components/forms/field-renderer.tsx
@@ -251,34 +251,36 @@ export function FormFieldRenderer({
     return null;
   }
 
+  // Grid styling - use inline styles to avoid Tailwind dynamic class issues
+  const gridSpan = field.grid?.span || 1;
+  const gridStyle: React.CSSProperties = { gridColumn: `span ${gridSpan}` };
+
   // Custom component renderer
   if (isCustomField(field) && customComponents[field.component]) {
     const CustomComponent = customComponents[field.component];
     return (
-      <Controller
-        name={field.name}
-        control={control}
-        defaultValue={field.defaultValue}
-        render={({ field: formField, fieldState: { error } }) => (
-          <CustomComponent
-            {...formField}
-            {...field.componentProps}
-            field={field}
-            disabled={formDisabled || fieldState.disabled}
-            required={fieldState.required}
-            error={error?.message}
-          />
-        )}
-      />
+      <div style={gridStyle}>
+        <Controller
+          name={field.name}
+          control={control}
+          defaultValue={field.defaultValue}
+          render={({ field: formField, fieldState: { error } }) => (
+            <CustomComponent
+              {...formField}
+              {...field.componentProps}
+              field={field}
+              disabled={formDisabled || fieldState.disabled}
+              required={fieldState.required}
+              error={error?.message}
+            />
+          )}
+        />
+      </div>
     );
   }
 
-  // Grid styling
-  const gridSpan = field.grid?.span || 1;
-  const gridClass = `col-span-${gridSpan}`;
-
   return (
-    <div className={gridClass}>
+    <div style={gridStyle}>
       <Controller
         name={field.name}
         control={control}

--- a/packages/apollo-wind/src/components/forms/metadata-form.tsx
+++ b/packages/apollo-wind/src/components/forms/metadata-form.tsx
@@ -341,9 +341,10 @@ function FormSection({ section, context, customComponents, disabled }: FormSecti
 
   const fieldsGrid = (
     <div
-      className={`grid gap-${gap}`}
+      className="grid"
       style={{
         gridTemplateColumns: `repeat(${gridColumns}, minmax(0, 1fr))`,
+        gap: `${gap * 0.25}rem`,
       }}
     >
       {section.fields.map((field) => (


### PR DESCRIPTION
## Summary
  - Fix grid.span property not being honored on MetadataForm fields
  - Fix custom field components not respecting grid layout configuration
  - Replace dynamic Tailwind classes with inline styles to ensure cross-environment compatibility

##  Problem
  The grid: { span: N } property on MetadataForm fields was not affecting the layout due to two issues:

  1. Dynamic Tailwind classes not generated: The code used template literals like `col-span-${gridSpan}` and `gap-${gap}`, which Tailwind's static content scanner cannot detect at build time, resulting in missing CSS rules.
  2. Custom components missing grid wrapper: Custom field components (type: 'custom') returned the <Controller> directly without a wrapper div, so the grid span was never applied to them.

##  Solution
  - Use inline CSS styles (gridColumn: 'span N', gap) instead of dynamic Tailwind classes
  - Wrap custom field components in a grid-styled div, consistent with standard field types

##  This approach:
  - Works out of the box without requiring consumer configuration
  - Supports non-Tailwind consuming applications
  - Is consistent with how gridTemplateColumns was already being handled via inline styles

##  Test plan
  - Verify fields with grid: { span: 2 } span full width in a 2-column layout
  - Verify custom field components respect grid.span configuration
  - Verify layout.gap is applied correctly to form sections
  - Unit tests updated and passing (179/179)