### PR TITLE
feat(apollo-react): add Modal Component to PLT-96037

### DIFF
--- a/apps/react-playground/src/App.tsx
+++ b/apps/react-playground/src/App.tsx
@@ -28,6 +28,7 @@ import { IconButtonShowcase } from "./pages/components/IconButtonShowcase";
 import { IconShowcase } from "./pages/components/IconShowcase";
 import { LinkShowcase } from "./pages/components/LinkShowcase";
 import { MenuShowcase } from "./pages/components/MenuShowcase";
+import { ModalShowcase } from "./pages/components/ModalShowcase";
 import { ProgressSpinnerShowcase } from "./pages/components/ProgressSpinnerShowcase";
 import { SkeletonShowcase } from "./pages/components/SkeletonShowcase";
 import { TextAreaShowcase } from "./pages/components/TextAreaShowcase";
@@ -156,6 +157,7 @@ function App() {
 							<Route path="/components/chat" element={<ApChatShowcase />} />
 							<Route path="/components/chip" element={<ChipShowcase />} />
 							<Route path="/components/link" element={<LinkShowcase />} />
+							<Route path="/components/modal" element={<ModalShowcase />} />
 							<Route path="/components/popover" element={<PopoverShowcase />} />
 							<Route
 								path="/components/skeleton"

--- a/apps/react-playground/src/components/Breadcrumb.tsx
+++ b/apps/react-playground/src/components/Breadcrumb.tsx
@@ -61,6 +61,7 @@ export function Breadcrumb() {
 		badge: "Badge",
 		button: "Button",
 		chat: "Chat",
+		modal: "Modal",
 		popover: "Popover",
 		"text-area": "Text Area",
 		"tool-call": "Tool Call",

--- a/apps/react-playground/src/components/CodeBlock.tsx
+++ b/apps/react-playground/src/components/CodeBlock.tsx
@@ -81,6 +81,12 @@ export function CodeBlock({
 					fontSize: 14,
 					margin: 0,
 				}}
+				codeTagProps={{
+					style: {
+						whiteSpace: "pre-wrap",
+						wordBreak: "break-all",
+					},
+				}}
 			>
 				{code}
 			</SyntaxHighlighter>

--- a/apps/react-playground/src/components/Sidebar.tsx
+++ b/apps/react-playground/src/components/Sidebar.tsx
@@ -58,6 +58,7 @@ export function Sidebar() {
 				{ label: "Icon Button", path: "/components/icon-button" },
 				{ label: "Link", path: "/components/link" },
 				{ label: "Menu", path: "/components/menu" },
+				{ label: "Modal", path: "/components/modal" },
 				{ label: "Popover", path: "/components/popover" },
 				{ label: "Progress Spinner", path: "/components/progress-spinner" },
 				{ label: "Sankey Diagram", path: "/components/sankey-diagram" },

--- a/apps/react-playground/src/pages/ComponentsHome.tsx
+++ b/apps/react-playground/src/pages/ComponentsHome.tsx
@@ -31,6 +31,7 @@ export function ComponentsHome() {
 		{ label: "Popover", path: "/components/popover", icon: "📋" },
 		{ label: "Link", path: "/components/link", icon: "🔗" },
 		{ label: "Menu", path: "/components/menu", icon: "☰" },
+		{ label: "Modal", path: "/components/modal", icon: "🪟" },
 		{
 			label: "Progress Spinner",
 			path: "/components/progress-spinner",

--- a/apps/react-playground/src/pages/components/ModalShowcase.tsx
+++ b/apps/react-playground/src/pages/components/ModalShowcase.tsx
@@ -1,0 +1,600 @@
+import {
+	ApAccordion,
+	ApButton,
+	ApModal,
+	ApTypography,
+} from "@uipath/apollo-react/material/components";
+import { useState } from "react";
+import styled from "styled-components";
+import { CodeBlock } from "../../components/CodeBlock";
+
+import {
+	PageContainer,
+	PageDescription,
+	PageTitle,
+} from "../../components/SharedStyles";
+import { FontVariantToken } from "@uipath/apollo-react";
+
+const ShowcaseSection = styled.div`
+	margin-top: 48px;
+	display: flex;
+	flex-direction: column;
+	gap: 24px;
+`;
+
+const SectionTitle = styled.h3`
+	font-size: 20px;
+	color: var(--color-primary);
+	margin-bottom: 16px;
+	border-bottom: 2px solid var(--color-border);
+	padding-bottom: 8px;
+`;
+
+const ComponentRow = styled.div`
+	display: flex;
+	flex-direction: column;
+	padding: 24px;
+	background: var(--color-background);
+	border-radius: 12px;
+	border: 2px solid var(--color-border);
+	gap: 16px;
+`;
+
+const ButtonGroup = styled.div`
+	display: flex;
+	flex-wrap: wrap;
+	gap: 16px;
+`;
+
+const Label = styled.div`
+	font-size: 14px;
+	color: var(--color-foreground-de-emp);
+	font-weight: 600;
+	margin-bottom: 8px;
+`;
+
+const basicModalCode = `
+import { ApModal, ApButton } from "@uipath/apollo-react/material/components";
+import { useState } from "react";
+
+export function Example() {
+	const [open, setOpen] = useState(false);
+
+	return (
+		<>
+			<ApButton
+				label="Open Modal"
+				onClick={() => setOpen(true)}
+			/>
+
+			<ApModal
+				open={open}
+				onClose={() => setOpen(false)}
+				header="Basic Modal"
+				message="This is a basic modal with default configuration."
+			/>
+		</>
+	);
+}
+`;
+
+const withActionsCode = `
+import { ApModal, ApButton } from "@uipath/apollo-react/material/components";
+import { useState } from "react";
+
+export function Example() {
+	const [open, setOpen] = useState(false);
+
+	return (
+		<>
+			<ApButton
+				label="Open Modal with Actions"
+				onClick={() => setOpen(true)}
+			/>
+
+			<ApModal
+				open={open}
+				onClose={() => setOpen(false)}
+				header="Modal with Actions"
+				message="This modal includes primary and secondary action buttons."
+				primaryAction={{
+					label: "Confirm",
+					onClick: () => console.log("Primary action clicked"),
+				}}
+				secondaryAction={{
+					label: "Cancel",
+					onClick: () => console.log("Secondary action clicked"),
+				}}
+			/>
+		</>
+	);
+}
+`;
+
+const sizesCode = `
+import { ApModal, ApButton } from "@uipath/apollo-react/material/components";
+import { useState } from "react";
+
+export function Example() {
+	const [openSmall, setOpenSmall] = useState(false);
+	const [openMedium, setOpenMedium] = useState(false);
+	const [openLarge, setOpenLarge] = useState(false);
+
+	return (
+		<>
+			<ApButton label="Small Modal" onClick={() => setOpenSmall(true)} />
+			<ApButton label="Medium Modal" onClick={() => setOpenMedium(true)} />
+			<ApButton label="Large Modal" onClick={() => setOpenLarge(true)} />
+
+			<ApModal
+				open={openSmall}
+				onClose={() => setOpenSmall(false)}
+				header="Small Modal"
+				size="small"
+				message="This is a small modal (480px width)."
+			/>
+
+			<ApModal
+				open={openMedium}
+				onClose={() => setOpenMedium(false)}
+				header="Medium Modal"
+				size="medium"
+				message="This is a medium modal (600px width)."
+			/>
+
+			<ApModal
+				open={openLarge}
+				onClose={() => setOpenLarge(false)}
+				header="Large Modal"
+				size="large"
+				message="This is a large modal (800px width)."
+			/>
+		</>
+	);
+}
+`;
+
+const loadingStateCode = `
+import { ApModal, ApButton } from "@uipath/apollo-react/material/components";
+import { useState } from "react";
+
+export function Example() {
+	const [open, setOpen] = useState(false);
+	const [primaryLoading, setPrimaryLoading] = useState(false);
+	const [secondaryLoading, setSecondaryLoading] = useState(false);
+
+	const handlePrimary = () => {
+		setPrimaryLoading(true);
+		// Simulate async operation
+		setTimeout(() => {
+			setPrimaryLoading(false);
+			setOpen(false);
+			alert("Saved!");
+		}, 2000);
+	};
+
+	const handleSecondary = () => {
+		setSecondaryLoading(true);
+		setTimeout(() => {
+			setSecondaryLoading(false);
+			setOpen(false);
+		}, 1500);
+	};
+
+	return (
+		<>
+			<ApButton
+				label="Open Modal"
+				onClick={() => setOpen(true)}
+			/>
+
+			<ApModal
+				open={open}
+				onClose={() => setOpen(false)}
+				header="Loading State Example"
+				message="Click a button to see loading states."
+				primaryAction={{
+					label: "Save",
+					onClick: handlePrimary,
+					loading: primaryLoading,
+				}}
+				secondaryAction={{
+					label: "Cancel",
+					onClick: handleSecondary,
+					loading: secondaryLoading,
+				}}
+			/>
+		</>
+	);
+}
+`;
+
+const customContentCode = `
+import { ApModal, ApButton, ApTypography } from "@uipath/apollo-react/material/components";
+import { useState } from "react";
+import { FontVariantToken } from "@uipath/apollo-react";
+
+export function Example() {
+	const [open, setOpen] = useState(false);
+
+	return (
+		<>
+			<ApButton
+				label="Open Modal with Custom Content"
+				onClick={() => setOpen(true)}
+			/>
+
+			<ApModal
+				open={open}
+				onClose={() => setOpen(false)}
+				header="Custom Content Modal"
+			>
+				<div>
+					<ApTypography variant={FontVariantToken.fontSizeH5Bold}>
+						Custom Heading
+					</ApTypography>
+					<ApTypography variant={FontVariantToken.fontSizeM}>
+						This modal contains custom React content instead of a simple message.
+						You can add any components, forms, or interactive elements here.
+					</ApTypography>
+				</div>
+			</ApModal>
+		</>
+	);
+}
+`;
+
+const preventCloseCode = `
+import { ApModal, ApButton } from "@uipath/apollo-react/material/components";
+import { useState } from "react";
+
+export function Example() {
+	const [open, setOpen] = useState(false);
+
+	return (
+		<>
+			<ApButton
+				label="Open Non-Dismissible Modal"
+				onClick={() => setOpen(true)}
+			/>
+
+			<ApModal
+				open={open}
+				onClose={() => setOpen(false)}
+				header="Non-Dismissible Modal"
+				message="This modal cannot be dismissed by clicking outside or pressing ESC. You must use the action button to close it."
+				preventClose
+				primaryAction={{
+					label: "Close",
+					onClick: () => setOpen(false),
+				}}
+			/>
+		</>
+	);
+}
+`;
+
+const hideCloseButtonCode = `
+import { ApModal, ApButton } from "@uipath/apollo-react/material/components";
+import { useState } from "react";
+
+export function Example() {
+	const [open, setOpen] = useState(false);
+
+	return (
+		<>
+			<ApButton
+				label="Open Modal without Close Button"
+				onClick={() => setOpen(true)}
+			/>
+
+			<ApModal
+				open={open}
+				onClose={() => setOpen(false)}
+				header="No Close Button"
+				message="This modal doesn't have a close button. You can click outside or use the action button."
+				hideCloseButton
+				primaryAction={{
+					label: "Close",
+					onClick: () => setOpen(false),
+				}}
+			/>
+		</>
+	);
+}
+`;
+
+export function ModalShowcase() {
+	const [basicOpen, setBasicOpen] = useState(false);
+	const [withActionsOpen, setWithActionsOpen] = useState(false);
+	const [loadingStateOpen, setLoadingStateOpen] = useState(false);
+	const [primaryLoading, setPrimaryLoading] = useState(false);
+	const [secondaryLoading, setSecondaryLoading] = useState(false);
+	const [smallOpen, setSmallOpen] = useState(false);
+	const [mediumOpen, setMediumOpen] = useState(false);
+	const [largeOpen, setLargeOpen] = useState(false);
+	const [customContentOpen, setCustomContentOpen] = useState(false);
+	const [preventCloseOpen, setPreventCloseOpen] = useState(false);
+	const [noCloseButtonOpen, setNoCloseButtonOpen] = useState(false);
+
+	const handlePrimaryAction = () => {
+		setPrimaryLoading(true);
+		// Simulate async operation (e.g., API call)
+		setTimeout(() => {
+			setPrimaryLoading(false);
+			setLoadingStateOpen(false);
+			alert("Operation completed successfully!");
+		}, 2000);
+	};
+
+	const handleSecondaryAction = () => {
+		setSecondaryLoading(true);
+		// Simulate async operation
+		setTimeout(() => {
+			setSecondaryLoading(false);
+			setLoadingStateOpen(false);
+		}, 1500);
+	};
+
+	return (
+		<PageContainer>
+			<PageTitle>Modal</PageTitle>
+			<PageDescription>
+				A centered overlay dialog that displays content above the main page,
+				requiring user interaction before returning to the main workflow. Modals
+				are used for critical information, confirmations, or form inputs.
+			</PageDescription>
+
+			<ShowcaseSection>
+				<SectionTitle>Basic Modal</SectionTitle>
+				<ComponentRow>
+					<Label>Default modal with header and message</Label>
+					<ButtonGroup>
+						<ApButton
+							label="Open Basic Modal"
+							onClick={() => setBasicOpen(true)}
+						/>
+					</ButtonGroup>
+
+					<ApModal
+						open={basicOpen}
+						onClose={() => setBasicOpen(false)}
+						header="Basic Modal"
+						message="This is a basic modal with default configuration. Click the close button, press ESC, or click outside to dismiss."
+					/>
+
+					<Label>Code Example:</Label>
+					<ApAccordion label="Basic Modal" disableDivider>
+						<CodeBlock>{basicModalCode}</CodeBlock>
+					</ApAccordion>
+				</ComponentRow>
+			</ShowcaseSection>
+
+			<ShowcaseSection>
+				<SectionTitle>With Actions</SectionTitle>
+				<ComponentRow>
+					<Label>Modal with primary and secondary action buttons</Label>
+					<ButtonGroup>
+						<ApButton
+							label="Open Modal with Actions"
+							onClick={() => setWithActionsOpen(true)}
+						/>
+					</ButtonGroup>
+
+					<ApModal
+						open={withActionsOpen}
+						onClose={() => setWithActionsOpen(false)}
+						header="Modal with Actions"
+						message="This modal includes action buttons at the bottom. The primary action confirms the operation, while the secondary action cancels."
+						primaryAction={{
+							label: "Confirm",
+							onClick: () => {
+								alert("Primary action clicked");
+								setWithActionsOpen(false);
+							},
+						}}
+						secondaryAction={{
+							label: "Cancel",
+							onClick: () => {
+								alert("Secondary action clicked");
+								setWithActionsOpen(false);
+							},
+						}}
+					/>
+
+					<Label>Code Example:</Label>
+					<ApAccordion label="With Actions" disableDivider>
+						<CodeBlock>{withActionsCode}</CodeBlock>
+					</ApAccordion>
+				</ComponentRow>
+			</ShowcaseSection>
+
+			<ShowcaseSection>
+				<SectionTitle>Loading States</SectionTitle>
+				<ComponentRow>
+					<Label>Action buttons with loading states for async operations</Label>
+					<ButtonGroup>
+						<ApButton
+							label="Open Modal with Loading States"
+							onClick={() => setLoadingStateOpen(true)}
+						/>
+					</ButtonGroup>
+
+					<ApModal
+						open={loadingStateOpen}
+						onClose={() => setLoadingStateOpen(false)}
+						header="Loading State Example"
+						message="Click an action button to see the loading state in action. The parent component controls the loading state and modal closure."
+						primaryAction={{
+							label: "Save",
+							onClick: handlePrimaryAction,
+							loading: primaryLoading,
+						}}
+						secondaryAction={{
+							label: "Cancel",
+							onClick: handleSecondaryAction,
+							loading: secondaryLoading,
+						}}
+					/>
+
+					<Label>Code Example:</Label>
+					<ApAccordion label="Loading States" disableDivider>
+						<CodeBlock>{loadingStateCode}</CodeBlock>
+					</ApAccordion>
+				</ComponentRow>
+			</ShowcaseSection>
+
+			<ShowcaseSection>
+				<SectionTitle>Modal Sizes</SectionTitle>
+				<ComponentRow>
+					<Label>
+						Different modal widths: small (480px), medium (600px), large (800px)
+					</Label>
+					<ButtonGroup>
+						<ApButton label="Small Modal" onClick={() => setSmallOpen(true)} />
+						<ApButton
+							label="Medium Modal"
+							onClick={() => setMediumOpen(true)}
+						/>
+						<ApButton label="Large Modal" onClick={() => setLargeOpen(true)} />
+					</ButtonGroup>
+
+					<ApModal
+						open={smallOpen}
+						onClose={() => setSmallOpen(false)}
+						header="Small Modal"
+						size="small"
+						message="This is a small modal with 480px width."
+					/>
+
+					<ApModal
+						open={mediumOpen}
+						onClose={() => setMediumOpen(false)}
+						header="Medium Modal"
+						size="medium"
+						message="This is a medium modal with 600px width."
+					/>
+
+					<ApModal
+						open={largeOpen}
+						onClose={() => setLargeOpen(false)}
+						header="Large Modal"
+						size="large"
+						message="This is a large modal with 800px width."
+					/>
+
+					<Label>Code Example:</Label>
+					<ApAccordion label="Modal Sizes" disableDivider>
+						<CodeBlock>{sizesCode}</CodeBlock>
+					</ApAccordion>
+				</ComponentRow>
+			</ShowcaseSection>
+
+			<ShowcaseSection>
+				<SectionTitle>Custom Content</SectionTitle>
+				<ComponentRow>
+					<Label>Modal with custom React content instead of a message</Label>
+					<ButtonGroup>
+						<ApButton
+							label="Open Modal with Custom Content"
+							onClick={() => setCustomContentOpen(true)}
+						/>
+					</ButtonGroup>
+
+					<ApModal
+						open={customContentOpen}
+						onClose={() => setCustomContentOpen(false)}
+						header="Custom Content Modal"
+					>
+						<div
+							style={{ display: "flex", flexDirection: "column", gap: "16px" }}
+						>
+							<ApTypography variant={FontVariantToken.fontSizeH4Bold}>
+								Custom Heading
+							</ApTypography>
+							<ApTypography variant={FontVariantToken.fontSizeM}>
+								This modal contains custom React content instead of a simple
+								message. You can add any components, forms, or interactive
+								elements here.
+							</ApTypography>
+							<ApTypography variant={FontVariantToken.fontSizeS}>
+								The modal provides a flexible container for complex UI patterns
+								while maintaining consistent styling and behavior.
+							</ApTypography>
+						</div>
+					</ApModal>
+
+					<Label>Code Example:</Label>
+					<ApAccordion label="Custom Content" disableDivider>
+						<CodeBlock>{customContentCode}</CodeBlock>
+					</ApAccordion>
+				</ComponentRow>
+			</ShowcaseSection>
+
+			<ShowcaseSection>
+				<SectionTitle>Prevent Close</SectionTitle>
+				<ComponentRow>
+					<Label>
+						Modal that cannot be closed by clicking outside or pressing ESC
+						(must use action buttons)
+					</Label>
+					<ButtonGroup>
+						<ApButton
+							label="Open Non-Dismissible Modal"
+							onClick={() => setPreventCloseOpen(true)}
+						/>
+					</ButtonGroup>
+
+					<ApModal
+						open={preventCloseOpen}
+						onClose={() => setPreventCloseOpen(false)}
+						header="Non-Dismissible Modal"
+						message="This modal cannot be dismissed by clicking outside or pressing ESC. You must use the action buttons to close it."
+						preventClose
+						primaryAction={{
+							label: "Close",
+							onClick: () => setPreventCloseOpen(false),
+						}}
+					/>
+
+					<Label>Code Example:</Label>
+					<ApAccordion label="Prevent Close" disableDivider>
+						<CodeBlock>{preventCloseCode}</CodeBlock>
+					</ApAccordion>
+				</ComponentRow>
+			</ShowcaseSection>
+
+			<ShowcaseSection>
+				<SectionTitle>Hide Close Button</SectionTitle>
+				<ComponentRow>
+					<Label>
+						Modal without close button (relies on actions or backdrop)
+					</Label>
+					<ButtonGroup>
+						<ApButton
+							label="Open Modal without Close Button"
+							onClick={() => setNoCloseButtonOpen(true)}
+						/>
+					</ButtonGroup>
+
+					<ApModal
+						open={noCloseButtonOpen}
+						onClose={() => setNoCloseButtonOpen(false)}
+						header="No Close Button"
+						message="This modal doesn't have a close button in the corner. You can click outside or use the action button below."
+						hideCloseButton
+						primaryAction={{
+							label: "Close",
+							onClick: () => setNoCloseButtonOpen(false),
+						}}
+					/>
+
+					<Label>Code Example:</Label>
+					<ApAccordion label="Hide Close Button" disableDivider>
+						<CodeBlock>{hideCloseButtonCode}</CodeBlock>
+					</ApAccordion>
+				</ComponentRow>
+			</ShowcaseSection>
+		</PageContainer>
+	);
+}

--- a/packages/apollo-react/src/material/components/ap-modal/ApModal.test.tsx
+++ b/packages/apollo-react/src/material/components/ap-modal/ApModal.test.tsx
@@ -1,0 +1,293 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { ApModal } from './ApModal';
+import type { ModalSize } from './ApModal.types';
+
+describe('ApModal', () => {
+  describe('Basic Rendering', () => {
+    it('renders the modal when open', () => {
+      render(<ApModal open={true} onClose={vi.fn()} header="Test Modal" />);
+      expect(screen.getByText('Test Modal')).toBeInTheDocument();
+    });
+
+    it('does not render content when closed', () => {
+      render(<ApModal open={false} onClose={vi.fn()} header="Test Modal" />);
+      expect(screen.queryByText('Test Modal')).not.toBeInTheDocument();
+    });
+
+    it('renders the modal with a message', () => {
+      render(<ApModal open={true} onClose={vi.fn()} header="Test Modal" message="Test message" />);
+      expect(screen.getByText('Test message')).toBeInTheDocument();
+    });
+
+    it('renders the modal with children instead of message', () => {
+      render(
+        <ApModal open={true} onClose={vi.fn()} header="Test Modal">
+          <div data-testid="custom-content">Custom Content</div>
+        </ApModal>
+      );
+      expect(screen.getByTestId('custom-content')).toBeInTheDocument();
+      expect(screen.queryByText('Test message')).not.toBeInTheDocument();
+    });
+
+    it('renders the close button by default', () => {
+      render(<ApModal open={true} onClose={vi.fn()} header="Test Modal" />);
+      const closeButton = screen.getByRole('button', { name: /icon button/i, hidden: true });
+      expect(closeButton).toBeInTheDocument();
+    });
+
+    it('hides the close button when hideCloseButton is true', () => {
+      render(<ApModal open={true} onClose={vi.fn()} header="Test Modal" hideCloseButton />);
+      const closeButton = screen.queryByRole('button', { name: /icon button/i, hidden: true });
+      expect(closeButton).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Modal Sizes', () => {
+    const sizes: ModalSize[] = ['small', 'medium', 'large'];
+
+    sizes.forEach((size) => {
+      it(`renders the modal with ${size} size`, () => {
+        render(<ApModal open={true} onClose={vi.fn()} header="Test Modal" size={size} />);
+        expect(screen.getByText('Test Modal')).toBeInTheDocument();
+      });
+    });
+
+    it('defaults to small size when not specified', () => {
+      render(<ApModal open={true} onClose={vi.fn()} header="Test Modal" />);
+      expect(screen.getByText('Test Modal')).toBeInTheDocument();
+    });
+  });
+
+  describe('Action Buttons', () => {
+    it('renders primary action button when provided', () => {
+      render(
+        <ApModal
+          open={true}
+          onClose={vi.fn()}
+          header="Test Modal"
+          primaryAction={{ label: 'Confirm', onClick: vi.fn() }}
+        />
+      );
+      expect(screen.getByText('Confirm')).toBeInTheDocument();
+    });
+
+    it('renders secondary action button when provided', () => {
+      render(
+        <ApModal
+          open={true}
+          onClose={vi.fn()}
+          header="Test Modal"
+          secondaryAction={{ label: 'Cancel', onClick: vi.fn() }}
+        />
+      );
+      expect(screen.getByText('Cancel')).toBeInTheDocument();
+    });
+
+    it('renders both primary and secondary action buttons', () => {
+      render(
+        <ApModal
+          open={true}
+          onClose={vi.fn()}
+          header="Test Modal"
+          primaryAction={{ label: 'Confirm', onClick: vi.fn() }}
+          secondaryAction={{ label: 'Cancel', onClick: vi.fn() }}
+        />
+      );
+      expect(screen.getByText('Confirm')).toBeInTheDocument();
+      expect(screen.getByText('Cancel')).toBeInTheDocument();
+    });
+
+    it('does not render action buttons when not provided', () => {
+      render(<ApModal open={true} onClose={vi.fn()} header="Test Modal" />);
+      expect(screen.queryByText('Confirm')).not.toBeInTheDocument();
+      expect(screen.queryByText('Cancel')).not.toBeInTheDocument();
+    });
+
+    it('calls primaryAction onClick when clicked', () => {
+      const handlePrimaryClick = vi.fn();
+      const handleClose = vi.fn();
+      render(
+        <ApModal
+          open={true}
+          onClose={handleClose}
+          header="Test Modal"
+          primaryAction={{ label: 'Confirm', onClick: handlePrimaryClick }}
+        />
+      );
+      const button = screen.getByText('Confirm');
+      button.click();
+      expect(handlePrimaryClick).toHaveBeenCalledTimes(1);
+      expect(handleClose).not.toHaveBeenCalled();
+    });
+
+    it('calls secondaryAction onClick when clicked', () => {
+      const handleSecondaryClick = vi.fn();
+      const handleClose = vi.fn();
+      render(
+        <ApModal
+          open={true}
+          onClose={handleClose}
+          header="Test Modal"
+          secondaryAction={{ label: 'Cancel', onClick: handleSecondaryClick }}
+        />
+      );
+      const button = screen.getByText('Cancel');
+      button.click();
+      expect(handleSecondaryClick).toHaveBeenCalledTimes(1);
+      expect(handleClose).not.toHaveBeenCalled();
+    });
+
+    it('shows loading state on primary action button', () => {
+      render(
+        <ApModal
+          open={true}
+          onClose={vi.fn()}
+          header="Test Modal"
+          primaryAction={{ label: 'Confirm', onClick: vi.fn(), loading: true }}
+        />
+      );
+      const button = screen.getByText('Confirm');
+      expect(button).toBeInTheDocument();
+    });
+
+    it('shows loading state on secondary action button', () => {
+      render(
+        <ApModal
+          open={true}
+          onClose={vi.fn()}
+          header="Test Modal"
+          secondaryAction={{ label: 'Cancel', onClick: vi.fn(), loading: true }}
+        />
+      );
+      const button = screen.getByText('Cancel');
+      expect(button).toBeInTheDocument();
+    });
+
+    it('disables primary action button when disabled is true', () => {
+      render(
+        <ApModal
+          open={true}
+          onClose={vi.fn()}
+          header="Test Modal"
+          primaryAction={{ label: 'Confirm', onClick: vi.fn(), disabled: true }}
+        />
+      );
+      const button = screen.getByRole('button', { name: /confirm/i, hidden: true });
+      expect(button).toBeDisabled();
+    });
+
+    it('sets id on primary action button', () => {
+      render(
+        <ApModal
+          open={true}
+          onClose={vi.fn()}
+          header="Test Modal"
+          primaryAction={{ label: 'Confirm', onClick: vi.fn(), id: 'primary-btn' }}
+        />
+      );
+      const button = screen.getByRole('button', { name: /confirm/i, hidden: true });
+      expect(button).toHaveAttribute('id', 'primary-btn');
+    });
+
+    it('sets id on secondary action button', () => {
+      render(
+        <ApModal
+          open={true}
+          onClose={vi.fn()}
+          header="Test Modal"
+          secondaryAction={{ label: 'Cancel', onClick: vi.fn(), id: 'secondary-btn' }}
+        />
+      );
+      const button = screen.getByRole('button', { name: /cancel/i, hidden: true });
+      expect(button).toHaveAttribute('id', 'secondary-btn');
+    });
+  });
+
+  describe('Close Behavior', () => {
+    it('calls onClose when close button is clicked', () => {
+      const handleClose = vi.fn();
+      render(<ApModal open={true} onClose={handleClose} header="Test Modal" />);
+      const closeButton = screen.getByRole('button', { name: /icon button/i, hidden: true });
+      closeButton.click();
+      expect(handleClose).toHaveBeenCalledWith({}, 'closeButtonClick');
+    });
+
+    it('calls onClose when backdrop is clicked', async () => {
+      const handleClose = vi.fn();
+      const { container } = render(
+        <ApModal open={true} onClose={handleClose} header="Test Modal" />
+      );
+      const backdrop = container.querySelector('.MuiBackdrop-root');
+      if (backdrop) {
+        fireEvent.click(backdrop);
+        await waitFor(() => {
+          expect(handleClose).toHaveBeenCalled();
+        });
+      }
+    });
+
+    it('does not call onClose when preventClose is true and close button clicked', () => {
+      const handleClose = vi.fn();
+      render(<ApModal open={true} onClose={handleClose} header="Test Modal" preventClose />);
+      // Close button should not be rendered when preventClose is true
+      const closeButton = screen.queryByRole('button', { name: /icon button/i, hidden: true });
+      expect(closeButton).not.toBeInTheDocument();
+    });
+
+    it('does not call onClose when preventClose is true and backdrop clicked', async () => {
+      const handleClose = vi.fn();
+      const { container } = render(
+        <ApModal open={true} onClose={handleClose} header="Test Modal" preventClose />
+      );
+      const backdrop = container.querySelector('.MuiBackdrop-root');
+      if (backdrop) {
+        fireEvent.click(backdrop);
+        await waitFor(() => {
+          expect(handleClose).not.toHaveBeenCalled();
+        });
+      }
+    });
+
+    it('sets id on close button', () => {
+      render(
+        <ApModal open={true} onClose={vi.fn()} header="Test Modal" closeButtonId="close-btn" />
+      );
+      const closeButton = screen.getByRole('button', { name: /icon button/i, hidden: true });
+      expect(closeButton).toHaveAttribute('id', 'close-btn');
+    });
+  });
+
+  describe('Material UI Props Pass-through', () => {
+    it('passes through keepMounted prop', () => {
+      render(<ApModal open={true} onClose={vi.fn()} header="Test Modal" keepMounted />);
+      expect(screen.getByText('Test Modal')).toBeInTheDocument();
+    });
+
+    it('passes through disablePortal prop', () => {
+      render(<ApModal open={true} onClose={vi.fn()} header="Test Modal" disablePortal />);
+      expect(screen.getByText('Test Modal')).toBeInTheDocument();
+    });
+  });
+
+  describe('Ref Forwarding', () => {
+    it('forwards ref to the underlying Modal component', () => {
+      const ref = vi.fn();
+      render(<ApModal ref={ref} open={true} onClose={vi.fn()} header="Test Modal" />);
+      expect(ref).toHaveBeenCalled();
+    });
+  });
+
+  describe('Accessibility', () => {
+    it('renders semantic HTML structure', () => {
+      render(<ApModal open={true} onClose={vi.fn()} header="Test Modal" />);
+      expect(screen.getByText('Test Modal')).toBeInTheDocument();
+    });
+
+    it('close button has accessible role', () => {
+      render(<ApModal open={true} onClose={vi.fn()} header="Test Modal" />);
+      const closeButton = screen.getByRole('button', { name: /icon button/i, hidden: true });
+      expect(closeButton).toBeInTheDocument();
+    });
+  });
+});

--- a/packages/apollo-react/src/material/components/ap-modal/ApModal.tsx
+++ b/packages/apollo-react/src/material/components/ap-modal/ApModal.tsx
@@ -1,0 +1,165 @@
+import CloseIcon from '@mui/icons-material/Close';
+import { Box, Modal } from '@mui/material';
+import token from '@uipath/apollo-core';
+import React, { useCallback } from 'react';
+
+import { ApButton } from '../ap-button';
+import { ApIconButton } from '../ap-icon-button';
+import { ApTypography } from '../ap-typography';
+import type { ApModalProps } from './ApModal.types';
+
+const getSizeWidth = (size: ApModalProps['size']): string => {
+  switch (size) {
+    case 'small':
+      return '480px';
+    case 'medium':
+      return '600px';
+    case 'large':
+      return '800px';
+    default:
+      return '480px';
+  }
+};
+
+export const ApModal = React.forwardRef<HTMLDivElement, ApModalProps>((props, ref) => {
+  const {
+    header,
+    message,
+    size = 'small',
+    open,
+    preventClose,
+    hideCloseButton,
+    primaryAction,
+    secondaryAction,
+    closeButtonId,
+    onClose,
+    children,
+    ...rest
+  } = props;
+
+  const handleClose = useCallback(
+    (event: {}, reason: 'backdropClick' | 'escapeKeyDown') => {
+      if (preventClose) {
+        return;
+      }
+      onClose?.(event, reason);
+    },
+    [preventClose, onClose]
+  );
+
+  const handleCloseButtonClick = useCallback(() => {
+    if (preventClose) {
+      return;
+    }
+    onClose?.({}, 'closeButtonClick');
+  }, [preventClose, onClose]);
+
+  const hasActions = primaryAction || secondaryAction;
+
+  return (
+    <Modal ref={ref} disablePortal open={open} onClose={handleClose} {...rest}>
+      <Box
+        sx={{
+          position: 'absolute',
+          top: '50%',
+          left: '50%',
+          transform: 'translate(-50%, -50%)',
+          width: getSizeWidth(size),
+          backgroundColor: 'var(--color-background)',
+          borderRadius: token.Border.BorderRadiusS,
+          padding: token.Spacing.SpacingL,
+          boxShadow: token.Shadow.ShadowDp8,
+          '&:focus-visible, &:focus': { outline: 'none' },
+        }}
+      >
+        {/* Header */}
+        {header && (
+          <Box
+            sx={{
+              paddingTop: token.Padding.PadXl,
+              paddingBottom: token.Padding.PadL,
+              display: 'flex',
+              alignItems: 'center',
+            }}
+          >
+            <ApTypography
+              variant={token.FontVariantToken.fontSizeH4Bold}
+              color="var(--color-foreground)"
+            >
+              {header}
+            </ApTypography>
+          </Box>
+        )}
+
+        {/* Close Button */}
+        {!hideCloseButton && !preventClose && (
+          <Box
+            sx={{
+              position: 'absolute',
+              right: '10px',
+              top: '10px',
+            }}
+          >
+            <ApIconButton
+              size="small"
+              id={closeButtonId}
+              color="secondary"
+              onClick={handleCloseButtonClick}
+            >
+              <CloseIcon
+                sx={{
+                  width: token.Icon.IconXs,
+                  height: token.Icon.IconXs,
+                }}
+              />
+            </ApIconButton>
+          </Box>
+        )}
+
+        {/* Content */}
+        {message ? (
+          <ApTypography variant={token.FontVariantToken.fontSizeM} color="var(--color-foreground)">
+            {message}
+          </ApTypography>
+        ) : (
+          children
+        )}
+
+        {/* Actions */}
+        {hasActions && (
+          <Box
+            sx={{
+              display: 'flex',
+              justifyContent: 'flex-end',
+              paddingTop: token.Spacing.SpacingM,
+            }}
+          >
+            {secondaryAction && (
+              <ApButton
+                variant="secondary"
+                id={secondaryAction.id}
+                label={secondaryAction.label}
+                loading={secondaryAction.loading}
+                onClick={secondaryAction.onClick}
+              />
+            )}
+            {primaryAction && (
+              <Box sx={{ paddingLeft: token.Padding.PadL }}>
+                <ApButton
+                  variant="primary"
+                  id={primaryAction.id}
+                  label={primaryAction.label}
+                  disabled={primaryAction.disabled}
+                  loading={primaryAction.loading}
+                  onClick={primaryAction.onClick}
+                />
+              </Box>
+            )}
+          </Box>
+        )}
+      </Box>
+    </Modal>
+  );
+});
+
+ApModal.displayName = 'ApModal';

--- a/packages/apollo-react/src/material/components/ap-modal/ApModal.types.ts
+++ b/packages/apollo-react/src/material/components/ap-modal/ApModal.types.ts
@@ -1,0 +1,76 @@
+import type { ModalProps } from '@mui/material/Modal';
+import type React from 'react';
+
+export type ModalSize = 'small' | 'medium' | 'large';
+
+export type ApModalCloseReason = 'backdropClick' | 'escapeKeyDown' | 'closeButtonClick';
+
+export interface ApModalProps extends Omit<ModalProps, 'onClose' | 'children'> {
+  /**
+   * Callback fired when the modal should close
+   *
+   * Note: Extends Material UI's onClose to include 'closeButtonClick' reason for the custom close button
+   *
+   * @param event - The event source of the callback
+   * @param reason - The reason for closing (backdropClick, escapeKeyDown, or closeButtonClick)
+   */
+  onClose?: (event: {}, reason: ApModalCloseReason) => void;
+
+  /**
+   * Modal content (alternative to message prop)
+   */
+  children?: React.ReactNode;
+
+  /**
+   * Header text displayed at the top of the modal
+   */
+  header?: React.ReactNode;
+
+  /**
+   * Optional message text displayed in the content area (alternative to children)
+   */
+  message?: React.ReactNode;
+
+  /**
+   * If true, prevents the modal from being closed by clicking backdrop or close button
+   */
+  preventClose?: boolean;
+
+  /**
+   * If true, hides the close button in the top-right corner
+   * @default false
+   */
+  hideCloseButton?: boolean;
+
+  /**
+   * Size of the modal (affects width)
+   * @default 'small'
+   */
+  size?: ModalSize;
+
+  /**
+   * Primary action button configuration
+   */
+  primaryAction?: {
+    label: string;
+    onClick?: () => void;
+    loading?: boolean;
+    disabled?: boolean;
+    id?: string;
+  };
+
+  /**
+   * Secondary action button configuration
+   */
+  secondaryAction?: {
+    label: string;
+    onClick?: () => void;
+    loading?: boolean;
+    id?: string;
+  };
+
+  /**
+   * ID for the close button
+   */
+  closeButtonId?: string;
+}

--- a/packages/apollo-react/src/material/components/ap-modal/index.ts
+++ b/packages/apollo-react/src/material/components/ap-modal/index.ts
@@ -1,0 +1,2 @@
+export { ApModal } from './ApModal';
+export type { ApModalProps, ModalSize } from './ApModal.types';

--- a/packages/apollo-react/src/material/components/index.ts
+++ b/packages/apollo-react/src/material/components/index.ts
@@ -9,6 +9,7 @@ export * from './ap-icon';
 export * from './ap-icon-button';
 export * from './ap-link';
 export * from './ap-menu';
+export * from './ap-modal';
 export * from './ap-popover';
 export * from './ap-progress-spinner';
 export * from './ap-skeleton';


### PR DESCRIPTION
- Updated React-Playground Code block component to wrap long lines 
- Added Modal Component, test, and showcase

https://github.com/user-attachments/assets/17d22da3-5598-42b1-b39a-deb626d85963

