### PR TITLE
fix(apollo-react): stabilize panOnDrag array reference to prevent unnecessary re-renders

### DIFF
--- a/packages/apollo-react/src/canvas/components/BaseCanvas/BaseCanvas.constants.ts
+++ b/packages/apollo-react/src/canvas/components/BaseCanvas/BaseCanvas.constants.ts
@@ -47,6 +47,9 @@ export const BASE_CANVAS_DEFAULTS = {
   organizeAnimationDuration: 500,
 } as const;
 
+/** Stable reference: restrict panning to middle-mouse-button only so left-click stays free for node interaction */
+export const PAN_ON_DRAG: [number] = [1];
+
 // Timing constants
 export const FIT_VIEW_DELAY_MS = 50;
 export const CANVAS_READY_DELAY_MS = 50;

--- a/packages/apollo-react/src/canvas/components/BaseCanvas/BaseCanvas.tsx
+++ b/packages/apollo-react/src/canvas/components/BaseCanvas/BaseCanvas.tsx
@@ -11,7 +11,7 @@ import {
   useState,
 } from 'react';
 import { useToolbarActionStore } from '../../hooks/ToolbarActionContext';
-import { BASE_CANVAS_DEFAULTS } from './BaseCanvas.constants';
+import { BASE_CANVAS_DEFAULTS, PAN_ON_DRAG } from './BaseCanvas.constants';
 import { useAutoLayout, useEnsureNodesInView, useMaintainNodesInView } from './BaseCanvas.hooks';
 import type { BaseCanvasProps, BaseCanvasRef } from './BaseCanvas.types';
 import { CanvasBackground } from './CanvasBackground';
@@ -175,7 +175,7 @@ const BaseCanvasInnerComponent = <NodeType extends Node = Node, EdgeType extends
         panOnScroll={isInteractive}
         zoomOnScroll={isInteractive}
         zoomOnDoubleClick={isInteractive && zoomOnDoubleClick}
-        panOnDrag={isInteractive ? [1] : false}
+        panOnDrag={isInteractive ? PAN_ON_DRAG : false}
         onInit={handleInit}
         onNodesChange={isInteractive ? onNodesChange : undefined}
         onEdgesChange={isInteractive ? onEdgesChange : undefined}


### PR DESCRIPTION
## Summary
  - Extract inline [1] array literal in BaseCanvas panOnDrag prop to a stable PAN_ON_DRAG constant, preventing a new reference on every render
