### PR TITLE
feat(apollo-vertex): remove nextjs specific theme selection

### DIFF
--- a/apps/apollo-vertex/app/components/theme-wrapper.tsx
+++ b/apps/apollo-vertex/app/components/theme-wrapper.tsx
@@ -51,7 +51,7 @@ export function ThemeWrapper({ children }: { children: React.ReactNode }) {
   }, []);
 
   return (
-    <ThemeProvider theme={themeConfig} storageKey="theme">
+    <ThemeProvider themeConfig={themeConfig} storageKey="theme">
       {children}
     </ThemeProvider>
   );

--- a/apps/apollo-vertex/registry/theme-provider/theme-toggle.tsx
+++ b/apps/apollo-vertex/registry/theme-provider/theme-toggle.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { Moon, Sun } from "lucide-react";
-import { useTheme } from "next-themes";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -10,6 +9,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { useLocalStorage } from "@/registry/use-local-storage/use-local-storage";
+import { useTheme } from "./theme-provider";
 
 export function ThemeToggle() {
   const [isCollapsed] = useLocalStorage("sidebar-collapsed", false);


### PR DESCRIPTION
Replace Next.js-dependent theme provider with a standalone implementation that manages light/dark/system theme state and persists preferences to localStorage. Adds useTheme hook for consuming components and maintains CSS variable override functionality for custom themes.