### PR TITLE
fix(apollo-react): apbutton sx props was completely overriding default

### DIFF
--- a/packages/apollo-react/src/material/components/ap-button/ApButton.tsx
+++ b/packages/apollo-react/src/material/components/ap-button/ApButton.tsx
@@ -1,6 +1,6 @@
 import { CircularProgress } from '@mui/material';
 import Button, { type ButtonProps } from '@mui/material/Button';
-import { styled } from '@mui/material/styles';
+import { styled, type SxProps } from '@mui/material/styles';
 import React from 'react';
 import token from '@uipath/apollo-core';
 
@@ -85,7 +85,8 @@ export const ApButton = React.forwardRef<HTMLButtonElement, ApButtonProps>((prop
   const shouldShowLoadingAsStartIcon = loading && hasStartIcon;
   const shouldShowLoadingAsEndIcon = loading && !hasStartIcon && hasEndIcon;
   const shouldShowLoadingAsLabel = loading && !hasStartIcon && !hasEndIcon;
-  const variantProps = variantToProps[variant];
+  const { sx: variantSx, ...restVariantProps } = variantToProps[variant];
+  const { sx: userSx, ...restProps } = rest;
 
   const loadingIndicator = loading ? <ButtonLoadingIndicator aria-label={label} /> : null;
 
@@ -108,16 +109,17 @@ export const ApButton = React.forwardRef<HTMLButtonElement, ApButtonProps>((prop
         onBlur={onBlur}
         startIcon={loading && shouldShowLoadingAsStartIcon ? loadingIndicator : startIcon}
         endIcon={loading && shouldShowLoadingAsEndIcon ? loadingIndicator : endIcon}
-        {...variantProps}
+        {...restVariantProps}
+        sx={[variantSx ?? {}, userSx ?? {}] as SxProps}
         tabIndex={tabIndex ?? (loading ? -1 : undefined)}
         aria-disabled={disabled || loading ? 'true' : undefined}
         aria-expanded={expanded}
         title={title}
-        className={joinClasses(variantProps?.className, loading && 'loading')}
+        className={joinClasses(restVariantProps?.className, loading && 'loading')}
         href={href}
         customSize={size}
         customWidth={widthMode}
-        {...rest}
+        {...restProps}
       >
         <span
           style={{


### PR DESCRIPTION
- ApButton sx prop passed in would override the default sx removing variant styles
- Changes make it so that the sx props merge so it doesn't completely override unless there is conflict stylings. Then user passed in sx takes precedence

Before: 
<img width="397" height="84" alt="image" src="https://github.com/user-attachments/assets/2a048a41-27d6-4964-a504-a600e9b2ab95" />
- from conditionally setting backgroudnColor through sx on text-foreground variant (text was supposed to be black)


Consumption Test with Dev Package
<img width="396" height="116" alt="image" src="https://github.com/user-attachments/assets/805403ff-2ecd-4887-93a6-5a9be0179c2e" />
- Use Case Buttons as tab and keeps selected state
