### PR TITLE
fix(apollo-react): add node panel performance [MST-6342]

### DIFF
--- a/packages/apollo-react/src/canvas/components/AddNodePanel/AddNodePanel.test.tsx
+++ b/packages/apollo-react/src/canvas/components/AddNodePanel/AddNodePanel.test.tsx
@@ -6,6 +6,14 @@ import type { ListItem, ToolboxProps } from '../Toolbox';
 import { AddNodePanel } from './AddNodePanel';
 import type { NodeItemData } from './AddNodePanel.types';
 
+// Mock usePreviewNode hook to avoid ReactFlow dependencies in tests
+vi.mock('../../hooks', () => ({
+  usePreviewNode: () => ({
+    previewNode: null,
+    previewNodeConnectionInfo: null,
+  }),
+}));
+
 // Mock Toolbox to test only AddNodePanel's data transformation logic
 vi.mock('../Toolbox', () => ({
   Toolbox: ({ title, initialItems, onClose, onItemSelect }: ToolboxProps<NodeItemData>) => (
@@ -24,10 +32,6 @@ vi.mock('../Toolbox', () => ({
       </button>
     </div>
   ),
-}));
-
-vi.mock('../../utils/icon-registry', () => ({
-  getIcon: undefined,
 }));
 
 describe('AddNodePanel', () => {

--- a/packages/apollo-react/src/canvas/components/AddNodePanel/AddNodePanel.tsx
+++ b/packages/apollo-react/src/canvas/components/AddNodePanel/AddNodePanel.tsx
@@ -1,7 +1,6 @@
-import { useCallback, useMemo } from 'react';
+import { memo, useCallback, useMemo } from 'react';
 import { useOptionalNodeTypeRegistry } from '../../core';
 import { usePreviewNode } from '../../hooks';
-import { getIcon } from '../../utils/icon-registry';
 import { type ListItem, Toolbox } from '../Toolbox';
 import type { AddNodePanelProps } from './AddNodePanel.types';
 
@@ -13,7 +12,7 @@ import type { AddNodePanelProps } from './AddNodePanel.types';
  * 1. Category-level filtering to quickly eliminate entire invalid categories
  * 2. Node-level filtering for comprehensive constraint validation
  */
-export function AddNodePanel({
+export const AddNodePanel = memo(function AddNodePanel({
   onNodeSelect,
   onClose,
   onSearch,
@@ -36,14 +35,14 @@ export function AddNodePanel({
    */
   const nodeListOptions = useMemo((): ListItem[] => {
     if (items) return items;
-    if (!registry) return [];
+    // Prevent premature access to registry during loading state
+    if (loading || !registry) return [];
 
     return registry.getNodeOptions({
       connections: previewNodeConnectionInfo,
       flattenSinglePath: true,
-      iconResolver: getIcon,
     });
-  }, [items, registry, previewNodeConnectionInfo]);
+  }, [items, registry, previewNodeConnectionInfo, loading]);
 
   const handleSearch = useCallback(
     (
@@ -57,7 +56,6 @@ export function AddNodePanel({
           category,
           search: query,
           flattenAll: true,
-          iconResolver: getIcon,
         });
         return Promise.resolve(listItems);
       }
@@ -89,4 +87,4 @@ export function AddNodePanel({
       onItemHover={onNodeHover}
     />
   );
-}
+});

--- a/packages/apollo-react/src/canvas/components/Toolbox/Header.tsx
+++ b/packages/apollo-react/src/canvas/components/Toolbox/Header.tsx
@@ -1,6 +1,7 @@
 import { FontVariantToken } from '@uipath/apollo-core';
 import { Row } from '@uipath/apollo-react/canvas/layouts';
 import { ApIcon, ApIconButton, ApTypography } from '@uipath/apollo-react/material';
+import { memo } from 'react';
 
 interface HeaderProps {
   title: string;
@@ -8,7 +9,7 @@ interface HeaderProps {
   onBack?: () => void;
 }
 
-export const Header: React.FC<HeaderProps> = ({ title, onBack, showBackButton }) => {
+export const Header = memo(function Header({ title, onBack, showBackButton }: HeaderProps) {
   const isBackButtonVisible = showBackButton && onBack;
 
   return (
@@ -49,4 +50,4 @@ export const Header: React.FC<HeaderProps> = ({ title, onBack, showBackButton })
       </ApTypography>
     </Row>
   );
-};
+});

--- a/packages/apollo-react/src/canvas/components/Toolbox/ListView.styles.ts
+++ b/packages/apollo-react/src/canvas/components/Toolbox/ListView.styles.ts
@@ -45,6 +45,8 @@ export const IconContainer = styled.div<{ bgColor?: string }>`
   color: var(--uix-canvas-foreground-emp);
   opacity: 0.9;
   flex-shrink: 0;
+  // Icons should show below the inset outline
+  z-index: -1;
 `;
 
 export const StyledList = styled(List)`

--- a/packages/apollo-react/src/canvas/components/Toolbox/ListView.test.tsx
+++ b/packages/apollo-react/src/canvas/components/Toolbox/ListView.test.tsx
@@ -61,7 +61,7 @@ describe('ListView', () => {
       render(<ListView {...defaultProps} items={items} />);
 
       expect(screen.getByText('Test Item')).toBeInTheDocument();
-      expect(screen.getByTestId('ap-icon')).toHaveAttribute('data-name', 'star');
+      expect(screen.getByTestId('list-item-icon').querySelector('svg')).toHaveClass('lucide-star');
     });
 
     it('should render item with description', () => {

--- a/packages/apollo-react/src/canvas/components/Toolbox/SearchBox.tsx
+++ b/packages/apollo-react/src/canvas/components/Toolbox/SearchBox.tsx
@@ -1,7 +1,6 @@
 import { cx } from '@uipath/apollo-react/canvas/utils';
 import { ApIcon } from '@uipath/apollo-react/material/components';
-import type React from 'react';
-import { useEffect, useRef } from 'react';
+import { memo, useEffect, useRef } from 'react';
 import { StyledSearchForm } from './SearchBox.styles';
 
 interface SearchBoxProps {
@@ -11,12 +10,12 @@ interface SearchBoxProps {
   placeholder?: string;
 }
 
-export const SearchBox: React.FC<SearchBoxProps> = ({
+export const SearchBox = memo(function SearchBox({
   value,
   onChange,
   clear,
   placeholder = 'Search...',
-}) => {
+}: SearchBoxProps) {
   const inputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
@@ -50,4 +49,4 @@ export const SearchBox: React.FC<SearchBoxProps> = ({
       </div>
     </StyledSearchForm>
   );
-};
+});

--- a/packages/apollo-react/src/canvas/core/CategoryTree.ts
+++ b/packages/apollo-react/src/canvas/core/CategoryTree.ts
@@ -325,7 +325,9 @@ export class CategoryTree {
         const matchesLabel = node.display.label.toLowerCase().includes(searchLower);
         const matchesType = node.nodeType.toLowerCase().includes(searchLower);
         const matchesDescription = node.description?.toLowerCase().includes(searchLower);
-        const matchesTags = node.tags?.some((tag) => tag.toLowerCase().includes(searchLower));
+        const matchesTags = node.tags?.some(
+          (tag) => typeof tag === 'string' && tag.toLowerCase().includes(searchLower)
+        );
 
         return matchesLabel || matchesType || matchesDescription || matchesTags;
       },

--- a/packages/apollo-react/src/canvas/core/CategoryTreeAdapter.ts
+++ b/packages/apollo-react/src/canvas/core/CategoryTreeAdapter.ts
@@ -3,20 +3,6 @@ import type { NodeManifest } from '../schema/node-definition';
 import type { CategoryTree, CategoryTreeNode } from './CategoryTree';
 
 /**
- * Icon resolver function type.
- * Takes an icon name and returns a React component to render.
- */
-export type IconResolver = (iconName: string) => React.ComponentType | undefined;
-
-/**
- * Options for converting category tree to list items.
- */
-export interface ToListItemsOptions {
-  /** Function to resolve icon names to React components */
-  iconResolver?: IconResolver;
-}
-
-/**
  * Adapter class for converting CategoryTree to various UI formats.
  *
  * Provides transformation methods to convert the hierarchical category tree
@@ -25,7 +11,7 @@ export interface ToListItemsOptions {
  * Usage:
  * ```typescript
  * const adapter = new CategoryTreeAdapter(categoryTree);
- * const listItems = adapter.toListItems({ iconResolver: getIcon });
+ * const listItems = adapter.toListItems();
  * ```
  */
 export class CategoryTreeAdapter {
@@ -42,12 +28,9 @@ export class CategoryTreeAdapter {
    * Empty categories (no nodes or children) are filtered out by default.
    * Root-level nodes are included after categories.
    *
-   * @param options - Configuration options for the conversion
    * @returns Array of list items representing the tree structure
    */
-  toListItems(options: ToListItemsOptions = {}): ListItem[] {
-    const { iconResolver } = options;
-
+  toListItems(): ListItem[] {
     const convertNodeManifest = (node: NodeManifest): ListItem => ({
       id: node.nodeType,
       name: node.display.label,
@@ -57,9 +40,7 @@ export class CategoryTreeAdapter {
         category: node.category,
         version: node.version,
       },
-      icon: iconResolver
-        ? { Component: iconResolver(node.display.icon) }
-        : { name: node.display.icon },
+      icon: { name: node.display.icon },
     });
 
     const convertCategories = (categoryNodes: CategoryTreeNode[]): ListItem[] => {
@@ -87,7 +68,7 @@ export class CategoryTreeAdapter {
           id: category.id,
           name: category.name,
           data: null,
-          icon: iconResolver ? { Component: iconResolver(category.icon) } : { name: category.icon },
+          icon: { name: category.icon },
           color: category.color,
           children,
         };

--- a/packages/apollo-react/src/canvas/core/NodeTypeRegistry.test.ts
+++ b/packages/apollo-react/src/canvas/core/NodeTypeRegistry.test.ts
@@ -694,23 +694,7 @@ describe('NodeTypeRegistry', () => {
       expect(items).toHaveLength(0);
     });
 
-    it('should handle iconResolver when provided', () => {
-      const mockIconResolver = (_iconName: string) => {
-        return () => null; // Mock component
-      };
-
-      const items = registry.getNodeOptions({
-        iconResolver: mockIconResolver,
-      });
-
-      // Check that icons have Component property
-      const firstCategory = items[0];
-      expect(firstCategory).toBeDefined();
-      expect(firstCategory?.icon).toBeDefined();
-      expect(firstCategory?.icon).toHaveProperty('Component');
-    });
-
-    it('should handle nodes without iconResolver', () => {
+    it('should handle node icons', () => {
       const items = registry.getNodeOptions({});
 
       // Check that icons have name property

--- a/packages/apollo-react/src/canvas/core/NodeTypeRegistry.ts
+++ b/packages/apollo-react/src/canvas/core/NodeTypeRegistry.ts
@@ -13,7 +13,7 @@ import {
   validateConnection,
 } from '../utils';
 import { CategoryTree, type ConnectionValidator } from './CategoryTree';
-import { CategoryTreeAdapter, type IconResolver } from './CategoryTreeAdapter';
+import { CategoryTreeAdapter } from './CategoryTreeAdapter';
 
 interface NodeHandles {
   source?: HandleManifest[];
@@ -404,7 +404,6 @@ export class NodeTypeRegistry {
    * @param options.search - Optional search term for filtering nodes
    * @param options.flattenAll - When true, flattens all categories for UI simplicity.
    * @param options.flattenSinglePath - When true, flattens when only a single path to leaf nodes exists.
-   * @param options.iconResolver - Optional icon resolver for list format
    * @returns Filtered results in the specified format
    *
    * @example
@@ -418,7 +417,6 @@ export class NodeTypeRegistry {
    * const items = registry.getNodeOptions({
    *   connections: previewNodeConnectionInfo,
    *   search: 'email',
-   *   iconResolver: getIcon
    * });
    */
   getNodeOptions(options: {
@@ -427,7 +425,6 @@ export class NodeTypeRegistry {
     search?: string;
     flattenAll?: boolean;
     flattenSinglePath?: boolean;
-    iconResolver?: IconResolver;
   }): ListItem[] {
     const {
       connections,
@@ -435,7 +432,6 @@ export class NodeTypeRegistry {
       search,
       flattenAll = false,
       flattenSinglePath = false,
-      iconResolver,
     } = options;
 
     let tree = this.getCategoryTree();
@@ -468,6 +464,6 @@ export class NodeTypeRegistry {
     }
 
     const adapter = new CategoryTreeAdapter(tree);
-    return adapter.toListItems({ iconResolver });
+    return adapter.toListItems();
   }
 }

--- a/packages/apollo-react/src/canvas/hooks/usePreviewNode.ts
+++ b/packages/apollo-react/src/canvas/hooks/usePreviewNode.ts
@@ -1,10 +1,12 @@
 import {
+  type Edge,
   type Node,
   type ReactFlowState,
   useReactFlow,
   useStore,
 } from '@uipath/apollo-react/canvas/xyflow/react';
 import { useMemo } from 'react';
+import { shallow } from 'zustand/shallow';
 import { PREVIEW_NODE_ID } from '../constants';
 import { useOptionalNodeTypeRegistry } from '../core';
 import type { HandleManifest, NodeManifest } from '../schema/node-definition';
@@ -30,10 +32,24 @@ export interface PreviewNodeConnectionInfo {
   previewEdgeId: string;
 }
 
-// Optimized selector - only find the preview node instead of filtering all nodes
-const previewNodeSelector = (state: ReactFlowState) => {
+// Optimized selector - return boolean to prevent re-renders on position changes
+const previewNodeSelectedSelector = (state: ReactFlowState) => {
   const node = state.nodes.find((n) => n.id === PREVIEW_NODE_ID);
-  return node?.selected ? node : null;
+  return node?.selected ?? false;
+};
+
+// Selector to track edges connected to preview node
+// Returns minimal edge data to avoid unnecessary re-renders
+const edgesConnectedToPreviewSelector = (state: ReactFlowState): Edge[] => {
+  return state.edges
+    .filter((edge) => edge.source === PREVIEW_NODE_ID || edge.target === PREVIEW_NODE_ID)
+    .map((edge) => ({
+      id: edge.id,
+      source: edge.source,
+      target: edge.target,
+      sourceHandle: edge.sourceHandle,
+      targetHandle: edge.targetHandle,
+    }));
 };
 
 interface UsePreviewNodeResult {
@@ -53,66 +69,71 @@ interface UsePreviewNodeResult {
  * about all connected edges and pre-computes handle manifests for efficient
  * constraint validation in the Add Node Panel.
  *
+ * Performance optimization: Uses boolean selector for node selection and tracks
+ * edges separately to prevent re-renders when only the preview node position changes.
+ *
  * @returns Object containing the preview node and its connection information.
  */
 export const usePreviewNode = (): UsePreviewNodeResult => {
   const reactFlowInstance = useReactFlow();
-  const previewNode = useStore(previewNodeSelector);
+  const isPreviewNodeSelected = useStore(previewNodeSelectedSelector);
+  const previewEdges = useStore(edgesConnectedToPreviewSelector, shallow);
   const registry = useOptionalNodeTypeRegistry();
 
+  // Get the actual node object for the return value (doesn't affect memoization)
+  const previewNode = isPreviewNodeSelected
+    ? (reactFlowInstance.getNode(PREVIEW_NODE_ID) ?? null)
+    : null;
+
   // Extract connection info when preview node is selected.
+  // This now only recalculates when selection state or edges change, not on position changes.
   const connectionInfo: Array<PreviewNodeConnectionInfo> | null = useMemo(() => {
-    if (previewNode) {
-      // Find all edges connected to the preview node.
-      const previewEdges = reactFlowInstance
-        .getEdges()
-        .filter((edge) => edge.source === PREVIEW_NODE_ID || edge.target === PREVIEW_NODE_ID);
-
-      // Build connection info with cached handle manifests.
-      const connections = previewEdges.map((previewEdge) => {
-        // Determine which end of the edge is the preview node.
-        const sourceIsPreviewNode = previewEdge.source === PREVIEW_NODE_ID;
-        const existingNodeId = sourceIsPreviewNode ? previewEdge.target : previewEdge.source;
-
-        // Get the existing node's manifest.
-        const existingNodeType = reactFlowInstance.getNode(existingNodeId)?.type;
-        const existingNodeManifest = existingNodeType
-          ? registry?.getManifest(existingNodeType)
-          : undefined;
-
-        // Determine which handle on the existing node is involved.
-        const existingHandleId = sourceIsPreviewNode
-          ? previewEdge.targetHandle || 'input'
-          : previewEdge.sourceHandle || 'output';
-
-        // Pre-compute the handle manifest here so consumers don't need to look it up repeatedly.
-        const existingHandleManifest = existingNodeManifest?.handleConfiguration
-          .flatMap((hg) => hg.handles)
-          .find((h) => {
-            if (h.id === existingHandleId) return true;
-
-            const repeatHandleIdBase = h.repeat && h.id.split('{')[0];
-            if (repeatHandleIdBase) {
-              return existingHandleId.startsWith(repeatHandleIdBase);
-            }
-            return false;
-          });
-
-        return {
-          addNewNodeAsSource: sourceIsPreviewNode,
-          existingNodeId,
-          existingHandleId,
-          existingNodeManifest,
-          existingHandleManifest,
-          previewEdgeId: previewEdge.id,
-        };
-      });
-      return connections;
-    } else {
+    if (!isPreviewNodeSelected) {
       // Preview node was deselected - clear connection info.
       return null;
     }
-  }, [previewNode, reactFlowInstance, registry]);
+
+    // Build connection info with cached handle manifests.
+    const connections = previewEdges.map((previewEdge) => {
+      // Determine which end of the edge is the preview node.
+      const sourceIsPreviewNode = previewEdge.source === PREVIEW_NODE_ID;
+      const existingNodeId = sourceIsPreviewNode ? previewEdge.target : previewEdge.source;
+
+      // Get the existing node's manifest.
+      const existingNodeType = reactFlowInstance.getNode(existingNodeId)?.type;
+      const existingNodeManifest = existingNodeType
+        ? registry?.getManifest(existingNodeType)
+        : undefined;
+
+      // Determine which handle on the existing node is involved.
+      const existingHandleId = sourceIsPreviewNode
+        ? previewEdge.targetHandle || 'input'
+        : previewEdge.sourceHandle || 'output';
+
+      // Pre-compute the handle manifest here so consumers don't need to look it up repeatedly.
+      const existingHandleManifest = existingNodeManifest?.handleConfiguration
+        .flatMap((hg) => hg.handles)
+        .find((h) => {
+          if (h.id === existingHandleId) return true;
+
+          const repeatHandleIdBase = h.repeat && h.id.split('{')[0];
+          if (repeatHandleIdBase) {
+            return existingHandleId.startsWith(repeatHandleIdBase);
+          }
+          return false;
+        });
+
+      return {
+        addNewNodeAsSource: sourceIsPreviewNode,
+        existingNodeId,
+        existingHandleId,
+        existingNodeManifest,
+        existingHandleManifest,
+        previewEdgeId: previewEdge.id,
+      };
+    });
+    return connections;
+  }, [isPreviewNodeSelected, previewEdges, reactFlowInstance, registry]);
 
   return { previewNode, previewNodeConnectionInfo: connectionInfo };
 };


### PR DESCRIPTION
- Improves performance for the Add Node Panel (Toolbox + ListView) by using memoized components and ensuring props are not changing unnecessarily.
  - Eliminates renders on hover since that method was not being used for anything.
  - NOTE: Still some work to be done on node drag. Investigating why we are still rendering after making changes to the click handler to not recalculate on node position change.

- Updates list item button icons to use the Lucide Icon registry out of the box.

- Tweaks the loading behavior for registry-driven AddNodePanel by waiting for loading to end before initializing options. This prevents a partially loaded registry from getting stuck in the panel.

BEFORE:

https://github.com/user-attachments/assets/d960b60c-b79e-4653-99af-2e0620e7c72e

AFTER:

https://github.com/user-attachments/assets/e9df57c7-a79e-46b9-8cdc-cd7e73b93c66

Polished focus styling:
<img width="452" height="474" alt="Screenshot 2026-02-05 at 10 20 02 AM" src="https://github.com/user-attachments/assets/ac3d6af0-07fa-4473-b70f-918f80bff351" />


