### PR TITLE
chore(repo): update apollo-vertex code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-/apps/apollo-vertex/ @0xr3ngar @alincadariu @ruudandriessen
+/apps/apollo-vertex/ @ruudandriessen @frankkluijtmans @0xr3ngar @alincadariu @angeloaltamiranom


### PR DESCRIPTION
Add @frankkluijtmans and @angeloaltamiranom as code owners for the apollo-vertex application.

Updated the CODEOWNERS file to include the complete team responsible for maintaining apollo-vertex.