### PR TITLE
fix(apollo-wind): switch dialog from transform to flex positioning

### DIFF
--- a/packages/apollo-wind/src/components/ui/dialog.tsx
+++ b/packages/apollo-wind/src/components/ui/dialog.tsx
@@ -36,7 +36,7 @@ const DialogOverlay = React.forwardRef<
     <DialogPrimitive.Overlay
       data-slot="dialog-overlay"
       className={cn(
-        'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50',
+        'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed flex items-center justify-center inset-0 z-50 bg-black/50',
         className
       )}
       ref={ref}
@@ -53,27 +53,28 @@ const DialogContent = React.forwardRef<
 >(function DialogContent({ className, children, showCloseButton = true, ...props }, ref) {
   return (
     <DialogPortal data-slot="dialog-portal">
-      <DialogOverlay />
-      <DialogPrimitive.Content
-        data-slot="dialog-content"
-        className={cn(
-          'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg',
-          className
-        )}
-        ref={ref}
-        {...props}
-      >
-        {children}
-        {showCloseButton && (
-          <DialogPrimitive.Close
-            data-slot="dialog-close"
-            className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
-          >
-            <XIcon />
-            <span className="sr-only">Close</span>
-          </DialogPrimitive.Close>
-        )}
-      </DialogPrimitive.Content>
+      <DialogOverlay>
+        <DialogPrimitive.Content
+          data-slot="dialog-content"
+          className={cn(
+            'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 z-50 grid w-full max-w-[calc(100%-2rem)] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg',
+            className
+          )}
+          ref={ref}
+          {...props}
+        >
+          {children}
+          {showCloseButton && (
+            <DialogPrimitive.Close
+              data-slot="dialog-close"
+              className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
+            >
+              <XIcon />
+              <span className="sr-only">Close</span>
+            </DialogPrimitive.Close>
+          )}
+        </DialogPrimitive.Content>
+      </DialogOverlay>
     </DialogPortal>
   );
 });


### PR DESCRIPTION
## Summary

Refactors the Dialog component from transform-based centering (`translate-x-[-50%] translate-y-[-50%]`) to flex-based centering, which avoids transform interference with child element calculations.

This is necessary to fix usage of the Monaco Editor in apollo-wind containers. Monaco has a bug where, inside transformed containers, the completion widget (and other widgets) are rendering incorrectly: https://github.com/microsoft/monaco-editor/issues/2793

This caused issues in flow where the code editor would be offset: 
<img width="1679" height="794" alt="Screenshot 2026-01-30 at 1 08 19 PM" src="https://github.com/user-attachments/assets/7d3f2690-07f4-466b-90d3-d056415127b9" />

Unfortunately, the workaround - to have a container we create on the fly to position widgets - aside from being quite complex, it caused issues when integrating flow into StudioWeb.

The easiest path forward seem to be adjust the dialog to be flex-positioned instead of transformed, which avoids the Monaco bug and simplifies position calculations. With this change, Monaco works well inside the dialog:
<img width="1627" height="808" alt="image" src="https://github.com/user-attachments/assets/fa685b6a-58bf-42eb-87da-33dc29cb7e00" />



## Changes

- **DialogOverlay**: Added `flex items-center justify-center` to enable flex-based centering
- **DialogContent**:
  - Removed `fixed top-[50%] left-[50%] translate-x-[-50%] translate-y-[-50%]` positioning
  - Now rendered as a child of `DialogOverlay` instead of a sibling
  - Retained `z-50` for proper stacking context

## Testing

- [x] Dialog opens centered in the viewport
- [x] Click-outside-to-close still works (clicking overlay closes dialog)
- [x] Open/close animations look correct (fade + zoom)
- [x] Close button (X) is positioned correctly and functional
- [x] Focus trapping works within dialog content
- [x] Dialog with tall content scrolls properly (if applicable)
- [x] Test dialog in storybook
- [x] Test dialog in flow


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
