### PR TITLE
feat(apollo-react): allow passing in error cta to agent flow nodes [AG-700]

### DIFF
--- a/packages/apollo-react/src/canvas/components/AgentCanvas/AgentFlow.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/AgentCanvas/AgentFlow.stories.tsx
@@ -1861,3 +1861,143 @@ export const ConversationalAgent: Story = {
     },
   },
 };
+
+/**
+ * Resource with Error CTA Story
+ * Demonstrates error call-to-action buttons on resource nodes
+ */
+
+const resourcesWithErrorCta: AgentFlowResource[] = [
+  {
+    id: 'tool-broken',
+    type: 'tool',
+    name: 'Broken Tool',
+    description: 'This tool has an error',
+    iconUrl: '',
+    hasBreakpoint: false,
+    hasGuardrails: false,
+    projectType: ProjectType.Internal,
+    errorAction: {
+      icon: 'refresh',
+      label: 'Retry Connection',
+    },
+  },
+  {
+    id: 'tool-config-error',
+    type: 'tool',
+    name: 'Misconfigured Tool',
+    description: 'Configuration error detected',
+    iconUrl: '',
+    hasBreakpoint: false,
+    hasGuardrails: false,
+    projectType: ProjectType.Api,
+    errorAction: {
+      icon: 'settings',
+      label: 'Fix Configuration',
+    },
+  },
+  {
+    id: 'context-error',
+    type: 'context',
+    name: 'Invalid Context',
+    description: 'Context validation failed',
+    hasBreakpoint: false,
+    errorAction: {
+      icon: 'warning',
+      label: 'Review Issues',
+    },
+  },
+  {
+    id: 'tool-working',
+    type: 'tool',
+    name: 'Working Tool',
+    description: 'This tool is functioning normally (no error CTA)',
+    iconUrl: '',
+    hasBreakpoint: false,
+    hasGuardrails: false,
+    projectType: ProjectType.Internal,
+    // No errorAction - this tool is working fine
+  },
+];
+
+const ResourceWithErrorCTAWrapper = () => {
+  const handleErrorAction = useCallback(
+    (_resourceId: string, resource: AgentFlowResourceNodeData) => {
+      console.log(resource);
+      // Route based on resource name
+      // resourceId format is typically: "parentNodeId=>resourceName:actualId"
+      const resourceName = resource.name;
+      switch (resourceName) {
+        case 'Broken Tool':
+          alert(`Retry action triggered for: ${resourceName}`);
+          break;
+        case 'Misconfigured Tool':
+          alert(`Fix configuration action triggered for: ${resourceName}`);
+          break;
+        case 'Invalid Context':
+          alert(`Review issues action triggered for: ${resourceName}`);
+          break;
+        default:
+          alert(`Error action triggered for: ${resourceName}`);
+      }
+    },
+    []
+  );
+
+  return (
+    <ReactFlowProvider>
+      <AgentFlow
+        allowDragging
+        definition={sampleAgentDefinition}
+        spans={[]}
+        name="Test Agent"
+        description="Testing error CTA on resources"
+        mode="design"
+        resources={resourcesWithErrorCta}
+        enableMemory
+        enableInstructions
+        onErrorAction={handleErrorAction}
+        instructions={{
+          system: 'System instructions here',
+          user: 'User instructions here',
+        }}
+      />
+      <StoryInfoPanel title="Error CTA Demo" position="top-right">
+        <Column mt={12} gap={8}>
+          <ApTypography variant={FontVariantToken.fontSizeS}>
+            Resources with <strong>errorAction</strong> defined will show an error action button in
+            their toolbar.
+          </ApTypography>
+          <ApTypography
+            variant={FontVariantToken.fontSizeS}
+            style={{ color: 'var(--uix-canvas-foreground-de-emp)' }}
+          >
+            Click the error action buttons (Retry, Fix Configuration, Review Issues) to trigger the
+            custom actions.
+          </ApTypography>
+          <ApTypography
+            variant={FontVariantToken.fontSizeS}
+            style={{ color: 'var(--uix-canvas-foreground-de-emp)' }}
+          >
+            The "Working Tool" has no error action and shows the normal toolbar.
+          </ApTypography>
+        </Column>
+      </StoryInfoPanel>
+    </ReactFlowProvider>
+  );
+};
+
+export const ResourceWithErrorCTA: Story = {
+  args: {
+    mode: 'design',
+  },
+  render: () => <ResourceWithErrorCTAWrapper />,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Demonstrates error call-to-action buttons on resource nodes. Resources can define an `errorAction` field with icon and label, and handle the action via the `onErrorAction` callback. The button appears next to the remove button in the toolbar. The consumer provides routing logic to handle different error actions for each resource. Hover or click on the resource nodes to see the error CTA buttons.',
+      },
+    },
+  },
+};

--- a/packages/apollo-react/src/canvas/components/AgentCanvas/AgentFlow.tsx
+++ b/packages/apollo-react/src/canvas/components/AgentCanvas/AgentFlow.tsx
@@ -203,6 +203,7 @@ const createResourceNodeWrapper = (opts: {
   onRemoveBreakpoint?: (resourceId: string, resource: AgentFlowResourceNodeData) => void;
   onAddGuardrail?: (resourceId: string, resource: AgentFlowResourceNodeData) => void;
   onGoToSource?: (resourceId: string, resource: AgentFlowResourceNodeData) => void;
+  onErrorAction?: (resourceId: string, resource: AgentFlowResourceNodeData) => void;
   onExpandResource?: (resourceId: string, resource: AgentFlowResourceNodeData) => void;
   onCollapseResource?: (resourceId: string, resource: AgentFlowResourceNodeData) => void;
   translations?: ResourceNodeTranslations;
@@ -225,6 +226,7 @@ const createResourceNodeWrapper = (opts: {
         onRemoveBreakpoint={opts.onRemoveBreakpoint}
         onAddGuardrail={opts.onAddGuardrail}
         onGoToSource={opts.onGoToSource}
+        onErrorAction={opts.onErrorAction}
         onRemoveResource={deleteNode}
         onExpandResource={opts.onExpandResource}
         onCollapseResource={opts.onCollapseResource}
@@ -247,6 +249,7 @@ const AgentFlowInner = memo(
     onRemoveBreakpoint,
     onAddGuardrail,
     onGoToSource,
+    onErrorAction,
     onAddResource: _onAddResource, // Handled by createResourcePlaceholder in store
     onSelectResource,
     setSpanForSelectedNode,
@@ -385,6 +388,7 @@ const AgentFlowInner = memo(
           onRemoveBreakpoint,
           onAddGuardrail,
           onGoToSource,
+          onErrorAction,
           onExpandResource,
           onCollapseResource,
           translations: resourceNodeTranslations,
@@ -399,6 +403,7 @@ const AgentFlowInner = memo(
       onRemoveBreakpoint,
       onAddGuardrail,
       onGoToSource,
+      onErrorAction,
       healthScore,
       onHealthScoreClick,
       createResourcePlaceholder,

--- a/packages/apollo-react/src/canvas/types.ts
+++ b/packages/apollo-react/src/canvas/types.ts
@@ -11,6 +11,7 @@ import type {
   StickyNoteColor,
   StickyNoteData,
 } from './components/StickyNoteNode/StickyNoteNode.types';
+import { ToolbarActionItem } from './components/Toolbar';
 
 // Re-export CanvasLevel for external consumers
 export type { CanvasLevel } from './types/canvas.types';
@@ -74,6 +75,7 @@ export type AgentFlowToolResource = {
   hasGuardrails?: boolean;
   projectId?: string;
   isDisabled?: boolean;
+  errorAction?: Omit<ToolbarActionItem, 'id' | 'onAction'>;
 };
 
 export type AgentFlowContextResource = {
@@ -88,6 +90,7 @@ export type AgentFlowContextResource = {
   hasGuardrails?: boolean;
   projectId?: string;
   isDisabled?: boolean;
+  errorAction?: Omit<ToolbarActionItem, 'id' | 'onAction'>;
 };
 
 export type AgentFlowEscalationResource = {
@@ -102,6 +105,7 @@ export type AgentFlowEscalationResource = {
   hasGuardrails?: boolean;
   projectId?: string;
   isDisabled?: boolean;
+  errorAction?: Omit<ToolbarActionItem, 'id' | 'onAction'>;
 };
 
 export type AgentFlowMcpResource = {
@@ -124,6 +128,7 @@ export type AgentFlowMcpResource = {
   hasGuardrails?: boolean;
   projectId?: string;
   isDisabled?: boolean;
+  errorAction?: Omit<ToolbarActionItem, 'id' | 'onAction'>;
 };
 
 export type AgentFlowMemorySpaceResource = {
@@ -138,6 +143,7 @@ export type AgentFlowMemorySpaceResource = {
   hasGuardrails?: boolean;
   projectId?: string;
   isDisabled?: boolean;
+  errorAction?: Omit<ToolbarActionItem, 'id' | 'onAction'>;
 };
 
 export type AgentFlowResource =
@@ -271,6 +277,7 @@ export type AgentFlowProps = {
   onRemoveBreakpoint?: (resourceId: string, resource: AgentFlowResourceNodeData) => void;
   onAddGuardrail?: (resourceId: string, resource: AgentFlowResourceNodeData) => void;
   onGoToSource?: (resourceId: string, resource: AgentFlowResourceNodeData) => void;
+  onErrorAction?: (resourceId: string, resource: AgentFlowResourceNodeData) => void;
   onAddResource?: (type: AgentFlowResourceType) => void;
   onRemoveResource?: (resource: AgentFlowResource) => void;
   onAgentNodeClick?: () => void;
@@ -475,6 +482,7 @@ export type SharedResourceData = {
   suggestionId?: string;
   suggestionType?: SuggestionType;
   isPlaceholder?: boolean; // for 'add' type suggestions
+  errorAction?: Omit<ToolbarActionItem, 'id' | 'onAction'>;
 };
 
 export type AgentFlowResourceNodeData = (

--- a/packages/apollo-react/src/canvas/utils/props-helpers.ts
+++ b/packages/apollo-react/src/canvas/utils/props-helpers.ts
@@ -179,6 +179,7 @@ const createResourceNode = (
     hasGuardrails: resource.hasGuardrails ?? false,
     isDisabled: resource.isDisabled ?? false,
     errors: resource.errors,
+    errorAction: resource.errorAction,
   };
 
   // Check if resource has explicit position defined


### PR DESCRIPTION
https://uipath.atlassian.net/browse/AG-700

- Allows consumers of agent flow to pass error cta action metadata (label & icon) on a per resource level
- Provides a way to give a callback which gets invoked when a cta action is clicked from the toolbar. This will allow consumers to route to the right logic from checks on their end

https://github.com/user-attachments/assets/3b005a62-5403-4697-a1b9-79578af53f46
