### PR TITLE
fix(apollo-react): nest dynamic handle data under inputs to match resolver context

### DIFF
--- a/apps/storybook/.storybook/preview.tsx
+++ b/apps/storybook/.storybook/preview.tsx
@@ -30,6 +30,9 @@ import "@uipath/apollo-react/core/fonts/font.css";
 import "@uipath/apollo-react/canvas/styles/variables.css";
 import "@uipath/apollo-react/canvas/xyflow/style.css";
 
+// Import Apollo Wind pre-compiled styles for apollo-wind components used in stories
+import "@uipath/apollo-wind/styles.css";
+
 // Theme type definition
 type ThemeMode = "light" | "dark" | "light-hc" | "dark-hc";
 

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.stories.tsx
@@ -1160,9 +1160,7 @@ const AddTaskLoadingStory = () => {
     (nodeId: string, loading: boolean) => {
       setNodes((nds) =>
         nds.map((node) =>
-          node.id === nodeId
-            ? { ...node, data: { ...node.data, addTaskLoading: loading } }
-            : node
+          node.id === nodeId ? { ...node, data: { ...node.data, addTaskLoading: loading } } : node
         )
       );
     },

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.tsx
@@ -524,11 +524,7 @@ const StageNodeComponent = (props: StageNodeProps) => {
             {(onTaskAdd || onAddTaskFromToolbox) && !isReadOnly && (
               <ApTooltip content={addTaskLoading ? 'Loading...' : addTaskLabel} placement="top">
                 <span>
-                  <ApIconButton
-                    onClick={handleTaskAddClick}
-                    size="small"
-                    disabled={addTaskLoading}
-                  >
+                  <ApIconButton onClick={handleTaskAddClick} size="small" disabled={addTaskLoading}>
                     {addTaskLoading ? (
                       <ApCircularProgress size={20} />
                     ) : (
@@ -548,7 +544,10 @@ const StageNodeComponent = (props: StageNodeProps) => {
                 <ApLink
                   onClick={addTaskLoading ? undefined : handleTaskAddClick}
                   variant={FontVariantToken.fontSizeS}
-                  style={{ maxWidth: 'fit-content', pointerEvents: addTaskLoading ? 'none' : undefined }}
+                  style={{
+                    maxWidth: 'fit-content',
+                    pointerEvents: addTaskLoading ? 'none' : undefined,
+                  }}
                 >
                   {defaultContent}
                 </ApLink>

--- a/packages/apollo-react/src/canvas/schema/node-instance/index.ts
+++ b/packages/apollo-react/src/canvas/schema/node-instance/index.ts
@@ -1,4 +1,3 @@
-
 // Re-export types
 export type {
   InstanceDisplayConfig,

--- a/packages/apollo-react/src/canvas/storybook-utils/mocks/nodes.ts
+++ b/packages/apollo-react/src/canvas/storybook-utils/mocks/nodes.ts
@@ -105,14 +105,18 @@ export function createNode<T = Record<string, unknown>>(
   } = options;
 
   // Build base data with required fields for manifest system
+  const resolvedHandleConfigs = handleConfigurations ?? (data as any).handleConfigurations;
+  const resolvedSmartHandles = useSmartHandles ?? (data as any).useSmartHandles;
+  const resolvedExecutionStatus = executionStatus ?? (data as any).executionStatus;
+
   const baseData: Partial<BaseNodeData> = {
     nodeType: type,
     version: (data as any).version || '1.0.0',
     parameters: (data as any).parameters || {},
     display: display || (data as any).display,
-    handleConfigurations: handleConfigurations || (data as any).handleConfigurations,
-    useSmartHandles: useSmartHandles ?? (data as any).useSmartHandles,
-    executionStatus: executionStatus || (data as any).executionStatus,
+    ...(resolvedHandleConfigs !== undefined && { handleConfigurations: resolvedHandleConfigs }),
+    ...(resolvedSmartHandles !== undefined && { useSmartHandles: resolvedSmartHandles }),
+    ...(resolvedExecutionStatus !== undefined && { executionStatus: resolvedExecutionStatus }),
   };
 
   return {

--- a/packages/apollo-react/src/canvas/utils/manifest-resolver.ts
+++ b/packages/apollo-react/src/canvas/utils/manifest-resolver.ts
@@ -19,7 +19,7 @@ import { getCollapsedShape } from './collapse';
 /**
  * Context object passed to resolution functions
  */
-export interface ResolutionContext {
+export interface ResolutionContext extends Record<string, unknown> {
   /** Instance display overrides */
   display?: InstanceDisplayConfig;
   /** Instance input values */
@@ -268,6 +268,7 @@ export function resolveHandles(
         // Generate one handle per array item
         return array.map((item, index) => {
           const vars: TemplateVars = {
+            ...context,
             [itemVar]: item,
             [indexVar]: index,
           };
@@ -298,6 +299,8 @@ export function resolveHandles(
 
       return {
         ...handle,
+        id: replaceTemplateVars(handle.id, context),
+        label: handle.label ? replaceTemplateVars(handle.label, context) : undefined,
         visible,
       } as ResolvedHandle;
     });


### PR DESCRIPTION
## Summary
- Fix BaseNode handle resolution to support per-instance handleConfigurations in node data (Priority 2), enabling edge stories and runtime handle overrides without a manifest
- Fix three stale/incorrect useMemo dependency arrays in BaseNode: display missed data changes, handleConfigurations missed id, and smartHandleElements used connectedHandleIds.has (always Set.prototype.has — never changes)
- Fix createNode storybook utility to not pollute node data with undefined values for optional fields
- Add DynamicHandles story demonstrating repeat expressions and templated handle labels

<img width="1258" height="795" alt="image" src="https://github.com/user-attachments/assets/15905dd0-7620-479e-8886-a67e51da9d08" />
