### PR TITLE
feat(apollo-react): add isreadOnly attribute in stage node props [MST-6193]

### DIFF
--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.stories.tsx
@@ -290,6 +290,7 @@ export const ExecutionStatus: Story = {
             escalation: '1h',
             escalationsTriggered: false,
             label: 'Application',
+            isReadOnly: true,
             tasks: [
               [{ id: '1', label: 'KYC and AML Checks', icon: <VerificationIcon /> }],
               [
@@ -325,6 +326,7 @@ export const ExecutionStatus: Story = {
             escalation: '1h',
             escalationsTriggered: true,
             label: 'Processing',
+            isReadOnly: true,
             tasks: [
               [{ id: '1', label: 'Liability Check', icon: <VerificationIcon /> }],
               [{ id: '2', label: 'Credit Review', icon: <DocumentIcon /> }],
@@ -381,6 +383,7 @@ export const ExecutionStatus: Story = {
         data: {
           stageDetails: {
             label: 'Underwriting',
+            isReadOnly: true,
             tasks: [
               [{ id: '1', label: 'Report Ordering', icon: <DocumentIcon /> }],
               [{ id: '2', label: 'Underwriting Verification', icon: <VerificationIcon /> }],
@@ -408,6 +411,7 @@ export const ExecutionStatus: Story = {
         data: {
           stageDetails: {
             label: 'Closing',
+            isReadOnly: true,
             tasks: [
               [{ id: '1', label: 'Loan Packet Creation', icon: <DocumentIcon /> }],
               [{ id: '2', label: 'Customer Signing', icon: <DocumentIcon /> }],
@@ -432,6 +436,7 @@ export const ExecutionStatus: Story = {
           stageDetails: {
             label: 'Rejected',
             isException: true,
+            isReadOnly: true,
             tasks: [
               [{ id: '1', label: 'Customer Notification', icon: <ProcessIcon /> }],
               [{ id: '2', label: 'Generate Audit Report', icon: <DocumentIcon /> }],
@@ -538,6 +543,7 @@ export const InteractiveTaskManagement: Story = {
         data: {
           stageDetails: {
             label: 'Execution Mode - Read Only',
+            isReadOnly: true,
             tasks: [
               [
                 {

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.tsx
@@ -84,6 +84,7 @@ const StageNodeComponent = (props: StageNodeProps) => {
   const taskIds = useMemo(() => flatTasks.map((task) => task.id), [flatTasks]);
 
   const isException = stageDetails?.isException;
+  const isReadOnly = !!stageDetails?.isReadOnly;
   const icon = stageDetails?.icon;
   const selectedTasks = stageDetails?.selectedTasks;
   const defaultContent = stageDetails?.defaultContent || 'Add first task';
@@ -96,7 +97,7 @@ const StageNodeComponent = (props: StageNodeProps) => {
     [onTaskGroupModification]
   );
 
-  const isStageTitleEditable = !!onStageTitleChange;
+  const isStageTitleEditable = !!onStageTitleChange && !isReadOnly;
 
   const [isHovered, setIsHovered] = useState(false);
   const [label, setLabel] = useState(props.stageDetails.label);
@@ -147,18 +148,15 @@ const StageNodeComponent = (props: StageNodeProps) => {
   const hasConnections = connectedHandleIds.size > 0;
 
   const shouldShowHandles = useMemo(() => {
-    if (status) {
-      return false;
-    }
-    return selected || isHovered || isConnecting || hasConnections;
-  }, [hasConnections, isConnecting, selected, isHovered, status]);
+    return !isReadOnly && (selected || isHovered || isConnecting || hasConnections);
+  }, [hasConnections, isConnecting, selected, isHovered, isReadOnly]);
 
   const handleMouseEnter = useCallback(() => setIsHovered(true), []);
   const handleMouseLeave = useCallback(() => setIsHovered(false), []);
 
   const shouldShowMenu = useMemo(() => {
-    return menuItems && menuItems.length > 0 && (selected || isHovered);
-  }, [menuItems, selected, isHovered]);
+    return menuItems && menuItems.length > 0 && (selected || isHovered) && !isReadOnly;
+  }, [menuItems, selected, isHovered, isReadOnly]);
 
   const handleStageTitleChange = useCallback((e: React.FormEvent<HTMLInputElement>) => {
     setIsStageTitleEditing(true);
@@ -514,7 +512,7 @@ const StageNodeComponent = (props: StageNodeProps) => {
               )}
             </Column>
           </Row>
-          <Row gap={Spacing.SpacingMicro} align={status ? 'start' : 'center'} py={Padding.PadS}>
+          <Row gap={Spacing.SpacingMicro} align={isReadOnly ? 'start' : 'center'} py={Padding.PadS}>
             {status && (
               <ApTooltip content={statusLabel} placement="top">
                 <ApIconButton size="small">
@@ -522,7 +520,7 @@ const StageNodeComponent = (props: StageNodeProps) => {
                 </ApIconButton>
               </ApTooltip>
             )}
-            {(onTaskAdd || onAddTaskFromToolbox) && (
+            {(onTaskAdd || onAddTaskFromToolbox) && !isReadOnly && (
               <ApTooltip content={addTaskLabel} placement="top">
                 <ApIconButton onClick={handleTaskAddClick} size="small">
                   <ApIcon name="add" size="20px" />

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.types.ts
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.types.ts
@@ -35,6 +35,7 @@ export interface StageNodeProps extends NodeProps {
     escalation?: string;
     escalationsTriggered?: boolean;
     isException?: boolean;
+    isReadOnly?: boolean;
     tasks: StageTaskItem[][];
     selectedTasks?: string[];
   };


### PR DESCRIPTION
Prior logic affects the handling of stage handles in a wrong way.
So I created a isReadOnly attribute to hide the handles in a right way.
Also used this variable wherever needed.


https://github.com/user-attachments/assets/9da9c2ea-b2e5-432b-9719-e2ef340d6942

