### PR TITLE
feat(apollo-wind): re-export toast function from sonner

### DIFF
--- a/packages/apollo-wind/src/components/ui/sonner.tsx
+++ b/packages/apollo-wind/src/components/ui/sonner.tsx
@@ -2,7 +2,7 @@
 
 import { CircleCheck, Info, LoaderCircle, OctagonX, TriangleAlert } from 'lucide-react';
 import { useTheme } from 'next-themes';
-import { Toaster as Sonner } from 'sonner';
+import { toast, Toaster as Sonner } from 'sonner';
 
 type ToasterProps = React.ComponentProps<typeof Sonner>;
 
@@ -34,4 +34,4 @@ const Toaster = ({ ...props }: ToasterProps) => {
   );
 };
 
-export { Toaster };
+export { toast, Toaster };

--- a/packages/apollo-wind/src/index.ts
+++ b/packages/apollo-wind/src/index.ts
@@ -224,7 +224,7 @@ export {
 
 export { Alert, AlertDescription, AlertTitle } from './components/ui/alert';
 
-export { Toaster } from './components/ui/sonner';
+export { toast, Toaster } from './components/ui/sonner';
 
 // -----------------------------------------------------------------------------
 // Navigation Components


### PR DESCRIPTION
## Summary                                                                                
- Re-exports the `toast` function from `sonner` via `@uipath/apollo-wind`, allowing consumers to import both `Toaster` and `toast` from a single package instead of requiring `sonner` as a direct dependency

## Test plan                                                                            
  - [ ] Verify `toast` is available in the built declaration files (`dist/index.d.ts`)    
  - [ ] Confirm `import { Toaster, toast } from '@uipath/apollo-wind'` works in a  consuming app                                                                            
  - [ ] Validate `toast.success()`, `toast.error()`, `toast.info()`, and `toast.warning()`   function correctly