### PR TITLE
feat(apollo-react): use icon registry icons for sticky note toolbar [AG-746]

### DIFF
--- a/packages/apollo-react/src/canvas/components/StickyNoteNode/StickyNoteNode.tsx
+++ b/packages/apollo-react/src/canvas/components/StickyNoteNode/StickyNoteNode.tsx
@@ -1,7 +1,7 @@
 import { Global } from '@emotion/react';
 import type { NodeProps } from '@uipath/apollo-react/canvas/xyflow/react';
 import { NodeResizeControl, useReactFlow } from '@uipath/apollo-react/canvas/xyflow/react';
-import { ApIcon } from '@uipath/apollo-react/material/components';
+import { NodeIcon } from '@uipath/apollo-react/canvas';
 import { AnimatePresence } from 'motion/react';
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import ReactMarkdown from 'react-markdown';
@@ -176,13 +176,13 @@ const StickyNoteNodeComponent = ({
     const actions: ToolbarAction[] = [
       {
         id: 'delete',
-        icon: <ApIcon variant="outlined" name="delete" />,
+        icon: <NodeIcon icon="trash" size={14} />,
         label: 'Delete',
         onAction: handleDelete,
       },
       {
         id: 'edit',
-        icon: <ApIcon variant="outlined" name="edit" />,
+        icon: <NodeIcon icon="pencil" size={14} />,
         label: 'Edit',
         onAction: handleEditClick,
       },

--- a/packages/apollo-react/src/canvas/utils/collapse.ts
+++ b/packages/apollo-react/src/canvas/utils/collapse.ts
@@ -31,7 +31,7 @@ export const getCollapsedShape = (originalShape?: NodeShape): NodeShape | undefi
  * Other shapes remain unchanged.
  */
 export const getExpandedShape = (collapsedShape?: NodeShape): NodeShape | undefined => {
-  return collapsedShape === 'square' ? 'rectangle' : collapsedShape ?? undefined;
+  return collapsedShape === 'square' ? 'rectangle' : (collapsedShape ?? undefined);
 };
 
 /**


### PR DESCRIPTION
https://uipath.atlassian.net/browse/AG-746

Using NodeIcon to leverage icon-registry so we can use Lucide icons and be consistent with the BaseNode's toolbar

https://github.com/user-attachments/assets/ef88f99a-24c1-40f7-abbf-bfe76e429cb2

