### PR TITLE
feat(apollo-wind): enable React Compiler

### DIFF
--- a/packages/apollo-wind/.storybook/main.ts
+++ b/packages/apollo-wind/.storybook/main.ts
@@ -50,6 +50,17 @@ const config: StorybookConfig = {
     : undefined,
 
   async viteFinal(config) {
+    // Enable React Compiler in Storybook so react-scan reflects real perf
+    const react = await import('@vitejs/plugin-react');
+    config.plugins ??= [];
+    config.plugins.push(
+      react.default({
+        babel: {
+          plugins: [['babel-plugin-react-compiler', { target: '18' }]],
+        },
+      })
+    );
+
     return {
       ...config,
       resolve: {

--- a/packages/apollo-wind/package.json
+++ b/packages/apollo-wind/package.json
@@ -86,6 +86,7 @@
     "jsep": "^1.4.0",
     "lucide-react": "^0.555.0",
     "next-themes": "^0.4.6",
+    "react-compiler-runtime": "^1.0.0",
     "react-day-picker": "^9.13.0",
     "react-hook-form": "^7.66.1",
     "react-resizable-panels": "^3.0.6",
@@ -96,6 +97,7 @@
     "zod": "^4.3.5"
   },
   "devDependencies": {
+    "@rsbuild/plugin-babel": "^1.0.6",
     "@rsbuild/plugin-react": "^1.4.1",
     "@rslib/core": "^0.17.0",
     "@semantic-release/changelog": "^6.0.3",
@@ -113,10 +115,12 @@
     "@types/node": "^24.10.1",
     "@types/react": "^19.2.6",
     "@types/react-dom": "^19.2.2",
+    "@vitejs/plugin-react": "^4.7.0",
     "@vitest/coverage-v8": "^4.0.14",
     "@vitest/ui": "^4.0.14",
     "ajv": "^8.17.1",
     "autoprefixer": "^10.4.22",
+    "babel-plugin-react-compiler": "1.0.0",
     "globals": "^16.5.0",
     "jest-axe": "^10.0.0",
     "jsdom": "^27.2.0",

--- a/packages/apollo-wind/rslib.config.ts
+++ b/packages/apollo-wind/rslib.config.ts
@@ -1,3 +1,4 @@
+import { pluginBabel } from '@rsbuild/plugin-babel';
 import { pluginReact } from '@rsbuild/plugin-react';
 import type { RslibConfig } from '@rslib/core';
 import { defineConfig } from '@rslib/core';
@@ -56,7 +57,19 @@ export default defineConfig({
       'postcss.config.export': './postcss.config.export.js',
     },
   },
-  plugins: [pluginReact()],
+  plugins: [
+    pluginReact(),
+    pluginBabel({
+      include: /\.(?:jsx?|tsx?)$/,
+      babelLoaderOptions(opts) {
+        if (!opts.plugins) {
+          opts.plugins = [];
+        }
+        opts.plugins.unshift(['babel-plugin-react-compiler', { target: '18' }]);
+        return opts;
+      },
+    }),
+  ],
   output: {
     target: 'web',
     cleanDistPath: true,

--- a/packages/apollo-wind/src/components/forms/form-designer.tsx
+++ b/packages/apollo-wind/src/components/forms/form-designer.tsx
@@ -1,20 +1,35 @@
-import { useState, useMemo, useEffect } from 'react';
-import type {
-  FormSchema,
-  FieldMetadata,
-  FieldRule,
-  FieldCondition,
-  DataSource,
-  FieldType,
-  FormPlugin,
-  ValidationConfig,
-} from './form-schema';
-import { schemaToJson } from './schema-serializer';
-import { MetadataForm } from './metadata-form';
+import {
+  AlertTriangle,
+  Asterisk,
+  Ban,
+  ChevronRight,
+  Code,
+  Database,
+  Eye,
+  EyeOff,
+  GitBranch,
+  GripVertical,
+  Layers,
+  MoveDown,
+  MoveUp,
+  Plus,
+  Settings,
+  Trash2,
+  View,
+} from 'lucide-react';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from '@/components/ui/accordion';
 import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Checkbox } from '@/components/ui/checkbox';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import { Textarea } from '@/components/ui/textarea';
+import { Grid } from '@/components/ui/layout/grid';
 import {
   Select,
   SelectContent,
@@ -22,37 +37,22 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import { Checkbox } from '@/components/ui/checkbox';
-import { Switch } from '@/components/ui/switch';
-import {
-  Trash2,
-  Plus,
-  MoveUp,
-  MoveDown,
-  Eye,
-  EyeOff,
-  Code,
-  Database,
-  GitBranch,
-  Layers,
-  ChevronRight,
-  GripVertical,
-  Settings,
-  AlertTriangle,
-  Asterisk,
-  Ban,
-  View,
-} from 'lucide-react';
 import { Separator } from '@/components/ui/separator';
-import {
-  Accordion,
-  AccordionContent,
-  AccordionItem,
-  AccordionTrigger,
-} from '@/components/ui/accordion';
-import { Grid } from '@/components/ui/layout/grid';
+import { Switch } from '@/components/ui/switch';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { Textarea } from '@/components/ui/textarea';
+import type {
+  DataSource,
+  FieldCondition,
+  FieldMetadata,
+  FieldRule,
+  FieldType,
+  FormPlugin,
+  FormSchema,
+  ValidationConfig,
+} from './form-schema';
+import { MetadataForm } from './metadata-form';
+import { schemaToJson } from './schema-serializer';
 
 /**
  * Enhanced Form Designer Component
@@ -669,7 +669,11 @@ function FieldConfigForm({ field, onUpdate, allFields, existingFieldNames }: Fie
   const schema = useMemo(() => createFieldConfigSchema(field), [field]);
 
   // Track current type for detecting type changes
-  const currentTypeRef = useMemo(() => ({ type: field.type }), [field.type]);
+  const currentTypeRef = useRef(field.type);
+
+  useEffect(() => {
+    currentTypeRef.current = field.type;
+  }, [field.type]);
 
   // Sync plugin - updates parent on any value change
   const plugins = useMemo<FormPlugin[]>(
@@ -734,7 +738,7 @@ function FieldConfigForm({ field, onUpdate, allFields, existingFieldNames }: Fie
           }
 
           // Clear properties from previous type if type changed
-          if (newType !== currentTypeRef.type) {
+          if (newType !== currentTypeRef.current) {
             // Preserve requiredMessage across type changes
             const preservedRequiredMessage = field.validation?.requiredMessage;
 
@@ -781,14 +785,14 @@ function FieldConfigForm({ field, onUpdate, allFields, existingFieldNames }: Fie
                 };
               }
             }
-            currentTypeRef.type = newType;
+            currentTypeRef.current = newType;
           }
 
           onUpdate(updates);
         },
       },
     ],
-    [onUpdate, currentTypeRef, field.validation?.requiredMessage]
+    [onUpdate, field.validation?.requiredMessage]
   );
 
   // Check if field type needs options editor
@@ -1692,7 +1696,7 @@ function RulesEditor({
       // For numeric fields, try to parse as number
       if (isNumericField) {
         const num = Number(val);
-        if (!isNaN(num)) return num;
+        if (!Number.isNaN(num)) return num;
       }
 
       // For text-based fields, keep as string
@@ -1988,7 +1992,7 @@ function RulesEditor({
                   type="button"
                   className={`flex items-center gap-2 p-2 rounded-lg border text-left text-sm transition-all ${
                     selectedEffect === effect.value
-                      ? effect.color + ' border-current'
+                      ? `${effect.color} border-current`
                       : 'hover:bg-muted'
                   }`}
                   onClick={() => setSelectedEffect(effect.value)}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -186,7 +186,7 @@ importers:
         version: 8.21.3(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@vercel/analytics':
         specifier: ^1.5.0
-        version: 1.5.0(next@16.1.5(@babel/core@7.28.5)(babel-plugin-macros@3.1.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.94.2))(react@19.2.3)
+        version: 1.5.0(next@16.1.5(@babel/core@7.28.5)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.94.2))(react@19.2.3)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -219,16 +219,16 @@ importers:
         version: 0.555.0(react@19.2.3)
       next:
         specifier: 16.1.5
-        version: 16.1.5(@babel/core@7.28.5)(babel-plugin-macros@3.1.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.94.2)
+        version: 16.1.5(@babel/core@7.28.5)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.94.2)
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       nextra:
         specifier: ^4.6.1
-        version: 4.6.1(next@16.1.5(@babel/core@7.28.5)(babel-plugin-macros@3.1.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.94.2))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
+        version: 4.6.1(next@16.1.5(@babel/core@7.28.5)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.94.2))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
       nextra-theme-docs:
         specifier: ^4.6.1
-        version: 4.6.1(@types/react@19.2.8)(next@16.1.5(@babel/core@7.28.5)(babel-plugin-macros@3.1.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.94.2))(nextra@4.6.1(next@16.1.5(@babel/core@7.28.5)(babel-plugin-macros@3.1.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.94.2))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(use-sync-external-store@1.6.0(react@19.2.3))
+        version: 4.6.1(@types/react@19.2.8)(next@16.1.5(@babel/core@7.28.5)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.94.2))(nextra@4.6.1(next@16.1.5(@babel/core@7.28.5)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.94.2))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(use-sync-external-store@1.6.0(react@19.2.3))
       pkce-challenge:
         specifier: ^6.0.0
         version: 6.0.0
@@ -414,7 +414,7 @@ importers:
         version: 10.2.4(esbuild@0.27.3)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.57.1)(storybook@10.2.4(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.9.3)(vite@6.4.1(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(sass@1.94.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.1))(webpack@5.105.0(esbuild@0.27.3))
       react-scan:
         specifier: ^0.4.3
-        version: 0.4.3(@types/react@19.2.8)(next@16.1.6(@babel/core@7.28.5)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.94.2))(react-dom@19.2.3(react@19.2.3))(react-router-dom@7.12.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-router@7.12.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(rollup@4.57.1)
+        version: 0.4.3(@types/react@19.2.8)(next@16.1.6(@babel/core@7.28.5)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.94.2))(react-dom@19.2.3(react@19.2.3))(react-router-dom@7.12.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-router@7.12.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(rollup@4.57.1)
       storybook:
         specifier: ^10.2.0
         version: 10.2.4(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -866,6 +866,9 @@ importers:
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      react-compiler-runtime:
+        specifier: ^1.0.0
+        version: 1.0.0(react@19.2.3)
       react-day-picker:
         specifier: ^9.13.0
         version: 9.13.0(react@19.2.3)
@@ -891,6 +894,9 @@ importers:
         specifier: ^4.3.5
         version: 4.3.5
     devDependencies:
+      '@rsbuild/plugin-babel':
+        specifier: ^1.0.6
+        version: 1.0.6(@rsbuild/core@1.6.7)
       '@rsbuild/plugin-react':
         specifier: ^1.4.1
         version: 1.4.2(@rsbuild/core@1.6.7)
@@ -939,6 +945,9 @@ importers:
       '@types/react-dom':
         specifier: ^19.2.2
         version: 19.2.3(@types/react@19.2.8)
+      '@vitejs/plugin-react':
+        specifier: ^4.7.0
+        version: 4.7.0(vite@7.3.0(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(sass@1.94.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.1))
       '@vitest/coverage-v8':
         specifier: ^4.0.14
         version: 4.0.14(vitest@4.0.14)
@@ -948,6 +957,9 @@ importers:
       ajv:
         specifier: ^8.17.1
         version: 8.17.1
+      babel-plugin-react-compiler:
+        specifier: 1.0.0
+        version: 1.0.0
       globals:
         specifier: ^16.5.0
         version: 16.5.0
@@ -971,7 +983,7 @@ importers:
         version: 19.2.3(react@19.2.3)
       react-scan:
         specifier: ^0.4.3
-        version: 0.4.3(@types/react@19.2.8)(next@16.1.6(@babel/core@7.28.5)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.94.2))(react-dom@19.2.3(react@19.2.3))(react-router-dom@7.12.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-router@7.12.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(rollup@4.57.1)
+        version: 0.4.3(@types/react@19.2.8)(next@16.1.6(@babel/core@7.28.5)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.94.2))(react-dom@19.2.3(react@19.2.3))(react-router-dom@7.12.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-router@7.12.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(rollup@4.57.1)
       semantic-release:
         specifier: ^25.0.2
         version: 25.0.2(typescript@5.9.3)
@@ -6465,6 +6477,9 @@ packages:
     peerDependencies:
       '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
 
+  babel-plugin-react-compiler@1.0.0:
+    resolution: {integrity: sha512-Ixm8tFfoKKIPYdCCKYTsqv+Fd4IJ0DQqMyEimo+pxUOMUR9cVPlwTrFt9Avu+3cb6Zp3mAzl+t1MrG2fxxKsxw==}
+
   bail@2.0.2:
     resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
 
@@ -10684,6 +10699,11 @@ packages:
     resolution: {integrity: sha512-ma2FePH0z3px2+WOu6h+YycZcEvFmmxIlAb62cF52bG86eMySciO/EQZeQMXd07kPCYB0a1dWDT5J+KE9mCDUw==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+
+  react-compiler-runtime@1.0.0:
+    resolution: {integrity: sha512-rRfjYv66HlG8896yPUDONgKzG5BxZD1nV9U6rkm+7VCuvQc903C4MjcoZR4zPw53IKSOX9wMQVpA1IAbRtzQ7w==}
+    peerDependencies:
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0 || ^0.0.0-experimental
 
   react-compiler-runtime@19.1.0-rc.3:
     resolution: {integrity: sha512-Cssogys2XZu6SqxRdX2xd8cQAf57BBvFbLEBlIa77161lninbKUn/EqbecCe7W3eqDQfg3rIoOwzExzgCh7h/g==}
@@ -17888,9 +17908,9 @@ snapshots:
 
   '@ungap/structured-clone@1.3.0': {}
 
-  '@vercel/analytics@1.5.0(next@16.1.5(@babel/core@7.28.5)(babel-plugin-macros@3.1.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.94.2))(react@19.2.3)':
+  '@vercel/analytics@1.5.0(next@16.1.5(@babel/core@7.28.5)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.94.2))(react@19.2.3)':
     optionalDependencies:
-      next: 16.1.5(@babel/core@7.28.5)(babel-plugin-macros@3.1.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.94.2)
+      next: 16.1.5(@babel/core@7.28.5)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.94.2)
       react: 19.2.3
 
   '@vitejs/plugin-react@4.7.0(vite@7.3.0(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(sass@1.94.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.1))':
@@ -18385,6 +18405,10 @@ snapshots:
       '@babel/helper-define-polyfill-provider': 0.6.5(@babel/core@7.28.5)
     transitivePeerDependencies:
       - supports-color
+
+  babel-plugin-react-compiler@1.0.0:
+    dependencies:
+      '@babel/types': 7.28.5
 
   bail@2.0.2: {}
 
@@ -22315,7 +22339,7 @@ snapshots:
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
 
-  next@16.1.5(@babel/core@7.28.5)(babel-plugin-macros@3.1.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.94.2):
+  next@16.1.5(@babel/core@7.28.5)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.94.2):
     dependencies:
       '@next/env': 16.1.5
       '@swc/helpers': 0.5.15
@@ -22334,13 +22358,14 @@ snapshots:
       '@next/swc-linux-x64-musl': 16.1.5
       '@next/swc-win32-arm64-msvc': 16.1.5
       '@next/swc-win32-x64-msvc': 16.1.5
+      babel-plugin-react-compiler: 1.0.0
       sass: 1.94.2
       sharp: 0.34.5
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros
 
-  next@16.1.6(@babel/core@7.28.5)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.94.2):
+  next@16.1.6(@babel/core@7.28.5)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.94.2):
     dependencies:
       '@next/env': 16.1.6
       '@swc/helpers': 0.5.15
@@ -22359,6 +22384,7 @@ snapshots:
       '@next/swc-linux-x64-musl': 16.1.6
       '@next/swc-win32-arm64-msvc': 16.1.6
       '@next/swc-win32-x64-msvc': 16.1.6
+      babel-plugin-react-compiler: 1.0.0
       sass: 1.94.2
       sharp: 0.34.5
     transitivePeerDependencies:
@@ -22366,13 +22392,13 @@ snapshots:
       - babel-plugin-macros
     optional: true
 
-  nextra-theme-docs@4.6.1(@types/react@19.2.8)(next@16.1.5(@babel/core@7.28.5)(babel-plugin-macros@3.1.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.94.2))(nextra@4.6.1(next@16.1.5(@babel/core@7.28.5)(babel-plugin-macros@3.1.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.94.2))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(use-sync-external-store@1.6.0(react@19.2.3)):
+  nextra-theme-docs@4.6.1(@types/react@19.2.8)(next@16.1.5(@babel/core@7.28.5)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.94.2))(nextra@4.6.1(next@16.1.5(@babel/core@7.28.5)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.94.2))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(use-sync-external-store@1.6.0(react@19.2.3)):
     dependencies:
       '@headlessui/react': 2.2.9(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       clsx: 2.1.1
-      next: 16.1.5(@babel/core@7.28.5)(babel-plugin-macros@3.1.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.94.2)
+      next: 16.1.5(@babel/core@7.28.5)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.94.2)
       next-themes: 0.4.6(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      nextra: 4.6.1(next@16.1.5(@babel/core@7.28.5)(babel-plugin-macros@3.1.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.94.2))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
+      nextra: 4.6.1(next@16.1.5(@babel/core@7.28.5)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.94.2))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
       react: 19.2.3
       react-compiler-runtime: 19.1.0-rc.3(react@19.2.3)
       react-dom: 19.2.3(react@19.2.3)
@@ -22384,7 +22410,7 @@ snapshots:
       - immer
       - use-sync-external-store
 
-  nextra@4.6.1(next@16.1.5(@babel/core@7.28.5)(babel-plugin-macros@3.1.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.94.2))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3):
+  nextra@4.6.1(next@16.1.5(@babel/core@7.28.5)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.94.2))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3):
     dependencies:
       '@formatjs/intl-localematcher': 0.6.2
       '@headlessui/react': 2.2.9(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -22405,7 +22431,7 @@ snapshots:
       mdast-util-gfm: 3.1.0
       mdast-util-to-hast: 13.2.1
       negotiator: 1.0.0
-      next: 16.1.5(@babel/core@7.28.5)(babel-plugin-macros@3.1.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.94.2)
+      next: 16.1.5(@babel/core@7.28.5)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.94.2)
       react: 19.2.3
       react-compiler-runtime: 19.1.0-rc.3(react@19.2.3)
       react-dom: 19.2.3(react@19.2.3)
@@ -23338,6 +23364,10 @@ snapshots:
       '@babel/runtime': 7.28.4
       react: 19.2.3
 
+  react-compiler-runtime@1.0.0(react@19.2.3):
+    dependencies:
+      react: 19.2.3
+
   react-compiler-runtime@19.1.0-rc.3(react@19.2.3):
     dependencies:
       react: 19.2.3
@@ -23480,7 +23510,7 @@ snapshots:
     optionalDependencies:
       react-dom: 19.2.3(react@19.2.3)
 
-  react-scan@0.4.3(@types/react@19.2.8)(next@16.1.6(@babel/core@7.28.5)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.94.2))(react-dom@19.2.3(react@19.2.3))(react-router-dom@7.12.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-router@7.12.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(rollup@4.57.1):
+  react-scan@0.4.3(@types/react@19.2.8)(next@16.1.6(@babel/core@7.28.5)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.94.2))(react-dom@19.2.3(react@19.2.3))(react-router-dom@7.12.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-router@7.12.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(rollup@4.57.1):
     dependencies:
       '@babel/core': 7.28.5
       '@babel/generator': 7.28.5
@@ -23502,7 +23532,7 @@ snapshots:
       react-dom: 19.2.3(react@19.2.3)
       tsx: 4.20.6
     optionalDependencies:
-      next: 16.1.6(@babel/core@7.28.5)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.94.2)
+      next: 16.1.6(@babel/core@7.28.5)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.94.2)
       react-router: 7.12.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react-router-dom: 7.12.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       unplugin: 2.1.0


### PR DESCRIPTION
## Summary

- Add `babel-plugin-react-compiler` to the Rslib build pipeline for `@uipath/apollo-wind`
- Fix 2 ref mutation violations in MetadataForm and FormDesigner that would cause the compiler to bail out
- Enable full compilation mode — **69/70 React components (98.6%)** are now compiler-optimized
- Add React Compiler to Storybook's Vite config so react-scan profiling reflects real compiled performance

## Changes

| Commit | What |
|--------|------|
| `add react compiler in annotation mode` | Install deps, configure `pluginBabel` with `compilationMode: 'annotation'` |
| `move ref assignments to useEffect` | Fix `valuesRef.current` and `contextRef.current` render-phase mutations in MetadataForm |
| `convert mutable useMemo to useRef` | Fix `currentTypeRef` mutable object pattern in FormDesigner |
| `enable react compiler for all components` | Switch from annotation mode to full compilation |
| `enable react compiler in storybook` | Add `@vitejs/plugin-react` with compiler to Storybook's Vite config |

## Verification

- 920/920 tests pass (zero failures)
- 69/70 React components compiled (1 example file skipped due to JSX in default params)
- Build: 91 files, 176.1 KB gzipped ESM
- Lint: 259 files checked, zero issues
- Zero `"use no memo"` opt-outs needed

Storybook template

<img width="1508" height="707" alt="image" src="https://github.com/user-attachments/assets/0afa436f-bcde-4b39-92ec-fe12faad5656" />


Consumption in flow-workbench

<img width="1512" height="703" alt="image" src="https://github.com/user-attachments/assets/94dbeb24-b394-4625-853e-41b0b92906da" />


