### PR TITLE
feat(apollo-react): Ap-Popover component implementation PLT-95438

### DIFF
--- a/apps/react-playground/package.json
+++ b/apps/react-playground/package.json
@@ -29,6 +29,7 @@
 		"react": "19.2.3",
 		"react-dom": "19.2.3",
 		"react-router-dom": "^7.12.0",
+		"react-syntax-highlighter": "^16.1.0",
 		"styled-components": "^6.1.19"
 	},
 	"devDependencies": {
@@ -37,6 +38,7 @@
 		"@rsbuild/plugin-react": "^1.4.1",
 		"@types/react": "^19.2.6",
 		"@types/react-dom": "^19.2.2",
+		"@types/react-syntax-highlighter": "^15.5.13",
 		"@types/styled-components": "^5.1.36",
 		"typescript": "^5.9.3"
 	}

--- a/apps/react-playground/src/App.tsx
+++ b/apps/react-playground/src/App.tsx
@@ -16,6 +16,7 @@ import { MaterialHome } from "./pages/MaterialHome";
 import { Screens } from "./pages/Screens";
 import { Shadows } from "./pages/Shadows";
 import { Spacing } from "./pages/Spacing";
+import { PopoverShowcase } from "./pages/components/PopoverShowcase";
 import { AccordionShowcase } from "./pages/components/AccordionShowcase";
 import { AlertBarShowcase } from "./pages/components/AlertBarShowcase";
 import { ApChatShowcase } from "./pages/components/ApChatShowcase";
@@ -155,6 +156,7 @@ function App() {
 							<Route path="/components/chat" element={<ApChatShowcase />} />
 							<Route path="/components/chip" element={<ChipShowcase />} />
 							<Route path="/components/link" element={<LinkShowcase />} />
+							<Route path="/components/popover" element={<PopoverShowcase />} />
 							<Route
 								path="/components/skeleton"
 								element={<SkeletonShowcase />}

--- a/apps/react-playground/src/components/Breadcrumb.tsx
+++ b/apps/react-playground/src/components/Breadcrumb.tsx
@@ -61,6 +61,7 @@ export function Breadcrumb() {
 		badge: "Badge",
 		button: "Button",
 		chat: "Chat",
+		popover: "Popover",
 		"text-area": "Text Area",
 		"tool-call": "Tool Call",
 		"tree-view": "Tree View",

--- a/apps/react-playground/src/components/CodeBlock.tsx
+++ b/apps/react-playground/src/components/CodeBlock.tsx
@@ -1,0 +1,89 @@
+import { useEffect, useRef, useState } from "react";
+import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
+import { coldarkDark } from "react-syntax-highlighter/dist/esm/styles/prism";
+
+export interface CodeBlockProps {
+	children: string;
+	language?: 'tsx' | 'javascript' | 'json' | 'css' | 'html';
+	showLineNumbers?: boolean;
+}
+
+export function CodeBlock({
+	children,
+	language = "tsx",
+	showLineNumbers = true,
+}: CodeBlockProps) {
+	const [status, setStatus] = useState<"idle" | "copied" | "error">("idle");
+	const timeoutRef = useRef<number | null>(null);
+
+	const code = children.trim();
+
+	async function copyToClipboard() {
+		try {
+			if (!navigator.clipboard?.writeText) {
+				throw new Error("Clipboard API not supported");
+			}
+
+			await navigator.clipboard.writeText(code);
+			setStatus("copied");
+
+			timeoutRef.current = window.setTimeout(() => setStatus("idle"), 1500);
+		} catch {
+			setStatus("error");
+			timeoutRef.current = window.setTimeout(() => setStatus("idle"), 1500);
+			console.error("Failed to copy code to clipboard");
+		}
+	}
+
+	useEffect(() => {
+		return () => {
+			if (timeoutRef.current !== null) {
+				clearTimeout(timeoutRef.current);
+			}
+		};
+	}, []);
+
+	const label =
+		status === "copied" ? "Copied!" : status === "error" ? "Error" : "Copy";
+
+	return (
+		<div style={{ position: "relative" }}>
+			<button
+				type="button"
+				onClick={copyToClipboard}
+				style={{
+					position: "absolute",
+					top: 14,
+					right: 14,
+					padding: "4px 8px",
+					fontSize: 12,
+					cursor: "pointer",
+					borderRadius: 4,
+					border: "none",
+					background:
+						status === "copied"
+							? "#22c55e"
+							: status === "error"
+								? "#ef4444"
+								: "#374151",
+					color: "#fff",
+				}}
+			>
+				{label}
+			</button>
+
+			<SyntaxHighlighter
+				language={language}
+				style={coldarkDark}
+				showLineNumbers={showLineNumbers}
+				customStyle={{
+					borderRadius: 8,
+					fontSize: 14,
+					margin: 0,
+				}}
+			>
+				{code}
+			</SyntaxHighlighter>
+		</div>
+	);
+}

--- a/apps/react-playground/src/components/Sidebar.tsx
+++ b/apps/react-playground/src/components/Sidebar.tsx
@@ -58,6 +58,7 @@ export function Sidebar() {
 				{ label: "Icon Button", path: "/components/icon-button" },
 				{ label: "Link", path: "/components/link" },
 				{ label: "Menu", path: "/components/menu" },
+				{ label: "Popover", path: "/components/popover" },
 				{ label: "Progress Spinner", path: "/components/progress-spinner" },
 				{ label: "Sankey Diagram", path: "/components/sankey-diagram" },
 				{ label: "Skeleton", path: "/components/skeleton" },

--- a/apps/react-playground/src/pages/ComponentsHome.tsx
+++ b/apps/react-playground/src/pages/ComponentsHome.tsx
@@ -28,6 +28,7 @@ export function ComponentsHome() {
 		},
 		{ label: "Icon", path: "/components/icon", icon: "⭐" },
 		{ label: "Icon Button", path: "/components/icon-button", icon: "🎯" },
+		{ label: "Popover", path: "/components/popover", icon: "📋" },
 		{ label: "Link", path: "/components/link", icon: "🔗" },
 		{ label: "Menu", path: "/components/menu", icon: "☰" },
 		{

--- a/apps/react-playground/src/pages/components/PopoverShowcase.tsx
+++ b/apps/react-playground/src/pages/components/PopoverShowcase.tsx
@@ -1,0 +1,282 @@
+import {
+	ApAccordion,
+	ApButton,
+	ApPopover,
+} from "@uipath/apollo-react/material/components";
+import styled from "styled-components";
+import { CodeBlock } from "../../components/CodeBlock";
+
+import {
+	PageContainer,
+	PageDescription,
+	PageTitle,
+} from "../../components/SharedStyles";
+import { useState } from "react";
+
+const ShowcaseSection = styled.div`
+	margin-top: 48px;
+	display: flex;
+	flex-direction: column;
+	gap: 24px;
+`;
+
+const SectionTitle = styled.h3`
+	font-size: 20px;
+	color: var(--color-primary);
+	margin-bottom: 16px;
+	border-bottom: 2px solid var(--color-border);
+	padding-bottom: 8px;
+`;
+
+const ComponentRow = styled.div`
+	display: flex;
+	flex-direction: column;
+	padding: 24px;
+	background: var(--color-background);
+	border-radius: 12px;
+	border: 2px solid var(--color-border);
+`;
+
+const Label = styled.div`
+	font-size: 14px;
+	color: var(--color-foreground-de-emp);
+	font-weight: 600;
+	margin-bottom: 8px;
+`;
+
+const defaultExampleCode = `
+import { ApPopover, ApButton } from "@uipath/apollo-react/material/components";
+
+export function Example() {
+	const [anchorEl, setAnchorEl] =  React.useState<null | HTMLButtonElement>(null);
+
+	const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+		setAnchorEl(event.currentTarget);
+	};
+
+	const handleClose = () => {
+		setAnchorEl(null);
+	};
+
+	const open = Boolean(anchorEl);
+
+	return (
+		<div>
+			<ApButton 
+				aria-describedby="simple-popover" 
+				onClick={handleClick} 
+				label="Show Popover"
+				type="button" 
+			/>
+
+			<ApPopover
+				anchorEl={anchorEl}
+				open={open}
+				id='simple-popover'
+				onClose={handleClose}
+				>
+				<div style={{ padding: "16px", maxWidth: "200px" }}>
+					This is a basic popover example positioned below and to the left
+					of the anchor point.
+				</div>
+			</ApPopover>
+		</div>
+	);
+}
+	`;
+
+const customPositioningCode = `
+import { ApPopover, ApButton } from "@uipath/apollo-react/material/components";
+
+export function Example() {
+	const [anchorEl, setAnchorEl] =  React.useState<null | HTMLButtonElement>(null);
+
+	const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+		setAnchorEl(event.currentTarget);
+	};
+
+	const handleClose = () => {
+		setAnchorEl(null);
+	};
+
+	const open = Boolean(anchorEl);
+
+	return (
+		<div>
+			<ApButton
+				aria-describedby="custom-popover"
+				onClick={handleClick}
+				label="Show Popover"
+				type="button"
+			/>
+
+			<ApPopover
+				anchorEl={anchorEl}
+				open={open}
+				id="custom-popover"
+				onClose={handleClose}
+				anchorOrigin={{ vertical: "top", horizontal: "right" }}
+				transformOrigin={{ vertical: "bottom", horizontal: "left" }}
+			>
+				<div style={{ padding: "16px", maxWidth: "200px" }}>
+					This popover is positioned above and to the right of the anchor
+					point.
+				</div>
+			</ApPopover>
+		</div>
+	);
+}
+	`;
+
+const positionOffsetsCode = `
+import { ApPopover, ApButton } from "@uipath/apollo-react/material/components";
+
+export function Example() {
+	const [anchorEl, setAnchorEl] =  React.useState<null | HTMLButtonElement>(null);
+
+	const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+		setAnchorEl(event.currentTarget);
+	};
+
+	const handleClose = () => {
+		setAnchorEl(null);
+	};
+
+	const open = Boolean(anchorEl);
+
+	return (
+		<div>
+			<ApButton
+				aria-describedby="offset-popover"
+				onClick={() => setPopover3(true)}
+				label="Show Popover"
+				type="button"
+			/>
+
+			<ApPopover
+				open={popover3}
+				id="offset-popover"
+				onClose={() => setPopover3(false)}
+				anchorPosition={{ top: 20, left: 50 }}
+			>
+				<div style={{ padding: "16px", maxWidth: "200px" }}>
+					This popover is offset by 20px vertically and 50px horizontally
+					from application area.
+				</div>
+	);
+}
+	`;
+
+export function PopoverShowcase() {
+	const [anchorEl1, setAnchorEl1] = useState<null | HTMLButtonElement>(null);
+	const [anchorEl2, setAnchorEl2] = useState<null | HTMLButtonElement>(null);
+	const [popover3, setPopover3] = useState<boolean>(false);
+	return (
+		<PageContainer>
+			<PageTitle>Popover</PageTitle>
+			<PageDescription>
+				Popovers are floating elements that display content when triggered by a
+				user action. They provide contextual information or options, enhancing
+				user interaction without navigating away from the current page.
+			</PageDescription>
+
+			<ShowcaseSection>
+				<SectionTitle>Default</SectionTitle>
+				<ComponentRow>
+					<div>
+						<ApButton
+							aria-describedby="simple-popover"
+							onClick={(e: React.MouseEvent<HTMLButtonElement>) =>
+								setAnchorEl1(e.currentTarget)
+							}
+							label="Show Popover"
+							type="button"
+						/>
+
+						<ApPopover
+							anchorEl={anchorEl1}
+							open={Boolean(anchorEl1)}
+							id="simple-popover"
+							onClose={() => setAnchorEl1(null)}
+						>
+							<div style={{ padding: "16px", maxWidth: "200px" }}>
+								This is a basic popover example positioned below and to the left
+								of the anchor point.
+							</div>
+						</ApPopover>
+					</div>
+					<br />
+					<Label>Code Example:</Label>
+					<ApAccordion label="Default Component" disableDivider>
+						<CodeBlock>{defaultExampleCode}</CodeBlock>
+					</ApAccordion>
+				</ComponentRow>
+
+				<SectionTitle>Customization</SectionTitle>
+				<ComponentRow>
+					<Label> Anchor Position and Transform Origin</Label>
+					<div>
+						<ApButton
+							aria-describedby="custom-popover"
+							onClick={(e: React.MouseEvent<HTMLButtonElement>) =>
+								setAnchorEl2(e.currentTarget)
+							}
+							label="Show Popover"
+							type="button"
+						/>
+
+						<ApPopover
+							anchorEl={anchorEl2}
+							open={Boolean(anchorEl2)}
+							id="custom-popover"
+							onClose={() => setAnchorEl2(null)}
+							anchorOrigin={{ vertical: "top", horizontal: "right" }}
+							transformOrigin={{ vertical: "bottom", horizontal: "left" }}
+						>
+							<div style={{ padding: "16px", maxWidth: "200px" }}>
+								This popover is positioned above and to the right of the anchor
+								point.
+							</div>
+						</ApPopover>
+					</div>
+					<br />
+
+					<Label>Code Example:</Label>
+					<ApAccordion label="Custom Positioning" disableDivider>
+						<CodeBlock>{customPositioningCode}</CodeBlock>
+					</ApAccordion>
+				</ComponentRow>
+
+				<ComponentRow>
+					<Label> Popover Position Offsets</Label>
+					<div>
+						<ApButton
+							aria-describedby="offset-popover"
+							onClick={() => setPopover3(true)}
+							label="Show Popover"
+							type="button"
+						/>
+
+						<ApPopover
+							open={popover3}
+							id="offset-popover"
+							onClose={() => setPopover3(false)}
+							anchorPosition={{ top: 20, left: 50 }}
+						>
+							<div style={{ padding: "16px", maxWidth: "200px" }}>
+								This popover is offset by 20px vertically and 50px horizontally
+								from application area.
+							</div>
+						</ApPopover>
+					</div>
+					<br />
+
+					<Label>Code Example:</Label>
+					<ApAccordion label="Popover Position Offsets" disableDivider>
+						<CodeBlock>{positionOffsetsCode}</CodeBlock>
+					</ApAccordion>
+				</ComponentRow>
+			</ShowcaseSection>
+		</PageContainer>
+	);
+}

--- a/packages/apollo-react/src/material/components/ap-popover/ApPopover.test.tsx
+++ b/packages/apollo-react/src/material/components/ap-popover/ApPopover.test.tsx
@@ -1,0 +1,175 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useState } from 'react';
+import { describe, expect, it } from 'vitest';
+import { ApPopover } from './ApPopover';
+
+describe('ApPopover', () => {
+  it('renders the popover when open is true', () => {
+    render(
+      <ApPopover open={true} anchorEl={document.body}>
+        <div>Popover Content</div>
+      </ApPopover>
+    );
+
+    expect(screen.getByText('Popover Content')).toBeInTheDocument();
+  });
+
+  it('does not render the popover when open is false', () => {
+    render(
+      <ApPopover open={false} anchorEl={document.body}>
+        <div>Popover Content</div>
+      </ApPopover>
+    );
+
+    expect(screen.queryByText('Popover Content')).not.toBeInTheDocument();
+  });
+
+  it('calls onClose when clicking outside the popover', async () => {
+    const TestComponent = () => {
+      const [anchorEl, setAnchorEl] = useState<null | HTMLButtonElement>(null);
+
+      const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+        setAnchorEl(event.currentTarget);
+      };
+      const handleClose = () => {
+        setAnchorEl(null);
+      };
+
+      const open = Boolean(anchorEl);
+
+      return (
+        <div>
+          <button data-testid="anchor-button" onClick={handleClick}>
+            Open Popover
+          </button>
+          <ApPopover open={open} anchorEl={anchorEl} onClose={handleClose}>
+            <div>Popover Content</div>
+          </ApPopover>
+        </div>
+      );
+    };
+
+    render(<TestComponent />);
+
+    const anchorButton = screen.getByTestId('anchor-button');
+    // Initially , the popover should not be in the document
+    expect(screen.queryByText('Popover Content')).not.toBeInTheDocument();
+    // Click the button to open the popover
+    await userEvent.click(anchorButton);
+    // Now the popover should be in the document
+    expect(screen.getByText('Popover Content')).toBeInTheDocument();
+    // Click the backdrop to close the popover
+    const backdrop = document.querySelector('.MuiBackdrop-root');
+    if (backdrop) {
+      fireEvent.click(backdrop);
+    }
+
+    await waitFor(() => {
+      expect(screen.queryByText('Popover Content')).not.toBeInTheDocument();
+    });
+  });
+
+  it('Opens and closes the popover based on click events', async () => {
+    const TestComponent = () => {
+      const [anchorEl, setAnchorEl] = useState<null | HTMLButtonElement>(null);
+
+      const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+        setAnchorEl(event.currentTarget);
+      };
+      const handleClose = () => {
+        setAnchorEl(null);
+      };
+
+      const open = Boolean(anchorEl);
+
+      return (
+        <div>
+          <button data-testid="anchor-button" onClick={handleClick}>
+            Open Popover
+          </button>
+          <ApPopover open={open} anchorEl={anchorEl} onClose={handleClose}>
+            <div>Popover Content</div>
+          </ApPopover>
+        </div>
+      );
+    };
+
+    render(<TestComponent />);
+    const anchorButton = screen.getByTestId('anchor-button');
+
+    // Initially, the popover should not be in the document
+    expect(screen.queryByText('Popover Content')).not.toBeInTheDocument();
+    // Click the button to open the popover
+    await userEvent.click(anchorButton);
+    // Now the popover should be in the document
+    expect(screen.getByText('Popover Content')).toBeInTheDocument();
+    // Click the backdrop to close the popover
+    const backdrop = document.querySelector('.MuiBackdrop-root');
+    if (backdrop) {
+      fireEvent.click(backdrop);
+    }
+    // The popover should no longer be in the document
+    await waitFor(() => {
+      expect(screen.queryByText('Popover Content')).not.toBeInTheDocument();
+    });
+  });
+
+  it('Opens and closes popover based on keyboard events', async () => {
+    const TestComponent = () => {
+      const [anchorEl, setAnchorEl] = useState<null | HTMLButtonElement>(null);
+
+      const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+        setAnchorEl(event.currentTarget);
+      };
+      const handleClose = () => {
+        setAnchorEl(null);
+      };
+
+      const open = Boolean(anchorEl);
+
+      return (
+        <div>
+          <button data-testid="anchor-button" onClick={handleClick}>
+            Open Popover
+          </button>
+          <ApPopover open={open} anchorEl={anchorEl} onClose={handleClose}>
+            <div>Popover Content</div>
+          </ApPopover>
+        </div>
+      );
+    };
+
+    render(<TestComponent />);
+    const anchorButton = screen.getByTestId('anchor-button');
+
+    // Initially, the popover should not be in the document
+    expect(screen.queryByText('Popover Content')).not.toBeInTheDocument();
+    // Focus and press Enter to open the popover
+    anchorButton.focus();
+    await userEvent.keyboard('{Enter}');
+    // Now the popover should be in the document
+    expect(screen.getByText('Popover Content')).toBeInTheDocument();
+    // Press Escape to close the popover
+    await userEvent.keyboard('{Escape}');
+    // The popover should no longer be in the document
+    await waitFor(() => {
+      expect(screen.queryByText('Popover Content')).not.toBeInTheDocument();
+    });
+  });
+
+  it('applies custom styles via sx prop', () => {
+    render(
+      <ApPopover
+        open={true}
+        anchorEl={document.body}
+        sx={{ '& .MuiPaper-root': { backgroundColor: 'red' } }}
+      >
+        <div>Styled Popover Content</div>
+      </ApPopover>
+    );
+
+    const popoverPaper = document.querySelector('.MuiPaper-root') as HTMLElement;
+    expect(popoverPaper).toHaveStyle('background-color: red');
+  });
+});

--- a/packages/apollo-react/src/material/components/ap-popover/ApPopover.tsx
+++ b/packages/apollo-react/src/material/components/ap-popover/ApPopover.tsx
@@ -1,0 +1,48 @@
+import Popover, { PopoverProps } from '@mui/material/Popover';
+import token from '@uipath/apollo-core';
+
+export const ApPopover: React.FC<PopoverProps> = (props) => {
+  const {
+    anchorOrigin = {
+      vertical: 'bottom',
+      horizontal: 'left',
+    },
+    transformOrigin = {
+      vertical: 'top',
+      horizontal: 'left',
+    },
+    anchorReference,
+    anchorPosition,
+    sx,
+    children,
+    open,
+    anchorEl,
+    onClose,
+    ...rest
+  } = props;
+
+  return (
+    <Popover
+      open={open}
+      onClose={onClose}
+      anchorEl={anchorEl}
+      sx={{
+        '& .MuiPaper-root': {
+          borderRadius: token.Border.BorderRadiusS,
+          background: 'var(--color-background)',
+          boxShadow: token.Shadow.ShadowDp6,
+        },
+        ...sx,
+      }}
+      anchorOrigin={anchorOrigin}
+      transformOrigin={transformOrigin}
+      anchorReference={anchorReference ?? (anchorPosition && !anchorEl ? 'anchorPosition' : 'anchorEl')}
+      anchorPosition={anchorPosition}
+      {...rest}
+    >
+      {children}
+    </Popover>
+  );
+};
+
+ApPopover.displayName = 'ApPopover';

--- a/packages/apollo-react/src/material/components/ap-popover/index.ts
+++ b/packages/apollo-react/src/material/components/ap-popover/index.ts
@@ -1,0 +1,1 @@
+export { ApPopover } from './ApPopover';

--- a/packages/apollo-react/src/material/components/index.ts
+++ b/packages/apollo-react/src/material/components/index.ts
@@ -9,6 +9,7 @@ export * from './ap-icon';
 export * from './ap-icon-button';
 export * from './ap-link';
 export * from './ap-menu';
+export * from './ap-popover';
 export * from './ap-progress-spinner';
 export * from './ap-skeleton';
 export * from './ap-text-area';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -376,6 +376,9 @@ importers:
       react-router-dom:
         specifier: ^7.12.0
         version: 7.12.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      react-syntax-highlighter:
+        specifier: ^16.1.0
+        version: 16.1.0(react@19.2.3)
       styled-components:
         specifier: ^6.1.19
         version: 6.1.19(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -395,6 +398,9 @@ importers:
       '@types/react-dom':
         specifier: ^19.2.2
         version: 19.2.3(@types/react@19.2.8)
+      '@types/react-syntax-highlighter':
+        specifier: ^15.5.13
+        version: 15.5.13
       '@types/styled-components':
         specifier: ^5.1.36
         version: 5.1.36
@@ -12861,6 +12867,7 @@ packages:
   tar@7.5.6:
     resolution: {integrity: sha512-xqUeu2JAIJpXyvskvU3uvQW8PAmHrtXp2KDuMJwQqW8Sqq0CaZBAQ+dKS3RBXVhU4wC5NjAdKrmh84241gO9cA==}
     engines: {node: '>=18'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exhorbitant rates) by contacting i@izs.me
 
   temp-dir@2.0.0:
     resolution: {integrity: sha512-aoBAniQmmwtcKp/7BzsH8Cxzv8OL736p7v1ihGb5e9DJ9kTwGWHrQrVB5+lfVDzfGrdRzXch+ig7LHaY1JTOrg==}
@@ -14137,7 +14144,7 @@ snapshots:
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@angular-devkit/architect': 0.2003.11(chokidar@4.0.3)
-      '@angular-devkit/build-webpack': 0.2003.11(chokidar@4.0.3)(webpack-dev-server@5.2.2(webpack@5.101.2))(webpack@5.101.2)
+      '@angular-devkit/build-webpack': 0.2003.11(chokidar@4.0.3)(webpack-dev-server@5.2.2(webpack@5.101.2))(webpack@5.101.2(esbuild@0.25.9))
       '@angular-devkit/core': 20.3.11(chokidar@4.0.3)
       '@angular/build': 20.3.11(e10da3677be0d28a771e42718d565797)
       '@angular/compiler-cli': 19.2.18(@angular/compiler@19.2.18)(typescript@5.7.3)
@@ -14151,13 +14158,13 @@ snapshots:
       '@babel/preset-env': 7.28.3(@babel/core@7.28.3)
       '@babel/runtime': 7.28.3
       '@discoveryjs/json-ext': 0.6.3
-      '@ngtools/webpack': 20.3.11(@angular/compiler-cli@19.2.18(@angular/compiler@19.2.18)(typescript@5.7.3))(typescript@5.7.3)(webpack@5.101.2)
+      '@ngtools/webpack': 20.3.11(@angular/compiler-cli@19.2.18(@angular/compiler@19.2.18)(typescript@5.7.3))(typescript@5.7.3)(webpack@5.101.2(esbuild@0.25.9))
       ansi-colors: 4.1.3
       autoprefixer: 10.4.21(postcss@8.5.6)
-      babel-loader: 10.0.0(@babel/core@7.28.3)(webpack@5.101.2)
+      babel-loader: 10.0.0(@babel/core@7.28.3)(webpack@5.101.2(esbuild@0.25.9))
       browserslist: 4.28.0
-      copy-webpack-plugin: 13.0.1(webpack@5.101.2)
-      css-loader: 7.1.2(@rspack/core@1.6.4(@swc/helpers@0.5.17))(webpack@5.101.2)
+      copy-webpack-plugin: 13.0.1(webpack@5.101.2(esbuild@0.25.9))
+      css-loader: 7.1.2(@rspack/core@1.6.4(@swc/helpers@0.5.17))(webpack@5.101.2(esbuild@0.25.9))
       esbuild-wasm: 0.25.9
       fast-glob: 3.3.3
       http-proxy-middleware: 3.0.5
@@ -14165,22 +14172,22 @@ snapshots:
       jsonc-parser: 3.3.1
       karma-source-map-support: 1.4.0
       less: 4.4.0
-      less-loader: 12.3.0(@rspack/core@1.6.4(@swc/helpers@0.5.17))(less@4.4.0)(webpack@5.101.2)
-      license-webpack-plugin: 4.0.2(webpack@5.101.2)
+      less-loader: 12.3.0(@rspack/core@1.6.4(@swc/helpers@0.5.17))(less@4.4.0)(webpack@5.101.2(esbuild@0.25.9))
+      license-webpack-plugin: 4.0.2(webpack@5.101.2(esbuild@0.25.9))
       loader-utils: 3.3.1
-      mini-css-extract-plugin: 2.9.4(webpack@5.101.2)
+      mini-css-extract-plugin: 2.9.4(webpack@5.101.2(esbuild@0.25.9))
       open: 10.2.0
       ora: 8.2.0
       picomatch: 4.0.3
       piscina: 5.1.3
       postcss: 8.5.6
-      postcss-loader: 8.1.1(@rspack/core@1.6.4(@swc/helpers@0.5.17))(postcss@8.5.6)(typescript@5.7.3)(webpack@5.101.2)
+      postcss-loader: 8.1.1(@rspack/core@1.6.4(@swc/helpers@0.5.17))(postcss@8.5.6)(typescript@5.7.3)(webpack@5.101.2(esbuild@0.25.9))
       resolve-url-loader: 5.0.0
       rxjs: 7.8.2
       sass: 1.90.0
-      sass-loader: 16.0.5(@rspack/core@1.6.4(@swc/helpers@0.5.17))(sass@1.90.0)(webpack@5.101.2)
+      sass-loader: 16.0.5(@rspack/core@1.6.4(@swc/helpers@0.5.17))(sass@1.90.0)(webpack@5.101.2(esbuild@0.25.9))
       semver: 7.7.2
-      source-map-loader: 5.0.0(webpack@5.101.2)
+      source-map-loader: 5.0.0(webpack@5.101.2(esbuild@0.25.9))
       source-map-support: 0.5.21
       terser: 5.43.1
       tree-kill: 1.2.2
@@ -14190,7 +14197,7 @@ snapshots:
       webpack-dev-middleware: 7.4.2(webpack@5.101.2)
       webpack-dev-server: 5.2.2(webpack@5.101.2)
       webpack-merge: 6.0.1
-      webpack-subresource-integrity: 5.1.0(webpack@5.101.2)
+      webpack-subresource-integrity: 5.1.0(webpack@5.101.2(esbuild@0.25.9))
     optionalDependencies:
       '@angular/core': 19.2.18(rxjs@7.8.2)(zone.js@0.15.1)
       '@angular/platform-browser': 19.2.18(@angular/animations@19.2.18(@angular/common@19.2.18(@angular/core@19.2.18(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@19.2.18(rxjs@7.8.2)(zone.js@0.15.1)))(@angular/common@19.2.18(@angular/core@19.2.18(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@19.2.18(rxjs@7.8.2)(zone.js@0.15.1))
@@ -14220,7 +14227,7 @@ snapshots:
       - webpack-cli
       - yaml
 
-  '@angular-devkit/build-webpack@0.2003.11(chokidar@4.0.3)(webpack-dev-server@5.2.2(webpack@5.101.2))(webpack@5.101.2)':
+  '@angular-devkit/build-webpack@0.2003.11(chokidar@4.0.3)(webpack-dev-server@5.2.2(webpack@5.101.2))(webpack@5.101.2(esbuild@0.25.9))':
     dependencies:
       '@angular-devkit/architect': 0.2003.11(chokidar@4.0.3)
       rxjs: 7.8.2
@@ -17828,7 +17835,7 @@ snapshots:
   '@next/swc-win32-x64-msvc@16.1.1':
     optional: true
 
-  '@ngtools/webpack@20.3.11(@angular/compiler-cli@19.2.18(@angular/compiler@19.2.18)(typescript@5.7.3))(typescript@5.7.3)(webpack@5.101.2)':
+  '@ngtools/webpack@20.3.11(@angular/compiler-cli@19.2.18(@angular/compiler@19.2.18)(typescript@5.7.3))(typescript@5.7.3)(webpack@5.101.2(esbuild@0.25.9))':
     dependencies:
       '@angular/compiler-cli': 19.2.18(@angular/compiler@19.2.18)(typescript@5.7.3)
       typescript: 5.7.3
@@ -20689,7 +20696,7 @@ snapshots:
       obug: 2.1.1
       std-env: 3.10.0
       tinyrainbow: 3.0.3
-      vitest: 4.0.14(@types/node@22.19.3)(@vitest/ui@4.0.14)(happy-dom@20.0.11)(jiti@2.6.1)(jsdom@27.3.0)(less@4.4.2)(lightningcss@1.30.2)(msw@2.12.3(@types/node@22.19.3)(typescript@5.9.3))(sass@1.94.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.1)
+      vitest: 4.0.14(@types/node@24.10.1)(@vitest/ui@4.0.14)(happy-dom@20.0.11)(jiti@2.6.1)(jsdom@27.3.0)(less@4.4.2)(lightningcss@1.30.2)(msw@2.12.3(@types/node@24.10.1)(typescript@5.9.3))(sass@1.94.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -20815,7 +20822,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vitest: 4.0.14(@types/node@22.19.3)(@vitest/ui@4.0.14)(happy-dom@20.0.11)(jiti@2.6.1)(jsdom@27.3.0)(less@4.4.2)(lightningcss@1.30.2)(msw@2.12.3(@types/node@22.19.3)(typescript@5.9.3))(sass@1.94.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.1)
+      vitest: 4.0.14(@types/node@24.10.1)(@vitest/ui@4.0.14)(happy-dom@20.0.11)(jiti@2.6.1)(jsdom@27.3.0)(less@4.4.2)(lightningcss@1.30.2)(msw@2.12.3(@types/node@24.10.1)(typescript@5.9.3))(sass@1.94.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.1)
 
   '@vitest/utils@3.2.4':
     dependencies:
@@ -21171,7 +21178,7 @@ snapshots:
 
   axe-core@4.11.0: {}
 
-  babel-loader@10.0.0(@babel/core@7.28.3)(webpack@5.101.2):
+  babel-loader@10.0.0(@babel/core@7.28.3)(webpack@5.101.2(esbuild@0.25.9)):
     dependencies:
       '@babel/core': 7.28.3
       find-up: 5.0.0
@@ -21743,7 +21750,7 @@ snapshots:
     dependencies:
       is-what: 3.14.1
 
-  copy-webpack-plugin@13.0.1(webpack@5.101.2):
+  copy-webpack-plugin@13.0.1(webpack@5.101.2(esbuild@0.25.9)):
     dependencies:
       glob-parent: 6.0.2
       normalize-path: 3.0.0
@@ -21845,7 +21852,7 @@ snapshots:
 
   css-functions-list@3.2.3: {}
 
-  css-loader@7.1.2(@rspack/core@1.6.4(@swc/helpers@0.5.17))(webpack@5.101.2):
+  css-loader@7.1.2(@rspack/core@1.6.4(@swc/helpers@0.5.17))(webpack@5.101.2(esbuild@0.25.9)):
     dependencies:
       icss-utils: 5.1.0(postcss@8.5.6)
       postcss: 8.5.6
@@ -24079,7 +24086,7 @@ snapshots:
 
   layout-base@2.0.1: {}
 
-  less-loader@12.3.0(@rspack/core@1.6.4(@swc/helpers@0.5.17))(less@4.4.0)(webpack@5.101.2):
+  less-loader@12.3.0(@rspack/core@1.6.4(@swc/helpers@0.5.17))(less@4.4.0)(webpack@5.101.2(esbuild@0.25.9)):
     dependencies:
       less: 4.4.0
     optionalDependencies:
@@ -24116,7 +24123,7 @@ snapshots:
 
   leven@3.1.0: {}
 
-  license-webpack-plugin@4.0.2(webpack@5.101.2):
+  license-webpack-plugin@4.0.2(webpack@5.101.2(esbuild@0.25.9)):
     dependencies:
       webpack-sources: 3.3.3
     optionalDependencies:
@@ -25012,7 +25019,7 @@ snapshots:
 
   min-indent@1.0.1: {}
 
-  mini-css-extract-plugin@2.9.4(webpack@5.101.2):
+  mini-css-extract-plugin@2.9.4(webpack@5.101.2(esbuild@0.25.9)):
     dependencies:
       schema-utils: 4.3.3
       tapable: 2.3.0
@@ -25951,7 +25958,7 @@ snapshots:
     optionalDependencies:
       postcss: 8.5.6
 
-  postcss-loader@8.1.1(@rspack/core@1.6.4(@swc/helpers@0.5.17))(postcss@8.5.6)(typescript@5.7.3)(webpack@5.101.2):
+  postcss-loader@8.1.1(@rspack/core@1.6.4(@swc/helpers@0.5.17))(postcss@8.5.6)(typescript@5.7.3)(webpack@5.101.2(esbuild@0.25.9)):
     dependencies:
       cosmiconfig: 9.0.0(typescript@5.7.3)
       jiti: 1.21.7
@@ -27101,7 +27108,7 @@ snapshots:
       parse-srcset: 1.0.2
       postcss: 8.5.6
 
-  sass-loader@16.0.5(@rspack/core@1.6.4(@swc/helpers@0.5.17))(sass@1.90.0)(webpack@5.101.2):
+  sass-loader@16.0.5(@rspack/core@1.6.4(@swc/helpers@0.5.17))(sass@1.90.0)(webpack@5.101.2(esbuild@0.25.9)):
     dependencies:
       neo-async: 2.6.2
     optionalDependencies:
@@ -27584,7 +27591,7 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
-  source-map-loader@5.0.0(webpack@5.101.2):
+  source-map-loader@5.0.0(webpack@5.101.2(esbuild@0.25.9)):
     dependencies:
       iconv-lite: 0.6.3
       source-map-js: 1.2.1
@@ -28878,7 +28885,7 @@ snapshots:
 
   webpack-sources@3.3.3: {}
 
-  webpack-subresource-integrity@5.1.0(webpack@5.101.2):
+  webpack-subresource-integrity@5.1.0(webpack@5.101.2(esbuild@0.25.9)):
     dependencies:
       typed-assert: 1.0.9
       webpack: 5.101.2(esbuild@0.25.9)


### PR DESCRIPTION
- Implemented Ap-Popover using Mui Popover
- Original popover in apollo-design-system was a pure stencil component and more complex than necessary to migrate. 


https://github.com/user-attachments/assets/d61022cb-7fb6-4c29-ab2d-e2d1d00f61b7



