### PR TITLE
fix(apollo-react): fix taskMenu's spacing MST-6400

### DIFF
--- a/packages/apollo-react/src/canvas/components/StageNode/TaskMenu.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/TaskMenu.tsx
@@ -3,6 +3,7 @@ import { ApIcon, ApIconButton, ApMenu } from '@uipath/apollo-react/material';
 import { memo, useCallback, useMemo, useRef, useState } from 'react';
 import type { NodeMenuAction, NodeMenuItem } from '../NodeContextMenu';
 import { transformMenuItems } from './StageNodeTaskUtilities';
+import token from '@uipath/apollo-core';
 
 interface TaskMenuProps {
   taskId: string;
@@ -80,6 +81,17 @@ const TaskMenuComponent = ({ taskId, contextMenuItems, onMenuOpenChange }: TaskM
           horizontal: 'right',
         }}
         width={300}
+        slotProps={{
+          paper: {
+            className: 'task-menu-paper',
+            sx: {
+              '&.task-menu-paper .MuiList-padding': {
+                paddingTop: token.Padding.PadL ,
+                paddingBottom: token.Padding.PadL,
+              },
+            },
+          },
+        }}
       />
     </>
   );

--- a/packages/apollo-react/src/material/components/ap-menu/ApMenu.types.ts
+++ b/packages/apollo-react/src/material/components/ap-menu/ApMenu.types.ts
@@ -1,3 +1,4 @@
+import type { MenuProps } from '@mui/material';
 import type React from 'react';
 
 export interface ApMenuOrigin {
@@ -83,4 +84,17 @@ export type ApMenuProps = React.PropsWithChildren<{
    * Transform origin for menu positioning
    */
   transformOrigin?: ApMenuOrigin;
+  /**
+   * Props applied to the underlying MUI Menu component slots.
+   * Allows customization of the root and paper elements.
+   *
+   * The paper slot supports both object and function forms:
+   * - Object: `{ paper: { sx: {...} } }`
+   * - Function: `{ paper: (ownerState) => ({ sx: {...} }) }`
+   *
+   * Default maxHeight and width are applied first, allowing user styles to override.
+   *
+   * Note: Currently only applies to the main menu, not submenus.
+   */
+  slotProps?: MenuProps['slotProps'];
 }>;


### PR DESCRIPTION
- Task Menu design has top and bottom padding that wasn't there
- Expose and consume SlotProps for underlying MUI component to allow custom styles
- Consume custom styles on task menu to match design

<img width="356" height="294" alt="image" src="https://github.com/user-attachments/assets/569c7bed-7947-4ce4-a4eb-a017b82ca784" />
