### PR TITLE
feat(apollo-react): loading state for toolbox

### DIFF
--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.stories.tsx
@@ -10,7 +10,7 @@ import {
 } from '@uipath/apollo-react/canvas/xyflow/react';
 import { ApButton, ApMenu } from '@uipath/apollo-react/material/components';
 import type { IMenuItem } from '@uipath/apollo-react/material/components/ap-menu/ApMenu.types';
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { DefaultCanvasTranslations } from '../../types';
 import {
   createGroupModificationHandlers,
@@ -1240,6 +1240,30 @@ export const AddAndReplaceTasks: Story = {
   args: {},
 };
 
+// Simulate async children fetch (2s delay)
+const fetchChildren = (id: string): Promise<ListItem[]> =>
+  new Promise((resolve) => {
+    setTimeout(() => {
+      resolve([
+        { id: `${id}-sub-1`, name: `${id} - Subtask A`, data: { type: `${id}-a` } },
+        { id: `${id}-sub-2`, name: `${id} - Subtask B`, data: { type: `${id}-b` } },
+        { id: `${id}-sub-3`, name: `${id} - Subtask C`, data: { type: `${id}-c` } },
+      ]);
+    }, 2000);
+  });
+
+// Top-level items with async children — level 2 loading is handled by Toolbox internally
+const loadedTaskOptionsWithChildren: ListItem[] = [
+  { id: 'email', name: 'Email', data: { type: 'email' }, children: (id) => fetchChildren(id) },
+  {
+    id: 'approval',
+    name: 'Approval',
+    data: { type: 'approval' },
+    children: (id) => fetchChildren(id),
+  },
+  { id: 'script', name: 'Script', data: { type: 'script' }, children: (id) => fetchChildren(id) },
+];
+
 const AddTaskLoadingStory = () => {
   const StageNodeWrapper = useMemo(
     () =>
@@ -1261,26 +1285,29 @@ const AddTaskLoadingStory = () => {
         width: 304,
         data: {
           stageDetails: {
-            label: 'Empty Stage (click +)',
+            label: 'Top-level loading (click +)',
             tasks: [],
           },
-          addTaskLoading: false,
+          // Top-level loading: skeletons until API returns items
+          addTaskLoading: true,
+          taskOptions: [] as ListItem[],
         },
       },
       {
-        id: 'loading-stage-with-tasks',
+        id: 'loading-stage-children',
         type: 'stage',
         position: { x: 400, y: 96 },
         width: 304,
         data: {
           stageDetails: {
-            label: 'With Tasks (click +)',
+            label: 'Async children (click +)',
             tasks: [
               [{ id: 'task-1', label: 'Existing Task', icon: <VerificationIcon /> }],
-              [{ id: 'task-2', label: 'Another Task', icon: <DocumentIcon /> }],
             ],
           },
+          // Children loading: items already available, level 2 loads on click
           addTaskLoading: false,
+          taskOptions: loadedTaskOptionsWithChildren,
         },
       },
     ],
@@ -1290,39 +1317,40 @@ const AddTaskLoadingStory = () => {
   const [nodesState, setNodes, onNodesChange] = useNodesState(initialNodes);
   const [edges, setEdges, onEdgesChange] = useEdgesState([]);
 
-  const setNodeLoading = useCallback(
-    (nodeId: string, loading: boolean) => {
+  // Simulate top-level API loading — after 3 seconds, items become available
+  useEffect(() => {
+    const timeout = setTimeout(() => {
       setNodes((nds) =>
         nds.map((node) =>
-          node.id === nodeId ? { ...node, data: { ...node.data, addTaskLoading: loading } } : node
+          node.id === 'loading-stage-empty'
+            ? {
+                ...node,
+                data: {
+                  ...node.data,
+                  addTaskLoading: false,
+                  taskOptions: loadedTaskOptionsWithChildren,
+                },
+              }
+            : node
         )
       );
-    },
-    [setNodes]
-  );
+    }, 3000);
+    return () => clearTimeout(timeout);
+  }, [setNodes]);
 
-  const handleTaskAddForNode = useCallback(
-    (nodeId: string) => {
-      setNodeLoading(nodeId, true);
-      // Simulate API delay of 3 seconds
-      setTimeout(() => {
-        setNodeLoading(nodeId, false);
-      }, 3000);
-    },
-    [setNodeLoading]
-  );
-
-  // Inject a per-node onTaskAdd handler
+  // Inject per-node handlers
   const nodesWithHandler = useMemo(
     () =>
       nodesState.map((node) => ({
         ...node,
         data: {
           ...node.data,
-          onTaskAdd: () => handleTaskAddForNode(node.id),
+          onAddTaskFromToolbox: (taskItem: ListItem) => {
+            window.alert(`Added task "${taskItem.name}" to ${node.id}`);
+          },
         },
       })),
-    [nodesState, handleTaskAddForNode]
+    [nodesState]
   );
 
   const onConnect = useCallback(

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.tsx
@@ -20,7 +20,6 @@ import { FontVariantToken, Padding, Spacing } from '@uipath/apollo-core';
 import { Column, Row } from '@uipath/apollo-react/canvas/layouts';
 import { Position, useStore, useViewport } from '@uipath/apollo-react/canvas/xyflow/react';
 import {
-  ApCircularProgress,
   ApIcon,
   ApIconButton,
   ApLink,
@@ -543,19 +542,14 @@ const StageNodeComponent = (props: StageNodeProps) => {
               </ApTooltip>
             )}
             {(onTaskAdd || onAddTaskFromToolbox) && !isReadOnly && (
-              <ApTooltip content={addTaskLoading ? 'Loading...' : addTaskLabel} placement="top">
+              <ApTooltip content={addTaskLabel} placement="top">
                 <span>
                   <ApIconButton
                     onClick={handleTaskAddClick}
                     size="small"
-                    disabled={addTaskLoading}
                     label={addTaskLabel}
                   >
-                    {addTaskLoading ? (
-                      <ApCircularProgress size={20} />
-                    ) : (
-                      <ApIcon name="add" size="20px" />
-                    )}
+                    <ApIcon name="add" size="20px" />
                   </ApIconButton>
                 </span>
               </ApTooltip>
@@ -682,6 +676,7 @@ const StageNodeComponent = (props: StageNodeProps) => {
           <Toolbox
             title={addTaskLabel}
             initialItems={taskOptions}
+            loading={addTaskLoading}
             onClose={() => setIsAddingTask(false)}
             onItemSelect={handleAddTaskToolboxItemSelected}
             onSearch={onTaskToolboxSearch}


### PR DESCRIPTION
## Description

Use loading state skeleton when + is clicked on stage node if the APIs are still in flight.

Once the APIs are successful, populate the toolbox. 

 1. Repurposed addTaskLoading prop on StageNode to drive loading state inside the Toolbox instead of showing a spinner on the + button. This is a breaking change
 2. The + button is now always clickable and shows the add icon regardless of addTaskLoading — loading is delegated to the Toolbox's skeleton/disabled-items UI.
 3. Updated the AddTaskLoading story to demonstrate both loading patterns:
 4. Top-level loading: addTaskLoading=true + empty taskOptions → Toolbox shows skeleton loaders until API returns items
 5. Async children loading: ListItem with async children function → Toolbox internally dims level 1 items while fetching level 2 subtasks (no extra props needed)
 6. Removed unused `ApCircularProgress` import from StageNode.tsx
 7. Updated tests to verify the new behavior (loading passed to Toolbox, button no longer disabled)

## Demo

https://github.com/user-attachments/assets/2c2e45f1-6d84-4c25-b6fe-79fed9282efd

