### PR TITLE
feat(apollo-react): add instruction experience on agent node (#AG-123)

### DIFF
--- a/packages/apollo-react/src/canvas/components/AgentCanvas/AgentFlow.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/AgentCanvas/AgentFlow.stories.tsx
@@ -335,7 +335,6 @@ interface AgentFlowWrapperProps {
   allowDragging?: boolean;
   agentNodePosition?: { x: number; y: number } | undefined;
   onAgentNodePositionChange?: (position: { x: number; y: number }) => void;
-  hasInstructions?: boolean;
   instructions?: { system?: string; user?: string };
 }
 
@@ -354,7 +353,6 @@ const AgentFlowWrapper = ({
   allowDragging = false,
   agentNodePosition = undefined,
   onAgentNodePositionChange = () => {},
-  hasInstructions,
   instructions,
 }: AgentFlowWrapperProps) => {
   const [resources, setResources] = useState<AgentFlowResource[]>(initialResources);
@@ -604,7 +602,6 @@ const AgentFlowWrapper = ({
             onRemoveStickyNote={handleRemoveStickyNote}
             healthScore={healthScore}
             onHealthScoreClick={onHealthScoreClick}
-            hasInstructions={hasInstructions}
             instructions={instructions}
           />
         </div>
@@ -1495,7 +1492,6 @@ const DesignModePlayground = () => {
             suggestionGroup={suggestionGroup}
             onActOnSuggestion={handleActOnSuggestion}
             onActOnSuggestionGroup={handleActOnSuggestionGroup}
-            hasInstructions={hasInstructions}
             instructions={instructions}
           />
           {renderControlPanel()}
@@ -1661,7 +1657,6 @@ const ViewModeWrapper = () => {
         spans={hasTimelinePlayer ? sampleSpans : []}
         definition={sampleAgentDefinition}
         enableTimelinePlayer={hasTimelinePlayer}
-        hasInstructions={hasInstructions}
         instructions={instructions}
       />
       {renderControlPanel()}

--- a/packages/apollo-react/src/canvas/components/AgentCanvas/AgentFlow.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/AgentCanvas/AgentFlow.stories.tsx
@@ -333,6 +333,7 @@ interface AgentFlowWrapperProps {
   enableTimelinePlayer?: boolean;
   enableMemory?: boolean;
   enableStickyNotes?: boolean;
+  enableInstructions?: boolean;
   healthScore?: number;
   onHealthScoreClick?: () => void;
   allowDragging?: boolean;
@@ -351,6 +352,7 @@ const AgentFlowWrapper = ({
   enableTimelinePlayer = true,
   enableMemory = true,
   enableStickyNotes = true,
+  enableInstructions = false,
   healthScore,
   onHealthScoreClick,
   allowDragging = false,
@@ -599,6 +601,7 @@ const AgentFlowWrapper = ({
             enableTimelinePlayer={mode === 'view' && enableTimelinePlayer}
             enableMemory={enableMemory}
             enableStickyNotes={enableStickyNotes}
+            enableInstructions={enableInstructions}
             stickyNotes={stickyNotes}
             onAddStickyNote={handleAddStickyNote}
             onUpdateStickyNote={handleUpdateStickyNote}
@@ -1480,6 +1483,7 @@ const DesignModePlayground = () => {
             onSelectResource={handleSelectResource}
             enableTimelinePlayer={false}
             enableMemory
+            enableInstructions={hasInstructions}
             enableStickyNotes={enableStickyNotes}
             stickyNotes={stickyNotes}
             onAddStickyNote={handleAddStickyNote}
@@ -1661,6 +1665,7 @@ const ViewModeWrapper = () => {
         spans={hasTimelinePlayer ? sampleSpans : []}
         definition={sampleAgentDefinition}
         enableTimelinePlayer={hasTimelinePlayer}
+        enableInstructions={hasInstructions}
         instructions={instructions}
       />
       {renderControlPanel()}

--- a/packages/apollo-react/src/canvas/components/AgentCanvas/AgentFlow.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/AgentCanvas/AgentFlow.stories.tsx
@@ -626,6 +626,9 @@ const DesignModePlayground = () => {
   const [suggestionMode, setSuggestionMode] = useState<SuggestionMode>('off');
   const [enableStickyNotes, setEnableStickyNotes] = useState(true);
   const [enableDragging, setEnableDragging] = useState(true);
+  const [hasInstructions, setHasInstructions] = useState(false);
+  const [showSystemPrompt, setShowSystemPrompt] = useState(true);
+  const [showUserPrompt, setShowUserPrompt] = useState(true);
 
   // Resources state
   const [resources, setResources] = useState<AgentFlowResource[]>(sampleResources);
@@ -654,8 +657,20 @@ const DesignModePlayground = () => {
   // Selection state
   const [selectedResourceId, setSelectedResourceId] = useState<string | null>(null);
 
+  // Instructions object
+  const instructions = hasInstructions
+    ? {
+        system: showSystemPrompt
+          ? 'You are a helpful claims processing agent. Follow company policies strictly and escalate when needed.'
+          : undefined,
+        user: showUserPrompt
+          ? 'Please process the submitted insurance claim and verify all required documentation.'
+          : undefined,
+      }
+    : undefined;
+
   // Generate a unique key for React to remount when major state changes
-  const stateKey = `${hasResources}-${suggestionMode}-${enableStickyNotes}-${enableDragging}`;
+  const stateKey = `${hasResources}-${suggestionMode}-${enableStickyNotes}-${enableDragging}-${hasInstructions}`;
 
   // Resource handlers
   const handleSelectResource = useCallback(
@@ -1201,7 +1216,7 @@ const DesignModePlayground = () => {
   );
 
   const renderControlPanel = () => (
-    <StoryInfoPanel title="Design Mode Playground" collapsible defaultCollapsed={false}>
+    <StoryInfoPanel title="Design Mode Playground" collapsible defaultCollapsed={false} position="top-right">
       <Column mt={12} gap={12}>
         {/* Resources toggle */}
         <Column gap={4}>
@@ -1347,6 +1362,43 @@ const DesignModePlayground = () => {
           </Row>
         </Column>
 
+        {/* Instructions toggle */}
+        <Column gap={4}>
+          <ApTypography variant={FontVariantToken.fontSizeS} style={{ fontWeight: 600 }}>
+            Instructions:
+          </ApTypography>
+          <Row gap={4}>
+            <ApButton
+              size="small"
+              variant={hasInstructions ? 'primary' : 'secondary'}
+              label="With"
+              onClick={() => setHasInstructions(true)}
+            />
+            <ApButton
+              size="small"
+              variant={!hasInstructions ? 'primary' : 'secondary'}
+              label="Without"
+              onClick={() => setHasInstructions(false)}
+            />
+          </Row>
+          {hasInstructions && (
+            <Row gap={4} style={{ flexWrap: 'wrap' }}>
+              <ApButton
+                size="small"
+                variant={showSystemPrompt ? 'primary' : 'secondary'}
+                label="System"
+                onClick={() => setShowSystemPrompt(!showSystemPrompt)}
+              />
+              <ApButton
+                size="small"
+                variant={showUserPrompt ? 'primary' : 'secondary'}
+                label="User"
+                onClick={() => setShowUserPrompt(!showUserPrompt)}
+              />
+            </Row>
+          )}
+        </Column>
+
         {/* Status info */}
         <Column
           gap={2}
@@ -1409,7 +1461,10 @@ const DesignModePlayground = () => {
             suggestionGroup={suggestionGroup}
             onActOnSuggestion={handleActOnSuggestion}
             onActOnSuggestionGroup={handleActOnSuggestionGroup}
+            hasInstructions={hasInstructions}
+            instructions={instructions}
           />
+          {renderControlPanel()}
           {/* Placeholder configuration modal */}
           {openModalType && (
             <>
@@ -1477,7 +1532,6 @@ const DesignModePlayground = () => {
             </>
           )}
         </div>
-        {renderControlPanel()}
         {renderSidebar()}
       </Row>
     </ReactFlowProvider>
@@ -1497,7 +1551,8 @@ export const DesignMode: Story = {
           '• **Resources**: With sample resources or empty canvas\n' +
           '• **Suggestions**: Off, Placeholders (click + buttons), or Autopilot (batch suggestions)\n' +
           '• **Sticky Notes**: Enable/disable with sample loading\n' +
-          '• **Dragging**: Enable/disable position control\n\n' +
+          '• **Dragging**: Enable/disable position control\n' +
+          '• **Instructions**: Toggle instruction prompts (system/user) on the agent node\n\n' +
           'Test features in isolation or combine them to verify interactions.',
       },
     },
@@ -1653,128 +1708,6 @@ export const HealthScore: Story = {
       description: {
         story:
           'Interactive health score demo. Use the control panel to toggle between different health score values (None, 0, 50, 95, 100). The health score badge appears below the agent name and is clickable.',
-      },
-    },
-  },
-};
-
-/**
- * Instructions Preview Story
- * Demonstrates the instruction prompt preview on the agent node footer
- */
-
-const InstructionsPreviewWrapper = () => {
-  const [hasInstructions, setHasInstructions] = useState(true);
-  const [showSystem, setShowSystem] = useState(true);
-  const [showUser, setShowUser] = useState(true);
-
-  const instructions = hasInstructions
-    ? {
-        system: showSystem
-          ? 'You are a helpful claims processing agent. Follow company policies strictly and escalate when needed.'
-          : undefined,
-        user: showUser
-          ? 'Please process the submitted insurance claim and verify all required documentation.'
-          : undefined,
-      }
-    : undefined;
-
-  const renderControlPanel = () => (
-    <StoryInfoPanel title="Instructions Preview Controls" collapsible defaultCollapsed={false}>
-      <Column mt={12} gap={12}>
-        <Column gap={4}>
-          <ApTypography variant={FontVariantToken.fontSizeS} style={{ fontWeight: 600 }}>
-            Instructions:
-          </ApTypography>
-          <Row gap={4}>
-            <ApButton
-              size="small"
-              variant={hasInstructions ? 'primary' : 'secondary'}
-              label="With"
-              onClick={() => setHasInstructions(true)}
-            />
-            <ApButton
-              size="small"
-              variant={!hasInstructions ? 'primary' : 'secondary'}
-              label="Without"
-              onClick={() => setHasInstructions(false)}
-            />
-          </Row>
-        </Column>
-
-        {hasInstructions && (
-          <>
-            <Column gap={4}>
-              <ApTypography variant={FontVariantToken.fontSizeS} style={{ fontWeight: 600 }}>
-                System prompt:
-              </ApTypography>
-              <Row gap={4}>
-                <ApButton
-                  size="small"
-                  variant={showSystem ? 'primary' : 'secondary'}
-                  label="Show"
-                  onClick={() => setShowSystem(true)}
-                />
-                <ApButton
-                  size="small"
-                  variant={!showSystem ? 'primary' : 'secondary'}
-                  label="Hide"
-                  onClick={() => setShowSystem(false)}
-                />
-              </Row>
-            </Column>
-
-            <Column gap={4}>
-              <ApTypography variant={FontVariantToken.fontSizeS} style={{ fontWeight: 600 }}>
-                User prompt:
-              </ApTypography>
-              <Row gap={4}>
-                <ApButton
-                  size="small"
-                  variant={showUser ? 'primary' : 'secondary'}
-                  label="Show"
-                  onClick={() => setShowUser(true)}
-                />
-                <ApButton
-                  size="small"
-                  variant={!showUser ? 'primary' : 'secondary'}
-                  label="Hide"
-                  onClick={() => setShowUser(false)}
-                />
-              </Row>
-            </Column>
-          </>
-        )}
-      </Column>
-    </StoryInfoPanel>
-  );
-
-  return (
-    <ReactFlowProvider key={`${hasInstructions}-${showSystem}-${showUser}`}>
-      <AgentFlowWrapper
-        mode="design"
-        initialResources={sampleResources}
-        hasInstructions={hasInstructions}
-        instructions={instructions}
-      />
-      {renderControlPanel()}
-    </ReactFlowProvider>
-  );
-};
-
-export const InstructionsPreview: Story = {
-  args: {
-    mode: 'design',
-  },
-  render: () => <InstructionsPreviewWrapper />,
-  parameters: {
-    docs: {
-      description: {
-        story:
-          'Demonstrates instruction prompt previews on the agent node. Toggle between:\n\n' +
-          '- **With/Without instructions**: Shows the "Add Instructions" button when empty, or prompt previews when set\n' +
-          '- **System/User prompts**: Show one or both prompt previews\n\n' +
-          'The footer area maintains a consistent 144px node height regardless of content.',
       },
     },
   },

--- a/packages/apollo-react/src/canvas/components/AgentCanvas/AgentFlow.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/AgentCanvas/AgentFlow.stories.tsx
@@ -627,8 +627,8 @@ const DesignModePlayground = () => {
   const [enableStickyNotes, setEnableStickyNotes] = useState(true);
   const [enableDragging, setEnableDragging] = useState(true);
   const [hasInstructions, setHasInstructions] = useState(false);
-  const [showSystemPrompt, setShowSystemPrompt] = useState(true);
-  const [showUserPrompt, setShowUserPrompt] = useState(true);
+  const [systemPrompt, setSystemPrompt] = useState('');
+  const [userPrompt, setUserPrompt] = useState('');
 
   // Resources state
   const [resources, setResources] = useState<AgentFlowResource[]>(sampleResources);
@@ -660,12 +660,8 @@ const DesignModePlayground = () => {
   // Instructions object
   const instructions = hasInstructions
     ? {
-        system: showSystemPrompt
-          ? 'You are a helpful claims processing agent. Follow company policies strictly and escalate when needed.'
-          : undefined,
-        user: showUserPrompt
-          ? 'Please process the submitted insurance claim and verify all required documentation.'
-          : undefined,
+        system: systemPrompt || undefined,
+        user: userPrompt || undefined,
       }
     : undefined;
 
@@ -1382,20 +1378,58 @@ const DesignModePlayground = () => {
             />
           </Row>
           {hasInstructions && (
-            <Row gap={4} style={{ flexWrap: 'wrap' }}>
-              <ApButton
-                size="small"
-                variant={showSystemPrompt ? 'primary' : 'secondary'}
-                label="System"
-                onClick={() => setShowSystemPrompt(!showSystemPrompt)}
-              />
-              <ApButton
-                size="small"
-                variant={showUserPrompt ? 'primary' : 'secondary'}
-                label="User"
-                onClick={() => setShowUserPrompt(!showUserPrompt)}
-              />
-            </Row>
+            <Column gap={8} style={{ marginTop: 8 }}>
+              <Column gap={2}>
+                <ApTypography
+                  variant={FontVariantToken.fontSizeXs}
+                  style={{ color: 'var(--uix-canvas-foreground-de-emp)' }}
+                >
+                  System prompt:
+                </ApTypography>
+                <textarea
+                  value={systemPrompt}
+                  onChange={(e) => setSystemPrompt(e.target.value)}
+                  placeholder="Enter system prompt..."
+                  style={{
+                    width: '100%',
+                    minHeight: 60,
+                    padding: 8,
+                    fontSize: 12,
+                    borderRadius: 4,
+                    border: '1px solid var(--uix-canvas-border-de-emp)',
+                    backgroundColor: 'var(--uix-canvas-background)',
+                    color: 'var(--uix-canvas-foreground)',
+                    resize: 'vertical',
+                    fontFamily: 'inherit',
+                  }}
+                />
+              </Column>
+              <Column gap={2}>
+                <ApTypography
+                  variant={FontVariantToken.fontSizeXs}
+                  style={{ color: 'var(--uix-canvas-foreground-de-emp)' }}
+                >
+                  User prompt:
+                </ApTypography>
+                <textarea
+                  value={userPrompt}
+                  onChange={(e) => setUserPrompt(e.target.value)}
+                  placeholder="Enter user prompt..."
+                  style={{
+                    width: '100%',
+                    minHeight: 60,
+                    padding: 8,
+                    fontSize: 12,
+                    borderRadius: 4,
+                    border: '1px solid var(--uix-canvas-border-de-emp)',
+                    backgroundColor: 'var(--uix-canvas-background)',
+                    color: 'var(--uix-canvas-foreground)',
+                    resize: 'vertical',
+                    fontFamily: 'inherit',
+                  }}
+                />
+              </Column>
+            </Column>
           )}
         </Column>
 
@@ -1561,33 +1595,65 @@ export const DesignMode: Story = {
 
 const ViewModeWrapper = () => {
   const [hasTimelinePlayer, setHasTimelinePlayer] = useState(false);
+  const [hasInstructions, setHasInstructions] = useState(true);
+
+  // Sample instructions for view mode
+  const instructions = hasInstructions
+    ? {
+        system: 'You are a helpful assistant that helps users with their tasks.',
+        user: 'Please help me complete my work efficiently.',
+      }
+    : undefined;
 
   const renderControlPanel = () => {
     return (
       <StoryInfoPanel title="View Mode Controls">
-        <Column mt={12} gap={8}>
-          <ApTypography variant={FontVariantToken.fontSizeM}>Timeline player:</ApTypography>
-          <Row gap={8}>
-            <ApButton
-              size="small"
-              variant={!hasTimelinePlayer ? 'primary' : 'secondary'}
-              label="Off"
-              onClick={() => setHasTimelinePlayer(false)}
-            />
-            <ApButton
-              size="small"
-              variant={hasTimelinePlayer ? 'primary' : 'secondary'}
-              label="With Spans"
-              onClick={() => setHasTimelinePlayer(true)}
-            />
-          </Row>
+        <Column mt={12} gap={12}>
+          <Column gap={4}>
+            <ApTypography variant={FontVariantToken.fontSizeS} style={{ fontWeight: 600 }}>
+              Timeline player:
+            </ApTypography>
+            <Row gap={8}>
+              <ApButton
+                size="small"
+                variant={!hasTimelinePlayer ? 'primary' : 'secondary'}
+                label="Off"
+                onClick={() => setHasTimelinePlayer(false)}
+              />
+              <ApButton
+                size="small"
+                variant={hasTimelinePlayer ? 'primary' : 'secondary'}
+                label="With Spans"
+                onClick={() => setHasTimelinePlayer(true)}
+              />
+            </Row>
+          </Column>
+          <Column gap={4}>
+            <ApTypography variant={FontVariantToken.fontSizeS} style={{ fontWeight: 600 }}>
+              Instructions:
+            </ApTypography>
+            <Row gap={8}>
+              <ApButton
+                size="small"
+                variant={hasInstructions ? 'primary' : 'secondary'}
+                label="With"
+                onClick={() => setHasInstructions(true)}
+              />
+              <ApButton
+                size="small"
+                variant={!hasInstructions ? 'primary' : 'secondary'}
+                label="Without"
+                onClick={() => setHasInstructions(false)}
+              />
+            </Row>
+          </Column>
         </Column>
       </StoryInfoPanel>
     );
   };
 
   return (
-    <ReactFlowProvider key={hasTimelinePlayer ? 'with-timeline' : 'no-timeline'}>
+    <ReactFlowProvider key={`${hasTimelinePlayer}-${hasInstructions}`}>
       <AgentFlowWrapper
         mode="view"
         initialResources={sampleResources}
@@ -1595,6 +1661,8 @@ const ViewModeWrapper = () => {
         spans={hasTimelinePlayer ? sampleSpans : []}
         definition={sampleAgentDefinition}
         enableTimelinePlayer={hasTimelinePlayer}
+        hasInstructions={hasInstructions}
+        instructions={instructions}
       />
       {renderControlPanel()}
     </ReactFlowProvider>
@@ -1610,7 +1678,9 @@ export const ViewMode: Story = {
     docs: {
       description: {
         story:
-          'Interactive view mode demo. Use the control panel to toggle between view mode with and without the timeline player.',
+          'Interactive view mode demo. Use the control panel to toggle:\n\n' +
+          '• **Timeline player**: Show/hide the timeline with spans\n' +
+          '• **Instructions**: Show/hide instruction prompts preview on the agent node',
       },
     },
   },

--- a/packages/apollo-react/src/canvas/components/AgentCanvas/AgentFlow.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/AgentCanvas/AgentFlow.stories.tsx
@@ -235,8 +235,11 @@ const sampleAgentDefinition = {
   name: 'Test Agent',
   version: '1.0',
   settings: {
-    model: 'gpt-4',
+    model: 'gpt-4o-2024-11-20',
     engine: 'test-engine',
+    temperature: 0,
+    maxTokens: 16384,
+    maxIteration: 10,
   },
   tools: [],
   resources: [],
@@ -1582,7 +1585,8 @@ export const DesignMode: Story = {
           '• **Suggestions**: Off, Placeholders (click + buttons), or Autopilot (batch suggestions)\n' +
           '• **Sticky Notes**: Enable/disable with sample loading\n' +
           '• **Dragging**: Enable/disable position control\n' +
-          '• **Instructions**: Toggle instruction prompts (system/user) on the agent node\n\n' +
+          '• **Instructions**: Toggle instruction prompts (system/user) on the agent node\n' +
+          '• **Hover Preview**: Hover over the agent node for 0.5s to see settings preview\n\n' +
           'Test features in isolation or combine them to verify interactions.',
       },
     },
@@ -1675,7 +1679,8 @@ export const ViewMode: Story = {
         story:
           'Interactive view mode demo. Use the control panel to toggle:\n\n' +
           '• **Timeline player**: Show/hide the timeline with spans\n' +
-          '• **Instructions**: Show/hide instruction prompts preview on the agent node',
+          '• **Instructions**: Show/hide instruction prompts preview on the agent node\n' +
+          '• **Hover Preview**: Hover over the agent node for 0.5s to see full settings preview',
       },
     },
   },

--- a/packages/apollo-react/src/canvas/components/AgentCanvas/AgentFlow.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/AgentCanvas/AgentFlow.stories.tsx
@@ -335,6 +335,8 @@ interface AgentFlowWrapperProps {
   allowDragging?: boolean;
   agentNodePosition?: { x: number; y: number } | undefined;
   onAgentNodePositionChange?: (position: { x: number; y: number }) => void;
+  hasInstructions?: boolean;
+  instructions?: { system?: string; user?: string };
 }
 
 const AgentFlowWrapper = ({
@@ -352,6 +354,8 @@ const AgentFlowWrapper = ({
   allowDragging = false,
   agentNodePosition = undefined,
   onAgentNodePositionChange = () => {},
+  hasInstructions,
+  instructions,
 }: AgentFlowWrapperProps) => {
   const [resources, setResources] = useState<AgentFlowResource[]>(initialResources);
   const [selectedResourceId, setSelectedResourceId] = useState<string | null>(null);
@@ -600,6 +604,8 @@ const AgentFlowWrapper = ({
             onRemoveStickyNote={handleRemoveStickyNote}
             healthScore={healthScore}
             onHealthScoreClick={onHealthScoreClick}
+            hasInstructions={hasInstructions}
+            instructions={instructions}
           />
         </div>
         {renderSidebar()}
@@ -1647,6 +1653,128 @@ export const HealthScore: Story = {
       description: {
         story:
           'Interactive health score demo. Use the control panel to toggle between different health score values (None, 0, 50, 95, 100). The health score badge appears below the agent name and is clickable.',
+      },
+    },
+  },
+};
+
+/**
+ * Instructions Preview Story
+ * Demonstrates the instruction prompt preview on the agent node footer
+ */
+
+const InstructionsPreviewWrapper = () => {
+  const [hasInstructions, setHasInstructions] = useState(true);
+  const [showSystem, setShowSystem] = useState(true);
+  const [showUser, setShowUser] = useState(true);
+
+  const instructions = hasInstructions
+    ? {
+        system: showSystem
+          ? 'You are a helpful claims processing agent. Follow company policies strictly and escalate when needed.'
+          : undefined,
+        user: showUser
+          ? 'Please process the submitted insurance claim and verify all required documentation.'
+          : undefined,
+      }
+    : undefined;
+
+  const renderControlPanel = () => (
+    <StoryInfoPanel title="Instructions Preview Controls" collapsible defaultCollapsed={false}>
+      <Column mt={12} gap={12}>
+        <Column gap={4}>
+          <ApTypography variant={FontVariantToken.fontSizeS} style={{ fontWeight: 600 }}>
+            Instructions:
+          </ApTypography>
+          <Row gap={4}>
+            <ApButton
+              size="small"
+              variant={hasInstructions ? 'primary' : 'secondary'}
+              label="With"
+              onClick={() => setHasInstructions(true)}
+            />
+            <ApButton
+              size="small"
+              variant={!hasInstructions ? 'primary' : 'secondary'}
+              label="Without"
+              onClick={() => setHasInstructions(false)}
+            />
+          </Row>
+        </Column>
+
+        {hasInstructions && (
+          <>
+            <Column gap={4}>
+              <ApTypography variant={FontVariantToken.fontSizeS} style={{ fontWeight: 600 }}>
+                System prompt:
+              </ApTypography>
+              <Row gap={4}>
+                <ApButton
+                  size="small"
+                  variant={showSystem ? 'primary' : 'secondary'}
+                  label="Show"
+                  onClick={() => setShowSystem(true)}
+                />
+                <ApButton
+                  size="small"
+                  variant={!showSystem ? 'primary' : 'secondary'}
+                  label="Hide"
+                  onClick={() => setShowSystem(false)}
+                />
+              </Row>
+            </Column>
+
+            <Column gap={4}>
+              <ApTypography variant={FontVariantToken.fontSizeS} style={{ fontWeight: 600 }}>
+                User prompt:
+              </ApTypography>
+              <Row gap={4}>
+                <ApButton
+                  size="small"
+                  variant={showUser ? 'primary' : 'secondary'}
+                  label="Show"
+                  onClick={() => setShowUser(true)}
+                />
+                <ApButton
+                  size="small"
+                  variant={!showUser ? 'primary' : 'secondary'}
+                  label="Hide"
+                  onClick={() => setShowUser(false)}
+                />
+              </Row>
+            </Column>
+          </>
+        )}
+      </Column>
+    </StoryInfoPanel>
+  );
+
+  return (
+    <ReactFlowProvider key={`${hasInstructions}-${showSystem}-${showUser}`}>
+      <AgentFlowWrapper
+        mode="design"
+        initialResources={sampleResources}
+        hasInstructions={hasInstructions}
+        instructions={instructions}
+      />
+      {renderControlPanel()}
+    </ReactFlowProvider>
+  );
+};
+
+export const InstructionsPreview: Story = {
+  args: {
+    mode: 'design',
+  },
+  render: () => <InstructionsPreviewWrapper />,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Demonstrates instruction prompt previews on the agent node. Toggle between:\n\n' +
+          '- **With/Without instructions**: Shows the "Add Instructions" button when empty, or prompt previews when set\n' +
+          '- **System/User prompts**: Show one or both prompt previews\n\n' +
+          'The footer area maintains a consistent 144px node height regardless of content.',
       },
     },
   },

--- a/packages/apollo-react/src/canvas/components/AgentCanvas/AgentFlow.tsx
+++ b/packages/apollo-react/src/canvas/components/AgentCanvas/AgentFlow.tsx
@@ -94,7 +94,7 @@ const createAgentNodeWrapper = (handlers: {
   suggestionGroupVersion?: string;
 }) => {
   return (props: NodeProps<AgentFlowNode>) => {
-    const { props: storeProps, nodes } = useAgentFlowStore();
+    const { props: storeProps, nodes, setSelectedNodeId } = useAgentFlowStore();
 
     const hasContext = nodes.some(
       (node) =>
@@ -160,6 +160,11 @@ const createAgentNodeWrapper = (handlers: {
           node.data.hasSuccess
       );
 
+    const handleAddInstructions = useCallback(() => {
+      setSelectedNodeId(props.id);
+      storeProps.onSelectResource?.(props.id);
+    }, [setSelectedNodeId, storeProps.onSelectResource, props.id]);
+
     return (
       <AgentNodeElement
         {...props}
@@ -174,6 +179,7 @@ const createAgentNodeWrapper = (handlers: {
         hasSuccess={hasSuccess}
         hasRunning={hasRunning}
         onAddResource={handlers.onAddResource}
+        onAddInstructions={handleAddInstructions}
         translations={handlers.translations ?? DefaultAgentNodeTranslations}
         suggestionTranslations={handlers.suggestionTranslations ?? DefaultSuggestionTranslations}
         enableMemory={handlers.enableMemory === true}

--- a/packages/apollo-react/src/canvas/components/AgentCanvas/AgentFlow.tsx
+++ b/packages/apollo-react/src/canvas/components/AgentCanvas/AgentFlow.tsx
@@ -89,6 +89,7 @@ const createAgentNodeWrapper = (handlers: {
   suggestionTranslations?: SuggestionTranslations;
   enableMcpTools?: boolean;
   enableMemory?: boolean;
+  enableInstructions?: boolean;
   healthScore?: number;
   onHealthScoreClick?: () => void;
   suggestionGroupVersion?: string;
@@ -183,6 +184,7 @@ const createAgentNodeWrapper = (handlers: {
         translations={handlers.translations ?? DefaultAgentNodeTranslations}
         suggestionTranslations={handlers.suggestionTranslations ?? DefaultSuggestionTranslations}
         enableMemory={handlers.enableMemory === true}
+        enableInstructions={handlers.enableInstructions === true}
         healthScore={handlers.healthScore}
         onHealthScoreClick={handlers.onHealthScoreClick}
         suggestionGroupVersion={handlers.suggestionGroupVersion}
@@ -258,6 +260,7 @@ const AgentFlowInner = memo(
     enableMcpTools,
     enableMemory,
     enableStickyNotes,
+    enableInstructions,
     healthScore,
     onHealthScoreClick,
     suggestionTranslations,
@@ -368,6 +371,7 @@ const AgentFlowInner = memo(
           suggestionTranslations,
           enableMcpTools,
           enableMemory,
+          enableInstructions,
           healthScore,
           onHealthScoreClick,
           suggestionGroupVersion,

--- a/packages/apollo-react/src/canvas/components/AgentCanvas/nodes/AgentNode.styles.ts
+++ b/packages/apollo-react/src/canvas/components/AgentCanvas/nodes/AgentNode.styles.ts
@@ -1,0 +1,142 @@
+import styled from '@emotion/styled';
+
+export const AddInstructionsButton = styled.button`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  width: 100%;
+  padding: 6px 12px;
+  background: transparent;
+  border: 1px dashed var(--uix-canvas-border-de-emp);
+  border-radius: 8px;
+  cursor: pointer;
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--uix-canvas-foreground-de-emp);
+  line-height: 16px;
+  transition:
+    border-color 0.15s ease,
+    color 0.15s ease;
+
+  &:hover {
+    border-color: var(--uix-canvas-selection-indicator);
+    color: var(--uix-canvas-selection-indicator);
+  }
+`;
+
+export const InstructionsLabel = styled.div`
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--uix-canvas-foreground);
+  line-height: 16px;
+`;
+
+export const InstructionsPreview = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  width: 100%;
+  font-size: 9px;
+  line-height: 13px;
+  color: var(--uix-canvas-foreground-de-emp);
+  cursor: pointer;
+`;
+
+export const InstructionsLine = styled.div`
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+
+  > strong {
+    font-weight: 600;
+  }
+`;
+
+export const SettingsPreviewContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 16px 20px;
+  min-width: 280px;
+  max-width: 320px;
+`;
+
+export const SettingsPreviewHeader = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding-bottom: 12px;
+  border-bottom: 1px solid var(--uix-canvas-border-de-emp);
+`;
+
+export const SettingsPreviewTitle = styled.div`
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--uix-canvas-foreground-emp);
+`;
+
+export const SettingsPreviewSubtitle = styled.div`
+  font-size: 12px;
+  color: var(--uix-canvas-foreground-de-emp);
+`;
+
+export const SettingsSection = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+`;
+
+export const SettingsSectionLabel = styled.div`
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--uix-canvas-foreground-de-emp);
+`;
+
+export const SettingsSectionValue = styled.div`
+  font-size: 14px;
+  color: var(--uix-canvas-foreground-emp);
+`;
+
+export const SettingsPromptBox = styled.div<{ isEmpty?: boolean }>`
+  font-size: 13px;
+  color: ${({ isEmpty }) =>
+    isEmpty ? 'var(--uix-canvas-foreground-de-emp)' : 'var(--uix-canvas-foreground)'};
+  font-style: ${({ isEmpty }) => (isEmpty ? 'italic' : 'normal')};
+  background: var(--uix-canvas-background-secondary);
+  border-radius: 6px;
+  padding: 8px 10px;
+  max-height: 80px;
+  overflow-y: auto;
+  white-space: pre-wrap;
+  word-break: break-word;
+
+  &::-webkit-scrollbar {
+    width: 4px;
+  }
+
+  &::-webkit-scrollbar-track {
+    background: transparent;
+  }
+
+  &::-webkit-scrollbar-thumb {
+    background: var(--uix-canvas-border-de-emp);
+    border-radius: 2px;
+  }
+`;
+
+export const SettingsRow = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 13px;
+`;
+
+export const SettingsRowLabel = styled.span`
+  color: var(--uix-canvas-foreground-de-emp);
+`;
+
+export const SettingsRowValue = styled.span`
+  color: var(--uix-canvas-foreground-emp);
+  font-weight: 500;
+`;

--- a/packages/apollo-react/src/canvas/components/AgentCanvas/nodes/AgentNode.styles.ts
+++ b/packages/apollo-react/src/canvas/components/AgentCanvas/nodes/AgentNode.styles.ts
@@ -140,3 +140,23 @@ export const SettingsRowValue = styled.span`
   color: var(--uix-canvas-foreground-emp);
   font-weight: 500;
 `;
+
+export const SubLabelContainer = styled.span`
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+`;
+
+export const HealthScoreBadge = styled.span`
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 6px;
+  background-color: var(--uix-canvas-background-secondary);
+  border-radius: 16px;
+  font-size: 10px;
+  font-weight: 700;
+  line-height: 16px;
+  color: var(--uix-canvas-foreground-de-emp);
+  cursor: pointer;
+`;

--- a/packages/apollo-react/src/canvas/components/AgentCanvas/nodes/AgentNode.test.tsx
+++ b/packages/apollo-react/src/canvas/components/AgentCanvas/nodes/AgentNode.test.tsx
@@ -74,6 +74,8 @@ const defaultTranslations: AgentNodeTranslations = {
   context: 'Context',
   tools: 'Tools',
   memory: 'Memory',
+  instructions: 'Instructions',
+  addInstructions: 'Add Instructions',
 };
 
 const defaultNodeProps = {

--- a/packages/apollo-react/src/canvas/components/AgentCanvas/nodes/AgentNode.test.tsx
+++ b/packages/apollo-react/src/canvas/components/AgentCanvas/nodes/AgentNode.test.tsx
@@ -76,6 +76,14 @@ const defaultTranslations: AgentNodeTranslations = {
   memory: 'Memory',
   instructions: 'Instructions',
   addInstructions: 'Add Instructions',
+  agentSettings: 'Agent Settings',
+  readOnlyPreview: 'Read-only preview',
+  systemPrompt: 'System prompt',
+  userPrompt: 'User prompt',
+  temperature: 'Temperature',
+  maxTokens: 'Max tokens',
+  maxIteration: 'Max iteration',
+  notConfigured: 'Not configured',
 };
 
 const defaultNodeProps = {

--- a/packages/apollo-react/src/canvas/components/AgentCanvas/nodes/AgentNode.test.tsx
+++ b/packages/apollo-react/src/canvas/components/AgentCanvas/nodes/AgentNode.test.tsx
@@ -273,6 +273,7 @@ describe('AgentNode - Instructions Footer', () => {
       <AgentNodeElement
         {...defaultNodeProps}
         mode="design"
+        enableInstructions
         onAddInstructions={onAddInstructions}
       />
     );
@@ -285,6 +286,7 @@ describe('AgentNode - Instructions Footer', () => {
       <AgentNodeElement
         {...defaultNodeProps}
         mode="view"
+        enableInstructions
         onAddInstructions={vi.fn()}
       />
     );
@@ -292,11 +294,30 @@ describe('AgentNode - Instructions Footer', () => {
     expect(screen.queryByText('Add Instructions')).not.toBeInTheDocument();
   });
 
+  it('does not show instructions when feature flag is disabled', () => {
+    render(
+      <AgentNodeElement
+        {...defaultNodeProps}
+        mode="design"
+        enableInstructions={false}
+        onAddInstructions={vi.fn()}
+        data={{
+          ...defaultNodeProps.data,
+          instructions: { system: 'You are a helpful assistant' },
+        }}
+      />
+    );
+
+    expect(screen.queryByText('Add Instructions')).not.toBeInTheDocument();
+    expect(screen.queryByText('Instructions')).not.toBeInTheDocument();
+  });
+
   it('shows instructions preview when only system instruction exists', () => {
     render(
       <AgentNodeElement
         {...defaultNodeProps}
         mode="design"
+        enableInstructions
         data={{
           ...defaultNodeProps.data,
           instructions: { system: 'You are a helpful assistant' },
@@ -314,6 +335,7 @@ describe('AgentNode - Instructions Footer', () => {
       <AgentNodeElement
         {...defaultNodeProps}
         mode="design"
+        enableInstructions
         data={{
           ...defaultNodeProps.data,
           instructions: { user: 'Help me with my task' },
@@ -331,6 +353,7 @@ describe('AgentNode - Instructions Footer', () => {
       <AgentNodeElement
         {...defaultNodeProps}
         mode="design"
+        enableInstructions
         data={{
           ...defaultNodeProps.data,
           instructions: {

--- a/packages/apollo-react/src/canvas/components/AgentCanvas/nodes/AgentNode.test.tsx
+++ b/packages/apollo-react/src/canvas/components/AgentCanvas/nodes/AgentNode.test.tsx
@@ -265,3 +265,84 @@ describe('AgentNode - Health Score', () => {
     });
   });
 });
+
+describe('AgentNode - Instructions Footer', () => {
+  it('shows add instructions button in design mode when no instructions', () => {
+    const onAddInstructions = vi.fn();
+    render(
+      <AgentNodeElement
+        {...defaultNodeProps}
+        mode="design"
+        onAddInstructions={onAddInstructions}
+      />
+    );
+
+    expect(screen.getByText('Add Instructions')).toBeInTheDocument();
+  });
+
+  it('does not show add instructions button in view mode', () => {
+    render(
+      <AgentNodeElement
+        {...defaultNodeProps}
+        mode="view"
+        onAddInstructions={vi.fn()}
+      />
+    );
+
+    expect(screen.queryByText('Add Instructions')).not.toBeInTheDocument();
+  });
+
+  it('shows instructions preview when only system instruction exists', () => {
+    render(
+      <AgentNodeElement
+        {...defaultNodeProps}
+        mode="design"
+        data={{
+          ...defaultNodeProps.data,
+          instructions: { system: 'You are a helpful assistant' },
+        }}
+      />
+    );
+
+    expect(screen.getByText('Instructions')).toBeInTheDocument();
+    expect(screen.getByText(/System:/)).toBeInTheDocument();
+    expect(screen.queryByText(/User:/)).not.toBeInTheDocument();
+  });
+
+  it('shows instructions preview when only user instruction exists', () => {
+    render(
+      <AgentNodeElement
+        {...defaultNodeProps}
+        mode="design"
+        data={{
+          ...defaultNodeProps.data,
+          instructions: { user: 'Help me with my task' },
+        }}
+      />
+    );
+
+    expect(screen.getByText('Instructions')).toBeInTheDocument();
+    expect(screen.getByText(/User:/)).toBeInTheDocument();
+    expect(screen.queryByText(/System:/)).not.toBeInTheDocument();
+  });
+
+  it('shows both system and user in preview when both exist', () => {
+    render(
+      <AgentNodeElement
+        {...defaultNodeProps}
+        mode="design"
+        data={{
+          ...defaultNodeProps.data,
+          instructions: {
+            system: 'You are a helpful assistant',
+            user: 'Help me with my task',
+          },
+        }}
+      />
+    );
+
+    expect(screen.getByText('Instructions')).toBeInTheDocument();
+    expect(screen.getByText(/System:/)).toBeInTheDocument();
+    expect(screen.getByText(/User:/)).toBeInTheDocument();
+  });
+});

--- a/packages/apollo-react/src/canvas/components/AgentCanvas/nodes/AgentNode.test.tsx
+++ b/packages/apollo-react/src/canvas/components/AgentCanvas/nodes/AgentNode.test.tsx
@@ -41,6 +41,12 @@ vi.mock('../store/agent-flow-store', () => ({
   }),
 }));
 
+vi.mock('../../FloatingCanvasPanel', () => ({
+  FloatingCanvasPanel: ({ children }: { children?: React.ReactNode }) => (
+    <div data-testid="floating-canvas-panel">{children}</div>
+  ),
+}));
+
 // Mock Icons from @uipath/apollo-react/canvas
 vi.mock('@uipath/apollo-react/canvas', () => ({
   // Re-export everything else from actual module

--- a/packages/apollo-react/src/canvas/components/AgentCanvas/nodes/AgentNode.tsx
+++ b/packages/apollo-react/src/canvas/components/AgentCanvas/nodes/AgentNode.tsx
@@ -89,6 +89,10 @@ const AgentNodeComponent = memo((props: NodeProps<Node<AgentNodeData>> & AgentNo
     id,
     data,
     selected = false,
+    positionAbsoluteX,
+    positionAbsoluteY,
+    width,
+    height,
     mode = 'design',
     hasMemory = false,
     hasContext = false,
@@ -302,8 +306,7 @@ const AgentNodeComponent = memo((props: NodeProps<Node<AgentNodeData>> & AgentNo
           fontWeight: '700',
           lineHeight: '16px',
           color: 'var(--uix-canvas-foreground-de-emp)',
-          cursor: 'pointer',
-          flexShrink: 0,
+          cursor: 'pointer'
         }}
       >
         <Icons.HealthScoreIcon w={14} h={14} />
@@ -522,7 +525,16 @@ const AgentNodeComponent = memo((props: NodeProps<Node<AgentNodeData>> & AgentNo
       />
       <FloatingCanvasPanel
         open={showSettingsPreview}
-        nodeId={id}
+        anchorRect={
+          positionAbsoluteX !== undefined && positionAbsoluteY !== undefined
+            ? {
+                x: positionAbsoluteX,
+                y: positionAbsoluteY,
+                width: width ?? 320,
+                height: height ?? 140,
+              }
+            : undefined
+        }
         placement="right-start"
         offset={16}
         portalToBody

--- a/packages/apollo-react/src/canvas/components/AgentCanvas/nodes/AgentNode.tsx
+++ b/packages/apollo-react/src/canvas/components/AgentCanvas/nodes/AgentNode.tsx
@@ -657,6 +657,7 @@ const AgentNodeComponent = memo((props: NodeProps<Node<AgentNodeData>> & AgentNo
         nodeId={id}
         placement="right-start"
         offset={16}
+        portalToBody
       >
         {settingsPreviewContent}
       </FloatingCanvasPanel>

--- a/packages/apollo-react/src/canvas/components/AgentCanvas/nodes/AgentNode.tsx
+++ b/packages/apollo-react/src/canvas/components/AgentCanvas/nodes/AgentNode.tsx
@@ -1,4 +1,3 @@
-import styled from '@emotion/styled';
 import * as Icons from '@uipath/apollo-react/canvas/icons';
 import type { Node, NodeProps } from '@uipath/apollo-react/canvas/xyflow/react';
 import { Position } from '@uipath/apollo-react/canvas/xyflow/react';
@@ -23,149 +22,25 @@ import { ExecutionStatusIcon } from '../../ExecutionStatusIcon/ExecutionStatusIc
 import type { NodeToolbarConfig, ToolbarAction } from '../../Toolbar';
 import { ResourceNodeType } from '../AgentFlow.constants';
 import { useAgentFlowStore } from '../store/agent-flow-store';
+import {
+  AddInstructionsButton,
+  InstructionsLabel,
+  InstructionsLine,
+  InstructionsPreview,
+  SettingsPreviewContainer,
+  SettingsPreviewHeader,
+  SettingsPreviewSubtitle,
+  SettingsPreviewTitle,
+  SettingsPromptBox,
+  SettingsRow,
+  SettingsRowLabel,
+  SettingsRowValue,
+  SettingsSection,
+  SettingsSectionLabel,
+  SettingsSectionValue,
+} from './AgentNode.styles';
 
 const { ConversationalAgentIcon, AutonomousAgentIcon } = Icons;
-
-const AddInstructionsButton = styled.button`
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 4px;
-  width: 100%;
-  padding: 6px 12px;
-  background: transparent;
-  border: 1px dashed var(--uix-canvas-border-de-emp);
-  border-radius: 8px;
-  cursor: pointer;
-  font-size: 11px;
-  font-weight: 600;
-  color: var(--uix-canvas-foreground-de-emp);
-  line-height: 16px;
-  transition:
-    border-color 0.15s ease,
-    color 0.15s ease;
-
-  &:hover {
-    border-color: var(--uix-canvas-selection-indicator);
-    color: var(--uix-canvas-selection-indicator);
-  }
-`;
-
-const InstructionsLabel = styled.div`
-  font-size: 11px;
-  font-weight: 600;
-  color: var(--uix-canvas-foreground);
-  line-height: 16px;
-`;
-
-const InstructionsPreview = styled.div`
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-  width: 100%;
-  font-size: 9px;
-  line-height: 13px;
-  color: var(--uix-canvas-foreground-de-emp);
-  cursor: pointer;
-`;
-
-const InstructionsLine = styled.div`
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-
-  > strong {
-    font-weight: 600;
-  }
-`;
-
-const SettingsPreviewContainer = styled.div`
-  display: flex;
-  flex-direction: column;
-  gap: 16px;
-  padding: 16px 20px;
-  min-width: 280px;
-  max-width: 320px;
-`;
-
-const SettingsPreviewHeader = styled.div`
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-  padding-bottom: 12px;
-  border-bottom: 1px solid var(--uix-canvas-border-de-emp);
-`;
-
-const SettingsPreviewTitle = styled.div`
-  font-size: 14px;
-  font-weight: 600;
-  color: var(--uix-canvas-foreground-emp);
-`;
-
-const SettingsPreviewSubtitle = styled.div`
-  font-size: 12px;
-  color: var(--uix-canvas-foreground-de-emp);
-`;
-
-const SettingsSection = styled.div`
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-`;
-
-const SettingsSectionLabel = styled.div`
-  font-size: 12px;
-  font-weight: 500;
-  color: var(--uix-canvas-foreground-de-emp);
-`;
-
-const SettingsSectionValue = styled.div`
-  font-size: 14px;
-  color: var(--uix-canvas-foreground-emp);
-`;
-
-const SettingsPromptBox = styled.div<{ isEmpty?: boolean }>`
-  font-size: 13px;
-  color: ${({ isEmpty }) =>
-    isEmpty ? 'var(--uix-canvas-foreground-de-emp)' : 'var(--uix-canvas-foreground)'};
-  font-style: ${({ isEmpty }) => (isEmpty ? 'italic' : 'normal')};
-  background: var(--uix-canvas-background-secondary);
-  border-radius: 6px;
-  padding: 8px 10px;
-  max-height: 80px;
-  overflow-y: auto;
-  white-space: pre-wrap;
-  word-break: break-word;
-
-  &::-webkit-scrollbar {
-    width: 4px;
-  }
-
-  &::-webkit-scrollbar-track {
-    background: transparent;
-  }
-
-  &::-webkit-scrollbar-thumb {
-    background: var(--uix-canvas-border-de-emp);
-    border-radius: 2px;
-  }
-`;
-
-const SettingsRow = styled.div`
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  font-size: 13px;
-`;
-
-const SettingsRowLabel = styled.span`
-  color: var(--uix-canvas-foreground-de-emp);
-`;
-
-const SettingsRowValue = styled.span`
-  color: var(--uix-canvas-foreground-emp);
-  font-weight: 500;
-`;
 
 interface AgentNodeData extends NewBaseNodeData {
   name: string;

--- a/packages/apollo-react/src/canvas/components/AgentCanvas/nodes/AgentNode.tsx
+++ b/packages/apollo-react/src/canvas/components/AgentCanvas/nodes/AgentNode.tsx
@@ -77,6 +77,7 @@ interface AgentNodeProps extends NewBaseNodeDisplayProps {
   onAddInstructions?: () => void;
   translations: AgentNodeTranslations;
   enableMemory?: boolean;
+  enableInstructions?: boolean;
   healthScore?: number;
   onHealthScoreClick?: () => void;
   suggestionTranslations?: SuggestionTranslations;
@@ -105,6 +106,7 @@ const AgentNodeComponent = memo((props: NodeProps<Node<AgentNodeData>> & AgentNo
     onAddInstructions,
     translations,
     enableMemory,
+    enableInstructions = false,
     healthScore,
     onHealthScoreClick,
     suggestionTranslations,
@@ -129,18 +131,20 @@ const AgentNodeComponent = memo((props: NodeProps<Node<AgentNodeData>> & AgentNo
     | undefined;
 
   const handleMouseEnter = useCallback(() => {
+    if (!enableInstructions) return;
     hoverTimeoutRef.current = setTimeout(() => {
       setShowSettingsPreview(true);
     }, HOVER_DELAY_MS);
-  }, []);
+  }, [enableInstructions]);
 
   const handleMouseLeave = useCallback(() => {
+    if (!enableInstructions) return;
     if (hoverTimeoutRef.current) {
       clearTimeout(hoverTimeoutRef.current);
       hoverTimeoutRef.current = null;
     }
     setShowSettingsPreview(false);
-  }, []);
+  }, [enableInstructions]);
 
   useEffect(() => {
     return () => {
@@ -304,6 +308,10 @@ const AgentNodeComponent = memo((props: NodeProps<Node<AgentNodeData>> & AgentNo
     instructionsFooter: React.ReactNode;
     footerVariant: 'none' | 'button' | 'single' | 'double';
   } => {
+    if (!enableInstructions) {
+      return { instructionsFooter: null, footerVariant: 'none' };
+    }
+
     const system = data.instructions?.system;
     const user = data.instructions?.user;
     const hasSystem = Boolean(system);
@@ -355,7 +363,7 @@ const AgentNodeComponent = memo((props: NodeProps<Node<AgentNodeData>> & AgentNo
       ),
       footerVariant: 'button',
     };
-  }, [data.instructions, mode, onAddInstructions, translations]);
+  }, [enableInstructions, data.instructions, mode, onAddInstructions, translations]);
 
   const shouldShowAddButtonFn = (opts: { showAddButton: boolean; selected: boolean }) => {
     return opts.showAddButton || opts.selected;
@@ -553,6 +561,7 @@ const AgentNodeWrapper = (props: NodeProps<Node<AgentNodeData>> & AgentNodeProps
     onAddInstructions,
     translations,
     enableMemory,
+    enableInstructions,
     healthScore,
     onHealthScoreClick,
     suggestionTranslations,
@@ -578,6 +587,7 @@ const AgentNodeWrapper = (props: NodeProps<Node<AgentNodeData>> & AgentNodeProps
       onAddInstructions={onAddInstructions}
       translations={translations}
       enableMemory={enableMemory}
+      enableInstructions={enableInstructions}
       healthScore={healthScore}
       onHealthScoreClick={onHealthScoreClick}
       suggestionTranslations={suggestionTranslations}

--- a/packages/apollo-react/src/canvas/components/AgentCanvas/nodes/AgentNode.tsx
+++ b/packages/apollo-react/src/canvas/components/AgentCanvas/nodes/AgentNode.tsx
@@ -328,12 +328,12 @@ const AgentNodeComponent = memo((props: NodeProps<Node<AgentNodeData>> & AgentNo
           <InstructionsLabel>{translations.instructions}</InstructionsLabel>
           {system && (
             <InstructionsLine>
-              <strong>{translations.system}:</strong> &quot;{system}&quot;
+              <strong>{translations.system}:</strong> "{system}"
             </InstructionsLine>
           )}
           {user && (
             <InstructionsLine>
-              <strong>{translations.user}:</strong> &quot;{user}&quot;
+              <strong>{translations.user}:</strong> "{user}"
             </InstructionsLine>
           )}
         </InstructionsPreview>

--- a/packages/apollo-react/src/canvas/components/AgentCanvas/nodes/AgentNode.tsx
+++ b/packages/apollo-react/src/canvas/components/AgentCanvas/nodes/AgentNode.tsx
@@ -89,10 +89,6 @@ const AgentNodeComponent = memo((props: NodeProps<Node<AgentNodeData>> & AgentNo
     id,
     data,
     selected = false,
-    positionAbsoluteX,
-    positionAbsoluteY,
-    width,
-    height,
     mode = 'design',
     hasMemory = false,
     hasContext = false,
@@ -137,6 +133,15 @@ const AgentNodeComponent = memo((props: NodeProps<Node<AgentNodeData>> & AgentNo
   }, []);
 
   const handleMouseLeave = useCallback(() => {
+    if (hoverTimeoutRef.current) {
+      clearTimeout(hoverTimeoutRef.current);
+      hoverTimeoutRef.current = null;
+    }
+    setShowSettingsPreview(false);
+  }, []);
+
+  const handleMouseDown = useCallback(() => {
+    // Close preview when starting to drag
     if (hoverTimeoutRef.current) {
       clearTimeout(hoverTimeoutRef.current);
       hoverTimeoutRef.current = null;
@@ -489,7 +494,7 @@ const AgentNodeComponent = memo((props: NodeProps<Node<AgentNodeData>> & AgentNo
   }, [data.instructions, settings, translations]);
 
   return (
-    <div onMouseEnter={handleMouseEnter} onMouseLeave={handleMouseLeave}>
+    <div onMouseEnter={handleMouseEnter} onMouseLeave={handleMouseLeave} onMouseDown={handleMouseDown}>
       <NewBaseNode
         {...nodeProps}
         id={id}
@@ -525,19 +530,9 @@ const AgentNodeComponent = memo((props: NodeProps<Node<AgentNodeData>> & AgentNo
       />
       <FloatingCanvasPanel
         open={showSettingsPreview}
-        anchorRect={
-          positionAbsoluteX !== undefined && positionAbsoluteY !== undefined
-            ? {
-                x: positionAbsoluteX,
-                y: positionAbsoluteY,
-                width: width ?? 320,
-                height: height ?? 140,
-              }
-            : undefined
-        }
+        nodeId={id}
         placement="right-start"
         offset={16}
-        portalToBody
       >
         {settingsPreviewContent}
       </FloatingCanvasPanel>

--- a/packages/apollo-react/src/canvas/components/AgentCanvas/nodes/AgentNode.tsx
+++ b/packages/apollo-react/src/canvas/components/AgentCanvas/nodes/AgentNode.tsx
@@ -24,6 +24,7 @@ import { ResourceNodeType } from '../AgentFlow.constants';
 import { useAgentFlowStore } from '../store/agent-flow-store';
 import {
   AddInstructionsButton,
+  HealthScoreBadge,
   InstructionsLabel,
   InstructionsLine,
   InstructionsPreview,
@@ -38,6 +39,7 @@ import {
   SettingsSection,
   SettingsSectionLabel,
   SettingsSectionValue,
+  SubLabelContainer,
 } from './AgentNode.styles';
 
 const { ConversationalAgentIcon, AutonomousAgentIcon } = Icons;
@@ -284,30 +286,17 @@ const AgentNodeComponent = memo((props: NodeProps<Node<AgentNodeData>> & AgentNo
       return null;
     }
     return (
-      <span
+      <HealthScoreBadge
         onClick={(e) => {
           if (onHealthScoreClick) {
             e.stopPropagation();
             onHealthScoreClick();
           }
         }}
-        style={{
-          display: 'inline-flex',
-          alignItems: 'center',
-          gap: '4px',
-          padding: '2px 6px',
-          backgroundColor: 'var(--uix-canvas-background-secondary)',
-          borderRadius: '16px',
-          fontSize: '10px',
-          fontWeight: '700',
-          lineHeight: '16px',
-          color: 'var(--uix-canvas-foreground-de-emp)',
-          cursor: 'pointer'
-        }}
       >
         <Icons.HealthScoreIcon w={14} h={14} />
         {healthScore.toString()}
-      </span>
+      </HealthScoreBadge>
     );
   }, [healthScore, onHealthScoreClick]);
 
@@ -508,12 +497,12 @@ const AgentNodeComponent = memo((props: NodeProps<Node<AgentNodeData>> & AgentNo
         display={{
           label: name,
           subLabel: (
-            <span style={{ display: 'inline-flex', alignItems: 'center', gap: '6px' }}>
+            <SubLabelContainer>
               {isConversational
                 ? translations.conversationalAgent
                 : translations.autonomousAgent}
               {healthScoreBadge}
-            </span>
+            </SubLabelContainer>
           ),
           shape: 'rectangle',
           background: 'var(--uix-canvas-background)',

--- a/packages/apollo-react/src/canvas/components/AgentCanvas/nodes/AgentNode.tsx
+++ b/packages/apollo-react/src/canvas/components/AgentCanvas/nodes/AgentNode.tsx
@@ -140,15 +140,6 @@ const AgentNodeComponent = memo((props: NodeProps<Node<AgentNodeData>> & AgentNo
     setShowSettingsPreview(false);
   }, []);
 
-  const handleMouseDown = useCallback(() => {
-    // Close preview when starting to drag
-    if (hoverTimeoutRef.current) {
-      clearTimeout(hoverTimeoutRef.current);
-      hoverTimeoutRef.current = null;
-    }
-    setShowSettingsPreview(false);
-  }, []);
-
   useEffect(() => {
     return () => {
       if (hoverTimeoutRef.current) {
@@ -494,7 +485,7 @@ const AgentNodeComponent = memo((props: NodeProps<Node<AgentNodeData>> & AgentNo
   }, [data.instructions, settings, translations]);
 
   return (
-    <div onMouseEnter={handleMouseEnter} onMouseLeave={handleMouseLeave} onMouseDown={handleMouseDown}>
+    <div onMouseEnter={handleMouseEnter} onMouseLeave={handleMouseLeave}>
       <NewBaseNode
         {...nodeProps}
         id={id}

--- a/packages/apollo-react/src/canvas/components/AgentCanvas/nodes/AgentNode.tsx
+++ b/packages/apollo-react/src/canvas/components/AgentCanvas/nodes/AgentNode.tsx
@@ -318,10 +318,12 @@ const AgentNodeComponent = memo((props: NodeProps<Node<AgentNodeData>> & AgentNo
   }, [healthScore, onHealthScoreClick]);
 
   const instructionsFooter = useMemo(() => {
-    // Show preview when instructions exist
-    if (data.hasInstructions && data.instructions) {
-      const { system, user } = data.instructions;
-      if (!system && !user) return null;
+    // Show preview when instructions have actual content
+    const system = data.instructions?.system;
+    const user = data.instructions?.user;
+    const hasContent = Boolean(system || user);
+
+    if (hasContent) {
       return (
         <InstructionsPreview
           onClick={(e) => {
@@ -344,7 +346,7 @@ const AgentNodeComponent = memo((props: NodeProps<Node<AgentNodeData>> & AgentNo
       );
     }
 
-    // Show add button in design mode when no instructions
+    // Show add button in design mode when no content
     if (mode !== 'design' || !onAddInstructions) return null;
     return (
       <AddInstructionsButton
@@ -358,7 +360,7 @@ const AgentNodeComponent = memo((props: NodeProps<Node<AgentNodeData>> & AgentNo
         {translations.addInstructions}
       </AddInstructionsButton>
     );
-  }, [data.hasInstructions, data.instructions, mode, onAddInstructions, translations]);
+  }, [data.instructions, mode, onAddInstructions, translations]);
 
   const shouldShowAddButtonFn = (opts: { showAddButton: boolean; selected: boolean }) => {
     return opts.showAddButton || opts.selected;

--- a/packages/apollo-react/src/canvas/components/AgentCanvas/nodes/AgentNode.tsx
+++ b/packages/apollo-react/src/canvas/components/AgentCanvas/nodes/AgentNode.tsx
@@ -79,7 +79,6 @@ const InstructionsLine = styled.div`
   }
 `;
 
-// Agent Settings Preview styles
 const SettingsPreviewContainer = styled.div`
   display: flex;
   flex-direction: column;
@@ -174,7 +173,6 @@ interface AgentNodeData extends NewBaseNodeData {
   definition: Record<string, unknown>;
   parentNodeId?: string;
   isConversational?: boolean;
-  // instructions
   instructions?: {
     system?: string;
     user?: string;
@@ -238,7 +236,6 @@ const AgentNodeComponent = memo((props: NodeProps<Node<AgentNodeData>> & AgentNo
   } = props;
   const { actOnSuggestion } = useAgentFlowStore();
 
-  // Hover preview state
   const [showSettingsPreview, setShowSettingsPreview] = useState(false);
   const hoverTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -254,7 +251,6 @@ const AgentNodeComponent = memo((props: NodeProps<Node<AgentNodeData>> & AgentNo
     | { model?: string; temperature?: number; maxTokens?: number; maxIteration?: number }
     | undefined;
 
-  // Hover handlers
   const handleMouseEnter = useCallback(() => {
     hoverTimeoutRef.current = setTimeout(() => {
       setShowSettingsPreview(true);
@@ -269,7 +265,6 @@ const AgentNodeComponent = memo((props: NodeProps<Node<AgentNodeData>> & AgentNo
     setShowSettingsPreview(false);
   }, []);
 
-  // Cleanup timeout on unmount
   useEffect(() => {
     return () => {
       if (hoverTimeoutRef.current) {
@@ -443,7 +438,6 @@ const AgentNodeComponent = memo((props: NodeProps<Node<AgentNodeData>> & AgentNo
   }, [healthScore, onHealthScoreClick]);
 
   const instructionsFooter = useMemo(() => {
-    // Show preview when instructions have actual content
     const system = data.instructions?.system;
     const user = data.instructions?.user;
     const hasContent = Boolean(system || user);
@@ -560,7 +554,6 @@ const AgentNodeComponent = memo((props: NodeProps<Node<AgentNodeData>> & AgentNo
     };
   }, [isSuggestion, suggestionType]);
 
-  // Settings preview content
   const settingsPreviewContent = useMemo(() => {
     const systemPrompt = data.instructions?.system ?? '';
     const userPrompt = data.instructions?.user ?? '';

--- a/packages/apollo-react/src/canvas/components/AgentCanvas/nodes/AgentNode.tsx
+++ b/packages/apollo-react/src/canvas/components/AgentCanvas/nodes/AgentNode.tsx
@@ -311,48 +311,61 @@ const AgentNodeComponent = memo((props: NodeProps<Node<AgentNodeData>> & AgentNo
     );
   }, [healthScore, onHealthScoreClick]);
 
-  const instructionsFooter = useMemo(() => {
+  const { instructionsFooter, footerVariant } = useMemo((): {
+    instructionsFooter: React.ReactNode;
+    footerVariant: 'none' | 'button' | 'single' | 'double';
+  } => {
     const system = data.instructions?.system;
     const user = data.instructions?.user;
-    const hasContent = Boolean(system || user);
+    const hasSystem = Boolean(system);
+    const hasUser = Boolean(user);
+    const hasContent = hasSystem || hasUser;
 
     if (hasContent) {
-      return (
-        <InstructionsPreview
-          onClick={(e) => {
-            e.stopPropagation();
-            onAddInstructions?.();
-          }}
-        >
-          <InstructionsLabel>{translations.instructions}</InstructionsLabel>
-          {system && (
-            <InstructionsLine>
-              <strong>{translations.system}:</strong> "{system}"
-            </InstructionsLine>
-          )}
-          {user && (
-            <InstructionsLine>
-              <strong>{translations.user}:</strong> "{user}"
-            </InstructionsLine>
-          )}
-        </InstructionsPreview>
-      );
+      return {
+        instructionsFooter: (
+          <InstructionsPreview
+            onClick={(e) => {
+              e.stopPropagation();
+              onAddInstructions?.();
+            }}
+          >
+            <InstructionsLabel>{translations.instructions}</InstructionsLabel>
+            {system && (
+              <InstructionsLine>
+                <strong>{translations.system}:</strong> "{system}"
+              </InstructionsLine>
+            )}
+            {user && (
+              <InstructionsLine>
+                <strong>{translations.user}:</strong> "{user}"
+              </InstructionsLine>
+            )}
+          </InstructionsPreview>
+        ),
+        footerVariant: hasSystem && hasUser ? 'double' : 'single',
+      };
     }
 
     // Show add button in design mode when no content
-    if (mode !== 'design' || !onAddInstructions) return null;
-    return (
-      <AddInstructionsButton
-        type="button"
-        onClick={(e) => {
-          e.stopPropagation();
-          onAddInstructions();
-        }}
-      >
-        <ApIcon name="add" size="14px" />
-        {translations.addInstructions}
-      </AddInstructionsButton>
-    );
+    if (mode !== 'design' || !onAddInstructions) {
+      return { instructionsFooter: null, footerVariant: 'none' };
+    }
+    return {
+      instructionsFooter: (
+        <AddInstructionsButton
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation();
+            onAddInstructions();
+          }}
+        >
+          <ApIcon name="add" size="14px" />
+          {translations.addInstructions}
+        </AddInstructionsButton>
+      ),
+      footerVariant: 'button',
+    };
   }, [data.instructions, mode, onAddInstructions, translations]);
 
   const shouldShowAddButtonFn = (opts: { showAddButton: boolean; selected: boolean }) => {
@@ -506,6 +519,7 @@ const AgentNodeComponent = memo((props: NodeProps<Node<AgentNodeData>> & AgentNo
           background: 'var(--uix-canvas-background)',
           iconBackground: 'var(--uix-canvas-background-secondary)',
           footerComponent: instructionsFooter,
+          footerVariant,
         }}
         toolbarConfig={toolbarConfig}
         adornments={{

--- a/packages/apollo-react/src/canvas/components/AgentCanvas/nodes/AgentNode.tsx
+++ b/packages/apollo-react/src/canvas/components/AgentCanvas/nodes/AgentNode.tsx
@@ -85,7 +85,6 @@ interface AgentNodeData extends NewBaseNodeData {
   parentNodeId?: string;
   isConversational?: boolean;
   // instructions
-  hasInstructions?: boolean;
   instructions?: {
     system?: string;
     user?: string;

--- a/packages/apollo-react/src/canvas/components/BaseNode/BaseNode.styles.ts
+++ b/packages/apollo-react/src/canvas/components/BaseNode/BaseNode.styles.ts
@@ -2,6 +2,13 @@ import { css, keyframes } from '@emotion/react';
 import styled from '@emotion/styled';
 import type { NodeShape } from '../../schema';
 
+// Grid-aligned node heights (multiples of 16px)
+const GRID_UNIT = 16;
+const NODE_HEIGHT_DEFAULT = GRID_UNIT * 6; // 96px
+const NODE_HEIGHT_FOOTER_BUTTON = GRID_UNIT * 9; // 144px
+const NODE_HEIGHT_FOOTER_SINGLE = GRID_UNIT * 10; // 160px
+const NODE_HEIGHT_FOOTER_DOUBLE = GRID_UNIT * 11; // 176px
+
 const pulseAnimation = (cssVar: string) => keyframes`
   0% {
     box-shadow: 0 0 0 0 color-mix(in srgb, var(${cssVar}) 20%, transparent);
@@ -140,16 +147,16 @@ export const BaseContainer = styled.div<{
     if (hasFooter) {
       switch (footerVariant) {
         case 'button':
-          return '144px'; // 9×16
+          return `${NODE_HEIGHT_FOOTER_BUTTON}px`;
         case 'single':
-          return '160px'; // 10×16
+          return `${NODE_HEIGHT_FOOTER_SINGLE}px`;
         case 'double':
-          return '176px'; // 11×16
+          return `${NODE_HEIGHT_FOOTER_DOUBLE}px`;
         default:
           return 'auto';
       }
     }
-    return height ? `${height}px` : '96px';
+    return height ? `${height}px` : `${NODE_HEIGHT_DEFAULT}px`;
   }};
   background: ${({ backgroundColor }) => backgroundColor || 'var(--uix-canvas-background)'};
   border: 1.5px solid var(--uix-canvas-border-de-emp);

--- a/packages/apollo-react/src/canvas/components/BaseNode/BaseNode.styles.ts
+++ b/packages/apollo-react/src/canvas/components/BaseNode/BaseNode.styles.ts
@@ -136,21 +136,20 @@ export const BaseContainer = styled.div<{
     }
     return `${defaultWidth}px`;
   }};
-  height: ${({ height, hasFooter }) => {
-    if (hasFooter) return 'auto';
-    return height ? `${height}px` : '96px';
-  }};
-  min-height: ${({ footerVariant }) => {
-    switch (footerVariant) {
-      case 'button':
-        return '144px'; // 9×16
-      case 'single':
-        return '160px'; // 10×16
-      case 'double':
-        return '176px'; // 11×16
-      default:
-        return undefined;
+  height: ${({ height, hasFooter, footerVariant }) => {
+    if (hasFooter) {
+      switch (footerVariant) {
+        case 'button':
+          return '144px'; // 9×16
+        case 'single':
+          return '160px'; // 10×16
+        case 'double':
+          return '176px'; // 11×16
+        default:
+          return 'auto';
+      }
     }
+    return height ? `${height}px` : '96px';
   }};
   background: ${({ backgroundColor }) => backgroundColor || 'var(--uix-canvas-background)'};
   border: 1.5px solid var(--uix-canvas-border-de-emp);

--- a/packages/apollo-react/src/canvas/components/BaseNode/BaseNode.styles.ts
+++ b/packages/apollo-react/src/canvas/components/BaseNode/BaseNode.styles.ts
@@ -139,7 +139,6 @@ export const BaseContainer = styled.div<{
     if (hasFooter) return 'auto';
     return height ? `${height}px` : '96px';
   }};
-  min-height: ${({ hasFooter }) => (hasFooter ? '96px' : 'unset')};
   background: ${({ backgroundColor }) => backgroundColor || 'var(--uix-canvas-background)'};
   border: 1.5px solid var(--uix-canvas-border-de-emp);
   border-radius: ${({ shape }) => {
@@ -151,15 +150,11 @@ export const BaseContainer = styled.div<{
   flex-direction: ${({ shape }) => (shape === 'rectangle' ? 'row' : 'column')};
   flex-wrap: ${({ hasFooter }) => (hasFooter ? 'wrap' : 'nowrap')};
   align-items: center;
-  align-content: ${({ hasFooter }) => (hasFooter ? 'flex-start' : 'normal')};
   justify-content: ${({ shape }) => (shape === 'rectangle' ? 'flex-start' : 'center')};
-  gap: ${({ shape, hasFooter }) => {
-    if (shape === 'rectangle') return hasFooter ? '8px' : '12px';
-    return '0';
-  }};
+  gap: ${({ shape }) => (shape === 'rectangle' ? '12px' : '0')};
   padding: ${({ shape, height, hasFooter }) => {
     if (shape === 'rectangle') {
-      if (hasFooter) return '10px';
+      if (hasFooter) return '16px';
       const scaleFactor = height ? height / 100 : 1;
       return `${14 * scaleFactor}px`;
     }

--- a/packages/apollo-react/src/canvas/components/BaseNode/BaseNode.styles.ts
+++ b/packages/apollo-react/src/canvas/components/BaseNode/BaseNode.styles.ts
@@ -126,6 +126,7 @@ export const BaseContainer = styled.div<{
   width?: number;
   height?: number;
   hasFooter?: boolean;
+  footerVariant?: 'none' | 'button' | 'single' | 'double';
 }>`
   position: relative;
   width: ${({ shape, width }) => {
@@ -138,6 +139,18 @@ export const BaseContainer = styled.div<{
   height: ${({ height, hasFooter }) => {
     if (hasFooter) return 'auto';
     return height ? `${height}px` : '96px';
+  }};
+  min-height: ${({ footerVariant }) => {
+    switch (footerVariant) {
+      case 'button':
+        return '144px'; // 9×16
+      case 'single':
+        return '160px'; // 10×16
+      case 'double':
+        return '176px'; // 11×16
+      default:
+        return undefined;
+    }
   }};
   background: ${({ backgroundColor }) => backgroundColor || 'var(--uix-canvas-background)'};
   border: 1.5px solid var(--uix-canvas-border-de-emp);

--- a/packages/apollo-react/src/canvas/components/BaseNode/BaseNode.styles.ts
+++ b/packages/apollo-react/src/canvas/components/BaseNode/BaseNode.styles.ts
@@ -125,6 +125,7 @@ export const BaseContainer = styled.div<{
   suggestionType?: string;
   width?: number;
   height?: number;
+  hasFooter?: boolean;
 }>`
   position: relative;
   width: ${({ shape, width }) => {
@@ -134,7 +135,11 @@ export const BaseContainer = styled.div<{
     }
     return `${defaultWidth}px`;
   }};
-  height: ${({ height }) => (height ? `${height}px` : '96px')};
+  height: ${({ height, hasFooter }) => {
+    if (hasFooter) return 'auto';
+    return height ? `${height}px` : '96px';
+  }};
+  min-height: ${({ hasFooter }) => (hasFooter ? '96px' : 'unset')};
   background: ${({ backgroundColor }) => backgroundColor || 'var(--uix-canvas-background)'};
   border: 1.5px solid var(--uix-canvas-border-de-emp);
   border-radius: ${({ shape }) => {
@@ -144,11 +149,17 @@ export const BaseContainer = styled.div<{
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
   display: flex;
   flex-direction: ${({ shape }) => (shape === 'rectangle' ? 'row' : 'column')};
+  flex-wrap: ${({ hasFooter }) => (hasFooter ? 'wrap' : 'nowrap')};
   align-items: center;
+  align-content: ${({ hasFooter }) => (hasFooter ? 'flex-start' : 'normal')};
   justify-content: ${({ shape }) => (shape === 'rectangle' ? 'flex-start' : 'center')};
-  gap: ${({ shape }) => (shape === 'rectangle' ? '12px' : '0')};
-  padding: ${({ shape, height }) => {
+  gap: ${({ shape, hasFooter }) => {
+    if (shape === 'rectangle') return hasFooter ? '8px' : '12px';
+    return '0';
+  }};
+  padding: ${({ shape, height, hasFooter }) => {
     if (shape === 'rectangle') {
+      if (hasFooter) return '10px';
       const scaleFactor = height ? height / 100 : 1;
       return `${14 * scaleFactor}px`;
     }

--- a/packages/apollo-react/src/canvas/components/BaseNode/NewBaseNode.tsx
+++ b/packages/apollo-react/src/canvas/components/BaseNode/NewBaseNode.tsx
@@ -91,6 +91,7 @@ const NewBaseNodeComponent = (
       ? 'var(--uix-canvas-background)'
       : finalDisplay.iconBackground;
   const displayCenterAdornment = finalDisplay.centerAdornmentComponent;
+  const displayFooter = finalDisplay.footerComponent;
 
   const isConnecting = useStore((state) => !!state.connectionClickStartHandle);
 
@@ -219,13 +220,14 @@ const NewBaseNodeComponent = (
         width={width}
         height={height}
         backgroundColor={displayBackground}
+        hasFooter={!!displayFooter}
       >
         {icon && (
           <BaseIconWrapper
             shape={displayShape as 'square' | 'circle' | 'rectangle'}
             backgroundColor={displayIconBackground}
-            height={height}
-            width={width ?? height}
+            height={displayFooter ? undefined : height}
+            width={displayFooter ? undefined : (width ?? height)}
           >
             {icon}
           </BaseIconWrapper>
@@ -277,6 +279,11 @@ const NewBaseNodeComponent = (
             </ApTooltip>
             {displayCenterAdornment}
           </BaseTextContainer>
+        )}
+        {displayFooter && (
+          <div style={{ flexBasis: '100%', paddingTop: '2px' }}>
+            {displayFooter}
+          </div>
         )}
       </BaseContainer>
       {toolbarConfig && (

--- a/packages/apollo-react/src/canvas/components/BaseNode/NewBaseNode.tsx
+++ b/packages/apollo-react/src/canvas/components/BaseNode/NewBaseNode.tsx
@@ -281,7 +281,7 @@ const NewBaseNodeComponent = (
           </BaseTextContainer>
         )}
         {displayFooter && (
-          <div style={{ flexBasis: '100%', paddingTop: '2px' }}>
+          <div style={{ flexBasis: '100%', paddingTop: '2px', minWidth: 0, overflow: 'hidden' }}>
             {displayFooter}
           </div>
         )}

--- a/packages/apollo-react/src/canvas/components/BaseNode/NewBaseNode.tsx
+++ b/packages/apollo-react/src/canvas/components/BaseNode/NewBaseNode.tsx
@@ -92,6 +92,7 @@ const NewBaseNodeComponent = (
       : finalDisplay.iconBackground;
   const displayCenterAdornment = finalDisplay.centerAdornmentComponent;
   const displayFooter = finalDisplay.footerComponent;
+  const displayFooterVariant = finalDisplay.footerVariant;
 
   const isConnecting = useStore((state) => !!state.connectionClickStartHandle);
 
@@ -221,6 +222,7 @@ const NewBaseNodeComponent = (
         height={height}
         backgroundColor={displayBackground}
         hasFooter={!!displayFooter}
+        footerVariant={displayFooterVariant}
       >
         {icon && (
           <BaseIconWrapper

--- a/packages/apollo-react/src/canvas/components/BaseNode/NewBaseNode.types.ts
+++ b/packages/apollo-react/src/canvas/components/BaseNode/NewBaseNode.types.ts
@@ -30,7 +30,7 @@ export interface NewBaseNodeDisplayProps {
 
 export interface NodeDisplay {
   label?: string;
-  subLabel?: string;
+  subLabel?: React.ReactNode;
   labelTooltip?: string;
   labelBackgroundColor?: string;
   shape?: NodeShape;
@@ -38,6 +38,7 @@ export interface NodeDisplay {
   iconBackground?: string;
   iconColor?: string;
   centerAdornmentComponent?: React.ReactNode;
+  footerComponent?: React.ReactNode;
 }
 
 export interface NodeAdornment {

--- a/packages/apollo-react/src/canvas/components/BaseNode/NewBaseNode.types.ts
+++ b/packages/apollo-react/src/canvas/components/BaseNode/NewBaseNode.types.ts
@@ -28,6 +28,8 @@ export interface NewBaseNodeDisplayProps {
   }) => boolean;
 }
 
+export type FooterVariant = 'none' | 'button' | 'single' | 'double';
+
 export interface NodeDisplay {
   label?: string;
   subLabel?: React.ReactNode;
@@ -39,6 +41,7 @@ export interface NodeDisplay {
   iconColor?: string;
   centerAdornmentComponent?: React.ReactNode;
   footerComponent?: React.ReactNode;
+  footerVariant?: FooterVariant;
 }
 
 export interface NodeAdornment {

--- a/packages/apollo-react/src/canvas/components/FloatingCanvasPanel/FloatingCanvasPanel.tsx
+++ b/packages/apollo-react/src/canvas/components/FloatingCanvasPanel/FloatingCanvasPanel.tsx
@@ -133,7 +133,7 @@ export function FloatingCanvasPanel({
 
     const screenPosition = getScreenSpacePosition();
 
-    return createPortal(
+    const fixedContent = (
       <PanelContainer
         className="nodrag nopan nowheel"
         isPinned={isPinned}
@@ -153,9 +153,11 @@ export function FloatingCanvasPanel({
         >
           {children}
         </PanelChrome>
-      </PanelContainer>,
-      document.body
+      </PanelContainer>
     );
+
+    // Use CanvasPortal by default to preserve CSS variables, only portal to body if explicitly requested
+    return portalToBody ? createPortal(fixedContent, document.body) : <CanvasPortal>{fixedContent}</CanvasPortal>;
   }
 
   // Default flow-space positioning

--- a/packages/apollo-react/src/canvas/components/FloatingCanvasPanel/FloatingCanvasPanel.tsx
+++ b/packages/apollo-react/src/canvas/components/FloatingCanvasPanel/FloatingCanvasPanel.tsx
@@ -41,6 +41,12 @@ export type FloatingCanvasPanelProps = {
    * This is useful when anchoring to elements outside the canvas (like toolbar buttons).
    */
   useFixedPosition?: boolean;
+  /**
+   * When true, renders the panel to document.body instead of the canvas portal.
+   * This ensures the panel appears above all other UI elements (toolbars, overlays, etc.)
+   * even when using flow-space positioning with nodeId.
+   */
+  portalToBody?: boolean;
 
   // Header/content
   title?: ReactNode;
@@ -59,6 +65,7 @@ export function FloatingCanvasPanel({
   offset = 20,
   isPinned = false,
   useFixedPosition = false,
+  portalToBody = false,
   title,
   header,
   headerActions,
@@ -152,6 +159,32 @@ export function FloatingCanvasPanel({
   }
 
   // Default flow-space positioning
+  const panelContent = (
+    <PanelContainer
+      ref={refs.setFloating}
+      className="nodrag nopan nowheel"
+      isPinned={isPinned}
+      style={{
+        ...(isPinned ? {} : floatingStyles),
+        position: isPinned ? 'fixed' : 'absolute',
+        right: isPinned ? 0 : undefined,
+        top: isPinned ? 0 : undefined,
+        zIndex: 10000,
+        pointerEvents: 'auto',
+      }}
+    >
+      <PanelChrome
+        title={title}
+        header={header}
+        headerActions={headerActions}
+        onClose={onClose}
+        scrollKey={scrollKey}
+      >
+        {children}
+      </PanelChrome>
+    </PanelContainer>
+  );
+
   return (
     <>
       <ViewportPortal>
@@ -168,31 +201,7 @@ export function FloatingCanvasPanel({
         />
       </ViewportPortal>
 
-      <CanvasPortal>
-        <PanelContainer
-          ref={refs.setFloating}
-          className="nodrag nopan nowheel"
-          isPinned={isPinned}
-          style={{
-            ...(isPinned ? {} : floatingStyles),
-            position: isPinned ? 'fixed' : 'absolute',
-            right: isPinned ? 0 : undefined,
-            top: isPinned ? 0 : undefined,
-            zIndex: 10000,
-            pointerEvents: 'auto',
-          }}
-        >
-          <PanelChrome
-            title={title}
-            header={header}
-            headerActions={headerActions}
-            onClose={onClose}
-            scrollKey={scrollKey}
-          >
-            {children}
-          </PanelChrome>
-        </PanelContainer>
-      </CanvasPortal>
+      {portalToBody ? createPortal(panelContent, document.body) : <CanvasPortal>{panelContent}</CanvasPortal>}
     </>
   );
 }

--- a/packages/apollo-react/src/canvas/components/FloatingCanvasPanel/FloatingCanvasPanel.tsx
+++ b/packages/apollo-react/src/canvas/components/FloatingCanvasPanel/FloatingCanvasPanel.tsx
@@ -83,11 +83,7 @@ export function FloatingCanvasPanel({
 
   if (!open || !computedAnchor) return null;
 
-  // For fixed positioning, render everything to document.body
-  // We calculate position manually since floating-ui doesn't handle fixed positioning well
   if (useFixedPosition && anchorRect) {
-    // Calculate position based on placement
-    // For "top" placement: position above the anchor, centered horizontally
     const getScreenSpacePosition = () => {
       const anchorCenterX = computedAnchor.x + computedAnchor.width / 2;
 
@@ -156,11 +152,9 @@ export function FloatingCanvasPanel({
       </PanelContainer>
     );
 
-    // Use CanvasPortal by default to preserve CSS variables, only portal to body if explicitly requested
     return portalToBody ? createPortal(fixedContent, document.body) : <CanvasPortal>{fixedContent}</CanvasPortal>;
   }
 
-  // Default flow-space positioning
   const panelContent = (
     <PanelContainer
       ref={refs.setFloating}

--- a/packages/apollo-react/src/canvas/storybook-utils/components/StoryInfoPanel.tsx
+++ b/packages/apollo-react/src/canvas/storybook-utils/components/StoryInfoPanel.tsx
@@ -15,6 +15,8 @@ export interface StoryInfoPanelProps {
   collapsible?: boolean;
   /** Initial collapsed state (only applies when collapsible is true) */
   defaultCollapsed?: boolean;
+  /** Panel position */
+  position?: 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right';
 }
 
 export function StoryInfoPanel({
@@ -23,13 +25,14 @@ export function StoryInfoPanel({
   children,
   collapsible = false,
   defaultCollapsed = false,
+  position = 'top-left',
 }: StoryInfoPanelProps) {
   const [isCollapsed, setIsCollapsed] = useState(defaultCollapsed);
 
   const hasContent = description || children;
 
   return (
-    <Panel position="top-left">
+    <Panel position={position}>
       <Column
         p={16}
         style={{

--- a/packages/apollo-react/src/canvas/types.ts
+++ b/packages/apollo-react/src/canvas/types.ts
@@ -334,7 +334,6 @@ export type AgentFlowProps = {
   enableStickyNotes?: boolean;
 
   // instructions
-  hasInstructions?: boolean;
   instructions?: {
     system?: string;
     user?: string;
@@ -413,7 +412,6 @@ export type AgentFlowNodeData = {
   suggestionId?: string;
   suggestionType?: SuggestionType;
   isProcessing?: boolean;
-  hasInstructions?: boolean;
   instructions?: {
     system?: string;
     user?: string;

--- a/packages/apollo-react/src/canvas/types.ts
+++ b/packages/apollo-react/src/canvas/types.ts
@@ -333,6 +333,13 @@ export type AgentFlowProps = {
   enableMemory?: boolean;
   enableStickyNotes?: boolean;
 
+  // instructions
+  hasInstructions?: boolean;
+  instructions?: {
+    system?: string;
+    user?: string;
+  };
+
   // health score
   healthScore?: number;
   onHealthScoreClick?: () => void;
@@ -407,6 +414,10 @@ export type AgentFlowNodeData = {
   suggestionType?: SuggestionType;
   isProcessing?: boolean;
   hasInstructions?: boolean;
+  instructions?: {
+    system?: string;
+    user?: string;
+  };
 };
 export type AgentFlowNode = Node<AgentFlowNodeData, 'agent'> & {
   extent?: 'parent' | CoordinateExtent | undefined;
@@ -514,6 +525,7 @@ export interface AgentNodeTranslations {
   context: string;
   tools: string;
   memory: string;
+  instructions: string;
   addInstructions: string;
 }
 
@@ -531,6 +543,7 @@ export const DefaultAgentNodeTranslations: AgentNodeTranslations = {
   context: 'Context',
   tools: 'Tools',
   memory: 'Memory',
+  instructions: 'Instructions',
   addInstructions: 'Add Instructions',
 };
 

--- a/packages/apollo-react/src/canvas/types.ts
+++ b/packages/apollo-react/src/canvas/types.ts
@@ -332,6 +332,7 @@ export type AgentFlowProps = {
   /** TODO: Remove once memory feature is fully implemented */
   enableMemory?: boolean;
   enableStickyNotes?: boolean;
+  enableInstructions?: boolean;
 
   instructions?: {
     system?: string;

--- a/packages/apollo-react/src/canvas/types.ts
+++ b/packages/apollo-react/src/canvas/types.ts
@@ -406,6 +406,7 @@ export type AgentFlowNodeData = {
   suggestionId?: string;
   suggestionType?: SuggestionType;
   isProcessing?: boolean;
+  hasInstructions?: boolean;
 };
 export type AgentFlowNode = Node<AgentFlowNodeData, 'agent'> & {
   extent?: 'parent' | CoordinateExtent | undefined;
@@ -513,6 +514,7 @@ export interface AgentNodeTranslations {
   context: string;
   tools: string;
   memory: string;
+  addInstructions: string;
 }
 
 export const DefaultAgentNodeTranslations: AgentNodeTranslations = {
@@ -529,6 +531,7 @@ export const DefaultAgentNodeTranslations: AgentNodeTranslations = {
   context: 'Context',
   tools: 'Tools',
   memory: 'Memory',
+  addInstructions: 'Add Instructions',
 };
 
 export interface ResourceNodeTranslations {

--- a/packages/apollo-react/src/canvas/types.ts
+++ b/packages/apollo-react/src/canvas/types.ts
@@ -333,7 +333,6 @@ export type AgentFlowProps = {
   enableMemory?: boolean;
   enableStickyNotes?: boolean;
 
-  // instructions
   instructions?: {
     system?: string;
     user?: string;

--- a/packages/apollo-react/src/canvas/types.ts
+++ b/packages/apollo-react/src/canvas/types.ts
@@ -525,6 +525,15 @@ export interface AgentNodeTranslations {
   memory: string;
   instructions: string;
   addInstructions: string;
+  // Settings preview
+  agentSettings: string;
+  readOnlyPreview: string;
+  systemPrompt: string;
+  userPrompt: string;
+  temperature: string;
+  maxTokens: string;
+  maxIteration: string;
+  notConfigured: string;
 }
 
 export const DefaultAgentNodeTranslations: AgentNodeTranslations = {
@@ -543,6 +552,15 @@ export const DefaultAgentNodeTranslations: AgentNodeTranslations = {
   memory: 'Memory',
   instructions: 'Instructions',
   addInstructions: 'Add Instructions',
+  // Settings preview
+  agentSettings: 'Agent Settings',
+  readOnlyPreview: 'Read-only preview',
+  systemPrompt: 'System prompt',
+  userPrompt: 'User prompt',
+  temperature: 'Temperature',
+  maxTokens: 'Max tokens',
+  maxIteration: 'Max iteration',
+  notConfigured: 'Not configured',
 };
 
 export interface ResourceNodeTranslations {

--- a/packages/apollo-react/src/canvas/utils/props-helpers.ts
+++ b/packages/apollo-react/src/canvas/utils/props-helpers.ts
@@ -151,6 +151,8 @@ const createAgentNode = (props: AgentFlowProps, parentNodeId?: string): AgentFlo
       description: props.description,
       definition: props.definition,
       parentNodeId,
+      hasInstructions: props.hasInstructions,
+      instructions: props.instructions,
     },
     draggable: Boolean(props.allowDragging && props.mode === 'design'), // Agent node is draggable in design mode, not in view mode
   };

--- a/packages/apollo-react/src/canvas/utils/props-helpers.ts
+++ b/packages/apollo-react/src/canvas/utils/props-helpers.ts
@@ -151,7 +151,6 @@ const createAgentNode = (props: AgentFlowProps, parentNodeId?: string): AgentFlo
       description: props.description,
       definition: props.definition,
       parentNodeId,
-      hasInstructions: props.hasInstructions,
       instructions: props.instructions,
     },
     draggable: Boolean(props.allowDragging && props.mode === 'design'), // Agent node is draggable in design mode, not in view mode


### PR DESCRIPTION
- Zero State - Agent Just Created - add "+ Add Instructions" Button on agent node
- Show Preview of the Prompt(s) on the agent node
- Show agent settings as preview when hover with cursor over the agent node >0.5s
- Make the floating panel on the top
- Feature flag

https://uipath.atlassian.net/browse/AG-685
https://uipath.atlassian.net/browse/AG-689
https://uipath.atlassian.net/browse/AG-690
https://uipath.atlassian.net/browse/AG-709

https://github.com/user-attachments/assets/14c8ad3f-ee25-4b9e-b075-06c853ece83b

Tested in frontend-sw locally:
https://github.com/user-attachments/assets/cf77a0bd-3d23-48e8-8abd-0e6ad319db33




