### PR TITLE
feat(apollo-vertex): make data table scrollable with optional sticky header [AGVSOL-1581]

### DIFF
--- a/apps/apollo-vertex/registry/data-table/data-table.tsx
+++ b/apps/apollo-vertex/registry/data-table/data-table.tsx
@@ -107,6 +107,7 @@ interface DataTableProps<TData, TValue> {
   enableViewOptions?: boolean;
   toolbarContent?: (table: TanstackTable<TData>) => React.ReactNode;
   noResultsMessage?: string;
+  stickyHeader?: boolean;
 }
 
 function DataTable<TData, TValue>({
@@ -134,6 +135,7 @@ function DataTable<TData, TValue>({
   enableViewOptions = true,
   toolbarContent,
   noResultsMessage,
+  stickyHeader = false,
 }: DataTableProps<TData, TValue>) {
   const { t } = useTranslation();
 
@@ -175,9 +177,16 @@ function DataTable<TData, TValue>({
         customContent={toolbarContent?.(table)}
       />
 
-      <div className="overflow-hidden rounded-md border">
+      <div
+        className={cn(
+          "rounded-md border",
+          stickyHeader ? "overflow-auto" : "overflow-hidden",
+        )}
+      >
         <Table>
-          <TableHeader>
+          <TableHeader
+            className={stickyHeader ? "sticky top-0 z-10 bg-background" : ""}
+          >
             {table.getHeaderGroups().map((headerGroup) => (
               <TableRow key={headerGroup.id}>
                 {headerGroup.headers.map((header) => (


### PR DESCRIPTION
## Summary
Add `stickyHeader` prop to DataTable component to enable vertical scrolling with a sticky header.

## Changes
- Added optional `stickyHeader` boolean prop (defaults to false)
- When enabled, table container switches from `overflow-hidden` to `overflow-auto`
- TableHeader receives `sticky top-0 z-10 bg-background` styling for positioning

## Usage
```tsx
<DataTable stickyHeader columns={columns} data={data} {...otherProps} />
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)