### PR TITLE
feat(apollo-react): add warning adornments to node

### DIFF
--- a/packages/apollo-react/src/canvas/components/BaseNode/BaseNode.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/BaseNode/BaseNode.stories.tsx
@@ -19,6 +19,7 @@ import {
   withCanvasProviders,
 } from '../../storybook-utils';
 import { DefaultCanvasTranslations } from '../../types';
+import type { ValidationErrorSeverity } from '../../types/validation';
 import { BaseCanvas } from '../BaseCanvas';
 import { CanvasPositionControls } from '../CanvasPositionControls';
 import { NodeInspector } from '../NodeInspector';
@@ -645,4 +646,110 @@ export const CustomizedSizes: Story = {
 export const DynamicHandles: Story = {
   name: 'Dynamic Handles',
   render: () => <DynamicHandlesStory />,
+};
+
+// ============================================================================
+// Validation States Story
+// ============================================================================
+
+const VALIDATION_SEVERITIES = ['WARNING', 'ERROR', 'CRITICAL'] as const;
+
+const validationMessages: Record<string, string> = {
+  WARNING: 'Trigger should be connected to at least one node',
+  ERROR: 'URL is required',
+  CRITICAL: 'Node configuration is invalid',
+};
+
+/**
+ * Creates a grid of nodes showing validation states across shapes.
+ */
+function createValidationGrid(): Node<BaseNodeData>[] {
+  const nodes: Node<BaseNodeData>[] = [];
+
+  VALIDATION_SEVERITIES.forEach((severity, rowIndex) => {
+    SHAPES.forEach((shape, colIndex) => {
+      const label = shape === 'rectangle' ? 'Invoice approval agent' : 'Header';
+      const nodeType = shape === 'rectangle' ? 'uipath.agent' : 'uipath.blank-node';
+
+      nodes.push(
+        createNode({
+          id: `validation-${shape}-${severity}`,
+          type: nodeType,
+          position: {
+            x: GRID_CONFIG.startX + colIndex * GRID_CONFIG.gapX,
+            y: GRID_CONFIG.startY + rowIndex * GRID_CONFIG.gapY,
+          },
+          data: {
+            nodeType,
+            version: '1.0.0',
+            display: {
+              label,
+              subLabel: severity,
+              shape,
+            },
+          },
+        })
+      );
+    });
+  });
+
+  return nodes;
+}
+
+function ValidationStatesStory() {
+  const initialNodes = useMemo(() => createValidationGrid(), []);
+  const { canvasProps } = useCanvasStory({ initialNodes });
+
+  return (
+    <BaseCanvas {...canvasProps} mode="design">
+      <Panel position="bottom-right">
+        <CanvasPositionControls translations={DefaultCanvasTranslations} />
+      </Panel>
+      <StoryInfoPanel
+        title="Validation States"
+        description="Grid showing warning, error, and critical validation badges across shapes. Warnings show a yellow badge only (no border). Errors/critical show a red badge."
+      />
+    </BaseCanvas>
+  );
+}
+
+export const ValidationStates: Story = {
+  name: 'Validation States',
+  decorators: [
+    (Story) => {
+      const registry = useMemo(() => {
+        const reg = new NodeTypeRegistry();
+        reg.registerManifest(sampleManifest.nodes, sampleManifest.categories);
+        return reg;
+      }, []);
+
+      const contextValue = useMemo(() => ({ registry }), [registry]);
+
+      return (
+        <NodeRegistryContext.Provider value={contextValue}>{Story()}</NodeRegistryContext.Provider>
+      );
+    },
+    withCanvasProviders({
+      executionState: {
+        getNodeExecutionState: () => undefined,
+        getEdgeExecutionState: () => undefined,
+      },
+      validationState: {
+        getElementValidationState: (elementId: string) => {
+          const severity = elementId.split('-').pop() as string;
+          if (!['WARNING', 'ERROR', 'CRITICAL'].includes(severity)) return undefined;
+          return {
+            validationStatus: severity as ValidationErrorSeverity,
+            validationError: {
+              code: `VALIDATION_${severity}`,
+              message: validationMessages[severity] ?? `Validation ${severity.toLowerCase()}`,
+              description: validationMessages[severity] ?? `Validation ${severity.toLowerCase()}`,
+              severity: severity as ValidationErrorSeverity,
+            },
+          };
+        },
+      },
+    }),
+  ],
+  render: () => <ValidationStatesStory />,
 };

--- a/packages/apollo-react/src/canvas/components/BaseNode/BaseNode.styles.ts
+++ b/packages/apollo-react/src/canvas/components/BaseNode/BaseNode.styles.ts
@@ -64,6 +64,20 @@ const getExecutionStatusBorder = (executionStatus?: string) => {
   }
 };
 
+const getValidationStatusBorder = (validationStatus?: string) => {
+  switch (validationStatus) {
+    case 'ERROR':
+    case 'CRITICAL':
+      return css`
+        border-color: var(--uix-canvas-error-icon);
+        background: var(--uix-canvas-error-background);
+        animation: ${pulseAnimation('--uix-canvas-error-icon')} 2s infinite;
+      `;
+    default:
+      return null;
+  }
+};
+
 const getInteractionStateBorder = (interactionState?: string) => {
   switch (interactionState) {
     case 'hover':
@@ -129,6 +143,7 @@ export const BaseContainer = styled.div<{
   backgroundColor?: string;
   shape?: NodeShape;
   executionStatus?: string;
+  validationStatus?: string;
   interactionState?: string;
   suggestionType?: string;
   width?: number;
@@ -183,6 +198,7 @@ export const BaseContainer = styled.div<{
   cursor: pointer;
 
   ${({ executionStatus }) => getExecutionStatusBorder(executionStatus)}
+  ${({ validationStatus }) => getValidationStatusBorder(validationStatus)}
   ${({ interactionState }) => getInteractionStateBorder(interactionState)}
   ${({ suggestionType }) => getSuggestionTypeBorder(suggestionType)}
 

--- a/packages/apollo-react/src/canvas/components/BaseNode/BaseNode.tsx
+++ b/packages/apollo-react/src/canvas/components/BaseNode/BaseNode.tsx
@@ -479,6 +479,7 @@ const BaseNodeComponent = (props: NodeProps<Node<BaseNodeData>>) => {
         className={cx(executionStatus, interactionState)}
         interactionState={interactionState}
         executionStatus={executionStatus}
+        validationStatus={validationState?.validationStatus}
         suggestionType={suggestionType}
         width={width}
         height={height}

--- a/packages/apollo-react/src/canvas/schema/node-definition/constraints.ts
+++ b/packages/apollo-react/src/canvas/schema/node-definition/constraints.ts
@@ -125,6 +125,14 @@ export const connectionConstraintSchema = z.object({
    * Example: "Agent Model can only connect to Agent node's model handle"
    */
   validationMessage: z.string().optional(),
+
+  /**
+   * Severity level for constraint violations
+   * Controls whether violations appear as errors or warnings
+   * - 'error' (default): Blocks execution/publish
+   * - 'warning': Shows advisory badge but doesn't block
+   */
+  severity: z.enum(['warning', 'error', 'critical', 'info']).optional(),
 });
 
 // Export inferred types

--- a/packages/apollo-react/src/canvas/utils/adornment-resolver.test.tsx
+++ b/packages/apollo-react/src/canvas/utils/adornment-resolver.test.tsx
@@ -6,8 +6,9 @@ import {
   BreakpointIndicator,
   ExecutionStartPointIndicator,
   ExecutionStatusIndicator,
-  ValidationErrorIndicator,
   resolveAdornments,
+  ValidationErrorIndicator,
+  ValidationWarningIndicator,
 } from './adornment-resolver';
 
 const baseContext: NodeStatusContext = { nodeId: 'node-1' };
@@ -110,7 +111,7 @@ describe('resolveAdornments', () => {
     expect((result.topRight as React.ReactElement)?.type).toBe(ValidationErrorIndicator);
   });
 
-  it('falls back to execution indicator for WARNING severity', () => {
+  it('shows warning indicator for WARNING severity', () => {
     const result = resolveAdornments({
       ...baseContext,
       validationState: {
@@ -123,7 +124,24 @@ describe('resolveAdornments', () => {
         },
       },
     });
-    expect((result.topRight as React.ReactElement)?.type).toBe(ExecutionStatusIndicator);
+    expect((result.topRight as React.ReactElement)?.type).toBe(ValidationWarningIndicator);
+  });
+
+  it('shows warning indicator even when executionState has status None', () => {
+    const result = resolveAdornments({
+      ...baseContext,
+      executionState: { status: 'None', count: 0 },
+      validationState: {
+        validationStatus: ValidationErrorSeverity.WARNING,
+        validationError: {
+          code: 'WARN',
+          message: 'Warning',
+          description: 'Warning',
+          severity: ValidationErrorSeverity.WARNING,
+        },
+      },
+    });
+    expect((result.topRight as React.ReactElement)?.type).toBe(ValidationWarningIndicator);
   });
 
   it('falls back to execution indicator for INFO severity', () => {
@@ -213,5 +231,17 @@ describe('ValidationErrorIndicator', () => {
 
   it('renders with default message when none provided', () => {
     expect(ValidationErrorIndicator({})).toBeTruthy();
+  });
+});
+
+describe('ValidationWarningIndicator', () => {
+  it('renders with custom message', () => {
+    const el = ValidationWarningIndicator({ message: 'Trigger should be connected' });
+    expect(el).toBeTruthy();
+    expect(isValidElement(el)).toBe(true);
+  });
+
+  it('renders with default message when none provided', () => {
+    expect(ValidationWarningIndicator({})).toBeTruthy();
   });
 });

--- a/packages/apollo-react/src/canvas/utils/adornment-resolver.tsx
+++ b/packages/apollo-react/src/canvas/utils/adornment-resolver.tsx
@@ -1,6 +1,6 @@
 import { ExecutionStatusIcon, NodeIcon } from '@uipath/apollo-react/canvas';
-import { ApIcon } from '@uipath/apollo-react/material/components';
 import { ApTooltip } from '@uipath/apollo-react/material';
+import { ApIcon } from '@uipath/apollo-react/material/components';
 import { memo } from 'react';
 import type { NodeAdornments, NodeStatusContext } from '../components';
 import { getExecutionStatusColor } from '../components/ExecutionStatusIcon/ExecutionStatusIcon';
@@ -80,6 +80,16 @@ export function ValidationErrorIndicator({ message }: { message?: string }) {
   );
 }
 
+export function ValidationWarningIndicator({ message }: { message?: string }) {
+  return (
+    <ApTooltip content={message || 'Validation warning'} placement="bottom">
+      <span style={{ display: 'inline-flex' }}>
+        <ApIcon name="warning" size="16px" color="var(--uix-canvas-warning-icon)" />
+      </span>
+    </ApTooltip>
+  );
+}
+
 const getDefaultAdornments = (context: NodeStatusContext): NodeAdornments => {
   const executionState = context.executionState;
 
@@ -94,11 +104,27 @@ const getDefaultAdornments = (context: NodeStatusContext): NodeAdornments => {
     context.validationState?.validationStatus === ValidationErrorSeverity.ERROR ||
     context.validationState?.validationStatus === ValidationErrorSeverity.CRITICAL;
 
+  const hasValidationWarning =
+    context.validationState?.validationStatus === ValidationErrorSeverity.WARNING;
+
+  const getTopRight = () => {
+    // An active execution status (anything other than 'None') takes priority
+    if (status && status !== 'None')
+      return <ExecutionStatusIndicator status={status} count={count} />;
+    if (hasValidationError)
+      return (
+        <ValidationErrorIndicator message={context.validationState?.validationError?.message} />
+      );
+    if (hasValidationWarning)
+      return (
+        <ValidationWarningIndicator message={context.validationState?.validationError?.message} />
+      );
+    return <ExecutionStatusIndicator status={status} count={count} />;
+  };
+
   return {
     topLeft: hasBreakpoint ? <BreakpointIndicator /> : undefined,
-    topRight: !status && hasValidationError
-      ? <ValidationErrorIndicator message={context.validationState?.validationError?.message} />
-      : <ExecutionStatusIndicator status={status} count={count} />,
+    topRight: getTopRight(),
     bottomLeft: isExecutionStartPoint ? <ExecutionStartPointIndicator /> : undefined,
     bottomRight: isOutputPinned ? <PinnedOutputIndicator /> : undefined,
   };


### PR DESCRIPTION
## Summary
- Add a new `ValidationWarningIndicator` component that displays a warning icon with a tooltip on canvas nodes when validation has WARNING severity
- Update `getDefaultAdornments` logic to distinguish between ERROR/CRITICAL and WARNING validation states, giving warnings their own dedicated indicator instead of falling back to the execution status indicator
- Add unit tests for the new `ValidationWarningIndicator` component

## Details

Previously, nodes with `WARNING` validation severity fell through to the default execution status indicator, making warnings invisible to users. This change introduces a dedicated warning adornment (yellow warning icon via `var(--uix-canvas-warning-icon)`) that renders in the `topRight` slot, sitting between error indicators (highest priority) and the default execution status indicator.

The `getDefaultAdornments` resolution priority is now:
1. **Execution status** (running/completed) — highest priority
2. **Validation error** (ERROR/CRITICAL severity)
3. **Validation warning** (WARNING severity)
4. **Default execution indicator** — fallback

## Test plan
- [x] Unit tests added for `ValidationWarningIndicator` with and without custom message
- [x] Existing test updated to assert WARNING severity now renders `ValidationWarningIndicator` instead of `ExecutionStatusIndicator`
- [ ] Verify visually in Storybook that warning icon renders correctly on nodes with WARNING validation state
- [ ] Confirm `--uix-canvas-warning-icon` CSS variable is defined in the theme


🤖 Generated with [Claude Code](https://claude.com/claude-code)