### PR TITLE
docs(apollo-vertex): add Data Querying documentation

### DIFF
--- a/apps/apollo-vertex/app/_meta.ts
+++ b/apps/apollo-vertex/app/_meta.ts
@@ -1,5 +1,6 @@
 export default {
   index: "Introduction",
+  "data-querying": "Data Querying",
   "shadcn-components": "Shadcn Components",
   "vertex-components": "Vertex Components",
   themes: "Themes",

--- a/apps/apollo-vertex/app/data-querying/_meta.ts
+++ b/apps/apollo-vertex/app/data-querying/_meta.ts
@@ -1,0 +1,4 @@
+export default {
+  "loading-data": "Loading Data",
+  "mutating-data": "Mutating Data",
+};

--- a/apps/apollo-vertex/app/data-querying/loading-data/page.mdx
+++ b/apps/apollo-vertex/app/data-querying/loading-data/page.mdx
@@ -1,0 +1,189 @@
+# Loading Data
+
+Access your UiPath Data Service entities through reactive collections using the `useSolution` hook.
+
+## Overview
+
+The `useSolution` hook provides access to your data collections through the `api.collections` object. Each entity you've configured in your solution is available as a collection that supports live queries via TanStack DB.
+
+```tsx
+import { useSolution } from '@uipath/vs-core';
+
+function MyComponent() {
+  const { api } = useSolution();
+
+  // Access collections for any configured entity
+  const invoices = api.collections.Invoices;
+  const customers = api.collections.Customers;
+}
+```
+
+## Using useLiveQuery
+
+Collections integrate with TanStack DB's `useLiveQuery` hook for reactive data fetching. Changes to your data automatically update your UI.
+
+```tsx
+import { useSolution } from '@uipath/vs-core';
+import { useLiveQuery } from '@tanstack/react-db';
+
+function InvoicesList() {
+  const { api } = useSolution();
+
+  const { data: invoices, isLoading } = useLiveQuery(q =>
+    q.from({ invoices: api.collections.Invoices })
+  );
+
+  if (isLoading) return <div>Loading...</div>;
+
+  return (
+    <ul>
+      {invoices?.map(invoice => (
+        <li key={invoice.Id}>{invoice.InvoiceNumber}</li>
+      ))}
+    </ul>
+  );
+}
+```
+
+## Filtering Data
+
+Use the `where` clause with comparison operators to filter your queries:
+
+```tsx
+import { useLiveQuery, eq, gt, and } from '@tanstack/react-db';
+
+function PendingInvoices() {
+  const { api } = useSolution();
+
+  const { data: pendingInvoices } = useLiveQuery(q =>
+    q.from({ invoices: api.collections.Invoices })
+     .where(({ invoices }) => eq(invoices.Status, 'Pending'))
+  );
+
+  // Multiple conditions with and()
+  const { data: highValuePending } = useLiveQuery(q =>
+    q.from({ invoices: api.collections.Invoices })
+     .where(({ invoices }) =>
+       and(
+         eq(invoices.Status, 'Pending'),
+         gt(invoices.Amount, 1000)
+       )
+     )
+  );
+
+  return <div>{/* Render filtered data */}</div>;
+}
+```
+
+## Joining Collections
+
+Join entity collections with process data to combine related information:
+
+```tsx
+import { useLiveQuery, eq } from '@tanstack/react-db';
+
+function InvoicesWithProcessStatus() {
+  const { api } = useSolution();
+
+  const { data: result } = useLiveQuery(q => {
+    return q.from({ entities: api.collections.Invoices })
+      .join(
+        { processes: api.collections.processes.all },
+        ({ entities, processes }) =>
+          eq(entities.InternalInstanceId, processes?.instanceId),
+        "inner"
+      )
+      .select(({ entities, processes }) => ({
+        ...entities,
+        processStatus: processes?.Status,
+        processState: processes?.State,
+      }));
+  });
+
+  return <div>{/* Render joined data */}</div>;
+}
+```
+
+## Selecting Specific Fields
+
+Use `select` to transform or limit the fields returned:
+
+```tsx
+const { data: invoiceSummaries } = useLiveQuery(q =>
+  q.from({ invoices: api.collections.Invoices })
+   .select(({ invoices }) => ({
+     id: invoices.Id,
+     number: invoices.InvoiceNumber,
+     total: invoices.Amount,
+   }))
+);
+```
+
+## Querying Single Records
+
+Filter by ID to retrieve a specific record:
+
+```tsx
+function InvoiceDetail({ invoiceId }: { invoiceId: string }) {
+  const { api } = useSolution();
+
+  const { data: [invoice] = [] } = useLiveQuery(q =>
+    q.from({ invoices: api.collections.Invoices })
+     .where(({ invoices }) => eq(invoices.Id, invoiceId))
+  );
+
+  if (!invoice) return <div>Not found</div>;
+
+  return <div>{invoice.InvoiceNumber}</div>;
+}
+```
+
+## Process Collections
+
+Access process instance data through dedicated process collections:
+
+```tsx
+function ProcessesList() {
+  const { api } = useSolution();
+
+  // All process instances
+  const { data: allProcesses } = useLiveQuery(q =>
+    q.from({ processes: api.collections.processes.all })
+  );
+
+  // Named process collection (if configured)
+  const { data: invoiceProcesses } = useLiveQuery(q =>
+    q.from({ processes: api.collections.processes.InvoiceProcessing })
+  );
+
+  return <div>{/* Render process data */}</div>;
+}
+```
+
+## Direct Collection Access
+
+For non-reactive access, use the collection methods directly:
+
+```tsx
+async function loadData() {
+  const { api } = useSolution();
+
+  // Get all items as array
+  const items = await api.collections.Invoices.toArrayWhenReady();
+
+  // Get a specific item by key
+  const item = api.collections.Invoices.get('invoice-123');
+
+  // Check if item exists
+  const exists = api.collections.Invoices.has('invoice-123');
+
+  // Get collection size
+  const count = api.collections.Invoices.size;
+}
+```
+
+## Learn More
+
+For advanced query patterns and the full TanStack DB API, see the official documentation:
+
+- [TanStack DB Live Queries](https://tanstack.com/db/latest/docs/guides/live-queries)

--- a/apps/apollo-vertex/app/data-querying/mutating-data/page.mdx
+++ b/apps/apollo-vertex/app/data-querying/mutating-data/page.mdx
@@ -1,0 +1,246 @@
+# Mutating Data
+
+Create, update, and delete records in your UiPath Data Service entities using collection mutations.
+
+## Overview
+
+All data mutations are performed through the `api.collections.<entityName>` methods. The mutation interface follows TanStack DB patterns with `insert`, `update`, and `delete` operations that return transaction objects.
+
+```tsx
+import { useSolution } from '@uipath/vs-core';
+
+function MyComponent() {
+  const { api } = useSolution();
+
+  // Access mutation methods on any collection
+  const collection = api.collections.Invoices;
+
+  // collection.insert()
+  // collection.update()
+  // collection.delete()
+}
+```
+
+## Inserting Records
+
+Use `insert` to create new records in your collection:
+
+```tsx
+function CreateInvoice() {
+  const { api } = useSolution();
+
+  async function handleCreate() {
+    const tx = api.collections.Invoices.insert({
+      InvoiceNumber: 'INV-001',
+      Amount: 1500.00,
+      Status: 'Pending',
+      CustomerName: 'Acme Corp',
+    });
+
+    // Wait for the record to be persisted
+    await tx.isPersisted.promise;
+    console.log('Invoice created!');
+  }
+
+  return <button onClick={handleCreate}>Create Invoice</button>;
+}
+```
+
+### Inserting Multiple Records
+
+Pass an array to insert multiple records in a single transaction:
+
+```tsx
+async function bulkCreate() {
+  const { api } = useSolution();
+
+  const tx = api.collections.Invoices.insert([
+    { InvoiceNumber: 'INV-001', Amount: 1500.00, Status: 'Pending' },
+    { InvoiceNumber: 'INV-002', Amount: 2300.00, Status: 'Pending' },
+    { InvoiceNumber: 'INV-003', Amount: 800.00, Status: 'Pending' },
+  ]);
+
+  await tx.isPersisted.promise;
+}
+```
+
+## Updating Records
+
+Use `update` with a callback function to modify existing records. The callback receives a draft object that you can mutate directly:
+
+```tsx
+function UpdateInvoice({ invoiceId }: { invoiceId: string }) {
+  const { api } = useSolution();
+
+  async function handleStatusChange(newStatus: string) {
+    const tx = api.collections.Invoices.update(invoiceId, (draft) => {
+      draft.Status = newStatus;
+    });
+
+    await tx.isPersisted.promise;
+    console.log('Invoice updated!');
+  }
+
+  return (
+    <button onClick={() => handleStatusChange('Approved')}>
+      Approve Invoice
+    </button>
+  );
+}
+```
+
+### Updating Multiple Fields
+
+Modify any number of fields within the update callback:
+
+```tsx
+async function processInvoice(invoiceId: string) {
+  const { api } = useSolution();
+
+  const tx = api.collections.Invoices.update(invoiceId, (draft) => {
+    draft.Status = 'Processed';
+    draft.ProcessedAt = new Date().toISOString();
+    draft.ProcessedBy = 'current-user-id';
+  });
+
+  await tx.isPersisted.promise;
+}
+```
+
+### Updating Multiple Records
+
+Pass an array of keys to update multiple records:
+
+```tsx
+async function bulkApprove(invoiceIds: string[]) {
+  const { api } = useSolution();
+
+  const tx = api.collections.Invoices.update(invoiceIds, (drafts) => {
+    drafts.forEach(draft => {
+      draft.Status = 'Approved';
+      draft.ApprovedAt = new Date().toISOString();
+    });
+  });
+
+  await tx.isPersisted.promise;
+}
+```
+
+## Deleting Records
+
+Use `delete` to remove records from your collection:
+
+```tsx
+function DeleteInvoice({ invoiceId }: { invoiceId: string }) {
+  const { api } = useSolution();
+
+  async function handleDelete() {
+    const tx = api.collections.Invoices.delete(invoiceId);
+
+    await tx.isPersisted.promise;
+    console.log('Invoice deleted!');
+  }
+
+  return <button onClick={handleDelete}>Delete Invoice</button>;
+}
+```
+
+### Deleting Multiple Records
+
+Pass an array of keys to delete multiple records:
+
+```tsx
+async function bulkDelete(invoiceIds: string[]) {
+  const { api } = useSolution();
+
+  const tx = api.collections.Invoices.delete(invoiceIds);
+
+  await tx.isPersisted.promise;
+}
+```
+
+## Transaction Objects
+
+All mutation methods return a transaction object with useful properties:
+
+```tsx
+const tx = api.collections.Invoices.insert({ /* data */ });
+
+// Access the mutations in this transaction
+console.log(tx.mutations);
+
+// Wait for persistence to complete
+await tx.isPersisted.promise;
+```
+
+## Optimistic Updates
+
+Mutations are applied optimistically to the local state immediately. This means your UI updates instantly while the change is being persisted to the server in the background.
+
+```tsx
+function OptimisticExample() {
+  const { api } = useSolution();
+  const { data: invoices } = useLiveQuery(q =>
+    q.from({ invoices: api.collections.Invoices })
+  );
+
+  function handleUpdate(id: string) {
+    // UI updates immediately
+    api.collections.Invoices.update(id, (draft) => {
+      draft.Status = 'Updated';
+    });
+    // No need to await - the change is already reflected in `invoices`
+  }
+
+  return <div>{/* UI shows updated state immediately */}</div>;
+}
+```
+
+## Error Handling
+
+Handle persistence errors by catching the `isPersisted` promise:
+
+```tsx
+async function safeUpdate(invoiceId: string) {
+  const { api } = useSolution();
+
+  try {
+    const tx = api.collections.Invoices.update(invoiceId, (draft) => {
+      draft.Status = 'Approved';
+    });
+
+    await tx.isPersisted.promise;
+    console.log('Successfully persisted');
+  } catch (error) {
+    console.error('Failed to persist:', error);
+    // Handle error - the optimistic update may need to be reverted
+  }
+}
+```
+
+## Direct Entity SDK Methods
+
+For advanced use cases, you can also use the direct entity SDK methods:
+
+```tsx
+const { api } = useSolution();
+
+// Insert via entity SDK
+await api.entities.insertById('Invoices', [
+  { InvoiceNumber: 'INV-001', Amount: 1500.00 }
+]);
+
+// Update via entity SDK
+await api.entities.updateById('Invoices', [
+  { Id: 'invoice-123', InvoiceNumber: 'INV-001-UPDATED' }
+]);
+
+// Delete via entity SDK
+await api.entities.deleteById('Invoices', ['invoice-123', 'invoice-456']);
+```
+
+## Learn More
+
+For advanced mutation patterns and the full TanStack DB API, see the official documentation:
+
+- [TanStack DB Collections](https://tanstack.com/db/latest/docs/guides/collections)

--- a/apps/apollo-vertex/next-env.d.ts
+++ b/apps/apollo-vertex/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
## Summary

Add comprehensive documentation for the `useSolution` hook in apollo-vertex with two new guide pages:

- **Loading Data**: Covers accessing collections with `useSolution`, reactive queries with `useLiveQuery`, filtering, joining collections, and process data.
- **Mutating Data**: Covers insert/update/delete operations, transaction handling, optimistic updates, and error handling patterns.

Includes code examples demonstrating all major patterns and links to TanStack DB documentation for deeper learning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)