### PR TITLE
fix(apollo-react): handles in flow [MST-6514]

### DIFF
--- a/packages/apollo-react/src/canvas/components/ButtonHandle/ButtonHandle.styles.tsx
+++ b/packages/apollo-react/src/canvas/components/ButtonHandle/ButtonHandle.styles.tsx
@@ -80,7 +80,11 @@ export const StyledLine = styled.div<{ $isVertical: boolean; $selected: boolean;
   transition: border-color 0.2s ease-in-out;
 `;
 
-export const StyledLabel = styled.div<{ $position: Position; $backgroundColor: string }>`
+export const StyledLabel = styled.div<{
+  $position: Position;
+  $backgroundColor: string;
+  $shouldTruncate?: boolean;
+}>`
   position: absolute;
   background-color: ${(p) => p.$backgroundColor};
   padding: 2px 6px;
@@ -88,6 +92,12 @@ export const StyledLabel = styled.div<{ $position: Position; $backgroundColor: s
   z-index: 1;
   white-space: nowrap;
   user-select: none;
+  ${(p) =>
+    p.$shouldTruncate &&
+    css`
+      max-width: 50px;
+      overflow: hidden;
+    `}
 
   ${(p) =>
     p.$position === Position.Top &&

--- a/packages/apollo-react/src/canvas/components/ButtonHandle/ButtonHandle.tsx
+++ b/packages/apollo-react/src/canvas/components/ButtonHandle/ButtonHandle.tsx
@@ -147,6 +147,10 @@ const ButtonHandleBase = ({
   const markAsHovered = useCallback(() => setIsHovered(true), []);
   const unmarkAsHovered = useCallback(() => setIsHovered(false), []);
 
+  const shouldTruncateLabel = useMemo(() => {
+    return showButton && !!onAction && type === 'source' && !isVertical;
+  }, [showButton, onAction, type, isVertical]);
+
   return (
     <StyledHandle
       type={type}
@@ -162,12 +166,25 @@ const ButtonHandleBase = ({
       onMouseDown={unmarkAsHovered}
     >
       {label && (
-        <StyledLabel $position={position} $backgroundColor={labelBackgroundColor}>
+        <StyledLabel
+          $position={position}
+          $backgroundColor={labelBackgroundColor}
+          $shouldTruncate={shouldTruncateLabel}
+        >
           <Row align="center" gap={4}>
             {labelIcon}
             <ApTypography
               color="var(--uix-canvas-foreground-de-emp)"
               variant={FontVariantToken.fontSizeSBold}
+              sx={
+                shouldTruncateLabel
+                  ? {
+                      overflow: 'hidden',
+                      textOverflow: 'ellipsis',
+                      whiteSpace: 'nowrap',
+                    }
+                  : undefined
+              }
             >
               {label}
             </ApTypography>


### PR DESCRIPTION
add button was hidden due to text label for handles.
limitize the text length when add button needs to be shown


https://github.com/user-attachments/assets/1343f8a7-08f4-4272-bc6d-c3916bd9edd4

