### PR TITLE
fix(apollo-react): initialize base node height only after reactFlow measure [MST-6329]

### DIFF
--- a/packages/apollo-react/src/canvas/components/BaseNode/BaseNode.tsx
+++ b/packages/apollo-react/src/canvas/components/BaseNode/BaseNode.tsx
@@ -44,7 +44,6 @@ const BaseNodeComponent = (props: NodeProps<Node<BaseNodeData>>) => {
   const [isHovered, setIsHovered] = useState(false);
   const [isFocused, setIsFocused] = useState(false);
 
-  const isInitialMountRef = useRef(true);
   const originalHeightRef = useRef<number | undefined>(undefined);
 
   // Get execution status from external source
@@ -140,9 +139,9 @@ const BaseNodeComponent = (props: NodeProps<Node<BaseNodeData>>) => {
 
   // Sync computed height to node when it changes
   useEffect(() => {
-    if (isInitialMountRef.current) {
-      isInitialMountRef.current = false;
-      originalHeightRef.current = height ?? DEFAULT_NODE_SIZE;
+    // Initialising originalHeightRef only when React Flow has finished measuring it and updated the height prop
+    if (!originalHeightRef.current && height) {
+      originalHeightRef.current = height;
       return;
     }
 


### PR DESCRIPTION
### Description

This PR

- Initialises originalHeightRef in BaseNode only after ReactFlow measures it dynamically. This prevents rendering issues when no height and width are passed to BaseNode. 

### Demo

Before:

<img width="391" height="148" alt="Screenshot 2026-01-30 at 11 59 30" src="https://github.com/user-attachments/assets/a0166a12-7ac0-4a8c-920e-fb4d497d54e9" />

After:

<img width="472" height="278" alt="Screenshot 2026-01-30 at 11 59 14" src="https://github.com/user-attachments/assets/f06f053a-2633-408d-a75f-a32dc89bf658" />
