### PR TITLE
chore(apollo-vertex): close sidebar menus by default

### DIFF
--- a/apps/apollo-vertex/app/layout.tsx
+++ b/apps/apollo-vertex/app/layout.tsx
@@ -83,7 +83,7 @@ export default async function RootLayout({
                 <Analytics />
                 <ThemeWrapper>
                     <Layout
-                        sidebar={{ autoCollapse: false }}
+                        sidebar={{ autoCollapse: false, defaultMenuCollapseLevel: 1 }}
                         navbar={navbar}
                         pageMap={await getPageMap()}
                         docsRepositoryBase="https://github.com/UiPath/apollo-ui/tree/main/apps/apollo-vertex"


### PR DESCRIPTION
Starting with components open is a pain