### PR TITLE
docs: add in-product notification documentation

### DIFF
--- a/.github/workflows/apollo-vertex-registry-check.yml
+++ b/.github/workflows/apollo-vertex-registry-check.yml
@@ -63,7 +63,7 @@ jobs:
           echo "result=${MATRIX}" >> "${GITHUB_OUTPUT}"
 
       - name: Create base shadcn app
-        run: cd ${{ runner.temp }} && pnpx shadcn@latest create minimal-app --preset "https://ui.shadcn.com/init?base=radix&style=vega&baseColor=neutral&theme=neutral&iconLibrary=lucide&font=inter&menuAccent=subtle&menuColor=default&radius=default&template=next&rtl=false" --template next
+        run: cd ${{ runner.temp }} && pnpx shadcn@latest init --preset a0 --template next --name minimal-app
 
       - name: Configure @uipath registry
         working-directory: ${{ runner.temp }}/minimal-app

--- a/apps/apollo-vertex/app/_meta.ts
+++ b/apps/apollo-vertex/app/_meta.ts
@@ -2,6 +2,7 @@ export default {
   index: "Introduction",
   dashboards: "Dashboards",
   "data-querying": "Data Querying",
+  patterns: "Patterns",
   "shadcn-components": "Shadcn Components",
   "vertex-components": "Vertex Components",
   themes: "Themes",

--- a/apps/apollo-vertex/app/patterns/_meta.ts
+++ b/apps/apollo-vertex/app/patterns/_meta.ts
@@ -1,0 +1,3 @@
+export default {
+  notifications: "Notifications",
+};

--- a/apps/apollo-vertex/app/patterns/notifications/_meta.ts
+++ b/apps/apollo-vertex/app/patterns/notifications/_meta.ts
@@ -1,0 +1,3 @@
+export default {
+  "in-product": "In-product",
+};

--- a/apps/apollo-vertex/app/patterns/notifications/in-product/layout-diagram.tsx
+++ b/apps/apollo-vertex/app/patterns/notifications/in-product/layout-diagram.tsx
@@ -1,0 +1,57 @@
+export function LayoutDiagram() {
+  return (
+    <div className="relative w-full border rounded-lg overflow-hidden bg-transparent">
+      {/* Header */}
+      <div className="flex items-center justify-between border-b bg-card px-4 py-2">
+        <div className="flex items-center gap-2">
+          <div className="h-4 w-4 rounded bg-muted-foreground/30" />
+          <span className="text-xs font-medium text-muted-foreground">App Header</span>
+        </div>
+        <div className="flex items-center gap-1.5">
+          <div className="rounded border border-dashed border-destructive bg-transparent px-2 py-0.5">
+            <span className="text-[10px] font-medium text-destructive">Reserved: Primary CTAs</span>
+          </div>
+        </div>
+      </div>
+
+      {/* Sonner position indicator */}
+      <div className="flex justify-center py-2">
+        <div className="rounded-md border border-info bg-transparent px-3 py-1.5 shadow-sm">
+          <span className="text-[10px] font-medium text-info">Sonner position: top-center</span>
+        </div>
+      </div>
+
+      {/* Body area */}
+      <div className="relative px-4 pb-4 pt-2">
+        {/* System banner example */}
+        <div className="mb-3 w-full rounded border border-warning bg-transparent px-3 py-1.5">
+          <span className="text-[10px] font-medium text-warning-foreground dark:text-warning">
+            System banner (full-width, below header) — for alerts with no UI anchor
+          </span>
+        </div>
+
+        {/* Content area with inline alert */}
+        <div className="flex gap-3">
+          <div className="flex-1 space-y-2">
+            <div className="h-3 w-3/4 rounded bg-muted-foreground/15" />
+            <div className="h-3 w-1/2 rounded bg-muted-foreground/15" />
+            <div className="rounded border border-info bg-transparent px-3 py-1.5 mt-2">
+              <span className="text-[10px] font-medium text-info">
+                Inline Alert — anchored near relevant content
+              </span>
+            </div>
+            <div className="h-3 w-2/3 rounded bg-muted-foreground/15" />
+            <div className="h-3 w-1/3 rounded bg-muted-foreground/15" />
+          </div>
+        </div>
+
+        {/* Chat reserved area */}
+        <div className="absolute bottom-3 right-3">
+          <div className="rounded border border-dashed border-destructive bg-transparent px-2 py-1">
+            <span className="text-[10px] font-medium text-destructive">Reserved: Chat</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/apollo-vertex/app/patterns/notifications/in-product/notification-examples.tsx
+++ b/apps/apollo-vertex/app/patterns/notifications/in-product/notification-examples.tsx
@@ -1,0 +1,386 @@
+"use client";
+
+import {
+  CircleCheckIcon,
+  InfoIcon,
+  OctagonXIcon,
+  TriangleAlertIcon,
+  XIcon,
+} from "lucide-react";
+import { type ReactNode, useEffect, useRef, useState } from "react";
+import { toast } from "sonner";
+
+import {
+  Alert,
+  AlertDescription,
+  AlertTitle,
+} from "@/registry/alert/alert";
+import { Badge } from "@/registry/badge/badge";
+import { Button } from "@/registry/button/button";
+
+import { Toaster } from "@/registry/sonner/sonner";
+
+// Accessible foreground colors for light mode only.
+// Same hue as the status token but darkened to pass WCAG AA (4.5:1) against --secondary.
+// Dark mode uses the standard status tokens (which already pass 4.5:1 on dark backgrounds).
+const statusForegroundStyles = `
+  :root {
+    --info-fg: oklch(0.49 0.12 210);
+    --success-fg: oklch(0.46 0.10 152);
+    --destructive-fg: oklch(0.50 0.14 18);
+  }
+`;
+
+// Shared icon alignment classes for sonner
+const iconAlign =
+  "[&>[data-icon]]:!items-start [&>[data-icon]>svg]:!mt-0.5";
+
+// Override Sonner's close button position: right side, inside the toast
+const closeButtonStyles = `
+  [data-sonner-toast] [data-close-button] {
+    left: unset !important;
+    right: 8px !important;
+    top: 8px !important;
+    transform: none !important;
+    border: none !important;
+    background: transparent !important;
+    border-radius: 4px !important;
+  }
+`;
+
+// Light: solid secondary bg with status border. Dark: tinted status bg blended with popover.
+// srgb interpolation avoids hue shift when mixing with blue-gray popover
+const toastClassNames = {
+  info: `!border-info !bg-secondary dark:!bg-[color-mix(in_srgb,var(--info)_25%,var(--popover)_75%)] [&>svg]:!text-[var(--info-fg)] dark:[&>svg]:!text-info ${iconAlign} `,
+  success: `!border-success !bg-secondary dark:!bg-[color-mix(in_srgb,var(--success)_25%,var(--popover)_75%)] [&>svg]:!text-[var(--success-fg)] dark:[&>svg]:!text-success ${iconAlign} `,
+  warning: `!border-warning !bg-secondary dark:!bg-[color-mix(in_srgb,var(--warning)_25%,var(--popover)_75%)] [&>svg]:!text-warning-foreground dark:[&>svg]:!text-warning ${iconAlign} `,
+  error: `!border-destructive !bg-secondary dark:!bg-[color-mix(in_srgb,var(--destructive)_25%,var(--popover)_75%)] [&>svg]:!text-[var(--destructive-fg)] dark:[&>svg]:!text-destructive ${iconAlign} `,
+};
+
+export function SonnerExamples() {
+  return (
+    <div className="space-y-3">
+      <style>{statusForegroundStyles}</style>
+      <style>{closeButtonStyles}</style>
+      <Toaster
+        position="top-center"
+        closeButton
+        toastOptions={{ classNames: toastClassNames }}
+      />
+      <div className="flex flex-wrap gap-2">
+        <Button
+          variant="outline"
+          className="border-info text-info dark:text-info bg-transparent hover:bg-info/15"
+          onClick={() =>
+            toast.info("Background sync complete", {
+              description: "All data is up to date.",
+            })
+          }
+        >
+          <InfoIcon className="h-4 w-4" /> Info
+        </Button>
+        <Button
+          variant="outline"
+          className="border-success text-success dark:text-success bg-transparent hover:bg-success/10"
+          onClick={() =>
+            toast.success("Changes saved", {
+              description: "Your updates have been applied.",
+            })
+          }
+        >
+          <CircleCheckIcon className="h-4 w-4" /> Success
+        </Button>
+        <Button
+          variant="outline"
+          className="border-warning text-warning-foreground dark:text-warning bg-transparent hover:bg-warning/15"
+          onClick={() =>
+            toast.warning("Storage almost full", {
+              description: "Consider removing unused files.",
+            })
+          }
+        >
+          <TriangleAlertIcon className="h-4 w-4" /> Warning
+        </Button>
+        <Button
+          variant="outline"
+          className="border-destructive text-destructive dark:text-destructive bg-transparent hover:bg-destructive/10"
+          onClick={() =>
+            toast.error("Upload failed", {
+              description: "Please check your connection and retry.",
+            })
+          }
+        >
+          <OctagonXIcon className="h-4 w-4" /> Error
+        </Button>
+      </div>
+      <p className="text-xs text-muted-foreground">
+        Click each button to trigger a toast at the top-center of the screen. Toasts auto-dismiss after 5 seconds.
+      </p>
+    </div>
+  );
+}
+
+export function AlertExamples() {
+  return (
+    <div className="space-y-3">
+      <style>{statusForegroundStyles}</style>
+      <Alert className="border-transparent bg-info/15 dark:bg-info/25 text-[var(--info-fg)] dark:text-white [&>svg]:text-[var(--info-fg)] dark:[&>svg]:text-white">
+        <InfoIcon className="h-4 w-4" />
+        <AlertTitle>New version available</AlertTitle>
+        <AlertDescription className="text-[var(--info-fg)] dark:text-white/80">
+          A new version of the platform is ready. Review the changelog for details.
+        </AlertDescription>
+      </Alert>
+
+      <Alert className="border-transparent bg-success/10 dark:bg-success/25 text-[var(--success-fg)] dark:text-white [&>svg]:text-[var(--success-fg)] dark:[&>svg]:text-white">
+        <CircleCheckIcon className="h-4 w-4" />
+        <AlertTitle>Changes saved</AlertTitle>
+        <AlertDescription className="text-[var(--success-fg)] dark:text-white/80">
+          Your configuration has been updated successfully.
+        </AlertDescription>
+      </Alert>
+
+      <Alert className="border-transparent bg-warning/15 dark:bg-warning/25 text-warning-foreground dark:text-white [&>svg]:text-warning-foreground dark:[&>svg]:text-warning">
+        <TriangleAlertIcon className="h-4 w-4" />
+        <AlertTitle>API rate limit approaching</AlertTitle>
+        <AlertDescription className="text-warning-foreground dark:text-white/80">
+          You have used 90% of your monthly API quota. Consider upgrading your plan.
+        </AlertDescription>
+      </Alert>
+
+      <Alert className="border-transparent bg-destructive/10 dark:bg-destructive/25 text-[var(--destructive-fg)] dark:text-white [&>svg]:text-[var(--destructive-fg)] dark:[&>svg]:text-white">
+        <OctagonXIcon className="h-4 w-4" />
+        <AlertTitle>Connection failed</AlertTitle>
+        <AlertDescription className="text-[var(--destructive-fg)] dark:text-white/80">
+          Unable to reach the server. Check your network connection and try again.
+        </AlertDescription>
+      </Alert>
+    </div>
+  );
+}
+
+function DismissibleAlert({
+  children,
+  className,
+}: {
+  children: ReactNode;
+  className?: string;
+}) {
+  const [visible, setVisible] = useState(true);
+  if (!visible) return null;
+  return (
+    <div className="relative">
+      <Alert className={className}>{children}</Alert>
+      <button
+        type="button"
+        onClick={() => setVisible(false)}
+        className="absolute top-3 right-3 rounded-sm opacity-70 hover:opacity-100 transition-opacity"
+        aria-label="Dismiss"
+      >
+        <XIcon className="h-4 w-4" />
+      </button>
+    </div>
+  );
+}
+
+export function AlertOutlineExamples() {
+  const [resetKey, setResetKey] = useState(0);
+
+  return (
+    <div className="space-y-3" key={resetKey}>
+      <DismissibleAlert className="border-info bg-transparent [&>svg]:text-info">
+        <InfoIcon className="h-4 w-4" />
+        <AlertTitle>New version available</AlertTitle>
+        <AlertDescription>
+          A new version of the platform is ready. Review the changelog for details.
+        </AlertDescription>
+      </DismissibleAlert>
+
+      <DismissibleAlert className="border-success bg-transparent [&>svg]:text-success">
+        <CircleCheckIcon className="h-4 w-4" />
+        <AlertTitle>Changes saved</AlertTitle>
+        <AlertDescription>
+          Your configuration has been updated successfully.
+        </AlertDescription>
+      </DismissibleAlert>
+
+      <DismissibleAlert className="border-warning bg-transparent [&>svg]:text-warning-foreground dark:[&>svg]:text-warning">
+        <TriangleAlertIcon className="h-4 w-4" />
+        <AlertTitle>API rate limit approaching</AlertTitle>
+        <AlertDescription>
+          You have used 90% of your monthly API quota. Consider upgrading your plan.
+        </AlertDescription>
+      </DismissibleAlert>
+
+      <DismissibleAlert className="border-destructive bg-transparent [&>svg]:text-destructive">
+        <OctagonXIcon className="h-4 w-4" />
+        <AlertTitle>Connection failed</AlertTitle>
+        <AlertDescription>
+          Unable to reach the server. Check your network connection and try again.
+        </AlertDescription>
+      </DismissibleAlert>
+
+      <button
+        type="button"
+        onClick={() => setResetKey((k) => k + 1)}
+        className="text-xs text-muted-foreground hover:text-foreground underline transition-colors"
+      >
+        Reset dismissed alerts
+      </button>
+    </div>
+  );
+}
+
+const alertDefaultBgStyles = `
+  :root:not(.dark) .alert-default-bg [data-slot="alert"] {
+    background-color: var(--secondary) !important;
+  }
+`;
+
+// Override Alert's [&>svg]:text-current which twMerge doesn't reliably resolve
+const alertDefaultIconStyles = `
+  .alert-default-bg [data-slot="alert"].alert-icon-info > svg { color: var(--info-fg) }
+  .alert-default-bg [data-slot="alert"].alert-icon-success > svg { color: var(--success-fg) }
+  .alert-default-bg [data-slot="alert"].alert-icon-warning > svg { color: var(--warning-foreground) }
+  .alert-default-bg [data-slot="alert"].alert-icon-destructive > svg { color: var(--destructive-fg) }
+
+  .dark .alert-default-bg [data-slot="alert"].alert-icon-info > svg { color: var(--info) }
+  .dark .alert-default-bg [data-slot="alert"].alert-icon-success > svg { color: var(--success) }
+  .dark .alert-default-bg [data-slot="alert"].alert-icon-warning > svg { color: var(--warning) }
+  .dark .alert-default-bg [data-slot="alert"].alert-icon-destructive > svg { color: var(--destructive) }
+`;
+
+export function AlertDefaultExamples() {
+  return (
+    <div className="alert-default-bg space-y-3">
+      <style>{statusForegroundStyles}</style>
+      <style>{alertDefaultBgStyles}</style>
+      <style>{alertDefaultIconStyles}</style>
+      <Alert className="alert-icon-info">
+        <InfoIcon className="h-4 w-4" />
+        <AlertTitle className="text-[var(--info-fg)] dark:text-info">New version available</AlertTitle>
+        <AlertDescription>
+          A new version of the platform is ready. Review the changelog for details.
+        </AlertDescription>
+      </Alert>
+
+      <Alert className="alert-icon-success">
+        <CircleCheckIcon className="h-4 w-4" />
+        <AlertTitle className="text-[var(--success-fg)] dark:text-success">Changes saved</AlertTitle>
+        <AlertDescription>
+          Your configuration has been updated successfully.
+        </AlertDescription>
+      </Alert>
+
+      <Alert className="alert-icon-warning">
+        <TriangleAlertIcon className="h-4 w-4" />
+        <AlertTitle className="text-warning-foreground dark:text-warning">API rate limit approaching</AlertTitle>
+        <AlertDescription>
+          You have used 90% of your monthly API quota. Consider upgrading your plan.
+        </AlertDescription>
+      </Alert>
+
+      <Alert className="alert-icon-destructive">
+        <OctagonXIcon className="h-4 w-4" />
+        <AlertTitle className="text-[var(--destructive-fg)] dark:text-destructive">Connection failed</AlertTitle>
+        <AlertDescription>
+          Unable to reach the server. Check your network connection and try again.
+        </AlertDescription>
+      </Alert>
+    </div>
+  );
+}
+
+const missingDocs = [
+  "W-9 Form",
+  "Proof of Address",
+  "Bank Statement",
+  "Tax Return (2025)",
+  "Employment Verification",
+  "Government-Issued ID",
+  "Utility Bill",
+];
+
+export function CollapsibleAlertExample() {
+  const [expanded, setExpanded] = useState(false);
+  const [overflows, setOverflows] = useState(false);
+  const [rowHeight, setRowHeight] = useState<number>(0);
+  const measureRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const el = measureRef.current;
+    if (!el) return;
+    const firstChild = el.firstElementChild as HTMLElement | null;
+    if (!firstChild) return;
+    const singleRow = firstChild.offsetHeight + 6;
+    setRowHeight(singleRow);
+    setOverflows(el.scrollHeight > singleRow);
+  }, []);
+
+  return (
+    <Alert className="border-warning bg-transparent [&>svg]:text-warning-foreground dark:[&>svg]:text-warning">
+      <TriangleAlertIcon className="h-4 w-4" />
+      <AlertTitle className="line-clamp-none">
+        {missingDocs.length} required documents missing
+      </AlertTitle>
+      <AlertDescription className="col-start-2">
+        <p>Upload these documents before completing quality check.</p>
+        {/* Hidden measurement container to detect overflow */}
+        <div ref={measureRef} className="flex flex-wrap gap-1.5 mt-2" style={{ position: "absolute", visibility: "hidden", left: 0, right: 0 }}>
+          {missingDocs.map((doc) => (
+            <Badge key={doc} variant="secondary" status="warning">
+              {doc}
+            </Badge>
+          ))}
+        </div>
+        <div
+          style={!expanded && overflows && rowHeight ? { maxHeight: rowHeight, overflow: "hidden" } : {}}
+          className="flex flex-wrap gap-1.5 mt-2"
+        >
+          {missingDocs.map((doc) => (
+            <Badge key={doc} variant="secondary" status="warning">
+              {doc}
+            </Badge>
+          ))}
+        </div>
+        {overflows && (
+          <button
+            type="button"
+            onClick={() => setExpanded(!expanded)}
+            className="mt-1.5 text-xs font-medium text-[oklch(0.60_0.125_210)] hover:underline transition-colors"
+          >
+            {expanded ? "Show less" : "Show all"}
+          </button>
+        )}
+      </AlertDescription>
+    </Alert>
+  );
+}
+
+export function ActionAlertExample() {
+  return (
+    <Alert className="border-info bg-transparent [&>svg]:text-info">
+      <InfoIcon className="h-4 w-4" />
+      <AlertTitle>12 documents unclassified</AlertTitle>
+      <AlertDescription>
+        <p>Some documents could not be automatically classified.</p>
+        <Button
+          variant="outline"
+          size="sm"
+          className="mt-1.5"
+        >
+          Filter unclassified
+        </Button>
+      </AlertDescription>
+    </Alert>
+  );
+}
+
+export function CompositeAlertExamples() {
+  return (
+    <div className="space-y-3">
+      <CollapsibleAlertExample />
+      <ActionAlertExample />
+    </div>
+  );
+}

--- a/apps/apollo-vertex/app/patterns/notifications/in-product/page.mdx
+++ b/apps/apollo-vertex/app/patterns/notifications/in-product/page.mdx
@@ -1,0 +1,348 @@
+import { SonnerExamples, AlertExamples, AlertOutlineExamples, AlertDefaultExamples, CollapsibleAlertExample, ActionAlertExample } from './notification-examples'
+import { LayoutDiagram } from './layout-diagram'
+
+# In-product notification
+
+Notifications provide timely feedback about user actions or system status. Used well, they build trust and clarity. Used carelessly, they interrupt flow.
+
+There are two primary patterns in our system:
+
+- [**Sonner**](/shadcn-components/sonner) — time-based, non-modal notifications for lightweight feedback. Floating, transient, always tied to a user action, never blocking.
+- [**Alert**](/shadcn-components/alert) — inline notifications within page content for contextual, persistent, or blocking feedback. Structural, anchored to content, can be persistent or blocking.
+
+Both components support status variants and theme-based contrast styles. Use them intentionally.
+
+---
+
+## When to use notifications
+
+### Task-generated notifications
+
+Triggered directly by a user action during a task.
+
+**Purpose:**
+- Provide immediate feedback
+- Confirm results
+- Surface validation or errors
+
+**Pattern:**
+- [Sonner](/shadcn-components/sonner) for success or lightweight confirmation
+- Inline ([Alert](/shadcn-components/alert)) for validation, warnings, or blocking errors
+
+The message must clearly relate to the user's action.
+
+### System-generated notifications
+
+Triggered by the system, independent of a user action.
+
+**Purpose:**
+- Communicate background updates
+- Inform about system status
+- Surface out-of-context events
+
+**Pattern:**
+- Inline ([Alert](/shadcn-components/alert)), anchored near relevant UI
+- Persistent when time-sensitive or important
+
+Avoid using [Sonner](/shadcn-components/sonner) for system-level updates that require awareness over time.
+
+**When there is no obvious relevant UI element** (for example, a background sync failure or session timeout), surface the alert as a persistent full-width banner directly below the main header. Do not use a floating Sonner notification for these cases.
+
+---
+
+## Sonner variant
+
+[Sonner](/shadcn-components/sonner) notifications are short, floating, non-modal messages used for quick feedback after a user action. They are always transient, never blocking, and always tied to something the user just did.
+
+### When to use Sonner
+
+Use [Sonner](/shadcn-components/sonner) when:
+
+- Confirming a successful or completed action — _example: "Project published", "Saved successfully"_
+- The feedback is short and non-blocking
+- No user action is required
+- The message is directly tied to a user-initiated action
+- You want to surface passive updates without interrupting workflow
+
+### Do not use Sonner for
+
+- Errors that block progress
+- Situations requiring user input
+- Form validation
+- Persistent guidance or contextual messaging
+- System-generated events with no direct user trigger
+
+Use Inline ([Alert](/shadcn-components/alert)) instead.
+
+### Placement and behavior
+
+[Sonner](/shadcn-components/sonner) notifications appear at the **top-center of the screen**.
+
+> **Rationale:** The top-right corner is reserved for primary CTAs across our solutions. The bottom-right corner is reserved for the chat component. Top-center keeps notifications prominent and visible without competing with either.
+
+| Property | Value |
+|---|---|
+| Position | Top-center of the screen |
+| Auto-dismiss | 5 seconds |
+| Manual dismiss | Close icon |
+| Persistent | Never |
+
+> Never use [Sonner](/shadcn-components/sonner) for errors that require resolution.
+
+### Example
+
+<div className="p-4 border rounded-lg mt-4">
+  <SonnerExamples />
+</div>
+
+---
+
+## Inline variant (Alert)
+
+Inline notifications use the [Alert](/shadcn-components/alert) component and appear within the layout, near relevant UI elements. They provide contextual feedback tied to the current task or workflow. Unlike [Sonner](/shadcn-components/sonner), they are structural — they occupy space in the layout rather than floating above it.
+
+### When to use Inline
+
+Use Inline ([Alert](/shadcn-components/alert)) when:
+
+- Feedback must remain visible in context
+- Displaying validation errors or warnings
+- The message relates to a specific form, section, or workflow state
+- The system requires user action
+- You need persistent contextual guidance
+- There is no direct user action to tie the message to
+
+Inline notifications may be persistent or dismissible depending on priority.
+
+### Placement and behavior
+
+- Appear inline with content, near the relevant UI
+- Persist until resolved or dismissed (if dismissible)
+- Should be visually connected to the related task or component
+- When no specific UI element is the anchor (e.g. session expiry, system outage), appear as a persistent full-width banner below the main header
+
+### Choosing a visual style
+
+Inline alerts support three visual styles. Choose based on the urgency and importance of the message — not personal preference. Do not mix styles within the same context.
+
+| Style | Variant | When to use | Dismissible |
+|---|---|---|---|
+| Default | Subtle | Routine info, background updates, non-disruptive confirmations | Optional |
+| Accent | Outline | Contextual warnings, guidance, acknowledged states, unresolved requirements | Context-dependent |
+| Bold | Tinted | Critical issues, blocking errors, authentication failures | No |
+
+> When unsure, start with **default**. Escalate only when the message demands immediate attention or blocks progress.
+
+#### Default (subtle)
+
+Neutral background with status color on the title and icon. Description text uses the standard muted color. Use for routine information, background updates, and non-disruptive feedback.
+
+<div className="p-4 border rounded-lg mt-4">
+  <AlertDefaultExamples />
+</div>
+
+#### Accent (outline)
+
+Status color on the border and icon, with default text colors. Use for contextual warnings, dismissible guidance, or messages the user has already acknowledged.
+
+<div className="p-4 border rounded-lg mt-4">
+  <AlertOutlineExamples />
+</div>
+
+#### Bold (tinted)
+
+Full status-colored background with white text in dark mode. Use for critical messages that demand immediate attention or block progress.
+
+<div className="p-4 border rounded-lg mt-4">
+  <AlertExamples />
+</div>
+
+### Complex alert patterns (edge cases)
+
+The patterns above cover the majority of notification needs. The following compositions are reserved for complex workflows where a standard alert is not sufficient. Do not use these as defaults — reach for them only when the workflow genuinely requires inline items or embedded actions.
+
+#### Collapsible content
+
+When an alert references a list of items (e.g., missing documents, failed validations), show items inline as chips. If the list overflows a single row, clip to one row and show a "Show all" toggle that expands to reveal the full list.
+
+**Overflow behavior:** Items display inline by default. The expand/collapse toggle only appears when items overflow the available space — keeping simple cases compact and reserving the toggle for edge cases with many items.
+
+<div className="p-4 border rounded-lg mt-4">
+  <CollapsibleAlertExample />
+</div>
+
+#### Action buttons
+
+When an alert can trigger a direct action (e.g., filtering a table, retrying an operation), include an action button inside the alert description area. Limit to one primary action per alert.
+
+<div className="p-4 border rounded-lg mt-4">
+  <ActionAlertExample />
+</div>
+
+#### Dynamic state updates
+
+Alerts should reflect real-time state changes client-side. When a user resolves an item referenced by an alert (e.g., uploads a missing document), the alert should update immediately without requiring a page refresh:
+
+- Update the count in the title ("3 required documents missing" becomes "2 required documents missing")
+- Remove resolved items from the collapsible list
+- Auto-dismiss the alert when all items are resolved
+
+Implement this by deriving alert visibility and content from reactive state (e.g., React state or a server state library like TanStack Query). Do not hard-code alert content.
+
+---
+
+## Layout boundaries
+
+The following areas are reserved and must not be obscured by floating notifications:
+
+| Area | Reserved for |
+|---|---|
+| Top-right | Primary CTAs |
+| Bottom-right | Chat component |
+
+No [Sonner](/shadcn-components/sonner) notification or floating overlay should appear in these areas. Top-center is the designated position for all [Sonner](/shadcn-components/sonner) notifications.
+
+<div className="mt-4">
+  <LayoutDiagram />
+</div>
+
+---
+
+## Dismissible vs persistent
+
+| Variant | Auto-dismiss | User-dismissible | Persistent |
+|---|---|---|---|
+| [Sonner](/shadcn-components/sonner) | Yes (5s) | Yes | No |
+| Inline ([Alert](/shadcn-components/alert)) | No | Optional | Yes |
+
+### Make Inline dismissible if
+
+- The message is low priority — _example: "Settings updated", "You've been signed out from another device"_
+- The user has already acknowledged the information
+- Dismissing improves focus and reduces clutter
+
+### Keep Inline persistent if
+
+- The message indicates an error that must be resolved
+- The system requires user input
+- The message provides important ongoing context
+
+> Never rely on dismissibility for critical blockers.
+
+> **Note:** Visual style does not determine dismissibility. An accent (outline) alert can be either dismissible or persistent depending on whether the condition it represents requires resolution. Missing required documents, for example, should use accent styling but remain persistent until all documents are provided.
+
+---
+
+## Status and semantic meaning
+
+Each notification has a status that communicates tone and urgency through color and icon. Choose status based on both urgency and user context.
+
+### Status definitions
+
+Notification statuses align with the [Badge](/shadcn-components/badge) status system for consistent semantic meaning across the design system.
+
+| Status | Usage | Token | Color | Inline notes |
+|---|---|---|---|---|
+| `info` | General updates, FYIs | `--info` | `oklch(0.60 0.125 210)` | Best for passive or contextual information |
+| `success` | Confirmation of completed tasks | `--success` | `oklch(0.57 0.105 152)` | Inline only when tied to direct user action |
+| `warning` | Potential issues or unintended consequences | `--warning` | `oklch(0.80 0.1401 80.82)` | Appropriate for both persistent and action-related messages |
+| `error` | Failures, blockers, critical issues | `--destructive` | `oklch(0.62 0.150 18)` | Inline only when tied to validation or error resolution |
+
+> Inline notifications should use **success** or **error** only when tied to a user-initiated action.
+> For persistent system guidance or background alerts, use **info** or **warning**.
+
+---
+
+## Content guidelines
+
+Notifications have limited space. Write for clarity and scanability.
+
+Users should understand:
+- **What** happened
+- **Why** it matters
+- **What to do** next
+
+### Title
+
+- Short and clear
+- Communicates the most important information
+- No period at the end
+- For errors, state what failed or what cannot be completed
+- _Examples: "Changes saved", "Connection failed"_
+
+> **Accessibility note:** Screen readers read the entire notification as one string. Do not rely on text styling alone to convey meaning.
+
+### Body text
+
+- Maximum two lines
+- Do not repeat the title
+- Support the title with context or next steps
+- Include troubleshooting guidance when relevant
+- User actions are mandatory for error messages
+- Never truncate critical or actionable content
+
+If more explanation is required:
+- Provide a short summary
+- Add a single "View more" link to a modal or page
+
+No bolding within body text. If emphasis is necessary, use quotation marks.
+
+### Lists and structured content
+
+Notifications should not contain bulleted or numbered lists. Lists add visual complexity and break the scanability of a compact notification.
+
+If the notification references multiple items:
+- Summarize with a count in the title — _example: "3 required documents missing"_
+- Show items as inline chips or a comma-separated string
+- Limit visible items to one row; use a "Show all" link for overflow
+- Never display more than one level of hierarchy
+
+For details that require a full list, link out to a dedicated view with "View details".
+
+### Call to action links
+
+Use links sparingly.
+
+| Guideline | Rule |
+|---|---|
+| Maximum links | One per notification |
+| Position | End of notification only |
+| Inline links | Do not embed links within body text |
+| Label length | One or two words |
+| Tone | Concise and action-oriented |
+
+_Examples: "View details", "Retry", "Fix"_
+
+Avoid driving users away from their workflow unless necessary.
+
+---
+
+## Quick decision guide
+
+### Use [Sonner](/shadcn-components/sonner) when
+
+- Confirming success
+- The message is short
+- No action is required
+- The feedback is tied to a user action
+
+### Use Inline ([Alert](/shadcn-components/alert)) when
+
+- Displaying validation errors
+- The issue blocks progress
+- Context must persist
+- The message relates to a specific UI element
+- The system requires action
+- There is no user action to tie the message to
+
+> If the message blocks progress, it should **never** use [Sonner](/shadcn-components/sonner).
+
+### Choosing an Alert style
+
+| Question | Answer | Style |
+|---|---|---|
+| Is the message routine, informational, or non-disruptive? | Yes | Default (subtle) |
+| Is the message contextual, a warning, or an unresolved requirement? | Yes | Accent (outline) |
+| Does the message block progress or require immediate action? | Yes | Bold (tinted) |
+
+> When unsure, start with **default** and escalate only if the message demands it.

--- a/apps/apollo-vertex/app/shadcn-components/alert/page.mdx
+++ b/apps/apollo-vertex/app/shadcn-components/alert/page.mdx
@@ -1,26 +1,36 @@
-import { Alert, AlertDescription, AlertTitle } from '@/registry/alert/alert'
-import { AlertCircle, CheckCircle2 } from 'lucide-react'
+import { Callout } from 'nextra/components'
+import { AlertDefaultExamples, AlertOutlineExamples, AlertExamples } from '@/app/patterns/notifications/in-product/notification-examples'
 
 # Alert
 
 Displays a callout for user attention.
 
-<div className="p-4 border rounded-lg mt-4 space-y-4">
-  <Alert>
-    <CheckCircle2 className="h-4 w-4" />
-    <AlertTitle>Success!</AlertTitle>
-    <AlertDescription>
-      Your changes have been saved successfully.
-    </AlertDescription>
-  </Alert>
+<Callout type="info">
+  For guidance on when to use Alert vs. Sonner, visual style selection, and content guidelines, see the [In-product notification](/patterns/notifications/in-product) pattern.
+</Callout>
 
-  <Alert variant="destructive">
-    <AlertCircle className="h-4 w-4" />
-    <AlertTitle>Error</AlertTitle>
-    <AlertDescription>
-      Your session has expired. Please log in again.
-    </AlertDescription>
-  </Alert>
+### Default (subtle)
+
+Neutral background with status-colored title and icon. Use for routine information and non-disruptive feedback.
+
+<div className="p-4 border rounded-lg mt-4">
+  <AlertDefaultExamples />
+</div>
+
+### Accent (outline)
+
+Status-colored border and icon with default text. Dismissible. Use for contextual warnings and acknowledged states.
+
+<div className="p-4 border rounded-lg mt-4">
+  <AlertOutlineExamples />
+</div>
+
+### Bold (tinted)
+
+Full status-colored background. Use for critical messages that demand immediate attention.
+
+<div className="p-4 border rounded-lg mt-4">
+  <AlertExamples />
 </div>
 
 ## Installation

--- a/apps/apollo-vertex/app/shadcn-components/sonner/page.mdx
+++ b/apps/apollo-vertex/app/shadcn-components/sonner/page.mdx
@@ -1,13 +1,15 @@
+import { Callout } from 'nextra/components'
 import { SonnerDemo } from './sonner-demo';
 
 # Sonner
 
 An opinionated toast component for React.
 
+<Callout type="info">
+  For guidance on when to use Sonner vs. Alert, placement rules, and content guidelines, see the [In-product notification](/patterns/notifications/in-product) pattern.
+</Callout>
+
 <div className="p-4 border rounded-lg mt-4">
-  <p className="text-sm text-muted-foreground mb-4">
-    Click the buttons below to trigger toast notifications.
-  </p>
   <SonnerDemo />
 </div>
 
@@ -27,7 +29,7 @@ export default function RootLayout({ children }) {
     <html lang="en">
       <body>
         {children}
-        <Toaster />
+        <Toaster position="top-center" closeButton />
       </body>
     </html>
   )
@@ -41,10 +43,20 @@ import { toast } from "sonner"
 ```
 
 ```tsx
-toast("Event has been created.")
+toast("Event has been created", {
+  description: "Sunday, December 03, 2023 at 9:00 AM",
+})
 
-toast.success("Success!")
-toast.error("Error!")
-toast.warning("Warning!")
-toast.info("Info!")
+toast.success("Changes saved", {
+  description: "Your updates have been applied.",
+})
+toast.error("Upload failed", {
+  description: "Please check your connection and retry.",
+})
+toast.warning("Storage almost full", {
+  description: "Consider removing unused files.",
+})
+toast.info("Background sync complete", {
+  description: "All data is up to date.",
+})
 ```

--- a/apps/apollo-vertex/app/shadcn-components/sonner/sonner-demo.tsx
+++ b/apps/apollo-vertex/app/shadcn-components/sonner/sonner-demo.tsx
@@ -1,36 +1,3 @@
 "use client";
 
-import { useTranslation } from "react-i18next";
-import { toast } from "sonner";
-import { Button } from "@/registry/button/button";
-
-export function SonnerDemo() {
-  const { t } = useTranslation();
-
-  return (
-    <div className="flex flex-wrap gap-2">
-      <Button
-        variant="outline"
-        onClick={() =>
-          toast("Event has been created", {
-            description: "Sunday, December 03, 2023 at 9:00 AM",
-          })
-        }
-      >
-        {t("show_toast")}
-      </Button>
-      <Button variant="outline" onClick={() => toast.success("Success!")}>
-        {t("success")}
-      </Button>
-      <Button variant="outline" onClick={() => toast.error("Error!")}>
-        {t("error")}
-      </Button>
-      <Button variant="outline" onClick={() => toast.warning("Warning!")}>
-        {t("warning")}
-      </Button>
-      <Button variant="outline" onClick={() => toast.info("Info!")}>
-        {t("info")}
-      </Button>
-    </div>
-  );
-}
+export { SonnerExamples as SonnerDemo } from "@/app/patterns/notifications/in-product/notification-examples";

--- a/apps/apollo-vertex/next-env.d.ts
+++ b/apps/apollo-vertex/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/apollo-vertex/registry.json
+++ b/apps/apollo-vertex/registry.json
@@ -315,6 +315,7 @@
       "title": "Button Group",
       "description": "Groups multiple buttons together.",
       "dependencies": ["@radix-ui/react-slot"],
+      "registryDependencies": ["separator"],
       "files": [
         {
           "path": "registry/button-group/button-group.tsx",
@@ -508,6 +509,7 @@
       "type": "registry:ui",
       "title": "Field",
       "description": "A form field component with label, input, and description.",
+      "registryDependencies": ["label", "separator"],
       "files": [{ "path": "registry/field/field.tsx", "type": "registry:ui" }]
     },
     {
@@ -522,6 +524,7 @@
         "zod",
         "react-hook-form"
       ],
+      "registryDependencies": ["label"],
       "files": [{ "path": "registry/form/form.tsx", "type": "registry:ui" }]
     },
     {
@@ -549,6 +552,7 @@
       "type": "registry:ui",
       "title": "Input Group",
       "description": "Groups input elements with addons and buttons.",
+      "registryDependencies": ["button", "input", "textarea"],
       "files": [
         {
           "path": "registry/input-group/input-group.tsx",
@@ -575,6 +579,7 @@
       "title": "Item",
       "description": "A list item component for displaying content in lists.",
       "dependencies": ["@radix-ui/react-slot"],
+      "registryDependencies": ["separator"],
       "files": [{ "path": "registry/item/item.tsx", "type": "registry:ui" }]
     },
     {


### PR DESCRIPTION
## Summary
- Adds a new **Notifications** page under `shadcn-components` in apollo-vertex
- Documents the two notification patterns: **Sonner** (toast) and **Alert** (inline)
- Covers usage guidelines, status definitions (aligned with Badge tokens), contrast rules, content guidelines, and a quick decision framework
- Links to existing Sonner, Alert, and Badge component pages for cross-reference

## Test plan
- [ ] Verify page renders at `/shadcn-components/notifications`
- [ ] Confirm sidebar navigation includes the new page
- [ ] Check all internal links (Sonner, Alert, Badge) resolve correctly
- [ ] Review content for accuracy and completeness

🤖 Generated with [Claude Code](https://claude.com/claude-code)