### PR TITLE
feat(apollo-wind file-upload): add per-file error display and external errors support to FileUpload

### DIFF
--- a/packages/apollo-wind/src/components/ui/file-upload.stories.tsx
+++ b/packages/apollo-wind/src/components/ui/file-upload.stories.tsx
@@ -116,3 +116,49 @@ export const WithMaxSize = {
     );
   },
 };
+
+export const WithExternalErrors = {
+  args: {},
+  render: () => {
+    const [files, setFiles] = useState<File[]>([]);
+    const [errors, setErrors] = useState<Record<string, string>>({});
+    const [isUploading, setIsUploading] = useState(false);
+
+    const simulateUpload = async () => {
+      if (files.length === 0) return;
+
+      setIsUploading(true);
+      setErrors({});
+
+      // Simulate upload with random failures
+      await new Promise((resolve) => setTimeout(resolve, 1500));
+
+      const newErrors: Record<string, string> = {};
+      files.forEach((file) => {
+        // Randomly fail some uploads for demo
+        if (Math.random() > 0.5) {
+          newErrors[file.name] = 'Upload failed: Server error';
+        }
+      });
+
+      setErrors(newErrors);
+      setIsUploading(false);
+    };
+
+    return (
+      <div className="w-[400px] space-y-4">
+        <FileUpload onFilesChange={setFiles} multiple errors={errors} />
+        <button
+          onClick={simulateUpload}
+          disabled={files.length === 0 || isUploading}
+          className="px-4 py-2 bg-primary text-primary-foreground rounded-md disabled:opacity-50"
+        >
+          {isUploading ? 'Uploading...' : 'Simulate Upload'}
+        </button>
+        <p className="text-xs text-muted-foreground">
+          Click &quot;Simulate Upload&quot; to see random upload failures displayed per file.
+        </p>
+      </div>
+    );
+  },
+};


### PR DESCRIPTION
https://uipath.atlassian.net/browse/PLT-97253

Also enforced type check. Added a new story for external errors prop
<img width="420" height="461" alt="Screenshot 2026-02-13 at 3 39 53 PM" src="https://github.com/user-attachments/assets/5c12a2aa-a21e-4391-b6d4-cdeed6a09ce0" />

