### PR TITLE
feat(apollo-react): add label support to SequenceEdge

### DIFF
--- a/packages/apollo-react/src/canvas/components/Edges/SequenceEdge.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/Edges/SequenceEdge.stories.tsx
@@ -312,6 +312,160 @@ function DefaultStory() {
 }
 
 // ============================================================================
+// Edge Labels Story
+// ============================================================================
+
+function EdgeLabelsStory() {
+  const initialNodes = useMemo(
+    () => [
+      createStickyNote(
+        'sticky-labels',
+        'green',
+        '**Edge Labels**\nLabels rendered at edge midpoint via data.label',
+        { x: 100, y: 80 },
+        { width: 550, height: 590 }
+      ),
+
+      // Horizontal edges with labels
+      createNode({
+        id: 'label-source-1',
+        label: 'Source',
+        x: 130,
+        y: 160,
+        sourcePositions: [Position.Right],
+      }),
+      createNode({
+        id: 'label-target-1',
+        label: 'Target',
+        x: 470,
+        y: 160,
+        targetPositions: [Position.Left],
+      }),
+
+      // Vertical edges with labels
+      createNode({
+        id: 'label-source-2',
+        label: 'Start',
+        x: 300,
+        y: 300,
+        sourcePositions: [Position.Bottom],
+      }),
+      createNode({
+        id: 'label-target-2',
+        label: 'End',
+        x: 300,
+        y: 480,
+        targetPositions: [Position.Top],
+      }),
+
+      // Diff edge with label
+      createStickyNote(
+        'sticky-labels-diff',
+        'white',
+        '**Labels + Diff States**\nEdge labels work alongside diff styling',
+        { x: 760, y: 80 },
+        { width: 420, height: 340 }
+      ),
+      createNode({
+        id: 'label-added-source',
+        label: 'Added',
+        x: 800,
+        y: 160,
+        sourcePositions: [Position.Right],
+      }),
+      createNode({
+        id: 'label-added-target',
+        label: 'Target',
+        x: 1020,
+        y: 160,
+        targetPositions: [Position.Left],
+      }),
+      createNode({
+        id: 'label-removed-source',
+        label: 'Removed',
+        x: 800,
+        y: 300,
+        sourcePositions: [Position.Right],
+      }),
+      createNode({
+        id: 'label-removed-target',
+        label: 'Target',
+        x: 1020,
+        y: 300,
+        targetPositions: [Position.Left],
+      }),
+
+      createStickyNote(
+        'sticky-info-labels',
+        'pink',
+        '## Edge Labels\n\nSet `data.label` on an edge to display a label at the edge midpoint.\n\n**Features:**\n- Rendered via SVG foreignObject\n- Positioned at computed midpoint (labelX, labelY)\n- Styled consistently with StageEdge labels\n- Works with all edge states (diff, selected, etc.)',
+        { x: 100, y: 720 },
+        { width: 350, height: 280 }
+      ),
+    ],
+    []
+  );
+
+  const initialEdges: Edge[] = useMemo(
+    () => [
+      {
+        id: 'e-label-horizontal',
+        source: 'label-source-1',
+        target: 'label-target-1',
+        sourceHandle: `out-${Position.Right}`,
+        targetHandle: `in-${Position.Left}`,
+        type: 'sequence',
+        data: { label: 'Success' },
+      },
+      {
+        id: 'e-label-vertical',
+        source: 'label-source-2',
+        target: 'label-target-2',
+        sourceHandle: `out-${Position.Bottom}`,
+        targetHandle: `in-${Position.Top}`,
+        type: 'sequence',
+        data: { label: 'Next Step' },
+      },
+      {
+        id: 'e-label-added',
+        source: 'label-added-source',
+        target: 'label-added-target',
+        sourceHandle: `out-${Position.Right}`,
+        targetHandle: `in-${Position.Left}`,
+        type: 'sequence',
+        data: { isDiffAdded: true, label: 'New connection' },
+        style: { stroke: 'var(--palette-positive-base)' },
+      },
+      {
+        id: 'e-label-removed',
+        source: 'label-removed-source',
+        target: 'label-removed-target',
+        sourceHandle: `out-${Position.Right}`,
+        targetHandle: `in-${Position.Left}`,
+        type: 'sequence',
+        data: { isDiffRemoved: true, label: 'Deprecated' },
+        style: { stroke: 'var(--palette-negative-base)', strokeDasharray: '5,5' },
+      },
+    ],
+    []
+  );
+
+  const { canvasProps } = useCanvasStory({
+    initialNodes,
+    initialEdges,
+    additionalNodeTypes: nodeTypes,
+  });
+
+  return (
+    <BaseCanvas {...canvasProps} edgeTypes={edgeTypes} mode="design">
+      <Panel position="bottom-right">
+        <CanvasPositionControls translations={DefaultCanvasTranslations} />
+      </Panel>
+    </BaseCanvas>
+  );
+}
+
+// ============================================================================
 // Readonly Mode Story (Execution States)
 // ============================================================================
 
@@ -806,6 +960,18 @@ function LoopEdgesStory() {
 
 export const Default: Story = {
   render: () => <DefaultStory />,
+};
+
+export const EdgeLabels: Story = {
+  render: () => <EdgeLabelsStory />,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Demonstrates edge labels rendered at the midpoint via data.label. Labels work alongside all edge states including diff styling.',
+      },
+    },
+  },
 };
 
 export const ExecutionStates: Story = {

--- a/packages/apollo-react/src/canvas/components/Edges/SequenceEdge.tsx
+++ b/packages/apollo-react/src/canvas/components/Edges/SequenceEdge.tsx
@@ -89,7 +89,7 @@ export const SequenceEdge = memo(function SequenceEdge({
   const angle = ANGLE_MAP[targetPosition];
   const { x: offsetX, y: offsetY } = ARROW_OFFSETS[targetPosition];
 
-  const { edgePath } = useEdgePath({
+  const { edgePath, labelX, labelY } = useEdgePath({
     sourceNodeId: source,
     targetNodeId: target,
     sourceHandleId,
@@ -203,6 +203,38 @@ export const SequenceEdge = memo(function SequenceEdge({
         />
 
         {getStatusAnimation(status, edgePath)}
+
+        {/* Edge label from data */}
+        {typeof data?.label === 'string' && data.label.length > 0 && (
+          <foreignObject
+            x={labelX}
+            y={labelY}
+            width={1}
+            height={1}
+            overflow="visible"
+            style={{ pointerEvents: 'none' }}
+          >
+            <div
+              className="react-flow__edge-label nodrag nopan"
+              style={{
+                position: 'absolute',
+                transform: 'translate(-50%, -50%)',
+                whiteSpace: 'nowrap',
+                pointerEvents: 'none',
+                color: 'var(--uix-canvas-foreground)',
+                background: 'var(--uix-canvas-background)',
+                padding: '4px 8px',
+                borderRadius: '4px',
+                fontSize: '12px',
+                fontWeight: 500,
+                border: `1px solid ${selected ? 'var(--uix-canvas-primary)' : 'var(--uix-canvas-border)'}`,
+                boxShadow: '0 1px 3px 0 rgba(0, 0, 0, 0.1)',
+              }}
+            >
+              {data.label}
+            </div>
+          </foreignObject>
+        )}
       </g>
 
       {/* Edge toolbar for adding nodes */}

--- a/packages/apollo-react/src/canvas/schema/node-instance/edge.ts
+++ b/packages/apollo-react/src/canvas/schema/node-instance/edge.ts
@@ -12,6 +12,13 @@ export const edgeSchema = z.object({
   targetNodeId: idSchema,
   /** The target port name (input port) */
   targetPort: z.string().min(1),
+  data: z
+    .object({
+      /** Optional label displayed at the edge midpoint */
+      label: z.string().optional(),
+    })
+    .passthrough()
+    .optional(),
 });
 
 // Export inferred TypeScript type


### PR DESCRIPTION
## Summary
- **SequenceEdge** now renders edge labels when `data.label` is provided, using an SVG `<foreignObject>` at the edge midpoint (`labelX`, `labelY` from `useEdgePath`)
- Extended `edgeSchema` with an optional `data.label` string field
- Added **EdgeLabels** Storybook story demonstrating horizontal, vertical, and diff-state labels

<img width="655" height="655" alt="image" src="https://github.com/user-attachments/assets/3b81e007-7379-49b5-850d-fda0839dbd25" />


## Details

The `SequenceEdge` component previously ignored `data.label` entirely, forcing consumers to duplicate the full edge implementation just to add label rendering. This change:

1. Destructures `labelX`/`labelY` from `useEdgePath` (already computed, previously unused)
2. Renders the label inside the edge's SVG `<g>` via `<foreignObject>` — this keeps it in the same stacking context as the edge, so it stays visible above the selection outline when selected
3. Styles the label consistently with `StageEdgeLabel` (font, padding, border, background)
4. Border color switches to primary when the edge is selected

## Test plan
- [x] Verify label renders at edge midpoint when `data.label` is set
- [x] Verify label stays above the selection outline when edge is selected
- [x] Verify label does not interfere with edge toolbar
- [x] Verify edges without `data.label` are unaffected
- [x] Verify EdgeLabels Storybook story renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)