### PR TITLE
docs(apollo-vertex): add CLAUDE.md with package guidelines

### DIFF
--- a/apps/apollo-vertex/AGENTS.md
+++ b/apps/apollo-vertex/AGENTS.md
@@ -1,0 +1,192 @@
+# AGENTS.md - Apollo Vertex
+
+This file provides guidance for AI coding agents working in the `apollo-vertex` app.
+
+## Project Overview
+
+Apollo Vertex is a Next.js 16 documentation site and component registry for the Apollo Design System. It uses:
+- **Next.js 16** with Turbopack for development
+- **Tailwind CSS 4** for styling
+- **Radix UI** primitives for accessible components
+- **shadcn/ui** patterns with `class-variance-authority`
+- **Nextra** for documentation
+
+## Build/Lint/Test Commands
+
+### Development
+```bash
+# Start dev server with Turbopack
+pnpm dev
+
+# From monorepo root
+pnpm dev:apollo-vertex
+```
+
+### Build
+```bash
+pnpm build                    # Build the app (includes registry:build)
+pnpm registry:build           # Build shadcn registry only
+```
+
+### Linting & Formatting
+```bash
+pnpm lint                     # Check with Biome
+pnpm format                   # Format with Biome
+pnpm format:check             # Check formatting without writing
+pnpm lint:deps                # Check dependency constraints
+```
+
+### From Monorepo Root
+```bash
+pnpm lint                     # Lint all packages
+pnpm lint:fix                 # Fix lint issues
+pnpm format                   # Format all packages
+pnpm typecheck                # TypeScript type checking
+pnpm test                     # Run all tests
+```
+
+### Running a Single Test (in packages with tests)
+```bash
+# Run a specific test file
+pnpm --filter @uipath/apollo-wind test -- button.test.tsx
+
+# Run tests matching a pattern
+pnpm --filter @uipath/apollo-react test -- --grep "ApButton"
+
+# Watch mode for a specific test
+pnpm --filter @uipath/apollo-wind test:watch -- button.test.tsx
+```
+
+Note: apollo-vertex currently has no test files. Tests are in `packages/apollo-wind` and `packages/apollo-react`.
+
+## Code Style Guidelines
+
+### Formatting (Biome)
+- **Indent**: 2 spaces
+- **Quotes**: Single quotes for JS/TS
+- **Semicolons**: Always
+- **Trailing commas**: ES5 style
+- **Line width**: 100 characters
+- **Arrow parens**: Always use parentheses
+
+### Imports
+- Biome auto-organizes imports on format
+- Group order: external packages, then internal (`@/*`)
+- Use path alias `@/*` for internal imports (e.g., `@/lib/utils`, `@/components/ui/button`)
+
+```typescript
+// External imports first
+import { Slot } from "@radix-ui/react-slot";
+import { cva, type VariantProps } from "class-variance-authority";
+import * as React from "react";
+
+// Internal imports after
+import { cn } from "@/lib/utils";
+```
+
+### TypeScript
+- **Strict mode** enabled
+- Use `type` imports when importing only types: `import type { Foo } from "bar"`
+- Prefer `interface` for object shapes, `type` for unions/intersections
+- Use `React.ComponentProps<"element">` for extending HTML element props
+- Avoid `any` - use `unknown` and narrow types
+
+### Component Patterns
+- Use function declarations (not arrow functions) for components
+- Use `class-variance-authority` (cva) for variant-based styling
+- Use `cn()` utility for merging Tailwind classes
+- Add `data-slot` attributes for styling hooks
+- Export both component and variants
+
+```typescript
+function Button({
+  className,
+  variant = "default",
+  size = "default",
+  asChild = false,
+  ...props
+}: React.ComponentProps<"button"> &
+  VariantProps<typeof buttonVariants> & {
+    asChild?: boolean;
+  }) {
+  const Comp = asChild ? Slot : "button";
+  return (
+    <Comp
+      data-slot="button"
+      data-variant={variant}
+      className={cn(buttonVariants({ variant, size, className }))}
+      {...props}
+    />
+  );
+}
+
+export { Button, buttonVariants };
+```
+
+### Naming Conventions
+- **Files**: kebab-case (`button-group.tsx`, `use-mobile.ts`)
+- **Components**: PascalCase (`Button`, `ButtonGroup`)
+- **Hooks**: camelCase with `use` prefix (`useMobile`, `useLocalStorage`)
+- **Utilities**: camelCase (`cn`, `formatDate`)
+- **CSS variables**: kebab-case (`--color-primary`, `--spacing-md`)
+
+### Tailwind CSS
+- Use Tailwind utility classes directly in JSX
+- Use `cn()` to merge conditional classes
+- Prefer semantic color tokens (`bg-primary`, `text-muted-foreground`)
+- Use CSS variables for theming: `var(--color-*)`
+
+### Error Handling
+- Use TypeScript's strict null checks
+- Handle loading and error states explicitly in UI
+- Use Zod for runtime validation when needed
+
+## File Structure
+
+```
+apollo-vertex/
+├── app/                    # Next.js app router pages
+│   ├── layout.tsx          # Root layout
+│   └── [routes]/           # Documentation pages (MDX)
+├── registry/               # UI component registry
+│   ├── button/
+│   │   └── button.tsx
+│   └── [component]/
+│       └── [component].tsx
+├── lib/
+│   └── utils.ts            # Utility functions (cn, etc.)
+├── templates/              # Page templates
+└── public/                 # Static assets
+```
+
+## Registry Components
+
+Components in `registry/` follow shadcn/ui patterns:
+- Each component in its own directory
+- Uses Radix UI primitives for accessibility
+- Styled with Tailwind CSS + cva variants
+- Path aliases configured in tsconfig.json
+
+## Git Workflow
+
+Follow conventional commits:
+```
+type(scope): description
+
+# Examples:
+feat(apollo-vertex): add new Button variant
+fix(apollo-vertex): resolve dark mode toggle issue
+docs(apollo-vertex): update component documentation
+```
+
+Valid scopes: `apollo-vertex`, `apollo-react`, `apollo-wind`, `apollo-core`, `repo`
+
+## Key Dependencies
+
+- `next@16` - React framework
+- `tailwindcss@4` - CSS framework
+- `@radix-ui/*` - Accessible UI primitives
+- `class-variance-authority` - Variant styling
+- `clsx` + `tailwind-merge` - Class utilities (via `cn()`)
+- `lucide-react` - Icons
+- `nextra` - Documentation framework

--- a/apps/apollo-vertex/CLAUDE.md
+++ b/apps/apollo-vertex/CLAUDE.md
@@ -1,16 +1,1 @@
-# apollo-vertex
-
-## Verification
-
-After making changes, run the same checks CI runs for this package:
-
-```sh
-pnpm --filter apollo-vertex lint
-pnpm --filter apollo-vertex format:check
-pnpm --filter apollo-vertex lint:deps
-pnpm --filter apollo-vertex build
-```
-
-## Code style
-
-- Prefer `??` (nullish coalescing) over `||`. Only use `||` when you explicitly need to handle all falsy values (empty string, `0`, `false`), not just `null`/`undefined`.
+@AGENTS.md

--- a/apps/apollo-vertex/CLAUDE.md
+++ b/apps/apollo-vertex/CLAUDE.md
@@ -1,0 +1,16 @@
+# apollo-vertex
+
+## Verification
+
+After making changes, run the same checks CI runs for this package:
+
+```sh
+pnpm --filter apollo-vertex lint
+pnpm --filter apollo-vertex format:check
+pnpm --filter apollo-vertex lint:deps
+pnpm --filter apollo-vertex build
+```
+
+## Code style
+
+- Prefer `??` (nullish coalescing) over `||`. Only use `||` when you explicitly need to handle all falsy values (empty string, `0`, `false`), not just `null`/`undefined`.


### PR DESCRIPTION
Adds a CLAUDE.md file to the apollo-vertex package documenting package-specific guidance.

Includes:
- Verification steps to run the same CI checks locally (lint, format, lint:deps, build)
- Code style preference for nullish coalescing (??) over logical OR (||)

This follows the pattern of hierarchical CLAUDE.md files in the monorepo, providing scoped context for agents working in this package.