### PR TITLE
feat(apollo-vertex): replace @uipath/auth-react with custom auth

### DIFF
--- a/apps/apollo-vertex/app/vertex-components/shell/page.mdx
+++ b/apps/apollo-vertex/app/vertex-components/shell/page.mdx
@@ -1,8 +1,9 @@
 import { ShellTemplate } from '@/templates/ShellTemplate';
+import { ShellTemplateWithAuth } from '@/templates/ShellTemplateWithAuth';
 
 # Shell
 
-A component that includes UiPath authentication and a collapsible sidebar.
+A component that includes UiPath authentication with a custom PKCE OAuth flow and a collapsible sidebar.
 
 <div className="not-prose my-8 rounded-lg overflow-hidden" style={{ height: '600px' }}>
   <div className="[&_.h-screen]:!h-full h-full">
@@ -20,9 +21,18 @@ Use the `variant="minimal"` prop to render a horizontal header layout instead of
   </div>
 </div>
 
+
+## Shell template with auth
+
+<div className="not-prose my-8 rounded-lg overflow-hidden" style={{ height: '600px' }}>
+  <div className="[&_.h-screen]:!h-full h-full">
+    <ShellTemplateWithAuth variant="minimal" />
+  </div>
+</div>
+
 ## Features
 
-- **UiPath Authentication**: Built-in authentication flow with `@uipath/auth-react`
+- **UiPath Authentication**: Built-in PKCE OAuth flow with automatic token refresh
 - **Theme Toggle**: Built-in light/dark mode support
 - **Language Toggle**: Built-in language switcher for internationalization
 - **User Profile**: Dropdown menu with user information and sign-out
@@ -36,17 +46,18 @@ npx shadcn@latest add @uipath/shell
 ## Usage
 
 ```tsx
-import { ApolloShell } from '@/components/ui/shell';
-import { onCallback, type AuthConfiguration } from '@uipath/auth-react';
+import { ApolloShell, type AuthConfiguration, type UserInfo } from '@/components/ui/shell';
 import { useNavigate } from '@tanstack/react-router';
 
 function App() {
   const navigate = useNavigate();
 
   const configuration: AuthConfiguration = {
-    authority: 'https://your-org.cloud.uipath.com/identity_',
-    redirect_uri: 'http://localhost:3000/auth_callback',
-    post_logout_redirect_uri: 'http://localhost:3000',
+    authority: 'https://staging.uipath.com/identity_',
+    clientId: 'your-client-id',
+    redirectUri: 'http://localhost:3000',
+    postLogoutRedirectUri: 'http://localhost:3000',
+    scope: 'openid profile email offline_access',
   };
 
   return (
@@ -54,10 +65,10 @@ function App() {
       configuration={configuration}
       companyName="Your Company"
       productName="Your Product"
-      onSigninCallback={(user) => {
-        onCallback(user, (to) => {
-          navigate({ to: to });
-        });
+      onSigninCallback={(user: UserInfo | null) => {
+        if (user) {
+          navigate({ to: '/dashboard' });
+        }
       }}
     >
       {/* ... your authenticated app content ... */}
@@ -66,3 +77,50 @@ function App() {
   );
 }
 ```
+
+## Authentication Configuration
+
+The `AuthConfiguration` object requires the following properties:
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `authority` | `string` | The base URL of the identity provider (e.g., `https://staging.uipath.com/identity_`) |
+| `clientId` | `string` | The OAuth client ID |
+| `redirectUri` | `string` | The URL to redirect to after authentication |
+| `scope` | `string` | OAuth scopes to request (e.g., `openid profile email offline_access`) |
+| `postLogoutRedirectUri` | `string` (optional) | The URL to redirect to after logout |
+
+## Using the Auth Hook
+
+You can access auth state anywhere in your app using the `useAuth` hook:
+
+```tsx
+import { useAuth } from '@/components/ui/shell';
+
+function MyComponent() {
+  const { user, isAuthenticated, isLoading, login, logout, accessToken } = useAuth();
+
+  if (isLoading) return <div>Loading...</div>;
+  if (!isAuthenticated) return <button onClick={login}>Sign in</button>;
+
+  return (
+    <div>
+      <p>Welcome, {user?.name}</p>
+      <p>Email: {user?.email}</p>
+      <button onClick={logout}>Sign out</button>
+    </div>
+  );
+}
+```
+
+## User Info Structure
+
+The `UserInfo` object returned by `useAuth` has the following properties:
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `name` | `string` | The user's display name |
+| `email` | `string` | The user's email address |
+| `sub` | `string` | The user's unique identifier |
+| `first_name` | `string` (optional) | The user's first name |
+| `last_name` | `string` (optional) | The user's last name |

--- a/apps/apollo-vertex/package.json
+++ b/apps/apollo-vertex/package.json
@@ -50,7 +50,6 @@
     "@radix-ui/react-tooltip": "^1.2.8",
     "@tailwindcss/postcss": "^4.1.17",
     "@tanstack/react-table": "^8.21.3",
-    "@uipath/auth-react": "^1.1.6",
     "@vercel/analytics": "^1.5.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/apps/apollo-vertex/registry.json
+++ b/apps/apollo-vertex/registry.json
@@ -643,13 +643,13 @@
       "name": "shell",
       "type": "registry:ui",
       "title": "Shell",
-      "description": "Provides UiPath authentication and renders children only when authenticated.",
+      "description": "Provides UiPath authentication with custom PKCE OAuth flow and renders children only when authenticated.",
       "dependencies": [
-        "@uipath/auth-react",
         "lucide-react",
         "framer-motion",
         "react-i18next",
-        "i18next"
+        "i18next",
+        "zod"
       ],
       "registryDependencies": [
         "button",
@@ -661,6 +661,34 @@
       ],
       "files": [
         { "path": "registry/shell/shell.tsx", "type": "registry:ui" },
+        {
+          "path": "registry/shell/auth-config.ts",
+          "type": "registry:ui"
+        },
+        {
+          "path": "registry/shell/auth-context.ts",
+          "type": "registry:ui"
+        },
+        {
+          "path": "registry/shell/auth-utils.ts",
+          "type": "registry:ui"
+        },
+        {
+          "path": "registry/shell/auth-provider.tsx",
+          "type": "registry:ui"
+        },
+        {
+          "path": "registry/shell/use-auth.ts",
+          "type": "registry:ui"
+        },
+        {
+          "path": "registry/shell/auth-guard.tsx",
+          "type": "registry:ui"
+        },
+        {
+          "path": "registry/shell/auth-login.tsx",
+          "type": "registry:ui"
+        },
         {
           "path": "registry/shell/shell-layout.tsx",
           "type": "registry:ui"

--- a/apps/apollo-vertex/registry/shell/auth-config.ts
+++ b/apps/apollo-vertex/registry/shell/auth-config.ts
@@ -1,0 +1,56 @@
+export interface AuthConfiguration {
+  /**
+   * The base URL of the identity provider (e.g., "https://staging.uipath.com")
+   */
+  authority: string;
+  /**
+   * The OAuth client ID
+   */
+  clientId: string;
+  /**
+   * The URL to redirect to after authentication
+   */
+  redirectUri: string;
+  /**
+   * The URL to redirect to after logout
+   */
+  postLogoutRedirectUri?: string;
+  /**
+   * OAuth scopes to request
+   */
+  scope: string;
+}
+
+export interface ResolvedAuthConfig {
+  baseUrl: string;
+  clientId: string;
+  redirectUri: string;
+  postLogoutRedirectUri: string;
+  scope: string;
+  authorizationEndpoint: string;
+  tokenEndpoint: string;
+}
+
+export const STORAGE_KEYS = {
+  TOKEN: "uipath_token",
+  CODE_VERIFIER: "uipath_code_verifier",
+  STATE: "uipath_state",
+} as const;
+
+export const resolveAuthConfig = (
+  config: AuthConfiguration
+): ResolvedAuthConfig => {
+  const baseUrl = config.authority.replace(/\/identity_\/?$/, "");
+  const idpRoute = "identity_";
+
+  return {
+    baseUrl,
+    clientId: config.clientId,
+    redirectUri: config.redirectUri,
+    postLogoutRedirectUri:
+      config.postLogoutRedirectUri ?? window.location.origin,
+    scope: config.scope,
+    authorizationEndpoint: `${baseUrl}/${idpRoute}/connect/authorize`,
+    tokenEndpoint: `${baseUrl}/${idpRoute}/connect/token`,
+  };
+};

--- a/apps/apollo-vertex/registry/shell/auth-context.ts
+++ b/apps/apollo-vertex/registry/shell/auth-context.ts
@@ -1,0 +1,22 @@
+import { createContext } from "react";
+
+export interface UserInfo {
+  name: string;
+  email: string;
+  sub: string;
+  first_name?: string;
+  last_name?: string;
+}
+
+export interface AuthContextValue {
+  user: UserInfo | null;
+  isAuthenticated: boolean;
+  isLoading: boolean;
+  login: () => Promise<void>;
+  logout: () => void;
+  accessToken: string | null;
+}
+
+export const AuthContext = createContext<AuthContextValue | undefined>(
+  undefined
+);

--- a/apps/apollo-vertex/registry/shell/auth-guard.tsx
+++ b/apps/apollo-vertex/registry/shell/auth-guard.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import type { FC, PropsWithChildren } from "react";
+import { AuthLogin } from "./auth-login";
+import { useAuth } from "./use-auth";
+import { Spinner } from "@/components/ui/spinner";
+
+export interface AuthGuardProps extends PropsWithChildren {
+  /**
+   * Custom loading component to show while checking auth status
+   */
+  loadingComponent?: React.ReactNode;
+  /**
+   * Custom login component to show when not authenticated
+   */
+  loginComponent?: React.ReactNode;
+}
+
+export const AuthGuard: FC<AuthGuardProps> = ({
+  children,
+  loadingComponent,
+  loginComponent,
+}) => {
+  const { isAuthenticated, isLoading } = useAuth();
+
+  if (isLoading) {
+    return (
+      loadingComponent ?? (
+        <div className="flex h-screen items-center justify-center bg-background">
+          <Spinner className="size-8" />
+        </div>
+      )
+    );
+  }
+
+  if (!isAuthenticated) {
+    return loginComponent ?? <AuthLogin />;
+  }
+
+  return <>{children}</>;
+};

--- a/apps/apollo-vertex/registry/shell/auth-login.tsx
+++ b/apps/apollo-vertex/registry/shell/auth-login.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import type { FC } from "react";
+import { useAuth } from "./use-auth";
+
+export interface AuthLoginProps {
+  /**
+   * The title to display on the login page
+   */
+  title?: string;
+  /**
+   * The description to display on the login page
+   */
+  description?: string;
+  /**
+   * The text to display on the login button
+   */
+  buttonText?: string;
+}
+
+export const AuthLogin: FC<AuthLoginProps> = ({
+  title = "Welcome",
+  description = "Sign in to access your dashboard",
+  buttonText = "Sign in with UiPath",
+}) => {
+  const { login } = useAuth();
+
+  return (
+    <div className="flex h-screen items-center justify-center bg-background">
+      <div className="w-full max-w-md">
+        <div className="bg-card rounded-lg shadow-lg p-8 border border-border">
+          <div className="text-center mb-8">
+            <h1 className="text-3xl font-bold text-foreground mb-2">{title}</h1>
+            <p className="text-muted-foreground">{description}</p>
+          </div>
+
+          <div className="space-y-6">
+            <button
+              type="button"
+              onClick={() => login()}
+              className="w-full px-6 py-3 bg-primary text-primary-foreground rounded-lg hover:bg-primary/90 transition-colors font-medium text-base shadow-sm hover:shadow-md"
+            >
+              {buttonText}
+            </button>
+          </div>
+        </div>
+
+        <div className="mt-6 text-center text-sm text-muted-foreground">
+          <p>Need help? Contact your administrator</p>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/apps/apollo-vertex/registry/shell/auth-provider.tsx
+++ b/apps/apollo-vertex/registry/shell/auth-provider.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import {
+  type FC,
+  type PropsWithChildren,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+import {
+  type AuthConfiguration,
+  resolveAuthConfig,
+} from "./auth-config";
+import { AuthContext, type UserInfo } from "./auth-context";
+import {
+  clearTokenData,
+  decodeJWT,
+  ensureValidToken,
+  getStoredTokenData,
+  handleOAuthCallback,
+  login as authLogin,
+  logout as authLogout,
+} from "./auth-utils";
+
+export interface AuthProviderProps extends PropsWithChildren {
+  configuration: AuthConfiguration;
+  onSigninCallback?: (user: UserInfo | null) => void;
+}
+
+export const AuthProvider: FC<AuthProviderProps> = ({
+  children,
+  configuration,
+  onSigninCallback,
+}) => {
+  const [accessToken, setAccessToken] = useState<string | null>(null);
+  const [user, setUser] = useState<UserInfo | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  const resolvedConfig = useMemo(
+    () => resolveAuthConfig(configuration),
+    [configuration]
+  );
+
+  useEffect(() => {
+    const initAuth = async () => {
+      try {
+        // Check if we're in an OAuth callback
+        const params = new URLSearchParams(window.location.search);
+        const isInOAuthCallback = params.has("code") && params.has("state");
+
+        if (isInOAuthCallback) {
+          await handleOAuthCallback(resolvedConfig);
+        }
+
+        // Get valid token
+        const token = await ensureValidToken(resolvedConfig);
+        setAccessToken(token);
+
+        if (token) {
+          const decoded = decodeJWT(token);
+          setUser(decoded);
+          onSigninCallback?.(decoded);
+        }
+      } catch (error) {
+        console.error("Auth initialization failed:", error);
+        clearTokenData();
+        setAccessToken(null);
+        setUser(null);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    initAuth();
+  }, [resolvedConfig, onSigninCallback]);
+
+  // Set up token refresh interval
+  useEffect(() => {
+    if (!accessToken) return;
+
+    const refreshInterval = setInterval(async () => {
+      const token = await ensureValidToken(resolvedConfig);
+      if (token !== accessToken) {
+        setAccessToken(token);
+        if (token) {
+          setUser(decodeJWT(token));
+        } else {
+          setUser(null);
+        }
+      }
+    }, 60 * 1000);
+
+    return () => clearInterval(refreshInterval);
+  }, [accessToken, resolvedConfig]);
+
+  const login = useCallback(async () => {
+    await authLogin(configuration);
+  }, [configuration]);
+
+  const logout = useCallback(() => {
+    authLogout(configuration);
+    setAccessToken(null);
+    setUser(null);
+  }, [configuration]);
+
+  const contextValue = useMemo(
+    () => ({
+      user,
+      isAuthenticated: accessToken != null,
+      isLoading,
+      login,
+      logout,
+      accessToken,
+    }),
+    [user, accessToken, isLoading, login, logout]
+  );
+
+  return (
+    <AuthContext.Provider value={contextValue}>{children}</AuthContext.Provider>
+  );
+};

--- a/apps/apollo-vertex/registry/shell/auth-utils.ts
+++ b/apps/apollo-vertex/registry/shell/auth-utils.ts
@@ -1,0 +1,280 @@
+import { z } from "zod";
+import {
+  type ResolvedAuthConfig,
+  STORAGE_KEYS,
+  type AuthConfiguration,
+  resolveAuthConfig,
+} from "./auth-config";
+
+const TokenDataSchema = z.object({
+  access_token: z.string(),
+  id_token: z.string(),
+  refresh_token: z.string(),
+  expires_in: z.number(),
+  token_type: z.string(),
+  expiresAt: z.number(),
+});
+
+export type TokenData = z.infer<typeof TokenDataSchema>;
+
+const JwtPayloadSchema = z.object({
+  email: z.string().email(),
+  first_name: z.string().optional(),
+  last_name: z.string().optional(),
+  name: z.string().optional(),
+  sub: z.string(),
+});
+
+const REFRESH_THRESHOLD_MS = 5 * 60 * 1000;
+
+function generateRandomString(length: number): string {
+  const charset =
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+  const randomValues = new Uint8Array(length);
+  crypto.getRandomValues(randomValues);
+  return Array.from(randomValues)
+    .map((x) => charset[x % charset.length])
+    .join("");
+}
+
+async function generatePKCEChallenge(): Promise<{
+  code_verifier: string;
+  code_challenge: string;
+}> {
+  const code_verifier = generateRandomString(64);
+  const encoder = new TextEncoder();
+  const data = encoder.encode(code_verifier);
+  const digest = await crypto.subtle.digest("SHA-256", data);
+  const base64 = btoa(String.fromCharCode(...new Uint8Array(digest)))
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+  return { code_verifier, code_challenge: base64 };
+}
+
+function base64UrlDecode(str: string): string {
+  const base64 = str.replace(/-/g, "+").replace(/_/g, "/");
+  const padded = base64 + "=".repeat((4 - (base64.length % 4)) % 4);
+  return atob(padded);
+}
+
+export function decodeJWT(token: string): {
+  name: string;
+  email: string;
+  sub: string;
+  first_name?: string;
+  last_name?: string;
+} | null {
+  try {
+    const parts = token.split(".");
+    if (parts.length !== 3) return null;
+
+    const payload = JSON.parse(base64UrlDecode(parts[1]));
+    const { data, success } = JwtPayloadSchema.safeParse(payload);
+
+    if (!success) return null;
+
+    const firstName = data.first_name ?? "";
+    const lastName = data.last_name ?? "";
+    const displayName =
+      data.name ?? ([firstName, lastName].filter(Boolean).join(" ") || "User");
+
+    return {
+      name: displayName,
+      email: data.email,
+      sub: data.sub,
+      first_name: firstName || undefined,
+      last_name: lastName || undefined,
+    };
+  } catch {
+    return null;
+  }
+}
+
+const isTokenExpired = (tokenData: TokenData): boolean => {
+  return tokenData.expiresAt <= Date.now();
+};
+
+const shouldRefreshToken = (tokenData: TokenData): boolean => {
+  const timeUntilExpiry = tokenData.expiresAt - Date.now();
+  return timeUntilExpiry < REFRESH_THRESHOLD_MS;
+};
+
+export const saveTokenData = (tokenData: TokenData): void => {
+  localStorage.setItem(STORAGE_KEYS.TOKEN, JSON.stringify(tokenData));
+};
+
+export const clearTokenData = (): void => {
+  localStorage.removeItem(STORAGE_KEYS.TOKEN);
+};
+
+export const getStoredTokenData = (): TokenData | null => {
+  const tokenDataStr = localStorage.getItem(STORAGE_KEYS.TOKEN);
+  if (!tokenDataStr) return null;
+
+  try {
+    const parsed = JSON.parse(tokenDataStr);
+    const { data, success } = TokenDataSchema.safeParse(parsed);
+    return success ? data : null;
+  } catch {
+    return null;
+  }
+};
+
+const fetchTokenData = async (
+  config: ResolvedAuthConfig,
+  body: URLSearchParams
+): Promise<TokenData> => {
+  const response = await fetch(config.tokenEndpoint, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+    },
+    body,
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(`Token request failed: ${errorText}`);
+  }
+
+  const data = await response.json();
+
+  return TokenDataSchema.parse({
+    access_token: data.access_token,
+    id_token: data.id_token,
+    refresh_token: data.refresh_token,
+    expires_in: data.expires_in,
+    token_type: data.token_type,
+    expiresAt: Date.now() + data.expires_in * 1000,
+  });
+};
+
+const refreshAccessToken = async (
+  config: ResolvedAuthConfig,
+  refreshToken: string
+): Promise<TokenData> => {
+  const body = new URLSearchParams({
+    grant_type: "refresh_token",
+    refresh_token: refreshToken,
+    client_id: config.clientId,
+  });
+
+  return await fetchTokenData(config, body);
+};
+
+const refreshTokenIfNeeded = async (
+  config: ResolvedAuthConfig,
+  tokenData: TokenData
+): Promise<string | null> => {
+  if (!tokenData.refresh_token) {
+    return null;
+  }
+
+  try {
+    const newTokenData = await refreshAccessToken(config, tokenData.refresh_token);
+    saveTokenData(newTokenData);
+    return newTokenData.access_token;
+  } catch {
+    clearTokenData();
+    return null;
+  }
+};
+
+const exchangeCodeForToken = async (
+  config: ResolvedAuthConfig,
+  code: string,
+  codeVerifier: string
+): Promise<TokenData> => {
+  const body = new URLSearchParams({
+    grant_type: "authorization_code",
+    code,
+    redirect_uri: config.redirectUri,
+    client_id: config.clientId,
+    code_verifier: codeVerifier,
+  });
+
+  return await fetchTokenData(config, body);
+};
+
+export const handleOAuthCallback = async (
+  config: ResolvedAuthConfig
+): Promise<boolean> => {
+  const params = new URLSearchParams(window.location.search);
+  const code = params.get("code");
+  const state = params.get("state");
+  const error = params.get("error");
+
+  if (error) {
+    throw new Error(`OAuth error: ${error}`);
+  }
+
+  if (!code || !state) {
+    return false;
+  }
+
+  const storedState = sessionStorage.getItem(STORAGE_KEYS.STATE);
+  if (state !== storedState) {
+    throw new Error("State mismatch");
+  }
+
+  const codeVerifier = sessionStorage.getItem(STORAGE_KEYS.CODE_VERIFIER);
+  if (!codeVerifier) {
+    throw new Error("Code verifier not found");
+  }
+
+  const tokenData = await exchangeCodeForToken(config, code, codeVerifier);
+  sessionStorage.removeItem(STORAGE_KEYS.CODE_VERIFIER);
+  sessionStorage.removeItem(STORAGE_KEYS.STATE);
+  saveTokenData(tokenData);
+  window.history.replaceState({}, document.title, window.location.pathname);
+
+  return true;
+};
+
+export const ensureValidToken = async (
+  config: ResolvedAuthConfig
+): Promise<string | null> => {
+  const tokenData = getStoredTokenData();
+  if (!tokenData) {
+    return null;
+  }
+
+  if (isTokenExpired(tokenData) || shouldRefreshToken(tokenData)) {
+    return refreshTokenIfNeeded(config, tokenData);
+  }
+
+  return tokenData.access_token;
+};
+
+export const login = async (config: AuthConfiguration): Promise<void> => {
+  const resolvedConfig = resolveAuthConfig(config);
+  const pkce = await generatePKCEChallenge();
+  const state = generateRandomString(32);
+
+  sessionStorage.setItem(STORAGE_KEYS.CODE_VERIFIER, pkce.code_verifier);
+  sessionStorage.setItem(STORAGE_KEYS.STATE, state);
+
+  const params = new URLSearchParams({
+    client_id: resolvedConfig.clientId,
+    redirect_uri: resolvedConfig.redirectUri,
+    response_type: "code",
+    scope: resolvedConfig.scope,
+    state,
+    code_challenge: pkce.code_challenge,
+    code_challenge_method: "S256",
+  });
+
+  window.location.href = `${resolvedConfig.authorizationEndpoint}?${params.toString()}`;
+};
+
+export const logout = (config: AuthConfiguration): void => {
+  clearTokenData();
+  sessionStorage.removeItem(STORAGE_KEYS.CODE_VERIFIER);
+  sessionStorage.removeItem(STORAGE_KEYS.STATE);
+
+  const resolvedConfig = resolveAuthConfig(config);
+  if (resolvedConfig.postLogoutRedirectUri) {
+    window.location.href = resolvedConfig.postLogoutRedirectUri;
+  }
+};

--- a/apps/apollo-vertex/registry/shell/shell-user-profile.tsx
+++ b/apps/apollo-vertex/registry/shell/shell-user-profile.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useAuth } from "@uipath/auth-react";
 import { AnimatePresence, motion } from "framer-motion";
 import { LogOut } from "lucide-react";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
@@ -10,29 +9,28 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { useAuth } from "./use-auth";
 
 interface UserProfileProps {
   isCollapsed: boolean;
 }
 
 export const UserProfile = ({ isCollapsed }: UserProfileProps) => {
-  const auth = useAuth();
+  const { user, logout } = useAuth();
 
-  const user = auth?.user;
-
-  const userInitials = user?.profile?.name
-    ? user.profile.name
+  const userInitials = user?.name
+    ? user.name
         .split(" ")
         .map((n: string) => n[0])
         .join("")
         .toUpperCase()
         .slice(0, 2)
-    : (user?.profile?.preferred_username?.[0]?.toUpperCase() ?? "U");
-  const firstName = user?.profile?.first_name as string;
-  const lastName = user?.profile?.last_name as string;
+    : "U";
+  const firstName = user?.first_name ?? user?.name?.split(" ")[0] ?? "";
+  const lastName = user?.last_name ?? user?.name?.split(" ").slice(1).join(" ") ?? "";
 
   const handleSignOut = () => {
-    auth?.signoutRedirect?.();
+    logout();
   };
 
   return (
@@ -93,7 +91,7 @@ export const UserProfile = ({ isCollapsed }: UserProfileProps) => {
               {firstName} {lastName}
             </span>
             <span className="text-xs text-sidebar-foreground/70 truncate">
-              {user?.profile?.email ?? "user@company.com"}
+              {user?.email ?? "user@company.com"}
             </span>
           </motion.div>
         </motion.div>
@@ -130,10 +128,10 @@ export const UserProfile = ({ isCollapsed }: UserProfileProps) => {
             <div className="flex flex-col gap-2 p-2">
               <div className="flex flex-col gap-0.5">
                 <span className="text-sm font-medium">
-                  {user?.profile?.name ?? "Business user"}
+                  {user?.name ?? "Business user"}
                 </span>
                 <span className="text-xs opacity-60">
-                  {user?.profile?.email ?? "user@company.com"}
+                  {user?.email ?? "user@company.com"}
                 </span>
               </div>
             </div>

--- a/apps/apollo-vertex/registry/shell/shell.tsx
+++ b/apps/apollo-vertex/registry/shell/shell.tsx
@@ -1,11 +1,8 @@
-import {
-  type AuthConfiguration,
-  AuthGuard,
-  type SigninArgsWithState,
-  UiPathAuthProvider,
-  type User,
-} from "@uipath/auth-react";
 import type { FC, PropsWithChildren } from "react";
+import { type AuthConfiguration } from "./auth-config";
+import type { UserInfo } from "./auth-context";
+import { AuthGuard } from "./auth-guard";
+import { AuthProvider } from "./auth-provider";
 import { ShellLayout } from "./shell-layout";
 import { LocaleProvider } from "./shell-locale-provider";
 
@@ -15,39 +12,79 @@ export interface CompanyLogo {
 }
 
 export interface ApolloShellProps extends PropsWithChildren {
+  /**
+   * Authentication configuration for the PKCE OAuth flow
+   */
   configuration: AuthConfiguration;
-  onSigninCallback: (user: void | User) => void;
-  extraSigninRequestArgs?: SigninArgsWithState;
+  /**
+   * Callback invoked after successful sign-in
+   */
+  onSigninCallback?: (user: UserInfo | null) => void;
+  /**
+   * The company name to display in the shell
+   */
   companyName: string;
+  /**
+   * The product name to display in the shell
+   */
   productName: string;
+  /**
+   * Optional company logo configuration
+   */
   companyLogo?: CompanyLogo;
+  /**
+   * Custom loading component to show while checking auth status
+   */
+  loadingComponent?: React.ReactNode;
+  /**
+   * Custom login component to show when not authenticated
+   */
+  loginComponent?: React.ReactNode;
+  /**
+   * The variant of the shell
+   */
+  variant?: "minimal";
 }
 
 export const ApolloShell: FC<ApolloShellProps> = ({
+  variant,
   children,
   configuration,
   onSigninCallback,
-  extraSigninRequestArgs,
   companyName,
   productName,
   companyLogo,
+  loadingComponent,
+  loginComponent,
 }) => {
   return (
-    <UiPathAuthProvider
+    <AuthProvider
       configuration={configuration}
       onSigninCallback={onSigninCallback}
     >
-      <AuthGuard extraSigninRequestArgs={extraSigninRequestArgs}>
+      <AuthGuard
+        loadingComponent={loadingComponent}
+        loginComponent={loginComponent}
+      >
         <LocaleProvider>
           <ShellLayout
             companyName={companyName}
             productName={productName}
             companyLogo={companyLogo}
+            variant={variant}
           >
             {children}
           </ShellLayout>
         </LocaleProvider>
       </AuthGuard>
-    </UiPathAuthProvider>
+    </AuthProvider>
   );
 };
+
+export type { AuthConfiguration } from "./auth-config";
+export type { AuthContextValue, UserInfo } from "./auth-context";
+export { AuthGuard } from "./auth-guard";
+export { AuthLogin } from "./auth-login";
+export { AuthProvider } from "./auth-provider";
+// Re-export auth utilities for consumers
+export { useAuth } from "./use-auth";

--- a/apps/apollo-vertex/registry/shell/use-auth.ts
+++ b/apps/apollo-vertex/registry/shell/use-auth.ts
@@ -1,0 +1,18 @@
+"use client";
+
+import { useContext } from "react";
+import { AuthContext } from "./auth-context";
+
+export const useAuth = () => {
+  const context = useContext(AuthContext);
+  return (
+    context ?? {
+      user: null,
+      isAuthenticated: false,
+      isLoading: false,
+      login: async () => {},
+      logout: () => {},
+      accessToken: null,
+    }
+  );
+};

--- a/apps/apollo-vertex/templates/ShellTemplateWithAuth.tsx
+++ b/apps/apollo-vertex/templates/ShellTemplateWithAuth.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import {
+  ApolloShell,
+  AuthConfiguration,
+  UserInfo,
+} from "@/registry/shell/shell";
+import { ShellLayout } from "@/registry/shell/shell-layout";
+import { LocaleProvider } from "@/registry/shell/shell-locale-provider";
+
+interface ShellTemplateProps {
+  variant?: "minimal";
+}
+
+export function ShellTemplateWithAuth({ variant }: ShellTemplateProps) {
+  const configuration: AuthConfiguration = {
+    authority: "https://alpha.uipath.com/identity_",
+    clientId: "e74e5981-cde0-4cd4-971c-6525cfba86b5",
+    redirectUri: "http://localhost:3000/vertex-components/shell",
+    postLogoutRedirectUri: "http://localhost:3000/vertex-components/shell",
+    scope: "openid profile email offline_access",
+  };
+  return (
+    <ApolloShell
+      configuration={configuration}
+      companyName="UiPath"
+      variant={variant}
+      productName="Apollo Vertex"
+      onSigninCallback={(user: UserInfo | null) => {
+        if (user) {
+          console.log("user", user);
+        }
+      }}
+    >
+      <div />
+    </ApolloShell>
+  );
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -181,9 +181,6 @@ importers:
       '@tanstack/react-table':
         specifier: ^8.21.3
         version: 8.21.3(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@uipath/auth-react':
-        specifier: ^1.1.6
-        version: 1.1.6(oidc-client-ts@3.3.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@vercel/analytics':
         specifier: ^1.5.0
         version: 1.5.0(next@16.1.5(@babel/core@7.28.5)(babel-plugin-macros@3.1.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.94.2))(react@19.2.3)
@@ -5802,17 +5799,6 @@ packages:
     peerDependencies:
       typescript: '*'
 
-  '@uipath/auth-core@1.1.6':
-    resolution: {integrity: sha512-YZ935iFkw4WbNqsrPvEJgG3ao0ku/YOPck0iz3l+7K1e15nBCwNxIcsT9NOftkjpRhA8ofXK0hNPAcjMspI+cg==, tarball: https://npm.pkg.github.com/download/@uipath/auth-core/1.1.6/47545d809a1bb1924cec5c92958daa2f006a6d39}
-    engines: {node: '>=16'}
-
-  '@uipath/auth-react@1.1.6':
-    resolution: {integrity: sha512-KcZXa+G4bb23LHCq6NdngU75oLabPYLHbpS2TaTVFnDBY9x1TQoRTkXA1Zp8QYbHj/8xNTdL1XArBsL09+YIkw==, tarball: https://npm.pkg.github.com/download/@uipath/auth-react/1.1.6/aca2dae49a17e7ce3a5581593ddbab84d093f080}
-    engines: {node: '>=16'}
-    peerDependencies:
-      react: '>=16'
-      react-dom: '>=16'
-
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
 
@@ -8379,10 +8365,6 @@ packages:
   jose@6.1.3:
     resolution: {integrity: sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==}
 
-  js-cookie@3.0.5:
-    resolution: {integrity: sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==}
-    engines: {node: '>=14'}
-
   js-sha256@0.10.1:
     resolution: {integrity: sha512-5obBtsz9301ULlsgggLg542s/jqtddfOpV5KJc4hajc9JV8GeY2gZHSVpYBn4nWqAUTJ9v+xwtbJ1mIBgIH5Vw==}
 
@@ -8440,10 +8422,6 @@ packages:
   jsonparse@1.3.1:
     resolution: {integrity: sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==}
     engines: {'0': node >= 0.2.0}
-
-  jwt-decode@4.0.0:
-    resolution: {integrity: sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==}
-    engines: {node: '>=18'}
 
   katex@0.16.27:
     resolution: {integrity: sha512-aeQoDkuRWSqQN6nSvVCEFvfXdqo1OQiCmmW1kc9xSdjutPv7BGO7pqY9sQRJpMOGrEdfDgF2TfRXe5eUAD2Waw==}
@@ -9375,10 +9353,6 @@ packages:
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
 
-  oidc-client-ts@3.3.0:
-    resolution: {integrity: sha512-t13S540ZwFOEZKLYHJwSfITugupW4uYLwuQSSXyKH/wHwZ+7FvgHE7gnNJh1YQIZ1Yd1hKSRjqeXGSUtS0r9JA==}
-    engines: {node: '>=18'}
-
   on-finished@2.4.1:
     resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
     engines: {node: '>= 0.8'}
@@ -10174,13 +10148,6 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-
-  react-oidc-context@3.3.0:
-    resolution: {integrity: sha512-302T/ma4AOVAxrHdYctDSKXjCq9KNHT564XEO2yOPxRfxEP58xa4nz+GQinNl8x7CnEXECSM5JEjQJk3Cr5BvA==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      oidc-client-ts: ^3.1.0
-      react: '>=16.14.0'
 
   react-refresh@0.17.0:
     resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
@@ -17041,21 +17008,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@uipath/auth-core@1.1.6':
-    dependencies:
-      js-cookie: 3.0.5
-      oidc-client-ts: 3.3.0
-      uuid: 11.1.0
-
-  '@uipath/auth-react@1.1.6(oidc-client-ts@3.3.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
-    dependencies:
-      '@uipath/auth-core': 1.1.6
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
-      react-oidc-context: 3.3.0(oidc-client-ts@3.3.0)(react@19.2.3)
-    transitivePeerDependencies:
-      - oidc-client-ts
-
   '@ungap/structured-clone@1.3.0': {}
 
   '@vercel/analytics@1.5.0(next@16.1.5(@babel/core@7.28.5)(babel-plugin-macros@3.1.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.94.2))(react@19.2.3)':
@@ -19947,8 +19899,6 @@ snapshots:
 
   jose@6.1.3: {}
 
-  js-cookie@3.0.5: {}
-
   js-sha256@0.10.1: {}
 
   js-tokens@4.0.0: {}
@@ -20011,8 +19961,6 @@ snapshots:
       graceful-fs: 4.2.11
 
   jsonparse@1.3.1: {}
-
-  jwt-decode@4.0.0: {}
 
   katex@0.16.27:
     dependencies:
@@ -21193,10 +21141,6 @@ snapshots:
 
   obug@2.1.1: {}
 
-  oidc-client-ts@3.3.0:
-    dependencies:
-      jwt-decode: 4.0.0
-
   on-finished@2.4.1:
     dependencies:
       ee-first: 1.1.1
@@ -22030,11 +21974,6 @@ snapshots:
     dependencies:
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
-
-  react-oidc-context@3.3.0(oidc-client-ts@3.3.0)(react@19.2.3):
-    dependencies:
-      oidc-client-ts: 3.3.0
-      react: 19.2.3
 
   react-refresh@0.17.0: {}
 


### PR DESCRIPTION
## Summary

- Replace the `@uipath/auth-react` dependency with a custom PKCE OAuth implementation
- The custom implementation is adapted from the [invoice-processing vertical solution](https://github.com/UiPath/vertical-solution-invoice-processing)
- Uses native Web Crypto API for PKCE generation (no external dependencies needed)
- Maintains the same consumer-facing API pattern with `AuthConfiguration` props

## Changes

**New files:**
- `auth-config.ts` - Configuration types and storage keys
- `auth-context.ts` - Auth context and user info types  
- `auth-utils.ts` - Token management, PKCE generation, login/logout
- `auth-provider.tsx` - AuthProvider component with PKCE flow
- `auth-guard.tsx` - Guard component for protected routes
- `auth-login.tsx` - Login component
- `use-auth.ts` - useAuth hook

**Modified files:**
- `shell.tsx` - Use custom AuthProvider/AuthGuard instead of @uipath/auth-react
- `shell-user-profile.tsx` - Update for new user structure (`user.name` vs `user.profile.name`)
- `package.json` - Remove @uipath/auth-react dependency
- `registry.json` - Add new auth files, remove @uipath/auth-react
- `page.mdx` - Update documentation with new configuration format

## New AuthConfiguration

```typescript
const configuration: AuthConfiguration = {
  authority: 'https://staging.uipath.com/identity_',
  clientId: 'your-client-id',
  redirectUri: 'http://localhost:3000',
  postLogoutRedirectUri: 'http://localhost:3000',
  scope: 'openid profile email offline_access',
};
```

## Test plan

- [ ] Verify build passes
- [ ] Test login flow with UiPath identity provider
- [ ] Test token refresh works automatically
- [ ] Test logout redirects correctly
- [ ] Verify user info displays in shell user profile

🤖 Generated with [Claude Code](https://claude.com/claude-code)