### PR TITLE
feat(apollo-react): support skeleton loader in BaseNode

### DIFF
--- a/packages/apollo-react/src/canvas/components/BaseNode/BaseNode.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/BaseNode/BaseNode.stories.tsx
@@ -199,6 +199,24 @@ const sampleManifest: { nodes: NodeManifest[]; categories: CategoryManifest[] } 
         },
       ],
     },
+    {
+      nodeType: 'uipath.control-flow.terminate',
+      version: '1.0.0',
+      category: 'control',
+      tags: ['control', 'terminate'],
+      sortOrder: 6,
+      display: {
+        label: 'Terminate',
+        icon: 'git-branch',
+        shape: 'circle',
+      },
+      handleConfiguration: [
+        {
+          position: 'right',
+          handles: [{ id: 'out', type: 'source', handleType: 'output', label: 'Output' }],
+        },
+      ],
+    },
   ],
 };
 
@@ -629,6 +647,53 @@ function DynamicHandlesStory() {
   );
 }
 
+/**
+ * Creates nodes demonstrating loading/skeleton states for all shapes.
+ * Uses `data.loading: true` to enable the skeleton state.
+ */
+function createLoadingGrid(): Node<BaseNodeData>[] {
+  const shapes = [
+    { type: 'uipath.blank-node', shape: 'square' as const, label: 'Square' },
+    { type: 'uipath.control-flow.terminate', shape: 'circle' as const, label: 'Circle' },
+    { type: 'uipath.agent', shape: 'rectangle' as const, label: 'Rectangle' },
+  ];
+
+  return shapes.map((config, index) =>
+    createNode({
+      id: `loading-${config.shape}`,
+      type: config.type,
+      position: { x: 96 + index * 192, y: 96 },
+      data: {
+        nodeType: config.type,
+        version: '1.0.0',
+        loading: true, // Enable skeleton loading state
+        display: {
+          label: config.label,
+          subLabel: 'Loading...',
+          shape: config.shape,
+        },
+      },
+    })
+  );
+}
+
+function LoadingStory() {
+  const initialNodes = useMemo(() => createLoadingGrid(), []);
+  const { canvasProps } = useCanvasStory({ initialNodes });
+
+  return (
+    <BaseCanvas {...canvasProps} mode="design">
+      <Panel position="bottom-right">
+        <CanvasPositionControls translations={DefaultCanvasTranslations} />
+      </Panel>
+      <StoryInfoPanel
+        title="Loading State"
+        description="Nodes in skeleton loading state for circle, square, and rectangle shapes."
+      />
+    </BaseCanvas>
+  );
+}
+
 // ============================================================================
 // Exported Stories
 // ============================================================================
@@ -752,4 +817,9 @@ export const ValidationStates: Story = {
     }),
   ],
   render: () => <ValidationStatesStory />,
+};
+
+export const Loading: Story = {
+  name: 'Loading',
+  render: () => <LoadingStory />,
 };

--- a/packages/apollo-react/src/canvas/components/BaseNode/BaseNode.styles.ts
+++ b/packages/apollo-react/src/canvas/components/BaseNode/BaseNode.styles.ts
@@ -1,5 +1,6 @@
 import { css, keyframes } from '@emotion/react';
 import styled from '@emotion/styled';
+import { ApSkeleton } from '../../../material/components/ap-skeleton';
 import type { NodeShape } from '../../schema';
 import type { FooterVariant } from './BaseNode.types';
 
@@ -9,6 +10,31 @@ const NODE_HEIGHT_DEFAULT = GRID_UNIT * 6; // 96px
 const NODE_HEIGHT_FOOTER_BUTTON = GRID_UNIT * 9; // 144px
 const NODE_HEIGHT_FOOTER_SINGLE = GRID_UNIT * 10; // 160px
 const NODE_HEIGHT_FOOTER_DOUBLE = GRID_UNIT * 11; // 176px
+
+/**
+ * Computes the icon wrapper dimensions for a given shape and node size.
+ * Shared between BaseIconWrapper and BaseSkeletonIcon for consistency.
+ */
+const getIconDimensions = (
+  shape: NodeShape | undefined,
+  nodeHeight: number | undefined,
+  nodeWidth: number | undefined
+) => {
+  const height = nodeHeight ?? 96;
+  const width = nodeWidth ?? 96;
+
+  // Width: Use default 3/4 scaling, derived from the height for rectangle, and use width for other shapes
+  const widthDimension = height !== width && shape === 'rectangle' ? height : width;
+  const widthScaleFactor = widthDimension / 96;
+  const iconWidth = 72 * widthScaleFactor;
+
+  // Height: Use 7/8 scaling for a vertical rectangle (expandable node), and use default 3/4 scaling for other shapes
+  const heightScaleFactor = height / 96;
+  const isExpandable = height !== width && shape !== 'rectangle';
+  const iconHeight = isExpandable ? 84 * heightScaleFactor : 72 * heightScaleFactor;
+
+  return { iconWidth, iconHeight };
+};
 
 const pulseAnimation = (cssVar: string) => keyframes`
   0% {
@@ -229,19 +255,13 @@ export const BaseIconWrapper = styled.div<{
   height?: number;
   width?: number;
 }>`
-  width: ${({ height, width, shape }) => {
-    // Use default 3/4 scaling, derived from the height for rectangle, and use width for other shapes
-    const dimension = height !== width && shape === 'rectangle' ? height : width;
-    const scaleFactor = dimension ? dimension / 96 : 1;
-    return `${72 * scaleFactor}px`;
-  }};
-  height: ${({ height, width, shape }) => {
-    // Use 7/8 scaling for a vertical rectangle, and use default 3/4 scaling for other shapes
-    const scaleFactor = height ? height / 96 : 1;
-    return height !== width && shape !== 'rectangle' // True for only a expandable node
-      ? `${84 * scaleFactor}px`
-      : `${72 * scaleFactor}px`;
-  }};
+  ${({ height, width, shape }) => {
+    const { iconWidth, iconHeight } = getIconDimensions(shape, height, width);
+    return css`
+      width: ${iconWidth}px;
+      height: ${iconHeight}px;
+    `;
+  }}
   display: flex;
   align-items: center;
   justify-content: center;
@@ -434,5 +454,29 @@ export const BaseBadgeSlot = styled.div<{
       case 'bottom-right':
         return `bottom: ${offset}; right: ${offset};`;
     }
+  }}
+`;
+
+/**
+ * Skeleton icon used in loading state. Uses the same dimension calculations as BaseIconWrapper.
+ */
+export const BaseSkeletonIcon = styled(ApSkeleton, {
+  shouldForwardProp: (prop) => prop !== 'shape' && prop !== 'nodeHeight' && prop !== 'nodeWidth',
+})<{
+  shape?: NodeShape;
+  nodeHeight?: number;
+  nodeWidth?: number;
+}>`
+  flex-grow: 0;
+  flex-shrink: 0;
+  ${({ shape, nodeHeight, nodeWidth }) => {
+    const { iconWidth, iconHeight } = getIconDimensions(shape, nodeHeight, nodeWidth);
+    const isCircle = shape === 'circle';
+
+    return css`
+      width: ${iconWidth}px;
+      height: ${iconHeight}px;
+      border-radius: ${isCircle ? '50%' : '8px'};
+    `;
   }}
 `;

--- a/packages/apollo-react/src/canvas/components/BaseNode/BaseNode.test.tsx
+++ b/packages/apollo-react/src/canvas/components/BaseNode/BaseNode.test.tsx
@@ -1,0 +1,111 @@
+import { render, screen } from '@testing-library/react';
+import type { Node, NodeProps } from '@uipath/apollo-react/canvas/xyflow/react';
+import { describe, expect, it, vi } from 'vitest';
+import type { BaseNodeData } from './BaseNode.types';
+
+// xyflow is globally mocked in canvas-mocks.ts; extend with updateNode.
+vi.mock('@uipath/apollo-react/canvas/xyflow/react', () => ({
+  Position: { Top: 'top', Bottom: 'bottom', Left: 'left', Right: 'right' },
+  useStore: () => false,
+  useUpdateNodeInternals: () => vi.fn(),
+  useReactFlow: () => ({ updateNodeData: vi.fn(), updateNode: vi.fn() }),
+}));
+
+vi.mock('../../hooks', () => ({
+  useNodeExecutionState: () => undefined,
+  useElementValidationStatus: () => undefined,
+}));
+
+vi.mock('../../core', () => ({
+  useNodeTypeRegistry: () => ({
+    getManifest: () => ({
+      display: { label: 'Test Node', shape: 'square', icon: 'test-icon' },
+      handleConfiguration: [],
+    }),
+  }),
+}));
+
+vi.mock('../BaseCanvas/BaseCanvasModeProvider', () => ({
+  useBaseCanvasMode: () => ({ mode: 'design' }),
+}));
+vi.mock('../BaseCanvas/ConnectedHandlesContext', () => ({ useConnectedHandles: () => new Set() }));
+vi.mock('../BaseCanvas/SelectionStateContext', () => ({
+  useSelectionState: () => ({ multipleNodesSelected: false }),
+}));
+vi.mock('../BaseCanvas/CanvasThemeContext', () => ({
+  useCanvasTheme: () => ({ isDarkMode: false }),
+}));
+vi.mock('../ButtonHandle/useButtonHandles', () => ({ useButtonHandles: () => null }));
+vi.mock('../ButtonHandle/SmartHandle', () => ({
+  SmartHandle: () => null,
+  SmartHandleProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+vi.mock('./BaseNodeConfigContext', () => ({ useBaseNodeOverrideConfig: () => ({}) }));
+vi.mock('../../utils/adornment-resolver', () => ({ resolveAdornments: () => ({}) }));
+vi.mock('../../utils/toolbar-resolver', () => ({ resolveToolbar: () => undefined }));
+vi.mock('@uipath/apollo-react/material/components', () => ({ ApIcon: () => null }));
+vi.mock('@uipath/apollo-react/canvas/utils', () => ({
+  cx: (...args: unknown[]) => args.filter(Boolean).join(' '),
+}));
+vi.mock('../../utils/icon-registry', () => ({
+  getIcon: () => () => <div data-testid="node-icon">Icon</div>,
+}));
+vi.mock('../../utils/manifest-resolver', () => ({
+  resolveDisplay: (display: Record<string, unknown> | undefined) => ({
+    label: 'Test Node',
+    subLabel: 'Test SubLabel',
+    shape: 'square',
+    icon: 'test-icon',
+    ...display,
+  }),
+  resolveHandles: () => [],
+}));
+
+vi.mock('./NodeLabel', () => ({
+  NodeLabel: ({ label }: { label?: string }) => <div data-testid="node-label">{label}</div>,
+}));
+
+import { BaseNode } from './BaseNode';
+
+const defaultProps: NodeProps<Node<BaseNodeData>> = {
+  id: 'test-node',
+  type: 'test',
+  data: {},
+  selected: false,
+  dragging: false,
+  draggable: true,
+  zIndex: 0,
+  isConnectable: true,
+  positionAbsoluteX: 0,
+  positionAbsoluteY: 0,
+  selectable: true,
+  deletable: true,
+};
+
+describe('BaseNode', () => {
+  describe('Loading state', () => {
+    it.each([
+      { loading: true, expectSkeleton: true },
+      { loading: false, expectSkeleton: false },
+      { loading: undefined, expectSkeleton: false },
+    ])('renders skeleton=$expectSkeleton when loading=$loading', ({ loading, expectSkeleton }) => {
+      const data = loading !== undefined ? { loading } : {};
+      render(<BaseNode {...defaultProps} data={data} />);
+
+      if (expectSkeleton) {
+        expect(screen.getByTestId('ap-skeleton')).toBeInTheDocument();
+        expect(screen.queryByTestId('node-icon')).not.toBeInTheDocument();
+      } else {
+        expect(screen.queryByTestId('ap-skeleton')).not.toBeInTheDocument();
+        expect(screen.getByTestId('node-icon')).toBeInTheDocument();
+      }
+    });
+
+    it('still renders label when loading', () => {
+      render(<BaseNode {...defaultProps} data={{ loading: true }} />);
+
+      expect(screen.getByTestId('ap-skeleton')).toBeInTheDocument();
+      expect(screen.getByText('Test Node')).toBeInTheDocument();
+    });
+  });
+});

--- a/packages/apollo-react/src/canvas/components/BaseNode/BaseNode.tsx
+++ b/packages/apollo-react/src/canvas/components/BaseNode/BaseNode.tsx
@@ -29,6 +29,7 @@ import {
   BaseContainer,
   BaseHeader,
   BaseIconWrapper,
+  BaseSkeletonIcon,
   BaseSubHeader,
   BaseTextContainer,
 } from './BaseNode.styles';
@@ -486,17 +487,29 @@ const BaseNodeComponent = (props: NodeProps<Node<BaseNodeData>>) => {
         backgroundColor={displayBackground}
         hasFooter={!!displayFooter}
         footerVariant={displayFooterVariant as FooterVariant}
+        aria-busy={data.loading || undefined}
       >
-        {Icon && (
-          <BaseIconWrapper
+        {data.loading ? (
+          // Always use rectangle variant; border-radius is controlled via shape prop
+          // to avoid ApSkeleton's circle variant overriding dimensions with !important.
+          <BaseSkeletonIcon
+            variant="rectangle"
             shape={displayShape}
-            color={displayColor}
-            backgroundColor={displayIconBackground}
-            height={displayFooter ? undefined : height}
-            width={displayFooter ? undefined : (width ?? height)}
-          >
-            {Icon}
-          </BaseIconWrapper>
+            nodeHeight={displayFooter ? undefined : height}
+            nodeWidth={displayFooter ? undefined : (width ?? height)}
+          />
+        ) : (
+          Icon && (
+            <BaseIconWrapper
+              shape={displayShape}
+              color={displayColor}
+              backgroundColor={displayIconBackground}
+              height={displayFooter ? undefined : height}
+              width={displayFooter ? undefined : (width ?? height)}
+            >
+              {Icon}
+            </BaseIconWrapper>
+          )
         )}
 
         {adornments?.topLeft && (

--- a/packages/apollo-react/src/canvas/components/BaseNode/BaseNode.types.ts
+++ b/packages/apollo-react/src/canvas/components/BaseNode/BaseNode.types.ts
@@ -29,6 +29,13 @@ export interface BaseNodeData extends Record<string, unknown> {
    * @default false
    */
   isCollapsed?: boolean;
+
+  /**
+   * When true, the icon area displays a skeleton shimmer placeholder.
+   * Other node elements (labels, handles, adornments) render normally.
+   * @default false
+   */
+  loading?: boolean;
 }
 
 export interface NodeAdornments {


### PR DESCRIPTION
use `loading` attribute in `NodeData` to render skeleton loader for BaseNode

<img width="755" height="267" alt="image" src="https://github.com/user-attachments/assets/42e3f814-ed09-49bf-9f9f-b85cb1a26273" />

