### PR TITLE
fix(apollo-react): allow visibility of button handles by base node [MST-6630]

### DIFF
--- a/packages/apollo-react/src/canvas/components/ButtonHandle/ButtonHandle.test.tsx
+++ b/packages/apollo-react/src/canvas/components/ButtonHandle/ButtonHandle.test.tsx
@@ -182,7 +182,7 @@ describe('ButtonHandles', () => {
     );
 
     const handle = screen.getByTestId('handle');
-    expect(handle).toBeInTheDocument();
+    expect(handle).toHaveStyle({ opacity: '1' });
 
     rerender(
       <ButtonHandles
@@ -193,7 +193,7 @@ describe('ButtonHandles', () => {
       />
     );
 
-    expect(screen.queryByTestId('handle')).not.toBeInTheDocument();
+    expect(handle).toHaveStyle({ opacity: '0' });
   });
 
   it('positions handles correctly for different positions', () => {

--- a/packages/apollo-react/src/canvas/components/ButtonHandle/ButtonHandle.tsx
+++ b/packages/apollo-react/src/canvas/components/ButtonHandle/ButtonHandle.tsx
@@ -258,13 +258,13 @@ const ButtonHandlesBase = ({
 }) => {
   const finalSelected = shouldShowAddButtonFn({ showAddButton, selected });
 
-  // Filter to only visible handles for spacing calculations
-  const visibleHandles = handles.filter((h) => visible && (h.visible ?? true));
+  // Filter only visible handles for spacing calculations
+  const visibleHandles = handles.filter((h) => h.visible ?? true);
   const total = visibleHandles.length;
 
   return (
     <>
-      {visibleHandles.map((handle, index) => (
+      {handles.map((handle, index) => (
         <ButtonHandle
           key={handle.id}
           id={handle.id}
@@ -278,6 +278,8 @@ const ButtonHandlesBase = ({
           index={index}
           total={total}
           selected={selected}
+          // Need top level visibility to be true and current handle visibility to be true to keep positioning of handles consistent
+          visible={visible && (handle.visible ?? true)}
           showButton={finalSelected && visible && handle.showButton}
           color={handle.color}
           onAction={handle.onAction}


### PR DESCRIPTION
### Description

This PR

- Fixes the button handle visibility logic to respect individual handle visibility state instead of being overridden by the base node's handle visibility

### Demo

https://github.com/user-attachments/assets/6f0a5d04-1c10-461d-9298-beb0a6c0e36b

