### PR TITLE
fix(apollo-react): sort flattened nodes [MST-6261]

### DIFF
--- a/packages/apollo-react/src/canvas/core/CategoryTree.test.ts
+++ b/packages/apollo-react/src/canvas/core/CategoryTree.test.ts
@@ -754,6 +754,67 @@ describe('CategoryTree', () => {
       expect(rootCategories).toHaveLength(0);
     });
 
+    it('should sort all nodes by sortOrder', () => {
+      const categories: CategoryManifest[] = [
+        {
+          id: 'cat-a',
+          name: 'A',
+          icon: 'a',
+          parentId: undefined,
+          sortOrder: 1,
+          tags: [],
+          color: 'blue',
+          colorDark: 'darkBlue',
+        },
+        {
+          id: 'cat-b',
+          name: 'B',
+          icon: 'b',
+          parentId: undefined,
+          sortOrder: 2,
+          tags: [],
+          color: 'blue',
+          colorDark: 'darkBlue',
+        },
+      ];
+
+      const nodes: NodeManifest[] = [
+        {
+          nodeType: 'node-3',
+          category: 'cat-a',
+          version: '1.0.0',
+          display: { label: 'Node 3', icon: 'n' },
+          sortOrder: 3,
+          handleConfiguration: [],
+          tags: [],
+        },
+        {
+          nodeType: 'node-1',
+          category: 'cat-b',
+          version: '1.0.0',
+          display: { label: 'Node 1', icon: 'n' },
+          sortOrder: 1,
+          handleConfiguration: [],
+          tags: [],
+        },
+        {
+          nodeType: 'node-2',
+          category: undefined,
+          version: '1.0.0',
+          display: { label: 'Node 2', icon: 'n' },
+          sortOrder: 2,
+          handleConfiguration: [],
+          tags: [],
+        },
+      ];
+
+      const tree = new CategoryTree(categories, nodes);
+      const flattened = tree.flatten();
+      const rootNodes = flattened.getRootNodes();
+
+      expect(rootNodes.map((n) => n.nodeType)).toEqual(['node-1', 'node-2', 'node-3']);
+    });
+
     it('should preserve all nodes', () => {
       const categories = createMockCategories();
       const nodes = createMockNodes();

--- a/packages/apollo-react/src/canvas/core/CategoryTree.ts
+++ b/packages/apollo-react/src/canvas/core/CategoryTree.ts
@@ -405,6 +405,7 @@ export class CategoryTree {
     };
 
     const allNodes = collectNodes(this.rootCategories).concat(this.rootNodes);
+    allNodes.sort((a, b) => a.sortOrder - b.sortOrder);
     return CategoryTree.fromPrebuilt([], allNodes);
   }
 


### PR DESCRIPTION
- Add missing sort to flattened node results. This ensures that node sort order can override category sort order when searching all nodes.