### PR TITLE
fix(apollo-react): canvas colors selector [MST-7209]

### DIFF
--- a/packages/apollo-react/src/canvas/styles/variables.css
+++ b/packages/apollo-react/src/canvas/styles/variables.css
@@ -6,22 +6,25 @@
  * by consumers to customize the appearance.
  *
  * Usage:
- *   import '@uipath/uix-canvas/styles';
+ *   import "@uipath/apollo-react/canvas/styles/variables.css";
  *
  * To override, define the variables in your own CSS:
- *   :root {
+ *   body.light {
  *     --uix-canvas-foreground: #333;
  *     --uix-canvas-background: #fff;
  *   }
  *
- * Note: We use `:where(*)` instead of `:root` because the --color-* variables
- * from Portal Shell are defined in the shadow DOM and cascade down to slotted
- * content. The `:where(*)` selector ensures our variables are evaluated in the
- * context of each element, allowing proper inheritance of the --color-* values.
- * `:where()` has zero specificity, making it easy to override these defaults.
+ * Note: We define these on each theme class (body.light, body.dark, etc.) to
+ * ensure the var() references resolve correctly. CSS variables can only reference
+ * other variables in the same scope or parent scopes. Since the base --color-*
+ * variables are defined on body.light, body.dark, etc., we must define canvas
+ * variables in the same context to ensure proper resolution.
  */
 
-:where(*) {
+body.light,
+body.dark,
+body.light-hc,
+body.dark-hc {
   /* ==========================================================================
      Core Colors
      ========================================================================== */


### PR DESCRIPTION
`where(*)` was causing those semantic tokens to be defined for all components

### DEMO in SW:
<img width="1869" height="891" alt="image" src="https://github.com/user-attachments/assets/0718a632-758f-4608-9f4a-669c1e0588af" />

### DEMO in VSIX:
<img width="1196" height="801" alt="image" src="https://github.com/user-attachments/assets/fa3e58d7-d2df-42c0-a5db-5cbcd33cdc19" />

### DEMO in flow-workbench:
<img width="1874" height="940" alt="image" src="https://github.com/user-attachments/assets/bc3fb9ea-1425-4eac-8fa2-d06a00697d66" />
