### PR TITLE
fix(apollo-react): HierarchicalCanvas with initial data handling and improved canvas navigation

### DIFF
--- a/packages/apollo-react/src/canvas/components/BaseCanvas/BaseCanvas.tsx
+++ b/packages/apollo-react/src/canvas/components/BaseCanvas/BaseCanvas.tsx
@@ -78,6 +78,7 @@ const BaseCanvasInnerComponent = <NodeType extends Node = Node, EdgeType extends
     nodesConnectable = true,
     elementsSelectable = true,
     onlyRenderVisibleElements = true,
+    zoomOnDoubleClick = true,
     snapToGrid = BASE_CANVAS_DEFAULTS.snapToGrid,
     snapGrid = BASE_CANVAS_DEFAULTS.snapGrid,
 
@@ -172,7 +173,7 @@ const BaseCanvasInnerComponent = <NodeType extends Node = Node, EdgeType extends
         maxZoom={maxZoom}
         panOnScroll={isInteractive}
         zoomOnScroll={isInteractive}
-        zoomOnDoubleClick={isInteractive}
+        zoomOnDoubleClick={isInteractive && zoomOnDoubleClick}
         panOnDrag={isInteractive ? [1] : false}
         onInit={handleInit}
         onNodesChange={isInteractive ? onNodesChange : undefined}

--- a/packages/apollo-react/src/canvas/components/BaseNode/BaseNode.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/BaseNode/BaseNode.stories.tsx
@@ -41,15 +41,11 @@ const sampleManifests: NodeManifest[] = [
     handleConfiguration: [
       {
         position: 'left',
-        handles: [
-          { id: 'in', type: 'target', handleType: 'input', label: 'Input' },
-        ],
+        handles: [{ id: 'in', type: 'target', handleType: 'input', label: 'Input' }],
       },
       {
         position: 'right',
-        handles: [
-          { id: 'out', type: 'source', handleType: 'output', label: 'Output' },
-        ],
+        handles: [{ id: 'out', type: 'source', handleType: 'output', label: 'Output' }],
       },
     ],
   },
@@ -80,15 +76,11 @@ const sampleManifests: NodeManifest[] = [
     handleConfiguration: [
       {
         position: 'left',
-        handles: [
-          { id: 'in', type: 'target', handleType: 'input', label: 'Input' },
-        ],
+        handles: [{ id: 'in', type: 'target', handleType: 'input', label: 'Input' }],
       },
       {
         position: 'right',
-        handles: [
-          { id: 'out', type: 'source', handleType: 'output', label: 'Output' },
-        ],
+        handles: [{ id: 'out', type: 'source', handleType: 'output', label: 'Output' }],
       },
     ],
   },
@@ -114,9 +106,7 @@ const meta: Meta<BaseNodeData> = {
       const contextValue = useMemo(() => ({ registry }), [registry]);
 
       return (
-        <NodeRegistryContext.Provider value={contextValue}>
-          {Story()}
-        </NodeRegistryContext.Provider>
+        <NodeRegistryContext.Provider value={contextValue}>{Story()}</NodeRegistryContext.Provider>
       );
     },
     withCanvasProviders(),
@@ -150,7 +140,7 @@ function createShapeStatusGrid(): Node<BaseNodeData>[] {
     SHAPES.forEach((shape, colIndex) => {
       const label = shape === 'rectangle' ? 'Invoice approval agent' : 'Header';
       const nodeType = shape === 'rectangle' ? 'uipath.agent' : 'uipath.blank-node';
-      
+
       nodes.push(
         createNode({
           id: `${shape}-${status}`,
@@ -164,9 +154,9 @@ function createShapeStatusGrid(): Node<BaseNodeData>[] {
             version: '1.0.0',
             parameters: {},
             executionStatus: status,
-            display: { 
-              label, 
-              subLabel: status.replace(/([A-Z])/g, ' $1').trim(), 
+            display: {
+              label,
+              subLabel: status.replace(/([A-Z])/g, ' $1').trim(),
               shape,
             },
           },

--- a/packages/apollo-react/src/canvas/components/BaseNode/NewBaseNode.tsx
+++ b/packages/apollo-react/src/canvas/components/BaseNode/NewBaseNode.tsx
@@ -8,6 +8,7 @@ import {
 } from '@uipath/apollo-react/canvas/xyflow/react';
 import { ApIcon, ApTooltip, ApTypography } from '@uipath/apollo-react/material/components';
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import type { HandleActionEvent } from '../ButtonHandle/ButtonHandle';
 import { useButtonHandles } from '../ButtonHandle/useButtonHandles';
 import { NodeToolbar } from '../Toolbar';
 import {
@@ -22,8 +23,8 @@ import type { NewBaseNodeData, NewBaseNodeDisplayProps, NodeAdornments } from '.
 
 // Internal component that expects display props as direct props
 const NewBaseNodeComponent = (
-  props: Omit<NodeProps<Node<NewBaseNodeData>>, 'data'> &
-    NewBaseNodeDisplayProps & { data?: NewBaseNodeData }
+  props: Partial<Omit<NodeProps<Node<NewBaseNodeData>>, 'data'>> &
+    NewBaseNodeDisplayProps & { data?: NewBaseNodeData; id: string }
 ) => {
   const {
     id,
@@ -133,7 +134,7 @@ const NewBaseNodeComponent = (
 
   // Handle action callback
   const handleAction = useCallback(
-    (event: any) => {
+    (event: HandleActionEvent) => {
       // First, check if there's a global handler passed as prop
       if (onHandleAction) {
         onHandleAction(event);
@@ -287,8 +288,8 @@ const NewBaseNodeComponent = (
 // Wrapper component that extracts display props from data for React Flow compatibility
 // Also supports direct props for standalone usage (non-React Flow components)
 const NewBaseNodeWrapper = (
-  props: Omit<NodeProps<Node<NewBaseNodeData>>, 'data'> &
-    NewBaseNodeDisplayProps & { data?: NewBaseNodeData }
+  props: Partial<Omit<NodeProps<Node<NewBaseNodeData>>, 'data'>> &
+    NewBaseNodeDisplayProps & { data?: NewBaseNodeData; id: string }
 ) => {
   const {
     data,

--- a/packages/apollo-react/src/canvas/components/BlankCanvasNode/BlankCanvasNode.tsx
+++ b/packages/apollo-react/src/canvas/components/BlankCanvasNode/BlankCanvasNode.tsx
@@ -1,7 +1,7 @@
 import { type NodeProps, useStoreApi } from '@uipath/apollo-react/canvas/xyflow/react';
 import { ApIcon } from '@uipath/apollo-react/material/components';
 import { useCallback, useRef } from 'react';
-import { useCanvasStore } from '../../stores/canvasStore';
+import { selectAddNode, selectRemoveNode, useCanvasStore } from '../../stores/canvasStore';
 import { AddNodePanel, type NodeItemData } from '../AddNodePanel';
 import { FloatingCanvasPanel } from '../FloatingCanvasPanel';
 import { Header, IconWrapper, NodeContainer, TextContainer } from './BlankCanvasNode.styles';
@@ -12,7 +12,8 @@ interface BlankCanvasNodeProps extends NodeProps {
 
 export const BlankCanvasNode = (props: BlankCanvasNodeProps) => {
   const nodeRef = useRef<HTMLDivElement>(null);
-  const store = useCanvasStore();
+  const removeNode = useCanvasStore(selectRemoveNode);
+  const addNode = useCanvasStore(selectAddNode);
   const storeApi = useStoreApi();
   const { id, selected, positionAbsoluteX, positionAbsoluteY, data } = props;
   const { label } = data;
@@ -24,10 +25,10 @@ export const BlankCanvasNode = (props: BlankCanvasNodeProps) => {
   const handleNodeSelect = useCallback(
     (nodeItemData: NodeItemData) => {
       const position = { x: positionAbsoluteX, y: positionAbsoluteY };
-      store.removeNode(id);
-      store.addNode(nodeItemData.type, position);
+      removeNode(id);
+      addNode(nodeItemData.type, position);
     },
-    [id, store, positionAbsoluteX, positionAbsoluteY]
+    [id, removeNode, addNode, positionAbsoluteX, positionAbsoluteY]
   );
 
   return (
@@ -45,7 +46,7 @@ export const BlankCanvasNode = (props: BlankCanvasNodeProps) => {
 
       <FloatingCanvasPanel open={selected} nodeId={id} placement="right-start" offset={20}>
         <AddNodePanel
-          onNodeSelect={(item) => handleNodeSelect(item.data)}
+          onNodeSelect={(item) => handleNodeSelect(item.data as NodeItemData)}
           onClose={handleClosePanel}
         />
       </FloatingCanvasPanel>

--- a/packages/apollo-react/src/canvas/components/ButtonHandle/ButtonHandle.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/ButtonHandle/ButtonHandle.stories.tsx
@@ -479,7 +479,7 @@ function LogicFlowStory() {
         id: 'if-node',
         type: 'uipath.control-flow.decision',
         position: { x: 300, y: 200 },
-        display: { label: 'If' },
+        display: { label: 'If', subLabel: 'Decision' },
         handleConfigurations: [
           {
             position: Position.Left,
@@ -500,7 +500,7 @@ function LogicFlowStory() {
         id: 'switch-node',
         type: 'uipath.control-flow.switch',
         position: { x: 300, y: 650 },
-        display: { label: 'Switch' },
+        display: { label: 'Switch', subLabel: 'Multi-way' },
         handleConfigurations: [
           {
             position: Position.Left,
@@ -556,6 +556,12 @@ function LogicFlowStory() {
         type: 'uipath.blank-node',
         position: { x: 600, y: 100 },
         display: { label: 'Then Action', subLabel: 'Execute if true', color: 'green' },
+        handleConfigurations: [
+          {
+            position: Position.Left,
+            handles: [{ id: 'input', type: 'target', handleType: 'input' }],
+          },
+        ],
       }),
 
       createNode({
@@ -563,6 +569,12 @@ function LogicFlowStory() {
         type: 'uipath.blank-node',
         position: { x: 600, y: 300 },
         display: { label: 'Else Action', subLabel: 'Execute if false', color: 'red' },
+        handleConfigurations: [
+          {
+            position: Position.Left,
+            handles: [{ id: 'input', type: 'target', handleType: 'input' }],
+          },
+        ],
       }),
 
       // Output nodes for SWITCH

--- a/packages/apollo-react/src/canvas/components/CodedAgent/CodedAgentFlow.tsx
+++ b/packages/apollo-react/src/canvas/components/CodedAgent/CodedAgentFlow.tsx
@@ -163,7 +163,8 @@ const createCodedAgentNodeWrapper = (
 
     return (
       <NewBaseNode
-        {...({ id, selected } as any)}
+        id={id}
+        selected={selected}
         data={nodeData}
         executionStatus={executionStatus}
         icon={<Icons.CodedAgentIcon w={40} h={40} />}
@@ -173,7 +174,7 @@ const createCodedAgentNodeWrapper = (
           shape: 'rectangle',
         }}
         adornments={{
-          topRight: statusAdornment,
+          topRight: statusAdornment ? { icon: statusAdornment } : undefined,
         }}
         handleConfigurations={[
           { position: Position.Left, handles: leftTargetHandle, visible: true },
@@ -224,7 +225,8 @@ const CodedResourceNodeElement = memo(({ data, selected, id }: NodeProps) => {
   return (
     <div style={{ position: 'relative' }}>
       <NewBaseNode
-        {...({ id, selected } as any)}
+        id={id}
+        selected={selected}
         data={nodeData}
         executionStatus={executionStatus}
         icon={resourceIcon}
@@ -232,7 +234,7 @@ const CodedResourceNodeElement = memo(({ data, selected, id }: NodeProps) => {
           shape: 'circle',
         }}
         adornments={{
-          topRight: statusAdornment,
+          topRight: statusAdornment ? { icon: statusAdornment } : undefined,
         }}
         handleConfigurations={[
           { position: Position.Left, handles: leftTargetHandle, visible: true },
@@ -259,7 +261,8 @@ const CodedFlowNodeElement = memo(({ data, selected, id }: NodeProps) => {
     return (
       <div style={{ position: 'relative' }}>
         <NewBaseNode
-          {...({ id, selected } as any)}
+          id={id}
+          selected={selected}
           data={nodeData}
           icon={<ApIcon variant="outlined" name={isStart ? 'circle' : 'trip_origin'} size="40px" />}
           display={{
@@ -281,7 +284,8 @@ const CodedFlowNodeElement = memo(({ data, selected, id }: NodeProps) => {
 
   return (
     <NewBaseNode
-      {...({ id, selected } as any)}
+      id={id}
+      selected={selected}
       data={nodeData}
       display={{
         label: nodeData.label,

--- a/packages/apollo-react/src/canvas/components/HierarchicalCanvas/HierarchicalCanvasWithControls.tsx
+++ b/packages/apollo-react/src/canvas/components/HierarchicalCanvas/HierarchicalCanvasWithControls.tsx
@@ -7,14 +7,57 @@ import {
 } from '@uipath/apollo-react/canvas/xyflow/react';
 import { ApButton, ApTypography } from '@uipath/apollo-react/material';
 import { ApIcon } from '@uipath/apollo-react/material/components';
-import React, { useCallback, useEffect } from 'react';
+import type React from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import type { NodeManifest } from '../../schema/node-definition/node-manifest';
-import { useCanvasStore } from '../../stores/canvasStore';
+import {
+  selectAddNode,
+  selectCurrentCanvas,
+  selectCurrentPathLength,
+  selectRemoveEdge,
+  selectRemoveNode,
+  selectUpdateNodes,
+  useCanvasStore,
+} from '../../stores/canvasStore';
 import type { CanvasLevel } from '../../types/canvas.types';
-import { canvasEventBus } from '../../utils';
-import { createAddNodePreview } from '../AddNodePanel';
-import { NodeRegistryProvider } from '../BaseNode';
+import { canvasEventBus } from '../../utils/CanvasEventBus';
+import { createAddNodePreview } from '../AddNodePanel/createAddNodePreview';
+import { NodeRegistryProvider } from '../BaseNode/NodeRegistryProvider';
 import { HierarchicalCanvas } from './HierarchicalCanvas';
+
+// Demo canvas data for Storybook testing
+const createDemoCanvases = (): Record<string, CanvasLevel> => {
+  const rootCanvas: CanvasLevel = {
+    id: 'root',
+    name: 'Main Workflow',
+    nodes: [
+      {
+        type: 'blank-canvas-node',
+        position: { x: 500, y: 500 },
+        id: 'blank-canvas-node',
+        data: {
+          label: 'Start Here',
+        },
+      },
+    ],
+    edges: [],
+    nodeTypes: ['default'],
+    edgeTypes: ['default'],
+    viewport: { x: 0, y: 0, zoom: 1 },
+    selection: {
+      isSingleNodeSelected: false,
+      isSingleEdgeSelected: false,
+      nodeIds: [],
+      edgeIds: [],
+    },
+    options: {},
+    properties: {},
+  };
+
+  return {
+    root: rootCanvas,
+  };
+};
 
 // ============================================================================
 // Workflow Node Manifests
@@ -190,16 +233,31 @@ const workflowManifests: NodeManifest[] = [
   },
 ];
 
+interface CanvasWithControlsContentProps {
+  initialCanvases: Record<string, CanvasLevel>;
+  initialPath: string[];
+  onCanvasesChange: (canvases: Record<string, CanvasLevel>) => void;
+  onPathChange: (path: string[]) => void;
+}
+
 /**
  * Inner component that uses the ReactFlow hooks
  */
-const CanvasWithControlsContent: React.FC = () => {
-  const store = useCanvasStore();
+const CanvasWithControlsContent: React.FC<CanvasWithControlsContentProps> = ({
+  initialCanvases,
+  initialPath,
+  onCanvasesChange,
+  onPathChange,
+}) => {
   const reactFlowInstance = useReactFlow();
-  const currentCanvas: CanvasLevel | undefined = useCanvasStore((state) => {
-    const lastIndex = state.currentPath[state.currentPath.length - 1];
-    return lastIndex !== undefined ? state.canvasStack[lastIndex] : undefined;
-  });
+
+  // Use stable selectors to avoid "getSnapshot should be cached" errors
+  const currentCanvas = useCanvasStore(selectCurrentCanvas);
+  const currentPathLength = useCanvasStore(selectCurrentPathLength);
+  const addNode = useCanvasStore(selectAddNode);
+  const removeNode = useCanvasStore(selectRemoveNode);
+  const removeEdge = useCanvasStore(selectRemoveEdge);
+  const updateNodes = useCanvasStore(selectUpdateNodes);
 
   // Listen for handle action events and create preview
   useEffect(() => {
@@ -227,19 +285,19 @@ const CanvasWithControlsContent: React.FC = () => {
       // Remove blank canvas node if it exists
       const blankNode = currentCanvas?.nodes.find((n) => n.id === 'blank-canvas-node');
       if (blankNode) {
-        store.removeNode('blank-canvas-node');
+        removeNode('blank-canvas-node');
       }
 
-      store.addNode(nodeType, position);
+      addNode(nodeType, position);
     },
-    [store, currentCanvas]
+    [addNode, removeNode, currentCanvas]
   );
 
   const handleAddSampleWorkflow = useCallback(() => {
     // Clear existing nodes
     if (currentCanvas?.nodes) {
       currentCanvas.nodes.forEach((node: Node) => {
-        store.removeNode(node.id);
+        removeNode(node.id);
       });
     }
 
@@ -254,21 +312,21 @@ const CanvasWithControlsContent: React.FC = () => {
 
     nodes.forEach((node, index) => {
       setTimeout(() => {
-        store.addNode(node.type, node.position);
+        addNode(node.type, node.position);
       }, index * 100);
     });
-  }, [store, currentCanvas]);
+  }, [addNode, removeNode, currentCanvas]);
 
   const handleClearCanvas = useCallback(() => {
     // Clear all nodes and edges
     if (currentCanvas?.nodes) {
       currentCanvas.nodes.forEach((node) => {
-        store.removeNode(node.id);
+        removeNode(node.id);
       });
     }
     if (currentCanvas?.edges) {
       currentCanvas.edges.forEach((edge) => {
-        store.removeEdge(edge.id);
+        removeEdge(edge.id);
       });
     }
 
@@ -280,12 +338,18 @@ const CanvasWithControlsContent: React.FC = () => {
       data: {},
     };
 
-    store.updateNodes([blankNode]);
-  }, [store, currentCanvas]);
+    updateNodes([blankNode]);
+  }, [removeNode, removeEdge, updateNodes, currentCanvas]);
 
   return (
     <div style={{ width: '100%', height: '100vh', position: 'relative' }}>
-      <HierarchicalCanvas mode="design" />
+      <HierarchicalCanvas
+        mode="design"
+        initialCanvases={initialCanvases}
+        initialPath={initialPath}
+        onCanvasesChange={onCanvasesChange}
+        onPathChange={onPathChange}
+      />
 
       {/* Control Panel */}
       <Panel position="center-right">
@@ -368,7 +432,7 @@ const CanvasWithControlsContent: React.FC = () => {
           <ApTypography variant={FontVariantToken.fontSizeMBold}>Canvas Info</ApTypography>
           <div>Nodes: {currentCanvas?.nodes?.length || 0}</div>
           <div>Edges: {currentCanvas?.edges?.length || 0}</div>
-          <div>Level: {store.currentPath.length}</div>
+          <div>Level: {currentPathLength}</div>
           <ApTypography variant={FontVariantToken.fontSizeMBold}>Instructions</ApTypography>
           <div style={{ fontSize: '11px', lineHeight: '1.4' }}>
             1. Add nodes or drag to create
@@ -386,13 +450,41 @@ const CanvasWithControlsContent: React.FC = () => {
 };
 
 /**
- * HierarchicalCanvas with test controls for Storybook
+ * HierarchicalCanvas with test controls for Storybook.
+ * Demonstrates the uncontrolled-with-callbacks pattern for consuming HierarchicalCanvas.
+ *
+ * Usage pattern:
+ * - initialCanvases/initialPath: Set once on mount, ignored after
+ * - onCanvasesChange: Called on every change - use for persistence/sync
+ * - onPathChange: Called on navigation - use for URL sync, analytics, etc.
  */
 export const HierarchicalCanvasWithControls: React.FC = () => {
+  // Initial data - only used on first render
+  const [initialCanvases] = useState<Record<string, CanvasLevel>>(() => createDemoCanvases());
+  const [initialPath] = useState<string[]>(['root']);
+
+  // Callbacks for persistence - these receive updates but don't control the component
+  const handleCanvasesChange = useCallback((canvases: Record<string, CanvasLevel>) => {
+    // Example: persist to localStorage, send to API, etc.
+    console.log('Canvas data changed:', Object.keys(canvases));
+    // localStorage.setItem('workflow-canvases', JSON.stringify(canvases));
+  }, []);
+
+  const handlePathChange = useCallback((path: string[]) => {
+    // Example: update URL, track analytics, etc.
+    console.log('Navigation path changed:', path);
+    // window.history.pushState({}, '', `?path=${path.join('/')}`);
+  }, []);
+
   return (
     <NodeRegistryProvider registrations={workflowManifests}>
       <ReactFlowProvider>
-        <CanvasWithControlsContent />
+        <CanvasWithControlsContent
+          initialCanvases={initialCanvases}
+          initialPath={initialPath}
+          onCanvasesChange={handleCanvasesChange}
+          onPathChange={handlePathChange}
+        />
       </ReactFlowProvider>
     </NodeRegistryProvider>
   );

--- a/packages/apollo-react/src/canvas/components/MiniCanvasNavigator/MiniCanvasNavigator.tsx
+++ b/packages/apollo-react/src/canvas/components/MiniCanvasNavigator/MiniCanvasNavigator.tsx
@@ -53,6 +53,7 @@ export const MiniCanvasNavigator = memo(
             showBackground={false}
             onNodeClick={onNodeClick}
             panOnDrag={false}
+            zoomOnDoubleClick={false}
             zoomOnScroll={false}
             zoomOnPinch={false}
             nodesDraggable={false}

--- a/packages/apollo-react/src/canvas/controls/Breadcrumb/Breadcrumb.tsx
+++ b/packages/apollo-react/src/canvas/controls/Breadcrumb/Breadcrumb.tsx
@@ -2,18 +2,21 @@ import styled from '@emotion/styled';
 import { FontVariantToken, Spacing } from '@uipath/apollo-core';
 import { ApTooltip, ApTypography } from '@uipath/apollo-react/material';
 import type React from 'react';
+import { memo } from 'react';
 
 import { Row } from '../../layouts';
 
+export type BreadcrumbItem = {
+  label: string;
+  onClick?: (
+    e: React.MouseEvent<HTMLButtonElement> | React.KeyboardEvent<HTMLButtonElement>
+  ) => void;
+  startAdornment?: React.ReactNode;
+  endAdornment?: React.ReactNode;
+};
+
 type BreadcrumbProps = {
-  items: {
-    label: string;
-    onClick?: (
-      e: React.MouseEvent<HTMLButtonElement> | React.KeyboardEvent<HTMLButtonElement>
-    ) => void;
-    startAdornment?: React.ReactNode;
-    endAdornment?: React.ReactNode;
-  }[];
+  items: BreadcrumbItem[];
   delimiter?: React.ReactNode | string;
 };
 
@@ -30,7 +33,7 @@ const LiStyled = styled.li`
   padding: 0;
 `;
 
-export const Breadcrumb: React.FC<BreadcrumbProps> = ({ items, delimiter = '>' }) => {
+export const Breadcrumb: React.FC<BreadcrumbProps> = memo(({ items, delimiter = '>' }) => {
   const delimiterNode =
     typeof delimiter === 'string' ? (
       <ApTypography aria-hidden="true" color="var(--color-foreground-de-emp)">
@@ -69,7 +72,7 @@ export const Breadcrumb: React.FC<BreadcrumbProps> = ({ items, delimiter = '>' }
                   gap={Spacing.SpacingMicro}
                   aria-current={index === items.length - 1 ? 'page' : undefined}
                 >
-                  {item.startAdornment ?? <></>}
+                  {item.startAdornment}
                   <ApTooltip smartTooltip content={item.label}>
                     <ApTypography
                       variant={
@@ -83,7 +86,7 @@ export const Breadcrumb: React.FC<BreadcrumbProps> = ({ items, delimiter = '>' }
                       {item.label}
                     </ApTypography>
                   </ApTooltip>
-                  {item.endAdornment ?? <></>}
+                  {item.endAdornment}
                 </Row>
               </button>
             ) : (
@@ -116,4 +119,6 @@ export const Breadcrumb: React.FC<BreadcrumbProps> = ({ items, delimiter = '>' }
       </OlStyled>
     </Row>
   );
-};
+});
+
+Breadcrumb.displayName = 'Breadcrumb';

--- a/packages/apollo-react/src/canvas/controls/Breadcrumb/index.ts
+++ b/packages/apollo-react/src/canvas/controls/Breadcrumb/index.ts
@@ -1,1 +1,1 @@
-export { Breadcrumb } from './Breadcrumb';
+export { Breadcrumb, type BreadcrumbItem } from './Breadcrumb';

--- a/packages/apollo-react/src/canvas/hooks/ToolbarActionContext.tsx
+++ b/packages/apollo-react/src/canvas/hooks/ToolbarActionContext.tsx
@@ -47,7 +47,11 @@ export function getToolbarActionStore(): ToolbarActionStore {
  * React hook to sync toolbar action store with component props
  * Use this in FlowEditor to keep the store updated
  */
-export function useToolbarActionStore(mode: string, onToolbarAction?: ToolbarActionHandler, breakpoints?: Set<string>): void {
+export function useToolbarActionStore(
+  mode: string,
+  onToolbarAction?: ToolbarActionHandler,
+  breakpoints?: Set<string>
+): void {
   useEffect(() => {
     setToolbarActionStore({ mode, onToolbarAction, breakpoints });
 

--- a/packages/apollo-react/src/canvas/storybook-utils/manifests/index.ts
+++ b/packages/apollo-react/src/canvas/storybook-utils/manifests/index.ts
@@ -1,2 +1,1 @@
 export * from './node-definitions';
-

--- a/packages/apollo-react/src/canvas/storybook-utils/manifests/node-definitions.ts
+++ b/packages/apollo-react/src/canvas/storybook-utils/manifests/node-definitions.ts
@@ -1,4 +1,4 @@
-import { NodeManifest } from "../../schema/node-definition";
+import { NodeManifest } from '../../schema/node-definition';
 
 export const allNodeManifests: NodeManifest[] = [
   // First Run Node

--- a/packages/apollo-react/src/canvas/types.ts
+++ b/packages/apollo-react/src/canvas/types.ts
@@ -12,6 +12,9 @@ import type {
   StickyNoteData,
 } from './components/StickyNoteNode/StickyNoteNode.types';
 
+// Re-export CanvasLevel for external consumers
+export type { CanvasLevel } from './types/canvas.types';
+
 export interface AgentFlowStickyNote {
   id: string;
   content: string;


### PR DESCRIPTION
## Summary

  - Refactor canvas store access to use granular selectors instead of whole-store subscriptions
  - Add controlled component API to HierarchicalCanvas for external state management
  - Fix potential infinite render loops in viewport and node change handlers
  - Improve type safety by removing any casts across canvas components
  - Memoize Breadcrumb component to prevent unnecessary re-renders

## Test plan

  - Verify canvas navigation (breadcrumb clicks, drill-in/out) works correctly
  - Verify node dragging doesn't cause performance issues or infinite loops
  - Verify viewport changes (pan/zoom) are smooth without flickering
  - Verify HierarchicalCanvasWithControls story renders and functions correctly
  - Verify handle connections work as expected
  - Run existing canvas tests

## Details

####  Performance Improvements

  Granular store selectors - Components now subscribe to individual store actions/state slices instead of the entire store, reducing unnecessary re-renders:
```
  // Before
  const store = useCanvasStore();
  // After
  const addNode = useCanvasStore(selectAddNode);
  const removeNode = useCanvasStore(selectRemoveNode);
```
  Viewport sync - Removed store updates from handleMove callback to prevent render loops. Viewport is now synced via refs and persisted
  before navigation.

  Memoized Breadcrumb - Wrapped Breadcrumb component with React.memo and exported BreadcrumbItem type for consumers.

#### New Features

  HierarchicalCanvas props - Added uncontrolled-with-callbacks pattern:
  - initialCanvases - Initial canvas data (used only on mount)
  - initialPath - Initial navigation path (used only on mount)
  - onCanvasesChange - Callback for persisting canvas changes
  - onPathChange - Callback for navigation tracking

  initializeWithData store action - Allows initializing the canvas store with external data.

####  Type Safety

  - Removed any casts in CodedAgentFlow.tsx and NewBaseNode.tsx
  - Added proper typing for HandleActionEvent
  - Fixed adornment type structure ({ icon: ... } wrapper)

####  Minor Changes

  - Disabled zoomOnDoubleClick in MiniCanvasNavigator
  - Code formatting cleanup (single-line arrays, quote consistency)
  - Re-exported CanvasLevel type from canvas/types.ts