### PR TITLE
feat: add minimal landing app for apollo

### DIFF
--- a/.github/workflows/vercel-deploy.yml
+++ b/.github/workflows/vercel-deploy.yml
@@ -37,6 +37,7 @@ jobs:
 
             const projects = [
               'apollo-canvas',
+              'apollo-landing',
               'apollo-ui-react',
               'apollo-vertex',
               'apollo-wind'
@@ -96,6 +97,8 @@ jobs:
         include:
           - project_name: apollo-canvas
             vercel_project_id_secret: VERCEL_PROJECT_ID_CANVAS
+          - project_name: apollo-landing
+            vercel_project_id_secret: VERCEL_PROJECT_ID_LANDING
           - project_name: apollo-ui-react
             vercel_project_id_secret: VERCEL_PROJECT_ID_UI_REACT
           - project_name: apollo-vertex
@@ -157,6 +160,9 @@ jobs:
           case "${{ matrix.vercel_project_id_secret }}" in
             VERCEL_PROJECT_ID_CANVAS)
               echo "VERCEL_PROJECT_ID=${{ secrets.VERCEL_PROJECT_ID_CANVAS }}" >> $GITHUB_ENV
+              ;;
+            VERCEL_PROJECT_ID_LANDING)
+              echo "VERCEL_PROJECT_ID=${{ secrets.VERCEL_PROJECT_ID_LANDING }}" >> $GITHUB_ENV
               ;;
             VERCEL_PROJECT_ID_UI_REACT)
               echo "VERCEL_PROJECT_ID=${{ secrets.VERCEL_PROJECT_ID_UI_REACT }}" >> $GITHUB_ENV

--- a/apps/landing/.gitignore
+++ b/apps/landing/.gitignore
@@ -1,0 +1,2 @@
+.vercel
+.env*.local

--- a/apps/landing/index.html
+++ b/apps/landing/index.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<title>Apollo Design System</title>
+		<link rel="preconnect" href="https://fonts.googleapis.com" />
+		<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+		<link
+			href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+			rel="stylesheet"
+		/>
+	</head>
+	<body>
+		<div id="app"></div>
+		<script type="module" src="/src/main.ts"></script>
+	</body>
+</html>

--- a/apps/landing/package.json
+++ b/apps/landing/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "apollo-landing",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Apollo Design System landing page",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview",
+    "clean": "rm -rf dist",
+    "typecheck": "tsc --noEmit",
+    "lint": "biome lint .",
+    "lint:fix": "biome lint --write .",
+    "format": "biome format --write .",
+    "format:check": "biome format ."
+  },
+  "devDependencies": {
+    "@biomejs/biome": "^2.3.6",
+    "typescript": "^5.9.3",
+    "vite": "^7.3.1"
+  }
+}

--- a/apps/landing/src/main.ts
+++ b/apps/landing/src/main.ts
@@ -1,0 +1,48 @@
+import './style.css';
+
+const CARDS = [
+  {
+    title: 'Apollo Wind',
+    description:
+      "UiPath's open-source design system for building consistent user experiences across all UiPath products.",
+    url: 'https://apollo-wind.vercel.app/',
+    iconClass: 'card__icon--wind',
+    iconSvg: `<svg width="20" height="24" viewBox="0 0 20 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M14.41.153l-.107 2.558a.163.163 0 00.262.136l.96-.73.77.592a.163.163 0 00.262-.132L16.44 0 18.4.051a1.397 1.397 0 011.326 1.467L19.1 21.562a1.397 1.397 0 01-1.327 1.33L1.87 23.98a1.397 1.397 0 01-1.45-1.36L0 2.543A1.397 1.397 0 011.318 1.12L14.41.153zm-2.154 8.996c0 .478 3.236.248 3.67-.087 0-3.244-1.743-4.943-4.93-4.943-3.186 0-4.967 1.737-4.967 4.34 0 4.494 6.058 4.571 6.058 7.017 0 .696-.32 1.09-.99 1.09-.906 0-1.252-.462-1.214-2.036 0-.374-3.746-.49-3.86 0-.303 4.068 2.252 5.247 5.112 5.247 2.785 0 4.954-1.478 4.954-4.151 0-4.82-6.172-4.687-6.172-7.055 0-.965.735-1.09 1.138-1.09.44 0 1.24.087 1.201 1.668z" fill="currentColor"/></svg>`,
+  },
+  {
+    title: 'Apollo Vertex',
+    description:
+      'The design system for verticals — tailored components, patterns, and documentation for vertical product teams.',
+    url: 'https://apollo-vertex.vercel.app/',
+    iconClass: 'card__icon--vertex',
+    iconSvg: `<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M12 2L2 19.5h20L12 2zm0 4l6.5 11.5h-13L12 6z" fill="currentColor"/></svg>`,
+  },
+] as const;
+
+function createCard(card: (typeof CARDS)[number]): string {
+  return `
+		<a href="${card.url}" class="card" target="_blank" rel="noopener noreferrer">
+			<div class="card__icon ${card.iconClass}">${card.iconSvg}</div>
+			<h2 class="card__title">${card.title}</h2>
+			<p class="card__description">${card.description}</p>
+			<span class="card__arrow">Visit &rarr;</span>
+		</a>
+	`;
+}
+
+function render(): void {
+  const app = document.querySelector<HTMLDivElement>('#app');
+  if (!app) return;
+
+  app.innerHTML = `
+		<main class="landing">
+			<h1 class="landing__title">Apollo Design System</h1>
+			<p class="landing__subtitle">UiPath's open-source component library</p>
+			<div class="cards">
+				${CARDS.map(createCard).join('')}
+			</div>
+		</main>
+	`;
+}
+
+render();

--- a/apps/landing/src/style.css
+++ b/apps/landing/src/style.css
@@ -1,0 +1,131 @@
+*,
+*::before,
+*::after {
+	box-sizing: border-box;
+	margin: 0;
+	padding: 0;
+}
+
+:root {
+	--color-bg: #0a0a0f;
+	--color-surface: #16161f;
+	--color-text: #e4e4e7;
+	--color-text-muted: #9ca3af;
+	--color-brand: #fa4616;
+	--color-brand-hover: #ff6a3d;
+	--color-accent: #764ba2;
+	--color-border: #2a2a35;
+	--shadow-card: 0 1px 3px rgba(0, 0, 0, 0.3), 0 4px 12px rgba(0, 0, 0, 0.2);
+	--shadow-card-hover: 0 4px 16px rgba(0, 0, 0, 0.4),
+		0 8px 32px rgba(250, 70, 22, 0.08);
+	--radius: 16px;
+}
+
+body {
+	font-family: 'Inter', system-ui, -apple-system, sans-serif;
+	background: var(--color-bg);
+	color: var(--color-text);
+	min-height: 100vh;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+}
+
+.landing {
+	text-align: center;
+	padding: 2rem;
+	max-width: 800px;
+}
+
+.landing__title {
+	font-size: 2.5rem;
+	font-weight: 700;
+	background: linear-gradient(
+		135deg,
+		var(--color-brand) 0%,
+		var(--color-accent) 100%
+	);
+	-webkit-background-clip: text;
+	-webkit-text-fill-color: transparent;
+	background-clip: text;
+	margin-bottom: 0.5rem;
+}
+
+.landing__subtitle {
+	font-size: 1.125rem;
+	color: var(--color-text-muted);
+	margin-bottom: 3rem;
+}
+
+.cards {
+	display: grid;
+	grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+	gap: 1.5rem;
+}
+
+.card {
+	display: flex;
+	flex-direction: column;
+	align-items: flex-start;
+	text-align: left;
+	background: var(--color-surface);
+	border: 1px solid var(--color-border);
+	border-radius: var(--radius);
+	padding: 2rem;
+	text-decoration: none;
+	color: inherit;
+	box-shadow: var(--shadow-card);
+	transition:
+		transform 0.2s ease,
+		box-shadow 0.2s ease;
+}
+
+.card:hover {
+	transform: translateY(-4px);
+	box-shadow: var(--shadow-card-hover);
+}
+
+.card__icon {
+	width: 48px;
+	height: 48px;
+	border-radius: 12px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	margin-bottom: 1rem;
+	font-size: 1.5rem;
+}
+
+.card__icon--wind {
+	background: #ff4785;
+	color: white;
+}
+
+.card__icon--vertex {
+	background: linear-gradient(
+		135deg,
+		var(--color-brand),
+		var(--color-accent)
+	);
+	color: white;
+}
+
+.card__title {
+	font-size: 1.25rem;
+	font-weight: 600;
+	margin-bottom: 0.5rem;
+}
+
+.card__description {
+	font-size: 0.9375rem;
+	color: var(--color-text-muted);
+	line-height: 1.6;
+}
+
+.card__arrow {
+	margin-top: auto;
+	padding-top: 1rem;
+	font-size: 0.875rem;
+	font-weight: 500;
+	color: var(--color-brand);
+}

--- a/apps/landing/tsconfig.json
+++ b/apps/landing/tsconfig.json
@@ -1,0 +1,13 @@
+{
+	"extends": "../../tsconfig.json",
+	"compilerOptions": {
+		"target": "ES2022",
+		"lib": ["ES2022", "DOM", "DOM.Iterable"],
+		"module": "ESNext",
+		"moduleResolution": "bundler",
+		"resolveJsonModule": true,
+		"isolatedModules": true,
+		"noEmit": true
+	},
+	"include": ["src"]
+}

--- a/apps/landing/vercel.json
+++ b/apps/landing/vercel.json
@@ -1,0 +1,7 @@
+{
+  "buildCommand": "cd ../.. && pnpm turbo build --filter=apollo-landing",
+  "installCommand": "cd ../.. && pnpm install",
+  "outputDirectory": "dist",
+  "framework": null,
+  "ignoreCommand": "git diff HEAD^ HEAD --quiet ."
+}

--- a/apps/landing/vite.config.ts
+++ b/apps/landing/vite.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+	build: {
+		outDir: 'dist',
+	},
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -310,10 +310,22 @@ importers:
         version: 1.4.0
       shadcn:
         specifier: latest
-        version: 3.8.5(@types/node@24.10.1)(babel-plugin-macros@3.1.0)(typescript@5.9.3)
+        version: 4.0.5(@types/node@24.10.1)(babel-plugin-macros@3.1.0)(typescript@5.9.3)
       tw-animate-css:
         specifier: ^1.4.0
         version: 1.4.0
+
+  apps/landing:
+    devDependencies:
+      '@biomejs/biome':
+        specifier: ^2.3.6
+        version: 2.4.4
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vite:
+        specifier: ^7.3.1
+        version: 7.3.1(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(sass@1.94.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.1)
 
   apps/react-playground:
     dependencies:
@@ -8435,8 +8447,8 @@ packages:
     resolution: {integrity: sha512-2dYz766i9HprMBasCMvHMuazJ7u4WzhJwo5kb3iPSiW/iRYV6uPari3zHoqZlnuaR7V1bEiNMxikhp37rdBXbw==}
     engines: {node: '>=12'}
 
-  ip-address@10.0.1:
-    resolution: {integrity: sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==}
+  ip-address@10.1.0:
+    resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
     engines: {node: '>= 12'}
 
   ipaddr.js@1.9.1:
@@ -11270,8 +11282,8 @@ packages:
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
 
-  shadcn@3.8.5:
-    resolution: {integrity: sha512-jPRx44e+eyeV7xwY3BLJXcfrks00+M0h5BGB9l6DdcBW4BpAj4x3lVmVy0TXPEs2iHEisxejr62sZAAw6B1EVA==}
+  shadcn@4.0.5:
+    resolution: {integrity: sha512-z0SOHEU1+ADam1UJHrgxJhUsOb0/jBoYc+u9mhWs071KrnORq48X7uCwG3mD2ysQEBtOfeK/MxMGsmzL5Jt+Jg==}
     hasBin: true
 
   shallowequal@1.1.0:
@@ -19857,7 +19869,7 @@ snapshots:
   express-rate-limit@8.3.1(express@5.2.1):
     dependencies:
       express: 5.2.1
-      ip-address: 10.0.1
+      ip-address: 10.1.0
 
   express@5.2.1:
     dependencies:
@@ -20737,7 +20749,7 @@ snapshots:
       from2: 2.3.0
       p-is-promise: 3.0.0
 
-  ip-address@10.0.1: {}
+  ip-address@10.1.0: {}
 
   ipaddr.js@1.9.1: {}
 
@@ -24105,7 +24117,7 @@ snapshots:
 
   setprototypeof@1.2.0: {}
 
-  shadcn@3.8.5(@types/node@24.10.1)(babel-plugin-macros@3.1.0)(typescript@5.9.3):
+  shadcn@4.0.5(@types/node@24.10.1)(babel-plugin-macros@3.1.0)(typescript@5.9.3):
     dependencies:
       '@antfu/ni': 25.0.0
       '@babel/core': 7.28.5


### PR DESCRIPTION

<img width="1724" height="895" alt="Screenshot 2026-03-11 at 16 45 36" src="https://github.com/user-attachments/assets/eb2dd285-7571-49e4-b15a-679568908f3a" />


## Summary
- Add `apps/landing` — minimal Vite vanilla-ts app with zero runtime dependencies
- Dark mode landing page with two cards linking to Apollo Wind and Apollo Vertex
- Vercel-ready with monorepo-aware build/install commands

## Details
The landing app serves as a hub to the two main Apollo deployments. Built with Vite (no React), totals ~2.5 KB gzipped. Includes Biome linting/formatting and TypeScript checking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)