### PR TITLE
feat(repo): add dual registry publishing support

### DIFF
--- a/.github/workflows/dev-cleanup.yml
+++ b/.github/workflows/dev-cleanup.yml
@@ -106,7 +106,8 @@ jobs:
 
           if [ -n "$COMMENT_ID" ]; then
             TIMESTAMP=$(TZ="America/Los_Angeles" date "+%Y-%m-%d %H:%M:%S PT")
-            COMMENT_BODY="## 📦 Dev Packages"$'\n\n'
+            COMMENT_BODY="<!-- dev-packages-comment -->"$'\n\n'
+            COMMENT_BODY+="## 📦 Dev Packages"$'\n\n'
             COMMENT_BODY+="🧹 Dev packages cleaned up after PR close."$'\n\n'
             COMMENT_BODY+="**Last updated:** ${TIMESTAMP}"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,6 +69,7 @@ jobs:
           NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
+          GH_NPM_REGISTRY_TOKEN: ${{ secrets.GH_NPM_REGISTRY_TOKEN }}
           HUSKY: 0
         run: pnpm release
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,45 @@ apollo-ui/
     └── react-playground/  # 🔬 React testing environment
 ```
 
+## 📥 Installation
+
+All Apollo packages are published to both **npm** and **GitHub Package Registry** for maximum accessibility.
+
+### For External Users (npm - Recommended)
+
+No special configuration needed. Just install packages directly:
+
+```bash
+npm install @uipath/apollo-react
+# or
+npm install @uipath/apollo-core @uipath/apollo-wind
+```
+
+### For Internal UiPath Users (GitHub Package Registry)
+
+If you have `.npmrc` configured with:
+```
+@uipath:registry=https://npm.pkg.github.com
+```
+
+Packages will automatically install from GitHub Package Registry. No changes needed!
+
+### Testing PR Previews
+
+To test a feature from an open PR before it's merged:
+
+```bash
+# Install latest PR preview
+npm install @uipath/apollo-react@dev
+
+# Or install specific PR version (from PR comment)
+npm install @uipath/apollo-react@5.6.1-pr188.4865fad
+```
+
+Preview versions are published automatically on every PR and cleaned up after merge.
+
+---
+
 ## 📦 Packages
 
 ### Core Foundation

--- a/packages/apollo-core/.releaserc.json
+++ b/packages/apollo-core/.releaserc.json
@@ -30,7 +30,7 @@
     [
       "@semantic-release/exec",
       {
-        "publishCmd": "pnpm publish --no-git-checks --@uipath:registry=https://registry.npmjs.org"
+        "publishCmd": "bash ../../scripts/publish-to-both.sh --no-git-checks --access public"
       }
     ],
     [

--- a/packages/apollo-core/README.md
+++ b/packages/apollo-core/README.md
@@ -20,6 +20,8 @@ pnpm add @uipath/apollo-core
 yarn add @uipath/apollo-core
 ```
 
+**Note:** This package is published to both npm and GitHub Package Registry. External users will automatically pull from npm. Internal UiPath users with `.npmrc` configured will automatically pull from GitHub Package Registry.
+
 ## Usage
 
 ### Design Tokens

--- a/packages/apollo-react/.releaserc.json
+++ b/packages/apollo-react/.releaserc.json
@@ -30,7 +30,7 @@
     [
       "@semantic-release/exec",
       {
-        "publishCmd": "pnpm publish --no-git-checks --@uipath:registry=https://registry.npmjs.org"
+        "publishCmd": "bash ../../scripts/publish-to-both.sh --no-git-checks --access public"
       }
     ],
     [

--- a/packages/apollo-react/README.md
+++ b/packages/apollo-react/README.md
@@ -68,6 +68,8 @@ pnpm add @uipath/apollo-react
 yarn add @uipath/apollo-react
 ```
 
+**Note:** This package is published to both npm and GitHub Package Registry. External users will automatically pull from npm. Internal UiPath users with `.npmrc` configured will automatically pull from GitHub Package Registry.
+
 ## Quick Start
 
 ### Apollo Themes with Standard Material UI

--- a/packages/apollo-wind/.releaserc.json
+++ b/packages/apollo-wind/.releaserc.json
@@ -30,7 +30,7 @@
     [
       "@semantic-release/exec",
       {
-        "publishCmd": "pnpm publish --no-git-checks --@uipath:registry=https://registry.npmjs.org"
+        "publishCmd": "bash ../../scripts/publish-to-both.sh --no-git-checks --access public"
       }
     ],
     [

--- a/packages/apollo-wind/README.md
+++ b/packages/apollo-wind/README.md
@@ -17,6 +17,8 @@ graph LR
 npm install @uipath/apollo-wind
 ```
 
+**Note:** This package is published to both npm and GitHub Package Registry. External users will automatically pull from npm. Internal UiPath users with `.npmrc` configured will automatically pull from GitHub Package Registry.
+
 **Option 1: Zero Config** (Recommended for quick starts)
 
 ```tsx

--- a/scripts/publish-to-both.sh
+++ b/scripts/publish-to-both.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# Publish to both npm and GitHub Package Registry
+# Usage: ./scripts/publish-to-both.sh [publish args...]
+
+set -e
+
+if [ -z "$NPM_AUTH_TOKEN" ]; then
+  echo "Error: NPM_AUTH_TOKEN environment variable is required"
+  exit 1
+fi
+
+if [ -z "$GH_NPM_REGISTRY_TOKEN" ]; then
+  echo "Error: GH_NPM_REGISTRY_TOKEN environment variable is required"
+  exit 1
+fi
+
+PUBLISH_ARGS="$@"
+
+echo "📦 Publishing to npm..."
+NPM_AUTH_TOKEN="$NPM_AUTH_TOKEN" \
+  NODE_AUTH_TOKEN="$NPM_AUTH_TOKEN" \
+  pnpm publish $PUBLISH_ARGS --@uipath:registry=https://registry.npmjs.org
+
+echo "✓ Published to npm"
+echo ""
+echo "📦 Publishing to GitHub Package Registry..."
+NPM_AUTH_TOKEN="$GH_NPM_REGISTRY_TOKEN" \
+  NODE_AUTH_TOKEN="$GH_NPM_REGISTRY_TOKEN" \
+  pnpm publish $PUBLISH_ARGS --@uipath:registry=https://npm.pkg.github.com
+
+echo "✓ Published to GitHub Package Registry"
+echo ""
+echo "✓ Successfully published to both registries"

--- a/web-packages/ap-chat/.releaserc.json
+++ b/web-packages/ap-chat/.releaserc.json
@@ -30,7 +30,7 @@
     [
       "@semantic-release/exec",
       {
-        "publishCmd": "pnpm publish --no-git-checks --@uipath:registry=https://registry.npmjs.org"
+        "publishCmd": "bash ../../scripts/publish-to-both.sh --no-git-checks --access public"
       }
     ],
     [

--- a/web-packages/ap-chat/README.md
+++ b/web-packages/ap-chat/README.md
@@ -44,6 +44,8 @@ pnpm add @uipath/ap-chat
 yarn add @uipath/ap-chat
 ```
 
+**Note:** This package is published to both npm and GitHub Package Registry. External users will automatically pull from npm. Internal UiPath users with `.npmrc` configured will automatically pull from GitHub Package Registry.
+
 ## Usage
 
 ### Vanilla JavaScript / HTML


### PR DESCRIPTION
## Problem
Internal UiPath users have `.npmrc` configured to pull `@uipath/*` packages from GitHub Package Registry, but we were only publishing to npm. This forced users to either:
- Change their `.npmrc` (breaks access to private packages)
- Use workarounds like `--registry` flags or `package-lock.json` tricks

## Solution
Publish all Apollo packages to **both** npm and GitHub Package Registry:
- External users: automatically install from npm (no auth)
- Internal users: automatically install from GitHub (existing `.npmrc` works)

## Changes
- ✅ Production releases publish to both registries
- ✅ PR preview releases publish to both registries
- ✅ Cleanup/deprecation handles both registries
- ✅ Documentation updated for all users

## Testing
- [x] Verify packages publish to npm
- [x] Verify packages publish to GitHub Package Registry
- [x] Test external installation (no .npmrc)
- [x] Test internal installation (with .npmrc)
- [x] Test PR preview publishing
- [x] Test cleanup workflow