### PR TITLE
fix(apollo-wind): fix prism import issues on vitest for consumers

### DIFF
--- a/packages/apollo-wind/src/components/ui/code-block.tsx
+++ b/packages/apollo-wind/src/components/ui/code-block.tsx
@@ -10,7 +10,8 @@ import {
   prism,
   vs,
   vscDarkPlus,
-} from 'react-syntax-highlighter/dist/esm/styles/prism';
+} from 'react-syntax-highlighter/dist/esm/styles/prism/index.js';
+
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib';
 
@@ -187,7 +188,8 @@ function getBodyTheme(): CodeBlockTheme {
   const bodyClasses = document.body.classList;
   const htmlClasses = document.documentElement.classList;
   return (
-    BODY_CLASS_PRIORITY.find((t) => bodyClasses.contains(t) || htmlClasses.contains(t)) ?? 'future-dark'
+    BODY_CLASS_PRIORITY.find((t) => bodyClasses.contains(t) || htmlClasses.contains(t)) ??
+    'future-dark'
   );
 }
 

--- a/packages/apollo-wind/src/types/react-syntax-highlighter.d.ts
+++ b/packages/apollo-wind/src/types/react-syntax-highlighter.d.ts
@@ -1,0 +1,13 @@
+/**
+ * Type declaration for the react-syntax-highlighter Prism styles barrel.
+ *
+ * The bare directory import (`…/styles/prism`) isn't supported by Node's
+ * ESM resolver, which breaks vitest / Jest in consuming projects.
+ * Pointing at the explicit `index.js` fixes the resolution while keeping
+ * the same named-export API. DefinitelyTyped only types the directory
+ * path, so we need this ambient declaration for the `.js` variant.
+ */
+
+declare module 'react-syntax-highlighter/dist/esm/styles/prism/index.js' {
+  export * from 'react-syntax-highlighter/dist/esm/styles/prism';
+}


### PR DESCRIPTION
Consumers running vitest/Jest fail when importing `@uipath/apollo-wind` because the `code-block` component uses a directory import (`react-syntax-highlighter/dist/esm/styles/prism`) that Node's ESM resolver cannot resolve.

### Root cause

`react-syntax-highlighter` has no `exports` map in its `package.json` — only [`main`/`module`](https://github.com/react-syntax-highlighter/react-syntax-highlighter/blob/master/package.json#L5-L6). Subpath imports resolve via the filesystem directly. Since `apollo-wind` is built with `bundle: false`, the import passes through as-is into `dist/`. When a consumer's test runner uses Node ESM resolution on dependencies in `node_modules`, it rejects directory imports (Node ESM requires explicit file paths, unlike CJS which auto-resolves `index.js`).

### Fix

- Point the import at the explicit `index.js` barrel file (`react-syntax-highlighter/dist/esm/styles/prism/index.js`)
- Add a minimal `.d.ts` declaration since `@types/react-syntax-highlighter` only types the directory path