### PR TITLE
fix(apollo-react): fix text alignment in execution state of StageNode [MST-6450]

### DIFF
--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.styles.ts
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.styles.ts
@@ -253,6 +253,8 @@ export const StageTaskIcon = styled.div`
 `;
 
 export const StageTaskRetryDuration = styled.div<{ status?: 'warning' | 'info' | 'error' }>`
+  display: flex;
+  align-items: center;
   ${({ status }) =>
     status === 'info' &&
     css`


### PR DESCRIPTION
- Add `align-item` style to container around task retry duration
<img width="1871" height="853" alt="Screenshot 2026-02-12 at 5 46 54 PM" src="https://github.com/user-attachments/assets/5e203013-41d8-4420-b03b-4daa049619c1" />
