### PR TITLE
refactor(apollo-vertex): replace date-fns with luxon [AGVSOL-1574]

### DIFF
--- a/apps/apollo-vertex/app/(preview)/layout.tsx
+++ b/apps/apollo-vertex/app/(preview)/layout.tsx
@@ -1,9 +1,5 @@
 import type { ReactNode } from "react";
 
 export default function PreviewLayout({ children }: { children: ReactNode }) {
-  return (
-    <div className="fixed inset-0 z-50 bg-background">
-      {children}
-    </div>
-  );
+  return <div className="fixed inset-0 z-50 bg-background">{children}</div>;
 }

--- a/apps/apollo-vertex/app/patterns/notifications/in-product/layout-diagram.tsx
+++ b/apps/apollo-vertex/app/patterns/notifications/in-product/layout-diagram.tsx
@@ -5,11 +5,15 @@ export function LayoutDiagram() {
       <div className="flex items-center justify-between border-b bg-card px-4 py-2">
         <div className="flex items-center gap-2">
           <div className="h-4 w-4 rounded bg-muted-foreground/30" />
-          <span className="text-xs font-medium text-muted-foreground">App Header</span>
+          <span className="text-xs font-medium text-muted-foreground">
+            App Header
+          </span>
         </div>
         <div className="flex items-center gap-1.5">
           <div className="rounded border border-dashed border-destructive bg-transparent px-2 py-0.5">
-            <span className="text-[10px] font-medium text-destructive">Reserved: Primary CTAs</span>
+            <span className="text-[10px] font-medium text-destructive">
+              Reserved: Primary CTAs
+            </span>
           </div>
         </div>
       </div>
@@ -17,7 +21,9 @@ export function LayoutDiagram() {
       {/* Sonner position indicator */}
       <div className="flex justify-center py-2">
         <div className="rounded-md border border-info bg-transparent px-3 py-1.5 shadow-sm">
-          <span className="text-[10px] font-medium text-info">Sonner position: top-center</span>
+          <span className="text-[10px] font-medium text-info">
+            Sonner position: top-center
+          </span>
         </div>
       </div>
 
@@ -26,7 +32,8 @@ export function LayoutDiagram() {
         {/* System banner example */}
         <div className="mb-3 w-full rounded border border-warning bg-transparent px-3 py-1.5">
           <span className="text-[10px] font-medium text-warning-foreground dark:text-warning">
-            System banner (full-width, below header) — for alerts with no UI anchor
+            System banner (full-width, below header) — for alerts with no UI
+            anchor
           </span>
         </div>
 
@@ -48,7 +55,9 @@ export function LayoutDiagram() {
         {/* Chat reserved area */}
         <div className="absolute bottom-3 right-3">
           <div className="rounded border border-dashed border-destructive bg-transparent px-2 py-1">
-            <span className="text-[10px] font-medium text-destructive">Reserved: Chat</span>
+            <span className="text-[10px] font-medium text-destructive">
+              Reserved: Chat
+            </span>
           </div>
         </div>
       </div>

--- a/apps/apollo-vertex/package.json
+++ b/apps/apollo-vertex/package.json
@@ -59,7 +59,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
-    "date-fns": "^4.1.0",
+    "luxon": "^3.7.1",
     "embla-carousel-react": "^8.6.0",
     "framer-motion": "^12.26.2",
     "i18next": "^25.8.1",
@@ -89,6 +89,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "^2.3.6",
+    "@types/luxon": "^3.7.1",
     "@types/node": "^24.10.1",
     "@types/react": "^19.2.6",
     "@types/react-dom": "^19.2.2",

--- a/apps/apollo-vertex/registry.json
+++ b/apps/apollo-vertex/registry.json
@@ -1170,7 +1170,7 @@
       "type": "registry:ui",
       "title": "Date Picker",
       "description": "A date picker component.",
-      "dependencies": ["date-fns", "lucide-react", "react-i18next"],
+      "dependencies": ["luxon", "@types/luxon", "lucide-react", "react-i18next"],
       "registryDependencies": ["button", "popover", "calendar"],
       "files": [
         {

--- a/apps/apollo-vertex/registry/date-picker/date-picker.tsx
+++ b/apps/apollo-vertex/registry/date-picker/date-picker.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { format } from "date-fns";
+import { DateTime } from "luxon";
 import { ChevronDownIcon } from "lucide-react";
 import * as React from "react";
 import { useTranslation } from "react-i18next";
@@ -28,7 +28,11 @@ export function DatePicker({ value, onValueChanged }: DatePickerProps) {
           data-empty={!value}
           className="data-[empty=true]:text-muted-foreground w-[212px] justify-between text-left font-normal"
         >
-          {value ? format(value, "PPP") : <span>{t("pick_a_date")}</span>}
+          {value ? (
+            DateTime.fromJSDate(value).toLocaleString(DateTime.DATE_FULL)
+          ) : (
+            <span>{t("pick_a_date")}</span>
+          )}
           <ChevronDownIcon />
         </Button>
       </PopoverTrigger>

--- a/apps/apollo-vertex/registry/shell/shell-minimal-company.tsx
+++ b/apps/apollo-vertex/registry/shell/shell-minimal-company.tsx
@@ -20,7 +20,7 @@ export const MinimalCompany = ({
             <img
               src={companyLogo.url}
               alt={companyLogo.alt}
-              className={`w-4 h-auto ${companyLogo.darkUrl ? 'dark:hidden' : ''}`}
+              className={`w-4 h-auto ${companyLogo.darkUrl ? "dark:hidden" : ""}`}
             />
             {companyLogo.darkUrl && (
               <img

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -202,9 +202,6 @@ importers:
       cmdk:
         specifier: ^1.1.1
         version: 1.1.1(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      date-fns:
-        specifier: ^4.1.0
-        version: 4.1.0
       embla-carousel-react:
         specifier: ^8.6.0
         version: 8.6.0(react@19.2.3)
@@ -223,6 +220,9 @@ importers:
       lucide-react:
         specifier: ^0.555.0
         version: 0.555.0(react@19.2.3)
+      luxon:
+        specifier: ^3.7.1
+        version: 3.7.2
       next:
         specifier: 16.1.5
         version: 16.1.5(@babel/core@7.28.5)(babel-plugin-macros@3.1.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.94.2)
@@ -287,6 +287,9 @@ importers:
       '@biomejs/biome':
         specifier: ^2.3.6
         version: 2.4.4
+      '@types/luxon':
+        specifier: ^3.7.1
+        version: 3.7.1
       '@types/node':
         specifier: ^24.10.1
         version: 24.10.1
@@ -8435,8 +8438,8 @@ packages:
     resolution: {integrity: sha512-2dYz766i9HprMBasCMvHMuazJ7u4WzhJwo5kb3iPSiW/iRYV6uPari3zHoqZlnuaR7V1bEiNMxikhp37rdBXbw==}
     engines: {node: '>=12'}
 
-  ip-address@10.0.1:
-    resolution: {integrity: sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==}
+  ip-address@10.1.0:
+    resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
     engines: {node: '>= 12'}
 
   ipaddr.js@1.9.1:
@@ -19857,7 +19860,7 @@ snapshots:
   express-rate-limit@8.3.1(express@5.2.1):
     dependencies:
       express: 5.2.1
-      ip-address: 10.0.1
+      ip-address: 10.1.0
 
   express@5.2.1:
     dependencies:
@@ -20737,7 +20740,7 @@ snapshots:
       from2: 2.3.0
       p-is-promise: 3.0.0
 
-  ip-address@10.0.1: {}
+  ip-address@10.1.0: {}
 
   ipaddr.js@1.9.1: {}
 


### PR DESCRIPTION
## Summary

Standardize on luxon for all date handling in apollo-vertex registry components, replacing date-fns in the date-picker component.

## Changes

- Updated date-picker to use luxon's `DateTime.DATE_FULL` format instead of date-fns's `"PPP"` format
- Removed date-fns dependency, added luxon and @types/luxon
- Updated registry.json dependencies entry for date-picker component

## Testing

Build verified with `pnpm build --filter apollo-vertex` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)