### PR TITLE
chore(apollo-vertex): update shadcn components to latest

### DIFF
--- a/apps/apollo-vertex/app/globals.css
+++ b/apps/apollo-vertex/app/globals.css
@@ -132,7 +132,7 @@
   --shadow-2xl: 0 0px 12px 0px hsl(220.0009 13.0382% 36.0747% / 0.25);
   --tracking-normal: 0em;
   --spacing: 0.25rem;
-  
+
   /* Custom Easing Functions - ease-out (for entering/exiting elements) */
   --ease-out-quad: cubic-bezier(0.25, 0.46, 0.45, 0.94);
   --ease-out-cubic: cubic-bezier(0.215, 0.61, 0.355, 1);
@@ -140,7 +140,7 @@
   --ease-out-quint: cubic-bezier(0.23, 1, 0.32, 1);
   --ease-out-expo: cubic-bezier(0.19, 1, 0.22, 1);
   --ease-out-circ: cubic-bezier(0.075, 0.82, 0.165, 1);
-  
+
   /* Custom Easing Functions - ease-in-out (for moving within screen) */
   --ease-in-out-quad: cubic-bezier(0.455, 0.03, 0.515, 0.955);
   --ease-in-out-cubic: cubic-bezier(0.645, 0.045, 0.355, 1);

--- a/apps/apollo-vertex/package.json
+++ b/apps/apollo-vertex/package.json
@@ -64,7 +64,7 @@
     "nextra-theme-docs": "^4.6.1",
     "postcss": "^8.5.6",
     "react": "19.2.3",
-    "react-day-picker": "^9.11.2",
+    "react-day-picker": "^9.13.0",
     "react-dom": "19.2.3",
     "react-hook-form": "^7.66.1",
     "react-resizable-panels": "^3.0.6",
@@ -73,7 +73,7 @@
     "tailwind-merge": "^2.6.0",
     "tailwindcss": "^4.1.17",
     "vaul": "^1.1.2",
-    "zod": "^4.1.13"
+    "zod": "^4.2.1"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.3.6",

--- a/apps/apollo-vertex/registry.json
+++ b/apps/apollo-vertex/registry.json
@@ -525,6 +525,15 @@
         "class-variance-authority",
         "lucide-react"
       ],
+      "registryDependencies": [
+        "button",
+        "input",
+        "separator",
+        "sheet",
+        "skeleton",
+        "tooltip",
+        "use-mobile"
+      ],
       "files": [
         {
           "path": "registry/sidebar/sidebar.tsx",

--- a/apps/apollo-vertex/registry/accordion/accordion.tsx
+++ b/apps/apollo-vertex/registry/accordion/accordion.tsx
@@ -2,7 +2,7 @@
 
 import * as AccordionPrimitive from "@radix-ui/react-accordion";
 import { ChevronDownIcon } from "lucide-react";
-import type * as React from "react";
+import * as React from "react";
 
 import { cn } from "@/lib/utils";
 

--- a/apps/apollo-vertex/registry/alert-dialog/alert-dialog.tsx
+++ b/apps/apollo-vertex/registry/alert-dialog/alert-dialog.tsx
@@ -1,5 +1,7 @@
+"use client";
+
 import * as AlertDialogPrimitive from "@radix-ui/react-alert-dialog";
-import type * as React from "react";
+import * as React from "react";
 import { buttonVariants } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 

--- a/apps/apollo-vertex/registry/alert/alert.tsx
+++ b/apps/apollo-vertex/registry/alert/alert.tsx
@@ -1,5 +1,5 @@
 import { cva, type VariantProps } from "class-variance-authority";
-import type * as React from "react";
+import * as React from "react";
 
 import { cn } from "@/lib/utils";
 

--- a/apps/apollo-vertex/registry/aspect-ratio/aspect-ratio.tsx
+++ b/apps/apollo-vertex/registry/aspect-ratio/aspect-ratio.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import * as AspectRatioPrimitive from "@radix-ui/react-aspect-ratio";
 
 function AspectRatio({

--- a/apps/apollo-vertex/registry/avatar/avatar.tsx
+++ b/apps/apollo-vertex/registry/avatar/avatar.tsx
@@ -1,5 +1,7 @@
+"use client";
+
 import * as AvatarPrimitive from "@radix-ui/react-avatar";
-import type * as React from "react";
+import * as React from "react";
 
 import { cn } from "@/lib/utils";
 

--- a/apps/apollo-vertex/registry/badge/badge.tsx
+++ b/apps/apollo-vertex/registry/badge/badge.tsx
@@ -1,6 +1,6 @@
 import { Slot } from "@radix-ui/react-slot";
 import { cva, type VariantProps } from "class-variance-authority";
-import type * as React from "react";
+import * as React from "react";
 
 import { cn } from "@/lib/utils";
 
@@ -32,7 +32,7 @@ function Badge({
   ...props
 }: React.ComponentProps<"span"> &
   VariantProps<typeof badgeVariants> & { asChild?: boolean }) {
-  const Comp: React.ElementType = asChild ? Slot : "span";
+  const Comp = asChild ? Slot : "span";
 
   return (
     <Comp

--- a/apps/apollo-vertex/registry/breadcrumb/breadcrumb.tsx
+++ b/apps/apollo-vertex/registry/breadcrumb/breadcrumb.tsx
@@ -1,6 +1,6 @@
 import { Slot } from "@radix-ui/react-slot";
 import { ChevronRight, MoreHorizontal } from "lucide-react";
-import type * as React from "react";
+import * as React from "react";
 
 import { cn } from "@/lib/utils";
 
@@ -38,7 +38,7 @@ function BreadcrumbLink({
 }: React.ComponentProps<"a"> & {
   asChild?: boolean;
 }) {
-  const Comp: React.ElementType = asChild ? Slot : "a";
+  const Comp = asChild ? Slot : "a";
 
   return (
     <Comp

--- a/apps/apollo-vertex/registry/button/button.tsx
+++ b/apps/apollo-vertex/registry/button/button.tsx
@@ -1,6 +1,6 @@
 import { Slot } from "@radix-ui/react-slot";
 import { cva, type VariantProps } from "class-variance-authority";
-import type * as React from "react";
+import * as React from "react";
 
 import { cn } from "@/lib/utils";
 
@@ -38,19 +38,21 @@ const buttonVariants = cva(
 
 function Button({
   className,
-  variant,
-  size,
+  variant = "default",
+  size = "default",
   asChild = false,
   ...props
 }: React.ComponentProps<"button"> &
   VariantProps<typeof buttonVariants> & {
     asChild?: boolean;
   }) {
-  const Comp: React.ElementType = asChild ? Slot : "button";
+  const Comp = asChild ? Slot : "button";
 
   return (
     <Comp
       data-slot="button"
+      data-variant={variant}
+      data-size={size}
       className={cn(buttonVariants({ variant, size, className }))}
       {...props}
     />

--- a/apps/apollo-vertex/registry/calendar/calendar.tsx
+++ b/apps/apollo-vertex/registry/calendar/calendar.tsx
@@ -1,4 +1,5 @@
 "use client";
+
 import {
   ChevronDownIcon,
   ChevronLeftIcon,
@@ -134,7 +135,7 @@ function Calendar({
           return (
             <div
               data-slot="calendar"
-              ref={rootRef as React.Ref<HTMLDivElement>}
+              ref={rootRef}
               className={cn(className)}
               {...props}
             />

--- a/apps/apollo-vertex/registry/card/card.tsx
+++ b/apps/apollo-vertex/registry/card/card.tsx
@@ -1,4 +1,4 @@
-import type * as React from "react";
+import * as React from "react";
 
 import { cn } from "@/lib/utils";
 

--- a/apps/apollo-vertex/registry/chart/chart.tsx
+++ b/apps/apollo-vertex/registry/chart/chart.tsx
@@ -1,12 +1,7 @@
 "use client";
 
 import * as React from "react";
-import type { TooltipProps } from "recharts";
 import * as RechartsPrimitive from "recharts";
-import type {
-  NameType,
-  ValueType,
-} from "recharts/types/component/DefaultTooltipContent";
 
 import { cn } from "@/lib/utils";
 
@@ -123,7 +118,7 @@ function ChartTooltipContent({
   color,
   nameKey,
   labelKey,
-}: TooltipProps<ValueType, NameType> &
+}: React.ComponentProps<typeof RechartsPrimitive.Tooltip> &
   React.ComponentProps<"div"> & {
     hideLabel?: boolean;
     hideIndicator?: boolean;

--- a/apps/apollo-vertex/registry/checkbox/checkbox.tsx
+++ b/apps/apollo-vertex/registry/checkbox/checkbox.tsx
@@ -2,7 +2,7 @@
 
 import * as CheckboxPrimitive from "@radix-ui/react-checkbox";
 import { CheckIcon } from "lucide-react";
-import type * as React from "react";
+import * as React from "react";
 
 import { cn } from "@/lib/utils";
 

--- a/apps/apollo-vertex/registry/command/command.tsx
+++ b/apps/apollo-vertex/registry/command/command.tsx
@@ -2,7 +2,7 @@
 
 import { Command as CommandPrimitive } from "cmdk";
 import { SearchIcon } from "lucide-react";
-import type * as React from "react";
+import * as React from "react";
 import {
   Dialog,
   DialogContent,

--- a/apps/apollo-vertex/registry/context-menu/context-menu.tsx
+++ b/apps/apollo-vertex/registry/context-menu/context-menu.tsx
@@ -2,7 +2,7 @@
 
 import * as ContextMenuPrimitive from "@radix-ui/react-context-menu";
 import { CheckIcon, ChevronRightIcon, CircleIcon } from "lucide-react";
-import type * as React from "react";
+import * as React from "react";
 
 import { cn } from "@/lib/utils";
 

--- a/apps/apollo-vertex/registry/dialog/dialog.tsx
+++ b/apps/apollo-vertex/registry/dialog/dialog.tsx
@@ -2,7 +2,7 @@
 
 import * as DialogPrimitive from "@radix-ui/react-dialog";
 import { XIcon } from "lucide-react";
-import type * as React from "react";
+import * as React from "react";
 
 import { cn } from "@/lib/utils";
 
@@ -60,7 +60,7 @@ function DialogContent({
       <DialogPrimitive.Content
         data-slot="dialog-content"
         className={cn(
-          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
+          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 outline-none sm:max-w-lg",
           className,
         )}
         {...props}

--- a/apps/apollo-vertex/registry/drawer/drawer.tsx
+++ b/apps/apollo-vertex/registry/drawer/drawer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type * as React from "react";
+import * as React from "react";
 import { Drawer as DrawerPrimitive } from "vaul";
 
 import { cn } from "@/lib/utils";

--- a/apps/apollo-vertex/registry/dropdown-menu/dropdown-menu.tsx
+++ b/apps/apollo-vertex/registry/dropdown-menu/dropdown-menu.tsx
@@ -2,7 +2,7 @@
 
 import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu";
 import { CheckIcon, ChevronRightIcon, CircleIcon } from "lucide-react";
-import type * as React from "react";
+import * as React from "react";
 
 import { cn } from "@/lib/utils";
 

--- a/apps/apollo-vertex/registry/hover-card/hover-card.tsx
+++ b/apps/apollo-vertex/registry/hover-card/hover-card.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import * as HoverCardPrimitive from "@radix-ui/react-hover-card";
-import type * as React from "react";
+import * as React from "react";
 
 import { cn } from "@/lib/utils";
 

--- a/apps/apollo-vertex/registry/input-otp/input-otp.tsx
+++ b/apps/apollo-vertex/registry/input-otp/input-otp.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { OTPInput, OTPInputContext, type RenderProps } from "input-otp";
+import { OTPInput, OTPInputContext } from "input-otp";
 import { MinusIcon } from "lucide-react";
 import * as React from "react";
 
@@ -43,9 +43,7 @@ function InputOTPSlot({
 }: React.ComponentProps<"div"> & {
   index: number;
 }) {
-  const inputOTPContext = React.useContext(
-    OTPInputContext,
-  ) as RenderProps | null;
+  const inputOTPContext = React.useContext(OTPInputContext);
   const { char, hasFakeCaret, isActive } = inputOTPContext?.slots[index] ?? {};
 
   return (

--- a/apps/apollo-vertex/registry/input/input.tsx
+++ b/apps/apollo-vertex/registry/input/input.tsx
@@ -1,4 +1,4 @@
-import type * as React from "react";
+import * as React from "react";
 
 import { cn } from "@/lib/utils";
 

--- a/apps/apollo-vertex/registry/label/label.tsx
+++ b/apps/apollo-vertex/registry/label/label.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import * as LabelPrimitive from "@radix-ui/react-label";
-import type * as React from "react";
+import * as React from "react";
 
 import { cn } from "@/lib/utils";
 

--- a/apps/apollo-vertex/registry/menubar/menubar.tsx
+++ b/apps/apollo-vertex/registry/menubar/menubar.tsx
@@ -2,7 +2,7 @@
 
 import * as MenubarPrimitive from "@radix-ui/react-menubar";
 import { CheckIcon, ChevronRightIcon, CircleIcon } from "lucide-react";
-import type * as React from "react";
+import * as React from "react";
 
 import { cn } from "@/lib/utils";
 

--- a/apps/apollo-vertex/registry/navigation-menu/navigation-menu.tsx
+++ b/apps/apollo-vertex/registry/navigation-menu/navigation-menu.tsx
@@ -1,7 +1,7 @@
 import * as NavigationMenuPrimitive from "@radix-ui/react-navigation-menu";
 import { cva } from "class-variance-authority";
 import { ChevronDownIcon } from "lucide-react";
-import type * as React from "react";
+import * as React from "react";
 
 import { cn } from "@/lib/utils";
 

--- a/apps/apollo-vertex/registry/pagination/pagination.tsx
+++ b/apps/apollo-vertex/registry/pagination/pagination.tsx
@@ -3,7 +3,7 @@ import {
   ChevronRightIcon,
   MoreHorizontalIcon,
 } from "lucide-react";
-import type * as React from "react";
+import * as React from "react";
 import { type Button, buttonVariants } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 

--- a/apps/apollo-vertex/registry/popover/popover.tsx
+++ b/apps/apollo-vertex/registry/popover/popover.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import * as PopoverPrimitive from "@radix-ui/react-popover";
-import type * as React from "react";
+import * as React from "react";
 
 import { cn } from "@/lib/utils";
 

--- a/apps/apollo-vertex/registry/progress/progress.tsx
+++ b/apps/apollo-vertex/registry/progress/progress.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import * as ProgressPrimitive from "@radix-ui/react-progress";
-import type * as React from "react";
+import * as React from "react";
 
 import { cn } from "@/lib/utils";
 

--- a/apps/apollo-vertex/registry/radio-group/radio-group.tsx
+++ b/apps/apollo-vertex/registry/radio-group/radio-group.tsx
@@ -2,7 +2,7 @@
 
 import * as RadioGroupPrimitive from "@radix-ui/react-radio-group";
 import { CircleIcon } from "lucide-react";
-import type * as React from "react";
+import * as React from "react";
 
 import { cn } from "@/lib/utils";
 

--- a/apps/apollo-vertex/registry/resizable/resizable.tsx
+++ b/apps/apollo-vertex/registry/resizable/resizable.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { GripVerticalIcon } from "lucide-react";
-import type * as React from "react";
+import * as React from "react";
 import * as ResizablePrimitive from "react-resizable-panels";
 
 import { cn } from "@/lib/utils";

--- a/apps/apollo-vertex/registry/scroll-area/scroll-area.tsx
+++ b/apps/apollo-vertex/registry/scroll-area/scroll-area.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import * as ScrollAreaPrimitive from "@radix-ui/react-scroll-area";
-import type * as React from "react";
+import * as React from "react";
 
 import { cn } from "@/lib/utils";
 

--- a/apps/apollo-vertex/registry/select/select.tsx
+++ b/apps/apollo-vertex/registry/select/select.tsx
@@ -2,7 +2,7 @@
 
 import * as SelectPrimitive from "@radix-ui/react-select";
 import { CheckIcon, ChevronDownIcon, ChevronUpIcon } from "lucide-react";
-import type * as React from "react";
+import * as React from "react";
 
 import { cn } from "@/lib/utils";
 
@@ -53,7 +53,7 @@ function SelectTrigger({
 function SelectContent({
   className,
   children,
-  position = "popper",
+  position = "item-aligned",
   align = "center",
   ...props
 }: React.ComponentProps<typeof SelectPrimitive.Content>) {
@@ -114,7 +114,10 @@ function SelectItem({
       )}
       {...props}
     >
-      <span className="absolute right-2 flex size-3.5 items-center justify-center">
+      <span
+        data-slot="select-item-indicator"
+        className="absolute right-2 flex size-3.5 items-center justify-center"
+      >
         <SelectPrimitive.ItemIndicator>
           <CheckIcon className="size-4" />
         </SelectPrimitive.ItemIndicator>

--- a/apps/apollo-vertex/registry/separator/separator.tsx
+++ b/apps/apollo-vertex/registry/separator/separator.tsx
@@ -1,5 +1,7 @@
+"use client";
+
 import * as SeparatorPrimitive from "@radix-ui/react-separator";
-import type * as React from "react";
+import * as React from "react";
 
 import { cn } from "@/lib/utils";
 

--- a/apps/apollo-vertex/registry/sheet/sheet.tsx
+++ b/apps/apollo-vertex/registry/sheet/sheet.tsx
@@ -1,6 +1,8 @@
+"use client";
+
 import * as SheetPrimitive from "@radix-ui/react-dialog";
 import { XIcon } from "lucide-react";
-import type * as React from "react";
+import * as React from "react";
 
 import { cn } from "@/lib/utils";
 

--- a/apps/apollo-vertex/registry/sidebar/sidebar.tsx
+++ b/apps/apollo-vertex/registry/sidebar/sidebar.tsx
@@ -21,8 +21,8 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { useIsMobile } from "@/hooks/use-mobile";
 import { cn } from "@/lib/utils";
-import { useIsMobile } from "@/registry/use-mobile/use-mobile";
 
 const SIDEBAR_COOKIE_NAME = "sidebar_state";
 const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7;
@@ -397,7 +397,7 @@ function SidebarGroupLabel({
   asChild = false,
   ...props
 }: React.ComponentProps<"div"> & { asChild?: boolean }) {
-  const Comp: React.ElementType = asChild ? Slot : "div";
+  const Comp = asChild ? Slot : "div";
 
   return (
     <Comp
@@ -418,7 +418,7 @@ function SidebarGroupAction({
   asChild = false,
   ...props
 }: React.ComponentProps<"button"> & { asChild?: boolean }) {
-  const Comp: React.ElementType = asChild ? Slot : "button";
+  const Comp = asChild ? Slot : "button";
 
   return (
     <Comp
@@ -507,7 +507,7 @@ function SidebarMenuButton({
   isActive?: boolean;
   tooltip?: string | React.ComponentProps<typeof TooltipContent>;
 } & VariantProps<typeof sidebarMenuButtonVariants>) {
-  const Comp: React.ElementType = asChild ? Slot : "button";
+  const Comp = asChild ? Slot : "button";
   const { isMobile, state } = useSidebar();
 
   const button = (
@@ -553,7 +553,7 @@ function SidebarMenuAction({
   asChild?: boolean;
   showOnHover?: boolean;
 }) {
-  const Comp: React.ElementType = asChild ? Slot : "button";
+  const Comp = asChild ? Slot : "button";
 
   return (
     <Comp
@@ -676,7 +676,7 @@ function SidebarMenuSubButton({
   size?: "sm" | "md";
   isActive?: boolean;
 }) {
-  const Comp: React.ElementType = asChild ? Slot : "a";
+  const Comp = asChild ? Slot : "a";
 
   return (
     <Comp

--- a/apps/apollo-vertex/registry/skeleton/skeleton.tsx
+++ b/apps/apollo-vertex/registry/skeleton/skeleton.tsx
@@ -1,4 +1,3 @@
-import type * as React from "react";
 import { cn } from "@/lib/utils";
 
 function Skeleton({ className, ...props }: React.ComponentProps<"div">) {

--- a/apps/apollo-vertex/registry/slider/slider.tsx
+++ b/apps/apollo-vertex/registry/slider/slider.tsx
@@ -1,5 +1,8 @@
+"use client";
+
 import * as SliderPrimitive from "@radix-ui/react-slider";
-import { useMemo } from "react";
+import * as React from "react";
+
 import { cn } from "@/lib/utils";
 
 function Slider({
@@ -10,7 +13,7 @@ function Slider({
   max = 100,
   ...props
 }: React.ComponentProps<typeof SliderPrimitive.Root>) {
-  const _values = useMemo(
+  const _values = React.useMemo(
     () =>
       Array.isArray(value)
         ? value

--- a/apps/apollo-vertex/registry/switch/switch.tsx
+++ b/apps/apollo-vertex/registry/switch/switch.tsx
@@ -1,5 +1,7 @@
+"use client";
+
 import * as SwitchPrimitive from "@radix-ui/react-switch";
-import type * as React from "react";
+import * as React from "react";
 
 import { cn } from "@/lib/utils";
 

--- a/apps/apollo-vertex/registry/table/table.tsx
+++ b/apps/apollo-vertex/registry/table/table.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type * as React from "react";
+import * as React from "react";
 
 import { cn } from "@/lib/utils";
 

--- a/apps/apollo-vertex/registry/tabs/tabs.tsx
+++ b/apps/apollo-vertex/registry/tabs/tabs.tsx
@@ -1,5 +1,7 @@
+"use client";
+
 import * as TabsPrimitive from "@radix-ui/react-tabs";
-import type * as React from "react";
+import * as React from "react";
 
 import { cn } from "@/lib/utils";
 

--- a/apps/apollo-vertex/registry/textarea/textarea.tsx
+++ b/apps/apollo-vertex/registry/textarea/textarea.tsx
@@ -1,4 +1,4 @@
-import type * as React from "react";
+import * as React from "react";
 
 import { cn } from "@/lib/utils";
 

--- a/apps/apollo-vertex/registry/toggle-group/toggle-group.tsx
+++ b/apps/apollo-vertex/registry/toggle-group/toggle-group.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import * as ToggleGroupPrimitive from "@radix-ui/react-toggle-group";
-import type { VariantProps } from "class-variance-authority";
+import { type VariantProps } from "class-variance-authority";
 import * as React from "react";
 import { toggleVariants } from "@/components/ui/toggle";
 import { cn } from "@/lib/utils";

--- a/apps/apollo-vertex/registry/toggle/toggle.tsx
+++ b/apps/apollo-vertex/registry/toggle/toggle.tsx
@@ -1,6 +1,8 @@
+"use client";
+
 import * as TogglePrimitive from "@radix-ui/react-toggle";
 import { cva, type VariantProps } from "class-variance-authority";
-import type * as React from "react";
+import * as React from "react";
 
 import { cn } from "@/lib/utils";
 

--- a/apps/apollo-vertex/registry/tooltip/tooltip.tsx
+++ b/apps/apollo-vertex/registry/tooltip/tooltip.tsx
@@ -1,5 +1,7 @@
+"use client";
+
 import * as TooltipPrimitive from "@radix-ui/react-tooltip";
-import type * as React from "react";
+import * as React from "react";
 
 import { cn } from "@/lib/utils";
 

--- a/apps/apollo-vertex/tsconfig.json
+++ b/apps/apollo-vertex/tsconfig.json
@@ -83,7 +83,8 @@
       ],
       "@/components/ui/toggle": ["./registry/toggle/toggle"],
       "@/components/ui/toggle-group": ["./registry/toggle-group/toggle-group"],
-      "@/components/ui/tooltip": ["./registry/tooltip/tooltip"]
+      "@/components/ui/tooltip": ["./registry/tooltip/tooltip"],
+      "@/hooks/use-mobile": ["./registry/use-mobile/use-mobile"]
     },
     "allowJs": true
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -268,8 +268,8 @@ importers:
         specifier: 19.2.3
         version: 19.2.3
       react-day-picker:
-        specifier: ^9.11.2
-        version: 9.11.2(react@19.2.3)
+        specifier: ^9.13.0
+        version: 9.13.0(react@19.2.3)
       react-dom:
         specifier: 19.2.3
         version: 19.2.3(react@19.2.3)
@@ -295,7 +295,7 @@ importers:
         specifier: ^1.1.2
         version: 1.1.2(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       zod:
-        specifier: ^4.1.13
+        specifier: ^4.2.1
         version: 4.2.1
     devDependencies:
       '@biomejs/biome':
@@ -11152,6 +11152,12 @@ packages:
 
   react-day-picker@9.11.2:
     resolution: {integrity: sha512-TD/xMUGg2oiKX8jUR21MST5pj+7Y36097YtnDHQFlIcZOu3mbLLw2B2JqEByEGrR3HHveWYnKlyls6WqJgohAg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      react: '>=16.8.0'
+
+  react-day-picker@9.13.0:
+    resolution: {integrity: sha512-euzj5Hlq+lOHqI53NiuNhCP8HWgsPf/bBAVijR50hNaY1XwjKjShAnIe8jm8RD2W9IJUvihDIZ+KrmqfFzNhFQ==}
     engines: {node: '>=18'}
     peerDependencies:
       react: '>=16.8.0'
@@ -25397,6 +25403,13 @@ snapshots:
       react: 19.2.3
 
   react-day-picker@9.11.2(react@19.2.3):
+    dependencies:
+      '@date-fns/tz': 1.4.1
+      date-fns: 4.1.0
+      date-fns-jalali: 4.1.0-0
+      react: 19.2.3
+
+  react-day-picker@9.13.0(react@19.2.3):
     dependencies:
       '@date-fns/tz': 1.4.1
       date-fns: 4.1.0


### PR DESCRIPTION
## Summary
Updated 44 shadcn components from the official registry. Changes include import normalization, default parameter values, enhanced data attributes for CSS targeting, and minor accessibility improvements.

Also updated sidebar registry dependencies to include the use-mobile hook, added tsconfig path alias, and bumped dependencies (react-day-picker ^9.13.0, zod ^4.2.1).

## Changes
- 44 shadcn components updated to latest
- Added path alias for use-mobile hook
- Updated sidebar registry dependencies
- Applied Biome formatting across all files
- Minor dependency updates

🤖 Generated with Claude Code