### PR TITLE
fix(apollo-react): resolve sankey diagram label overlap

### DIFF
--- a/apps/react-playground/src/pages/components/ApSankeyShowcase.tsx
+++ b/apps/react-playground/src/pages/components/ApSankeyShowcase.tsx
@@ -1,5 +1,5 @@
-import { ApSankeyDiagram } from "@uipath/apollo-react/material/components";
 import * as ApolloCore from "@uipath/apollo-react/core";
+import { ApSankeyDiagram } from "@uipath/apollo-react/material/components";
 import {
 	PageContainer,
 	PageDescription,


### PR DESCRIPTION
## Summary
- Replace character-count-based label truncation with pixel-accurate canvas `measureText` truncation using binary search
- Place all node labels to the right of their nodes (remove left/right midpoint logic)
- Increase label font size from `fontSizeS` to `fontSizeL` with explicit font family
- Truncate labels based on available gap to the next column; last-column labels are never truncated

<img width="1409" height="770" alt="Screenshot 2026-02-23 at 2 28 38 PM" src="https://github.com/user-attachments/assets/569376ee-eeed-4d4b-b1c8-87d6d169a69b" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)