### PR TITLE
chore(repo): add dev publish [MST-6092]

### DIFF
--- a/.github/workflows/dev-cleanup.yml
+++ b/.github/workflows/dev-cleanup.yml
@@ -1,0 +1,97 @@
+name: Dev Cleanup
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - main
+
+env:
+  TURBO_TELEMETRY_DISABLED: 1
+  DO_NOT_TRACK: 1
+
+jobs:
+  cleanup:
+    name: Cleanup Dev Packages
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      packages: write
+
+    steps:
+      - name: Get published packages from PR comment
+        id: packages
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          COMMENT=$(gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
+            --jq '[.[] | select(.body | startswith("## 📦 Dev Packages")) | .body][0]' 2>/dev/null) || true
+
+          if [ -z "$COMMENT" ]; then
+            echo "No dev packages comment found"
+            echo "packages=" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          # Extract package@version from within backticks (e.g., `@uipath/apollo-core@5.6.0-pr123`)
+          # Store newline-separated for safer iteration
+          PACKAGES=$(echo "$COMMENT" | grep -oE '`@uipath/[a-z0-9-]+@[0-9.]+-pr[0-9]+`' | tr -d '`' | sort -u)
+          # Use delimiter for GitHub output (newlines not supported)
+          echo "packages<<EOF" >> $GITHUB_OUTPUT
+          echo "$PACKAGES" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+          echo "Found: $PACKAGES"
+
+      - name: Cleanup dev packages
+        if: steps.packages.outputs.packages != ''
+        env:
+          GH_TOKEN: ${{ secrets.GH_NPM_REGISTRY_TOKEN }}
+          PACKAGES: ${{ steps.packages.outputs.packages }}
+        run: |
+          echo "$PACKAGES" | while IFS= read -r pkg_version; do
+            [ -z "$pkg_version" ] && continue
+            # Validate format for defense in depth
+            if ! [[ "$pkg_version" =~ ^@uipath/[a-z0-9-]+@[0-9.]+-pr[0-9]+$ ]]; then
+              echo "::warning::Skipping invalid package version: $pkg_version"
+              continue
+            fi
+
+            # Extract package name (without @uipath/) and version
+            pkg_name="${pkg_version%@*}"
+            pkg_short="${pkg_name#@uipath/}"
+            version="${pkg_version##*@}"
+
+            echo "Deleting $pkg_name@$version..."
+
+            # Get version ID from GitHub API
+            VERSION_ID=$(gh api "orgs/uipath/packages/npm/${pkg_short}/versions" \
+              --jq ".[] | select(.name == \"${version}\") | .id" 2>/dev/null) || true
+
+            if [ -n "$VERSION_ID" ]; then
+              gh api -X DELETE "orgs/uipath/packages/npm/${pkg_short}/versions/${VERSION_ID}" || echo "Failed to delete"
+              echo "Deleted $pkg_name@$version"
+            else
+              echo "Version not found: $pkg_name@$version"
+            fi
+          done
+
+      - name: Update PR comment
+        if: steps.packages.outputs.packages != ''
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          COMMENT_ID=$(gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
+            --jq '.[] | select(.body | startswith("## 📦 Dev Packages")) | .id' 2>/dev/null | head -1) || true
+
+          if [ -n "$COMMENT_ID" ]; then
+            TIMESTAMP=$(TZ="America/Los_Angeles" date "+%Y-%m-%d %H:%M:%S PT")
+            COMMENT_BODY="## 📦 Dev Packages"$'\n\n'
+            COMMENT_BODY+="🧹 Dev packages cleaned up after PR close."$'\n\n'
+            COMMENT_BODY+="**Last updated:** ${TIMESTAMP}"
+
+            gh api "repos/${{ github.repository }}/issues/comments/${COMMENT_ID}" \
+              -X PATCH -f body="$COMMENT_BODY" 2>/dev/null || true
+          fi

--- a/.github/workflows/dev-publish.yml
+++ b/.github/workflows/dev-publish.yml
@@ -1,0 +1,255 @@
+name: Dev Publish
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches:
+      - main
+
+env:
+  GH_NPM_REGISTRY_TOKEN: ${{ secrets.GH_NPM_REGISTRY_TOKEN }}
+  TURBO_TELEMETRY_DISABLED: 1
+  DO_NOT_TRACK: 1
+
+concurrency:
+  group: dev-publish-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  dev-publish:
+    name: Dev Publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+
+      - name: Check for existing dev packages comment
+        id: existing
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          COMMENT=$(gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
+            --jq '[.[] | select(.body | startswith("## 📦 Dev Packages")) | .body][0]' 2>/dev/null) || true
+
+          if [ -z "$COMMENT" ]; then
+            echo "No existing dev packages comment found"
+            echo "has_comment=false" >> $GITHUB_OUTPUT
+            echo "has_published=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          echo "has_comment=true" >> $GITHUB_OUTPUT
+
+          # Extract package@version from 🟢 Published lines
+          PUBLISHED=$(echo "$COMMENT" | grep -oE '`@uipath/[a-z0-9-]+@[0-9.]+-pr[0-9]+`' | tr -d '`' | sort -u)
+
+          if [ -z "$PUBLISHED" ]; then
+            echo "No previously published packages in comment"
+            echo "has_published=false" >> $GITHUB_OUTPUT
+          else
+            echo "has_published=true" >> $GITHUB_OUTPUT
+            echo "published<<EOF" >> $GITHUB_OUTPUT
+            echo "$PUBLISHED" >> $GITHUB_OUTPUT
+            echo "EOF" >> $GITHUB_OUTPUT
+            echo "Found published packages: $PUBLISHED"
+          fi
+
+      - name: Get changed packages
+        id: changed
+        run: |
+          CHANGED_FILES=$(git diff --name-only origin/main...HEAD)
+          PACKAGES=""
+
+          for pkg_dir in packages/* web-packages/*; do
+            if [ -f "$pkg_dir/package.json" ]; then
+              pkg_folder=$(basename "$pkg_dir")
+              parent_folder=$(dirname "$pkg_dir")
+              if echo "$CHANGED_FILES" | grep -q "^${parent_folder}/${pkg_folder}/"; then
+                name=$(jq -r '.name' "$pkg_dir/package.json")
+                # Validate package name format to prevent shell injection
+                if ! [[ "$name" =~ ^@uipath/[a-z0-9-]+$ ]]; then
+                  echo "::warning::Skipping invalid package name: $name"
+                  continue
+                fi
+                # Skip angular (excluded from release)
+                if [ "$name" != "@uipath/apollo-angular" ]; then
+                  PACKAGES="$PACKAGES $name"
+                fi
+              fi
+            fi
+          done
+
+          PACKAGES=$(echo "$PACKAGES" | xargs)
+          if [ -z "$PACKAGES" ]; then
+            echo "has_changes=false" >> $GITHUB_OUTPUT
+          else
+            echo "packages=$PACKAGES" >> $GITHUB_OUTPUT
+            echo "has_changes=true" >> $GITHUB_OUTPUT
+          fi
+          echo "Changed packages: $PACKAGES"
+
+      - name: Setup pnpm
+        if: steps.changed.outputs.has_changes == 'true' || steps.existing.outputs.has_published == 'true'
+        uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4
+
+      - name: Setup Node.js
+        if: steps.changed.outputs.has_changes == 'true' || steps.existing.outputs.has_published == 'true'
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 22
+          cache: 'pnpm'
+          registry-url: 'https://npm.pkg.github.com'
+          scope: '@uipath'
+
+      - name: Install dependencies
+        if: steps.changed.outputs.has_changes == 'true' || steps.existing.outputs.has_published == 'true'
+        run: pnpm install --frozen-lockfile
+
+      - name: Cleanup previous dev packages
+        if: steps.existing.outputs.has_published == 'true'
+        env:
+          GH_NPM_REGISTRY_TOKEN: ${{ secrets.GH_NPM_REGISTRY_TOKEN }}
+          PUBLISHED: ${{ steps.existing.outputs.published }}
+        run: |
+          echo "Cleaning up previous dev packages:"
+          echo "$PUBLISHED" | while IFS= read -r pkg_version; do
+            [ -z "$pkg_version" ] && continue
+            # Validate format for defense in depth
+            if ! [[ "$pkg_version" =~ ^@uipath/[a-z0-9-]+@[0-9.]+-pr[0-9]+$ ]]; then
+              echo "::warning::Skipping invalid package version: $pkg_version"
+              continue
+            fi
+            pkg_name="${pkg_version%@*}"
+            version="${pkg_version##*@}"
+            echo "  Unpublishing $pkg_name@$version..."
+            pnpm unpublish:dev "$pkg_name" "$version" 2>/dev/null || true
+          done
+
+      - name: Delete comment (no packages to publish)
+        if: steps.changed.outputs.has_changes != 'true' && steps.existing.outputs.has_comment == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          COMMENT_ID=$(gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
+            --jq '.[] | select(.body | startswith("## 📦 Dev Packages")) | .id' | head -1) || true
+
+          if [ -n "$COMMENT_ID" ]; then
+            echo "Deleting dev packages comment (no packages to publish)..."
+            gh api -X DELETE "repos/${{ github.repository }}/issues/comments/${COMMENT_ID}"
+          fi
+
+      - name: Update PR comment (publishing)
+        if: steps.changed.outputs.has_changes == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PACKAGES: ${{ steps.changed.outputs.packages }}
+        run: |
+          TIMESTAMP=$(TZ="America/Los_Angeles" date "+%Y-%m-%d %H:%M:%S PT")
+          COMMENT_BODY="## 📦 Dev Packages"$'\n\n'
+
+          for name in $PACKAGES; do
+            pkg_json=$(find packages web-packages -name package.json -exec grep -l "\"name\": \"$name\"" {} \; | head -1 || true)
+            if [ -n "$pkg_json" ] && [ -f "$pkg_json" ]; then
+              version=$(jq -r '.version // empty' "$pkg_json" 2>/dev/null || true)
+              if [ -n "$version" ]; then
+                COMMENT_BODY+="🟡 Publishing... \`${name}@${version}-pr${PR_NUMBER}\`"$'\n'
+              else
+                COMMENT_BODY+="🔴 Error: Could not read version for \`${name}\`"$'\n'
+              fi
+            else
+              COMMENT_BODY+="🔴 Error: Could not find package.json for \`${name}\`"$'\n'
+            fi
+          done
+
+          COMMENT_BODY+=$'\n'"**Last updated:** ${TIMESTAMP}"
+
+          COMMENT_ID=$(gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
+            --jq '.[] | select(.body | startswith("## 📦 Dev Packages")) | .id' | head -1) || true
+
+          if [ -n "$COMMENT_ID" ]; then
+            gh api "repos/${{ github.repository }}/issues/comments/${COMMENT_ID}" -X PATCH -f body="$COMMENT_BODY"
+          else
+            gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" -f body="$COMMENT_BODY"
+          fi
+
+      - name: Build all packages
+        if: steps.changed.outputs.has_changes == 'true'
+        run: pnpm build
+
+      - name: Publish dev packages
+        if: steps.changed.outputs.has_changes == 'true'
+        id: publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GH_NPM_REGISTRY_TOKEN }}
+          NPM_TOKEN: ${{ secrets.GH_NPM_REGISTRY_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PACKAGES: ${{ steps.changed.outputs.packages }}
+        run: |
+          RESULTS=""
+          SUFFIX="pr${PR_NUMBER}"
+
+          for name in $PACKAGES; do
+            echo "::group::Publishing $name"
+
+            if pnpm publish:dev "$name" "$SUFFIX"; then
+              pkg_json=$(find packages web-packages -name package.json -exec grep -l "\"name\": \"$name\"" {} \; | head -1)
+              version=$(jq -r '.version' "$pkg_json" 2>/dev/null || echo "unknown")
+              RESULTS="${RESULTS}${name}@${version}-${SUFFIX}:success"$'\n'
+            else
+              RESULTS="${RESULTS}${name}:error"$'\n'
+            fi
+
+            echo "::endgroup::"
+          done
+
+          # Use heredoc for multiline output
+          echo "results<<EOF" >> $GITHUB_OUTPUT
+          echo "$RESULTS" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+      - name: Update PR comment (final)
+        if: steps.changed.outputs.has_changes == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          RESULTS: ${{ steps.publish.outputs.results }}
+        run: |
+          TIMESTAMP=$(TZ="America/Los_Angeles" date "+%Y-%m-%d %H:%M:%S PT")
+          COMMENT_BODY="## 📦 Dev Packages"$'\n\n'
+
+          while IFS= read -r result; do
+            [ -z "$result" ] && continue
+            pkg="${result%:*}"
+            status="${result##*:}"
+            # Validate format for defense in depth
+            if ! [[ "$pkg" =~ ^@uipath/[a-z0-9-]+(@[0-9.]+-pr[0-9]+)?$ ]]; then
+              echo "::warning::Skipping invalid result: $result"
+              continue
+            fi
+            if [ "$status" = "success" ]; then
+              COMMENT_BODY+="🟢 Published \`${pkg}\`"$'\n'
+            else
+              COMMENT_BODY+="🔴 Error publishing \`${pkg}\`"$'\n'
+            fi
+          done <<< "$RESULTS"
+
+          COMMENT_BODY+=$'\n'"**Last updated:** ${TIMESTAMP}"
+
+          COMMENT_ID=$(gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
+            --jq '.[] | select(.body | startswith("## 📦 Dev Packages")) | .id' | head -1) || true
+
+          if [ -n "$COMMENT_ID" ]; then
+            gh api "repos/${{ github.repository }}/issues/comments/${COMMENT_ID}" -X PATCH -f body="$COMMENT_BODY"
+          else
+            gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" -f body="$COMMENT_BODY"
+          fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,7 @@ Thank you for your interest in contributing to the Apollo Design System! This do
 - [Commit Message Guidelines](#commit-message-guidelines)
 - [Making Changes](#making-changes)
 - [Release Process](#release-process)
+- [Dev Packages (Preview Releases)](#dev-packages-preview-releases)
 - [Code of Conduct](#code-of-conduct)
 
 ## Development Setup
@@ -225,6 +226,51 @@ Each package is versioned independently:
 - `@uipath/apollo-angular@1.5.0`
 
 Only packages with new commits since their last release will be published.
+
+### Dev Packages (Preview Releases)
+
+For testing unreleased changes, dev packages are automatically published for every PR.
+
+**Automatic (CI):**
+- When you push to a PR branch, packages with changes are published as `<version>-pr<number>`
+- Example: `@uipath/apollo-react@3.19.3-pr123`
+- A comment is added to the PR with the published versions
+- Packages are automatically cleaned up when the PR is closed or merged
+
+> **Note:** Cleanup runs when a PR is closed or merged via GitHub's UI. If a branch is deleted directly (e.g., via `git push origin --delete branch`) without closing the PR, packages may remain published until manually cleaned up.
+
+**Manual (Local):**
+
+```bash
+# Publish a dev version
+pnpm publish:dev @uipath/apollo-react my-feature
+# → Publishes @uipath/apollo-react@3.19.3-my-feature
+
+# Unpublish a dev version (requires token with delete:packages scope)
+pnpm unpublish:dev @uipath/apollo-react my-feature
+```
+
+**Token Setup (for manual publishing):**
+
+1. Go to GitHub → Settings → Developer settings → Personal access tokens → Tokens (classic)
+2. Generate a new token with scopes:
+   - `write:packages` (for publishing)
+   - `delete:packages` (for unpublishing)
+   - `read:packages`
+3. Set the environment variable:
+   ```bash
+   export GH_NPM_REGISTRY_TOKEN=your_token_here
+   ```
+
+**Installing dev packages:**
+
+```bash
+# Install a PR preview version (from CI)
+npm install @uipath/apollo-react@3.19.3-pr123
+
+# Install a manually published dev version (local)
+npm install @uipath/apollo-react@3.19.3-my-feature
+```
 
 ### Version Ranges
 

--- a/package.json
+++ b/package.json
@@ -40,6 +40,8 @@
     "clean": "turbo run clean && rm -rf .turbo && rm -rf node_modules",
     "release": "pnpm --workspace-concurrency=1 --sort --filter './packages/*' --filter '!@uipath/apollo-angular' --filter './web-packages/*' exec -- semantic-release",
     "release:dry-run": "pnpm --workspace-concurrency=1 --sort --filter './packages/*' --filter '!@uipath/apollo-angular' --filter './web-packages/*' exec -- semantic-release --dry-run",
+    "publish:dev": "tsx scripts/publish-dev.ts",
+    "unpublish:dev": "tsx scripts/unpublish-dev.ts",
     "prepare": "husky"
   },
   "devDependencies": {

--- a/scripts/package-utils.ts
+++ b/scripts/package-utils.ts
@@ -1,0 +1,87 @@
+/**
+ * Shared utilities for package scripts.
+ */
+
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+export const rootDir = resolve(__dirname, '..');
+
+export interface PackageJson {
+  name: string;
+  version: string;
+  [key: string]: unknown;
+}
+
+export interface PackageInfo {
+  path: string;
+  version: string;
+}
+
+export function getPackageDirs(): string[] {
+  return ['packages', 'web-packages'];
+}
+
+export function getSubdirs(dir: string): string[] {
+  if (!existsSync(dir)) return [];
+  return readdirSync(dir, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name);
+}
+
+export function findPackagePath(packageName: string): string | null {
+  for (const dir of getPackageDirs()) {
+    const packagesDir = join(rootDir, dir);
+    const subdirs = getSubdirs(packagesDir);
+
+    for (const subdir of subdirs) {
+      const packageJsonPath = join(packagesDir, subdir, 'package.json');
+      if (existsSync(packageJsonPath)) {
+        const pkg = JSON.parse(readFileSync(packageJsonPath, 'utf-8')) as PackageJson;
+        if (pkg.name === packageName) {
+          return join(packagesDir, subdir);
+        }
+      }
+    }
+  }
+  return null;
+}
+
+export function findPackageInfo(packageName: string): PackageInfo | null {
+  for (const dir of getPackageDirs()) {
+    const packagesDir = join(rootDir, dir);
+    const subdirs = getSubdirs(packagesDir);
+
+    for (const subdir of subdirs) {
+      const packageJsonPath = join(packagesDir, subdir, 'package.json');
+      if (existsSync(packageJsonPath)) {
+        const pkg = JSON.parse(readFileSync(packageJsonPath, 'utf-8')) as PackageJson;
+        if (pkg.name === packageName) {
+          return { path: join(packagesDir, subdir), version: pkg.version };
+        }
+      }
+    }
+  }
+  return null;
+}
+
+export function getAllPackageNames(): string[] {
+  const names: string[] = [];
+  for (const dir of getPackageDirs()) {
+    const packagesDir = join(rootDir, dir);
+    const subdirs = getSubdirs(packagesDir);
+
+    for (const subdir of subdirs) {
+      const packageJsonPath = join(packagesDir, subdir, 'package.json');
+      if (existsSync(packageJsonPath)) {
+        const pkg = JSON.parse(readFileSync(packageJsonPath, 'utf-8')) as PackageJson;
+        if (pkg.name && !pkg.name.includes('playground') && !pkg.name.includes('storybook')) {
+          names.push(pkg.name);
+        }
+      }
+    }
+  }
+  return names;
+}

--- a/scripts/publish-dev.ts
+++ b/scripts/publish-dev.ts
@@ -1,0 +1,91 @@
+#!/usr/bin/env tsx
+/**
+ * Publish a package with a dev version suffix.
+ *
+ * Usage: pnpm publish:dev <package-name> <suffix>
+ * Example: pnpm publish:dev @uipath/apollo-react test
+ *   -> Publishes @uipath/apollo-react@3.19.3-test
+ */
+
+import { execSync } from 'node:child_process';
+import { readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { type PackageJson, findPackagePath, getAllPackageNames } from './package-utils.js';
+
+function main() {
+  const args = process.argv.slice(2);
+
+  if (args.length < 2) {
+    console.error('Usage: pnpm publish:dev <package-name> <suffix>');
+    console.error('Example: pnpm publish:dev @uipath/apollo-react test');
+    console.error('\nAvailable packages:');
+    for (const name of getAllPackageNames()) {
+      console.error(`  - ${name}`);
+    }
+    process.exit(1);
+  }
+
+  const [packageName, suffix] = args as [string, string];
+
+  // Validate suffix (alphanumeric, may contain hyphens, must not start with hyphen)
+  if (!/^[a-zA-Z0-9][a-zA-Z0-9-]*$/.test(suffix)) {
+    console.error(
+      `Error: Invalid suffix "${suffix}". Suffix must start with alphanumeric and contain only letters, digits, or hyphens.`
+    );
+    process.exit(1);
+  }
+
+  // Find package
+  const packagePath = findPackagePath(packageName);
+  if (!packagePath) {
+    console.error(`Error: Package "${packageName}" not found in monorepo.`);
+    console.error('\nAvailable packages:');
+    for (const name of getAllPackageNames()) {
+      console.error(`  - ${name}`);
+    }
+    process.exit(1);
+  }
+
+  const packageJsonPath = join(packagePath, 'package.json');
+  const originalContent = readFileSync(packageJsonPath, 'utf-8');
+  const pkg = JSON.parse(originalContent) as PackageJson;
+  const originalVersion = pkg.version;
+  const devVersion = `${originalVersion}-${suffix}`;
+
+  console.log(`\nPublishing ${packageName}@${devVersion}`);
+  console.log(`Package path: ${packagePath}\n`);
+
+  try {
+    // Update version
+    pkg.version = devVersion;
+    writeFileSync(packageJsonPath, JSON.stringify(pkg, null, 2) + '\n');
+    console.log(`Updated version to ${devVersion}`);
+
+    // Publish with 'dev' tag to avoid affecting 'latest'
+    // Note: Assumes package is already built (run `pnpm build` first)
+    console.log('\nPublishing with tag "dev"...');
+    try {
+      execSync('pnpm publish --no-git-checks --access public --tag dev', {
+        cwd: packagePath,
+        stdio: 'inherit',
+      });
+    } catch {
+      console.error(
+        `\nPublish failed for ${packageName}. Check NPM_TOKEN permissions and registry access.`
+      );
+      process.exit(1);
+    }
+
+    console.log(`\nSuccessfully published ${packageName}@${devVersion}`);
+  } catch (error) {
+    console.error('\nUnexpected error:', error);
+    process.exit(1);
+  } finally {
+    // Restore original version
+    writeFileSync(packageJsonPath, originalContent);
+    console.log(`\nRestored original version (${originalVersion})`);
+  }
+}
+
+main();

--- a/scripts/unpublish-dev.ts
+++ b/scripts/unpublish-dev.ts
@@ -1,0 +1,179 @@
+#!/usr/bin/env tsx
+/**
+ * Unpublish a dev version of a package from GitHub Packages.
+ *
+ * Usage: pnpm unpublish:dev <package-name> <suffix-or-version>
+ * Example: pnpm unpublish:dev @uipath/apollo-react test
+ *   -> Unpublishes @uipath/apollo-react@3.19.3-test
+ *
+ * Or with full version:
+ * Example: pnpm unpublish:dev @uipath/apollo-react 3.19.3-test
+ *   -> Unpublishes @uipath/apollo-react@3.19.3-test
+ *
+ * Requires GH_NPM_REGISTRY_TOKEN or GITHUB_TOKEN environment variable.
+ */
+
+import { findPackageInfo, getAllPackageNames } from './package-utils.js';
+
+interface GitHubPackageVersion {
+  id: number;
+  name: string;
+}
+
+async function deletePackageVersion(packageName: string, version: string): Promise<boolean> {
+  const token = process.env.GH_NPM_REGISTRY_TOKEN || process.env.GITHUB_TOKEN;
+  if (!token) {
+    console.error('Error: GH_NPM_REGISTRY_TOKEN or GITHUB_TOKEN environment variable is required.');
+    return false;
+  }
+
+  // Extract package name without scope (e.g., "apollo-react" from "@uipath/apollo-react")
+  const packageNameWithoutScope = packageName.replace('@uipath/', '');
+  const org = 'uipath';
+
+  try {
+    // First, list all versions to find the version ID
+    console.log(`Looking up version ID for ${packageName}@${version}...`);
+
+    const listResponse = await fetch(
+      `https://api.github.com/orgs/${org}/packages/npm/${packageNameWithoutScope}/versions?per_page=100`,
+      {
+        headers: {
+          Accept: 'application/vnd.github+json',
+          Authorization: `Bearer ${token}`,
+          'X-GitHub-Api-Version': '2022-11-28',
+        },
+      }
+    );
+
+    if (!listResponse.ok) {
+      if (listResponse.status === 404) {
+        console.error(`Package ${packageName} not found in GitHub Packages.`);
+        return false;
+      }
+      const errorText = await listResponse.text();
+      console.error(`Failed to list versions: ${listResponse.status} ${errorText}`);
+      return false;
+    }
+
+    const versions = (await listResponse.json()) as GitHubPackageVersion[];
+    const targetVersion = versions.find((v) => v.name === version);
+
+    if (!targetVersion) {
+      console.error(`Version ${version} not found for ${packageName}.`);
+      if (versions.length === 100) {
+        console.error(
+          'Note: Only checked the 100 most recent versions. The target version may exist in older pages.'
+        );
+      }
+      console.log('Recent versions:');
+      for (const v of versions.slice(0, 10)) {
+        console.log(`  - ${v.name}`);
+      }
+      if (versions.length > 10) {
+        console.log(`  ... and ${versions.length - 10} more`);
+      }
+      return false;
+    }
+
+    // Delete the version
+    console.log(`Deleting ${packageName}@${version} (version ID: ${targetVersion.id})...`);
+
+    const deleteResponse = await fetch(
+      `https://api.github.com/orgs/${org}/packages/npm/${packageNameWithoutScope}/versions/${targetVersion.id}`,
+      {
+        method: 'DELETE',
+        headers: {
+          Accept: 'application/vnd.github+json',
+          Authorization: `Bearer ${token}`,
+          'X-GitHub-Api-Version': '2022-11-28',
+        },
+      }
+    );
+
+    if (!deleteResponse.ok) {
+      if (deleteResponse.status === 403) {
+        console.error(
+          'Failed to delete version: 403 Forbidden. The token may be missing the "delete:packages" permission.'
+        );
+        return false;
+      }
+      if (deleteResponse.status === 404) {
+        console.error(
+          `Failed to delete version: 404 Not Found. Version ${version} may already be deleted.`
+        );
+        return false;
+      }
+      const errorText = await deleteResponse.text();
+      console.error(`Failed to delete version: ${deleteResponse.status} ${errorText}`);
+      return false;
+    }
+
+    return true;
+  } catch (error) {
+    console.error('Error:', error);
+    return false;
+  }
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+
+  if (args.length < 2) {
+    console.error('Usage: pnpm unpublish:dev <package-name> <suffix-or-version>');
+    console.error('');
+    console.error('Examples:');
+    console.error('  pnpm unpublish:dev @uipath/apollo-react test');
+    console.error('    -> Unpublishes @uipath/apollo-react@<current>-test');
+    console.error('');
+    console.error('  pnpm unpublish:dev @uipath/apollo-react 3.19.3-test');
+    console.error('    -> Unpublishes @uipath/apollo-react@3.19.3-test');
+    console.error('');
+    console.error('  pnpm unpublish:dev @uipath/apollo-react pr123');
+    console.error('    -> Unpublishes @uipath/apollo-react@<current>-pr123');
+    console.error('');
+    console.error('Requires: GH_NPM_REGISTRY_TOKEN or GITHUB_TOKEN env var');
+    console.error('\nAvailable packages:');
+    for (const name of getAllPackageNames()) {
+      console.error(`  - ${name}`);
+    }
+    process.exit(1);
+  }
+
+  const [packageName, suffixOrVersion] = args as [string, string];
+
+  // Find package to get current version
+  const packageInfo = findPackageInfo(packageName);
+  if (!packageInfo) {
+    console.error(`Error: Package "${packageName}" not found in monorepo.`);
+    console.error('\nAvailable packages:');
+    for (const name of getAllPackageNames()) {
+      console.error(`  - ${name}`);
+    }
+    process.exit(1);
+  }
+
+  // Determine if suffixOrVersion is a full version or just a suffix
+  // Full version contains a dot (e.g., "3.19.3-test")
+  // Suffix doesn't (e.g., "test", "pr123")
+  let versionToUnpublish: string;
+  if (suffixOrVersion.includes('.')) {
+    // It's a full version
+    versionToUnpublish = suffixOrVersion;
+  } else {
+    // It's a suffix, prepend current version
+    versionToUnpublish = `${packageInfo.version}-${suffixOrVersion}`;
+  }
+
+  console.log(`\nUnpublishing ${packageName}@${versionToUnpublish}...`);
+
+  const success = await deletePackageVersion(packageName, versionToUnpublish);
+
+  if (success) {
+    console.log(`\nSuccessfully unpublished ${packageName}@${versionToUnpublish}`);
+  } else {
+    process.exit(1);
+  }
+}
+
+main();


### PR DESCRIPTION
 ## Add dev package publishing for PRs                                                                                    
                                               
  Automatically publish preview packages for PRs to enable testing unreleased changes (alternative to link for now).   

  ### Changes                                                                                                              
  - `publish:dev` / `unpublish:dev` scripts for local publishing  
  - `dev-publish.yml` workflow - publishes `<version>-pr<number>` on PR push
  - `dev-cleanup.yml` workflow - cleans up packages when PR closes
  - PR comment shows publish status with live updates

  ### Usage
  ```bash
  # Local
  pnpm publish:dev @uipath/apollo-react my-feature

  # Install from PR
  npm install @uipath/apollo-react@3.19.3-pr123
```

When changes are detected in the PR, for a specific package, it deletes old packages for that PR and creates new ones.
<img width="911" height="313" alt="image" src="https://github.com/user-attachments/assets/fe758615-2564-4070-93a3-3a65d4166394" />

## Successfull delete on close
https://github.com/UiPath/apollo-ui/actions/runs/21738503979/job/62708661593