### PR TITLE
fix(apollo-react): filter invisible handles in calcuation of spacing [MST-6413]

### DIFF
--- a/packages/apollo-react/src/canvas/components/BaseNode/BaseNode.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/BaseNode/BaseNode.stories.tsx
@@ -3,6 +3,8 @@
  *
  * Demonstrates the BaseNode component with various shapes, sizes, and execution states.
  */
+
+import { Checkbox, FormControlLabel } from '@mui/material';
 import type { Meta, StoryObj } from '@storybook/react';
 import { FontVariantToken } from '@uipath/apollo-core';
 import { Column, Row } from '@uipath/apollo-react/canvas/layouts';
@@ -141,6 +143,13 @@ const sampleManifest: WorkflowManifest = {
               handleType: 'output',
               label: '{item.name}',
               repeat: 'dynamicOutputs',
+            },
+            {
+              id: 'default',
+              type: 'source',
+              handleType: 'output',
+              label: 'Default Output',
+              visible: 'hasDefault',
             },
           ],
         },
@@ -377,6 +386,7 @@ function DynamicHandlesStory() {
       { label: 'Tertiary Input' },
     ],
     dynamicOutputs: [{ name: 'Success Path' }, { name: 'Failure Path' }],
+    hasDefault: false,
   });
 
   const initialNodes = useMemo(() => {
@@ -392,6 +402,7 @@ function DynamicHandlesStory() {
             inputs: {
               dynamicInputs: nodeData.dynamicInputs,
               dynamicOutputs: nodeData.dynamicOutputs,
+              hasDefault: nodeData.hasDefault,
             },
             display: {
               label: 'Dynamic Handles',
@@ -420,6 +431,7 @@ function DynamicHandlesStory() {
                 inputs: {
                   dynamicInputs: nodeData.dynamicInputs,
                   dynamicOutputs: nodeData.dynamicOutputs,
+                  hasDefault: nodeData.hasDefault,
                 },
                 display: {
                   ...(node.data.display || {}),
@@ -503,6 +515,19 @@ function DynamicHandlesStory() {
               </Row>
             </Column>
           ))}
+          <Column gap={6} align="flex-start">
+            <FormControlLabel
+              control={
+                <Checkbox
+                  checked={nodeData.hasDefault}
+                  onChange={(e) =>
+                    setNodeData((prev) => ({ ...prev, hasDefault: e.target.checked }))
+                  }
+                />
+              }
+              label="Has Default Output"
+            />
+          </Column>
           <ApButton
             size="small"
             variant="secondary"
@@ -511,6 +536,7 @@ function DynamicHandlesStory() {
               setNodeData({
                 dynamicInputs: [{ label: 'Primary Input' }],
                 dynamicOutputs: [{ name: 'Success Path' }],
+                hasDefault: false,
               })
             }
           />

--- a/packages/apollo-react/src/canvas/components/ButtonHandle/ButtonHandle.test.tsx
+++ b/packages/apollo-react/src/canvas/components/ButtonHandle/ButtonHandle.test.tsx
@@ -182,7 +182,7 @@ describe('ButtonHandles', () => {
     );
 
     const handle = screen.getByTestId('handle');
-    expect(handle).toHaveStyle({ opacity: '1' });
+    expect(handle).toBeInTheDocument();
 
     rerender(
       <ButtonHandles
@@ -193,7 +193,7 @@ describe('ButtonHandles', () => {
       />
     );
 
-    expect(handle).toHaveStyle({ opacity: '0' });
+    expect(screen.queryByTestId('handle')).not.toBeInTheDocument();
   });
 
   it('positions handles correctly for different positions', () => {

--- a/packages/apollo-react/src/canvas/components/ButtonHandle/ButtonHandle.tsx
+++ b/packages/apollo-react/src/canvas/components/ButtonHandle/ButtonHandle.tsx
@@ -256,12 +256,15 @@ const ButtonHandlesBase = ({
     selected: boolean;
   }) => boolean;
 }) => {
-  const total = handles.length;
   const finalSelected = shouldShowAddButtonFn({ showAddButton, selected });
+
+  // Filter to only visible handles for spacing calculations
+  const visibleHandles = handles.filter((h) => visible && (h.visible ?? true));
+  const total = visibleHandles.length;
 
   return (
     <>
-      {handles.map((handle, index) => (
+      {visibleHandles.map((handle, index) => (
         <ButtonHandle
           key={handle.id}
           id={handle.id}
@@ -275,8 +278,6 @@ const ButtonHandlesBase = ({
           index={index}
           total={total}
           selected={selected}
-          // Need top level visibility to be true and current handle visibility to be true to keep positioning of handles consistent
-          visible={visible && (handle.visible ?? true)}
           showButton={finalSelected && visible && handle.showButton}
           color={handle.color}
           onAction={handle.onAction}


### PR DESCRIPTION
### Description

This PR

- Filters out handles with `visible:true` before calculation of spacing on the node
- Adds a story to demonstrate the same

### Demo

Before:


https://github.com/user-attachments/assets/e661fad2-0dc2-43ad-970f-af793db90e6c

After:


https://github.com/user-attachments/assets/4cf8285e-cdc4-4f50-8f70-456020f1ae78

