### PR TITLE
fix(apollo-react): update items in addnodepanel for dynamic nodes

### DIFF
--- a/packages/apollo-react/src/canvas/components/Toolbox/Toolbox.tsx
+++ b/packages/apollo-react/src/canvas/components/Toolbox/Toolbox.tsx
@@ -273,6 +273,15 @@ export function Toolbox<T>({
     }
   }, [initialItems, navigationStack, currentParentItem]);
 
+  // Re-run active search when items change so results reflect newly loaded data
+  // (e.g. dynamic manifests streaming in while a search query is already entered).
+  // biome-ignore lint/correctness/useExhaustiveDependencies: Only re-run when items update, not on search/handleSearch changes
+  useEffect(() => {
+    if (search) {
+      handleSearch(search);
+    }
+  }, [items]);
+
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
       if (e.key === 'Escape') {


### PR DESCRIPTION
re-run search query if items themselves change
this helps in the case that a user searches while items in the panel are still loading in