### PR TITLE
fix(apollo-wind): upgrade react-resizable-panels to v4 and optimize form render performance

### DIFF
--- a/apps/apollo-vertex/app/shadcn-components/resizable/page.mdx
+++ b/apps/apollo-vertex/app/shadcn-components/resizable/page.mdx
@@ -6,24 +6,24 @@ Accessible resizable panel groups and layouts with keyboard support.
 
 <div className="p-4 border rounded-lg mt-4">
   <ResizablePanelGroup
-    direction="horizontal"
+    orientation="horizontal"
     className="max-w-md rounded-lg border"
   >
-    <ResizablePanel defaultSize={50}>
+    <ResizablePanel defaultSize="50%">
       <div className="flex h-[200px] items-center justify-center p-6">
         <span className="font-semibold">One</span>
       </div>
     </ResizablePanel>
     <ResizableHandle />
-    <ResizablePanel defaultSize={50}>
-      <ResizablePanelGroup direction="vertical">
-        <ResizablePanel defaultSize={25}>
+    <ResizablePanel defaultSize="50%">
+      <ResizablePanelGroup orientation="vertical">
+        <ResizablePanel defaultSize="25%">
           <div className="flex h-full items-center justify-center p-6">
             <span className="font-semibold">Two</span>
           </div>
         </ResizablePanel>
         <ResizableHandle />
-        <ResizablePanel defaultSize={75}>
+        <ResizablePanel defaultSize="75%">
           <div className="flex h-full items-center justify-center p-6">
             <span className="font-semibold">Three</span>
           </div>
@@ -50,7 +50,7 @@ import {
 ```
 
 ```tsx
-<ResizablePanelGroup direction="horizontal">
+<ResizablePanelGroup orientation="horizontal">
   <ResizablePanel>One</ResizablePanel>
   <ResizableHandle />
   <ResizablePanel>Two</ResizablePanel>

--- a/apps/apollo-vertex/package.json
+++ b/apps/apollo-vertex/package.json
@@ -80,7 +80,7 @@
     "react-hook-form": "^7.66.1",
     "react-i18next": "^16.5.4",
     "react-markdown": "^10.1.0",
-    "react-resizable-panels": "^3.0.6",
+    "react-resizable-panels": "^4.7.3",
     "recharts": "2.15.4",
     "remark-gfm": "^4.0.1",
     "sonner": "^2.0.7",

--- a/apps/apollo-vertex/registry.json
+++ b/apps/apollo-vertex/registry.json
@@ -794,7 +794,7 @@
       "type": "registry:ui",
       "title": "Resizable",
       "description": "Accessible resizable panel groups and layouts.",
-      "dependencies": ["react-resizable-panels@^3.0.6"],
+      "dependencies": ["react-resizable-panels@^4.7.3"],
       "files": [
         {
           "path": "registry/resizable/resizable.tsx",

--- a/apps/apollo-vertex/registry/resizable/resizable.tsx
+++ b/apps/apollo-vertex/registry/resizable/resizable.tsx
@@ -2,44 +2,39 @@
 
 import { GripVerticalIcon } from "lucide-react";
 import * as React from "react";
-import * as ResizablePrimitive from "react-resizable-panels";
+import { Group, Panel, Separator } from "react-resizable-panels";
 
 import { cn } from "@/lib/utils";
 
 function ResizablePanelGroup({
   className,
   ...props
-}: React.ComponentProps<typeof ResizablePrimitive.PanelGroup>) {
+}: React.ComponentProps<typeof Group>) {
   return (
-    <ResizablePrimitive.PanelGroup
+    <Group
       data-slot="resizable-panel-group"
-      className={cn(
-        "flex h-full w-full data-[panel-group-direction=vertical]:flex-col",
-        className,
-      )}
+      className={cn("flex h-full w-full", className)}
       {...props}
     />
   );
 }
 
-function ResizablePanel({
-  ...props
-}: React.ComponentProps<typeof ResizablePrimitive.Panel>) {
-  return <ResizablePrimitive.Panel data-slot="resizable-panel" {...props} />;
+function ResizablePanel({ ...props }: React.ComponentProps<typeof Panel>) {
+  return <Panel data-slot="resizable-panel" {...props} />;
 }
 
 function ResizableHandle({
   withHandle,
   className,
   ...props
-}: React.ComponentProps<typeof ResizablePrimitive.PanelResizeHandle> & {
+}: React.ComponentProps<typeof Separator> & {
   withHandle?: boolean;
 }) {
   return (
-    <ResizablePrimitive.PanelResizeHandle
+    <Separator
       data-slot="resizable-handle"
       className={cn(
-        "bg-border focus-visible:ring-ring relative flex w-px items-center justify-center after:absolute after:inset-y-0 after:left-1/2 after:w-1 after:-translate-x-1/2 focus-visible:ring-1 focus-visible:ring-offset-1 focus-visible:outline-hidden data-[panel-group-direction=vertical]:h-px data-[panel-group-direction=vertical]:w-full data-[panel-group-direction=vertical]:after:left-0 data-[panel-group-direction=vertical]:after:h-1 data-[panel-group-direction=vertical]:after:w-full data-[panel-group-direction=vertical]:after:translate-x-0 data-[panel-group-direction=vertical]:after:-translate-y-1/2 [&[data-panel-group-direction=vertical]>div]:rotate-90",
+        "bg-border focus-visible:ring-ring relative flex w-px items-center justify-center after:absolute after:inset-y-0 after:left-1/2 after:w-1 after:-translate-x-1/2 focus-visible:ring-1 focus-visible:ring-offset-1 focus-visible:outline-hidden aria-[orientation=horizontal]:h-px aria-[orientation=horizontal]:w-full aria-[orientation=horizontal]:after:left-0 aria-[orientation=horizontal]:after:h-1 aria-[orientation=horizontal]:after:w-full aria-[orientation=horizontal]:after:translate-x-0 aria-[orientation=horizontal]:after:-translate-y-1/2 [&[aria-orientation=horizontal]>div]:rotate-90",
         className,
       )}
       {...props}
@@ -49,7 +44,7 @@ function ResizableHandle({
           <GripVerticalIcon className="size-2.5" />
         </div>
       )}
-    </ResizablePrimitive.PanelResizeHandle>
+    </Separator>
   );
 }
 

--- a/packages/apollo-wind/package.json
+++ b/packages/apollo-wind/package.json
@@ -119,7 +119,7 @@
     "react-day-picker": "^9.13.0",
     "react-hook-form": "^7.66.1",
     "react-live": "^4.1.8",
-    "react-resizable-panels": "^3.0.6",
+    "react-resizable-panels": "^4.7.3",
     "react-syntax-highlighter": "^16.1.0",
     "recharts": "2.15.4",
     "sonner": "^2.0.7",

--- a/packages/apollo-wind/src/components/ui/resizable.stories.tsx
+++ b/packages/apollo-wind/src/components/ui/resizable.stories.tsx
@@ -17,14 +17,14 @@ export const Horizontal = {
   args: {},
   render: () => (
     <div className="h-screen p-4">
-      <ResizablePanelGroup direction="horizontal" className="min-h-[400px] rounded-lg border">
-        <ResizablePanel defaultSize={50} minSize={20}>
+      <ResizablePanelGroup orientation="horizontal" className="min-h-[400px] rounded-lg border">
+        <ResizablePanel defaultSize="50%" minSize="20%">
           <Row h="full" align="center" justify="center" className="p-6">
             <span className="font-semibold">Left Panel</span>
           </Row>
         </ResizablePanel>
         <ResizableHandle />
-        <ResizablePanel defaultSize={50} minSize={20}>
+        <ResizablePanel defaultSize="50%" minSize="20%">
           <Row h="full" align="center" justify="center" className="p-6">
             <span className="font-semibold">Right Panel</span>
           </Row>
@@ -38,14 +38,14 @@ export const Vertical = {
   args: {},
   render: () => (
     <div className="h-screen p-4">
-      <ResizablePanelGroup direction="vertical" className="min-h-[400px] rounded-lg border">
-        <ResizablePanel defaultSize={50} minSize={20}>
+      <ResizablePanelGroup orientation="vertical" className="min-h-[400px] rounded-lg border">
+        <ResizablePanel defaultSize="50%" minSize="20%">
           <Row h="full" align="center" justify="center" className="p-6">
             <span className="font-semibold">Top Panel</span>
           </Row>
         </ResizablePanel>
         <ResizableHandle />
-        <ResizablePanel defaultSize={50} minSize={20}>
+        <ResizablePanel defaultSize="50%" minSize="20%">
           <Row h="full" align="center" justify="center" className="p-6">
             <span className="font-semibold">Bottom Panel</span>
           </Row>
@@ -59,20 +59,20 @@ export const ThreePanels = {
   args: {},
   render: () => (
     <div className="h-screen p-4">
-      <ResizablePanelGroup direction="horizontal" className="min-h-[400px] rounded-lg border">
-        <ResizablePanel defaultSize={25} minSize={15}>
+      <ResizablePanelGroup orientation="horizontal" className="min-h-[400px] rounded-lg border">
+        <ResizablePanel defaultSize="25%" minSize="15%">
           <Row h="full" align="center" justify="center" className="p-6">
             <span className="font-semibold">Sidebar</span>
           </Row>
         </ResizablePanel>
         <ResizableHandle />
-        <ResizablePanel defaultSize={50} minSize={30}>
+        <ResizablePanel defaultSize="50%" minSize="30%">
           <Row h="full" align="center" justify="center" className="p-6">
             <span className="font-semibold">Main Content</span>
           </Row>
         </ResizablePanel>
         <ResizableHandle />
-        <ResizablePanel defaultSize={25} minSize={15}>
+        <ResizablePanel defaultSize="25%" minSize="15%">
           <Row h="full" align="center" justify="center" className="p-6">
             <span className="font-semibold">Right Sidebar</span>
           </Row>
@@ -86,22 +86,22 @@ export const Nested = {
   args: {},
   render: () => (
     <div className="h-screen p-4">
-      <ResizablePanelGroup direction="horizontal" className="min-h-[400px] rounded-lg border">
-        <ResizablePanel defaultSize={25} minSize={15}>
+      <ResizablePanelGroup orientation="horizontal" className="min-h-[400px] rounded-lg border">
+        <ResizablePanel defaultSize="25%" minSize="15%">
           <Row h="full" align="center" justify="center" className="p-6">
             <span className="font-semibold">Left Sidebar</span>
           </Row>
         </ResizablePanel>
         <ResizableHandle />
-        <ResizablePanel defaultSize={75}>
-          <ResizablePanelGroup direction="vertical">
-            <ResizablePanel defaultSize={50} minSize={30}>
+        <ResizablePanel defaultSize="75%">
+          <ResizablePanelGroup orientation="vertical">
+            <ResizablePanel defaultSize="50%" minSize="30%">
               <Row h="full" align="center" justify="center" className="p-6">
                 <span className="font-semibold">Top Content</span>
               </Row>
             </ResizablePanel>
             <ResizableHandle />
-            <ResizablePanel defaultSize={50} minSize={30}>
+            <ResizablePanel defaultSize="50%" minSize="30%">
               <Row h="full" align="center" justify="center" className="p-6">
                 <span className="font-semibold">Bottom Content</span>
               </Row>
@@ -117,14 +117,14 @@ export const WithHandleVariant = {
   args: {},
   render: () => (
     <div className="h-screen p-4">
-      <ResizablePanelGroup direction="horizontal" className="min-h-[400px] rounded-lg border">
-        <ResizablePanel defaultSize={50} minSize={20}>
+      <ResizablePanelGroup orientation="horizontal" className="min-h-[400px] rounded-lg border">
+        <ResizablePanel defaultSize="50%" minSize="20%">
           <Row h="full" align="center" justify="center" className="p-6">
             <span className="font-semibold">Left Panel</span>
           </Row>
         </ResizablePanel>
         <ResizableHandle withHandle />
-        <ResizablePanel defaultSize={50} minSize={20}>
+        <ResizablePanel defaultSize="50%" minSize="20%">
           <Row h="full" align="center" justify="center" className="p-6">
             <span className="font-semibold">Right Panel</span>
           </Row>

--- a/packages/apollo-wind/src/components/ui/resizable.test.tsx
+++ b/packages/apollo-wind/src/components/ui/resizable.test.tsx
@@ -5,12 +5,12 @@ import { describe, expect, it } from 'vitest';
 import { ResizablePanelGroup, ResizablePanel, ResizableHandle } from './resizable';
 
 const BasicResizable = ({ withHandle = false }: { withHandle?: boolean }) => (
-  <ResizablePanelGroup direction="horizontal">
-    <ResizablePanel defaultSize={50}>
+  <ResizablePanelGroup orientation="horizontal">
+    <ResizablePanel defaultSize="50%">
       <div>Panel 1</div>
     </ResizablePanel>
     <ResizableHandle withHandle={withHandle} />
-    <ResizablePanel defaultSize={50}>
+    <ResizablePanel defaultSize="50%">
       <div>Panel 2</div>
     </ResizablePanel>
   </ResizablePanelGroup>
@@ -26,7 +26,7 @@ describe('Resizable', () => {
 
     it('renders handle without grip icon by default', () => {
       const { container } = render(<BasicResizable />);
-      expect(container.querySelector('[data-panel-resize-handle-id]')).toBeInTheDocument();
+      expect(container.querySelector('[data-separator]')).toBeInTheDocument();
       expect(container.querySelector('svg')).not.toBeInTheDocument();
     });
 
@@ -37,37 +37,33 @@ describe('Resizable', () => {
 
     it('renders vertical panel group', () => {
       const { container } = render(
-        <ResizablePanelGroup direction="vertical">
-          <ResizablePanel defaultSize={50}>
+        <ResizablePanelGroup orientation="vertical">
+          <ResizablePanel defaultSize="50%">
             <div>Top</div>
           </ResizablePanel>
           <ResizableHandle />
-          <ResizablePanel defaultSize={50}>
+          <ResizablePanel defaultSize="50%">
             <div>Bottom</div>
           </ResizablePanel>
         </ResizablePanelGroup>
       );
 
-      expect(
-        container.querySelector("[data-panel-group-direction='vertical']")
-      ).toBeInTheDocument();
+      const separator = container.querySelector('[data-separator]');
+      expect(separator).toBeInTheDocument();
+      expect(separator).toHaveAttribute('aria-orientation', 'horizontal');
     });
   });
 
   describe('Accessibility', () => {
-    // Note: react-resizable-panels has a known a11y issue - missing aria-valuenow on slider role
-    // This should be fixed upstream in the library
-    it('has accessibility violation for missing aria-valuenow (known library issue)', async () => {
+    it('has no accessibility violations', async () => {
       const { container } = render(<BasicResizable />);
       const results = await axe(container);
-      // The library doesn't provide aria-valuenow which is required for slider role
-      expect(results.violations.length).toBeGreaterThan(0);
-      expect(results.violations[0].id).toBe('aria-required-attr');
+      expect(results.violations).toHaveLength(0);
     });
 
     it('handle is keyboard focusable', () => {
       const { container } = render(<BasicResizable />);
-      const handle = container.querySelector('[data-panel-resize-handle-id]');
+      const handle = container.querySelector('[data-separator]');
       expect(handle).toHaveAttribute('tabindex', '0');
     });
   });
@@ -75,8 +71,8 @@ describe('Resizable', () => {
   describe('Props', () => {
     it('applies custom className to panel group', () => {
       const { container } = render(
-        <ResizablePanelGroup direction="horizontal" className="custom-group">
-          <ResizablePanel defaultSize={100}>
+        <ResizablePanelGroup orientation="horizontal" className="custom-group">
+          <ResizablePanel defaultSize="100%">
             <div>Content</div>
           </ResizablePanel>
         </ResizablePanelGroup>
@@ -87,28 +83,28 @@ describe('Resizable', () => {
 
     it('applies custom className to handle', () => {
       const { container } = render(
-        <ResizablePanelGroup direction="horizontal">
-          <ResizablePanel defaultSize={50}>
+        <ResizablePanelGroup orientation="horizontal">
+          <ResizablePanel defaultSize="50%">
             <div>Panel 1</div>
           </ResizablePanel>
           <ResizableHandle className="custom-handle" />
-          <ResizablePanel defaultSize={50}>
+          <ResizablePanel defaultSize="50%">
             <div>Panel 2</div>
           </ResizablePanel>
         </ResizablePanelGroup>
       );
 
-      expect(container.querySelector('[data-panel-resize-handle-id]')).toHaveClass('custom-handle');
+      expect(container.querySelector('[data-separator]')).toHaveClass('custom-handle');
     });
 
     it('renders panel with minSize', () => {
       render(
-        <ResizablePanelGroup direction="horizontal">
-          <ResizablePanel defaultSize={50} minSize={25}>
+        <ResizablePanelGroup orientation="horizontal">
+          <ResizablePanel defaultSize="50%" minSize="25%">
             <div>Panel 1</div>
           </ResizablePanel>
           <ResizableHandle />
-          <ResizablePanel defaultSize={50}>
+          <ResizablePanel defaultSize="50%">
             <div>Panel 2</div>
           </ResizablePanel>
         </ResizablePanelGroup>
@@ -119,12 +115,12 @@ describe('Resizable', () => {
 
     it('renders panel with maxSize', () => {
       render(
-        <ResizablePanelGroup direction="horizontal">
-          <ResizablePanel defaultSize={50} maxSize={75}>
+        <ResizablePanelGroup orientation="horizontal">
+          <ResizablePanel defaultSize="50%" maxSize="75%">
             <div>Panel 1</div>
           </ResizablePanel>
           <ResizableHandle />
-          <ResizablePanel defaultSize={50}>
+          <ResizablePanel defaultSize="50%">
             <div>Panel 2</div>
           </ResizablePanel>
         </ResizablePanelGroup>
@@ -135,12 +131,12 @@ describe('Resizable', () => {
 
     it('renders collapsible panel', () => {
       render(
-        <ResizablePanelGroup direction="horizontal">
-          <ResizablePanel defaultSize={50} collapsible collapsedSize={0}>
+        <ResizablePanelGroup orientation="horizontal">
+          <ResizablePanel defaultSize="50%" collapsible collapsedSize="0%">
             <div>Collapsible</div>
           </ResizablePanel>
           <ResizableHandle />
-          <ResizablePanel defaultSize={50}>
+          <ResizablePanel defaultSize="50%">
             <div>Panel 2</div>
           </ResizablePanel>
         </ResizablePanelGroup>
@@ -153,16 +149,16 @@ describe('Resizable', () => {
   describe('Multiple Panels', () => {
     it('renders three panels with two handles', () => {
       const { container } = render(
-        <ResizablePanelGroup direction="horizontal">
-          <ResizablePanel defaultSize={33}>
+        <ResizablePanelGroup orientation="horizontal">
+          <ResizablePanel defaultSize="33%">
             <div>Panel 1</div>
           </ResizablePanel>
           <ResizableHandle />
-          <ResizablePanel defaultSize={34}>
+          <ResizablePanel defaultSize="34%">
             <div>Panel 2</div>
           </ResizablePanel>
           <ResizableHandle />
-          <ResizablePanel defaultSize={33}>
+          <ResizablePanel defaultSize="33%">
             <div>Panel 3</div>
           </ResizablePanel>
         </ResizablePanelGroup>
@@ -171,7 +167,7 @@ describe('Resizable', () => {
       expect(screen.getByText('Panel 1')).toBeInTheDocument();
       expect(screen.getByText('Panel 2')).toBeInTheDocument();
       expect(screen.getByText('Panel 3')).toBeInTheDocument();
-      expect(container.querySelectorAll('[data-panel-resize-handle-id]')).toHaveLength(2);
+      expect(container.querySelectorAll('[data-separator]')).toHaveLength(2);
     });
   });
 });

--- a/packages/apollo-wind/src/components/ui/resizable.tsx
+++ b/packages/apollo-wind/src/components/ui/resizable.tsx
@@ -1,40 +1,36 @@
 import { GripVertical } from 'lucide-react';
-import * as ResizablePrimitive from 'react-resizable-panels';
+import { Group, Panel, Separator } from 'react-resizable-panels';
+import type { PanelImperativeHandle } from 'react-resizable-panels';
 
 import { cn } from '@/lib/index';
 
-const ResizablePanelGroup = ({
-  className,
-  ...props
-}: React.ComponentProps<typeof ResizablePrimitive.PanelGroup>) => (
-  <ResizablePrimitive.PanelGroup
-    className={cn('flex h-full w-full data-[panel-group-direction=vertical]:flex-col', className)}
-    {...props}
-  />
+const ResizablePanelGroup = ({ className, ...props }: React.ComponentProps<typeof Group>) => (
+  <Group className={cn('flex h-full w-full', className)} {...props} />
 );
 
-const ResizablePanel = ResizablePrimitive.Panel;
+const ResizablePanel = Panel;
 
 const ResizableHandle = ({
   withHandle,
   className,
   ...props
-}: React.ComponentProps<typeof ResizablePrimitive.PanelResizeHandle> & {
+}: React.ComponentProps<typeof Separator> & {
   withHandle?: boolean;
 }) => (
-  <ResizablePrimitive.PanelResizeHandle
+  <Separator
     className={cn(
-      'group relative flex w-px items-center justify-center bg-border transition-colors data-[resize-handle-state=hover]:bg-primary data-[resize-handle-state=drag]:bg-primary after:absolute after:inset-y-0 after:left-1/2 after:w-1 after:-translate-x-1/2 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 data-[panel-group-direction=vertical]:h-px data-[panel-group-direction=vertical]:w-full data-[panel-group-direction=vertical]:after:left-0 data-[panel-group-direction=vertical]:after:h-1 data-[panel-group-direction=vertical]:after:w-full data-[panel-group-direction=vertical]:after:-translate-y-1/2 data-[panel-group-direction=vertical]:after:translate-x-0 [&[data-panel-group-direction=vertical]>div]:rotate-90',
+      'group relative flex w-px items-center justify-center bg-border transition-colors data-[separator=hover]:bg-primary data-[separator=active]:bg-primary after:absolute after:inset-y-0 after:left-1/2 after:w-1 after:-translate-x-1/2 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 aria-[orientation=horizontal]:h-px aria-[orientation=horizontal]:w-full aria-[orientation=horizontal]:after:left-0 aria-[orientation=horizontal]:after:h-1 aria-[orientation=horizontal]:after:w-full aria-[orientation=horizontal]:after:-translate-y-1/2 aria-[orientation=horizontal]:after:translate-x-0 [&[aria-orientation=horizontal]>div]:rotate-90',
       className
     )}
     {...props}
   >
     {withHandle && (
-      <div className="z-10 flex h-4 w-3 items-center justify-center rounded-sm border bg-border transition-colors group-data-[resize-handle-state=hover]:bg-primary group-data-[resize-handle-state=drag]:bg-primary">
+      <div className="z-10 flex h-4 w-3 items-center justify-center rounded-sm border bg-border transition-colors group-data-[separator=hover]:bg-primary group-data-[separator=active]:bg-primary">
         <GripVertical className="h-2.5 w-2.5" />
       </div>
     )}
-  </ResizablePrimitive.PanelResizeHandle>
+  </Separator>
 );
 
 export { ResizablePanelGroup, ResizablePanel, ResizableHandle };
+export type { PanelImperativeHandle };

--- a/packages/apollo-wind/src/templates/Forms/form-builder-example.tsx
+++ b/packages/apollo-wind/src/templates/Forms/form-builder-example.tsx
@@ -89,8 +89,8 @@ export function FormBuilderExample() {
 
   return (
     <Column h="screen" w="full" className="bg-background">
-      <ResizablePanelGroup direction="horizontal">
-        <ResizablePanel defaultSize={50} minSize={30}>
+      <ResizablePanelGroup orientation="horizontal">
+        <ResizablePanel defaultSize="50%" minSize="30%">
           <ScrollArea className="h-screen">
             <div className="p-6">
               <div className="mb-6">
@@ -374,7 +374,7 @@ export function FormBuilderExample() {
 
         <ResizableHandle withHandle />
 
-        <ResizablePanel defaultSize={50} minSize={30}>
+        <ResizablePanel defaultSize="50%" minSize="30%">
           <Column h="screen" className="border-l">
             <ScrollArea className="h-full">
               <div className="p-6">

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -267,8 +267,8 @@ importers:
         specifier: ^10.1.0
         version: 10.1.0(@types/react@19.2.8)(react@19.2.3)
       react-resizable-panels:
-        specifier: ^3.0.6
-        version: 3.0.6(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        specifier: ^4.7.3
+        version: 4.7.3(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       recharts:
         specifier: 2.15.4
         version: 2.15.4(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -937,8 +937,8 @@ importers:
         specifier: ^4.1.8
         version: 4.1.8(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react-resizable-panels:
-        specifier: ^3.0.6
-        version: 3.0.6(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        specifier: ^4.7.3
+        version: 4.7.3(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react-syntax-highlighter:
         specifier: ^16.1.0
         version: 16.1.0(react@19.2.3)
@@ -10814,11 +10814,11 @@ packages:
       '@types/react':
         optional: true
 
-  react-resizable-panels@3.0.6:
-    resolution: {integrity: sha512-b3qKHQ3MLqOgSS+FRYKapNkJZf5EQzuf6+RLiq1/IlTHw99YrZ2NJZLk4hQIzTnnIkRg2LUqyVinu6YWWpUYew==}
+  react-resizable-panels@4.7.3:
+    resolution: {integrity: sha512-PYcYMLtvJD+Pr0TQNeMvddcnLOwUa/Yb4iNwU7ThNLlHaQYEEC9MIBWHaBGODzYuXIkPRZ/OWe5sbzG1Rzq5ew==}
     peerDependencies:
-      react: ^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
-      react-dom: ^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
 
   react-router-dom@7.12.0:
     resolution: {integrity: sha512-pfO9fiBcpEfX4Tx+iTYKDtPbrSLLCbwJ5EqP+SPYQu1VYCXdy79GSj0wttR0U4cikVdlImZuEZ/9ZNCgoaxwBA==}
@@ -23463,7 +23463,7 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.8
 
-  react-resizable-panels@3.0.6(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+  react-resizable-panels@4.7.3(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)


### PR DESCRIPTION
##  Summary

  - Upgrade react-resizable-panels from ^3.0.6 to ^4.7.3
  - Migrate all usages to v4 API: PanelGroup → Group, PanelResizeHandle → Separator, direction → orientation
  - Update size props from bare numbers (v3 treated as percentages) to explicit percentage strings (v4
  treats numbers as pixels)
  - Re-export PanelImperativeHandle type from the resizable wrapper so consumers don't need to import from
  react-resizable-panels directly
  - Map v4 data attributes for hover/active/vertical styling (data-[separator=hover|active],
  aria-[orientation=horizontal])

##  Breaking changes

  This is a breaking change for consumers of ResizablePanelGroup, ResizablePanel, and ResizableHandle:

```
  ┌──────────────────────────────────┬──────────────────────────────────────────────────────┐
  │           v3 (before)            │                      v4 (after)                      │
  ├──────────────────────────────────┼──────────────────────────────────────────────────────┤
  │ direction="horizontal"           │ orientation="horizontal"                             │
  ├──────────────────────────────────┼──────────────────────────────────────────────────────┤
  │ defaultSize={50} (percentage)    │ defaultSize="50%" (numbers are now pixels)           │
  ├──────────────────────────────────┼──────────────────────────────────────────────────────┤
  │ ref={panelRef}                   │ panelRef={panelRef}                                  │
  ├──────────────────────────────────┼──────────────────────────────────────────────────────┤
  │ onResize={(size: number) => ...} │ onResize={(size: { asPercentage, inPixels }) => ...} │
  ├──────────────────────────────────┼──────────────────────────────────────────────────────┤
  │ onCollapse / onExpand            │ Removed — use onResize                               │
  ├──────────────────────────────────┼──────────────────────────────────────────────────────┤
  │ autoSaveId                       │ Removed — use useDefaultLayout hook                  │
  └──────────────────────────────────┴──────────────────────────────────────────────────────┘
```
##  Test plan

  - All 12 existing resizable unit tests pass
  - TypeScript compiles with no errors
  - Visually verify hover/active highlight on handles
  - Visually verify horizontal separator renders correctly in vertical (top/bottom) layouts
  - Visually verify grip icon rotates for vertical layouts
  - Check Storybook stories render correctly (Horizontal, Vertical, ThreePanels, Nested, WithHandleVariant)
  - Verify FlowEditorLayout bottom panel resize + switcher positioning still works