### PR TITLE
feat(apollo-react): BaseCanvas - add flag for toggling back navigation

### DIFF
--- a/packages/apollo-react/src/canvas/components/BaseCanvas/BaseCanvas.tsx
+++ b/packages/apollo-react/src/canvas/components/BaseCanvas/BaseCanvas.tsx
@@ -82,6 +82,7 @@ const BaseCanvasInnerComponent = <NodeType extends Node = Node, EdgeType extends
     zoomOnDoubleClick = true,
     snapToGrid = BASE_CANVAS_DEFAULTS.snapToGrid,
     snapGrid = BASE_CANVAS_DEFAULTS.snapGrid,
+    preventScrolling = false,
 
     // Layout
     initialAutoLayout,
@@ -90,6 +91,9 @@ const BaseCanvasInnerComponent = <NodeType extends Node = Node, EdgeType extends
     // Toolbar
     onToolbarAction,
     breakpoints,
+
+    // Navigation
+    enableBackNavigationPrevention = true,
 
     // Pan Shortcut Teaching UI
     panShortcutTeachingUIMessage = 'Hold Space and drag to pan around the canvas!',
@@ -109,7 +113,8 @@ const BaseCanvasInnerComponent = <NodeType extends Node = Node, EdgeType extends
   const { ensureNodesInView, ensureAllNodesInView, centerNode } = useEnsureNodesInView();
 
   // Prevent browser back navigation on touch gestures
-  usePreventBackNavigation();
+  const preventBackNavigationEnabled = preventScrolling === false && enableBackNavigationPrevention;
+  usePreventBackNavigation(preventBackNavigationEnabled);
 
   // Maintain specified nodes in view when canvas resizes
   // This ensures important nodes remain visible in responsive layouts

--- a/packages/apollo-react/src/canvas/components/BaseCanvas/BaseCanvas.types.ts
+++ b/packages/apollo-react/src/canvas/components/BaseCanvas/BaseCanvas.types.ts
@@ -187,6 +187,13 @@ export interface BaseCanvasProps<NodeType extends Node = Node, EdgeType extends 
    * @default undefined
    */
   isDarkMode?: boolean;
+
+  /**
+   * Whether to prevent browser back navigation on touch gestures and horizontal wheel scrolling.
+   * Disable this when the canvas is embedded in a scrollable page where horizontal scroll should work normally.
+   * @default true
+   */
+  enableBackNavigationPrevention?: boolean;
 }
 
 /**

--- a/packages/apollo-react/src/canvas/components/BaseCanvas/usePreventBackNavigation.ts
+++ b/packages/apollo-react/src/canvas/components/BaseCanvas/usePreventBackNavigation.ts
@@ -4,8 +4,9 @@ import { useEffect } from 'react';
  * Custom hook to prevent browser back navigation on touch gestures and horizontal wheel scrolling.
  * This is useful for canvas/flow components where accidental navigation can interrupt user work.
  */
-export function usePreventBackNavigation() {
+export function usePreventBackNavigation(enabled = true) {
   useEffect(() => {
+    if (!enabled) return;
     const preventBackNavigation = (e: TouchEvent) => {
       if (e.touches.length === 2) {
         e.preventDefault();
@@ -28,5 +29,5 @@ export function usePreventBackNavigation() {
       document.removeEventListener('touchmove', preventBackNavigation);
       document.removeEventListener('wheel', preventWheel);
     };
-  }, []);
+  }, [enabled]);
 }


### PR DESCRIPTION
## Why do we need this flag?
The `usePreventBackNavigation` hook that's used in `apollo-react/BaseCanvas` prevents horizontal '`wheel`' scroll events globally ([source](https://github.com/UiPath/apollo-ui/blob/728a2936566b07f6926e489d4d17b919542cbcb4/packages/apollo-react/src/canvas/components/BaseCanvas/usePreventBackNavigation.ts#L17)). It's intended to prevent accidental back navigation via gesture.

However, this hook adds a global '`wheel`' event listener that intercepts and stops any horizontal scroll events. This is preventing horizontal scrolling from being implemented naturally in flow, and affects other consumers the same way.

I would prefer to delete this hook altogether, but there may be other consumers that depend on this functionality. In the meantime, we can add a flag (`enableBackNavigationPrevention`) to disable this hook's functionality. This gives us the ability to disable this functionality in Flow while not affecting other consumers until we're able to delete this hook in its entirety.

### If we delete this hook, how do we prevent accidental gesture back navigation?
The same end result can be achieved by setting the [`overscroll-behavior-x`](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/overscroll-behavior-x) property to `contain` on the desired scroll element (e.g. `ScrollArea`, `BaseCanvas`, etc., or at page level, `html`)

**At the moment, I'm questioning the necessity of this hook, since even without it I'm unable to navigate backward from within `BaseCanvas`.**