### PR TITLE
feat(apollo-wind): add horizontal scroll support to ScrollArea [MST-6957]

### DIFF
--- a/packages/apollo-wind/src/components/ui/scroll-area.stories.tsx
+++ b/packages/apollo-wind/src/components/ui/scroll-area.stories.tsx
@@ -30,3 +30,43 @@ export const Default = {
     </ScrollArea>
   ),
 };
+
+export const HorizontalOverflow = {
+  args: {},
+  render: () => (
+    <ScrollArea className="w-96 rounded-md border">
+      <div className="flex gap-4 p-4">
+        {Array.from({ length: 20 }).map((_, i) => (
+          <div
+            key={i}
+            className="flex h-20 w-36 shrink-0 items-center justify-center rounded-md border bg-muted text-sm"
+          >
+            Item {i + 1}
+          </div>
+        ))}
+      </div>
+    </ScrollArea>
+  ),
+};
+
+export const BothAxesOverflow = {
+  args: {},
+  render: () => (
+    <ScrollArea className="h-72 w-96 rounded-md border">
+      <div className="p-4">
+        {Array.from({ length: 20 }).map((_, row) => (
+          <div key={row} className="flex gap-4 py-2">
+            {Array.from({ length: 10 }).map((_, col) => (
+              <div
+                key={col}
+                className="flex h-16 w-32 shrink-0 items-center justify-center rounded-md border bg-muted text-sm"
+              >
+                {row + 1}, {col + 1}
+              </div>
+            ))}
+          </div>
+        ))}
+      </div>
+    </ScrollArea>
+  ),
+};

--- a/packages/apollo-wind/src/components/ui/scroll-area.tsx
+++ b/packages/apollo-wind/src/components/ui/scroll-area.tsx
@@ -17,7 +17,8 @@ const ScrollArea = React.forwardRef<
     <ScrollAreaPrimitive.Viewport className="h-full w-full rounded-[inherit]">
       {children}
     </ScrollAreaPrimitive.Viewport>
-    <ScrollBar />
+    <ScrollBar orientation="vertical" />
+    <ScrollBar orientation="horizontal" />
     <ScrollAreaPrimitive.Corner />
   </ScrollAreaPrimitive.Root>
 ));
@@ -32,8 +33,8 @@ const ScrollBar = React.forwardRef<
     orientation={orientation}
     className={cn(
       'flex touch-none select-none transition-colors',
-      orientation === 'vertical' && 'h-full w-2.5 border-l border-l-transparent p-[1px]',
-      orientation === 'horizontal' && 'h-2.5 flex-col border-t border-t-transparent p-[1px]',
+      orientation === 'vertical' && 'h-full w-2.5 border-l border-l-transparent p-px',
+      orientation === 'horizontal' && 'h-2.5 flex-col border-t border-t-transparent p-px',
       className
     )}
     {...props}

--- a/packages/apollo-wind/src/components/ui/scroll-area.tsx
+++ b/packages/apollo-wind/src/components/ui/scroll-area.tsx
@@ -11,7 +11,7 @@ const ScrollArea = React.forwardRef<
 >(({ className, children, ...props }, ref) => (
   <ScrollAreaPrimitive.Root
     ref={ref}
-    className={cn('relative overflow-hidden', className)}
+    className={cn('relative overflow-hidden overscroll-x-contain', className)}
     {...props}
   >
     <ScrollAreaPrimitive.Viewport className="h-full w-full rounded-[inherit]">


### PR DESCRIPTION
Adds horizontal scroll support to the `ScrollArea` component, which is directly required by flow ([example](https://uipath.atlassian.net/browse/MST-6957?atlOrigin=eyJpIjoiZjE2MGZmMzJhMDY2NDAyYjkzODQ1MTQ1NTI5MDc4NzIiLCJwIjoiaiJ9))

Also adds `overscroll-contain-x` to the `ScrollArea` component to prevent accidental backward navigation (via touchpad gesture) when scrolling left.

**Demo**

https://github.com/user-attachments/assets/a852a3d7-b813-4339-a655-5d9d825a5f3f

**Test Plan**
- [x] Ensure horizontal scrollbar is only shown if there is horizontal overflow
- [x] Ensure direct consumers are unaffected _(via Storybook)_
    - [x] Test directly in Flow, ensure ability to scroll horizontally (_manually, more context on [Slack](https://uipath-product.slack.com/archives/C0AH25MT3L5/p1773081374050689)_) in `ElementDetailsPanel` and relevant children (`VariablesView`, `IncidentsList`)
    - [x] Admin
    - [x] Form Builder (default, ootb cases)
