### PR TITLE
fix(apollo-react): fallback for broken tool image (#AG-699)

### DIFF
--- a/packages/apollo-react/src/canvas/components/AgentCanvas/AgentFlow.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/AgentCanvas/AgentFlow.stories.tsx
@@ -52,8 +52,19 @@ const sampleContexts = [
   { name: 'Environment Variables', description: 'System environment settings' },
 ];
 
-const sampleTools = [
+const sampleTools: {
+  name: string;
+  description: string;
+  projectType: ProjectType;
+  iconUrl?: string;
+}[] = [
   { name: 'Send Email', description: 'Email Service', projectType: ProjectType.Internal },
+  {
+    name: 'Broken Icon Tool',
+    description: 'Automation',
+    projectType: ProjectType.Internal,
+    iconUrl: 'https://testtest.broken/blah/blah',
+  },
   { name: 'Query Database', description: 'Database', projectType: ProjectType.Internal },
   { name: 'Call API', description: 'REST API', projectType: ProjectType.Api },
   { name: 'Process Document', description: 'Document AI', projectType: ProjectType.Internal },

--- a/packages/apollo-react/src/canvas/components/AgentCanvas/AgentFlow.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/AgentCanvas/AgentFlow.stories.tsx
@@ -105,7 +105,7 @@ const createSampleTool = (): AgentFlowResource => {
     type: 'tool',
     name: sample.name,
     description: sample.description,
-    iconUrl: '',
+    iconUrl: sample.iconUrl ?? '',
     hasBreakpoint: false,
     hasGuardrails: false,
     projectType: sample.projectType as ProjectType,

--- a/packages/apollo-react/src/canvas/components/AgentCanvas/components/ToolResourceIcon/ToolResourceIcon.tsx
+++ b/packages/apollo-react/src/canvas/components/AgentCanvas/components/ToolResourceIcon/ToolResourceIcon.tsx
@@ -1,4 +1,5 @@
 import * as Icons from '@uipath/apollo-react/canvas/icons';
+import { useState } from 'react';
 import {
   BuiltInToolType,
   ProjectType,
@@ -18,12 +19,15 @@ interface ToolResourceIconProps {
 
 /** Mapped icons from agents frontend-sw */
 export const ToolResourceIcon = ({ size = 24, tool }: ToolResourceIconProps) => {
-  if (tool.iconUrl) {
+  const [imgError, setImgError] = useState(false);
+
+  if (tool.iconUrl && !imgError) {
     return (
       <img
         src={tool.iconUrl}
         alt={tool.name}
         style={{ width: size, height: size, objectFit: 'contain' }}
+        onError={() => setImgError(true)}
       />
     );
   }


### PR DESCRIPTION
this PR creates a fallback if IconURL is a 404 image or is blank, will default back to the processIcon