### PR TITLE
fix(apollo-react): use icon registry icons for resource node toolbar [AG-771]

### DIFF
--- a/packages/apollo-react/src/canvas/components/AgentCanvas/nodes/ResourceNode.tsx
+++ b/packages/apollo-react/src/canvas/components/AgentCanvas/nodes/ResourceNode.tsx
@@ -1,4 +1,5 @@
 import * as Icons from '@uipath/apollo-react/canvas/icons';
+import { NodeIcon } from '@uipath/apollo-react/canvas/utils';
 import { Row } from '@uipath/apollo-react/canvas/layouts';
 import { type NodeProps, Position } from '@uipath/apollo-react/canvas/xyflow/react';
 import { ApIcon } from '@uipath/apollo-react/material/components';
@@ -161,18 +162,17 @@ export const ResourceNode = memo(
     }, [data]);
 
     const toolbarConfig = useMemo((): NodeToolbarConfig | null | undefined => {
-      if (mode === 'view') {
-        return null; // Explicitly disable toolbar in view mode
+      // Explicitly disable toolbar in view mode or for placeholder nodes
+      if (mode === 'view' || (data.isPlaceholder && (!isSuggestion || !suggestionId))) {
+        return null;
       }
-
-      // Note: Removed standalone placeholder check - placeholders now show the same toolbar as permanent nodes
 
       // If this is a suggestion, show accept/reject actions only if version is not "0.0.1"
       if (isSuggestion && suggestionId) {
         if (suggestionGroupVersion === '0.0.1') return null;
         const rejectAction: ToolbarAction = {
           id: 'reject-suggestion',
-          icon: 'close',
+          icon: <NodeIcon icon="X" size={14} />,
           label: suggestTranslations.reject,
           disabled: false,
           onAction: () => handleActOnSuggestion(suggestionId, 'reject'),
@@ -180,7 +180,7 @@ export const ResourceNode = memo(
 
         const acceptAction: ToolbarAction = {
           id: 'accept-suggestion',
-          icon: 'check',
+          icon: <NodeIcon icon="check" size={14} />,
           label: suggestTranslations.accept,
           disabled: false,
           onAction: () => handleActOnSuggestion(suggestionId, 'accept'),
@@ -221,7 +221,7 @@ export const ResourceNode = memo(
 
       const removeAction: ToolbarAction = {
         id: 'remove',
-        icon: 'delete',
+        icon: <NodeIcon icon="trash" size={14} />,
         label: translations?.remove ?? '',
         disabled: false,
         onAction: handleClickRemove,


### PR DESCRIPTION
https://uipath.atlassian.net/browse/AG-771

### Summary

Fixes two bugs in the `ResourceNode` toolbar:

1. **Toolbar showing on placeholder nodes** — Placeholder items (empty slots) were incorrectly displaying a toolbar as if they were selected resources. The standalone placeholder check had been removed previously, causing the toolbar to render for non-suggestion placeholders. Re-introduced a guard that returns `null` for placeholder nodes unless they are active suggestions.

2. **Inconsistent toolbar icons** — Resource node toolbar actions used plain string icon names (`'close'`, `'check'`, `'delete'`) which rendered differently from the sticky notes toolbar. Replaced them with `<NodeIcon>` components using the icon registry (`X`, `check`, `trash` at size 14), matching the pattern already used by sticky notes. Also aligned the `ExecutionStatusIcon` size from 16 → 14 for consistency.

### Changes

- `ResourceNode.tsx` — Single file change:
  - Added `NodeIcon` import from canvas utils
  - Combined `view` mode and placeholder guards into a single early return
  - Replaced string `icon` values with `<NodeIcon>` components for reject, accept, and remove actions

### Testing

- Verified in Storybook across resource node states (default, selected, placeholder, suggestion)
- Screen recording attached

https://github.com/user-attachments/assets/aa4a4d0a-0b1a-4939-aef7-d2f6e681f8bd

