### PR TITLE
fix(apollo-react): increase icon size for URL based icons [MST-6486]

### DIFF
--- a/packages/apollo-react/src/canvas/utils/icon-registry.tsx
+++ b/packages/apollo-react/src/canvas/utils/icon-registry.tsx
@@ -73,8 +73,8 @@ export function getIcon(iconId: string): IconComponent {
         src={iconId}
         alt="icon"
         style={{
-          width: w ?? 24,
-          height: h ?? 24,
+          width: w,
+          height: h,
         }}
       />
     );


### PR DESCRIPTION
## Description

This PR

- Allows fallback to CSS iconSize in BaseNode if no height or width is given

## Demo
Before:
<img width="539" height="254" alt="Screenshot 2026-02-11 at 18 03 57" src="https://github.com/user-attachments/assets/90fe48a7-1550-4c5e-a5cf-af60bf110cf2" />
After:
<img width="638" height="291" alt="Screenshot 2026-02-11 at 18 03 02" src="https://github.com/user-attachments/assets/253d19e1-5e59-44e4-98ec-8c3c7863a0ab" />
