### PR TITLE
feat(apollo-react): add collapsed state management for nodes in BaseCanvas [AG-683]

### DIFF
--- a/packages/apollo-react/src/canvas/components/BaseNode/BaseNode.tsx
+++ b/packages/apollo-react/src/canvas/components/BaseNode/BaseNode.tsx
@@ -112,8 +112,8 @@ const BaseNodeComponent = (props: NodeProps<Node<BaseNodeData>>) => {
     (typeof executionState === 'string' ? executionState : executionState?.status);
 
   const display = useMemo(
-    () => resolveDisplay(manifest?.display, data.display),
-    [manifest, data.display]
+    () => resolveDisplay(manifest?.display, { ...data, nodeId: id }),
+    [manifest, data.display, id]
   );
 
   // Icon resolution: component prop takes precedence, then icon string from display
@@ -138,7 +138,8 @@ const BaseNodeComponent = (props: NodeProps<Node<BaseNodeData>>) => {
 
     // Priority 2: Manifest default
     if (!manifest) return [];
-    const resolved = resolveHandles(manifest.handleConfiguration, data);
+    // Pass nodeId and collapsed for collapse state lookup
+    const resolved = resolveHandles(manifest.handleConfiguration, { ...data, nodeId: id });
 
     // Convert resolved handles to HandleGroupManifest format for ButtonHandle
     return resolved.map((group) => ({

--- a/packages/apollo-react/src/canvas/components/BaseNode/BaseNode.types.ts
+++ b/packages/apollo-react/src/canvas/components/BaseNode/BaseNode.types.ts
@@ -22,6 +22,12 @@ export interface BaseNodeData extends Record<string, unknown> {
    * @default false
    */
   useSmartHandles?: boolean;
+
+  /**
+   * Whether the node is collapsed.
+   * @default false
+   */
+  isCollapsed?: boolean;
 }
 
 export interface NodeAdornments {

--- a/packages/apollo-react/src/canvas/components/ButtonHandle/useButtonHandles.tsx
+++ b/packages/apollo-react/src/canvas/components/ButtonHandle/useButtonHandles.tsx
@@ -6,7 +6,6 @@ import { resolveHandles } from '../../utils/manifest-resolver';
 import { useConnectedHandles } from '../BaseCanvas/ConnectedHandlesContext';
 import type { HandleActionEvent } from '../ButtonHandle';
 import { ButtonHandles } from '../ButtonHandle';
-import { getToolbarActionStore } from '../../hooks/ToolbarActionContext';
 
 export const useButtonHandles = ({
   handleConfigurations,
@@ -46,9 +45,6 @@ export const useButtonHandles = ({
     selected: boolean;
   }) => boolean;
 }) => {
-  const { collapsed } = getToolbarActionStore();
-  const isCollapsed = Boolean(collapsed?.has(nodeId));
-
   const connectedHandleIds = useConnectedHandles(nodeId);
   const node = useNodesData(nodeId);
 
@@ -66,14 +62,11 @@ export const useButtonHandles = ({
       const hasConnectedHandle = config.handles.some((h) => connectedHandleIds.has(h.id));
       const finalVisible = hasConnectedHandle || (shouldShowHandles && (config.visible ?? true));
 
-      // Enhance handles with the unified action handler and filter out artifact handles if the node is collapsed
-      const enhancedHandles = config.handles
-        .filter((handle) => (isCollapsed ? handle.handleType !== 'artifact' : true))
-        .map((handle) => ({
-          ...handle,
-          // Preserve individual handle's onAction if it exists, otherwise use global handleAction
-          onAction: handle.onAction || handleAction,
-        }));
+      const enhancedHandles = config.handles.map((handle) => ({
+        ...handle,
+        // Preserve individual handle's onAction if it exists, otherwise use global handleAction
+        onAction: handle.onAction || handleAction,
+      }));
 
       return (
         <ButtonHandles

--- a/packages/apollo-react/src/canvas/hooks/ToolbarActionContext.tsx
+++ b/packages/apollo-react/src/canvas/hooks/ToolbarActionContext.tsx
@@ -18,7 +18,6 @@ interface ToolbarActionStore {
   mode: string;
   onToolbarAction?: ToolbarActionHandler;
   breakpoints?: Set<string>;
-  collapsed?: Set<string>;
 }
 
 // Module-level singleton store
@@ -26,7 +25,6 @@ let toolbarActionStore: ToolbarActionStore = {
   mode: 'design',
   onToolbarAction: undefined,
   breakpoints: undefined,
-  collapsed: undefined,
 };
 
 /**
@@ -52,11 +50,10 @@ export function getToolbarActionStore(): ToolbarActionStore {
 export function useToolbarActionStore(
   mode: string,
   onToolbarAction?: ToolbarActionHandler,
-  breakpoints?: Set<string>,
-  collapsed?: Set<string>
+  breakpoints?: Set<string>
 ): void {
   useEffect(() => {
-    setToolbarActionStore({ mode, onToolbarAction, breakpoints, collapsed });
+    setToolbarActionStore({ mode, onToolbarAction, breakpoints });
 
     // Cleanup: reset handler when component unmounts or switches
     // This prevents stale handlers from being invoked on the wrong canvas
@@ -65,8 +62,7 @@ export function useToolbarActionStore(
         mode: 'design',
         onToolbarAction: undefined,
         breakpoints: undefined,
-        collapsed: undefined,
       });
     };
-  }, [mode, onToolbarAction, breakpoints, collapsed]);
+  }, [mode, onToolbarAction, breakpoints]);
 }

--- a/packages/apollo-react/src/canvas/utils/collapse.ts
+++ b/packages/apollo-react/src/canvas/utils/collapse.ts
@@ -1,0 +1,44 @@
+/**
+ * Collapse/Expand Transformation Helpers
+ *
+ * Utilities for transforming node dimensions and shapes between collapsed and expanded states.
+ * These helpers ensure consistent behavior across the codebase.
+ */
+
+import type { NodeShape } from '../schema/node-definition';
+
+/**
+ * Default dimension for collapsed nodes when no measured dimensions are available.
+ */
+export const COLLAPSED_NODE_SIZE = 96;
+
+/**
+ * Transform a shape to its collapsed form.
+ * Rectangle nodes collapse to square, other shapes remain unchanged.
+ */
+export const getCollapsedShape = (originalShape: NodeShape | undefined): NodeShape => {
+  const shape = originalShape ?? 'rectangle';
+  return shape === 'rectangle' ? 'square' : shape;
+};
+
+/**
+ * Transform a collapsed shape back to its expanded form.
+ * Square nodes expand to rectangle (since rectangle → square when collapsing).
+ * Other shapes remain unchanged.
+ */
+export const getExpandedShape = (collapsedShape: NodeShape | undefined): NodeShape => {
+  const shape = collapsedShape ?? 'rectangle';
+  return shape === 'square' ? 'rectangle' : shape;
+};
+
+/**
+ * Calculate the collapsed size (square) from original dimensions.
+ * Uses height as the basis for the square dimension.
+ */
+export const getCollapsedSize = (
+  width: number | undefined,
+  height: number | undefined,
+  measured?: { width?: number; height?: number }
+): number => {
+  return height ?? measured?.height ?? width ?? measured?.width ?? COLLAPSED_NODE_SIZE;
+};

--- a/packages/apollo-react/src/canvas/utils/index.ts
+++ b/packages/apollo-react/src/canvas/utils/index.ts
@@ -2,6 +2,7 @@ export * from './ArrayUtil';
 export * from './auto-layout';
 export * from './CanvasEventBus';
 export * from './CssUtil';
+export * from './collapse';
 export * from './coded-agents/d3-layout';
 export * from './coded-agents/mermaid-parser';
 export * from './constraint-validator';

--- a/packages/apollo-react/src/canvas/utils/toolbar-resolver.tsx
+++ b/packages/apollo-react/src/canvas/utils/toolbar-resolver.tsx
@@ -159,32 +159,16 @@ function mergeToolbarConfigs(
 export function resolveToolbar(
   manifest: NodeManifest,
   context: ExtendedNodeContext,
-  nodeData?: (Record<string, unknown> & { nodeId?: string }) | undefined
+  nodeData?: Record<string, unknown>
 ): NodeToolbarConfig | undefined {
   const { nodeType, toolbarExtensions: manifestToolbarExtensions } = manifest;
 
   // Get mode from module-level store for filtering/defaults
   // (UIX doesn't pass custom properties through its context)
-  // Note: onToolbarAction is read at click time in convertToNodeAction to avoid stale closures
-  const { mode, collapsed } = getToolbarActionStore();
+  const { mode } = getToolbarActionStore();
 
   // Step 1: Get mode defaults (applies to all nodes)
-  let modeDefaults = toolbarRegistry.getModeDefaults(mode);
-  modeDefaults = {
-    ...modeDefaults,
-    actions: modeDefaults?.actions?.map((action) => {
-      const isCollapsed = Boolean(nodeData?.nodeId && collapsed?.has(nodeData.nodeId));
-      switch (action.id) {
-        case 'collapse':
-          return {
-            ...action,
-            icon: isCollapsed ? 'chevrons-up-down' : 'chevrons-down-up',
-          };
-        default:
-          return action;
-      }
-    }),
-  };
+  const modeDefaults = toolbarRegistry.getModeDefaults(mode);
 
   // Step 2: Get node-type-specific extensions
   const nodeExtensions = manifestToolbarExtensions?.[mode];

--- a/packages/apollo-react/src/material/components/ap-chat/components/header/header-actions.tsx
+++ b/packages/apollo-react/src/material/components/ap-chat/components/header/header-actions.tsx
@@ -20,8 +20,14 @@ const StyledActions = styled('div')(() => ({
 function AutopilotChatHeaderActionsComponent() {
   const { _ } = useLingui();
   const chatService = useChatService();
-  const { disabledFeatures, chatMode, historyOpen, settingsOpen, setHistoryAnchorElement, readOnly } =
-    useChatState();
+  const {
+    disabledFeatures,
+    chatMode,
+    historyOpen,
+    settingsOpen,
+    setHistoryAnchorElement,
+    readOnly,
+  } = useChatState();
   const { clearAttachments } = useAttachments();
   const { customHeaderActions, handleCustomHeaderAction } = usePicker();
   const [actionMenuAnchorEl, setActionMenuAnchorEl] = React.useState<HTMLElement | null>(null);


### PR DESCRIPTION
https://uipath.atlassian.net/browse/AG-683

Tested in flow-workbench `@uipath/apollo-react@3.28.0-pr163.f29ed98`

https://github.com/user-attachments/assets/7c9b18e2-b868-4bbd-8d6a-e8ecc9f95332