### PR TITLE
docs(apollo-vertex): add MCP server configuration guide

### DIFF
--- a/apps/apollo-vertex/app/mcp-server/page.mdx
+++ b/apps/apollo-vertex/app/mcp-server/page.mdx
@@ -1,0 +1,44 @@
+# MCP Server
+
+Use Model Context Protocol (MCP) to let AI assistants install Apollo Vertex components directly into your project.
+
+For complete MCP documentation, see the [shadcn MCP docs](https://ui.shadcn.com/docs/mcp).
+
+## Quick Setup
+
+### 1. Configure the Apollo Vertex Registry
+
+Add the Apollo Vertex registry to your `components.json`:
+
+```json
+{
+  "registries": {
+    "@uipath": "https://apollo-vertex.vercel.app/r/{name}.json"
+  }
+}
+```
+
+### 2. Add the MCP Server
+
+Add the shadcn MCP server to your project's `.mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "shadcn": {
+      "command": "npx",
+      "args": ["-y", "shadcn@canary", "mcp"]
+    }
+  }
+}
+```
+
+## Usage
+
+Once configured, you can ask Claude to install components using the `@uipath` registry prefix:
+
+- "Add the @uipath/button component"
+- "Install @uipath/dialog and @uipath/form"
+- "Add @uipath/sidebar to my project"
+
+The MCP server will handle installing components with the correct dependencies and configurations from the Apollo Vertex registry.

--- a/apps/apollo-vertex/next-env.d.ts
+++ b/apps/apollo-vertex/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
Add a new MCP Server page to the Apollo Vertex documentation that guides users on configuring the shadcn MCP server with Apollo Vertex components.

The page includes:
- Apollo Vertex registry configuration for components.json
- MCP server setup for .mcp.json
- Usage examples for installing components with the @uipath registry prefix