### PR TITLE
feat(apollo-wind): migrate Future themes to Tailwind v4 vars and add code syntax tokens

### DIFF
--- a/packages/apollo-wind/.storybook/preview.tsx
+++ b/packages/apollo-wind/.storybook/preview.tsx
@@ -63,7 +63,7 @@ const preview: Preview = {
         order: [
           'Introduction',
           'Theme',
-          ['Colors', 'Icons', 'Spacing', 'Typography', 'Future', ['*', 'Theme']],
+          ['Colors', 'Icons', 'Spacing', 'Typography', 'Future', ['Theme', '*']],
           'Components',
           [
             'All Components',

--- a/packages/apollo-wind/.storybook/preview.tsx
+++ b/packages/apollo-wind/.storybook/preview.tsx
@@ -76,7 +76,7 @@ const preview: Preview = {
             'UiPath',
           ],
           'Templates',
-          ['Admin', 'Delegate', 'Flow', 'Maestro', 'Future'],
+          ['Admin', 'Delegate', 'Flow', 'Maestro', 'Studio', 'Future'],
           'Forms',
           'Experiments',
           '*',

--- a/packages/apollo-wind/src/foundation/Future/colors.stories.tsx
+++ b/packages/apollo-wind/src/foundation/Future/colors.stories.tsx
@@ -31,6 +31,17 @@ interface ColorToken {
   lightTw: string;
 }
 
+interface CodeSyntaxToken {
+  name: string;
+  usage: string;
+  darkVar: string;
+  darkTw: string;
+  darkHex: string;
+  lightVar: string;
+  lightTw: string;
+  lightHex: string;
+}
+
 interface GradientToken {
   name: string;
   twClass: string;
@@ -340,6 +351,69 @@ const gradientTokens: GradientToken[] = [
   },
 ];
 
+const codeSyntaxTokens: CodeSyntaxToken[] = [
+  {
+    name: '--code-rest',
+    usage: 'Default text, identifiers, plain code',
+    darkVar: 'var(--color-zinc-400)',
+    darkTw: 'zinc-400',
+    darkHex: '#a1a1aa',
+    lightVar: 'var(--color-zinc-600)',
+    lightTw: 'zinc-600',
+    lightHex: '#52525b',
+  },
+  {
+    name: '--code-punctuation',
+    usage: 'Brackets, commas, semicolons',
+    darkVar: 'var(--color-zinc-500)',
+    darkTw: 'zinc-500',
+    darkHex: '#71717a',
+    lightVar: 'var(--color-zinc-500)',
+    lightTw: 'zinc-500',
+    lightHex: '#71717a',
+  },
+  {
+    name: '--code-key',
+    usage: 'Keywords, properties, attributes',
+    darkVar: 'var(--color-cyan-400)',
+    darkTw: 'cyan-400',
+    darkHex: '#22d3ee',
+    lightVar: 'var(--color-cyan-700)',
+    lightTw: 'cyan-700',
+    lightHex: '#0e7490',
+  },
+  {
+    name: '--code-string',
+    usage: 'String values',
+    darkVar: 'var(--color-emerald-400)',
+    darkTw: 'emerald-400',
+    darkHex: '#34d399',
+    lightVar: 'var(--color-emerald-700)',
+    lightTw: 'emerald-700',
+    lightHex: '#047857',
+  },
+  {
+    name: '--code-number',
+    usage: 'Numeric literals',
+    darkVar: 'var(--color-amber-400)',
+    darkTw: 'amber-400',
+    darkHex: '#fbbf24',
+    lightVar: 'var(--color-amber-700)',
+    lightTw: 'amber-700',
+    lightHex: '#b45309',
+  },
+  {
+    name: '--code-literal',
+    usage: 'Booleans, null, undefined',
+    darkVar: 'var(--color-violet-400)',
+    darkTw: 'violet-400',
+    darkHex: '#a78bfa',
+    lightVar: 'var(--color-violet-600)',
+    lightTw: 'violet-600',
+    lightHex: '#7c3aed',
+  },
+];
+
 // ============================================================================
 // Table components
 // ============================================================================
@@ -351,10 +425,11 @@ function ColorTokenTable({ groups }: { groups: ColorGroup[] }) {
         <thead>
           <tr className="border-b border-border bg-surface-overlay">
             <th className="px-4 py-2.5 text-left font-medium text-foreground-muted">Token</th>
+            <th className="px-4 py-2.5 text-left font-medium text-foreground-muted">Usage</th>
             <th className="px-4 py-2.5 text-left font-medium text-foreground-muted">
               Tailwind Class
             </th>
-            <th className="px-4 py-2.5 text-left font-medium text-foreground-muted">Usage</th>
+            <th className="w-56 px-4 py-2.5 text-left font-medium text-foreground-muted">CSS Variable</th>
             <th className="px-4 py-2.5 text-center font-medium text-foreground-muted">Dark</th>
             <th className="px-4 py-2.5 text-center font-medium text-foreground-muted">Light</th>
           </tr>
@@ -364,7 +439,7 @@ function ColorTokenTable({ groups }: { groups: ColorGroup[] }) {
             <React.Fragment key={group.group}>
               <tr className="border-b border-border bg-surface-raised/50">
                 <td
-                  colSpan={5}
+                  colSpan={6}
                   className="px-4 py-2 text-xs font-semibold uppercase tracking-wider text-foreground-muted"
                 >
                   {group.group}
@@ -380,6 +455,7 @@ function ColorTokenTable({ groups }: { groups: ColorGroup[] }) {
                       {token.name}
                     </code>
                   </td>
+                  <td className="px-4 py-2 text-xs text-foreground-muted">{token.usage}</td>
                   <td className="px-4 py-2">
                     <code
                       className="text-xs text-foreground-subtle"
@@ -388,7 +464,22 @@ function ColorTokenTable({ groups }: { groups: ColorGroup[] }) {
                       {token.twClass}
                     </code>
                   </td>
-                  <td className="px-4 py-2 text-foreground-muted">{token.usage}</td>
+                  <td className="w-56 px-4 py-2">
+                    <div className="flex flex-col gap-0.5">
+                      <code
+                        className="whitespace-nowrap text-[10px] text-foreground-accent/70"
+                        style={{ fontFamily: fontFamily.monospace }}
+                      >
+                        {`var(--color-${token.darkTw})`}
+                      </code>
+                      <code
+                        className="whitespace-nowrap text-[10px] text-foreground-subtle"
+                        style={{ fontFamily: fontFamily.monospace }}
+                      >
+                        {`var(--color-${token.lightTw})`}
+                      </code>
+                    </div>
+                  </td>
                   <td className="px-4 py-2">
                     <div className="flex items-center justify-center gap-2">
                       <div
@@ -397,13 +488,13 @@ function ColorTokenTable({ groups }: { groups: ColorGroup[] }) {
                       />
                       <div className="flex flex-col">
                         <code
-                          className="text-xs text-foreground-muted"
+                          className="whitespace-nowrap text-xs text-foreground-muted"
                           style={{ fontFamily: fontFamily.monospace }}
                         >
                           {token.dark}
                         </code>
                         <code
-                          className="text-[10px] text-foreground-accent/70"
+                          className="whitespace-nowrap text-[10px] text-foreground-accent/70"
                           style={{ fontFamily: fontFamily.monospace }}
                         >
                           {token.darkTw}
@@ -419,13 +510,13 @@ function ColorTokenTable({ groups }: { groups: ColorGroup[] }) {
                       />
                       <div className="flex flex-col">
                         <code
-                          className="text-xs text-foreground-muted"
+                          className="whitespace-nowrap text-xs text-foreground-muted"
                           style={{ fontFamily: fontFamily.monospace }}
                         >
                           {token.light}
                         </code>
                         <code
-                          className="text-[10px] text-foreground-accent/70"
+                          className="whitespace-nowrap text-[10px] text-foreground-accent/70"
                           style={{ fontFamily: fontFamily.monospace }}
                         >
                           {token.lightTw}
@@ -436,6 +527,110 @@ function ColorTokenTable({ groups }: { groups: ColorGroup[] }) {
                 </tr>
               ))}
             </React.Fragment>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function CodeSyntaxTable({ tokens }: { tokens: CodeSyntaxToken[] }) {
+  return (
+    <div className="overflow-hidden rounded-lg border border-border">
+      <table className="w-full text-sm" style={{ fontFamily: fontFamily.base }}>
+        <thead>
+          <tr className="border-b border-border bg-surface-overlay">
+            <th className="px-4 py-2.5 text-left font-medium text-foreground-muted">Token</th>
+            <th className="px-4 py-2.5 text-left font-medium text-foreground-muted">Usage</th>
+            <th className="px-4 py-2.5 text-left font-medium text-foreground-muted">
+              Tailwind Class
+            </th>
+            <th className="w-56 px-4 py-2.5 text-left font-medium text-foreground-muted">CSS Variable</th>
+            <th className="px-4 py-2.5 text-center font-medium text-foreground-muted">Dark</th>
+            <th className="px-4 py-2.5 text-center font-medium text-foreground-muted">Light</th>
+          </tr>
+        </thead>
+        <tbody>
+          {tokens.map((token) => (
+            <tr key={token.name} className="border-b border-border-subtle last:border-b-0">
+              <td className="px-4 py-2">
+                <code
+                  className="text-xs text-foreground-accent"
+                  style={{ fontFamily: fontFamily.monospace }}
+                >
+                  {token.name}
+                </code>
+              </td>
+              <td className="px-4 py-2 text-xs text-foreground-muted">{token.usage}</td>
+              <td className="px-4 py-2">
+                <code
+                  className="text-xs text-foreground-subtle"
+                  style={{ fontFamily: fontFamily.monospace }}
+                >
+                  —
+                </code>
+              </td>
+              <td className="w-56 px-4 py-2">
+                <div className="flex flex-col gap-0.5">
+                  <code
+                    className="whitespace-nowrap text-[10px] text-foreground-accent/70"
+                    style={{ fontFamily: fontFamily.monospace }}
+                  >
+                    {token.darkVar}
+                  </code>
+                  <code
+                    className="whitespace-nowrap text-[10px] text-foreground-subtle"
+                    style={{ fontFamily: fontFamily.monospace }}
+                  >
+                    {token.lightVar}
+                  </code>
+                </div>
+              </td>
+              <td className="px-4 py-2">
+                <div className="flex items-center justify-center gap-2">
+                  <div
+                    className="h-5 w-5 shrink-0 rounded border border-border"
+                    style={{ backgroundColor: token.darkHex }}
+                  />
+                  <div className="flex flex-col">
+                    <code
+                      className="whitespace-nowrap text-xs text-foreground-muted"
+                      style={{ fontFamily: fontFamily.monospace }}
+                    >
+                      {token.darkHex}
+                    </code>
+                    <code
+                      className="whitespace-nowrap text-[10px] text-foreground-accent/70"
+                      style={{ fontFamily: fontFamily.monospace }}
+                    >
+                      {token.darkTw}
+                    </code>
+                  </div>
+                </div>
+              </td>
+              <td className="px-4 py-2">
+                <div className="flex items-center justify-center gap-2">
+                  <div
+                    className="h-5 w-5 shrink-0 rounded border border-border"
+                    style={{ backgroundColor: token.lightHex }}
+                  />
+                  <div className="flex flex-col">
+                    <code
+                      className="whitespace-nowrap text-xs text-foreground-muted"
+                      style={{ fontFamily: fontFamily.monospace }}
+                    >
+                      {token.lightHex}
+                    </code>
+                    <code
+                      className="whitespace-nowrap text-[10px] text-foreground-accent/70"
+                      style={{ fontFamily: fontFamily.monospace }}
+                    >
+                      {token.lightTw}
+                    </code>
+                  </div>
+                </div>
+              </td>
+            </tr>
           ))}
         </tbody>
       </table>
@@ -531,6 +726,27 @@ export const Default: Story = {
         </div>
 
         <ColorTokenTable groups={colorGroups} />
+
+        <div>
+          <h2
+            className="mb-4 text-xl font-bold tracking-tight text-foreground"
+            style={{ fontFamily: fontFamily.base }}
+          >
+            Components
+          </h2>
+          <p className="mb-6 text-sm text-foreground-muted">
+            Semantic color tokens scoped to specific components. Each token maps to a Tailwind v4
+            palette variable and resolves to a different value in dark and light themes. Reference
+            tokens directly via <code style={{ fontFamily: fontFamily.monospace }}>var(--code-*)</code> in component styles.
+          </p>
+          <h3
+            className="mb-3 text-sm font-semibold tracking-tight text-foreground"
+            style={{ fontFamily: fontFamily.base }}
+          >
+            Code Block
+          </h3>
+          <CodeSyntaxTable tokens={codeSyntaxTokens} />
+        </div>
 
         <div>
           <h2

--- a/packages/apollo-wind/src/foundation/Future/colors.stories.tsx
+++ b/packages/apollo-wind/src/foundation/Future/colors.stories.tsx
@@ -481,7 +481,7 @@ function ColorTokenTable({ groups }: { groups: ColorGroup[] }) {
                     </div>
                   </td>
                   <td className="px-4 py-2">
-                    <div className="flex items-center justify-center gap-2">
+                    <div className="flex items-center justify-start gap-2">
                       <div
                         className="h-5 w-5 shrink-0 rounded border border-border"
                         style={{ backgroundColor: token.dark }}
@@ -503,7 +503,7 @@ function ColorTokenTable({ groups }: { groups: ColorGroup[] }) {
                     </div>
                   </td>
                   <td className="px-4 py-2">
-                    <div className="flex items-center justify-center gap-2">
+                    <div className="flex items-center justify-start gap-2">
                       <div
                         className="h-5 w-5 shrink-0 rounded border border-border"
                         style={{ backgroundColor: token.light }}
@@ -587,7 +587,7 @@ function CodeSyntaxTable({ tokens }: { tokens: CodeSyntaxToken[] }) {
                 </div>
               </td>
               <td className="px-4 py-2">
-                <div className="flex items-center justify-center gap-2">
+                <div className="flex items-center justify-start gap-2">
                   <div
                     className="h-5 w-5 shrink-0 rounded border border-border"
                     style={{ backgroundColor: token.darkHex }}
@@ -609,7 +609,7 @@ function CodeSyntaxTable({ tokens }: { tokens: CodeSyntaxToken[] }) {
                 </div>
               </td>
               <td className="px-4 py-2">
-                <div className="flex items-center justify-center gap-2">
+                <div className="flex items-center justify-start gap-2">
                   <div
                     className="h-5 w-5 shrink-0 rounded border border-border"
                     style={{ backgroundColor: token.lightHex }}

--- a/packages/apollo-wind/src/foundation/Future/theme.stories.tsx
+++ b/packages/apollo-wind/src/foundation/Future/theme.stories.tsx
@@ -517,6 +517,16 @@ function ThemePage({ globalTheme }: { globalTheme: string }) {
           <strong>Demo</strong> themes (Wireframe, Vertex, Canvas). Use the theme selector in the
           toolbar above to switch between them. Everything on this page updates live.
         </SectionDescription>
+        <p
+          className="mb-6 rounded-lg border border-border bg-muted/50 px-4 py-3 text-sm leading-relaxed text-muted-foreground"
+          style={{ fontFamily: fontFamily.base }}
+        >
+          <strong className="text-foreground">For consumer apps, use Core themes</strong>{' '}
+          — apply <InlineCode>light</InlineCode>, <InlineCode>dark</InlineCode>,{' '}
+          <InlineCode>light-hc</InlineCode>, or <InlineCode>dark-hc</InlineCode> as
+          a class on <InlineCode>&lt;body&gt;</InlineCode>. Future and Demo themes
+          are intended for internal prototyping and experimentation.
+        </p>
 
         <div className="inline-flex items-center gap-2 rounded-lg border border-border bg-muted/50 px-3 py-1.5 text-sm text-muted-foreground">
           Active theme: <strong className="text-foreground">{label}</strong>

--- a/packages/apollo-wind/src/styles/tailwind.consumer.css
+++ b/packages/apollo-wind/src/styles/tailwind.consumer.css
@@ -337,64 +337,64 @@ body.light-hc {
 
 .future-dark {
   /* ── Surfaces ─────────────────────────────────────────────────────────── */
-  --surface: #09090b;
-  /* zinc-950  — page / canvas */
-  --surface-raised: #18181b;
-  /* zinc-900  — cards, overlays, panels */
-  --surface-overlay: #27272a;
-  /* zinc-800  — panels, inputs, tabs */
-  --surface-hover: #3f3f46;
-  /* zinc-700  — hover, selected nav */
-  --surface-muted: #71717a;
-  /* zinc-500  — badges, indicators */
-  --surface-inverse: #fafafa;
-  /* zinc-50   — buttons on dark bg */
+  --surface: var(--color-zinc-950);
+  /* page / canvas */
+  --surface-raised: var(--color-zinc-900);
+  /* cards, overlays, panels */
+  --surface-overlay: var(--color-zinc-800);
+  /* panels, inputs, tabs */
+  --surface-hover: var(--color-zinc-700);
+  /* hover, selected nav */
+  --surface-muted: var(--color-zinc-500);
+  /* badges, indicators */
+  --surface-inverse: var(--color-zinc-50);
+  /* buttons on dark bg */
 
   /* ── Brand ──────────────────────────────────────────────────────────── */
-  --brand: #0891b2;
-  /* cyan-600  — logo, submit, run */
-  --brand-subtle: #083344;
-  /* cyan-950  — status badge, active nav */
+  --brand: var(--color-cyan-600);
+  /* logo, submit, run */
+  --brand-subtle: var(--color-cyan-950);
+  /* status badge, active nav */
 
   /* ── Foreground (text / icons) ────────────────────────────────────────── */
-  --foreground: #fafafa;
-  /* zinc-50   — primary headings */
-  --foreground-secondary: #f4f4f5;
-  /* zinc-100  — body, messages */
-  --foreground-hover: #d4d4d8;
-  /* zinc-300  — hover states */
-  --foreground-muted: #a1a1aa;
-  /* zinc-400  — nav, secondary UI */
-  --foreground-subtle: #71717a;
-  /* zinc-500  — labels, muted */
-  --foreground-inverse: #09090b;
-  /* zinc-950  — icons on light bg */
-  --foreground-on-accent: #fafafa;
-  /* zinc-50   — text on accent bg */
-  --foreground-accent: #0891b2;
-  /* cyan-600  — accent text */
-  --foreground-accent-muted: #22d3ee;
-  /* cyan-400 — muted accent text */
+  --foreground: var(--color-zinc-50);
+  /* primary headings */
+  --foreground-secondary: var(--color-zinc-100);
+  /* body, messages */
+  --foreground-hover: var(--color-zinc-300);
+  /* hover states */
+  --foreground-muted: var(--color-zinc-400);
+  /* nav, secondary UI */
+  --foreground-subtle: var(--color-zinc-500);
+  /* labels, muted */
+  --foreground-inverse: var(--color-zinc-950);
+  /* icons on light bg */
+  --foreground-on-accent: var(--color-zinc-50);
+  /* text on accent bg */
+  --foreground-accent: var(--color-cyan-600);
+  /* accent text */
+  --foreground-accent-muted: var(--color-cyan-400);
+  /* muted accent text */
 
   /* ── Borders ──────────────────────────────────────────────────────────── */
-  --ap-wind-border: #3f3f46;
-  /* zinc-700  — primary borders */
-  --border-subtle: #27272a;
-  /* zinc-800  — subtle dividers */
-  --border-muted: #18181b;
-  /* zinc-900  — content borders */
-  --border-deep: #09090b;
-  /* zinc-950  — nested containers */
-  --border-inverse: #e4e4e7;
-  /* zinc-200  — borders on inverse bg */
-  --border-hover: #52525b;
-  /* zinc-600  — border hover state */
+  --ap-wind-border: var(--color-zinc-700);
+  /* primary borders */
+  --border-subtle: var(--color-zinc-800);
+  /* subtle dividers */
+  --border-muted: var(--color-zinc-900);
+  /* content borders */
+  --border-deep: var(--color-zinc-950);
+  /* nested containers */
+  --border-inverse: var(--color-zinc-200);
+  /* borders on inverse bg */
+  --border-hover: var(--color-zinc-600);
+  /* border hover state */
 
   /* ── Ring ──────────────────────────────────────────────────────────────── */
-  --ring: #52525b;
-  /* zinc-600  — selection ring */
+  --ring: var(--color-zinc-600);
+  /* selection ring */
 
-  /* ── Gradients ───────────────────────────────────────────────────────── */
+  /* ── Gradients (kept as hex — adjusted values that don't map 1:1 to palette steps) ── */
   --gradient-1: linear-gradient(127deg, #3f3f47 25.94%, #27272a 74.06%);
   /* zinc-700 → zinc-800 */
   --gradient-2: linear-gradient(128deg, #09090b 1.26%, #18181b 52.69%);
@@ -407,6 +407,20 @@ body.light-hc {
   /* zinc-950 → zinc-900 */
   --gradient-6: linear-gradient(106deg, #0092b8 28.08%, #053345 71.92%);
   /* cyan-600 → cyan-950 */
+
+  /* ── Code window / syntax ────────────────────────────────────────────── */
+  --code-rest: var(--color-zinc-400);
+  /* default text, identifiers, plain code */
+  --code-punctuation: var(--color-zinc-500);
+  /* brackets, commas, semicolons */
+  --code-key: var(--color-cyan-400);
+  /* keywords, properties, attributes */
+  --code-string: var(--color-emerald-400);
+  /* string values */
+  --code-number: var(--color-amber-400);
+  /* numeric literals */
+  --code-literal: var(--color-violet-400);
+  /* booleans, null, undefined */
 
   /* ── shadcn aliases — maps to standard names for shadcn component compat ── */
   --background: var(--surface);
@@ -422,9 +436,9 @@ body.light-hc {
   --muted-foreground: var(--foreground-muted);
   --accent: var(--surface-hover);
   --accent-foreground: var(--foreground);
-  --destructive: #ef4444;
-  --destructive-foreground: #fafafa;
-  /* zinc-50 — text on destructive bg */
+  --destructive: var(--color-red-500);
+  --destructive-foreground: var(--color-zinc-50);
+  /* text on destructive bg */
   --border-de-emp: var(--border-subtle);
   --input: var(--ap-wind-border);
 }
@@ -435,64 +449,64 @@ body.light-hc {
 
 .future-light {
   /* ── Surfaces ─────────────────────────────────────────────────────────── */
-  --surface: #fafafa;
-  /* zinc-50   — page / canvas */
-  --surface-raised: #f4f4f5;
-  /* zinc-100  — cards, overlays, panels */
-  --surface-overlay: #e4e4e7;
-  /* zinc-200  — panels, inputs, tabs */
-  --surface-hover: #d4d4d8;
-  /* zinc-300  — hover, selected nav */
-  --surface-muted: #a1a1aa;
-  /* zinc-400  — badges, indicators */
-  --surface-inverse: #09090b;
-  /* zinc-950  — buttons on light bg */
+  --surface: var(--color-zinc-50);
+  /* page / canvas */
+  --surface-raised: var(--color-zinc-100);
+  /* cards, overlays, panels */
+  --surface-overlay: var(--color-zinc-200);
+  /* panels, inputs, tabs */
+  --surface-hover: var(--color-zinc-300);
+  /* hover, selected nav */
+  --surface-muted: var(--color-zinc-400);
+  /* badges, indicators */
+  --surface-inverse: var(--color-zinc-950);
+  /* buttons on light bg */
 
   /* ── Brand ──────────────────────────────────────────────────────────── */
-  --brand: #0891b2;
-  /* cyan-600  — logo, submit, run */
-  --brand-subtle: #ecfeff;
-  /* cyan-50   — status badge, active nav */
+  --brand: var(--color-cyan-600);
+  /* logo, submit, run */
+  --brand-subtle: var(--color-cyan-50);
+  /* status badge, active nav */
 
   /* ── Foreground (text / icons) ────────────────────────────────────────── */
-  --foreground: #09090b;
-  /* zinc-950  — primary headings */
-  --foreground-secondary: #18181b;
-  /* zinc-900  — body, messages */
-  --foreground-hover: #52525b;
-  /* zinc-600  — hover states */
-  --foreground-muted: #71717a;
-  /* zinc-500  — nav, secondary UI */
-  --foreground-subtle: #a1a1aa;
-  /* zinc-400  — labels, muted */
-  --foreground-inverse: #fafafa;
-  /* zinc-50   — icons on dark bg */
-  --foreground-on-accent: #fafafa;
-  /* zinc-50   — text on accent bg */
-  --foreground-accent: #0891b2;
-  /* cyan-600  — accent text */
-  --foreground-accent-muted: #0891b2;
-  /* cyan-600 — muted accent text */
+  --foreground: var(--color-zinc-950);
+  /* primary headings */
+  --foreground-secondary: var(--color-zinc-900);
+  /* body, messages */
+  --foreground-hover: var(--color-zinc-600);
+  /* hover states */
+  --foreground-muted: var(--color-zinc-500);
+  /* nav, secondary UI */
+  --foreground-subtle: var(--color-zinc-400);
+  /* labels, muted */
+  --foreground-inverse: var(--color-zinc-50);
+  /* icons on dark bg */
+  --foreground-on-accent: var(--color-zinc-50);
+  /* text on accent bg */
+  --foreground-accent: var(--color-cyan-600);
+  /* accent text */
+  --foreground-accent-muted: var(--color-cyan-600);
+  /* muted accent text */
 
   /* ── Borders ──────────────────────────────────────────────────────────── */
-  --ap-wind-border: #d4d4d8;
-  /* zinc-300  — primary borders */
-  --border-subtle: #e4e4e7;
-  /* zinc-200  — subtle dividers */
-  --border-muted: #f4f4f5;
-  /* zinc-100  — content borders */
-  --border-deep: #fafafa;
-  /* zinc-50   — nested containers */
-  --border-inverse: #3f3f46;
-  /* zinc-700  — borders on inverse bg */
-  --border-hover: #a1a1aa;
-  /* zinc-400  — border hover state */
+  --ap-wind-border: var(--color-zinc-300);
+  /* primary borders */
+  --border-subtle: var(--color-zinc-200);
+  /* subtle dividers */
+  --border-muted: var(--color-zinc-100);
+  /* content borders */
+  --border-deep: var(--color-zinc-50);
+  /* nested containers */
+  --border-inverse: var(--color-zinc-700);
+  /* borders on inverse bg */
+  --border-hover: var(--color-zinc-400);
+  /* border hover state */
 
   /* ── Ring ──────────────────────────────────────────────────────────────── */
-  --ring: #a1a1aa;
-  /* zinc-400  — selection ring */
+  --ring: var(--color-zinc-400);
+  /* selection ring */
 
-  /* ── Gradients ───────────────────────────────────────────────────────── */
+  /* ── Gradients (kept as hex — adjusted values that don't map 1:1 to palette steps) ── */
   --gradient-1: linear-gradient(127deg, #e4e4e7 25.94%, #f4f4f5 74.06%);
   /* zinc-200 → zinc-100 */
   --gradient-2: linear-gradient(128deg, #fafafa 1.26%, #fafafa 52.69%);
@@ -505,6 +519,20 @@ body.light-hc {
   /* zinc-50 → zinc-50 */
   --gradient-6: linear-gradient(106deg, #22d3ee 28.08%, #cffafe 71.92%);
   /* cyan-400 → cyan-100 */
+
+  /* ── Code window / syntax ────────────────────────────────────────────── */
+  --code-rest: var(--color-zinc-600);
+  /* default text, identifiers, plain code */
+  --code-punctuation: var(--color-zinc-500);
+  /* brackets, commas, semicolons */
+  --code-key: var(--color-cyan-700);
+  /* keywords, properties, attributes */
+  --code-string: var(--color-emerald-700);
+  /* string values */
+  --code-number: var(--color-amber-700);
+  /* numeric literals */
+  --code-literal: var(--color-violet-600);
+  /* booleans, null, undefined */
 
   /* ── shadcn aliases ──────────────────────────────────────────────────── */
   --background: var(--surface);
@@ -520,9 +548,9 @@ body.light-hc {
   --muted-foreground: var(--foreground-muted);
   --accent: var(--surface-hover);
   --accent-foreground: var(--foreground);
-  --destructive: #ef4444;
-  --destructive-foreground: #fafafa;
-  /* zinc-50 — text on destructive bg */
+  --destructive: var(--color-red-500);
+  --destructive-foreground: var(--color-zinc-50);
+  /* text on destructive bg */
   --border-de-emp: var(--border-subtle);
   --input: var(--ap-wind-border);
 }


### PR DESCRIPTION
## Summary

- **Migrate Future theme tokens to Tailwind v4**: All hardcoded hex values in `.future-dark` and `.future-light` CSS classes have been replaced with native Tailwind v4 `var(--color-*)` references (e.g., `var(--color-zinc-950)`, `var(--color-cyan-600)`). Gradients retain hex values as they use adjusted steps that don't map 1:1 to palette steps.
- **Add code syntax tokens**: New `--code-*` CSS custom properties added to both Future themes for use in code block / syntax highlighting components (`--code-rest`, `--code-punctuation`, `--code-key`, `--code-string`, `--code-number`, `--code-literal`).
- **Update `Theme/Future/Colors` Storybook page**: Added a CSS Variable column to the color token table; added a new "Components" section with a "Code Block" sub-table documenting the new syntax tokens with dark/light swatches.
- **Sidebar ordering**: Future template moved to last position in the Templates group (after Studio); minor sidebar labeling improvement.

## Files changed

- `packages/apollo-wind/src/styles/tailwind.consumer.css` — token migration + new `--code-*` tokens
- `packages/apollo-wind/src/foundation/Future/colors.stories.tsx` — updated color table + new Components/Code Block section
- `packages/apollo-wind/.storybook/preview.tsx` — storySort updated to pin Future last in Templates

## Test plan

- [ ] Verify `.future-dark` and `.future-light` themes render correctly (no broken token references)
- [ ] Check `Theme/Future/Colors` Storybook page shows CSS Variable column and Code Block table
- [ ] Confirm Templates sidebar order shows Future after Studio
- [ ] Confirm gradients are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)