### PR TITLE
feat(apollo-react): make empty stage node text clickable [MST-6401]

### DIFF
--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.tsx
@@ -19,7 +19,13 @@ import {
 import { FontVariantToken, Padding, Spacing } from '@uipath/apollo-core';
 import { Column, Row } from '@uipath/apollo-react/canvas/layouts';
 import { Position, useStore, useViewport } from '@uipath/apollo-react/canvas/xyflow/react';
-import { ApIcon, ApIconButton, ApTooltip, ApTypography } from '@uipath/apollo-react/material';
+import {
+  ApIcon,
+  ApIconButton,
+  ApLink,
+  ApTooltip,
+  ApTypography,
+} from '@uipath/apollo-react/material';
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import type { HandleGroupManifest } from '../../schema/node-definition';
@@ -533,12 +539,22 @@ const StageNodeComponent = (props: StageNodeProps) => {
         <StageContent>
           {!tasks || tasks.length === 0 ? (
             <Column py={2}>
-              <ApTypography
-                variant={FontVariantToken.fontSizeS}
-                color="var(--uix-canvas-foreground-de-emp)"
-              >
-                {defaultContent}
-              </ApTypography>
+              {(onTaskAdd || onAddTaskFromToolbox) && !isReadOnly ? (
+                <ApLink
+                  onClick={handleTaskAddClick}
+                  variant={FontVariantToken.fontSizeS}
+                  style={{ maxWidth: 'fit-content' }}
+                >
+                  {defaultContent}
+                </ApLink>
+              ) : (
+                <ApTypography
+                  variant={FontVariantToken.fontSizeS}
+                  color="var(--uix-canvas-foreground-de-emp)"
+                >
+                  {defaultContent}
+                </ApTypography>
+              )}
             </Column>
           ) : (
             <DndContext


### PR DESCRIPTION
## Description
Updated the StageNode component to display the empty state content as a clickable link instead of plain text when task addition is available and the node is not read-only.

## Demo
<img width="354" height="208" alt="image" src="https://github.com/user-attachments/assets/26b45f7e-8203-458d-8268-b15e2f3880a1" />


## Key Changes
- Added `ApLink` import to the material components
- Replaced static `ApTypography` with conditional rendering:
  - When `onTaskAdd` or `onAddTaskFromToolbox` callbacks exist and the node is not read-only, the empty state text is now rendered as an `ApLink` that triggers `handleTaskAddClick`
  - Otherwise, it falls back to the original `ApTypography` display
- This improves UX by making the empty state more discoverable and actionable

## Implementation Details
- The link uses the same `FontVariantToken.fontSizeS` variant for visual consistency
- The conditional logic checks for both task addition callbacks and read-only status to determine interactivity
- The change maintains backward compatibility for read-only nodes and nodes without task addition handlers

https://claude.ai/code/session_01Lvobb2cFYqMc8QB2WmwGz9