### PR TITLE
fix(apollo-vertex): generate registry index.json for MCP

### DIFF
--- a/apps/apollo-vertex/package.json
+++ b/apps/apollo-vertex/package.json
@@ -8,7 +8,7 @@
     "dev": "next --turbopack",
     "build": "pnpm registry:build && next build",
     "start": "next start",
-    "registry:build": "shadcn build",
+    "registry:build": "shadcn build && node --experimental-strip-types scripts/generate-registry-index.ts",
     "postbuild": "pagefind --site .next/server/app --output-path public/_pagefind",
     "format": "biome format --write .",
     "format:check": "biome format .",

--- a/apps/apollo-vertex/scripts/generate-registry-index.ts
+++ b/apps/apollo-vertex/scripts/generate-registry-index.ts
@@ -1,0 +1,50 @@
+/**
+ * Generates index.json from registry.json for MCP server compatibility.
+ *
+ * The shadcn build command generates registry.json with metadata:
+ *   { "$schema": "...", "name": "...", "items": [...] }
+ *
+ * MCP servers expect index.json as a flat array:
+ *   [...]
+ *
+ * This script extracts the items array into index.json.
+ */
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const registryPath = join(__dirname, "../public/r/registry.json");
+const indexPath = join(__dirname, "../public/r/index.json");
+
+let fileContent: string;
+try {
+  fileContent = readFileSync(registryPath, "utf-8");
+} catch (error) {
+  console.error(
+    `Failed to read registry file at ${registryPath}:`,
+    (error as Error).message,
+  );
+  process.exit(1);
+}
+
+let registry: { items: unknown[] };
+try {
+  registry = JSON.parse(fileContent);
+} catch (error) {
+  console.error("Failed to parse registry JSON:", (error as Error).message);
+  process.exit(1);
+}
+
+try {
+  writeFileSync(indexPath, JSON.stringify(registry.items, null, 2));
+} catch (error) {
+  console.error(
+    `Failed to write index file at ${indexPath}:`,
+    (error as Error).message,
+  );
+  process.exit(1);
+}
+
+console.log(`Generated ${indexPath} with ${registry.items.length} components`);


### PR DESCRIPTION
## Summary
- Add post-build step to extract components array from registry.json into index.json
- Enables MCP server to discover all available components in the registry
- Solves issue where registry didn't expose a component listing endpoint

## Testing
Registry build now generates both registry.json and index.json with proper component metadata.