### PR TITLE
feat(apollo-react): add support for validation adornments on node

### DIFF
--- a/packages/apollo-react/src/canvas/components/AgentCanvas/nodes/AgentNode.test.tsx
+++ b/packages/apollo-react/src/canvas/components/AgentCanvas/nodes/AgentNode.test.tsx
@@ -33,10 +33,6 @@ vi.mock('../../ButtonHandle/useButtonHandles', () => ({
   useButtonHandles: () => null,
 }));
 
-vi.mock('../../ExecutionStatusIcon/ExecutionStatusIcon', async () => ({
-  ...(await vi.importActual('../../ExecutionStatusIcon/ExecutionStatusIcon')),
-}));
-
 vi.mock('../store/agent-flow-store', () => ({
   useAgentFlowStore: () => ({
     actOnSuggestion: vi.fn(),

--- a/packages/apollo-react/src/canvas/components/BaseNode/BaseNode.tsx
+++ b/packages/apollo-react/src/canvas/components/BaseNode/BaseNode.tsx
@@ -10,7 +10,7 @@ import { ApIcon } from '@uipath/apollo-react/material/components';
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { DEFAULT_NODE_SIZE } from '../../constants';
 import { useNodeTypeRegistry } from '../../core';
-import { useNodeExecutionState } from '../../hooks';
+import { useElementValidationStatus, useNodeExecutionState } from '../../hooks';
 import type { HandleGroupManifest } from '../../schema/node-definition';
 import { resolveAdornments } from '../../utils/adornment-resolver';
 import { getIcon } from '../../utils/icon-registry';
@@ -32,6 +32,7 @@ import {
   BaseSubHeader,
   BaseTextContainer,
 } from './BaseNode.styles';
+import type { ExecutionState } from '../../types/execution';
 import type {
   BaseNodeData,
   FooterVariant,
@@ -75,6 +76,7 @@ const BaseNodeComponent = (props: NodeProps<Node<BaseNodeData>>) => {
 
   // Get execution status from external source
   const executionState = useNodeExecutionState(id);
+  const validationState = useElementValidationStatus(id);
   const nodeTypeRegistry = useNodeTypeRegistry();
   const { mode } = useBaseCanvasMode();
 
@@ -92,13 +94,14 @@ const BaseNodeComponent = (props: NodeProps<Node<BaseNodeData>>) => {
   const statusContext: NodeStatusContext = useMemo(
     () => ({
       nodeId: id,
-      executionState,
+      executionState: (executionStatusOverride as ExecutionState) ?? executionState,
+      validationState,
       isConnecting,
       isSelected: selected,
       isDragging: dragging,
       mode,
     }),
-    [id, executionState, isConnecting, selected, dragging, mode]
+    [id, executionStatusOverride, executionState, validationState, isConnecting, selected, dragging, mode]
   );
 
   // Callbacks: Use props only (no longer in data)

--- a/packages/apollo-react/src/canvas/components/BaseNode/BaseNode.types.ts
+++ b/packages/apollo-react/src/canvas/components/BaseNode/BaseNode.types.ts
@@ -1,5 +1,6 @@
 import type { NodeShape } from '../../schema';
 import type { ExecutionState } from '../../types/execution';
+import type { ValidationState } from '../../types/validation';
 
 export type FooterVariant = 'none' | 'button' | 'single' | 'double';
 
@@ -40,6 +41,7 @@ export interface NodeAdornments {
 export interface NodeStatusContext {
   nodeId: string;
   executionState?: ExecutionState;
+  validationState?: ValidationState;
   isHovered?: boolean;
   isConnecting?: boolean;
   isSelected?: boolean;

--- a/packages/apollo-react/src/canvas/utils/adornment-resolver.test.tsx
+++ b/packages/apollo-react/src/canvas/utils/adornment-resolver.test.tsx
@@ -1,0 +1,217 @@
+import { isValidElement } from 'react';
+import { describe, expect, it } from 'vitest';
+import type { NodeStatusContext } from '../components';
+import { ValidationErrorSeverity } from '../types/validation';
+import {
+  BreakpointIndicator,
+  ExecutionStartPointIndicator,
+  ExecutionStatusIndicator,
+  ValidationErrorIndicator,
+  resolveAdornments,
+} from './adornment-resolver';
+
+const baseContext: NodeStatusContext = { nodeId: 'node-1' };
+
+describe('resolveAdornments', () => {
+  // ── No status ───────────────────────────────────────────
+
+  it('returns execution status indicator as default topRight', () => {
+    const result = resolveAdornments(baseContext);
+    expect(result.topLeft).toBeUndefined();
+    expect((result.topRight as React.ReactElement)?.type).toBe(ExecutionStatusIndicator);
+    expect(result.bottomLeft).toBeUndefined();
+    expect(result.bottomRight).toBeUndefined();
+  });
+
+  // ── Execution status (topRight) ─────────────────────────
+
+  it('shows execution indicator for string execution state', () => {
+    const result = resolveAdornments({ ...baseContext, executionState: 'Completed' });
+    expect((result.topRight as React.ReactElement)?.type).toBe(ExecutionStatusIndicator);
+  });
+
+  it('shows execution indicator for object execution state', () => {
+    const result = resolveAdornments({
+      ...baseContext,
+      executionState: { status: 'Failed', count: 2 },
+    });
+    expect((result.topRight as React.ReactElement)?.type).toBe(ExecutionStatusIndicator);
+  });
+
+  // ── Breakpoint (topLeft) ────────────────────────────────
+
+  it('shows breakpoint when debug is true', () => {
+    const result = resolveAdornments({
+      ...baseContext,
+      executionState: { status: 'None', debug: true },
+    });
+    expect(result.topLeft).toBeTruthy();
+  });
+
+  it('no breakpoint without debug flag', () => {
+    const result = resolveAdornments({
+      ...baseContext,
+      executionState: { status: 'None' },
+    });
+    expect(result.topLeft).toBeUndefined();
+  });
+
+  // ── Start point (bottomLeft) ────────────────────────────
+
+  it('shows start point indicator when isExecutionStartPoint', () => {
+    const result = resolveAdornments({
+      ...baseContext,
+      executionState: { status: 'None', isExecutionStartPoint: true },
+    });
+    expect(result.bottomLeft).toBeTruthy();
+  });
+
+  // ── Pinned output (bottomRight) ─────────────────────────
+
+  it('shows pinned output indicator when isOutputPinned', () => {
+    const result = resolveAdornments({
+      ...baseContext,
+      executionState: { status: 'None', isOutputPinned: true },
+    });
+    expect(result.bottomRight).toBeTruthy();
+  });
+
+  // ── Validation errors (topRight) ────────────────────────
+
+  it('shows validation indicator for ERROR severity', () => {
+    const result = resolveAdornments({
+      ...baseContext,
+      validationState: {
+        validationStatus: ValidationErrorSeverity.ERROR,
+        validationError: {
+          code: 'REQUIRED',
+          message: 'URL is required',
+          description: 'URL is required',
+          severity: ValidationErrorSeverity.ERROR,
+        },
+      },
+    });
+    expect((result.topRight as React.ReactElement)?.type).toBe(ValidationErrorIndicator);
+  });
+
+  it('shows validation indicator for CRITICAL severity', () => {
+    const result = resolveAdornments({
+      ...baseContext,
+      validationState: {
+        validationStatus: ValidationErrorSeverity.CRITICAL,
+        validationError: {
+          code: 'CRITICAL_ERROR',
+          message: 'Critical error',
+          description: 'Critical error',
+          severity: ValidationErrorSeverity.CRITICAL,
+        },
+      },
+    });
+    expect((result.topRight as React.ReactElement)?.type).toBe(ValidationErrorIndicator);
+  });
+
+  it('falls back to execution indicator for WARNING severity', () => {
+    const result = resolveAdornments({
+      ...baseContext,
+      validationState: {
+        validationStatus: ValidationErrorSeverity.WARNING,
+        validationError: {
+          code: 'WARN',
+          message: 'Warning',
+          description: 'Warning',
+          severity: ValidationErrorSeverity.WARNING,
+        },
+      },
+    });
+    expect((result.topRight as React.ReactElement)?.type).toBe(ExecutionStatusIndicator);
+  });
+
+  it('falls back to execution indicator for INFO severity', () => {
+    const result = resolveAdornments({
+      ...baseContext,
+      validationState: {
+        validationStatus: ValidationErrorSeverity.INFO,
+        validationError: undefined,
+      },
+    });
+    expect((result.topRight as React.ReactElement)?.type).toBe(ExecutionStatusIndicator);
+  });
+
+  // ── Priority: execution status > validation ─────────────
+
+  it('execution status takes priority over validation error', () => {
+    const result = resolveAdornments({
+      ...baseContext,
+      executionState: 'Completed',
+      validationState: {
+        validationStatus: ValidationErrorSeverity.ERROR,
+        validationError: {
+          code: 'REQUIRED',
+          message: 'URL is required',
+          description: 'URL is required',
+          severity: ValidationErrorSeverity.ERROR,
+        },
+      },
+    });
+    expect((result.topRight as React.ReactElement)?.type).toBe(ExecutionStatusIndicator);
+  });
+
+  it('validation shown when no execution state', () => {
+    const result = resolveAdornments({
+      ...baseContext,
+      executionState: undefined,
+      validationState: {
+        validationStatus: ValidationErrorSeverity.ERROR,
+        validationError: {
+          code: 'REQUIRED',
+          message: 'Field required',
+          description: 'Field required',
+          severity: ValidationErrorSeverity.ERROR,
+        },
+      },
+    });
+    expect((result.topRight as React.ReactElement)?.type).toBe(ValidationErrorIndicator);
+  });
+
+  it('falls back to execution indicator when no validation state', () => {
+    const result = resolveAdornments({
+      ...baseContext,
+      validationState: undefined,
+    });
+    expect((result.topRight as React.ReactElement)?.type).toBe(ExecutionStatusIndicator);
+  });
+});
+
+// ── Component unit tests ────────────────────────────────────
+
+describe('BreakpointIndicator', () => {
+  it('renders when active', () => {
+    expect(BreakpointIndicator({ isActive: true })).toBeTruthy();
+  });
+
+  it('returns null when inactive', () => {
+    expect(BreakpointIndicator({ isActive: false })).toBeNull();
+  });
+});
+
+describe('ExecutionStartPointIndicator', () => {
+  it('renders when active', () => {
+    expect(ExecutionStartPointIndicator({ isActive: true })).toBeTruthy();
+  });
+
+  it('returns null when inactive', () => {
+    expect(ExecutionStartPointIndicator({ isActive: false })).toBeNull();
+  });
+});
+
+describe('ValidationErrorIndicator', () => {
+  it('renders with custom message', () => {
+    const el = ValidationErrorIndicator({ message: 'URL is required' });
+    expect(el).toBeTruthy();
+    expect(isValidElement(el)).toBe(true);
+  });
+
+  it('renders with default message when none provided', () => {
+    expect(ValidationErrorIndicator({})).toBeTruthy();
+  });
+});

--- a/packages/apollo-react/src/canvas/utils/adornment-resolver.tsx
+++ b/packages/apollo-react/src/canvas/utils/adornment-resolver.tsx
@@ -1,8 +1,10 @@
 import { ExecutionStatusIcon, NodeIcon } from '@uipath/apollo-react/canvas';
+import { ApIcon } from '@uipath/apollo-react/material/components';
 import { ApTooltip } from '@uipath/apollo-react/material';
 import { memo } from 'react';
 import type { NodeAdornments, NodeStatusContext } from '../components';
 import { getExecutionStatusColor } from '../components/ExecutionStatusIcon/ExecutionStatusIcon';
+import { ValidationErrorSeverity } from '../types/validation';
 
 interface BreakpointIndicatorProps {
   isActive?: boolean;
@@ -68,6 +70,16 @@ function PinnedOutputIndicator() {
 
 export const ExecutionStatusIndicator = memo(ExecutionStatusIndicatorInternal);
 
+export function ValidationErrorIndicator({ message }: { message?: string }) {
+  return (
+    <ApTooltip content={message || 'Validation error'} placement="bottom">
+      <span style={{ display: 'inline-flex' }}>
+        <ApIcon name="error" size="16px" color="var(--uix-canvas-error-icon)" />
+      </span>
+    </ApTooltip>
+  );
+}
+
 const getDefaultAdornments = (context: NodeStatusContext): NodeAdornments => {
   const executionState = context.executionState;
 
@@ -78,9 +90,15 @@ const getDefaultAdornments = (context: NodeStatusContext): NodeAdornments => {
     typeof executionState === 'object' && executionState?.isExecutionStartPoint;
   const isOutputPinned = typeof executionState === 'object' && executionState?.isOutputPinned;
 
+  const hasValidationError =
+    context.validationState?.validationStatus === ValidationErrorSeverity.ERROR ||
+    context.validationState?.validationStatus === ValidationErrorSeverity.CRITICAL;
+
   return {
     topLeft: hasBreakpoint ? <BreakpointIndicator /> : undefined,
-    topRight: <ExecutionStatusIndicator status={status} count={count} />,
+    topRight: !status && hasValidationError
+      ? <ValidationErrorIndicator message={context.validationState?.validationError?.message} />
+      : <ExecutionStatusIndicator status={status} count={count} />,
     bottomLeft: isExecutionStartPoint ? <ExecutionStartPointIndicator /> : undefined,
     bottomRight: isOutputPinned ? <PinnedOutputIndicator /> : undefined,
   };


### PR DESCRIPTION
## Summary
- Add native validation error adornments to BaseNode via the existing `ValidationStatusContext`
- BaseNode now calls `useElementValidationStatus(id)` and passes `validationState` into `NodeStatusContext`
- The adornment resolver shows a `ValidationErrorIndicator` (error icon with tooltip) in the `topRight` slot when there are validation errors and no execution status is active
- Exports a new `ValidationErrorIndicator` component from the adornment resolver

## Motivation
Previously, consumers (e.g., flow-workbench) had to use `BaseNodeOverrideConfigProvider` to inject validation adornments into every node. This was a blunt override that replaced the entire `topRight` slot. With this change, validation adornments are resolved natively by the adornment resolver, consistent with how breakpoints, execution status, and pinned outputs already work.

## Changes
- **`BaseNode.types.ts`** — Added optional `validationState` to `NodeStatusContext` interface
- **`BaseNode.tsx`** — Calls `useElementValidationStatus(id)` and includes result in `statusContext`
- **`adornment-resolver.tsx`** — Added `ValidationErrorIndicator` component; resolver shows it in `topRight` when validation errors exist and no execution status is present (execution status takes priority)

## Test plan
- [ ] Verify nodes with validation errors show error icon badge in top-right corner
- [ ] Verify execution status indicator still takes priority over validation in debug/evaluate mode
- [ ] Verify tooltip shows validation error message on hover
- [ ] Verify no adornment shows when there are no validation errors