### PR TITLE
fix(apollo-react): avoid button handles trigger on label click [MST-6600]

### DIFF
--- a/packages/apollo-react/src/canvas/components/ButtonHandle/ButtonHandle.tsx
+++ b/packages/apollo-react/src/canvas/components/ButtonHandle/ButtonHandle.tsx
@@ -170,6 +170,7 @@ const ButtonHandleBase = ({
           $position={position}
           $backgroundColor={labelBackgroundColor}
           $shouldTruncate={shouldTruncateLabel}
+          onClick={(e) => e.stopPropagation()}
         >
           <Row align="center" gap={4}>
             {labelIcon}


### PR DESCRIPTION
### Description

This PR

- Prevents unintended handle action triggers when clicking on handle labels in the canvas ButtonHandle component

### Demo


https://github.com/user-attachments/assets/f9367fcd-772b-4bd9-9a00-e8e78689ae86

