### PR TITLE
feat(apollo-react): add tooltip to add node icon in flow[MST-6942]

### DIFF
--- a/packages/apollo-react/src/canvas/components/ButtonHandle/ButtonHandle.tsx
+++ b/packages/apollo-react/src/canvas/components/ButtonHandle/ButtonHandle.tsx
@@ -2,7 +2,7 @@ import { FontVariantToken } from '@uipath/apollo-core';
 import { Row } from '@uipath/apollo-react/canvas/layouts';
 import { Position } from '@uipath/apollo-react/canvas/xyflow/react';
 import { ApTypography } from '@uipath/apollo-react/material';
-import { ApIcon } from '@uipath/apollo-react/material/components';
+import { ApIcon, ApTooltip } from '@uipath/apollo-react/material/components';
 import { AnimatePresence } from 'motion/react';
 import { memo, useCallback, useMemo, useState } from 'react';
 import type { HandleConfigurationSpecificPosition } from '../../schema/node-definition/handle';
@@ -198,9 +198,11 @@ const ButtonHandleBase = ({
             $selected={selected}
             $size={label ? '60px' : '16px'}
           />
-          <div className="nodrag nopan" style={{ pointerEvents: 'auto' }}>
-            <AddButton onAction={handleButtonClick} />
-          </div>
+          <ApTooltip content="Add node" placement="bottom">
+            <div className="nodrag nopan" style={{ pointerEvents: 'auto' }}>
+              <AddButton onAction={handleButtonClick} />
+            </div>
+          </ApTooltip>
         </StyledWrapper>
       )}
       <StyledNotch


### PR DESCRIPTION
tooltip for add node icon

<img width="1893" height="1037" alt="Screenshot 2026-03-06 at 4 25 25 PM" src="https://github.com/user-attachments/assets/d95486c0-26cc-4ad5-89bf-d46a7b150264" />
