### PR TITLE
fix(apollo-react): fix icon width for rectangle nodes [AG-704]

### DIFF
--- a/apps/react-playground/vercel.json
+++ b/apps/react-playground/vercel.json
@@ -1,13 +1,13 @@
 {
-  "buildCommand": "cd ../.. && pnpm turbo build --filter=react-playground",
-  "installCommand": "cd ../.. && pnpm install",
-  "outputDirectory": "dist",
-  "framework": null,
-  "ignoreCommand": "git diff HEAD^ HEAD --quiet . && git diff HEAD^ HEAD --quiet ../../packages",
-  "rewrites": [
-    {
-      "source": "/(.*)",
-      "destination": "/index.html"
-    }
-  ]
+	"buildCommand": "cd ../.. && pnpm turbo build --filter=react-playground",
+	"installCommand": "cd ../.. && pnpm install",
+	"outputDirectory": "dist",
+	"framework": null,
+	"ignoreCommand": "git diff HEAD^ HEAD --quiet . && git diff HEAD^ HEAD --quiet ../../packages",
+	"rewrites": [
+		{
+			"source": "/(.*)",
+			"destination": "/index.html"
+		}
+	]
 }

--- a/packages/apollo-react/src/canvas/components/AgentCanvas/AgentFlow.tsx
+++ b/packages/apollo-react/src/canvas/components/AgentCanvas/AgentFlow.tsx
@@ -286,15 +286,20 @@ const AgentFlowInner = memo(
       closePaneContextMenu,
     } = useAgentFlowStore();
 
-    const nodeTypesBase = useMemo(() => ({
-      stickyNote: (props: StickyNoteNodeProps) => (
-        <StickyNoteNode
-          {...props}
-          placeholder={(stickyNoteNodeTranslations ?? DefaultStickyNoteNodeTranslations).placeholder}
-          renderPlaceholderOnSelect={true}
-        />
-      ),
-    }), [stickyNoteNodeTranslations]);
+    const nodeTypesBase = useMemo(
+      () => ({
+        stickyNote: (props: StickyNoteNodeProps) => (
+          <StickyNoteNode
+            {...props}
+            placeholder={
+              (stickyNoteNodeTranslations ?? DefaultStickyNoteNodeTranslations).placeholder
+            }
+            renderPlaceholderOnSelect={true}
+          />
+        ),
+      }),
+      [stickyNoteNodeTranslations]
+    );
 
     const { fitView: reactFlowFitView, screenToFlowPosition: reactFlowScreenToFlowPosition } =
       useReactFlow();

--- a/packages/apollo-react/src/canvas/components/BaseNode/BaseNode.styles.ts
+++ b/packages/apollo-react/src/canvas/components/BaseNode/BaseNode.styles.ts
@@ -187,16 +187,19 @@ export const BaseIconWrapper = styled.div<{
   height?: number;
   width?: number;
 }>`
-  width: ${({ width }) => {
-    const scaleFactor = width ? width / 96 : 1;
+  width: ${({ height, width, shape }) => {
+    // Use default 3/4 scaling, derived from the height for rectangle, and use width for other shapes
+    const dimension = height !== width && shape === 'rectangle' ? height : width;
+    const scaleFactor = dimension ? dimension / 96 : 1;
     return `${72 * scaleFactor}px`;
   }};
- height: ${({ height, width, shape }) => {
-   const scaleFactor = height ? height / 96 : 1;
-   return height !== width && shape === 'vertical-rectangle'
-     ? `${84 * scaleFactor}px` // Using 7/8 scaling for a vertical rectangle
-     : `${72 * scaleFactor}px`; // Using default 3/4 scaling for other shapes
- }}; 
+  height: ${({ height, width, shape }) => {
+    // Use 7/8 scaling for a vertical rectangle, and use default 3/4 scaling for other shapes
+    const scaleFactor = height ? height / 96 : 1;
+    return height !== width && shape === 'vertical-rectangle'
+      ? `${84 * scaleFactor}px`
+      : `${72 * scaleFactor}px`
+  }};
   display: flex;
   align-items: center;
   justify-content: center;

--- a/packages/apollo-react/src/canvas/components/StickyNoteNode/StickyNoteNode.tsx
+++ b/packages/apollo-react/src/canvas/components/StickyNoteNode/StickyNoteNode.tsx
@@ -34,7 +34,14 @@ export interface StickyNoteNodeProps extends NodeProps {
 const minWidth = GRID_SPACING * 8;
 const minHeight = GRID_SPACING * 8;
 
-const StickyNoteNodeComponent = ({ id, data, selected, dragging, placeholder = 'Add text', renderPlaceholderOnSelect = false }: StickyNoteNodeProps) => {
+const StickyNoteNodeComponent = ({
+  id,
+  data,
+  selected,
+  dragging,
+  placeholder = 'Add text',
+  renderPlaceholderOnSelect = false,
+}: StickyNoteNodeProps) => {
   const { updateNodeData } = useReactFlow();
   const [isEditing, setIsEditing] = useState(data.autoFocus ?? false);
   const [isResizing, setIsResizing] = useState(false);

--- a/packages/apollo-react/src/canvas/utils/auto-layout.ts
+++ b/packages/apollo-react/src/canvas/utils/auto-layout.ts
@@ -171,7 +171,11 @@ const arrangeAgent = (
         }
 
         // Right-side resources (Tool/MCP: bottom-right, Escalation: top-right)
-        if (handleId === ResourceNodeType.Tool || handleId === ResourceNodeType.MCP || handleId === ResourceNodeType.Escalation) {
+        if (
+          handleId === ResourceNodeType.Tool ||
+          handleId === ResourceNodeType.MCP ||
+          handleId === ResourceNodeType.Escalation
+        ) {
           handleCenterX = agentCenterX + GROUP_SPACING * 1.5;
         }
 

--- a/packages/apollo-react/src/material/components/ap-chat/components/history/chat-history-item.tsx
+++ b/packages/apollo-react/src/material/components/ap-chat/components/history/chat-history-item.tsx
@@ -8,7 +8,11 @@ import { ApTypography } from '../../../ap-typography';
 import { useChatService } from '../../providers/chat-service.provider';
 import { useChatState } from '../../providers/chat-state-provider';
 import { useLoading } from '../../providers/loading-provider';
-import { AutopilotChatEvent, AutopilotChatPreHookAction, type AutopilotChatHistory } from '../../service';
+import {
+  AutopilotChatEvent,
+  AutopilotChatPreHookAction,
+  type AutopilotChatHistory,
+} from '../../service';
 import { AutopilotChatActionButton } from '../common/action-button';
 
 const GroupItem = styled('div')<{ isActive: boolean; showRemoveIcon: boolean }>(
@@ -153,15 +157,16 @@ const AutopilotChatHistoryItemComponent: React.FC<AutopilotChatHistoryItemProps>
 
       if (!chatService) {
         return;
-    }
+      }
 
-    chatService.getPreHook(AutopilotChatPreHookAction.DeleteConversation)({ conversationId: itemId })
-      .then((proceed) => {
-        if (!proceed) {
-          return;
-        }
-        chatService.deleteConversation(itemId);
-      });
+      chatService
+        .getPreHook(AutopilotChatPreHookAction.DeleteConversation)({ conversationId: itemId })
+        .then((proceed) => {
+          if (!proceed) {
+            return;
+          }
+          chatService.deleteConversation(itemId);
+        });
     },
     [chatService]
   );


### PR DESCRIPTION
- 2nd commit is just me running the format command

**BEFORE**
<img width="1218" height="651" alt="Screenshot 2026-01-26 at 11 10 41 AM" src="https://github.com/user-attachments/assets/4a2c4d53-5e59-4aa0-92f7-c49e22ec9b36" />
<img width="2430" height="1320" alt="Screenshot 2026-01-26 at 10 58 04 AM" src="https://github.com/user-attachments/assets/9d97db0b-2259-4d5a-9717-f779bc481be1" />


**AFTER**

https://github.com/user-attachments/assets/167641bb-6c73-4898-87df-0a2470e6f2b5

