### PR TITLE
feat(apollo-react): migrated ap-accordion and ApButton accept custom Styles PLT-94897

### DIFF
--- a/apps/react-playground/src/App.tsx
+++ b/apps/react-playground/src/App.tsx
@@ -9,28 +9,32 @@ import { Colors } from "./pages/Colors";
 import { ComponentsHome } from "./pages/ComponentsHome";
 import { CoreHome } from "./pages/CoreHome";
 import { CssVariables } from "./pages/CssVariables";
+import { Fonts } from "./pages/Fonts";
+import { Icons } from "./pages/Icons";
+import { MainHome } from "./pages/MainHome";
+import { MaterialHome } from "./pages/MaterialHome";
+import { Screens } from "./pages/Screens";
+import { Shadows } from "./pages/Shadows";
+import { Spacing } from "./pages/Spacing";
+import { AccordionShowcase } from "./pages/components/AccordionShowcase";
 import { AlertBarShowcase } from "./pages/components/AlertBarShowcase";
 import { ApChatShowcase } from "./pages/components/ApChatShowcase";
 import { BadgeShowcase } from "./pages/components/BadgeShowcase";
 import { ButtonShowcase } from "./pages/components/ButtonShowcase";
 import { ChipShowcase } from "./pages/components/ChipShowcase";
+import { CircularProgressShowcase } from "./pages/components/CircularProgressShowcase";
+import { IconButtonShowcase } from "./pages/components/IconButtonShowcase";
+import { IconShowcase } from "./pages/components/IconShowcase";
 import { LinkShowcase } from "./pages/components/LinkShowcase";
+import { MenuShowcase } from "./pages/components/MenuShowcase";
+import { ProgressSpinnerShowcase } from "./pages/components/ProgressSpinnerShowcase";
 import { SkeletonShowcase } from "./pages/components/SkeletonShowcase";
 import { TextAreaShowcase } from "./pages/components/TextAreaShowcase";
 import { TextFieldShowcase } from "./pages/components/TextFieldShowcase";
 import { ToolCallShowcase } from "./pages/components/ToolCallShowcase";
+import { TooltipShowcase } from "./pages/components/TooltipShowcase";
 import { TreeViewShowcase } from "./pages/components/TreeViewShowcase";
 import { TypographyShowcase } from "./pages/components/TypographyShowcase";
-import { CircularProgressShowcase } from "./pages/components/CircularProgressShowcase";
-import { IconShowcase } from "./pages/components/IconShowcase";
-import { IconButtonShowcase } from "./pages/components/IconButtonShowcase";
-import { MenuShowcase } from "./pages/components/MenuShowcase";
-import { ProgressSpinnerShowcase } from "./pages/components/ProgressSpinnerShowcase";
-import { TooltipShowcase } from "./pages/components/TooltipShowcase";
-import { Fonts } from "./pages/Fonts";
-import { Icons } from "./pages/Icons";
-import { MainHome } from "./pages/MainHome";
-import { MaterialHome } from "./pages/MaterialHome";
 import { MaterialAlert } from "./pages/material/MaterialAlert";
 import { MaterialAutocomplete } from "./pages/material/MaterialAutocomplete";
 import { MaterialButtonBase } from "./pages/material/MaterialButtonBase";
@@ -58,9 +62,6 @@ import { MaterialTabs } from "./pages/material/MaterialTabs";
 import { MaterialTextField } from "./pages/material/MaterialTextField";
 import { MaterialTooltip } from "./pages/material/MaterialTooltip";
 import { MaterialTypography } from "./pages/material/MaterialTypography";
-import { Screens } from "./pages/Screens";
-import { Shadows } from "./pages/Shadows";
-import { Spacing } from "./pages/Spacing";
 
 function App() {
 	return (
@@ -140,6 +141,10 @@ function App() {
 								element={<MaterialTypography />}
 							/>
 							<Route path="/components" element={<ComponentsHome />} />
+							<Route
+								path="/components/accordion"
+								element={<AccordionShowcase />}
+							/>
 							<Route
 								path="/components/alert-bar"
 								element={<AlertBarShowcase />}

--- a/apps/react-playground/src/components/Breadcrumb.tsx
+++ b/apps/react-playground/src/components/Breadcrumb.tsx
@@ -56,6 +56,7 @@ export function Breadcrumb() {
 		tooltip: "Tooltip",
 		typography: "Typography",
 		// Apollo component routes
+		accordion: "Accordion",
 		"alert-bar": "Alert Bar",
 		badge: "Badge",
 		button: "Button",

--- a/apps/react-playground/src/components/Sidebar.tsx
+++ b/apps/react-playground/src/components/Sidebar.tsx
@@ -47,6 +47,7 @@ export function Sidebar() {
 			path: "/components",
 			icon: "🧩",
 			children: [
+				{ label: "Accordion", path: "/components/accordion" },
 				{ label: "Alert Bar", path: "/components/alert-bar" },
 				{ label: "Badge", path: "/components/badge" },
 				{ label: "Button", path: "/components/button" },

--- a/apps/react-playground/src/pages/ComponentsHome.tsx
+++ b/apps/react-playground/src/pages/ComponentsHome.tsx
@@ -15,6 +15,7 @@ import {
 
 export function ComponentsHome() {
 	const components = [
+		{ label: "Accordion", path: "/components/accordion", icon: "📂" },
 		{ label: "Alert Bar", path: "/components/alert-bar", icon: "⚠️" },
 		{ label: "Badge", path: "/components/badge", icon: "🏷️" },
 		{ label: "Button", path: "/components/button", icon: "🔘" },

--- a/apps/react-playground/src/pages/components/AccordionShowcase.tsx
+++ b/apps/react-playground/src/pages/components/AccordionShowcase.tsx
@@ -1,0 +1,216 @@
+import { ApAccordion } from "@uipath/apollo-react/material/components";
+import styled from "styled-components";
+import { Search } from "@uipath/apollo-react/icons";
+
+import {
+	PageContainer,
+	PageDescription,
+	PageTitle,
+} from "../../components/SharedStyles";
+
+const ShowcaseSection = styled.div`
+	margin-top: 48px;
+	display: flex;
+	flex-direction: column;
+	gap: 24px;
+`;
+
+const SectionTitle = styled.h3`
+	font-size: 20px;
+	color: var(--color-primary);
+	margin-bottom: 16px;
+	border-bottom: 2px solid var(--color-border);
+	padding-bottom: 8px;
+`;
+
+const ComponentRow = styled.div`
+	display: flex;
+	flex-direction: column;
+	padding: 24px;
+	background: var(--color-background);
+	border-radius: 12px;
+	border: 2px solid var(--color-border);
+`;
+
+const Label = styled.div`
+	font-size: 14px;
+	color: var(--color-foreground-de-emp);
+	font-weight: 600;
+	margin-bottom: 8px;
+`;
+
+const AccordionContent = styled.div`
+	font-size: 14px;
+	color: var(--color-foreground-de-emp);
+	padding: 10px 40px 10px 40px;
+	box-sizing: border-box;
+`;
+
+export function AccordionShowcase() {
+	return (
+		<PageContainer>
+			<PageTitle>Accordion</PageTitle>
+			<PageDescription>
+				Accordions allow users to expand and collapse sections of content,
+				helping to manage large amounts of information in a compact space.
+			</PageDescription>
+
+			<ShowcaseSection>
+				<SectionTitle>Default</SectionTitle>
+				<ComponentRow>
+					<div style={{ width: "284px" }}>
+						<ApAccordion label="Accordion Title">
+							<AccordionContent tabIndex={0}>Child</AccordionContent>
+							<AccordionContent tabIndex={0}>Child</AccordionContent>
+							<AccordionContent tabIndex={0}>Child</AccordionContent>
+							<AccordionContent tabIndex={0}>Child</AccordionContent>
+						</ApAccordion>
+						<ApAccordion label="Accordion Title" defaultExpanded>
+							<AccordionContent tabIndex={0}>Child</AccordionContent>
+							<AccordionContent tabIndex={0}>Child</AccordionContent>
+							<AccordionContent tabIndex={0}>Child</AccordionContent>
+						</ApAccordion>
+						<ApAccordion label="Accordion Title">
+							<AccordionContent tabIndex={0}>Child</AccordionContent>
+							<AccordionContent tabIndex={0}>Child</AccordionContent>
+							<AccordionContent tabIndex={0}>Child</AccordionContent>
+						</ApAccordion>
+						<ApAccordion label="Accordion Title">
+							<AccordionContent tabIndex={0}>Child</AccordionContent>
+							<AccordionContent tabIndex={0}>Child</AccordionContent>
+							<AccordionContent tabIndex={0}>Child</AccordionContent>
+						</ApAccordion>
+						<ApAccordion label="Accordion Title">
+							<AccordionContent tabIndex={0}>Child</AccordionContent>
+							<AccordionContent tabIndex={0}>Child</AccordionContent>
+							<AccordionContent tabIndex={0}>Child</AccordionContent>
+						</ApAccordion>
+					</div>
+				</ComponentRow>
+
+				<ComponentRow>
+					<div style={{ width: "284px" }}>
+						<ApAccordion label="Accordion Title">
+							<AccordionContent tabIndex={0}>Test</AccordionContent>
+							<AccordionContent tabIndex={0}>Child</AccordionContent>
+							<AccordionContent tabIndex={0}>Child</AccordionContent>
+							<AccordionContent tabIndex={0}>Child</AccordionContent>
+						</ApAccordion>
+					</div>
+				</ComponentRow>
+			</ShowcaseSection>
+
+			<ShowcaseSection>
+				<SectionTitle>Icon Customization</SectionTitle>
+				<ComponentRow>
+					<Label> Custom Start Icon</Label>
+					<ApAccordion
+						label="Accordion Title"
+						startIcon={<Search size="20px" />}
+						disableDivider
+					>
+						<AccordionContent tabIndex={0}>
+							This is the content inside the accordion. It can include text,
+							images, or any other elements.
+						</AccordionContent>
+					</ApAccordion>
+					<ApAccordion
+						label="Accordion Title"
+						startIcon={<Search size="20px" />}
+					>
+						<AccordionContent tabIndex={0}>
+							This is the content inside the accordion. It can include text,
+							images, or any other elements.
+						</AccordionContent>
+					</ApAccordion>
+				</ComponentRow>
+				<ComponentRow>
+					<Label> Expand Icon Position: Start</Label>
+					<ApAccordion
+						label="Accordion Title"
+						startIcon={<Search size="20px" />}
+						expandIconPosition="start"
+						disableDivider
+					>
+						<AccordionContent tabIndex={0}>
+							This is the content inside the accordion. It can include text,
+							images, or any other elements.
+						</AccordionContent>
+					</ApAccordion>
+					<ApAccordion label="Accordion Title" expandIconPosition="start">
+						<AccordionContent tabIndex={0}>
+							This is the content inside the accordion. It can include text,
+							images, or any other elements.
+						</AccordionContent>
+					</ApAccordion>
+				</ComponentRow>
+			</ShowcaseSection>
+
+			<ShowcaseSection>
+				<SectionTitle>Customization</SectionTitle>
+				<ComponentRow>
+					<Label>Custom Font Size</Label>
+					<ApAccordion
+						label="Accordion Title"
+						labelFontSize="20px"
+						disableDivider
+					>
+						<AccordionContent tabIndex={0}>
+							This is the content inside the accordion. It can include text,
+							images, or any other elements.
+						</AccordionContent>
+					</ApAccordion>
+					<ApAccordion label="Accordion Title" labelFontSize="20px">
+						<AccordionContent tabIndex={0}>
+							This is the content inside the accordion. It can include text,
+							images, or any other elements.
+						</AccordionContent>
+					</ApAccordion>
+				</ComponentRow>
+
+				<ComponentRow>
+					<Label>Custom Font Weight</Label>
+					<ApAccordion
+						label="Accordion Title"
+						labelFontWeight="700"
+						disableDivider
+					>
+						<AccordionContent tabIndex={0}>
+							This is the content inside the accordion. It can include text,
+							images, or any other elements.
+						</AccordionContent>
+					</ApAccordion>
+					<ApAccordion label="Accordion Title" labelFontWeight="700">
+						<AccordionContent tabIndex={0}>
+							This is the content inside the accordion. It can include text,
+							images, or any other elements.
+						</AccordionContent>
+					</ApAccordion>
+				</ComponentRow>
+
+				<ComponentRow>
+					<Label>Custom Label Color</Label>
+					<ApAccordion
+						label="Accordion Title"
+						labelColor="var(--color-primary)"
+						disableDivider
+					>
+						<AccordionContent tabIndex={0}>
+							This is the content inside the accordion. It can include text,
+							images, or any other elements.
+						</AccordionContent>
+					</ApAccordion>
+					<ApAccordion
+						label="Accordion Title"
+						labelColor="var(--color-primary)"
+					>
+						<AccordionContent tabIndex={0}>
+							This is the content inside the accordion. It can include text,
+							images, or any other elements.
+						</AccordionContent>
+					</ApAccordion>
+				</ComponentRow>
+			</ShowcaseSection>
+		</PageContainer>
+	);
+}

--- a/packages/apollo-react/src/material/components/ap-accordion/ApAccordion.test.tsx
+++ b/packages/apollo-react/src/material/components/ap-accordion/ApAccordion.test.tsx
@@ -1,0 +1,245 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { ApAccordion } from './ApAccordion';
+import userEvent from '@testing-library/user-event';
+
+describe('ApAccordion', () => {
+  describe('Basic Rendering', () => {
+    it('should render the accordion with label', () => {
+      render(
+        <ApAccordion label="Test Accordion">
+          <div>Accordion Content</div>
+        </ApAccordion>
+      );
+      expect(screen.getByText('Test Accordion')).toBeInTheDocument();
+    });
+
+    it('should render the accordion expanded by default when defaultExpanded is true', () => {
+      render(
+        <ApAccordion label="Test Accordion" defaultExpanded>
+          <div>Accordion Content</div>
+        </ApAccordion>
+      );
+      expect(screen.getByText('Accordion Content')).toBeVisible();
+    });
+
+    it('should render the accordion collapsed by default when defaultExpanded is false', () => {
+      render(
+        <ApAccordion label="Test Accordion">
+          <div>Accordion Content</div>
+        </ApAccordion>
+      );
+      expect(screen.queryByText('Accordion Content')).not.toBeVisible();
+    });
+
+    it('should render the start icon when provided', () => {
+      const StartIcon = () => <span data-testid="start-icon">S</span>;
+      render(
+        <ApAccordion label="Test Accordion" startIcon={<StartIcon />}>
+          <div>Accordion Content</div>
+        </ApAccordion>
+      );
+      expect(screen.getByTestId('start-icon')).toBeInTheDocument();
+    });
+  });
+
+  describe('User Interaction', () => {
+    it('should expand the accordion when clicked', () => {
+      render(
+        <ApAccordion label="Test Accordion">
+          <div>Accordion Content</div>
+        </ApAccordion>
+      );
+      const summary = screen.getByText('Test Accordion');
+      fireEvent.click(summary);
+      expect(screen.getByText('Accordion Content')).toBeVisible();
+    });
+
+    it('should collapse the accordion when clicked again', async () => {
+      render(
+        <ApAccordion label="Test Accordion">
+          <div>Accordion Content</div>
+        </ApAccordion>
+      );
+      const summary = screen.getByText('Test Accordion');
+      expect(screen.queryByText('Accordion Content')).not.toBeVisible();
+      fireEvent.click(summary);
+      expect(screen.getByText('Accordion Content')).toBeVisible();
+      fireEvent.click(summary);
+      await waitFor(() => {
+        expect(screen.queryByText('Accordion Content')).not.toBeVisible();
+      });
+    });
+  });
+
+  describe('Props Functionality', () => {
+    it('should set the label color when labelColor is provided', () => {
+      const { container } = render(
+        <ApAccordion label="Test Accordion" labelColor="red">
+          <div>Accordion Content</div>
+        </ApAccordion>
+      );
+      const summary = container.querySelector('.MuiTypography-root') as HTMLElement;
+      expect(summary).toHaveStyle('color: red');
+    });
+
+    it('should set the label font size when labelFontSize is provided', () => {
+      const { container } = render(
+        <ApAccordion label="Test Accordion" labelFontSize="20px">
+          <div>Accordion Content</div>
+        </ApAccordion>
+      );
+      const summary = container.querySelector('.MuiTypography-root') as HTMLElement;
+      expect(summary).toHaveStyle('font-size: 20px');
+    });
+
+    it('should set the label font weight when labelFontWeight is provided', () => {
+      const { container } = render(
+        <ApAccordion label="Test Accordion" labelFontWeight="700">
+          <div>Accordion Content</div>
+        </ApAccordion>
+      );
+      const summary = container.querySelector('.MuiTypography-root') as HTMLElement;
+      expect(summary).toHaveStyle('font-weight: 700');
+    });
+
+    it('should disable the divider when disableDivider is true', () => {
+      const { container } = render(
+        <ApAccordion label="Test Accordion" disableDivider>
+          <div>Accordion Content</div>
+        </ApAccordion>
+      );
+      const divider = container.querySelector('.MuiAccordionSummary-root::before') as HTMLElement;
+      expect(divider).not.toBeInTheDocument();
+    });
+
+    it('should apply custom sx to summary when summarySx is provided', () => {
+      const { container } = render(
+        <ApAccordion label="Test Accordion" summarySx={{ backgroundColor: 'lightgray' }}>
+          <div>Accordion Content</div>
+        </ApAccordion>
+      );
+      const summary = container.querySelector('.MuiAccordionSummary-root') as HTMLElement;
+      expect(summary).toHaveStyle('background-color: lightgray');
+    });
+
+    it('should apply custom sx to details when detailsSx is provided', () => {
+      const { container } = render(
+        <ApAccordion label="Test Accordion" detailsSx={{ backgroundColor: 'lightblue' }}>
+          <div>Accordion Content</div>
+        </ApAccordion>
+      );
+      const details = container.querySelector('.MuiAccordionDetails-root') as HTMLElement;
+      expect(details).toHaveStyle('background-color: lightblue');
+    });
+
+    it('should position the expand icon correctly based on expandIconPosition prop', () => {
+      const { container: containerStart } = render(
+        <ApAccordion label="Test Accordion" expandIconPosition="start">
+          <div>Accordion Content</div>
+        </ApAccordion>
+      );
+      const summaryStart = containerStart.querySelector('.MuiAccordionSummary-root') as HTMLElement;
+      expect(summaryStart).toHaveStyle('flex-direction: row-reverse');
+    });
+
+    it('should position the expand icon correctly when expandIconPosition is end', () => {
+      const { container: containerEnd } = render(
+        <ApAccordion label="Test Accordion" expandIconPosition="end">
+          <div>Accordion Content</div>
+        </ApAccordion>
+      );
+      const summaryEnd = containerEnd.querySelector('.MuiAccordionSummary-root') as HTMLElement;
+      expect(summaryEnd).toHaveStyle('flex-direction: row');
+    });
+  });
+
+  describe('Accessibility', () => {
+    it('should have appropriate ARIA attributes', () => {
+      render(
+        <ApAccordion label="Test Accordion">
+          <div>Accordion Content</div>
+        </ApAccordion>
+      );
+      const summaryButton = screen.getByRole('button');
+
+      expect(summaryButton).toHaveAttribute('aria-expanded');
+      expect(summaryButton).toHaveAttribute('aria-expanded', 'false');
+      fireEvent.click(summaryButton);
+      expect(summaryButton).toHaveAttribute('aria-expanded', 'true');
+    });
+
+    it('should be operable via keyboard - Enter', async () => {
+      render(
+        <ApAccordion label="Test Accordion">
+          <div>Accordion Content</div>
+        </ApAccordion>
+      );
+      const summary = screen.getByRole('button');
+      expect(screen.getByText('Accordion Content')).not.toBeVisible();
+
+      const user = userEvent.setup();
+
+      await user.tab();
+      expect(summary).toHaveFocus();
+
+      await user.keyboard('{Enter}');
+      await waitFor(() => {
+        expect(screen.getByText('Accordion Content')).toBeVisible();
+      });
+
+      await user.keyboard('{Enter}');
+      await waitFor(() => {
+        expect(screen.getByText('Accordion Content')).not.toBeVisible();
+      });
+    });
+
+    it('should be operable via keyboard - Space', async () => {
+      render(
+        <ApAccordion label="Test Accordion">
+          <div>Accordion Content</div>
+        </ApAccordion>
+      );
+      const summary = screen.getByRole('button');
+      expect(screen.getByText('Accordion Content')).not.toBeVisible();
+
+      const user = userEvent.setup();
+
+      await user.tab();
+      expect(summary).toHaveFocus();
+
+      fireEvent.keyDown(summary, { key: ' ', code: 'Space' });
+      fireEvent.keyUp(summary, { key: ' ', code: 'Space' });
+
+      await waitFor(() => {
+        expect(screen.getByText('Accordion Content')).toBeVisible();
+      });
+
+      fireEvent.keyDown(summary, { key: ' ', code: 'Space' });
+      fireEvent.keyUp(summary, { key: ' ', code: 'Space' });
+      await waitFor(() => {
+        expect(screen.getByText('Accordion Content')).not.toBeVisible();
+      });
+    });
+
+    it('should have focus visible when focused', async () => {
+      render(
+        <ApAccordion label="Test Accordion">
+          <div>Accordion Content</div>
+        </ApAccordion>
+      );
+      const summary = screen.getByRole('button');
+      expect(screen.getByText('Accordion Content')).not.toBeVisible();
+
+      const user = userEvent.setup();
+
+      await user.tab();
+      expect(summary).toHaveFocus();
+      expect(summary.classList.contains('Mui-focusVisible')).toBe(true);
+
+      await user.click(document.body);
+      expect(summary.classList.contains('Mui-focusVisible')).toBe(false);
+      expect(summary).not.toHaveFocus();
+    });
+  });
+});

--- a/packages/apollo-react/src/material/components/ap-accordion/ApAccordion.tsx
+++ b/packages/apollo-react/src/material/components/ap-accordion/ApAccordion.tsx
@@ -1,0 +1,149 @@
+import Accordion from '@mui/material/Accordion';
+import AccordionDetails from '@mui/material/AccordionDetails';
+import AccordionSummary from '@mui/material/AccordionSummary';
+import { styled } from '@mui/material/styles';
+import { FontVariantToken, PadL } from '@uipath/apollo-core';
+import token from '@uipath/apollo-core';
+import { ChevronDown } from '@uipath/apollo-react/icons';
+import { ApTypography } from '../ap-typography';
+import { ApAccordionProps } from './ApAccordion.types';
+
+interface StyledAccordionSummaryProps {
+  disableDivider?: boolean;
+  dividerLeftPosition?: string;
+  dividerRightPosition?: string;
+  expandIconPosition?: 'start' | 'end';
+}
+
+const StyledAccordion = styled(Accordion, {
+  shouldForwardProp: (prop) => prop !== 'accordionPadding',
+})(() => ({
+  '&.MuiPaper-root': { boxShadow: 'unset' },
+  position: 'relative',
+
+  // remove expanded margin
+  '&.Mui-expanded': {
+    margin: 0,
+  },
+
+  // Hide default divider
+  '&::before': {
+    display: 'none',
+  },
+
+  // remove top divider for first accordion
+  '&:first-of-type .MuiAccordionSummary-root::before': {
+    display: 'none',
+  },
+}));
+
+const StyledAccordionSummary = styled(AccordionSummary, {
+  shouldForwardProp: (prop) =>
+    prop !== 'disableDivider' &&
+    prop !== 'accordionPadding' &&
+    prop !== 'dividerLeftPosition' &&
+    prop !== 'dividerRightPosition' &&
+    prop !== 'expandIconPosition',
+})<StyledAccordionSummaryProps>(
+  ({ disableDivider, dividerLeftPosition, dividerRightPosition, expandIconPosition }) => ({
+    // root styles
+    '&:hover, &:focus': {
+      backgroundColor: 'transparent',
+    },
+
+    // Stop focus outline from cutting off
+    '&:focus-visible': {
+      zIndex: 1,
+    },
+
+    flexDirection: expandIconPosition !== 'end' ? 'row-reverse' : 'row',
+
+    padding: `${token.Padding.PadXl} ${token.Padding.PadXxxl}`,
+    minHeight: token.Spacing.SpacingXxl,
+
+    position: 'relative',
+    // Divider
+    '&::before': {
+      content: '""',
+      position: 'absolute',
+      top: 0,
+      left: dividerLeftPosition || token.Padding.PadXxxl,
+      right: dividerRightPosition || token.Padding.PadXxxl,
+      height: 1,
+      backgroundColor: 'var(--color-border-de-emp)',
+      display: disableDivider ? 'none' : 'block',
+      pointerEvents: 'none',
+    },
+
+    '&.Mui-expanded': {
+      minHeight: token.Spacing.SpacingXxl,
+    },
+
+    // content slot
+    '& .MuiAccordionSummary-content': {
+      margin: '0px',
+
+      '&.Mui-expanded': {
+        margin: '0px',
+      },
+    },
+  })
+);
+
+//NOTE: expanded state the top element has margin
+export function ApAccordion(props: Readonly<ApAccordionProps>) {
+  const {
+    startIcon,
+    label,
+    defaultExpanded,
+    children,
+    expandIconPosition = 'end',
+    labelFontSize,
+    labelFontWeight,
+    labelColor,
+    disableDivider,
+    summarySx,
+    summaryProps,
+    dividerLeftPosition,
+    dividerRightPosition,
+    detailsSx,
+    detailsProps,
+
+    ...accordionProps
+  } = props;
+
+  return (
+    <StyledAccordion defaultExpanded={defaultExpanded} {...accordionProps}>
+      <StyledAccordionSummary
+        sx={summarySx}
+        dividerLeftPosition={dividerLeftPosition}
+        dividerRightPosition={dividerRightPosition}
+        expandIcon={<ChevronDown size="20px" style={{ marginTop: '-2px' }} aria-hidden="true" />}
+        expandIconPosition={expandIconPosition}
+        disableDivider={disableDivider}
+        {...summaryProps}
+      >
+        <ApTypography
+          variant={FontVariantToken.fontSizeM}
+          color={labelColor || 'var(--color-foreground-de-emp)'}
+          style={{
+            ...(labelFontSize && { fontSize: labelFontSize }),
+            ...(labelFontWeight && { fontWeight: labelFontWeight }),
+            display: 'flex',
+            alignItems: 'center',
+          }}
+        >
+          {startIcon ? (
+            <span style={{ display: 'flex', marginRight: PadL }}>{startIcon}</span>
+          ) : null}
+          {label}
+        </ApTypography>
+      </StyledAccordionSummary>
+      <AccordionDetails sx={{ padding: 'unset', ...detailsSx }} {...detailsProps}>
+        {children}
+      </AccordionDetails>
+    </StyledAccordion>
+  );
+}
+
+ApAccordion.displayName = 'ApAccordion';

--- a/packages/apollo-react/src/material/components/ap-accordion/ApAccordion.types.ts
+++ b/packages/apollo-react/src/material/components/ap-accordion/ApAccordion.types.ts
@@ -1,0 +1,36 @@
+import React from 'react';
+import { AccordionProps } from '@mui/material/Accordion';
+import { SxProps, Theme } from '@mui/material/styles';
+import { AccordionSummaryProps } from '@mui/material/AccordionSummary';
+import { AccordionDetailsProps } from '@mui/material/AccordionDetails';
+
+export interface ApAccordionProps extends AccordionProps {
+  /** Sets the start icon of the accordion */
+  startIcon?: React.ReactNode;
+  /** Sets the label of the accordion */
+  label: string;
+  /** Sets the default expanded state of the accordion */
+  defaultExpanded?: boolean;
+  /** Sets the font size of the label */
+  labelFontSize?: string;
+  /** Sets the font weight of the label */
+  labelFontWeight?: string | number;
+  /** Sets the color of the label */
+  labelColor?: string;
+  /** Sets the sx props for the summary */
+  summarySx?: SxProps<Theme>;
+  /** Sets the props for the summary */
+  summaryProps?: Partial<AccordionSummaryProps>;
+  /** Sets the sx props for the details */
+  detailsSx?: SxProps<Theme>;
+  /** Sets the props for the details */
+  detailsProps?: Partial<AccordionDetailsProps>;
+  /** Sets the position of the expand icon (start or end) */
+  expandIconPosition?: 'start' | 'end';
+  /** If `true`, disables the divider line above the accordion */
+  disableDivider?: boolean;
+  /** Sets the left position of the divider area */
+  dividerLeftPosition?: string;
+  /** Sets the right position of the divider area */
+  dividerRightPosition?: string;
+}

--- a/packages/apollo-react/src/material/components/ap-accordion/index.ts
+++ b/packages/apollo-react/src/material/components/ap-accordion/index.ts
@@ -1,0 +1,2 @@
+export { ApAccordion } from './ApAccordion';
+export type { ApAccordionProps } from './ApAccordion.types';

--- a/packages/apollo-react/src/material/components/ap-button/ApButton.tsx
+++ b/packages/apollo-react/src/material/components/ap-button/ApButton.tsx
@@ -2,6 +2,7 @@ import { CircularProgress } from '@mui/material';
 import Button, { type ButtonProps } from '@mui/material/Button';
 import { styled } from '@mui/material/styles';
 import React from 'react';
+import token from '@uipath/apollo-core';
 
 import type { ApButtonProps, ButtonVariants } from './ApButton.types';
 
@@ -76,6 +77,7 @@ export const ApButton = React.forwardRef<HTMLButtonElement, ApButtonProps>((prop
     onFocus,
     onBlur,
     onKeyDown,
+    ...rest
   } = props;
 
   const hasStartIcon = !!startIcon;
@@ -115,6 +117,7 @@ export const ApButton = React.forwardRef<HTMLButtonElement, ApButtonProps>((prop
         href={href}
         customSize={size}
         customWidth={widthMode}
+        {...rest}
       >
         <span
           style={{
@@ -141,9 +144,9 @@ const StyledButton = styled(Button, {
     customWidth: string;
   }
 >(({ customSize, customWidth }) => ({
-  '--border-radius': `3px`,
+  '--border-radius': token.Border.BorderRadiusM,
   '--focus-border-offset': `1px`,
-  '--focus-border-width': `2px`,
+  '--focus-border-width': token.Border.BorderThickM,
   // Automatically calculate the outer focus border radius and position
   '--focus-border-radius': `calc( var(--border-radius) + var(--focus-border-offset) + var(--focus-border-width) )`,
   '--focus-border-inset': `calc( -1 * (var(--focus-border-offset) + var(--focus-border-width) + 1px))`,
@@ -151,7 +154,7 @@ const StyledButton = styled(Button, {
   position: 'relative',
   borderRadius: 'var(--border-radius)',
   minWidth: customWidth === 'fit-content' ? undefined : '120px',
-  height: customSize === 'tall' ? '40px' : '32px',
+  height: customSize === 'tall' ? token.Spacing.SpacingXxl : token.Spacing.SpacingXl,
 
   '&.loading': { pointerEvents: 'none' },
 

--- a/packages/apollo-react/src/material/components/index.ts
+++ b/packages/apollo-react/src/material/components/index.ts
@@ -1,3 +1,4 @@
+export * from './ap-accordion';
 export * from './ap-alert-bar';
 export * from './ap-badge';
 export * from './ap-button';


### PR DESCRIPTION
https://github.com/user-attachments/assets/08d12ae6-94fa-4bfc-94e5-76345bb1e854


- Migrated ap-accordion from apollo-design-system
- Removed some of the props used to provide custom stylings as consumers can style them now a restriction from web components. 

- Kept Label props for Font Weight and Color - for easier stylings as they are hard to reach with style and sx props 
- Added props to position the left and right endings of the divider as sx Props passed to summary would not work
- Added disableDivider prop to disable divider 
    - Mui also has the problem where if its previous sibiling is a `div` and the Accordion is the first accordion it doesn't register it as a first and shows the divider.  
 - removed `expanded` prop as it had the same purpose as `defaultExpanded` and its purpose was more `defaultExpanded` prop instead


- ApButton switch to use tokens and also accept custom styles