### PR TITLE
feat(apollo-vertex): enable import organization in format script

### DIFF
--- a/apps/apollo-vertex/package.json
+++ b/apps/apollo-vertex/package.json
@@ -10,8 +10,8 @@
     "start": "next start",
     "registry:build": "shadcn build && node --experimental-strip-types scripts/generate-registry-index.ts",
     "postbuild": "pagefind --site .next/server/app --output-path public/_pagefind",
-    "format": "biome format --write .",
-    "format:check": "biome format .",
+    "format": "biome check --write .",
+    "format:check": "biome check .",
     "lint": "biome check .",
     "lint:deps": "depcruise registry --config .dependency-cruiser.js"
   },


### PR DESCRIPTION
## Summary

Update the format scripts in apollo-vertex to use `biome check --write` instead of `biome format --write`. This enables import organization via the assist actions already configured in the root biome.json, ensuring imports are properly sorted when running the format command.

## Changes

- Modified `format` script from `biome format --write .` to `biome check --write .`
- Modified `format:check` script from `biome format .` to `biome check .`

Both scripts now align with the lint script behavior and the configured assist actions.