### PR TITLE
fix(apollo-react): ApModal was missing secondary action disable prop

### DIFF
--- a/apps/react-playground/src/pages/components/ModalShowcase.tsx
+++ b/apps/react-playground/src/pages/components/ModalShowcase.tsx
@@ -1,3 +1,4 @@
+import { FontVariantToken } from "@uipath/apollo-react";
 import {
 	ApAccordion,
 	ApButton,
@@ -7,13 +8,11 @@ import {
 import { useState } from "react";
 import styled from "styled-components";
 import { CodeBlock } from "../../components/CodeBlock";
-
 import {
 	PageContainer,
 	PageDescription,
 	PageTitle,
 } from "../../components/SharedStyles";
-import { FontVariantToken } from "@uipath/apollo-react";
 
 const ShowcaseSection = styled.div`
 	margin-top: 48px;
@@ -209,6 +208,62 @@ export function Example() {
 }
 `;
 
+const disabledStateCode = `
+import { ApModal, ApButton } from "@uipath/apollo-react/material/components";
+import { useState } from "react";
+
+export function Example() {
+	const [primaryDisabledOpen, setPrimaryDisabledOpen] = useState(false);
+	const [secondaryDisabledOpen, setSecondaryDisabledOpen] = useState(false);
+
+	return (
+		<>
+			{/* Primary button disabled */}
+			<ApButton
+				label="Disabled Primary Button"
+				onClick={() => setPrimaryDisabledOpen(true)}
+			/>
+			<ApModal
+				open={primaryDisabledOpen}
+				onClose={() => setPrimaryDisabledOpen(false)}
+				header="Disabled Primary Action"
+				message="The primary action button is disabled. This is common when form validation fails or required conditions aren't met."
+				primaryAction={{
+					label: "Submit",
+					onClick: () => setPrimaryDisabledOpen(false),
+					disabled: true,
+				}}
+				secondaryAction={{
+					label: "Cancel",
+					onClick: () => setPrimaryDisabledOpen(false),
+				}}
+			/>
+
+			{/* Secondary button disabled */}
+			<ApButton
+				label="Disabled Secondary Button"
+				onClick={() => setSecondaryDisabledOpen(true)}
+			/>
+			<ApModal
+				open={secondaryDisabledOpen}
+				onClose={() => setSecondaryDisabledOpen(false)}
+				header="Disabled Secondary Action"
+				message="The secondary action button is disabled. This can be used to enforce a specific workflow or prevent cancellation."
+				primaryAction={{
+					label: "Confirm",
+					onClick: () => setSecondaryDisabledOpen(false),
+				}}
+				secondaryAction={{
+					label: "Cancel",
+					onClick: () => setSecondaryDisabledOpen(false),
+					disabled: true,
+				}}
+			/>
+		</>
+	);
+}
+`;
+
 const customContentCode = `
 import { ApModal, ApButton, ApTypography } from "@uipath/apollo-react/material/components";
 import { useState } from "react";
@@ -310,6 +365,8 @@ export function ModalShowcase() {
 	const [loadingStateOpen, setLoadingStateOpen] = useState(false);
 	const [primaryLoading, setPrimaryLoading] = useState(false);
 	const [secondaryLoading, setSecondaryLoading] = useState(false);
+	const [primaryDisabledOpen, setPrimaryDisabledOpen] = useState(false);
+	const [secondaryDisabledOpen, setSecondaryDisabledOpen] = useState(false);
 	const [smallOpen, setSmallOpen] = useState(false);
 	const [mediumOpen, setMediumOpen] = useState(false);
 	const [largeOpen, setLargeOpen] = useState(false);
@@ -440,6 +497,64 @@ export function ModalShowcase() {
 					<Label>Code Example:</Label>
 					<ApAccordion label="Loading States" disableDivider>
 						<CodeBlock>{loadingStateCode}</CodeBlock>
+					</ApAccordion>
+				</ComponentRow>
+			</ShowcaseSection>
+
+			<ShowcaseSection>
+				<SectionTitle>Disabled States</SectionTitle>
+				<ComponentRow>
+					<Label>
+						Action buttons can be disabled to prevent user interaction based on
+						conditions (e.g., form validation, permissions, workflow
+						enforcement)
+					</Label>
+					<ButtonGroup>
+						<ApButton
+							label="Disabled Primary Button"
+							onClick={() => setPrimaryDisabledOpen(true)}
+						/>
+						<ApButton
+							label="Disabled Secondary Button"
+							onClick={() => setSecondaryDisabledOpen(true)}
+						/>
+					</ButtonGroup>
+
+					<ApModal
+						open={primaryDisabledOpen}
+						onClose={() => setPrimaryDisabledOpen(false)}
+						header="Disabled Primary Action"
+						message="The primary action button is disabled. This is common when form validation fails or required conditions aren't met."
+						primaryAction={{
+							label: "Submit",
+							onClick: () => setPrimaryDisabledOpen(false),
+							disabled: true,
+						}}
+						secondaryAction={{
+							label: "Cancel",
+							onClick: () => setPrimaryDisabledOpen(false),
+						}}
+					/>
+
+					<ApModal
+						open={secondaryDisabledOpen}
+						onClose={() => setSecondaryDisabledOpen(false)}
+						header="Disabled Secondary Action"
+						message="The secondary action button is disabled. This can be used to enforce a specific workflow or prevent cancellation."
+						primaryAction={{
+							label: "Confirm",
+							onClick: () => setSecondaryDisabledOpen(false),
+						}}
+						secondaryAction={{
+							label: "Cancel",
+							onClick: () => setSecondaryDisabledOpen(false),
+							disabled: true,
+						}}
+					/>
+
+					<Label>Code Example:</Label>
+					<ApAccordion label="Disabled States" disableDivider>
+						<CodeBlock>{disabledStateCode}</CodeBlock>
 					</ApAccordion>
 				</ComponentRow>
 			</ShowcaseSection>

--- a/packages/apollo-react/src/material/components/ap-modal/ApModal.test.tsx
+++ b/packages/apollo-react/src/material/components/ap-modal/ApModal.test.tsx
@@ -165,16 +165,35 @@ describe('ApModal', () => {
     });
 
     it('disables primary action button when disabled is true', () => {
+      const handlePrimaryClick = vi.fn();
       render(
         <ApModal
           open={true}
           onClose={vi.fn()}
           header="Test Modal"
-          primaryAction={{ label: 'Confirm', onClick: vi.fn(), disabled: true }}
+          primaryAction={{ label: 'Confirm', onClick: handlePrimaryClick, disabled: true }}
         />
       );
       const button = screen.getByRole('button', { name: /confirm/i, hidden: true });
       expect(button).toBeDisabled();
+      button.click();
+      expect(handlePrimaryClick).not.toHaveBeenCalled();
+    });
+
+    it('disables secondary action button when disabled is true', () => {
+      const handleSecondaryClick = vi.fn();
+      render(
+        <ApModal
+          open={true}
+          onClose={vi.fn()}
+          header="Test Modal"
+          secondaryAction={{ label: 'Cancel', onClick: handleSecondaryClick, disabled: true }}
+        />
+      );
+      const button = screen.getByRole('button', { name: /cancel/i, hidden: true });
+      expect(button).toBeDisabled();
+      button.click();
+      expect(handleSecondaryClick).not.toHaveBeenCalled();
     });
 
     it('sets id on primary action button', () => {

--- a/packages/apollo-react/src/material/components/ap-modal/ApModal.tsx
+++ b/packages/apollo-react/src/material/components/ap-modal/ApModal.tsx
@@ -139,6 +139,7 @@ export const ApModal = React.forwardRef<HTMLDivElement, ApModalProps>((props, re
                 variant="secondary"
                 id={secondaryAction.id}
                 label={secondaryAction.label}
+                disabled={secondaryAction.disabled}
                 loading={secondaryAction.loading}
                 onClick={secondaryAction.onClick}
               />

--- a/packages/apollo-react/src/material/components/ap-modal/ApModal.types.ts
+++ b/packages/apollo-react/src/material/components/ap-modal/ApModal.types.ts
@@ -66,6 +66,7 @@ export interface ApModalProps extends Omit<ModalProps, 'onClose' | 'children'> {
     label: string;
     onClick?: () => void;
     loading?: boolean;
+    disabled?: boolean;
     id?: string;
   };
 


### PR DESCRIPTION
<img width="534" height="241" alt="image" src="https://github.com/user-attachments/assets/57bb1db1-939b-43ab-9fcf-98f2f9ffb93a" />
Secondary Action button didn't have prop type defined for disabled.
- Needed for case management modals in PO.Frontend