### PR TITLE
fix(apollo-vertex): sync Nextra navbar/footer background with theme

### DIFF
--- a/apps/apollo-vertex/app/globals.css
+++ b/apps/apollo-vertex/app/globals.css
@@ -150,6 +150,9 @@
   --ease-in-out-quint: cubic-bezier(0.86, 0, 0.07, 1);
   --ease-in-out-expo: cubic-bezier(1, 0, 0, 1);
   --ease-in-out-circ: cubic-bezier(0.785, 0.135, 0.15, 0.86);
+
+  /* Override Nextra's background to match our theme */
+  --x-color-nextra-bg: var(--background);
 }
 
 .dark {
@@ -205,6 +208,9 @@
   --shadow-2xl: 0 0px 12px 0px hsl(0 0% 0% / 0.25);
   --tracking-normal: 0em;
   --spacing: 0.25rem;
+
+  /* Override Nextra's background to match our theme */
+  --x-color-nextra-bg: var(--background);
 }
 
 @layer base {

--- a/apps/apollo-vertex/next-env.d.ts
+++ b/apps/apollo-vertex/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
## Summary
Fixed dark mode styling inconsistency where the navbar, footer, and sidebar footer had a black background while the main content area used a custom blue-ish background. 

## Changes
Override Nextra's `--x-color-nextra-bg` CSS variable in both light and dark themes to use the custom `--background` variable instead of hardcoded black.

## Test plan
- Run `pnpm dev` in `apps/apollo-vertex`
- Switch to dark mode
- Verify navbar, footer, and sidebar footer now have the same blue-ish background as the main content area

🤖 Generated with [Claude Code](https://claude.com/claude-code)