### PR TITLE
fix(apollo-react): use combination search for add node panel [MST-6789]

### DIFF
--- a/packages/apollo-react/src/canvas/core/CategoryTree.test.ts
+++ b/packages/apollo-react/src/canvas/core/CategoryTree.test.ts
@@ -450,6 +450,66 @@ describe('CategoryTree', () => {
       const filtered = tree.filterBySearch('nonexistent-search-term');
       expect(filtered.isEmpty()).toBe(true);
     });
+
+    it('should match multi-word search across different node attributes', () => {
+      const categories = createMockCategories();
+      const nodes = createMockNodes();
+      const tree = new CategoryTree(categories, nodes);
+
+      // "send" matches label "Send Email", "message" matches description "Send an email message"
+      const filtered = tree.filterBySearch('send message');
+      const emailCategory = filtered.findCategory('automation.email');
+
+      expect(emailCategory?.nodes).toHaveLength(1);
+      expect(emailCategory?.nodes[0]?.nodeType).toBe('send-email');
+    });
+
+    it('should match multi-word search across node and category attributes', () => {
+      const categories = createMockCategories();
+      const nodes = createMockNodes();
+      const tree = new CategoryTree(categories, nodes);
+
+      // "automation" matches category name, "read" matches node label/tags
+      const filtered = tree.filterBySearch('automation read');
+      const filesCategory = filtered.findCategory('automation.files');
+
+      expect(filesCategory?.nodes).toHaveLength(1);
+      expect(filesCategory?.nodes[0]?.nodeType).toBe('read-file');
+    });
+
+    it('should match multi-word search regardless of word order', () => {
+      const categories = createMockCategories();
+      const nodes = createMockNodes();
+      const tree = new CategoryTree(categories, nodes);
+
+      const filtered1 = tree.filterBySearch('email automation');
+      const filtered2 = tree.filterBySearch('automation email');
+
+      expect(filtered1.findCategory('automation.email')?.nodes).toHaveLength(1);
+      expect(filtered2.findCategory('automation.email')?.nodes).toHaveLength(1);
+    });
+
+    it('should require all words to match for multi-word search', () => {
+      const categories = createMockCategories();
+      const nodes = createMockNodes();
+      const tree = new CategoryTree(categories, nodes);
+
+      // "email" matches but "zzz" matches nothing
+      const filtered = tree.filterBySearch('email zzz');
+      expect(filtered.isEmpty()).toBe(true);
+    });
+
+    it('should match across nested category names', () => {
+      const categories = createMockCategories();
+      const nodes = createMockNodes();
+      const tree = new CategoryTree(categories, nodes);
+
+      // "files" matches subcategory name, "content" matches description
+      const filtered = tree.filterBySearch('files content');
+      const filesCategory = filtered.findCategory('automation.files');
+
+      expect(filesCategory?.nodes).toHaveLength(2);
+    });
   });
 
   describe('filterByConnections', () => {

--- a/packages/apollo-react/src/canvas/core/CategoryTree.ts
+++ b/packages/apollo-react/src/canvas/core/CategoryTree.ts
@@ -305,8 +305,14 @@ export class CategoryTree {
   }
 
   /**
-   * Filter the tree by search term.
-   * Searches node labels, types, descriptions, and tags.
+   * Filter the tree by search term using combination search.
+   *
+   * The search term is split into words. A node matches if every word matches
+   * at least one searchable attribute: node label, type, description, tags,
+   * or ancestor category names.
+   *
+   * This allows queries like "Outlook Email" to match a node named "Archive Email"
+   * inside a "Microsoft Outlook 365" category.
    *
    * This is an immutable operation - returns a new CategoryTree instance.
    *
@@ -318,20 +324,62 @@ export class CategoryTree {
       return this;
     }
 
-    const searchLower = searchTerm.toLowerCase();
+    const searchWords = searchTerm
+      .toLowerCase()
+      .split(/\s+/)
+      .filter(Boolean);
 
-    return this.filter({
-      nodeFilter: (node) => {
-        const matchesLabel = node.display.label.toLowerCase().includes(searchLower);
-        const matchesType = node.nodeType.toLowerCase().includes(searchLower);
-        const matchesDescription = node.description?.toLowerCase().includes(searchLower);
-        const matchesTags = node.tags?.some(
-          (tag) => typeof tag === 'string' && tag.toLowerCase().includes(searchLower)
+    if (searchWords.length === 0) {
+      return this;
+    }
+
+    const matchesAllWords = (
+      node: NodeManifest,
+      ancestorCategoryNames: string[],
+    ): boolean => {
+      const searchableTexts = [
+        node.display.label.toLowerCase(),
+        node.nodeType.toLowerCase(),
+        ...(node.description ? [node.description.toLowerCase()] : []),
+        ...(node.tags
+          ?.filter((tag): tag is string => typeof tag === 'string')
+          .map((tag) => tag.toLowerCase()) ?? []),
+        ...ancestorCategoryNames,
+      ];
+
+      return searchWords.every((word) =>
+        searchableTexts.some((text) => text.includes(word)),
+      );
+    };
+
+    const filterTree = (
+      tree: CategoryTreeNode[],
+      ancestorNames: string[],
+    ): CategoryTreeNode[] => {
+      const filtered: CategoryTreeNode[] = [];
+
+      for (const item of tree) {
+        const categoryNames = [...ancestorNames, item.name.toLowerCase()];
+
+        const nestedCategories = filterTree(item.nestedCategories, categoryNames);
+        const nodes = item.nodes.filter((node) =>
+          matchesAllWords(node, categoryNames),
         );
 
-        return matchesLabel || matchesType || matchesDescription || matchesTags;
-      },
-    });
+        if (nestedCategories.length > 0 || nodes.length > 0) {
+          filtered.push({ ...item, nestedCategories, nodes });
+        }
+      }
+
+      return filtered;
+    };
+
+    const filteredRoots = filterTree(this.rootCategories, []);
+    const filteredRootNodes = this.rootNodes.filter((node) =>
+      matchesAllWords(node, []),
+    );
+
+    return CategoryTree.fromPrebuilt(filteredRoots, filteredRootNodes);
   }
 
   /**


### PR DESCRIPTION
[CategoryTree.ts:316-388]() — Rewrote filterBySearch() to support combination search:
- Splits the search term into individual words.
- Each word must match at least one searchable attribute (label, nodeType, description, tags, or ancestor category names).
- Uses a custom recursive traversal that passes category names down the tree, so nodes inherit their parent categories as searchable context.

[CategoryTree.test.ts:454-508]() — Added 5 new tests:
- Multi-word matching across different node attributes.
- Multi-word matching across node + category attributes.
- Word order independence.
- All words must match (no partial matches).
- Matching across nested category names.


With this change, the following queries would all work for the "Archive Email" node in "Microsoft Outlook 365" > "Connector":
- "Outlook Email" — "outlook" matches category name, "email" matches node label
- "Connector Email Archive" — "connector" matches category, "email"/"archive" match label
- "Email outlook" — same as first, order-independent