### PR TITLE
feat(apollo-react): loading icon for add task button

### DIFF
--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.test.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.test.tsx
@@ -608,3 +608,69 @@ describe('StageNode - Replace Task Functionality', () => {
     });
   });
 });
+
+describe('StageNode - Add Task Loading State', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should show the add icon by default when addTaskLoading is not set', () => {
+    const onTaskAdd = vi.fn();
+    renderStageNode({ onTaskAdd });
+
+    // The add icon should be present, no spinner
+    expect(screen.queryByTestId('ap-circular-progress')).not.toBeInTheDocument();
+  });
+
+  it('should show a loading spinner instead of the add icon when addTaskLoading is true', () => {
+    const onTaskAdd = vi.fn();
+    renderStageNode({ onTaskAdd, addTaskLoading: true });
+
+    expect(screen.getByTestId('ap-circular-progress')).toBeInTheDocument();
+  });
+
+  it('should disable the add task button when addTaskLoading is true', () => {
+    const onTaskAdd = vi.fn();
+    renderStageNode({ onTaskAdd, addTaskLoading: true });
+
+    const spinner = screen.getByTestId('ap-circular-progress');
+    // The disabled button is the closest button ancestor of the spinner
+    const button = spinner.closest('button');
+    expect(button).toBeDisabled();
+  });
+
+  it('should not call onTaskAdd when button is disabled while loading', () => {
+    const onTaskAdd = vi.fn();
+    renderStageNode({ onTaskAdd, addTaskLoading: true });
+
+    const spinner = screen.getByTestId('ap-circular-progress');
+    const button = spinner.closest('button') as HTMLButtonElement;
+
+    // Button is disabled and has pointer-events: none, preventing any clicks
+    expect(button).toBeDisabled();
+    button.click();
+    expect(onTaskAdd).not.toHaveBeenCalled();
+  });
+
+  it('should show the add icon when addTaskLoading is false', () => {
+    const onTaskAdd = vi.fn();
+    renderStageNode({ onTaskAdd, addTaskLoading: false });
+
+    expect(screen.queryByTestId('ap-circular-progress')).not.toBeInTheDocument();
+  });
+
+  it('should switch from spinner back to add icon when addTaskLoading changes to false', () => {
+    const onTaskAdd = vi.fn();
+    const { rerender } = renderStageNode({ onTaskAdd, addTaskLoading: true });
+
+    expect(screen.getByTestId('ap-circular-progress')).toBeInTheDocument();
+
+    rerender(
+      <ReactFlowProvider>
+        <StageNode {...defaultProps} onTaskAdd={onTaskAdd} addTaskLoading={false} />
+      </ReactFlowProvider>
+    );
+
+    expect(screen.queryByTestId('ap-circular-progress')).not.toBeInTheDocument();
+  });
+});

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.tsx
@@ -20,6 +20,7 @@ import { FontVariantToken, Padding, Spacing } from '@uipath/apollo-core';
 import { Column, Row } from '@uipath/apollo-react/canvas/layouts';
 import { Position, useStore, useViewport } from '@uipath/apollo-react/canvas/xyflow/react';
 import {
+  ApCircularProgress,
   ApIcon,
   ApIconButton,
   ApLink,
@@ -70,6 +71,7 @@ const StageNodeComponent = (props: StageNodeProps) => {
     execution,
     stageDetails,
     addTaskLabel = 'Add task',
+    addTaskLoading = false,
     replaceTaskLabel = 'Replace task',
     taskOptions = [],
     menuItems,
@@ -520,10 +522,20 @@ const StageNodeComponent = (props: StageNodeProps) => {
               </ApTooltip>
             )}
             {(onTaskAdd || onAddTaskFromToolbox) && !isReadOnly && (
-              <ApTooltip content={addTaskLabel} placement="top">
-                <ApIconButton onClick={handleTaskAddClick} size="small">
-                  <ApIcon name="add" size="20px" />
-                </ApIconButton>
+              <ApTooltip content={addTaskLoading ? 'Loading...' : addTaskLabel} placement="top">
+                <span>
+                  <ApIconButton
+                    onClick={handleTaskAddClick}
+                    size="small"
+                    disabled={addTaskLoading}
+                  >
+                    {addTaskLoading ? (
+                      <ApCircularProgress size={20} />
+                    ) : (
+                      <ApIcon name="add" size="20px" />
+                    )}
+                  </ApIconButton>
+                </span>
               </ApTooltip>
             )}
           </Row>
@@ -534,9 +546,9 @@ const StageNodeComponent = (props: StageNodeProps) => {
             <Column py={2}>
               {(onTaskAdd || onAddTaskFromToolbox) && !isReadOnly ? (
                 <ApLink
-                  onClick={handleTaskAddClick}
+                  onClick={addTaskLoading ? undefined : handleTaskAddClick}
                   variant={FontVariantToken.fontSizeS}
-                  style={{ maxWidth: 'fit-content' }}
+                  style={{ maxWidth: 'fit-content', pointerEvents: addTaskLoading ? 'none' : undefined }}
                 >
                   {defaultContent}
                 </ApLink>

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.types.ts
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.types.ts
@@ -41,6 +41,7 @@ export interface StageNodeProps extends NodeProps {
     selectedTasks?: string[];
   };
   addTaskLabel?: string;
+  addTaskLoading?: boolean;
   replaceTaskLabel?: string;
   taskOptions?: ListItem[];
   execution?: {


### PR DESCRIPTION
## Description 


  - Add addTaskLoading prop to StageNode that shows a circular progress spinner in place of the + icon and disables the button
  - Wrap the disabled button in a <span> to fix MUI Tooltip compatibility with disabled elements
  - Add Storybook story to demo the loading behavior with a simulated 3-second API delay

## Demo 


https://github.com/user-attachments/assets/f7cdbf8c-66cf-45f2-87f2-e4cacb87b41a

