### PR TITLE
feat(apollo-react): add read-only mode to ap-chat

### DIFF
--- a/apps/react-playground/src/pages/components/ApChatShowcase.tsx
+++ b/apps/react-playground/src/pages/components/ApChatShowcase.tsx
@@ -76,6 +76,7 @@ export function ApChatShowcase() {
 		customScrollTheme: false,
 		copy: true, // Copy enabled by default
 		attachmentsAsync: false,
+		readOnly: false,
 	});
 	const [selectedAgentMode, setSelectedAgentMode] = useState<string>("agent");
 	const [selectedModel, setSelectedModel] = useState<string>("gpt-4");
@@ -380,6 +381,7 @@ export function ApChatShowcase() {
 			instanceName: "showcase-chat",
 			config: {
 				mode: AutopilotChatMode.SideBySide,
+				readOnly: features.readOnly,
 				disabledFeatures: {
 					history: !features.history,
 					settings: !features.settings,
@@ -627,6 +629,7 @@ export function ApChatShowcase() {
 		features.htmlPreview,
 		features.resize,
 		features.settings,
+		features.readOnly,
 	]);
 
 	// Update embedded container when in embedded mode
@@ -648,6 +651,7 @@ export function ApChatShowcase() {
 		if (chatService) {
 			chatService.initialize({
 				mode: chatMode,
+				readOnly: features.readOnly,
 				disabledFeatures: {
 					history: !features.history,
 					settings: !features.settings,
@@ -1922,6 +1926,14 @@ console.log(processUserData(exampleUser, { source: 'web', ipAddress: '192.168.1.
 							onChange={() => toggleFeature("attachmentsAsync")}
 						/>
 						Attachments Async
+					</Checkbox>
+					<Checkbox>
+						<input
+							type="checkbox"
+							checked={features.readOnly}
+							onChange={() => toggleFeature("readOnly")}
+						/>
+						Read Only
 					</Checkbox>
 				</Section>
 

--- a/packages/apollo-react/src/material/components/ap-chat/ap-chat.tsx
+++ b/packages/apollo-react/src/material/components/ap-chat/ap-chat.tsx
@@ -92,7 +92,7 @@ const ApI18nWithLocale = React.memo(({ children }: { children: React.ReactNode }
 
 const AutopilotChatContent = React.memo(() => {
   const { width, shouldAnimate } = useChatWidth();
-  const { historyOpen, settingsOpen, disabledFeatures, chatMode } = useChatState();
+  const { historyOpen, settingsOpen, disabledFeatures, chatMode, readOnly } = useChatState();
 
   return (
     <ChatContainer
@@ -111,6 +111,7 @@ const AutopilotChatContent = React.memo(() => {
           settingsDisabled={disabledFeatures.settings ?? false}
           headerSeparatorDisabled={disabledFeatures.headerSeparator ?? false}
           mode={chatMode}
+          readOnly={readOnly}
         />
       ) : (
         <StandardLayout
@@ -121,6 +122,7 @@ const AutopilotChatContent = React.memo(() => {
           headerDisabled={disabledFeatures.header ?? false}
           headerSeparatorDisabled={disabledFeatures.headerSeparator ?? false}
           mode={chatMode}
+          readOnly={readOnly}
         />
       )}
     </ChatContainer>

--- a/packages/apollo-react/src/material/components/ap-chat/components/header/header-actions.tsx
+++ b/packages/apollo-react/src/material/components/ap-chat/components/header/header-actions.tsx
@@ -20,7 +20,7 @@ const StyledActions = styled('div')(() => ({
 function AutopilotChatHeaderActionsComponent() {
   const { _ } = useLingui();
   const chatService = useChatService();
-  const { disabledFeatures, chatMode, historyOpen, settingsOpen, setHistoryAnchorElement } =
+  const { disabledFeatures, chatMode, historyOpen, settingsOpen, setHistoryAnchorElement, readOnly } =
     useChatState();
   const { clearAttachments } = useAttachments();
   const { customHeaderActions, handleCustomHeaderAction } = usePicker();
@@ -129,7 +129,7 @@ function AutopilotChatHeaderActionsComponent() {
 
   return (
     <StyledActions>
-      {!disabledFeatures.newChat && (
+      {!readOnly && !disabledFeatures.newChat && (
         <AutopilotChatActionButton
           iconName="new_chat"
           variant="custom"
@@ -140,7 +140,7 @@ function AutopilotChatHeaderActionsComponent() {
         />
       )}
 
-      {!disabledFeatures.settings && (
+      {!readOnly && !disabledFeatures.settings && (
         <AutopilotChatActionButton
           iconName="settings"
           tooltip={_(msg({ id: 'autopilot-chat.header.actions.settings', message: `Settings` }))}
@@ -150,7 +150,7 @@ function AutopilotChatHeaderActionsComponent() {
         />
       )}
 
-      {!disabledFeatures.history && (
+      {!readOnly && !disabledFeatures.history && (
         <AutopilotChatActionButton
           ref={setHistoryAnchorElement}
           iconName="history"
@@ -180,7 +180,7 @@ function AutopilotChatHeaderActionsComponent() {
         />
       )}
 
-      {customHeaderActions.length > 0 && (
+      {!readOnly && customHeaderActions.length > 0 && (
         <>
           <AutopilotChatActionButton
             iconName="more_vert"

--- a/packages/apollo-react/src/material/components/ap-chat/components/layout/full-screen-layout.tsx
+++ b/packages/apollo-react/src/material/components/ap-chat/components/layout/full-screen-layout.tsx
@@ -61,6 +61,7 @@ interface FullScreenLayoutProps {
   settingsDisabled: boolean;
   mode: AutopilotChatMode;
   headerSeparatorDisabled: boolean;
+  readOnly: boolean;
 }
 
 export const FullScreenLayout: React.FC<FullScreenLayoutProps> = ({
@@ -70,6 +71,7 @@ export const FullScreenLayout: React.FC<FullScreenLayoutProps> = ({
   settingsDisabled,
   mode,
   headerSeparatorDisabled,
+  readOnly,
 }) => {
   const { setFullScreenContainer } = useChatState();
   const chatInternalService = useChatService().__internalService__;
@@ -107,11 +109,13 @@ export const FullScreenLayout: React.FC<FullScreenLayoutProps> = ({
         <MainContainer ref={mainContainerRef} historyOpen={historyOpen}>
           <ChatScrollContainer mode={mode} />
 
-          <InputBackground>
-            <InputContainer>
-              <AutopilotChatInput />
-            </InputContainer>
-          </InputBackground>
+          {!readOnly && (
+            <InputBackground>
+              <InputContainer>
+                <AutopilotChatInput />
+              </InputContainer>
+            </InputBackground>
+          )}
         </MainContainer>
 
         {!historyDisabled && <AutopilotChatHistory open={historyOpen} isFullScreen={true} />}

--- a/packages/apollo-react/src/material/components/ap-chat/components/layout/standard-layout.tsx
+++ b/packages/apollo-react/src/material/components/ap-chat/components/layout/standard-layout.tsx
@@ -50,6 +50,7 @@ interface StandardLayoutProps {
   mode: AutopilotChatMode;
   headerDisabled: boolean;
   headerSeparatorDisabled: boolean;
+  readOnly: boolean;
 }
 
 export const StandardLayout: React.FC<StandardLayoutProps> = ({
@@ -60,6 +61,7 @@ export const StandardLayout: React.FC<StandardLayoutProps> = ({
   mode,
   headerDisabled,
   headerSeparatorDisabled,
+  readOnly,
 }) => {
   return (
     <>
@@ -78,11 +80,13 @@ export const StandardLayout: React.FC<StandardLayoutProps> = ({
 
         <ChatScrollContainer mode={mode} />
 
-        <InputBackground>
-          <InputContainer>
-            <AutopilotChatInput />
-          </InputContainer>
-        </InputBackground>
+        {!readOnly && (
+          <InputBackground>
+            <InputContainer>
+              <AutopilotChatInput />
+            </InputContainer>
+          </InputBackground>
+        )}
       </MainContainer>
 
       {!historyDisabled && <AutopilotChatHistory open={historyOpen} isFullScreen={false} />}

--- a/packages/apollo-react/src/material/components/ap-chat/components/message/actions/chat-actions.tsx
+++ b/packages/apollo-react/src/material/components/ap-chat/components/message/actions/chat-actions.tsx
@@ -23,7 +23,7 @@ function AutopilotChatMessageActionsComponent({
 }: AutopilotChatMessageActionsProps) {
   const { _ } = useLingui();
   const chatService = useChatService();
-  const { disabledFeatures } = useChatState();
+  const { disabledFeatures, readOnly } = useChatState();
   const [isLastAssistantMessage, setIsLastAssistantMessage] = React.useState(false);
   const [isVisible, setIsVisible] = React.useState(false);
   const isUserInteractingWithActions = React.useRef(false);
@@ -76,7 +76,7 @@ function AutopilotChatMessageActionsComponent({
     }
 
     // If not an assistant message, just return copy action
-    if (message.role !== AutopilotChatRole.Assistant || disabledFeatures.feedback) {
+    if (message.role !== AutopilotChatRole.Assistant || readOnly || disabledFeatures.feedback) {
       return baseActions;
     }
 
@@ -121,7 +121,7 @@ function AutopilotChatMessageActionsComponent({
         },
       },
     ];
-  }, [message, disabledFeatures.feedback, disabledFeatures.copy, _]);
+  }, [message, readOnly, disabledFeatures.feedback, disabledFeatures.copy, _]);
 
   const isRelatedTarget = React.useCallback((target: Node) => {
     return (

--- a/packages/apollo-react/src/material/components/ap-chat/providers/chat-state-provider.tsx
+++ b/packages/apollo-react/src/material/components/ap-chat/providers/chat-state-provider.tsx
@@ -43,6 +43,7 @@ interface AutopilotChatStateContextType {
   spacing: DeepRequired<NonNullable<AutopilotChatConfiguration['spacing']>>;
   theming?: AutopilotChatConfiguration['theming'];
   portalContainer?: HTMLElement;
+  readOnly: boolean;
 }
 
 const AutopilotChatStateContext = React.createContext<AutopilotChatStateContextType | null>(null);
@@ -163,6 +164,7 @@ export const AutopilotChatStateProvider: React.FC<AutopilotChatStateProviderProp
     }
   );
   const [hasMessages, setHasMessages] = React.useState(false);
+  const [readOnly, setReadOnly] = React.useState(chatService?.getReadOnly() ?? false);
   const [spacing, setSpacing] = React.useState(calculateSpacing(chatService?.getConfig()?.spacing));
   const [theming, setTheming] = React.useState(chatService?.getConfig()?.theming);
 
@@ -217,6 +219,13 @@ export const AutopilotChatStateProvider: React.FC<AutopilotChatStateProviderProp
       }
     );
 
+    const unsubscribeReadOnly = chatService.on(
+      AutopilotChatEvent.SetReadOnly,
+      (isReadOnly: boolean) => {
+        setReadOnly(isReadOnly);
+      }
+    );
+
     const unsubscribeSpacing = chatInternalService.on(
       AutopilotChatInternalEvent.SetSpacing,
       (spacingConfig: AutopilotChatConfiguration['spacing']) => {
@@ -238,6 +247,7 @@ export const AutopilotChatStateProvider: React.FC<AutopilotChatStateProviderProp
       unsubscribeDisabledFeatures();
       unsubscribeOverrideLabels();
       unsubscribeFirstRunExperience();
+      unsubscribeReadOnly();
       unsubscribeAllowedAttachments();
       unsubscribeSpacing();
       unsubscribeTheming();
@@ -262,6 +272,7 @@ export const AutopilotChatStateProvider: React.FC<AutopilotChatStateProviderProp
       spacing,
       theming,
       portalContainer,
+      readOnly,
     }),
     [
       historyOpen,
@@ -280,6 +291,7 @@ export const AutopilotChatStateProvider: React.FC<AutopilotChatStateProviderProp
       spacing,
       theming,
       portalContainer,
+      readOnly,
     ]
   );
 

--- a/packages/apollo-react/src/material/components/ap-chat/service/ChatModel.ts
+++ b/packages/apollo-react/src/material/components/ap-chat/service/ChatModel.ts
@@ -210,6 +210,7 @@ export interface AutopilotChatError {
  * @property {string} HistoryLoadMore - Emitted when the history load more is triggered (scrolling to bottom)
  * @property {string} HistorySearch - Emitted when the history search is triggered (search for a conversation in the history list)
  * @property {string} SetResourceManager - Emitted when a resource manager is set for the variable picker
+ * @property {string} SetReadOnly - Emitted when the read-only mode is set
  * @property {string} ResourceItemSelected - Emitted when a resource item is selected from the variable picker
  */
 export enum AutopilotChatEvent {
@@ -247,6 +248,7 @@ export enum AutopilotChatEvent {
   SetSelectedAgentMode = 'setSelectedAgentMode',
   SetCustomHeaderActions = 'setCustomHeaderActions',
   CustomHeaderActionClicked = 'customHeaderActionClicked',
+  SetReadOnly = 'setReadOnly',
   SetResourceManager = 'setResourceManager',
   ResourceItemSelected = 'resourceItemSelected',
 }
@@ -490,6 +492,7 @@ export enum AutopilotChatPreHookAction {
  * @property preHooks - The hooks that trigger before the user action (UI interaction) of
  *                      the chat. Hooks expose current data for the action **before** the
  *                      state change is attempted.
+ * @property readOnly - Whether the chat is in read-only mode (hides input area and some action buttons)
  * @property paginatedMessages - Flag to determine if the chat conversation is paginated
  * @property settingsRenderer - The renderer for the settings page. This will be used to
  *                               render the settings page in the chat.
@@ -516,6 +519,7 @@ export interface AutopilotChatConfiguration {
   selectedModel?: AutopilotChatModelInfo;
   agentModes?: AutopilotChatAgentModeInfo[];
   selectedAgentMode?: AutopilotChatAgentModeInfo;
+  readOnly?: boolean;
   preHooks?: Partial<Record<AutopilotChatPreHookAction, (data?: any) => Promise<boolean>>>;
   paginatedMessages?: boolean;
   paginatedHistory?: boolean;

--- a/packages/apollo-react/src/material/components/ap-chat/service/ChatService.ts
+++ b/packages/apollo-react/src/material/components/ap-chat/service/ChatService.ts
@@ -166,6 +166,8 @@ export class AutopilotChatService {
     this.getTheme = this.getTheme.bind(this);
     this.setResourceManager = this.setResourceManager.bind(this);
     this.getResourceManager = this.getResourceManager.bind(this);
+    this.setReadOnly = this.setReadOnly.bind(this);
+    this.getReadOnly = this.getReadOnly.bind(this);
   }
 
   static Instantiate({
@@ -296,6 +298,10 @@ export class AutopilotChatService {
 
     if (config.resourceManager) {
       this.setResourceManager(config.resourceManager);
+    }
+
+    if (config.readOnly !== undefined) {
+      this.setReadOnly(config.readOnly);
     }
 
     messageRenderers.forEach((renderer) => this.injectMessageRenderer(renderer));
@@ -1140,6 +1146,27 @@ export class AutopilotChatService {
    */
   getResourceManager() {
     return this._resourceManager;
+  }
+
+  /**
+   * Sets the read-only mode for the chat interface.
+   * When enabled, the input area and some action buttons are hidden.
+   *
+   * @param readOnly - Whether to enable read-only mode
+   */
+  setReadOnly(readOnly: boolean) {
+    this._config.readOnly = readOnly;
+
+    this._eventBus.publish(AutopilotChatEvent.SetReadOnly, readOnly);
+  }
+
+  /**
+   * Gets the current read-only mode state
+   *
+   * @returns Whether the chat is in read-only mode
+   */
+  getReadOnly() {
+    return this._config.readOnly ?? false;
   }
 
   /**


### PR DESCRIPTION
https://uipath.atlassian.net/browse/JAR-9292
- hide input and action buttons during read-only mode
- add read-only checkbox to ApChatShowcase

Non read-only:
<img width="771" height="981" alt="Screenshot 2026-02-11 144059" src="https://github.com/user-attachments/assets/81f2785c-783f-4d36-8b5c-526215619c1b" />
read-only:
<img width="777" height="987" alt="Screenshot 2026-02-11 144116" src="https://github.com/user-attachments/assets/6f592019-1266-474a-84a6-f3880f8b0bd6" />
