### PR TITLE
fix(apollo-react): support ELK edge routing in SequenceEdge [MST-6513]

### DIFF
--- a/packages/apollo-react/src/canvas/components/Edges/EdgeRoutingUtils.test.ts
+++ b/packages/apollo-react/src/canvas/components/Edges/EdgeRoutingUtils.test.ts
@@ -1,0 +1,276 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  arrowFromLastSegment,
+  buildOrthogonalPath,
+  calculatePathMidpoint,
+  toOrthogonalPoints,
+} from './EdgeRoutingUtils';
+
+describe('toOrthogonalPoints', () => {
+  it('returns empty/single points unchanged', () => {
+    expect(toOrthogonalPoints([])).toEqual([]);
+    expect(toOrthogonalPoints([{ x: 1, y: 2 }])).toEqual([{ x: 1, y: 2 }]);
+  });
+
+  it('passes through already-orthogonal points', () => {
+    const pts = [
+      { x: 0, y: 0 },
+      { x: 100, y: 0 },
+      { x: 100, y: 100 },
+    ];
+    const result = toOrthogonalPoints(pts);
+    expect(result).toEqual(pts);
+  });
+
+  it('snaps sub-threshold Y difference to align with previous point', () => {
+    const pts = [
+      { x: 0, y: 0 },
+      { x: 50, y: 0.5 }, // dy < 1 — snap y to prev
+      { x: 50, y: 100 },
+    ];
+    const result = toOrthogonalPoints(pts);
+    expect(result[1]!.y).toBe(0); // snapped to prev y
+    expect(result[1]!.x).toBe(50);
+  });
+
+  it('snaps sub-threshold X difference to align with previous point', () => {
+    const pts = [
+      { x: 0, y: 0 },
+      { x: 0, y: 50 },
+      { x: 0.5, y: 50 }, // dx < 1 — snap x to prev
+      { x: 100, y: 50 },
+    ];
+    const result = toOrthogonalPoints(pts);
+    expect(result[2]!.x).toBe(0); // snapped to prev x
+  });
+
+  it('inserts step midpoints for diagonal segments', () => {
+    // Two points with both dx > 1 and dy > 1 after snapping
+    const pts = [
+      { x: 0, y: 0 },
+      { x: 100, y: 100 },
+    ];
+    const result = toOrthogonalPoints(pts);
+    // Should insert a step: (0,0) → (50,0) → (50,100) → (100,100)
+    expect(result.length).toBe(4);
+    expect(result[1]).toEqual({ x: 50, y: 0 });
+    expect(result[2]).toEqual({ x: 50, y: 100 });
+  });
+
+  it('snaps sub-threshold differences to zero', () => {
+    const pts = [
+      { x: 0, y: 0 },
+      { x: 100, y: 0.5 }, // dy < 1, within threshold — should snap to 0
+      { x: 100, y: 100 },
+    ];
+    const result = toOrthogonalPoints(pts);
+    expect(result[1]!.y).toBe(0); // snapped to source y
+    expect(result[1]!.x).toBe(100); // x unchanged
+  });
+});
+
+describe('buildOrthogonalPath', () => {
+  it('returns empty path for fewer than 2 points', () => {
+    expect(buildOrthogonalPath([]).path).toBe('');
+    expect(buildOrthogonalPath([{ x: 0, y: 0 }]).path).toBe('');
+  });
+
+  it('returns a straight line for 2 points', () => {
+    const { path } = buildOrthogonalPath([
+      { x: 0, y: 0 },
+      { x: 100, y: 0 },
+    ]);
+    expect(path).toBe('M 0 0 L 100 0');
+  });
+
+  it('returns orthoPoints alongside the path', () => {
+    const { path, orthoPoints } = buildOrthogonalPath([
+      { x: 0, y: 0 },
+      { x: 100, y: 0 },
+      { x: 100, y: 100 },
+    ]);
+    expect(path).toBeTruthy();
+    expect(orthoPoints.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('creates rounded corners for 3+ orthogonal points', () => {
+    const { path } = buildOrthogonalPath(
+      [
+        { x: 0, y: 0 },
+        { x: 100, y: 0 },
+        { x: 100, y: 100 },
+      ],
+      16
+    );
+    // Should contain M, L, Q, L commands
+    expect(path).toMatch(/^M /);
+    expect(path).toContain('Q');
+    expect(path).toMatch(/L 100 100$/);
+  });
+
+  it('clamps border radius to half the shorter segment', () => {
+    // Short segment of 10px — radius should be clamped to 5
+    const { path } = buildOrthogonalPath(
+      [
+        { x: 0, y: 0 },
+        { x: 10, y: 0 },
+        { x: 10, y: 100 },
+      ],
+      16
+    );
+    // The Q control point should use r=5, not r=16
+    // L before Q should be at x=5 (10 - 5)
+    expect(path).toContain('L 5 0');
+  });
+
+  it('falls back to L for very short segments (r < 1)', () => {
+    const { path } = buildOrthogonalPath([
+      { x: 0, y: 0 },
+      { x: 0.5, y: 0 }, // segment length 0.5, r = 0.25 < 1
+      { x: 0.5, y: 100 },
+    ]);
+    // Should contain L 0.5 0 (no Q curve)
+    expect(path).not.toContain('Q');
+  });
+
+  it('orthogonalizes non-axis-aligned input internally', () => {
+    // Diagonal input — buildOrthogonalPath should snap it internally
+    const { path, orthoPoints } = buildOrthogonalPath([
+      { x: 0, y: 0 },
+      { x: 100, y: 100 },
+    ]);
+    // toOrthogonalPoints inserts step midpoints for diagonal segments
+    expect(orthoPoints.length).toBe(4);
+    expect(path).toBeTruthy();
+  });
+});
+
+describe('arrowFromLastSegment', () => {
+  it('returns zero values for fewer than 2 points', () => {
+    expect(arrowFromLastSegment([])).toEqual({ angle: 0, offsetX: 0, offsetY: 0 });
+    expect(arrowFromLastSegment([{ x: 0, y: 0 }])).toEqual({ angle: 0, offsetX: 0, offsetY: 0 });
+  });
+
+  it('detects rightward arrow (angle 0)', () => {
+    const result = arrowFromLastSegment([
+      { x: 0, y: 0 },
+      { x: 100, y: 0 },
+    ]);
+    expect(result.angle).toBe(0);
+    expect(result.offsetX).toBeGreaterThan(0);
+    expect(result.offsetY).toBe(0);
+  });
+
+  it('detects leftward arrow (angle PI)', () => {
+    const result = arrowFromLastSegment([
+      { x: 100, y: 0 },
+      { x: 0, y: 0 },
+    ]);
+    expect(result.angle).toBe(Math.PI);
+    expect(result.offsetX).toBeLessThan(0);
+    expect(result.offsetY).toBe(0);
+  });
+
+  it('detects downward arrow (angle PI/2)', () => {
+    const result = arrowFromLastSegment([
+      { x: 0, y: 0 },
+      { x: 0, y: 100 },
+    ]);
+    expect(result.angle).toBe(Math.PI / 2);
+    expect(result.offsetX).toBe(0);
+    expect(result.offsetY).toBeGreaterThan(0);
+  });
+
+  it('detects upward arrow (angle -PI/2)', () => {
+    const result = arrowFromLastSegment([
+      { x: 0, y: 100 },
+      { x: 0, y: 0 },
+    ]);
+    expect(result.angle).toBe(-Math.PI / 2);
+    expect(result.offsetX).toBe(0);
+    expect(result.offsetY).toBeLessThan(0);
+  });
+
+  it('uses the last two points only', () => {
+    const result = arrowFromLastSegment([
+      { x: 0, y: 0 },
+      { x: 0, y: 50 }, // vertical
+      { x: 100, y: 50 }, // last segment is rightward
+    ]);
+    expect(result.angle).toBe(0);
+  });
+
+  it('skips trailing zero-length segments', () => {
+    const result = arrowFromLastSegment([
+      { x: 0, y: 0 },
+      { x: 100, y: 0 }, // rightward
+      { x: 100, y: 0 }, // duplicate
+    ]);
+    expect(result.angle).toBe(0);
+    expect(result.offsetX).toBeGreaterThan(0);
+  });
+
+  it('returns neutral fallback when all points are identical', () => {
+    const result = arrowFromLastSegment([
+      { x: 50, y: 50 },
+      { x: 50, y: 50 },
+      { x: 50, y: 50 },
+    ]);
+    expect(result).toEqual({ angle: 0, offsetX: 0, offsetY: 0 });
+  });
+});
+
+describe('calculatePathMidpoint', () => {
+  it('returns origin for empty array', () => {
+    expect(calculatePathMidpoint([])).toEqual({ x: 0, y: 0 });
+  });
+
+  it('returns the point for single-element array', () => {
+    expect(calculatePathMidpoint([{ x: 42, y: 99 }])).toEqual({ x: 42, y: 99 });
+  });
+
+  it('returns midpoint for a straight 2-point segment', () => {
+    const result = calculatePathMidpoint([
+      { x: 0, y: 0 },
+      { x: 100, y: 0 },
+    ]);
+    expect(result.x).toBeCloseTo(50);
+    expect(result.y).toBeCloseTo(0);
+  });
+
+  it('finds midpoint along a multi-segment L-shaped path', () => {
+    // Total length: 100 (horizontal) + 100 (vertical) = 200
+    // Midpoint at length 100 = end of first segment = (100, 0)
+    const result = calculatePathMidpoint([
+      { x: 0, y: 0 },
+      { x: 100, y: 0 },
+      { x: 100, y: 100 },
+    ]);
+    expect(result.x).toBeCloseTo(100);
+    expect(result.y).toBeCloseTo(0);
+  });
+
+  it('handles midpoint falling in the middle of a segment', () => {
+    // Total: 50 + 200 + 50 = 300, midpoint at 150 → 100 into the second segment (200 long)
+    // Second segment: (50,0) → (50,200), t = 100/200 = 0.5, y = 100
+    const result = calculatePathMidpoint([
+      { x: 0, y: 0 },
+      { x: 50, y: 0 },
+      { x: 50, y: 200 },
+      { x: 100, y: 200 },
+    ]);
+    expect(result.x).toBeCloseTo(50);
+    expect(result.y).toBeCloseTo(100);
+  });
+
+  it('handles zero-length segments without errors', () => {
+    const result = calculatePathMidpoint([
+      { x: 0, y: 0 },
+      { x: 0, y: 0 }, // zero-length
+      { x: 100, y: 0 },
+    ]);
+    expect(result.x).toBeCloseTo(50);
+    expect(result.y).toBeCloseTo(0);
+  });
+});

--- a/packages/apollo-react/src/canvas/components/Edges/EdgeRoutingUtils.ts
+++ b/packages/apollo-react/src/canvas/components/Edges/EdgeRoutingUtils.ts
@@ -1,0 +1,167 @@
+/**
+ * Edge routing utilities for ELK-computed orthogonal paths.
+ *
+ * When ELK's layered algorithm with ORTHOGONAL edge routing is used,
+ * it produces bend points that route edges around nodes. These utilities
+ * convert those points into SVG paths with rounded corners.
+ */
+
+import { EDGE_BORDER_RADIUS, HANDLE_OFFSET } from '../../constants';
+
+export interface RoutingPoint {
+  x: number;
+  y: number;
+}
+
+/** Threshold (px) below which a coordinate difference is treated as zero. */
+const ORTHO_SNAP_THRESHOLD = 1;
+
+/**
+ * Ensure all segments in the point array are orthogonal (axis-aligned).
+ *
+ * The caller is responsible for providing waypoints that already encode the
+ * correct exit/entry direction (based on handle positions). This function
+ * only snaps near-zero coordinate differences and inserts step midpoints
+ * for any remaining diagonal segments.
+ */
+export function toOrthogonalPoints(points: RoutingPoint[]): RoutingPoint[] {
+  if (points.length < 2) return points;
+
+  const pts = points.map((p) => ({ ...p }));
+
+  const result: RoutingPoint[] = [pts[0]!];
+  for (let i = 1; i < pts.length; i++) {
+    const prev = result[result.length - 1]!;
+    const curr = pts[i]!;
+    const dx = Math.abs(curr.x - prev.x);
+    const dy = Math.abs(curr.y - prev.y);
+    if (dx < ORTHO_SNAP_THRESHOLD || dy < ORTHO_SNAP_THRESHOLD) {
+      // Snap the near-zero axis to be exactly aligned
+      if (dx < ORTHO_SNAP_THRESHOLD) curr.x = prev.x;
+      if (dy < ORTHO_SNAP_THRESHOLD) curr.y = prev.y;
+      result.push(curr);
+      continue;
+    }
+    const midX = (prev.x + curr.x) / 2;
+    result.push({ x: midX, y: prev.y });
+    result.push({ x: midX, y: curr.y });
+    result.push(curr);
+  }
+  return result;
+}
+
+/**
+ * Build an SVG path from routing points. Points are first orthogonalized
+ * (snapped to axis-aligned segments) and then connected with rounded corners
+ * — matching the visual style of getSmoothStepPath.
+ *
+ * Returns both the SVG path string and the orthogonalized points so that
+ * callers can reuse them for label placement and arrow direction without
+ * re-running the orthogonalization.
+ *
+ * @param points - Raw array of {x, y} routing coordinates
+ * @param borderRadius - Radius for rounded corners at bends (default: 16)
+ */
+export function buildOrthogonalPath(
+  points: RoutingPoint[],
+  borderRadius = EDGE_BORDER_RADIUS
+): { path: string; orthoPoints: RoutingPoint[] } {
+  if (points.length < 2) return { path: '', orthoPoints: [] };
+
+  const ortho = toOrthogonalPoints(points);
+
+  if (ortho.length < 2) return { path: '', orthoPoints: ortho };
+  if (ortho.length === 2) {
+    return {
+      path: `M ${ortho[0]!.x} ${ortho[0]!.y} L ${ortho[1]!.x} ${ortho[1]!.y}`,
+      orthoPoints: ortho,
+    };
+  }
+
+  const parts: string[] = [`M ${ortho[0]!.x} ${ortho[0]!.y}`];
+  for (let i = 1; i < ortho.length - 1; i++) {
+    const prev = ortho[i - 1]!;
+    const curr = ortho[i]!;
+    const next = ortho[i + 1]!;
+    const d1 = Math.abs(curr.x - prev.x) + Math.abs(curr.y - prev.y);
+    const d2 = Math.abs(next.x - curr.x) + Math.abs(next.y - curr.y);
+    const r = Math.min(borderRadius, d1 / 2, d2 / 2);
+    if (r < 1) {
+      parts.push(`L ${curr.x} ${curr.y}`);
+      continue;
+    }
+    const dx1 = d1 > 0 ? (curr.x - prev.x) / d1 : 0;
+    const dy1 = d1 > 0 ? (curr.y - prev.y) / d1 : 0;
+    const dx2 = d2 > 0 ? (next.x - curr.x) / d2 : 0;
+    const dy2 = d2 > 0 ? (next.y - curr.y) / d2 : 0;
+    parts.push(`L ${curr.x - dx1 * r} ${curr.y - dy1 * r}`);
+    parts.push(`Q ${curr.x} ${curr.y} ${curr.x + dx2 * r} ${curr.y + dy2 * r}`);
+  }
+  parts.push(`L ${ortho[ortho.length - 1]!.x} ${ortho[ortho.length - 1]!.y}`);
+  return { path: parts.join(' '), orthoPoints: ortho };
+}
+
+/**
+ * Determine the arrow angle from the last segment of a routed path.
+ * Returns the angle the arrow should point (INTO the target node)
+ * and the offset to keep the arrow away from the node edge.
+ *
+ * Skips trailing zero-length segments (duplicate points from ELK or snapping)
+ * and returns a neutral fallback when no direction can be inferred.
+ */
+export function arrowFromLastSegment(points: RoutingPoint[]): {
+  angle: number;
+  offsetX: number;
+  offsetY: number;
+} {
+  if (points.length < 2) return { angle: 0, offsetX: 0, offsetY: 0 };
+
+  // Walk backwards to find a non-zero-length segment
+  const last = points[points.length - 1]!;
+  for (let i = points.length - 2; i >= 0; i--) {
+    const prev = points[i]!;
+    const dx = last.x - prev.x;
+    const dy = last.y - prev.y;
+    if (Math.abs(dx) < ORTHO_SNAP_THRESHOLD && Math.abs(dy) < ORTHO_SNAP_THRESHOLD) continue;
+
+    if (Math.abs(dx) >= Math.abs(dy)) {
+      return dx > 0
+        ? { angle: 0, offsetX: HANDLE_OFFSET, offsetY: 0 }
+        : { angle: Math.PI, offsetX: -HANDLE_OFFSET, offsetY: 0 };
+    }
+    return dy > 0
+      ? { angle: Math.PI / 2, offsetX: 0, offsetY: HANDLE_OFFSET }
+      : { angle: -Math.PI / 2, offsetX: 0, offsetY: -HANDLE_OFFSET };
+  }
+
+  return { angle: 0, offsetX: 0, offsetY: 0 };
+}
+
+/**
+ * Calculate the midpoint of a polyline path for label positioning.
+ * Walks along the path segments and returns the point at half the total length.
+ */
+export function calculatePathMidpoint(points: RoutingPoint[]): { x: number; y: number } {
+  if (points.length === 0) return { x: 0, y: 0 };
+  if (points.length === 1) return points[0]!;
+
+  let totalLength = 0;
+  const segLens: number[] = [];
+  for (let i = 1; i < points.length; i++) {
+    const len = Math.hypot(points[i]!.x - points[i - 1]!.x, points[i]!.y - points[i - 1]!.y);
+    segLens.push(len);
+    totalLength += len;
+  }
+  let remaining = totalLength / 2;
+  for (let i = 0; i < segLens.length; i++) {
+    if (remaining <= segLens[i]!) {
+      const t = segLens[i]! > 0 ? remaining / segLens[i]! : 0;
+      return {
+        x: points[i]!.x + (points[i + 1]!.x - points[i]!.x) * t,
+        y: points[i]!.y + (points[i + 1]!.y - points[i]!.y) * t,
+      };
+    }
+    remaining -= segLens[i]!;
+  }
+  return points[points.length - 1]!;
+}

--- a/packages/apollo-react/src/canvas/components/Edges/SequenceEdge.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/Edges/SequenceEdge.stories.tsx
@@ -955,6 +955,182 @@ function LoopEdgesStory() {
 }
 
 // ============================================================================
+// ELK Routing Story
+// ============================================================================
+
+function ElkRoutingStory() {
+  const initialNodes = useMemo(
+    () => [
+      createStickyNote(
+        'sticky-elk',
+        'green',
+        '**ELK Routing**\nEdges with `data.elkRouting` use orthogonal bend points to route around nodes',
+        { x: 48, y: 32 },
+        { width: 880, height: 800 }
+      ),
+
+      // Row 1: Straight edge
+      createNode({
+        id: 'elk-a1',
+        label: 'Source',
+        x: 96,
+        y: 96,
+        sourcePositions: [Position.Right],
+      }),
+      createNode({
+        id: 'elk-b1',
+        label: 'Target',
+        x: 352,
+        y: 96,
+        targetPositions: [Position.Left],
+      }),
+
+      // Row 2: Routed around obstacle
+      createNode({
+        id: 'elk-a2',
+        label: 'Source',
+        x: 96,
+        y: 288,
+        sourcePositions: [Position.Right],
+      }),
+      createNode({
+        id: 'elk-obstacle',
+        label: 'Obstacle',
+        x: 352,
+        y: 288,
+        targetPositions: [Position.Left],
+        sourcePositions: [Position.Right],
+      }),
+      createNode({
+        id: 'elk-b2',
+        label: 'Target',
+        x: 608,
+        y: 288,
+        targetPositions: [Position.Left],
+      }),
+
+      // Row 3: S-shape with label
+      createNode({
+        id: 'elk-a3',
+        label: 'Source',
+        x: 96,
+        y: 480,
+        sourcePositions: [Position.Right],
+      }),
+      createNode({
+        id: 'elk-b3',
+        label: 'Target',
+        x: 352,
+        y: 576,
+        targetPositions: [Position.Left],
+      }),
+
+      // Info panel
+      createStickyNote(
+        'sticky-elk-info',
+        'pink',
+        '## ELK Edge Routing\n\nWhen `edge.data.elkRouting` is set, SequenceEdge draws an orthogonal path with rounded corners using ELK-computed bend points.\n\n**Row 1:** Straight — only start/end points, no bends\n**Row 2:** Routed around obstacle — bend points go above\n**Row 3:** S-shape with edge label — vertical + horizontal bends',
+        { x: 48, y: 864 },
+        { width: 480, height: 224 }
+      ),
+    ],
+    []
+  );
+
+  const initialEdges: Edge[] = useMemo(
+    () => [
+      // Row 1: Straight
+      {
+        id: 'e-elk-straight',
+        source: 'elk-a1',
+        target: 'elk-b1',
+        sourceHandle: `out-${Position.Right}`,
+        targetHandle: `in-${Position.Left}`,
+        type: 'sequence',
+        data: {
+          elkRouting: [
+            { x: 256, y: 144 },
+            { x: 352, y: 144 },
+          ],
+        },
+      },
+
+      // Row 2: Routed around obstacle
+      {
+        id: 'e-elk-routed',
+        source: 'elk-a2',
+        target: 'elk-b2',
+        sourceHandle: `out-${Position.Right}`,
+        targetHandle: `in-${Position.Left}`,
+        type: 'sequence',
+        data: {
+          elkRouting: [
+            { x: 256, y: 336 },
+            { x: 304, y: 336 },
+            { x: 304, y: 240 },
+            { x: 560, y: 240 },
+            { x: 560, y: 336 },
+            { x: 608, y: 336 },
+          ],
+        },
+      },
+
+      // Normal edges through obstacle
+      {
+        id: 'e-elk-obstacle-in',
+        source: 'elk-a2',
+        target: 'elk-obstacle',
+        sourceHandle: `out-${Position.Right}`,
+        targetHandle: `in-${Position.Left}`,
+        type: 'sequence',
+      },
+      {
+        id: 'e-elk-obstacle-out',
+        source: 'elk-obstacle',
+        target: 'elk-b2',
+        sourceHandle: `out-${Position.Right}`,
+        targetHandle: `in-${Position.Left}`,
+        type: 'sequence',
+      },
+
+      // Row 3: S-shape with label
+      {
+        id: 'e-elk-s-shape',
+        source: 'elk-a3',
+        target: 'elk-b3',
+        sourceHandle: `out-${Position.Right}`,
+        targetHandle: `in-${Position.Left}`,
+        type: 'sequence',
+        data: {
+          label: 'Routed',
+          elkRouting: [
+            { x: 256, y: 528 },
+            { x: 304, y: 528 },
+            { x: 304, y: 624 },
+            { x: 352, y: 624 },
+          ],
+        },
+      },
+    ],
+    []
+  );
+
+  const { canvasProps } = useCanvasStory({
+    initialNodes,
+    initialEdges,
+    additionalNodeTypes: nodeTypes,
+  });
+
+  return (
+    <BaseCanvas {...canvasProps} edgeTypes={edgeTypes} mode="design">
+      <Panel position="bottom-right">
+        <CanvasPositionControls translations={DefaultCanvasTranslations} />
+      </Panel>
+    </BaseCanvas>
+  );
+}
+
+// ============================================================================
 // Exported Stories
 // ============================================================================
 
@@ -1005,6 +1181,18 @@ export const LoopEdges: Story = {
       description: {
         story:
           'Demonstrates loop edges with custom paths. SequenceEdge automatically detects self-loops and loopBack edges, rendering them with paths that go below the node. Success handle loops have larger dimensions than output handle loops.',
+      },
+    },
+  },
+};
+
+export const ElkRouting: Story = {
+  render: () => <ElkRoutingStory />,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Demonstrates ELK edge routing support. When edge.data.elkRouting is set with routing points from ELK's layered algorithm (ORTHOGONAL edge routing), SequenceEdge renders an orthogonal path with rounded corners. The first and last routing points are replaced by React Flow handle coordinates; intermediate points are the bend points. Row 1: straight edge, Row 2: edge routed around an obstacle, Row 3: S-shape with edge label.",
       },
     },
   },

--- a/packages/apollo-react/src/canvas/components/Edges/SequenceEdge.tsx
+++ b/packages/apollo-react/src/canvas/components/Edges/SequenceEdge.tsx
@@ -1,11 +1,26 @@
 import { type EdgeProps, Position } from '@uipath/apollo-react/canvas/xyflow/react';
-import { memo, useRef, useState } from 'react';
-import { PREVIEW_EDGE_ID } from '../../constants';
+import { memo, useMemo, useRef, useState } from 'react';
+
+import { EDGE_BORDER_RADIUS, HANDLE_OFFSETS, PREVIEW_EDGE_ID } from '../../constants';
 import { useEdgeExecutionState, useEdgePath, useElementValidationStatus } from '../../hooks';
 import type { NodeExecutionStateWithDebug } from '../../types/execution';
 import { useBaseCanvasMode } from '../BaseCanvas/BaseCanvasModeProvider';
 import { EdgeToolbar, useEdgeToolbarState } from '../Toolbar';
+import {
+  arrowFromLastSegment,
+  buildOrthogonalPath,
+  calculatePathMidpoint,
+  type RoutingPoint,
+} from './EdgeRoutingUtils';
 import { edgeTargetStatusToEdgeColor, getStatusAnimation } from './EdgeUtils';
+
+/** Typed edge data for SequenceEdge. */
+export interface SequenceEdgeData {
+  label?: string;
+  isDiffAdded?: boolean;
+  isDiffRemoved?: boolean;
+  elkRouting?: RoutingPoint[];
+}
 
 const ARROW_SIZE = 10;
 
@@ -17,14 +32,6 @@ const ANGLE_MAP: Record<Position, number> = {
   [Position.Right]: Math.PI, // Edge enters right side, arrow points left
   [Position.Top]: Math.PI / 2, // Edge enters top, arrow points down
   [Position.Bottom]: -Math.PI / 2, // Edge enters bottom, arrow points up
-};
-
-// Offset to position start/arrow slightly away from the node edge
-const ARROW_OFFSETS: Record<Position, { x: number; y: number }> = {
-  [Position.Left]: { x: 8, y: 0 },
-  [Position.Right]: { x: -8, y: 0 },
-  [Position.Top]: { x: 0, y: 8 },
-  [Position.Bottom]: { x: 0, y: -8 },
 };
 
 // Custom comparison to prevent re-renders during pan/zoom
@@ -81,14 +88,15 @@ export const SequenceEdge = memo(function SequenceEdge({
     ? ((executionStatus as NodeExecutionStateWithDebug)?.status ?? executionStatus)
     : validationStatus;
 
+  const edgeData = data as SequenceEdgeData | undefined;
+
   // Check if this edge has diff styling applied
-  const isDiffAdded = data?.isDiffAdded === true;
-  const isDiffRemoved = data?.isDiffRemoved === true;
+  const isDiffAdded = edgeData?.isDiffAdded === true;
+  const isDiffRemoved = edgeData?.isDiffRemoved === true;
 
-  const angle = ANGLE_MAP[targetPosition];
-  const { x: offsetX, y: offsetY } = ARROW_OFFSETS[targetPosition];
-
-  const { edgePath, labelX, labelY } = useEdgePath({
+  // Standard path from useEdgePath (always computed — hooks cannot be called
+  // conditionally, and we need isLoopEdge to decide the ELK branch)
+  const standardPath = useEdgePath({
     sourceNodeId: source,
     targetNodeId: target,
     sourceHandleId,
@@ -100,6 +108,77 @@ export const SequenceEdge = memo(function SequenceEdge({
     targetY,
     targetPosition,
   });
+
+  // Use ELK-computed routing when available (avoids nodes after auto-layout).
+  // ELK routing is intentionally ignored for loop edges because SequenceEdge
+  // has purpose-built loop paths that handle self-loops and loopBack edges.
+  const elkRouting = edgeData?.elkRouting;
+  const useElk = !!elkRouting && elkRouting.length >= 2 && !standardPath.isLoopEdge;
+
+  const elkPath = useMemo(() => {
+    if (!useElk || !elkRouting) return null;
+
+    const { x: sourceOffsetX, y: sourceOffsetY } = HANDLE_OFFSETS[sourcePosition];
+    const sourcePt: RoutingPoint = { x: sourceX + sourceOffsetX, y: sourceY + sourceOffsetY };
+    const targetPt: RoutingPoint = { x: targetX, y: targetY };
+    const intermediates = elkRouting.slice(1, -1);
+
+    // Adapt ELK intermediate points so the first/last segments match the
+    // actual handle directions. ELK computed bend points for its own anchor
+    // positions which may differ from the React Flow handle coordinates.
+    // We adjust the nearest intermediate coordinate rather than inserting
+    // extra waypoints, which avoids path backtracking (V-shapes).
+    const adapted = intermediates.map((p) => ({ ...p }));
+
+    const isHorizontalExit = sourcePosition === Position.Left || sourcePosition === Position.Right;
+    const isHorizontalEntry = targetPosition === Position.Left || targetPosition === Position.Right;
+
+    // Source exit: align the first intermediate so the exit segment
+    // matches the handle direction (horizontal for Left/Right, vertical for Top/Bottom).
+    if (adapted.length > 0) {
+      const first = adapted[0]!;
+      if (isHorizontalExit && Math.abs(first.y - sourcePt.y) > 1) {
+        first.y = sourcePt.y;
+      } else if (!isHorizontalExit && Math.abs(first.x - sourcePt.x) > 1) {
+        first.x = sourcePt.x;
+      }
+    }
+
+    // Target entry: align the last intermediate so the entry segment
+    // matches the handle direction.
+    if (adapted.length > 0) {
+      const last = adapted[adapted.length - 1]!;
+      if (isHorizontalEntry && Math.abs(last.y - targetPt.y) > 1) {
+        last.y = targetPt.y;
+      } else if (!isHorizontalEntry && Math.abs(last.x - targetPt.x) > 1) {
+        last.x = targetPt.x;
+      }
+    }
+
+    const rawPoints: RoutingPoint[] = [sourcePt, ...adapted, targetPt];
+
+    // buildOrthogonalPath orthogonalizes internally and returns the
+    // axis-aligned points so arrow/label use the same geometry as the path.
+    const { path: edgePath, orthoPoints } = buildOrthogonalPath(rawPoints, EDGE_BORDER_RADIUS);
+    const mid = calculatePathMidpoint(orthoPoints);
+    const arrow = arrowFromLastSegment(orthoPoints);
+
+    return {
+      edgePath,
+      labelX: mid.x,
+      labelY: mid.y,
+      arrowAngle: arrow.angle,
+      arrowOffsetX: arrow.offsetX,
+      arrowOffsetY: arrow.offsetY,
+    };
+  }, [useElk, elkRouting, sourceX, sourceY, sourcePosition, targetX, targetY, targetPosition]);
+
+  const edgePath = elkPath?.edgePath ?? standardPath.edgePath;
+  const labelX = elkPath?.labelX ?? standardPath.labelX;
+  const labelY = elkPath?.labelY ?? standardPath.labelY;
+  const arrowAngle = elkPath?.arrowAngle ?? ANGLE_MAP[targetPosition];
+  const arrowOffsetX = elkPath?.arrowOffsetX ?? HANDLE_OFFSETS[targetPosition].x;
+  const arrowOffsetY = elkPath?.arrowOffsetY ?? HANDLE_OFFSETS[targetPosition].y;
 
   // Edge toolbar state
   const {
@@ -189,22 +268,22 @@ export const SequenceEdge = memo(function SequenceEdge({
         <polygon
           points={`
             ${targetX},${targetY}
-            ${targetX - ARROW_SIZE * Math.cos(angle - Math.PI / 6)},${targetY - ARROW_SIZE * Math.sin(angle - Math.PI / 6)}
-            ${targetX - ARROW_SIZE * Math.cos(angle + Math.PI / 6)},${targetY - ARROW_SIZE * Math.sin(angle + Math.PI / 6)}
+            ${targetX - ARROW_SIZE * Math.cos(arrowAngle - Math.PI / 6)},${targetY - ARROW_SIZE * Math.sin(arrowAngle - Math.PI / 6)}
+            ${targetX - ARROW_SIZE * Math.cos(arrowAngle + Math.PI / 6)},${targetY - ARROW_SIZE * Math.sin(arrowAngle + Math.PI / 6)}
           `}
           fill={edgeColor}
           style={{
             pointerEvents: 'none',
             opacity: style?.opacity !== undefined ? style.opacity : 1,
             transition: 'fill 0.2s ease, opacity 0.2s ease',
-            transform: `translate(${offsetX}px, ${offsetY}px)`,
+            transform: `translate(${arrowOffsetX}px, ${arrowOffsetY}px)`,
           }}
         />
 
         {getStatusAnimation(status, edgePath)}
 
         {/* Edge label from data */}
-        {typeof data?.label === 'string' && data.label.length > 0 && (
+        {typeof edgeData?.label === 'string' && edgeData.label.length > 0 && (
           <foreignObject
             x={labelX}
             y={labelY}
@@ -230,7 +309,7 @@ export const SequenceEdge = memo(function SequenceEdge({
                 boxShadow: '0 1px 3px 0 rgba(0, 0, 0, 0.1)',
               }}
             >
-              {data.label}
+              {edgeData.label}
             </div>
           </foreignObject>
         )}

--- a/packages/apollo-react/src/canvas/components/Edges/index.ts
+++ b/packages/apollo-react/src/canvas/components/Edges/index.ts
@@ -1,1 +1,9 @@
+export type { RoutingPoint } from './EdgeRoutingUtils';
+export {
+  arrowFromLastSegment,
+  buildOrthogonalPath,
+  calculatePathMidpoint,
+  toOrthogonalPoints,
+} from './EdgeRoutingUtils';
+export { edgeTargetStatusToEdgeColor, getStatusAnimation } from './EdgeUtils';
 export * from './SequenceEdge';

--- a/packages/apollo-react/src/canvas/constants.ts
+++ b/packages/apollo-react/src/canvas/constants.ts
@@ -6,3 +6,28 @@ export const GRID_SPACING = 16;
 
 /** Canvas viewport width below which compact layout is used. */
 export const CANVAS_COMPACT_BREAKPOINT = 600;
+
+/** Border radius for rounded corners on edge paths (both standard and ELK-routed). */
+export const EDGE_BORDER_RADIUS = GRID_SPACING;
+
+/**
+ * Offset (in px) applied to source/arrow handles to keep them slightly
+ * away from the node edge. Used by useEdgePath, SequenceEdge, and
+ * EdgeRoutingUtils — kept here as the single source of truth.
+ */
+export const HANDLE_OFFSET = 8;
+
+/**
+ * Per-position offsets that pull the edge start/end point slightly away from
+ * the node boundary. Used for both source handle offsets and arrow positioning.
+ *
+ * The sign convention is: the offset moves the point *inward* from the handle
+ * centre (i.e., toward the interior of the gap between node edge and path start).
+ */
+export const HANDLE_OFFSETS: Record<'left' | 'right' | 'top' | 'bottom', { x: number; y: number }> =
+  {
+    left: { x: HANDLE_OFFSET, y: 0 },
+    right: { x: -HANDLE_OFFSET, y: 0 },
+    top: { x: 0, y: HANDLE_OFFSET },
+    bottom: { x: 0, y: -HANDLE_OFFSET },
+  };

--- a/packages/apollo-react/src/canvas/hooks/useEdgePath.ts
+++ b/packages/apollo-react/src/canvas/hooks/useEdgePath.ts
@@ -1,6 +1,7 @@
 import { getSmoothStepPath, Position } from '@uipath/apollo-react/canvas/xyflow/react';
 import { useMemo } from 'react';
-import { GRID_SPACING } from '../constants';
+
+import { EDGE_BORDER_RADIUS, GRID_SPACING, HANDLE_OFFSETS } from '../constants';
 
 // Constants
 const LOOP_HEIGHT = GRID_SPACING * 6;
@@ -9,12 +10,6 @@ const LOOP_RIGHT_EXTENSION = GRID_SPACING * 3;
 const LOOP_SUCCESS_RIGHT_EXTENSION = GRID_SPACING * 4;
 const LOOP_LEFT_EXTENSION = GRID_SPACING * 2;
 const LOOP_CORNER_RADIUS = GRID_SPACING;
-const SOURCE_OFFSETS: Record<Position, { x: number; y: number }> = {
-  [Position.Left]: { x: 8, y: 0 },
-  [Position.Right]: { x: -8, y: 0 },
-  [Position.Top]: { x: 0, y: 8 },
-  [Position.Bottom]: { x: 0, y: -8 },
-};
 
 // Helper function to snap a value to the grid
 const snapToGrid = (value: number): number => {
@@ -32,7 +27,7 @@ const createLoopPath = ({
   targetY,
   sourceHandleId,
 }: EdgePathParams): { path: string; loopHeight: number } => {
-  const offsets = SOURCE_OFFSETS[sourcePosition];
+  const offsets = HANDLE_OFFSETS[sourcePosition];
   const sourceOffsetX = sourceX + offsets.x;
   const sourceOffsetY = sourceY + offsets.y;
   const loopHeight = sourceHandleId === 'success' ? LOOP_SUCCESS_HEIGHT : LOOP_HEIGHT;
@@ -145,8 +140,8 @@ export function useEdgePath({
       labelY = Math.max(sourceY, targetY) + loopHeight;
     } else {
       const { sourceOffsetX, sourceOffsetY } = {
-        sourceOffsetX: sourceX + SOURCE_OFFSETS[sourcePosition].x,
-        sourceOffsetY: sourceY + SOURCE_OFFSETS[sourcePosition].y,
+        sourceOffsetX: sourceX + HANDLE_OFFSETS[sourcePosition].x,
+        sourceOffsetY: sourceY + HANDLE_OFFSETS[sourcePosition].y,
       };
       [edgePath, labelX, labelY] = getSmoothStepPath({
         sourceX: sourceOffsetX,
@@ -155,7 +150,7 @@ export function useEdgePath({
         targetX,
         targetY,
         targetPosition,
-        borderRadius: 16,
+        borderRadius: EDGE_BORDER_RADIUS,
       });
     }
 


### PR DESCRIPTION
### Description

This pull request introduces support for ELK orthogonal edge routing in the `SequenceEdge` component, allowing edges to be rendered with axis-aligned, bend-point-based paths and rounded corners. It adds a new utility module for converting ELK bend points to SVG paths, updates the edge rendering logic to use these paths when ELK routing data is present, and provides comprehensive tests and Storybook documentation for the new feature.

**ELK Edge Routing Support:**

- Added a new utility module `EdgeRoutingUtils.ts` that provides functions to convert ELK bend points into axis-aligned (orthogonal) SVG paths with rounded corners, compute arrow directions, and calculate label midpoints.
- Updated `SequenceEdge` to support an optional `elkRouting` property in edge data. When present, the edge is rendered using the orthogonal path generated from ELK bend points instead of the default path logic. The edge arrow and label placement are also updated accordingly. 
- Refactored the edge arrow offset logic to use a shared constant and the new routing utilities, removing the old `ARROW_OFFSETS` mapping.

**Testing and Documentation:**

- Added a comprehensive test suite for the new edge routing utilities in `EdgeRoutingUtils.test.ts`, covering snapping, orthogonalization, path generation, arrow direction, and midpoint calculation.
- Introduced a new Storybook story, `ElkRouting`, that demonstrates the ELK edge routing feature with multiple edge scenarios, including straight, routed-around-obstacle, and S-shaped edges. 

### Demo


https://github.com/user-attachments/assets/1beb12c0-d621-4a2b-8479-79d088a2b24c

