### PR TITLE
fix(apollo-react): stage node icon alignment in design time [MST-6560]

### DIFF
--- a/packages/apollo-react/src/canvas/components/StageNode/DraggableTask.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/DraggableTask.tsx
@@ -82,34 +82,35 @@ export const TaskContent = memo(({ task, taskExecution, isDragging }: TaskConten
             <ExecutionStatusIcon status={taskExecution.status} />
           ))}
       </Row>
-      {taskExecution && (
-        <Row align="center" justify="space-between">
-          <Row gap={'2px'}>
-            {taskExecution?.duration && (
-              <ApTypography
-                variant={FontVariantToken.fontSizeS}
-                color="var(--uix-canvas-foreground-de-emp)"
-              >
-                {taskExecution.duration}
-              </ApTypography>
-            )}
-            {taskExecution?.retryDuration && (
-              <StageTaskRetryDuration status={taskExecution.badgeStatus ?? 'warning'}>
-                <ApTypography variant={FontVariantToken.fontSizeS} color="inherit">
-                  {`(+${taskExecution.retryDuration})`}
+      {taskExecution &&
+        (taskExecution.duration || taskExecution.retryDuration || taskExecution.badge) && (
+          <Row align="center" justify="space-between">
+            <Row gap={'2px'}>
+              {taskExecution?.duration && (
+                <ApTypography
+                  variant={FontVariantToken.fontSizeS}
+                  color="var(--uix-canvas-foreground-de-emp)"
+                >
+                  {taskExecution.duration}
                 </ApTypography>
-              </StageTaskRetryDuration>
+              )}
+              {taskExecution?.retryDuration && (
+                <StageTaskRetryDuration status={taskExecution.badgeStatus ?? 'warning'}>
+                  <ApTypography variant={FontVariantToken.fontSizeS} color="inherit">
+                    {`(+${taskExecution.retryDuration})`}
+                  </ApTypography>
+                </StageTaskRetryDuration>
+              )}
+            </Row>
+            {taskExecution?.badge && (
+              <ApBadge
+                size={BadgeSize.SMALL}
+                status={taskExecution.badgeStatus as StatusTypes}
+                label={generateBadgeText(taskExecution) ?? ''}
+              />
             )}
           </Row>
-          {taskExecution?.badge && (
-            <ApBadge
-              size={BadgeSize.SMALL}
-              status={taskExecution.badgeStatus as StatusTypes}
-              label={generateBadgeText(taskExecution) ?? ''}
-            />
-          )}
-        </Row>
-      )}
+        )}
     </Column>
   </>
 ));

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.styles.ts
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.styles.ts
@@ -245,7 +245,6 @@ export const StageTaskIcon = styled.div`
   align-items: center;
   justify-content: center;
   flex-shrink: 0;
-  margin-top: 2px;
 
   svg {
     width: 16px;


### PR DESCRIPTION
Before:
&nbsp;
<img width="780" height="630" alt="image" src="https://github.com/user-attachments/assets/9625b4f1-2ae1-4341-a807-c275426c00f7" />

After:
&nbsp;

<img width="787" height="630" alt="image" src="https://github.com/user-attachments/assets/3bdb514d-598a-4e4f-81f1-63de9e17597c" />
