### PR TITLE
fix(apollo-react): disable edge toolbar on preview edges [MST-6274]

### DIFF
--- a/packages/apollo-react/src/canvas/components/Toolbar/EdgeToolbar/useEdgeToolbarState.test.ts
+++ b/packages/apollo-react/src/canvas/components/Toolbar/EdgeToolbar/useEdgeToolbarState.test.ts
@@ -136,6 +136,30 @@ describe('useEdgeToolbarState', () => {
       expect(result.current.showToolbar).toBe(false);
     });
 
+    it('should not show toolbar when source is preview node', () => {
+      const { result } = renderHook(() =>
+        useEdgeToolbarState({
+          ...defaultProps,
+          isHovered: true,
+          source: PREVIEW_NODE_ID,
+        })
+      );
+
+      expect(result.current.showToolbar).toBe(false);
+    });
+
+    it('should not show toolbar when target is preview node', () => {
+      const { result } = renderHook(() =>
+        useEdgeToolbarState({
+          ...defaultProps,
+          isHovered: true,
+          target: PREVIEW_NODE_ID,
+        })
+      );
+
+      expect(result.current.showToolbar).toBe(false);
+    });
+
     it('should not show toolbar when positionData is null', () => {
       vi.mocked(useEdgeToolbarPositioning).mockReturnValue({
         positionData: null,
@@ -170,6 +194,27 @@ describe('useEdgeToolbarState', () => {
       expect(useEdgeToolbarPositioning).toHaveBeenCalledWith({
         pathElementRef,
         isEnabled: true,
+        targetPosition: Position.Left,
+      });
+    });
+
+    it('should disable positioning tracking for preview edges', () => {
+      const pathElementRef = {
+        current: document.createElementNS('http://www.w3.org/2000/svg', 'path'),
+      };
+
+      renderHook(() =>
+        useEdgeToolbarState({
+          ...defaultProps,
+          pathElementRef,
+          isHovered: true,
+          source: PREVIEW_NODE_ID,
+        })
+      );
+
+      expect(useEdgeToolbarPositioning).toHaveBeenCalledWith({
+        pathElementRef,
+        isEnabled: false,
         targetPosition: Position.Left,
       });
     });

--- a/packages/apollo-react/src/canvas/components/Toolbar/EdgeToolbar/useEdgeToolbarState.ts
+++ b/packages/apollo-react/src/canvas/components/Toolbar/EdgeToolbar/useEdgeToolbarState.ts
@@ -42,10 +42,12 @@ export function useEdgeToolbarState({
   const { mode } = useBaseCanvasMode();
   const isDesignMode = mode === 'design';
 
-  // Only track mouse position when hovering and in design mode
+  const isPreviewEdge = source === PREVIEW_NODE_ID || target === PREVIEW_NODE_ID;
+
+  // Only track mouse position when hovering and in design mode (not on preview edges)
   const { positionData, handleMouseMoveOnPath } = useEdgeToolbarPositioning({
     pathElementRef,
-    isEnabled: isHovered && isDesignMode,
+    isEnabled: isHovered && isDesignMode && !isPreviewEdge,
     targetPosition,
   });
 
@@ -126,8 +128,8 @@ export function useEdgeToolbarState({
     [handleAddNodeOnEdge]
   );
 
-  // Show toolbar when hovering, in design mode, and have a valid mouse position
-  const showToolbar = isHovered && isDesignMode && positionData !== null;
+  // Show toolbar when hovering, in design mode, have a valid mouse position, and not a preview edge
+  const showToolbar = isHovered && isDesignMode && positionData !== null && !isPreviewEdge;
 
   return {
     showToolbar,


### PR DESCRIPTION
- Prevents edge toolbar from showing on preview edges.

Before:
https://github.com/user-attachments/assets/b1f713f3-e726-4ff4-9b50-e2cdd3947a14

After:
https://github.com/user-attachments/assets/bf5e84c8-ac03-4141-b39f-f86946a326e1

