### PR TITLE
fix(apollo-react): integrate NodeRegistryProvider into AgentFlow [AG-708]

### DIFF
--- a/packages/apollo-react/src/canvas/components/AgentCanvas/AgentFlow.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/AgentCanvas/AgentFlow.stories.tsx
@@ -5,7 +5,6 @@ import { FontVariantToken } from '@uipath/apollo-react/core';
 import { ApButton, ApTypography } from '@uipath/apollo-react/material';
 import { useCallback, useState } from 'react';
 import type { IRawSpan } from '../../../types/TraceModels';
-import { NodeRegistryProvider } from '../../core/NodeRegistryProvider';
 import { StoryInfoPanel } from '../../storybook-utils';
 import {
   type AgentFlowProps,
@@ -18,26 +17,23 @@ import {
   ProjectType,
 } from '../../types';
 import { AgentFlow } from './AgentFlow';
-import { agentFlowManifest } from './agent-flow.manifest';
 
 const meta: Meta<typeof AgentFlow> = {
   title: 'Canvas/AgentFlow',
   component: AgentFlow,
   decorators: [
     (Story) => (
-      <NodeRegistryProvider manifest={agentFlowManifest}>
-        <div
-          style={{
-            position: 'absolute',
-            top: 0,
-            left: 0,
-            width: '100%',
-            height: '100%',
-          }}
-        >
-          <Story />
-        </div>
-      </NodeRegistryProvider>
+      <div
+        style={{
+          position: 'absolute',
+          top: 0,
+          left: 0,
+          width: '100%',
+          height: '100%',
+        }}
+      >
+        <Story />
+      </div>
     ),
   ],
 };

--- a/packages/apollo-react/src/canvas/components/AgentCanvas/AgentFlow.tsx
+++ b/packages/apollo-react/src/canvas/components/AgentCanvas/AgentFlow.tsx
@@ -37,6 +37,8 @@ import { Edge } from './edges/Edge';
 import { AgentNodeElement } from './nodes/AgentNode';
 import { ResourceNode } from './nodes/ResourceNode';
 import { AgentFlowProvider, useAgentFlowStore } from './store/agent-flow-store';
+import { NodeRegistryProvider } from '../../core/NodeRegistryProvider';
+import { agentFlowManifest } from './agent-flow.manifest';
 
 const ToolbarContainer = styled.div`
   display: flex;
@@ -714,8 +716,10 @@ AgentFlowInner.displayName = 'AgentFlowInner';
 
 export const AgentFlow = (props: PropsWithChildren<AgentFlowProps>) => {
   return (
-    <AgentFlowProvider {...props}>
-      <AgentFlowInner {...props} />
-    </AgentFlowProvider>
+    <NodeRegistryProvider manifest={agentFlowManifest}>
+      <AgentFlowProvider {...props}>
+        <AgentFlowInner {...props} />
+      </AgentFlowProvider>
+    </NodeRegistryProvider>
   );
 };

--- a/packages/apollo-react/src/canvas/components/AgentCanvas/components/TimelinePlayer.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/AgentCanvas/components/TimelinePlayer.stories.tsx
@@ -4,7 +4,6 @@ import { ReactFlowProvider } from '@uipath/apollo-react/canvas/xyflow/react';
 import { useCallback, useState } from 'react';
 
 import type { IRawSpan } from '../../../../types/TraceModels';
-import { NodeRegistryProvider } from '../../../core/NodeRegistryProvider';
 import {
   type AgentFlowResource,
   type AgentFlowResourceNodeData,
@@ -12,7 +11,6 @@ import {
   ProjectType,
 } from '../../../types';
 import { AgentFlow } from '../AgentFlow';
-import { agentFlowManifest } from '../agent-flow.manifest';
 import { TimelinePlayer } from './TimelinePlayer';
 
 const meta: Meta<typeof TimelinePlayer> = {
@@ -388,33 +386,31 @@ const AgentFlowWithTimeline = ({
   }, []);
 
   return (
-    <NodeRegistryProvider manifest={agentFlowManifest}>
-      <ReactFlowProvider>
-        <Row w="100%" h="100%" style={{ position: 'relative' }}>
-          <div style={{ flex: 1, position: 'relative' }}>
-            <AgentFlow
-              allowDragging={false}
-              definition={sampleDefinition}
-              spans={spans}
-              name="Quick Query Agent"
-              description="Processes quick queries with context loading and response generation"
-              mode="view"
-              resources={resources}
-              activeResourceIds={activeResourceIds}
-              setSpanForSelectedNode={setSpanForSelectedNode}
-              getNodeFromSelectedSpan={getNodeFromSelectedSpan}
-              onAddBreakpoint={handleAddBreakpoint}
-              onRemoveBreakpoint={handleRemoveBreakpoint}
-              onAddGuardrail={handleAddGuardrail}
-              onAddResource={handleAddResourceRequest}
-              onRemoveResource={handleRemoveResource}
-              onSelectResource={handleSelectResource}
-              enableTimelinePlayer={enableTimelinePlayer}
-            />
-          </div>
-        </Row>
-      </ReactFlowProvider>
-    </NodeRegistryProvider>
+    <ReactFlowProvider>
+      <Row w="100%" h="100%" style={{ position: 'relative' }}>
+        <div style={{ flex: 1, position: 'relative' }}>
+          <AgentFlow
+            allowDragging={false}
+            definition={sampleDefinition}
+            spans={spans}
+            name="Quick Query Agent"
+            description="Processes quick queries with context loading and response generation"
+            mode="view"
+            resources={resources}
+            activeResourceIds={activeResourceIds}
+            setSpanForSelectedNode={setSpanForSelectedNode}
+            getNodeFromSelectedSpan={getNodeFromSelectedSpan}
+            onAddBreakpoint={handleAddBreakpoint}
+            onRemoveBreakpoint={handleRemoveBreakpoint}
+            onAddGuardrail={handleAddGuardrail}
+            onAddResource={handleAddResourceRequest}
+            onRemoveResource={handleRemoveResource}
+            onSelectResource={handleSelectResource}
+            enableTimelinePlayer={enableTimelinePlayer}
+          />
+        </div>
+      </Row>
+    </ReactFlowProvider>
   );
 };
 

--- a/packages/apollo-react/src/canvas/components/CodedAgent/CodedAgentFlow.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/CodedAgent/CodedAgentFlow.stories.tsx
@@ -1,26 +1,22 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { NodeRegistryProvider } from '../../core/NodeRegistryProvider';
 import { CodedAgentFlow } from './CodedAgentFlow';
-import { codedAgentManifest } from './coded-agent.manifest';
 
 const meta: Meta<typeof CodedAgentFlow> = {
   title: 'Canvas/CodedAgentFlow',
   component: CodedAgentFlow,
   decorators: [
     (Story) => (
-      <NodeRegistryProvider manifest={codedAgentManifest}>
-        <div
-          style={{
-            position: 'absolute',
-            top: 0,
-            left: 0,
-            width: '100%',
-            height: '100%',
-          }}
-        >
-          <Story />
-        </div>
-      </NodeRegistryProvider>
+      <div
+        style={{
+          position: 'absolute',
+          top: 0,
+          left: 0,
+          width: '100%',
+          height: '100%',
+        }}
+      >
+        <Story />
+      </div>
     ),
   ],
 };

--- a/packages/apollo-react/src/canvas/components/CodedAgent/CodedAgentFlow.test.tsx
+++ b/packages/apollo-react/src/canvas/components/CodedAgent/CodedAgentFlow.test.tsx
@@ -2,9 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ReactElement } from 'react';
 import { render, screen, waitFor } from '../../utils/testing';
 import { BaseCanvasModeProvider } from '../BaseCanvas/BaseCanvasModeProvider';
-import { NodeRegistryProvider } from '../../core/NodeRegistryProvider';
 import { CodedAgentFlow } from './CodedAgentFlow';
-import { codedAgentManifest } from './coded-agent.manifest';
 
 // Mock BaseCanvas to avoid ReactFlow dependencies in tests
 vi.mock('../BaseCanvas', () => ({
@@ -128,11 +126,7 @@ vi.mock('mermaid', () => {
 
 // Test wrapper that provides required context
 const renderWithProviders = (ui: ReactElement) => {
-  return render(
-    <BaseCanvasModeProvider mode="design">
-      <NodeRegistryProvider manifest={codedAgentManifest}>{ui}</NodeRegistryProvider>
-    </BaseCanvasModeProvider>
-  );
+  return render(<BaseCanvasModeProvider mode="design">{ui}</BaseCanvasModeProvider>);
 };
 
 describe('CodedAgentFlow', () => {

--- a/packages/apollo-react/src/canvas/components/CodedAgent/CodedAgentFlow.tsx
+++ b/packages/apollo-react/src/canvas/components/CodedAgent/CodedAgentFlow.tsx
@@ -34,6 +34,8 @@ import { BaseNode } from '../BaseNode/BaseNode';
 import type { BaseNodeData } from '../BaseNode/BaseNode.types';
 import { CanvasPositionControls } from '../CanvasPositionControls';
 import type { HandleGroupManifest } from '../../schema/node-definition';
+import { NodeRegistryProvider } from '../../core/NodeRegistryProvider';
+import { codedAgentManifest } from './coded-agent.manifest';
 
 const LAYOUT_SPACING = [110, 80] as [number, number]; // Horizontal and vertical spacing for layout
 
@@ -540,8 +542,10 @@ const CodedAgentFlowInner = (props: CodedAgentFlowProps): ReactElement => {
 
 export const CodedAgentFlow = (props: CodedAgentFlowProps): ReactElement => {
   return (
-    <ReactFlowProvider>
-      <CodedAgentFlowInner {...props} />
-    </ReactFlowProvider>
+    <NodeRegistryProvider manifest={codedAgentManifest}>
+      <ReactFlowProvider>
+        <CodedAgentFlowInner {...props} />
+      </ReactFlowProvider>
+    </NodeRegistryProvider>
   );
 };


### PR DESCRIPTION
https://uipath.atlassian.net/browse/AG-708

Fixes so consumers of AgentFlow and CodedAgentFlow don't need to render the NodeRegistryProvider, and it's done already within the AgentFlow and CodedAgentFlow components