### PR TITLE
fix(apollo-react): prevent cite-end tag when citing text-block ending in url

### DIFF
--- a/packages/apollo-react/src/material/components/ap-chat/components/message/markdown/parsers/citation-parser.tsx
+++ b/packages/apollo-react/src/material/components/ap-chat/components/message/markdown/parsers/citation-parser.tsx
@@ -148,7 +148,10 @@ export function contentPartsToMarkdown(messageId: string, contentParts: ContentP
         }));
 
         const encodedData = btoa(JSON.stringify(citationsData));
-        text = `[[cite-start:${encodedData}]]${text}[[cite-end]]`;
+        // Add a space before [[cite-end]] when text ends with a URL to prevent
+        // link parser from absorbing [[cite-end]] into the URL and rendering it as part of the link.
+        const endsWithUrl = /https?:\/\/\S+$/.test(text);
+        text = `[[cite-start:${encodedData}]]${text}${endsWithUrl ? ' ' : ''}[[cite-end]]`;
       }
       return text;
     })


### PR DESCRIPTION
Fixes a customer-raised issue where content-blocks with text ending in a URL that has citations has `[[cite-end]]` injected into the link markdown. Note that this only occurs when it ends with a url - when it has a space/other-characters after the URL, or when it begins with a URL, no issue happens.

Don't think there's an easy fix besides adding a space when this happens, which is the simplest solution that does not have much affect on the visual. The space is only added when necessary (URL-ending texts), so non-URL cases are unaffected.

Claude explanation:

> GFM's autolink parser seems to treat [ and ] as valid URL characters (per spec: "zero or more characters that are not ASCII space or <"). When [[cite-end]] immediately follows a URL, the entire string https://url.com[[cite-end]] gets parsed as a single autolink. This means [[cite-end]] ends up inside the link node's url property, which is used to generate the display text — so the marker renders as visible text instead of being processed by the citation plugin.


[JAR-9429]: https://uipath.atlassian.net/browse/JAR-9429?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ