### PR TITLE
feat(apollo-react): add tooltip for big names in tooltip [MST-7088]

### DIFF
--- a/packages/apollo-react/src/canvas/components/AddNodePanel/AddNodePanel.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/AddNodePanel/AddNodePanel.stories.tsx
@@ -65,7 +65,7 @@ const NODE_OPTIONS: ListItem<NodeItemData>[] = [
   },
   {
     id: '4',
-    name: 'AI Agent',
+    name: 'AI Agent long long long long long long name',
     icon: { name: 'smart_toy' },
     data: { type: 'ai-agent', category: 'AI' },
     description: 'Autonomous AI assistant',

--- a/packages/apollo-react/src/canvas/components/Toolbox/ListView.tsx
+++ b/packages/apollo-react/src/canvas/components/Toolbox/ListView.tsx
@@ -2,7 +2,7 @@ import { FontVariantToken } from '@uipath/apollo-core';
 import { Column } from '@uipath/apollo-react/canvas/layouts';
 import { NodeIcon, partition } from '@uipath/apollo-react/canvas/utils';
 import { ApSkeleton, ApTypography } from '@uipath/apollo-react/material';
-import { ApIcon } from '@uipath/apollo-react/material/components';
+import { ApIcon, ApTooltip } from '@uipath/apollo-react/material/components';
 import { memo, useCallback, useMemo } from 'react';
 import type { RowComponentProps } from 'react-window';
 import { useCanvasTheme } from '../BaseCanvas/CanvasThemeContext';
@@ -118,13 +118,15 @@ const ListViewRow = memo(
           {item.icon?.Component && <item.icon.Component />}
         </IconContainerMemoized>
         <Column flex={1} overflow="hidden">
-          <ApTypography
-            variant={FontVariantToken.fontSizeM}
-            className="list-view-item-name"
-            color="var(--uix-canvas-foreground-emp)"
-          >
-            {item.name}
-          </ApTypography>
+          <ApTooltip content={item.name} placement="top" smartTooltip>
+            <ApTypography
+              variant={FontVariantToken.fontSizeM}
+              className="list-view-item-name"
+              color="var(--uix-canvas-foreground-emp)"
+            >
+              {item.name}
+            </ApTypography>
+          </ApTooltip>
           {item.description && (
             <ApTypography
               variant={FontVariantToken.fontSizeXs}


### PR DESCRIPTION
tootips are added for large names in toolbox for better visibilty


https://github.com/user-attachments/assets/058099a1-3016-4e8f-a067-505643a16069

