### PR TITLE
fix(apollo-react): hideHandles on execution time [MST-6071]

### DIFF
--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.tsx
@@ -144,8 +144,11 @@ const StageNodeComponent = (props: StageNodeProps) => {
   const hasConnections = connectedHandleIds.size > 0;
 
   const shouldShowHandles = useMemo(() => {
+    if(status) {
+      return false;
+    }
     return selected || isHovered || isConnecting || hasConnections;
-  }, [hasConnections, isConnecting, selected, isHovered]);
+  }, [hasConnections, isConnecting, selected, isHovered, status]);
 
   const handleMouseEnter = useCallback(() => setIsHovered(true), []);
   const handleMouseLeave = useCallback(() => setIsHovered(false), []);


### PR DESCRIPTION
 hideHandles on execution time

before 
<img width="1273" height="812" alt="image (1) (1)" src="https://github.com/user-attachments/assets/2d4b2aea-6f54-402d-b4c9-c4518729cd1b" />

after

https://github.com/user-attachments/assets/0e70af75-bd87-4cc9-a863-441723c1c4a0

