### PR TITLE
feat(apollo-vertex): add registry deps CI check [AGVSOL-962]

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -23,6 +23,7 @@ jobs:
           - Lint
           - Lint CSS
           - Lint Deps
+          - Lint Registry Deps
           - Typecheck
           - Test Coverage
           - Build
@@ -71,6 +72,10 @@ jobs:
       - name: Run Lint Deps
         if: matrix.check == 'Lint Deps'
         run: pnpm lint:deps --affected
+
+      - name: Run Lint Registry Deps
+        if: matrix.check == 'Lint Registry Deps'
+        run: pnpm lint:registry-deps --affected
 
       - name: Run Typecheck
         if: matrix.check == 'Typecheck'

--- a/apps/apollo-vertex/package.json
+++ b/apps/apollo-vertex/package.json
@@ -13,7 +13,8 @@
     "format": "biome format --write .",
     "format:check": "biome format .",
     "lint": "biome check .",
-    "lint:deps": "depcruise registry --config .dependency-cruiser.js"
+    "lint:deps": "depcruise registry --config .dependency-cruiser.js",
+    "lint:registry-deps": "node --experimental-strip-types scripts/validate-registry-deps.ts"
   },
   "keywords": [],
   "author": "",

--- a/apps/apollo-vertex/registry.json
+++ b/apps/apollo-vertex/registry.json
@@ -8,7 +8,9 @@
       "type": "registry:ui",
       "title": "Accordion",
       "description": "A vertically stacked set of interactive headings that reveal content.",
-      "dependencies": ["@radix-ui/react-accordion"],
+      "dependencies": [
+        "@radix-ui/react-accordion"
+      ],
       "files": [
         {
           "path": "registry/accordion/accordion.tsx",
@@ -21,19 +23,29 @@
       "type": "registry:ui",
       "title": "Alert",
       "description": "Displays a callout for user attention.",
-      "files": [{ "path": "registry/alert/alert.tsx", "type": "registry:ui" }]
+      "files": [
+        {
+          "path": "registry/alert/alert.tsx",
+          "type": "registry:ui"
+        }
+      ]
     },
     {
       "name": "alert-dialog",
       "type": "registry:ui",
       "title": "Alert Dialog",
       "description": "A modal dialog that interrupts the user with important content.",
-      "dependencies": ["@radix-ui/react-alert-dialog"],
+      "dependencies": [
+        "@radix-ui/react-alert-dialog"
+      ],
       "files": [
         {
           "path": "registry/alert-dialog/alert-dialog.tsx",
           "type": "registry:ui"
         }
+      ],
+      "registryDependencies": [
+        "button"
       ]
     },
     {
@@ -41,7 +53,9 @@
       "type": "registry:ui",
       "title": "Aspect Ratio",
       "description": "Displays content within a desired ratio.",
-      "dependencies": ["@radix-ui/react-aspect-ratio"],
+      "dependencies": [
+        "@radix-ui/react-aspect-ratio"
+      ],
       "files": [
         {
           "path": "registry/aspect-ratio/aspect-ratio.tsx",
@@ -54,23 +68,39 @@
       "type": "registry:ui",
       "title": "Avatar",
       "description": "An image element with a fallback for representing the user.",
-      "dependencies": ["@radix-ui/react-avatar"],
-      "files": [{ "path": "registry/avatar/avatar.tsx", "type": "registry:ui" }]
+      "dependencies": [
+        "@radix-ui/react-avatar"
+      ],
+      "files": [
+        {
+          "path": "registry/avatar/avatar.tsx",
+          "type": "registry:ui"
+        }
+      ]
     },
     {
       "name": "badge",
       "type": "registry:ui",
       "title": "Badge",
       "description": "Displays a badge or a component that looks like a badge.",
-      "dependencies": ["@radix-ui/react-slot"],
-      "files": [{ "path": "registry/badge/badge.tsx", "type": "registry:ui" }]
+      "dependencies": [
+        "@radix-ui/react-slot"
+      ],
+      "files": [
+        {
+          "path": "registry/badge/badge.tsx",
+          "type": "registry:ui"
+        }
+      ]
     },
     {
       "name": "breadcrumb",
       "type": "registry:ui",
       "title": "Breadcrumb",
       "description": "Displays the path to the current resource using a hierarchy of links.",
-      "dependencies": ["@radix-ui/react-slot"],
+      "dependencies": [
+        "@radix-ui/react-slot"
+      ],
       "files": [
         {
           "path": "registry/breadcrumb/breadcrumb.tsx",
@@ -83,8 +113,15 @@
       "type": "registry:ui",
       "title": "Button",
       "description": "Displays a button or a component that looks like a button.",
-      "dependencies": ["@radix-ui/react-slot"],
-      "files": [{ "path": "registry/button/button.tsx", "type": "registry:ui" }]
+      "dependencies": [
+        "@radix-ui/react-slot"
+      ],
+      "files": [
+        {
+          "path": "registry/button/button.tsx",
+          "type": "registry:ui"
+        }
+      ]
     },
     {
       "name": "button-group",
@@ -96,6 +133,9 @@
           "path": "registry/button-group/button-group.tsx",
           "type": "registry:ui"
         }
+      ],
+      "registryDependencies": [
+        "separator"
       ]
     },
     {
@@ -103,12 +143,18 @@
       "type": "registry:ui",
       "title": "Calendar",
       "description": "A date field component that allows users to enter and edit date.",
-      "dependencies": ["react-day-picker@latest", "date-fns"],
+      "dependencies": [
+        "react-day-picker@latest",
+        "date-fns"
+      ],
       "files": [
         {
           "path": "registry/calendar/calendar.tsx",
           "type": "registry:ui"
         }
+      ],
+      "registryDependencies": [
+        "button"
       ]
     },
     {
@@ -116,19 +162,29 @@
       "type": "registry:ui",
       "title": "Card",
       "description": "Displays a card with header, content, and footer.",
-      "files": [{ "path": "registry/card/card.tsx", "type": "registry:ui" }]
+      "files": [
+        {
+          "path": "registry/card/card.tsx",
+          "type": "registry:ui"
+        }
+      ]
     },
     {
       "name": "carousel",
       "type": "registry:ui",
       "title": "Carousel",
       "description": "A carousel with motion and swipe built using Embla.",
-      "dependencies": ["embla-carousel-react"],
+      "dependencies": [
+        "embla-carousel-react"
+      ],
       "files": [
         {
           "path": "registry/carousel/carousel.tsx",
           "type": "registry:ui"
         }
+      ],
+      "registryDependencies": [
+        "button"
       ]
     },
     {
@@ -136,15 +192,25 @@
       "type": "registry:ui",
       "title": "Chart",
       "description": "Beautiful charts using Recharts with consistent theming.",
-      "dependencies": ["recharts@2.15.4", "lucide-react"],
-      "files": [{ "path": "registry/chart/chart.tsx", "type": "registry:ui" }]
+      "dependencies": [
+        "recharts@2.15.4",
+        "lucide-react"
+      ],
+      "files": [
+        {
+          "path": "registry/chart/chart.tsx",
+          "type": "registry:ui"
+        }
+      ]
     },
     {
       "name": "checkbox",
       "type": "registry:ui",
       "title": "Checkbox",
       "description": "A control that allows the user to toggle between checked and not checked.",
-      "dependencies": ["@radix-ui/react-checkbox"],
+      "dependencies": [
+        "@radix-ui/react-checkbox"
+      ],
       "files": [
         {
           "path": "registry/checkbox/checkbox.tsx",
@@ -157,7 +223,9 @@
       "type": "registry:ui",
       "title": "Collapsible",
       "description": "An interactive component which expands/collapses a panel.",
-      "dependencies": ["@radix-ui/react-collapsible"],
+      "dependencies": [
+        "@radix-ui/react-collapsible"
+      ],
       "files": [
         {
           "path": "registry/collapsible/collapsible.tsx",
@@ -170,12 +238,17 @@
       "type": "registry:ui",
       "title": "Command",
       "description": "A command menu for searching and executing commands.",
-      "dependencies": ["cmdk"],
+      "dependencies": [
+        "cmdk"
+      ],
       "files": [
         {
           "path": "registry/command/command.tsx",
           "type": "registry:ui"
         }
+      ],
+      "registryDependencies": [
+        "dialog"
       ]
     },
     {
@@ -183,7 +256,9 @@
       "type": "registry:ui",
       "title": "Context Menu",
       "description": "Displays a menu located at the pointer, triggered by a right-click.",
-      "dependencies": ["@radix-ui/react-context-menu"],
+      "dependencies": [
+        "@radix-ui/react-context-menu"
+      ],
       "files": [
         {
           "path": "registry/context-menu/context-menu.tsx",
@@ -196,23 +271,40 @@
       "type": "registry:ui",
       "title": "Dialog",
       "description": "A modal dialog that appears in front of app content.",
-      "dependencies": ["@radix-ui/react-dialog"],
-      "files": [{ "path": "registry/dialog/dialog.tsx", "type": "registry:ui" }]
+      "dependencies": [
+        "@radix-ui/react-dialog"
+      ],
+      "files": [
+        {
+          "path": "registry/dialog/dialog.tsx",
+          "type": "registry:ui"
+        }
+      ]
     },
     {
       "name": "drawer",
       "type": "registry:ui",
       "title": "Drawer",
       "description": "A drawer component that slides in from the edge of the screen.",
-      "dependencies": ["vaul", "@radix-ui/react-dialog"],
-      "files": [{ "path": "registry/drawer/drawer.tsx", "type": "registry:ui" }]
+      "dependencies": [
+        "vaul",
+        "@radix-ui/react-dialog"
+      ],
+      "files": [
+        {
+          "path": "registry/drawer/drawer.tsx",
+          "type": "registry:ui"
+        }
+      ]
     },
     {
       "name": "dropdown-menu",
       "type": "registry:ui",
       "title": "Dropdown Menu",
       "description": "Displays a menu to the user triggered by a button.",
-      "dependencies": ["@radix-ui/react-dropdown-menu"],
+      "dependencies": [
+        "@radix-ui/react-dropdown-menu"
+      ],
       "files": [
         {
           "path": "registry/dropdown-menu/dropdown-menu.tsx",
@@ -225,14 +317,28 @@
       "type": "registry:ui",
       "title": "Empty",
       "description": "An empty state component for when there's no data to display.",
-      "files": [{ "path": "registry/empty/empty.tsx", "type": "registry:ui" }]
+      "files": [
+        {
+          "path": "registry/empty/empty.tsx",
+          "type": "registry:ui"
+        }
+      ]
     },
     {
       "name": "field",
       "type": "registry:ui",
       "title": "Field",
       "description": "A form field component with label, input, and description.",
-      "files": [{ "path": "registry/field/field.tsx", "type": "registry:ui" }]
+      "files": [
+        {
+          "path": "registry/field/field.tsx",
+          "type": "registry:ui"
+        }
+      ],
+      "registryDependencies": [
+        "label",
+        "separator"
+      ]
     },
     {
       "name": "form",
@@ -246,14 +352,24 @@
         "zod",
         "react-hook-form"
       ],
-      "files": [{ "path": "registry/form/form.tsx", "type": "registry:ui" }]
+      "files": [
+        {
+          "path": "registry/form/form.tsx",
+          "type": "registry:ui"
+        }
+      ],
+      "registryDependencies": [
+        "label"
+      ]
     },
     {
       "name": "hover-card",
       "type": "registry:ui",
       "title": "Hover Card",
       "description": "For sighted users to preview content available behind a link.",
-      "dependencies": ["@radix-ui/react-hover-card"],
+      "dependencies": [
+        "@radix-ui/react-hover-card"
+      ],
       "files": [
         {
           "path": "registry/hover-card/hover-card.tsx",
@@ -266,7 +382,12 @@
       "type": "registry:ui",
       "title": "Input",
       "description": "Displays a form input field.",
-      "files": [{ "path": "registry/input/input.tsx", "type": "registry:ui" }]
+      "files": [
+        {
+          "path": "registry/input/input.tsx",
+          "type": "registry:ui"
+        }
+      ]
     },
     {
       "name": "input-group",
@@ -278,6 +399,11 @@
           "path": "registry/input-group/input-group.tsx",
           "type": "registry:ui"
         }
+      ],
+      "registryDependencies": [
+        "button",
+        "input",
+        "textarea"
       ]
     },
     {
@@ -285,7 +411,9 @@
       "type": "registry:ui",
       "title": "Input OTP",
       "description": "A one-time password input component.",
-      "dependencies": ["input-otp"],
+      "dependencies": [
+        "input-otp"
+      ],
       "files": [
         {
           "path": "registry/input-otp/input-otp.tsx",
@@ -298,29 +426,51 @@
       "type": "registry:ui",
       "title": "Item",
       "description": "A list item component for displaying content in lists.",
-      "files": [{ "path": "registry/item/item.tsx", "type": "registry:ui" }]
+      "files": [
+        {
+          "path": "registry/item/item.tsx",
+          "type": "registry:ui"
+        }
+      ],
+      "registryDependencies": [
+        "separator"
+      ]
     },
     {
       "name": "kbd",
       "type": "registry:ui",
       "title": "Kbd",
       "description": "Displays keyboard shortcuts.",
-      "files": [{ "path": "registry/kbd/kbd.tsx", "type": "registry:ui" }]
+      "files": [
+        {
+          "path": "registry/kbd/kbd.tsx",
+          "type": "registry:ui"
+        }
+      ]
     },
     {
       "name": "label",
       "type": "registry:ui",
       "title": "Label",
       "description": "Renders an accessible label associated with controls.",
-      "dependencies": ["@radix-ui/react-label"],
-      "files": [{ "path": "registry/label/label.tsx", "type": "registry:ui" }]
+      "dependencies": [
+        "@radix-ui/react-label"
+      ],
+      "files": [
+        {
+          "path": "registry/label/label.tsx",
+          "type": "registry:ui"
+        }
+      ]
     },
     {
       "name": "menubar",
       "type": "registry:ui",
       "title": "Menubar",
       "description": "A horizontally stacked menu bar with dropdown submenus.",
-      "dependencies": ["@radix-ui/react-menubar"],
+      "dependencies": [
+        "@radix-ui/react-menubar"
+      ],
       "files": [
         {
           "path": "registry/menubar/menubar.tsx",
@@ -333,7 +483,9 @@
       "type": "registry:ui",
       "title": "Navigation Menu",
       "description": "A navigation menu with dropdown support.",
-      "dependencies": ["@radix-ui/react-navigation-menu"],
+      "dependencies": [
+        "@radix-ui/react-navigation-menu"
+      ],
       "files": [
         {
           "path": "registry/navigation-menu/navigation-menu.tsx",
@@ -351,6 +503,9 @@
           "path": "registry/pagination/pagination.tsx",
           "type": "registry:ui"
         }
+      ],
+      "registryDependencies": [
+        "button"
       ]
     },
     {
@@ -358,7 +513,9 @@
       "type": "registry:ui",
       "title": "Popover",
       "description": "Displays rich content in a portal, triggered by a button.",
-      "dependencies": ["@radix-ui/react-popover"],
+      "dependencies": [
+        "@radix-ui/react-popover"
+      ],
       "files": [
         {
           "path": "registry/popover/popover.tsx",
@@ -371,7 +528,9 @@
       "type": "registry:ui",
       "title": "Progress",
       "description": "Displays an indicator showing the completion progress of a task.",
-      "dependencies": ["@radix-ui/react-progress"],
+      "dependencies": [
+        "@radix-ui/react-progress"
+      ],
       "files": [
         {
           "path": "registry/progress/progress.tsx",
@@ -384,7 +543,9 @@
       "type": "registry:ui",
       "title": "Radio Group",
       "description": "A set of checkable buttons where no more than one can be checked.",
-      "dependencies": ["@radix-ui/react-radio-group"],
+      "dependencies": [
+        "@radix-ui/react-radio-group"
+      ],
       "files": [
         {
           "path": "registry/radio-group/radio-group.tsx",
@@ -397,7 +558,9 @@
       "type": "registry:ui",
       "title": "Resizable",
       "description": "Accessible resizable panel groups and layouts.",
-      "dependencies": ["react-resizable-panels"],
+      "dependencies": [
+        "react-resizable-panels"
+      ],
       "files": [
         {
           "path": "registry/resizable/resizable.tsx",
@@ -410,7 +573,9 @@
       "type": "registry:ui",
       "title": "Scroll Area",
       "description": "Augments native scroll functionality for custom, cross-browser styling.",
-      "dependencies": ["@radix-ui/react-scroll-area"],
+      "dependencies": [
+        "@radix-ui/react-scroll-area"
+      ],
       "files": [
         {
           "path": "registry/scroll-area/scroll-area.tsx",
@@ -423,15 +588,24 @@
       "type": "registry:ui",
       "title": "Select",
       "description": "Displays a list of options for the user to pick from.",
-      "dependencies": ["@radix-ui/react-select"],
-      "files": [{ "path": "registry/select/select.tsx", "type": "registry:ui" }]
+      "dependencies": [
+        "@radix-ui/react-select"
+      ],
+      "files": [
+        {
+          "path": "registry/select/select.tsx",
+          "type": "registry:ui"
+        }
+      ]
     },
     {
       "name": "separator",
       "type": "registry:ui",
       "title": "Separator",
       "description": "Visually or semantically separates content.",
-      "dependencies": ["@radix-ui/react-separator"],
+      "dependencies": [
+        "@radix-ui/react-separator"
+      ],
       "files": [
         {
           "path": "registry/separator/separator.tsx",
@@ -444,23 +618,39 @@
       "type": "registry:ui",
       "title": "Sheet",
       "description": "Extends the Dialog component to display content that slides in.",
-      "dependencies": ["@radix-ui/react-dialog"],
-      "files": [{ "path": "registry/sheet/sheet.tsx", "type": "registry:ui" }]
+      "dependencies": [
+        "@radix-ui/react-dialog"
+      ],
+      "files": [
+        {
+          "path": "registry/sheet/sheet.tsx",
+          "type": "registry:ui"
+        }
+      ]
     },
     {
       "name": "shell",
       "type": "registry:ui",
       "title": "Shell",
       "description": "Provides UiPath authentication and renders children only when authenticated.",
-      "dependencies": ["@uipath/auth-react", "lucide-react", "framer-motion"],
+      "dependencies": [
+        "@uipath/auth-react",
+        "lucide-react",
+        "framer-motion"
+      ],
       "registryDependencies": [
         "button",
         "tooltip",
         "avatar",
-        "@uipath/use-local-storage"
+        "@uipath/use-local-storage",
+        "theme-provider",
+        "dropdown-menu"
       ],
       "files": [
-        { "path": "registry/shell/shell.tsx", "type": "registry:ui" },
+        {
+          "path": "registry/shell/shell.tsx",
+          "type": "registry:ui"
+        },
         {
           "path": "registry/shell/internal/shell-layout.tsx",
           "type": "registry:ui"
@@ -546,23 +736,40 @@
       "type": "registry:ui",
       "title": "Slider",
       "description": "An input where the user selects a value from within a given range.",
-      "dependencies": ["@radix-ui/react-slider"],
-      "files": [{ "path": "registry/slider/slider.tsx", "type": "registry:ui" }]
+      "dependencies": [
+        "@radix-ui/react-slider"
+      ],
+      "files": [
+        {
+          "path": "registry/slider/slider.tsx",
+          "type": "registry:ui"
+        }
+      ]
     },
     {
       "name": "sonner",
       "type": "registry:ui",
       "title": "Sonner",
       "description": "An opinionated toast component for React.",
-      "dependencies": ["sonner", "next-themes"],
-      "files": [{ "path": "registry/sonner/sonner.tsx", "type": "registry:ui" }]
+      "dependencies": [
+        "sonner",
+        "next-themes"
+      ],
+      "files": [
+        {
+          "path": "registry/sonner/sonner.tsx",
+          "type": "registry:ui"
+        }
+      ]
     },
     {
       "name": "spinner",
       "type": "registry:ui",
       "title": "Spinner",
       "description": "A loading spinner component.",
-      "dependencies": ["class-variance-authority"],
+      "dependencies": [
+        "class-variance-authority"
+      ],
       "files": [
         {
           "path": "registry/spinner/spinner.tsx",
@@ -575,23 +782,42 @@
       "type": "registry:ui",
       "title": "Switch",
       "description": "A control that allows the user to toggle between on and off.",
-      "dependencies": ["@radix-ui/react-switch"],
-      "files": [{ "path": "registry/switch/switch.tsx", "type": "registry:ui" }]
+      "dependencies": [
+        "@radix-ui/react-switch"
+      ],
+      "files": [
+        {
+          "path": "registry/switch/switch.tsx",
+          "type": "registry:ui"
+        }
+      ]
     },
     {
       "name": "table",
       "type": "registry:ui",
       "title": "Table",
       "description": "A responsive table component.",
-      "files": [{ "path": "registry/table/table.tsx", "type": "registry:ui" }]
+      "files": [
+        {
+          "path": "registry/table/table.tsx",
+          "type": "registry:ui"
+        }
+      ]
     },
     {
       "name": "tabs",
       "type": "registry:ui",
       "title": "Tabs",
       "description": "A set of layered sections of content shown one at a time.",
-      "dependencies": ["@radix-ui/react-tabs"],
-      "files": [{ "path": "registry/tabs/tabs.tsx", "type": "registry:ui" }]
+      "dependencies": [
+        "@radix-ui/react-tabs"
+      ],
+      "files": [
+        {
+          "path": "registry/tabs/tabs.tsx",
+          "type": "registry:ui"
+        }
+      ]
     },
     {
       "name": "textarea",
@@ -610,20 +836,32 @@
       "type": "registry:ui",
       "title": "Toggle",
       "description": "A two-state button that can be either on or off.",
-      "dependencies": ["@radix-ui/react-toggle"],
-      "files": [{ "path": "registry/toggle/toggle.tsx", "type": "registry:ui" }]
+      "dependencies": [
+        "@radix-ui/react-toggle"
+      ],
+      "files": [
+        {
+          "path": "registry/toggle/toggle.tsx",
+          "type": "registry:ui"
+        }
+      ]
     },
     {
       "name": "toggle-group",
       "type": "registry:ui",
       "title": "Toggle Group",
       "description": "A set of two-state buttons that can be toggled on or off.",
-      "dependencies": ["@radix-ui/react-toggle-group"],
+      "dependencies": [
+        "@radix-ui/react-toggle-group"
+      ],
       "files": [
         {
           "path": "registry/toggle-group/toggle-group.tsx",
           "type": "registry:ui"
         }
+      ],
+      "registryDependencies": [
+        "toggle"
       ]
     },
     {
@@ -631,7 +869,9 @@
       "type": "registry:ui",
       "title": "Tooltip",
       "description": "A popup that displays information related to an element.",
-      "dependencies": ["@radix-ui/react-tooltip"],
+      "dependencies": [
+        "@radix-ui/react-tooltip"
+      ],
       "files": [
         {
           "path": "registry/tooltip/tooltip.tsx",
@@ -656,8 +896,14 @@
       "type": "registry:ui",
       "title": "Theme Toggle",
       "description": "A dropdown menu component that allows users to toggle between light, dark, and system theme preferences.",
-      "dependencies": ["lucide-react"],
-      "registryDependencies": ["button", "dropdown-menu", "use-local-storage"],
+      "dependencies": [
+        "lucide-react"
+      ],
+      "registryDependencies": [
+        "button",
+        "dropdown-menu",
+        "use-local-storage"
+      ],
       "files": [
         {
           "path": "registry/theme-provider/theme-toggle.tsx",

--- a/apps/apollo-vertex/registry.json
+++ b/apps/apollo-vertex/registry.json
@@ -8,9 +8,7 @@
       "type": "registry:ui",
       "title": "Accordion",
       "description": "A vertically stacked set of interactive headings that reveal content.",
-      "dependencies": [
-        "@radix-ui/react-accordion"
-      ],
+      "dependencies": ["@radix-ui/react-accordion"],
       "files": [
         {
           "path": "registry/accordion/accordion.tsx",
@@ -35,27 +33,21 @@
       "type": "registry:ui",
       "title": "Alert Dialog",
       "description": "A modal dialog that interrupts the user with important content.",
-      "dependencies": [
-        "@radix-ui/react-alert-dialog"
-      ],
+      "dependencies": ["@radix-ui/react-alert-dialog"],
       "files": [
         {
           "path": "registry/alert-dialog/alert-dialog.tsx",
           "type": "registry:ui"
         }
       ],
-      "registryDependencies": [
-        "button"
-      ]
+      "registryDependencies": ["button"]
     },
     {
       "name": "aspect-ratio",
       "type": "registry:ui",
       "title": "Aspect Ratio",
       "description": "Displays content within a desired ratio.",
-      "dependencies": [
-        "@radix-ui/react-aspect-ratio"
-      ],
+      "dependencies": ["@radix-ui/react-aspect-ratio"],
       "files": [
         {
           "path": "registry/aspect-ratio/aspect-ratio.tsx",
@@ -68,9 +60,7 @@
       "type": "registry:ui",
       "title": "Avatar",
       "description": "An image element with a fallback for representing the user.",
-      "dependencies": [
-        "@radix-ui/react-avatar"
-      ],
+      "dependencies": ["@radix-ui/react-avatar"],
       "files": [
         {
           "path": "registry/avatar/avatar.tsx",
@@ -83,9 +73,7 @@
       "type": "registry:ui",
       "title": "Badge",
       "description": "Displays a badge or a component that looks like a badge.",
-      "dependencies": [
-        "@radix-ui/react-slot"
-      ],
+      "dependencies": ["@radix-ui/react-slot"],
       "files": [
         {
           "path": "registry/badge/badge.tsx",
@@ -98,9 +86,7 @@
       "type": "registry:ui",
       "title": "Breadcrumb",
       "description": "Displays the path to the current resource using a hierarchy of links.",
-      "dependencies": [
-        "@radix-ui/react-slot"
-      ],
+      "dependencies": ["@radix-ui/react-slot"],
       "files": [
         {
           "path": "registry/breadcrumb/breadcrumb.tsx",
@@ -113,9 +99,7 @@
       "type": "registry:ui",
       "title": "Button",
       "description": "Displays a button or a component that looks like a button.",
-      "dependencies": [
-        "@radix-ui/react-slot"
-      ],
+      "dependencies": ["@radix-ui/react-slot"],
       "files": [
         {
           "path": "registry/button/button.tsx",
@@ -134,28 +118,21 @@
           "type": "registry:ui"
         }
       ],
-      "registryDependencies": [
-        "separator"
-      ]
+      "registryDependencies": ["separator"]
     },
     {
       "name": "calendar",
       "type": "registry:ui",
       "title": "Calendar",
       "description": "A date field component that allows users to enter and edit date.",
-      "dependencies": [
-        "react-day-picker@latest",
-        "date-fns"
-      ],
+      "dependencies": ["react-day-picker@latest", "date-fns"],
       "files": [
         {
           "path": "registry/calendar/calendar.tsx",
           "type": "registry:ui"
         }
       ],
-      "registryDependencies": [
-        "button"
-      ]
+      "registryDependencies": ["button"]
     },
     {
       "name": "card",
@@ -174,28 +151,21 @@
       "type": "registry:ui",
       "title": "Carousel",
       "description": "A carousel with motion and swipe built using Embla.",
-      "dependencies": [
-        "embla-carousel-react"
-      ],
+      "dependencies": ["embla-carousel-react"],
       "files": [
         {
           "path": "registry/carousel/carousel.tsx",
           "type": "registry:ui"
         }
       ],
-      "registryDependencies": [
-        "button"
-      ]
+      "registryDependencies": ["button"]
     },
     {
       "name": "chart",
       "type": "registry:ui",
       "title": "Chart",
       "description": "Beautiful charts using Recharts with consistent theming.",
-      "dependencies": [
-        "recharts@2.15.4",
-        "lucide-react"
-      ],
+      "dependencies": ["recharts@2.15.4", "lucide-react"],
       "files": [
         {
           "path": "registry/chart/chart.tsx",
@@ -208,9 +178,7 @@
       "type": "registry:ui",
       "title": "Checkbox",
       "description": "A control that allows the user to toggle between checked and not checked.",
-      "dependencies": [
-        "@radix-ui/react-checkbox"
-      ],
+      "dependencies": ["@radix-ui/react-checkbox"],
       "files": [
         {
           "path": "registry/checkbox/checkbox.tsx",
@@ -223,9 +191,7 @@
       "type": "registry:ui",
       "title": "Collapsible",
       "description": "An interactive component which expands/collapses a panel.",
-      "dependencies": [
-        "@radix-ui/react-collapsible"
-      ],
+      "dependencies": ["@radix-ui/react-collapsible"],
       "files": [
         {
           "path": "registry/collapsible/collapsible.tsx",
@@ -238,27 +204,21 @@
       "type": "registry:ui",
       "title": "Command",
       "description": "A command menu for searching and executing commands.",
-      "dependencies": [
-        "cmdk"
-      ],
+      "dependencies": ["cmdk"],
       "files": [
         {
           "path": "registry/command/command.tsx",
           "type": "registry:ui"
         }
       ],
-      "registryDependencies": [
-        "dialog"
-      ]
+      "registryDependencies": ["dialog"]
     },
     {
       "name": "context-menu",
       "type": "registry:ui",
       "title": "Context Menu",
       "description": "Displays a menu located at the pointer, triggered by a right-click.",
-      "dependencies": [
-        "@radix-ui/react-context-menu"
-      ],
+      "dependencies": ["@radix-ui/react-context-menu"],
       "files": [
         {
           "path": "registry/context-menu/context-menu.tsx",
@@ -271,9 +231,7 @@
       "type": "registry:ui",
       "title": "Dialog",
       "description": "A modal dialog that appears in front of app content.",
-      "dependencies": [
-        "@radix-ui/react-dialog"
-      ],
+      "dependencies": ["@radix-ui/react-dialog"],
       "files": [
         {
           "path": "registry/dialog/dialog.tsx",
@@ -286,10 +244,7 @@
       "type": "registry:ui",
       "title": "Drawer",
       "description": "A drawer component that slides in from the edge of the screen.",
-      "dependencies": [
-        "vaul",
-        "@radix-ui/react-dialog"
-      ],
+      "dependencies": ["vaul", "@radix-ui/react-dialog"],
       "files": [
         {
           "path": "registry/drawer/drawer.tsx",
@@ -302,9 +257,7 @@
       "type": "registry:ui",
       "title": "Dropdown Menu",
       "description": "Displays a menu to the user triggered by a button.",
-      "dependencies": [
-        "@radix-ui/react-dropdown-menu"
-      ],
+      "dependencies": ["@radix-ui/react-dropdown-menu"],
       "files": [
         {
           "path": "registry/dropdown-menu/dropdown-menu.tsx",
@@ -335,10 +288,7 @@
           "type": "registry:ui"
         }
       ],
-      "registryDependencies": [
-        "label",
-        "separator"
-      ]
+      "registryDependencies": ["label", "separator"]
     },
     {
       "name": "form",
@@ -358,18 +308,14 @@
           "type": "registry:ui"
         }
       ],
-      "registryDependencies": [
-        "label"
-      ]
+      "registryDependencies": ["label"]
     },
     {
       "name": "hover-card",
       "type": "registry:ui",
       "title": "Hover Card",
       "description": "For sighted users to preview content available behind a link.",
-      "dependencies": [
-        "@radix-ui/react-hover-card"
-      ],
+      "dependencies": ["@radix-ui/react-hover-card"],
       "files": [
         {
           "path": "registry/hover-card/hover-card.tsx",
@@ -400,20 +346,14 @@
           "type": "registry:ui"
         }
       ],
-      "registryDependencies": [
-        "button",
-        "input",
-        "textarea"
-      ]
+      "registryDependencies": ["button", "input", "textarea"]
     },
     {
       "name": "input-otp",
       "type": "registry:ui",
       "title": "Input OTP",
       "description": "A one-time password input component.",
-      "dependencies": [
-        "input-otp"
-      ],
+      "dependencies": ["input-otp"],
       "files": [
         {
           "path": "registry/input-otp/input-otp.tsx",
@@ -432,9 +372,7 @@
           "type": "registry:ui"
         }
       ],
-      "registryDependencies": [
-        "separator"
-      ]
+      "registryDependencies": ["separator"]
     },
     {
       "name": "kbd",
@@ -453,9 +391,7 @@
       "type": "registry:ui",
       "title": "Label",
       "description": "Renders an accessible label associated with controls.",
-      "dependencies": [
-        "@radix-ui/react-label"
-      ],
+      "dependencies": ["@radix-ui/react-label"],
       "files": [
         {
           "path": "registry/label/label.tsx",
@@ -468,9 +404,7 @@
       "type": "registry:ui",
       "title": "Menubar",
       "description": "A horizontally stacked menu bar with dropdown submenus.",
-      "dependencies": [
-        "@radix-ui/react-menubar"
-      ],
+      "dependencies": ["@radix-ui/react-menubar"],
       "files": [
         {
           "path": "registry/menubar/menubar.tsx",
@@ -483,9 +417,7 @@
       "type": "registry:ui",
       "title": "Navigation Menu",
       "description": "A navigation menu with dropdown support.",
-      "dependencies": [
-        "@radix-ui/react-navigation-menu"
-      ],
+      "dependencies": ["@radix-ui/react-navigation-menu"],
       "files": [
         {
           "path": "registry/navigation-menu/navigation-menu.tsx",
@@ -504,18 +436,14 @@
           "type": "registry:ui"
         }
       ],
-      "registryDependencies": [
-        "button"
-      ]
+      "registryDependencies": ["button"]
     },
     {
       "name": "popover",
       "type": "registry:ui",
       "title": "Popover",
       "description": "Displays rich content in a portal, triggered by a button.",
-      "dependencies": [
-        "@radix-ui/react-popover"
-      ],
+      "dependencies": ["@radix-ui/react-popover"],
       "files": [
         {
           "path": "registry/popover/popover.tsx",
@@ -528,9 +456,7 @@
       "type": "registry:ui",
       "title": "Progress",
       "description": "Displays an indicator showing the completion progress of a task.",
-      "dependencies": [
-        "@radix-ui/react-progress"
-      ],
+      "dependencies": ["@radix-ui/react-progress"],
       "files": [
         {
           "path": "registry/progress/progress.tsx",
@@ -543,9 +469,7 @@
       "type": "registry:ui",
       "title": "Radio Group",
       "description": "A set of checkable buttons where no more than one can be checked.",
-      "dependencies": [
-        "@radix-ui/react-radio-group"
-      ],
+      "dependencies": ["@radix-ui/react-radio-group"],
       "files": [
         {
           "path": "registry/radio-group/radio-group.tsx",
@@ -558,9 +482,7 @@
       "type": "registry:ui",
       "title": "Resizable",
       "description": "Accessible resizable panel groups and layouts.",
-      "dependencies": [
-        "react-resizable-panels"
-      ],
+      "dependencies": ["react-resizable-panels"],
       "files": [
         {
           "path": "registry/resizable/resizable.tsx",
@@ -573,9 +495,7 @@
       "type": "registry:ui",
       "title": "Scroll Area",
       "description": "Augments native scroll functionality for custom, cross-browser styling.",
-      "dependencies": [
-        "@radix-ui/react-scroll-area"
-      ],
+      "dependencies": ["@radix-ui/react-scroll-area"],
       "files": [
         {
           "path": "registry/scroll-area/scroll-area.tsx",
@@ -588,9 +508,7 @@
       "type": "registry:ui",
       "title": "Select",
       "description": "Displays a list of options for the user to pick from.",
-      "dependencies": [
-        "@radix-ui/react-select"
-      ],
+      "dependencies": ["@radix-ui/react-select"],
       "files": [
         {
           "path": "registry/select/select.tsx",
@@ -603,9 +521,7 @@
       "type": "registry:ui",
       "title": "Separator",
       "description": "Visually or semantically separates content.",
-      "dependencies": [
-        "@radix-ui/react-separator"
-      ],
+      "dependencies": ["@radix-ui/react-separator"],
       "files": [
         {
           "path": "registry/separator/separator.tsx",
@@ -618,9 +534,7 @@
       "type": "registry:ui",
       "title": "Sheet",
       "description": "Extends the Dialog component to display content that slides in.",
-      "dependencies": [
-        "@radix-ui/react-dialog"
-      ],
+      "dependencies": ["@radix-ui/react-dialog"],
       "files": [
         {
           "path": "registry/sheet/sheet.tsx",
@@ -633,11 +547,7 @@
       "type": "registry:ui",
       "title": "Shell",
       "description": "Provides UiPath authentication and renders children only when authenticated.",
-      "dependencies": [
-        "@uipath/auth-react",
-        "lucide-react",
-        "framer-motion"
-      ],
+      "dependencies": ["@uipath/auth-react", "lucide-react", "framer-motion"],
       "registryDependencies": [
         "button",
         "tooltip",
@@ -736,9 +646,7 @@
       "type": "registry:ui",
       "title": "Slider",
       "description": "An input where the user selects a value from within a given range.",
-      "dependencies": [
-        "@radix-ui/react-slider"
-      ],
+      "dependencies": ["@radix-ui/react-slider"],
       "files": [
         {
           "path": "registry/slider/slider.tsx",
@@ -751,10 +659,7 @@
       "type": "registry:ui",
       "title": "Sonner",
       "description": "An opinionated toast component for React.",
-      "dependencies": [
-        "sonner",
-        "next-themes"
-      ],
+      "dependencies": ["sonner", "next-themes"],
       "files": [
         {
           "path": "registry/sonner/sonner.tsx",
@@ -767,9 +672,7 @@
       "type": "registry:ui",
       "title": "Spinner",
       "description": "A loading spinner component.",
-      "dependencies": [
-        "class-variance-authority"
-      ],
+      "dependencies": ["class-variance-authority"],
       "files": [
         {
           "path": "registry/spinner/spinner.tsx",
@@ -782,9 +685,7 @@
       "type": "registry:ui",
       "title": "Switch",
       "description": "A control that allows the user to toggle between on and off.",
-      "dependencies": [
-        "@radix-ui/react-switch"
-      ],
+      "dependencies": ["@radix-ui/react-switch"],
       "files": [
         {
           "path": "registry/switch/switch.tsx",
@@ -809,9 +710,7 @@
       "type": "registry:ui",
       "title": "Tabs",
       "description": "A set of layered sections of content shown one at a time.",
-      "dependencies": [
-        "@radix-ui/react-tabs"
-      ],
+      "dependencies": ["@radix-ui/react-tabs"],
       "files": [
         {
           "path": "registry/tabs/tabs.tsx",
@@ -836,9 +735,7 @@
       "type": "registry:ui",
       "title": "Toggle",
       "description": "A two-state button that can be either on or off.",
-      "dependencies": [
-        "@radix-ui/react-toggle"
-      ],
+      "dependencies": ["@radix-ui/react-toggle"],
       "files": [
         {
           "path": "registry/toggle/toggle.tsx",
@@ -851,27 +748,21 @@
       "type": "registry:ui",
       "title": "Toggle Group",
       "description": "A set of two-state buttons that can be toggled on or off.",
-      "dependencies": [
-        "@radix-ui/react-toggle-group"
-      ],
+      "dependencies": ["@radix-ui/react-toggle-group"],
       "files": [
         {
           "path": "registry/toggle-group/toggle-group.tsx",
           "type": "registry:ui"
         }
       ],
-      "registryDependencies": [
-        "toggle"
-      ]
+      "registryDependencies": ["toggle"]
     },
     {
       "name": "tooltip",
       "type": "registry:ui",
       "title": "Tooltip",
       "description": "A popup that displays information related to an element.",
-      "dependencies": [
-        "@radix-ui/react-tooltip"
-      ],
+      "dependencies": ["@radix-ui/react-tooltip"],
       "files": [
         {
           "path": "registry/tooltip/tooltip.tsx",
@@ -896,14 +787,8 @@
       "type": "registry:ui",
       "title": "Theme Toggle",
       "description": "A dropdown menu component that allows users to toggle between light, dark, and system theme preferences.",
-      "dependencies": [
-        "lucide-react"
-      ],
-      "registryDependencies": [
-        "button",
-        "dropdown-menu",
-        "use-local-storage"
-      ],
+      "dependencies": ["lucide-react"],
+      "registryDependencies": ["button", "dropdown-menu", "use-local-storage"],
       "files": [
         {
           "path": "registry/theme-provider/theme-toggle.tsx",

--- a/apps/apollo-vertex/registry.json
+++ b/apps/apollo-vertex/registry.json
@@ -8,7 +8,7 @@
       "type": "registry:ui",
       "title": "Accordion",
       "description": "A vertically stacked set of interactive headings that reveal content.",
-      "dependencies": ["@radix-ui/react-accordion"],
+      "dependencies": ["@radix-ui/react-accordion", "lucide-react"],
       "files": [
         {
           "path": "registry/accordion/accordion.tsx",
@@ -26,7 +26,8 @@
           "path": "registry/alert/alert.tsx",
           "type": "registry:ui"
         }
-      ]
+      ],
+      "dependencies": ["class-variance-authority"]
     },
     {
       "name": "alert-dialog",
@@ -73,7 +74,7 @@
       "type": "registry:ui",
       "title": "Badge",
       "description": "Displays a badge or a component that looks like a badge.",
-      "dependencies": ["@radix-ui/react-slot"],
+      "dependencies": ["@radix-ui/react-slot", "class-variance-authority"],
       "files": [
         {
           "path": "registry/badge/badge.tsx",
@@ -86,7 +87,7 @@
       "type": "registry:ui",
       "title": "Breadcrumb",
       "description": "Displays the path to the current resource using a hierarchy of links.",
-      "dependencies": ["@radix-ui/react-slot"],
+      "dependencies": ["@radix-ui/react-slot", "lucide-react"],
       "files": [
         {
           "path": "registry/breadcrumb/breadcrumb.tsx",
@@ -99,7 +100,7 @@
       "type": "registry:ui",
       "title": "Button",
       "description": "Displays a button or a component that looks like a button.",
-      "dependencies": ["@radix-ui/react-slot"],
+      "dependencies": ["@radix-ui/react-slot", "class-variance-authority"],
       "files": [
         {
           "path": "registry/button/button.tsx",
@@ -118,14 +119,15 @@
           "type": "registry:ui"
         }
       ],
-      "registryDependencies": ["separator"]
+      "registryDependencies": ["separator"],
+      "dependencies": ["class-variance-authority", "@radix-ui/react-slot"]
     },
     {
       "name": "calendar",
       "type": "registry:ui",
       "title": "Calendar",
       "description": "A date field component that allows users to enter and edit date.",
-      "dependencies": ["react-day-picker@latest", "date-fns"],
+      "dependencies": ["react-day-picker@latest", "date-fns", "lucide-react"],
       "files": [
         {
           "path": "registry/calendar/calendar.tsx",
@@ -151,7 +153,7 @@
       "type": "registry:ui",
       "title": "Carousel",
       "description": "A carousel with motion and swipe built using Embla.",
-      "dependencies": ["embla-carousel-react"],
+      "dependencies": ["embla-carousel-react", "lucide-react"],
       "files": [
         {
           "path": "registry/carousel/carousel.tsx",
@@ -178,7 +180,7 @@
       "type": "registry:ui",
       "title": "Checkbox",
       "description": "A control that allows the user to toggle between checked and not checked.",
-      "dependencies": ["@radix-ui/react-checkbox"],
+      "dependencies": ["@radix-ui/react-checkbox", "lucide-react"],
       "files": [
         {
           "path": "registry/checkbox/checkbox.tsx",
@@ -204,7 +206,7 @@
       "type": "registry:ui",
       "title": "Command",
       "description": "A command menu for searching and executing commands.",
-      "dependencies": ["cmdk"],
+      "dependencies": ["cmdk", "lucide-react"],
       "files": [
         {
           "path": "registry/command/command.tsx",
@@ -218,7 +220,7 @@
       "type": "registry:ui",
       "title": "Context Menu",
       "description": "Displays a menu located at the pointer, triggered by a right-click.",
-      "dependencies": ["@radix-ui/react-context-menu"],
+      "dependencies": ["@radix-ui/react-context-menu", "lucide-react"],
       "files": [
         {
           "path": "registry/context-menu/context-menu.tsx",
@@ -231,7 +233,7 @@
       "type": "registry:ui",
       "title": "Dialog",
       "description": "A modal dialog that appears in front of app content.",
-      "dependencies": ["@radix-ui/react-dialog"],
+      "dependencies": ["@radix-ui/react-dialog", "lucide-react"],
       "files": [
         {
           "path": "registry/dialog/dialog.tsx",
@@ -257,7 +259,7 @@
       "type": "registry:ui",
       "title": "Dropdown Menu",
       "description": "Displays a menu to the user triggered by a button.",
-      "dependencies": ["@radix-ui/react-dropdown-menu"],
+      "dependencies": ["@radix-ui/react-dropdown-menu", "lucide-react"],
       "files": [
         {
           "path": "registry/dropdown-menu/dropdown-menu.tsx",
@@ -275,7 +277,8 @@
           "path": "registry/empty/empty.tsx",
           "type": "registry:ui"
         }
-      ]
+      ],
+      "dependencies": ["class-variance-authority"]
     },
     {
       "name": "field",
@@ -288,7 +291,8 @@
           "type": "registry:ui"
         }
       ],
-      "registryDependencies": ["label", "separator"]
+      "registryDependencies": ["label", "separator"],
+      "dependencies": ["class-variance-authority"]
     },
     {
       "name": "form",
@@ -346,14 +350,15 @@
           "type": "registry:ui"
         }
       ],
-      "registryDependencies": ["button", "input", "textarea"]
+      "registryDependencies": ["button", "input", "textarea"],
+      "dependencies": ["class-variance-authority"]
     },
     {
       "name": "input-otp",
       "type": "registry:ui",
       "title": "Input OTP",
       "description": "A one-time password input component.",
-      "dependencies": ["input-otp"],
+      "dependencies": ["input-otp", "lucide-react"],
       "files": [
         {
           "path": "registry/input-otp/input-otp.tsx",
@@ -372,7 +377,8 @@
           "type": "registry:ui"
         }
       ],
-      "registryDependencies": ["separator"]
+      "registryDependencies": ["separator"],
+      "dependencies": ["class-variance-authority", "@radix-ui/react-slot"]
     },
     {
       "name": "kbd",
@@ -404,7 +410,7 @@
       "type": "registry:ui",
       "title": "Menubar",
       "description": "A horizontally stacked menu bar with dropdown submenus.",
-      "dependencies": ["@radix-ui/react-menubar"],
+      "dependencies": ["@radix-ui/react-menubar", "lucide-react"],
       "files": [
         {
           "path": "registry/menubar/menubar.tsx",
@@ -417,7 +423,11 @@
       "type": "registry:ui",
       "title": "Navigation Menu",
       "description": "A navigation menu with dropdown support.",
-      "dependencies": ["@radix-ui/react-navigation-menu"],
+      "dependencies": [
+        "@radix-ui/react-navigation-menu",
+        "lucide-react",
+        "class-variance-authority"
+      ],
       "files": [
         {
           "path": "registry/navigation-menu/navigation-menu.tsx",
@@ -436,7 +446,8 @@
           "type": "registry:ui"
         }
       ],
-      "registryDependencies": ["button"]
+      "registryDependencies": ["button"],
+      "dependencies": ["lucide-react"]
     },
     {
       "name": "popover",
@@ -469,7 +480,7 @@
       "type": "registry:ui",
       "title": "Radio Group",
       "description": "A set of checkable buttons where no more than one can be checked.",
-      "dependencies": ["@radix-ui/react-radio-group"],
+      "dependencies": ["@radix-ui/react-radio-group", "lucide-react"],
       "files": [
         {
           "path": "registry/radio-group/radio-group.tsx",
@@ -482,7 +493,7 @@
       "type": "registry:ui",
       "title": "Resizable",
       "description": "Accessible resizable panel groups and layouts.",
-      "dependencies": ["react-resizable-panels"],
+      "dependencies": ["react-resizable-panels", "lucide-react"],
       "files": [
         {
           "path": "registry/resizable/resizable.tsx",
@@ -508,7 +519,7 @@
       "type": "registry:ui",
       "title": "Select",
       "description": "Displays a list of options for the user to pick from.",
-      "dependencies": ["@radix-ui/react-select"],
+      "dependencies": ["@radix-ui/react-select", "lucide-react"],
       "files": [
         {
           "path": "registry/select/select.tsx",
@@ -534,7 +545,7 @@
       "type": "registry:ui",
       "title": "Sheet",
       "description": "Extends the Dialog component to display content that slides in.",
-      "dependencies": ["@radix-ui/react-dialog"],
+      "dependencies": ["@radix-ui/react-dialog", "lucide-react"],
       "files": [
         {
           "path": "registry/sheet/sheet.tsx",
@@ -659,7 +670,7 @@
       "type": "registry:ui",
       "title": "Sonner",
       "description": "An opinionated toast component for React.",
-      "dependencies": ["sonner", "next-themes"],
+      "dependencies": ["sonner", "next-themes", "lucide-react"],
       "files": [
         {
           "path": "registry/sonner/sonner.tsx",
@@ -672,7 +683,7 @@
       "type": "registry:ui",
       "title": "Spinner",
       "description": "A loading spinner component.",
-      "dependencies": ["class-variance-authority"],
+      "dependencies": ["class-variance-authority", "lucide-react"],
       "files": [
         {
           "path": "registry/spinner/spinner.tsx",
@@ -735,7 +746,7 @@
       "type": "registry:ui",
       "title": "Toggle",
       "description": "A two-state button that can be either on or off.",
-      "dependencies": ["@radix-ui/react-toggle"],
+      "dependencies": ["@radix-ui/react-toggle", "class-variance-authority"],
       "files": [
         {
           "path": "registry/toggle/toggle.tsx",
@@ -748,7 +759,10 @@
       "type": "registry:ui",
       "title": "Toggle Group",
       "description": "A set of two-state buttons that can be toggled on or off.",
-      "dependencies": ["@radix-ui/react-toggle-group"],
+      "dependencies": [
+        "@radix-ui/react-toggle-group",
+        "class-variance-authority"
+      ],
       "files": [
         {
           "path": "registry/toggle-group/toggle-group.tsx",

--- a/apps/apollo-vertex/scripts/validate-registry-deps.ts
+++ b/apps/apollo-vertex/scripts/validate-registry-deps.ts
@@ -1,0 +1,122 @@
+/**
+ * Validates that all dependencies in registry.json are properly declared.
+ *
+ * Checks:
+ * 1. All `registryDependencies` that are local (non-scoped) must exist in the registry
+ *    - Local: "button", "tooltip" → must exist as registry component names
+ *    - External: "@uipath/use-local-storage" → skipped (external registry references)
+ * 2. All `dependencies` reference packages in package.json (dependencies or devDependencies)
+ */
+
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+interface RegistryItem {
+  name: string;
+  dependencies?: string[];
+  registryDependencies?: string[];
+}
+
+interface Registry {
+  items: RegistryItem[];
+}
+
+interface PackageJson {
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+}
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const registryPath = join(__dirname, "../registry.json");
+const packageJsonPath = join(__dirname, "../package.json");
+
+function readJsonFile<T>(path: string, name: string): T {
+  let content: string;
+  try {
+    content = readFileSync(path, "utf-8");
+  } catch (error) {
+    console.error(`Failed to read ${name} at ${path}:`, (error as Error).message);
+    process.exit(1);
+  }
+
+  try {
+    return JSON.parse(content);
+  } catch (error) {
+    console.error(`Failed to parse ${name}:`, (error as Error).message);
+    process.exit(1);
+  }
+}
+
+function extractPackageName(dep: string): string {
+  // Handle version specifiers like "react-day-picker@latest" or "recharts@2.15.4"
+  const atIndex = dep.lastIndexOf("@");
+  // Check if @ is not the first character (scoped package like @radix-ui/react-slot)
+  if (atIndex > 0) {
+    return dep.substring(0, atIndex);
+  }
+  return dep;
+}
+
+function isScopedPackage(dep: string): boolean {
+  return dep.startsWith("@");
+}
+
+function main(): void {
+  const registry = readJsonFile<Registry>(registryPath, "registry.json");
+  const packageJson = readJsonFile<PackageJson>(packageJsonPath, "package.json");
+
+  const registryComponentNames = new Set(registry.items.map((item) => item.name));
+  const installedPackages = new Set([
+    ...Object.keys(packageJson.dependencies ?? {}),
+    ...Object.keys(packageJson.devDependencies ?? {}),
+  ]);
+
+  const errors: string[] = [];
+
+  for (const item of registry.items) {
+    // Check registryDependencies
+    if (item.registryDependencies) {
+      for (const dep of item.registryDependencies) {
+        if (isScopedPackage(dep)) {
+          // Scoped packages (e.g., @uipath/use-local-storage) are external registry
+          // references handled by shadcn CLI - skip validation
+          continue;
+        }
+        // Non-scoped names should be local registry components
+        if (!registryComponentNames.has(dep)) {
+          errors.push(
+            `Component "${item.name}" has registryDependency "${dep}" which does not exist in the registry`,
+          );
+        }
+      }
+    }
+
+    // Check dependencies (npm packages)
+    if (item.dependencies) {
+      for (const dep of item.dependencies) {
+        const packageName = extractPackageName(dep);
+        if (!installedPackages.has(packageName)) {
+          errors.push(
+            `Component "${item.name}" has dependency "${packageName}" which is not in package.json`,
+          );
+        }
+      }
+    }
+  }
+
+  if (errors.length > 0) {
+    console.error("Registry dependency validation failed:\n");
+    for (const error of errors) {
+      console.error(`  ✗ ${error}`);
+    }
+    console.error(`\n${errors.length} error(s) found.`);
+    process.exit(1);
+  }
+
+  console.log(
+    `✓ Registry dependency validation passed (${registry.items.length} components checked)`,
+  );
+}
+
+main();

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "lint:css": "turbo run lint:css",
     "lint:css:fix": "turbo run lint:css:fix",
     "lint:deps": "turbo run lint:deps",
+    "lint:registry-deps": "turbo run lint:registry-deps",
     "format": "turbo run format",
     "format:check": "turbo run format:check",
     "test": "turbo run test",

--- a/turbo.json
+++ b/turbo.json
@@ -28,6 +28,9 @@
     "lint:deps": {
       "outputs": []
     },
+    "lint:registry-deps": {
+      "outputs": []
+    },
     "format": {
       "cache": false
     },


### PR DESCRIPTION
## Summary

Add CI validation for apollo-vertex registry.json dependencies on every PR. The new `validate-registry-deps.ts` script ensures:
- Local registryDependencies reference existing components
- External scoped packages (@uipath/*) are recognized as external registry refs
- All npm dependencies exist in package.json

## Test plan

- Validation runs via `pnpm lint:registry-deps --affected` in PR checks
- Script detects missing local components and npm packages
- Supports external registry references with @scope prefixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)