### PR TITLE
fix(apollo-react): visibility of edge color [MST-6924]

### DIFF
--- a/packages/apollo-react/src/canvas/components/Edges/SequenceEdge.tsx
+++ b/packages/apollo-react/src/canvas/components/Edges/SequenceEdge.tsx
@@ -77,10 +77,9 @@ export const SequenceEdge = memo(function SequenceEdge({
   const { validationStatus } = useElementValidationStatus(id) ?? { validationStatus: undefined };
 
   // Use provided status or fall back to hook values
-  const status =
-    mode !== 'design'
-      ? ((executionStatus as NodeExecutionStateWithDebug)?.status ?? executionStatus)
-      : validationStatus;
+  const status = executionStatus
+    ? ((executionStatus as NodeExecutionStateWithDebug)?.status ?? executionStatus)
+    : validationStatus;
 
   // Check if this edge has diff styling applied
   const isDiffAdded = data?.isDiffAdded === true;


### PR DESCRIPTION
Now after debug completion, we are passing mode as design to open edit option,
but we want to keep the execution state until user click on back to design mode.
So I changed the mode = design condition to fix this

after

<img width="1224" height="812" alt="Screenshot 2026-02-25 at 4 52 36 PM" src="https://github.com/user-attachments/assets/d056388e-5fee-4725-b2b1-9106cdc9259a" />

before

<img width="1224" height="812" alt="Screenshot 2026-02-25 at 4 58 42 PM" src="https://github.com/user-attachments/assets/0c123c88-eb3b-4610-98f0-ce5acb3364a8" />
