### PR TITLE
fix(apollo-react): move handle to bottom for memory and escalation nodes

### DIFF
--- a/packages/apollo-react/src/canvas/storybook-utils/manifests/node-definitions.ts
+++ b/packages/apollo-react/src/canvas/storybook-utils/manifests/node-definitions.ts
@@ -465,7 +465,7 @@ export const allNodeManifests: NodeManifest[] = [
     },
     handleConfiguration: [
       {
-        position: 'top',
+        position: 'bottom',
         handles: [
           {
             id: 'input',
@@ -495,7 +495,7 @@ export const allNodeManifests: NodeManifest[] = [
     },
     handleConfiguration: [
       {
-        position: 'top',
+        position: 'bottom',
         handles: [
           {
             id: 'input',

--- a/packages/apollo-react/src/canvas/utils/createPreviewNode.ts
+++ b/packages/apollo-react/src/canvas/utils/createPreviewNode.ts
@@ -75,6 +75,19 @@ function calculatePositionFromDrop(
 }
 
 /**
+ * Returns the spread offset for a handle within a multi-handle group.
+ * Left/top half shifts by -size, right/bottom half by +size, middle stays at 0.
+ */
+function computeSpreadOffset(handle: HandleContext | undefined, size: number): number {
+  const index = handle?.index ?? null;
+  const count = handle?.count ?? 1;
+  if (index === null || count <= 1) return 0;
+  if (index < Math.floor(count / 2)) return -size;
+  if (index >= Math.ceil(count / 2)) return size;
+  return 0;
+}
+
+/**
  * Calculates the preview node position when no drop position is provided.
  * Positions the preview node on the appropriate side based on handle position.
  * Uses overlap detection to ensure the preview doesn't overlap existing nodes.
@@ -115,37 +128,26 @@ function calculateAutoPosition(
       };
       direction = 'left';
       break;
-    case Position.Right: {
-      // Place preview to the right of source node, vertically aligned with the handle.
-      // When multiple handles share the same side, spread preview nodes vertically: top half shifts up,
-      // bottom half shifts down, middle (odd count) stays centered.
-      let yOffset = 0;
-      const handleIndex = handle?.index ?? null;
-      const handleCount = handle?.count ?? 1;
-      if (handleIndex !== null && handleCount > 1) {
-        if (handleIndex < Math.floor(handleCount / 2)) yOffset = -previewNodeSize.height;
-        else if (handleIndex >= Math.ceil(handleCount / 2)) yOffset = previewNodeSize.height;
-      }
-
+    case Position.Right:
+      // Spread vertically when multiple handles share the right side.
       initialPosition = {
         x: sourceAbsolutePosition.x + sourceWidth + offset,
-        y: anchorY - previewNodeSize.height / 2 + yOffset,
+        y: anchorY - previewNodeSize.height / 2 + computeSpreadOffset(handle, previewNodeSize.height),
       };
       direction = 'right';
       break;
-    }
     case Position.Top:
-      // Place preview above source node, horizontally aligned with the handle
+      // Spread horizontally when multiple handles share the top side.
       initialPosition = {
-        x: anchorX - previewNodeSize.width / 2,
+        x: anchorX - previewNodeSize.width / 2 + computeSpreadOffset(handle, previewNodeSize.width / 2),
         y: sourceAbsolutePosition.y - previewNodeSize.height - offset,
       };
       direction = 'top';
       break;
     case Position.Bottom:
-      // Place preview below source node, horizontally aligned with the handle
+      // Spread horizontally when multiple handles share the bottom side.
       initialPosition = {
-        x: anchorX - previewNodeSize.width / 2,
+        x: anchorX - previewNodeSize.width / 2 + computeSpreadOffset(handle, previewNodeSize.width / 2),
         y: sourceAbsolutePosition.y + sourceHeight + offset,
       };
       direction = 'bottom';


### PR DESCRIPTION
## Summary

- Nodes attached to top/bottom-facing handles now spread horizontally on preview _**(key change)**_.
- Handle on memory/escalation nodes have been moved from the top to the bottom. _(optional, less important)_
    - **why did I mark this as optional?** node title readability (e.g. Agent Memory, Agent Escalation) is worsened by having the arrow entering the bottom of the memory/escalation nodes. It might be worth keeping existing handle position on these nodes for that reason.
   
| Before  | After |
| ------------- | ------------- |
| <img width="377" height="587" alt="image" src="https://github.com/user-attachments/assets/fed48f0c-96c6-4f2a-8875-943e116001ab" />  | <img width="384" height="537" alt="image" src="https://github.com/user-attachments/assets/1ad5def7-4b45-42da-b1af-7b062d725cab" />  |

## Changes

- `node-definitions.ts`: `uipath.agent.resource.memory` handle position `top` → `bottom`
- `node-definitions.ts`: `uipath.agent.resource.escalation` handle position `top` → `bottom`

## Testing

- [x] `pnpm run test` passes (63 suites, 1232 tests)
- [x] `pnpm run lint` passes (warnings only, pre-existing)
- [x] Manual testing performed — verify handle dot appears at bottom of resource nodes in AgentFlow story
