### PR TITLE
fix(apollo-react): delete vertical-rectangle type and support switch with square [MST-6216]

### DIFF
--- a/packages/apollo-react/src/canvas/components/BaseNode/BaseNode.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/BaseNode/BaseNode.stories.tsx
@@ -117,7 +117,7 @@ const sampleManifest: WorkflowManifest = {
       display: {
         label: 'Dynamic Handle Node',
         icon: 'git-branch',
-        shape: 'vertical-rectangle',
+        shape: 'square',
       },
       handleConfiguration: [
         {
@@ -401,7 +401,7 @@ function DynamicHandlesStory() {
             display: {
               label: 'Dynamic Handles',
               subLabel: `${nodeData.dynamicInputs.length} inputs, ${nodeData.dynamicOutputs.length} outputs`,
-              shape: 'vertical-rectangle',
+              shape: 'square',
             },
           },
         }),

--- a/packages/apollo-react/src/canvas/components/BaseNode/BaseNode.styles.ts
+++ b/packages/apollo-react/src/canvas/components/BaseNode/BaseNode.styles.ts
@@ -196,9 +196,9 @@ export const BaseIconWrapper = styled.div<{
   height: ${({ height, width, shape }) => {
     // Use 7/8 scaling for a vertical rectangle, and use default 3/4 scaling for other shapes
     const scaleFactor = height ? height / 96 : 1;
-    return height !== width && shape === 'vertical-rectangle'
+    return height !== width && shape !== 'rectangle' // True for only a expandable node
       ? `${84 * scaleFactor}px`
-      : `${72 * scaleFactor}px`
+      : `${72 * scaleFactor}px`;
   }};
   display: flex;
   align-items: center;

--- a/packages/apollo-react/src/canvas/components/BaseNode/BaseNode.tsx
+++ b/packages/apollo-react/src/canvas/components/BaseNode/BaseNode.tsx
@@ -135,12 +135,11 @@ const BaseNodeComponent = (props: NodeProps<Node<BaseNodeData>>) => {
 
     const leftRightHandles = Math.max(leftHandles, rightHandles);
 
-    if (leftRightHandles <= 3) return height;
     return Math.max(
       originalHeightRef.current ?? DEFAULT_NODE_SIZE,
       leftRightHandles * handleSpacing
     );
-  }, [height, handleConfigurations]);
+  }, [handleConfigurations]);
 
   // Sync computed height to node when it changes
   useEffect(() => {
@@ -168,11 +167,7 @@ const BaseNodeComponent = (props: NodeProps<Node<BaseNodeData>>) => {
   const displaySubLabel = display.subLabel;
   const displayLabelTooltip = display.labelTooltip as string | undefined;
   const displayLabelBackgroundColor = display.labelBackgroundColor as string | undefined;
-  const displayShape = (display.shape ?? 'square') as
-    | 'circle'
-    | 'square'
-    | 'rectangle'
-    | 'vertical-rectangle';
+  const displayShape = (display.shape ?? 'square') as 'circle' | 'square' | 'rectangle';
   const displayBackground = display.background;
   const displayColor = display.color;
   const displayIconBackground = display.iconBackground;
@@ -270,7 +265,6 @@ const BaseNodeComponent = (props: NodeProps<Node<BaseNodeData>>) => {
     showNotches,
     nodeWidth: width,
     nodeHeight: height,
-    isExpandable: displayShape === 'vertical-rectangle',
   });
 
   // Generate SmartHandle elements from handle configurations (opt-in)

--- a/packages/apollo-react/src/canvas/components/ButtonHandle/ButtonHandle.tsx
+++ b/packages/apollo-react/src/canvas/components/ButtonHandle/ButtonHandle.tsx
@@ -74,7 +74,6 @@ type ButtonHandleProps = {
   customPositionAndOffsets?: HandleConfigurationSpecificPosition;
   nodeWidth?: number;
   nodeHeight?: number;
-  isExpandable?: boolean;
 };
 
 const ButtonHandleBase = ({
@@ -97,7 +96,6 @@ const ButtonHandleBase = ({
   customPositionAndOffsets,
   nodeWidth,
   nodeHeight,
-  isExpandable,
 }: ButtonHandleProps) => {
   const [isHovered, setIsHovered] = useState(false);
   const isVertical = position === Position.Top || position === Position.Bottom;
@@ -110,14 +108,14 @@ const ButtonHandleBase = ({
 
     // If node size is available, use grid-aligned positioning
     if (relevantSize && relevantSize > 0) {
-      const gridPositions = calculateGridAlignedHandlePositions(relevantSize, total, isExpandable);
+      const gridPositions = calculateGridAlignedHandlePositions(relevantSize, total);
       const pixelPosition = gridPositions[index] ?? relevantSize / 2;
       return pixelToPercent(pixelPosition, relevantSize);
     }
 
     // Fallback to percentage-based positioning
     return ((index + 1) / (total + 1)) * 100;
-  }, [index, total, isVertical, nodeWidth, nodeHeight, isExpandable]);
+  }, [index, total, isVertical, nodeWidth, nodeHeight]);
 
   const handleButtonClick = useCallback(
     (event: React.MouseEvent) => {
@@ -230,7 +228,6 @@ const ButtonHandlesBase = ({
   shouldShowAddButtonFn = ({ showAddButton, selected }) => showAddButton && selected,
   nodeWidth,
   nodeHeight,
-  isExpandable,
 }: {
   nodeId: string;
   handles: ButtonHandleConfig[];
@@ -242,7 +239,6 @@ const ButtonHandlesBase = ({
   customPositionAndOffsets?: HandleConfigurationSpecificPosition;
   nodeWidth?: number;
   nodeHeight?: number;
-  isExpandable?: boolean;
 
   /**
    * Allows for consumers to control the predicate for showing the add button from the props that's passed in
@@ -288,7 +284,6 @@ const ButtonHandlesBase = ({
           customPositionAndOffsets={customPositionAndOffsets}
           nodeWidth={nodeWidth}
           nodeHeight={nodeHeight}
-          isExpandable={isExpandable}
         />
       ))}
     </>

--- a/packages/apollo-react/src/canvas/components/ButtonHandle/ButtonHandleStyleUtils.test.ts
+++ b/packages/apollo-react/src/canvas/components/ButtonHandle/ButtonHandleStyleUtils.test.ts
@@ -875,97 +875,48 @@ describe('ButtonHandleStyleUtils', () => {
     });
 
     it('should return center grid position for 1 handle', () => {
-      // 96px node: ideal position 48px (center), snaps to 48
       expect(calculateGridAlignedHandlePositions(96, 1)).toEqual([48]);
     });
 
-    it('should divide equally and snap for 2 handles', () => {
-      // 96px node: ideal positions 32px (96/3), 64px (2*96/3)
-      // 32 < center(48): floor → 32, 64 > center: ceil → 64
+    it('should calculate equidistant positions for 2 handles', () => {
+      // 2 handles: ideal spacing = 96/3 = 32, grid-aligned = 32, start = (96-32)/2 = 32
+      // Positions: 32, 64
       expect(calculateGridAlignedHandlePositions(96, 2)).toEqual([32, 64]);
     });
 
-    it('should divide equally and snap for 3 handles', () => {
-      // 96px node: ideal positions 24px, 48px, 72px
-      // 24 < center(48): floor(24/16)*16 = 16
-      // 48 = center: snap → 48
-      // 72 > center: ceil(72/16)*16 = 80
+    it('should calculate equidistant positions for 3 handles', () => {
+      // 3 handles: ideal spacing = 96/4 = 24, grid-aligned = round(24/16)*16 = 32
+      // totalSpan = 2*32 = 64, start = (96-64)/2 = 16
+      // Positions: 16, 48, 80
       expect(calculateGridAlignedHandlePositions(96, 3)).toEqual([16, 48, 80]);
     });
 
-    it('should divide equally and snap for 4 handles', () => {
-      // 96px node: ideal positions 19.2px, 38.4px, 57.6px, 76.8px
-      // 19.2 < 48: floor → 16, 38.4 < 48: floor → 32
-      // 57.6 > 48: ceil → 64, 76.8 > 48: ceil → 80
-      expect(calculateGridAlignedHandlePositions(96, 4)).toEqual([16, 32, 64, 80]);
+    it('should calculate equidistant positions for 4 handles', () => {
+      // 4 handles: ideal spacing = 96/5 = 19.2, grid-aligned = round(19.2/16)*16 = 16
+      // totalSpan = 3*16 = 48, start = (96-48)/2 = 24
+      // Positions: 24, 40, 56, 72, snapped: 32, 48, 64, 80
+      expect(calculateGridAlignedHandlePositions(96, 4)).toEqual([32, 48, 64, 80]);
     });
 
     it('should work with larger node sizes', () => {
-      // 160px node with 3 handles: ideal positions 40px, 80px, 120px
-      // center = 80px
-      // 40 < 80: floor(40/16)*16 = 32
-      // 80 = center: snap → 80
-      // 120 > 80: ceil(120/16)*16 = 128
+      // 160px node with 3 handles: ideal spacing = 160/4 = 40, grid-aligned = round(40/16)*16 = 48
+      // totalSpan = 2*48 = 96, start = (160-96)/2 = 32
+      // Positions: 32, 80, 128
       expect(calculateGridAlignedHandlePositions(160, 3)).toEqual([32, 80, 128]);
     });
 
     it('should use custom grid size', () => {
-      // 100px node with grid size 10: ideal positions 33.3px, 66.7px
-      // center = 50px
-      // 33.3 < 50: floor(33.3/10)*10 = 30
-      // 66.7 > 50: ceil(66.7/10)*10 = 70
-      // But default grid is 16, so: 33.3 < 50: floor(33.3/16)*16 = 32
-      // 66.7 > 50: ceil(66.7/16)*16 = 80
-      expect(calculateGridAlignedHandlePositions(100, 2, false, 10)).toEqual([30, 70]);
+      // 100px node with 2 handles, grid size 10: ideal spacing = 100/3 = 33.33
+      // grid-aligned = round(33.33/10)*10 = 30, totalSpan = 1*30 = 30, start = (100-30)/2 = 35
+      // Positions: 35, 65, snapped: 40, 70
+      expect(calculateGridAlignedHandlePositions(100, 2, 10)).toEqual([40, 70]);
     });
 
-    it('should handle 5 handles on a 96px node', () => {
-      // 96px node: ideal positions 16px, 32px, 48px, 64px, 80px
-      // 16 < 48: floor → 16, 32 < 48: floor → 32
-      // 48 = center: snap → 48
-      // 64 > 48: ceil → 64, 80 > 48: ceil → 80
+    it('should calculate equidistant positions for 5 handles', () => {
+      // 5 handles: ideal spacing = 96/6 = 16, grid-aligned = 16
+      // totalSpan = 4*16 = 64, start = (96-64)/2 = 16
+      // Positions: 16, 32, 48, 64, 80
       expect(calculateGridAlignedHandlePositions(96, 5)).toEqual([16, 32, 48, 64, 80]);
-    });
-
-    describe('with isExpandable=true', () => {
-      it('should center single handle when expandable', () => {
-        // 96px node: center = 48px, snaps to 48
-        expect(calculateGridAlignedHandlePositions(96, 1, true)).toEqual([48]);
-      });
-
-      it('should center multiple handles around middle when expandable', () => {
-        // 96px node: ideal spacing = 96/3 = 32px, snapped = 32px
-        // totalSpan = 32 * (2-1) = 32px
-        // startOffset = 48 - 32/2 = 32px
-        // positions: 32, 64 (snapped to grid)
-        expect(calculateGridAlignedHandlePositions(96, 2, true)).toEqual([32, 64]);
-      });
-
-      it('should center 3 handles around middle when expandable', () => {
-        // 96px node: ideal spacing = 96/4 = 24px, snapped = 32px (rounds up)
-        // totalSpan = 32 * (3-1) = 64px
-        // startOffset = 48 - 64/2 = 16px
-        // positions: 16, 48, 80 (snapped to grid)
-        expect(calculateGridAlignedHandlePositions(96, 3, true)).toEqual([16, 48, 80]);
-      });
-
-      it('should center 4 handles around middle when expandable', () => {
-        // 96px node: ideal spacing = 96/5 = 19.2px, snapped = 16px (rounds down)
-        // totalSpan = 16 * (4-1) = 48px
-        // startOffset = 48 - 48/2 = 24px
-        // positions: 24, 40, 56, 72 (snapped to grid: Math.round(24/16)*16=32, Math.round(40/16)*16=48, Math.round(56/16)*16=64, Math.round(72/16)*16=80)
-        const result = calculateGridAlignedHandlePositions(96, 4, true);
-        expect(result).toEqual([32, 48, 64, 80]);
-      });
-
-      it('should work with larger node sizes when expandable', () => {
-        // 160px node: center = 80px
-        // ideal spacing = 160/4 = 40px, snapped = Math.round(40/16)*16 = 48px (rounds up)
-        // totalSpan = 48 * (3-1) = 96px
-        // startOffset = 80 - 96/2 = 32px
-        // positions: 32, 80, 128 (snapped to grid: 32, 80, 128)
-        expect(calculateGridAlignedHandlePositions(160, 3, true)).toEqual([32, 80, 128]);
-      });
     });
   });
 

--- a/packages/apollo-react/src/canvas/components/ButtonHandle/ButtonHandleStyleUtils.ts
+++ b/packages/apollo-react/src/canvas/components/ButtonHandle/ButtonHandleStyleUtils.ts
@@ -25,70 +25,36 @@ export const snapToGrid = (value: number, gridSize: number = GRID_SPACING): numb
 };
 
 /**
- * Calculates grid-aligned positions for handles along a dimension.
- * Ensures even spacing between handles while aligning to grid.
+ * Calculates grid-aligned positions for handles that look equidistant and symmetric.
  * @param nodeSize - The size of the node in the relevant dimension (width for Top/Bottom handles, height for Left/Right handles)
  * @param numHandles - Number of handles to position
- * @param isExpandable - Whether the node is expandable (like switch)
  * @param gridSize - The grid size
  * @returns Array of grid-snapped pixel positions for each handle
  */
 export const calculateGridAlignedHandlePositions = (
   nodeSize: number,
   numHandles: number,
-  isExpandable: boolean = false,
   gridSize: number = GRID_SPACING
 ): number[] => {
   if (numHandles === 0) return [];
   if (nodeSize <= 0) return [];
 
-  const center = nodeSize / 2;
-
-  // Calculate ideal spacing between handles
-  // For numHandles handles, divide space into (numHandles + 1) equal parts
+  // Calculate ideal spacing for equidistant distribution
   const idealSpacing = nodeSize / (numHandles + 1);
 
-  // Snap the spacing to grid while maintaining even distribution
-  const snappedSpacing = Math.round(idealSpacing / gridSize) * gridSize;
+  // Find the best grid-aligned spacing (round to nearest multiple of gridSize)
+  // This ensures equal spacing between handles while staying on grid
+  const gridAlignedSpacing = Math.round(idealSpacing / gridSize) * gridSize;
+
+  const totalSpan = (numHandles - 1) * gridAlignedSpacing;
+
+  const startPosition = (nodeSize - totalSpan) / 2;
 
   const positions: number[] = [];
-
-  if (isExpandable) {
-    if (numHandles === 1) {
-      positions.push(snapToGrid(center));
-    } else {
-      // Calculate the total span needed for all handles
-      const totalSpan = snappedSpacing * (numHandles - 1);
-      const startOffset = center - totalSpan / 2;
-
-      // Generate positions centered around the middle
-      for (let i = 0; i < numHandles; i++) {
-        const idealPosition = startOffset + snappedSpacing * i;
-        // Snap to grid to ensure alignment
-        const snappedPosition = snapToGrid(idealPosition);
-        positions.push(snappedPosition);
-      }
-    }
-  } else {
-    for (let i = 0; i < numHandles; i++) {
-      // Calculate ideal position using equal division
-      const idealPosition = ((i + 1) / (numHandles + 1)) * nodeSize;
-
-      // Snap to grid, rounding away from center to spread handles out
-      let snappedPosition: number;
-      if (idealPosition < center) {
-        // Below center: round down
-        snappedPosition = Math.floor(idealPosition / gridSize) * gridSize;
-      } else if (idealPosition > center) {
-        // Above center: round up
-        snappedPosition = Math.ceil(idealPosition / gridSize) * gridSize;
-      } else {
-        // At center: snap to nearest
-        snappedPosition = snapToGrid(idealPosition, gridSize);
-      }
-
-      positions.push(snappedPosition);
-    }
+  for (let i = 0; i < numHandles; i++) {
+    const position = startPosition + i * gridAlignedSpacing;
+    const snappedPosition = snapToGrid(position, gridSize);
+    positions.push(snappedPosition);
   }
 
   return positions;

--- a/packages/apollo-react/src/canvas/components/ButtonHandle/useButtonHandles.tsx
+++ b/packages/apollo-react/src/canvas/components/ButtonHandle/useButtonHandles.tsx
@@ -18,7 +18,6 @@ export const useButtonHandles = ({
   shouldShowAddButtonFn,
   nodeWidth,
   nodeHeight,
-  isExpandable,
 }: {
   handleConfigurations: HandleGroupManifest[];
   shouldShowHandles: boolean;
@@ -29,7 +28,6 @@ export const useButtonHandles = ({
   showNotches?: boolean;
   nodeWidth?: number;
   nodeHeight?: number;
-  isExpandable?: boolean;
 
   /**
    * Allows for consumers to control the predicate for showing the add button from the props that's passed in
@@ -84,7 +82,6 @@ export const useButtonHandles = ({
           shouldShowAddButtonFn={shouldShowAddButtonFn}
           nodeWidth={nodeWidth}
           nodeHeight={nodeHeight}
-          isExpandable={isExpandable}
         />
       );
     });
@@ -102,7 +99,6 @@ export const useButtonHandles = ({
     shouldShowAddButtonFn,
     nodeWidth,
     nodeHeight,
-    isExpandable,
     node?.data,
   ]);
 

--- a/packages/apollo-react/src/canvas/schema/node-definition/node-manifest.ts
+++ b/packages/apollo-react/src/canvas/schema/node-definition/node-manifest.ts
@@ -12,7 +12,7 @@ import { handleGroupManifestSchema } from './handle';
 /**
  * Node shape for display
  */
-export const nodeShapeSchema = z.enum(['circle', 'square', 'rectangle', 'vertical-rectangle']);
+export const nodeShapeSchema = z.enum(['circle', 'square', 'rectangle']);
 
 /**
  * Display configuration for a node


### PR DESCRIPTION
### This PR

- Removes vertical-rectangle node shape and supports styling for it as a square node 

 ### Demo



https://github.com/user-attachments/assets/81d52d81-e95d-49f6-897c-9828f1face3c



