### PR TITLE
fix(apollo-vertex): resolve button content layout

### DIFF
--- a/apps/apollo-vertex/app/shadcn-components/button/page.mdx
+++ b/apps/apollo-vertex/app/shadcn-components/button/page.mdx
@@ -26,21 +26,14 @@ Displays a button or a component that looks like a button.
 ## With Icon
 
 <div className="p-4 border rounded-lg mt-4 flex flex-wrap gap-2">
-  <Button>
-    <Mail className="mr-2 h-4 w-4" /> Login with Email
-  </Button>
-  <Button variant="outline">
-    Next <ChevronRight className="ml-2 h-4 w-4" />
-  </Button>
+  <Button><Mail className="mr-2 h-4 w-4" /> Login with Email</Button>
+  <Button variant="outline">Next <ChevronRight className="ml-2 h-4 w-4" /></Button>
 </div>
 
 ## Loading
 
 <div className="p-4 border rounded-lg mt-4 flex flex-wrap gap-2">
-  <Button disabled>
-    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-    Please wait
-  </Button>
+  <Button disabled><Loader2 className="mr-2 h-4 w-4 animate-spin" /> Please wait</Button>
 </div>
 
 ## Installation


### PR DESCRIPTION
from
<img width="345" height="348" alt="Screenshot 2026-02-24 at 11 17 37" src="https://github.com/user-attachments/assets/150c1291-e7d3-4a7b-a07b-0cae75d205ad" />

to
<img width="358" height="313" alt="Screenshot 2026-02-24 at 11 36 03" src="https://github.com/user-attachments/assets/6942aeb9-23c5-40e3-a273-89775af13802" />


## Summary
Fixed button content layout in Apollo Vertex documentation by placing button children on the same line as JSX tags. This prevents MDX from wrapping content in `<p>` tags, which was causing SVG icons to display with `display: block` and stack vertically instead of aligning horizontally with text.

## Changes
- Reformatted button examples in `button/page.mdx` to keep JSX children inline with tags
- Fixes "Login with Email", "Next", and "Please wait" buttons in the button documentation

## Test Plan
- View the button documentation page at `/shadcn-components/button`
- Verify buttons with icons display inline (icon + text horizontally aligned)
- Check that all button variants render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)