### PR TITLE
fix(apollo-react): change task context menu labels to sentence case [MST-6888]

### DIFF
--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.test.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.test.tsx
@@ -219,7 +219,7 @@ describe('StageNode - Replace Task Functionality', () => {
       // Check if replace task menu item is present
       const replaceMenuItem = screen.getByTestId('menu-item-task-1-replace-task');
       expect(replaceMenuItem).toBeInTheDocument();
-      expect(replaceMenuItem).toHaveTextContent('Replace Task');
+      expect(replaceMenuItem).toHaveTextContent('Replace task');
     });
 
     it('should not show replace task menu item when onTaskReplace is not provided', async () => {
@@ -249,7 +249,7 @@ describe('StageNode - Replace Task Functionality', () => {
       const buttons = menuItems.querySelectorAll('button');
 
       // First item should be replace task
-      expect(buttons[0]).toHaveTextContent('Replace Task');
+      expect(buttons[0]).toHaveTextContent('Replace task');
     });
   });
 

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.tsx
@@ -54,7 +54,7 @@ import {
 } from './StageNode.styles';
 import type { StageNodeProps } from './StageNode.types';
 import { flattenTasks, getProjection, reorderTasks } from './StageNode.utils';
-import { getContextMenuItems, getMenuItem } from './StageNodeTaskUtilities';
+import { getContextMenuItems, getDivider, getMenuItem } from './StageNodeTaskUtilities';
 
 interface TaskStateReference {
   isParallel: boolean;
@@ -138,7 +138,7 @@ const StageNodeComponent = (props: StageNodeProps) => {
         taskIndex: pendingReplaceTask.taskIndex,
       };
       setIsReplacingTask(true);
-    }
+    } else setIsReplacingTask(false);
   }, [pendingReplaceTask, tasks]);
 
   const [activeDragId, setActiveDragId] = useState<string | null>(null);
@@ -245,7 +245,8 @@ const StageNodeComponent = (props: StageNodeProps) => {
       const items: NodeMenuItem[] = [];
 
       if (onReplaceTaskFromToolbox) {
-        items.push(getMenuItem('replace-task', 'Replace Task', () => setIsReplacingTask(true)));
+        items.push(getMenuItem('replace-task', 'Replace task', () => setIsReplacingTask(true)));
+        items.push(getDivider());
       }
 
       if (onTaskGroupModification) {
@@ -306,15 +307,20 @@ const StageNodeComponent = (props: StageNodeProps) => {
   const handleReplaceTaskToolboxItemSelected = useCallback(
     (item: ListItem) => {
       setIsReplacingTask(true);
+      const groupIndex = taskStateReference.current.groupIndex;
+      const taskIndex = taskStateReference.current.taskIndex;
+      const taskId = tasks[groupIndex]?.[taskIndex]?.id;
+      if (taskId) {
+        onTaskClick?.(taskId);
+      }
       onReplaceTaskFromToolbox?.(
         item,
         taskStateReference.current.groupIndex,
         taskStateReference.current.taskIndex
       );
       setIsReplacingTask(false);
-      setSelectedNodeId(id);
     },
-    [onReplaceTaskFromToolbox, setSelectedNodeId, id]
+    [onReplaceTaskFromToolbox, onTaskClick, tasks]
   );
 
   const handleConfigurations: HandleGroupManifest[] = useMemo(

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNodeTaskUtilities.ts
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNodeTaskUtilities.ts
@@ -19,10 +19,10 @@ export const getContextMenuItems = (
   ) => void
 ): NodeMenuItem[] => {
   const CONTEXT_MENU_ITEMS = {
-    MOVE_UP: getMenuItem('move-up', 'Move Up', () =>
+    MOVE_UP: getMenuItem('move-up', 'Move up', () =>
       reGroupTaskFunction(GroupModificationType.TASK_GROUP_UP, groupIndex, taskIndex)
     ),
-    MOVE_DOWN: getMenuItem('move-down', 'Move Down', () =>
+    MOVE_DOWN: getMenuItem('move-down', 'Move down', () =>
       reGroupTaskFunction(GroupModificationType.TASK_GROUP_DOWN, groupIndex, taskIndex)
     ),
     UNGROUP_ALL: getMenuItem('ungroup', 'Ungroup parallel tasks', () =>
@@ -109,7 +109,7 @@ export function getMenuItem(
   return { id, label, onClick, disabled: isDisabled };
 }
 
-const getDivider = (): NodeMenuItem => {
+export const getDivider = (): NodeMenuItem => {
   return {
     type: 'divider' as const,
   };


### PR DESCRIPTION
### Description

This PR

- Adds a divider for replace task as per design
- Changes the context menu labels to sentence case

### Demo
Before:
<img width="475" height="394" alt="Screenshot 2026-02-24 at 16 52 57" src="https://github.com/user-attachments/assets/47d4f00e-7a37-4438-8ad6-6d90996b674b" />


After: 
<img width="532" height="417" alt="Screenshot 2026-02-24 at 16 50 11" src="https://github.com/user-attachments/assets/1e942489-9db2-476f-bbcf-4c78c6051b8f" />
