### PR TITLE
feat(apollo-wind): update FlowPanel and ChatComposer with Figma desig…

### DIFF
--- a/packages/apollo-wind/src/components/custom/chat-composer.tsx
+++ b/packages/apollo-wind/src/components/custom/chat-composer.tsx
@@ -1,4 +1,4 @@
-import { CornerDownLeft, Plus, Workflow } from 'lucide-react';
+import { Circle, CornerRightUp, Mic, Plus, Settings2, Workflow } from 'lucide-react';
 import * as React from 'react';
 import { cn } from '@/lib';
 
@@ -22,8 +22,7 @@ export interface ChatComposerProps {
  * Reusable chat composer input with action buttons.
  *
  * Features a text area, left-side action buttons (add, workflow),
- * and a cyan submit button. Fixed at 800px max-width to match the
- * Delegate design spec.
+ * and an accent submit button. Max-width 800px.
  */
 export function ChatComposer({
   className,
@@ -31,6 +30,7 @@ export function ChatComposer({
   onSubmit,
 }: ChatComposerProps) {
   const [value, setValue] = React.useState('');
+  const [focused, setFocused] = React.useState(false);
 
   const handleSubmit = () => {
     if (value.trim()) {
@@ -46,53 +46,88 @@ export function ChatComposer({
     }
   };
 
+  const showEnter = value.length > 0;
+
   return (
     <div
       className={cn(
-        'w-full max-w-[800px] rounded-[32px] bg-gradient-to-b from-surface to-surface-raised p-2',
+        'w-full max-w-[800px] rounded-[32px] bg-surface-raised p-2',
         className
       )}
     >
-      <div className="flex min-h-[124px] flex-col justify-between rounded-3xl border border-border bg-surface-overlay pb-3 pl-4 pr-3 pt-4">
+      <div className="group/input flex flex-col gap-3 rounded-[24px] border border-border bg-surface pb-3 pl-4 pr-3 pt-4 transition-colors hover:border-border-hover focus-within:border-border-hover">
         {/* Text area */}
         <textarea
-          className="w-full resize-none bg-transparent text-base font-medium leading-5 text-foreground placeholder:text-foreground-subtle focus:outline-none"
+          className="w-full resize-none bg-transparent text-sm font-normal leading-5 text-foreground placeholder:text-foreground-muted group-hover/input:placeholder:text-foreground-secondary focus:placeholder:text-foreground-secondary focus:outline-none"
           placeholder={placeholder}
-          rows={2}
+          rows={3}
           value={value}
           onChange={(e) => setValue(e.target.value)}
           onKeyDown={handleKeyDown}
+          onFocus={() => setFocused(true)}
+          onBlur={() => setFocused(false)}
         />
 
         {/* Bottom toolbar */}
         <div className="flex items-center justify-between">
-          {/* Left actions */}
+          {/* Left actions — no bg fill in default, show on hover */}
           <div className="flex items-center gap-1">
             <button
               type="button"
-              className="flex h-8 w-8 items-center justify-center rounded-2xl border border-border-inverse bg-surface-inverse transition-opacity hover:opacity-80"
+              className="group flex h-8 w-8 items-center justify-center rounded-lg hover:bg-surface-hover"
               aria-label="Add attachment"
             >
-              <Plus className="h-5 w-5 text-foreground-inverse" />
+              <Plus className="h-5 w-5 text-foreground-muted group-hover:text-foreground-hover" />
             </button>
             <button
               type="button"
-              className="flex h-8 w-8 items-center justify-center rounded-2xl border border-border-inverse bg-surface-inverse transition-opacity hover:opacity-80"
+              className="group flex h-8 w-8 items-center justify-center rounded-lg hover:bg-surface-hover"
               aria-label="Add workflow"
             >
-              <Workflow className="h-5 w-5 text-foreground-inverse" />
+              <Workflow className="h-5 w-5 text-foreground-muted group-hover:text-foreground-hover" />
+            </button>
+            <button
+              type="button"
+              className="group flex h-8 w-8 items-center justify-center rounded-lg hover:bg-surface-hover"
+              aria-label="Settings"
+            >
+              <Settings2 className="h-5 w-5 text-foreground-muted group-hover:text-foreground-hover" />
             </button>
           </div>
 
-          {/* Submit button */}
-          <button
-            type="button"
-            className="flex h-8 w-8 items-center justify-center rounded-2xl bg-brand transition-opacity hover:opacity-90"
-            onClick={handleSubmit}
-            aria-label="Submit message"
-          >
-            <CornerDownLeft className="h-5 w-5 -scale-y-100 rotate-90 text-foreground-on-accent" />
-          </button>
+          {/* Right actions */}
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              className="group flex h-8 w-8 items-center justify-center rounded-lg hover:bg-surface-hover"
+              aria-label="Record"
+            >
+              <Circle className="h-5 w-5 text-foreground-muted group-hover:text-foreground-hover" />
+            </button>
+            {showEnter ? (
+              <button
+                type="button"
+                className="flex h-8 w-8 items-center justify-center rounded-lg bg-foreground-accent hover:bg-foreground-accent-muted"
+                onClick={handleSubmit}
+                aria-label="Submit message"
+              >
+                <CornerRightUp className="h-5 w-5 text-white" />
+              </button>
+            ) : (
+              <button
+                type="button"
+                className={cn(
+                  'flex h-8 w-8 items-center justify-center rounded-lg',
+                  focused
+                    ? 'bg-foreground-accent hover:bg-foreground-accent-muted'
+                    : 'bg-surface-hover hover:bg-foreground-accent-muted'
+                )}
+                aria-label="Voice input"
+              >
+                <Mic className="h-5 w-5 text-white" />
+              </button>
+            )}
+          </div>
         </div>
       </div>
     </div>

--- a/packages/apollo-wind/src/components/custom/chat-prompt-suggestions.tsx
+++ b/packages/apollo-wind/src/components/custom/chat-prompt-suggestions.tsx
@@ -39,7 +39,7 @@ export function PromptSuggestions({
       {suggestions.map((suggestion) => (
         <button type="button"
           key={suggestion.id}
-          className="flex h-10 items-center rounded-xl border border-border bg-surface-overlay px-4 py-2.5 text-sm font-medium leading-5 text-foreground transition-colors hover:bg-surface-hover"
+          className="flex h-10 items-center rounded-xl border border-border-subtle bg-surface-raised hover:border-border-hover px-4 py-2.5 text-sm font-normal leading-5 text-foreground-secondary transition-colors hover:bg-surface-hover hover:text-foreground"
           onClick={() => onSelect?.(suggestion)}
         >
           {suggestion.label}

--- a/packages/apollo-wind/src/components/custom/panel-delegate.stories.tsx
+++ b/packages/apollo-wind/src/components/custom/panel-delegate.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { Folder, History, MessageCirclePlus, Settings } from 'lucide-react';
+import { Folder, History, MessageCircle, Settings } from 'lucide-react';
 import { DelegatePanel } from './panel-delegate';
 
 const meta = {
@@ -17,7 +17,7 @@ const sampleNavItems = [
   {
     id: 'chat',
     label: 'Chat',
-    icon: <MessageCirclePlus className="h-5 w-5" />,
+    icon: <MessageCircle className="h-5 w-5" />,
     defaultOpen: true,
     children: [
       { id: 'chat-1', label: 'Invoice processing' },
@@ -48,7 +48,7 @@ const sampleNavItems = [
 
 export const Default: Story = {
   render: () => (
-    <div className="flex h-[600px] bg-surface">
+    <div className="flex h-screen bg-surface">
       <DelegatePanel
         defaultOpen
         navItems={sampleNavItems}
@@ -64,7 +64,7 @@ export const Default: Story = {
 
 export const Collapsed: Story = {
   render: () => (
-    <div className="flex h-[600px] bg-surface">
+    <div className="flex h-screen bg-surface">
       <DelegatePanel defaultOpen={false} navItems={sampleNavItems} activeNavId="chat" />
       <div className="flex flex-1 items-center justify-center text-sm text-foreground-muted">
         Content area

--- a/packages/apollo-wind/src/components/custom/panel-delegate.tsx
+++ b/packages/apollo-wind/src/components/custom/panel-delegate.tsx
@@ -51,13 +51,13 @@ export interface DelegatePanelProps {
 /** UiPath logo mark */
 function UiPathLogo({ className }: { className?: string }) {
   return (
-    <div
-      className={cn(
-        'flex h-9 w-9 items-center justify-center rounded-lg bg-brand shadow-sm',
-        className
-      )}
-    >
-      <span className="text-xs font-bold text-foreground-on-accent select-none">Ui</span>
+    <div className={cn('flex h-9 w-9 items-center justify-center overflow-clip rounded-lg bg-[#0092b8] shadow-sm', className)}>
+      <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" className="h-[22px] w-[22px]" aria-hidden="true">
+        <path d="M18.57 11.4014H18.273C17.3139 11.4014 16.7183 12.002 16.7183 12.9686V22.4331C16.7183 23.3997 17.3139 24.0003 18.273 24.0003H18.57C19.5289 24.0003 20.1246 23.3997 20.1246 22.4331V12.9686C20.1246 12.002 19.5289 11.4014 18.57 11.4014Z" fill="white" />
+        <path d="M22.689 5.54073C20.5215 5.19295 18.8111 3.48437 18.463 1.31918C18.4564 1.27831 18.4034 1.27831 18.3968 1.31918C18.0487 3.48437 16.3383 5.19295 14.1708 5.54073C14.1299 5.54728 14.1299 5.60028 14.1708 5.60683C16.3383 5.95453 18.0487 7.66319 18.3968 9.82838C18.4034 9.86925 18.4564 9.86925 18.463 9.82838C18.8111 7.66319 20.5215 5.95453 22.689 5.60683C22.73 5.60028 22.73 5.54728 22.689 5.54073ZM20.5595 5.59031C19.4757 5.76416 18.6205 6.61848 18.4465 7.70108C18.4432 7.72151 18.4167 7.72151 18.4134 7.70108C18.2393 6.61848 17.3841 5.76416 16.3003 5.59031C16.2799 5.58703 16.2799 5.56053 16.3003 5.55725C17.3841 5.38337 18.2393 4.52907 18.4134 3.44648C18.4167 3.42604 18.4432 3.42604 18.4465 3.44648C18.6205 4.52907 19.4757 5.38337 20.5595 5.55725C20.5799 5.56053 20.5799 5.58703 20.5595 5.59031Z" fill="white" />
+        <path d="M23.9846 2.15915C22.9008 2.33301 22.0456 3.18733 21.8716 4.26993C21.8683 4.29036 21.8418 4.29036 21.8385 4.26993C21.6645 3.18733 20.8092 2.33301 19.7255 2.15915C19.705 2.15588 19.705 2.12938 19.7255 2.1261C20.8092 1.95221 21.6645 1.09792 21.8385 0.0153254C21.8418 -0.00510845 21.8683 -0.00510845 21.8716 0.0153254C22.0456 1.09792 22.9008 1.95221 23.9846 2.1261C24.0051 2.12938 24.0051 2.15588 23.9846 2.15915Z" fill="white" />
+        <path d="M12.7647 6.85913H12.4063C11.4704 6.85913 10.889 7.4373 10.889 8.36778V15.8529C10.889 19.4018 9.80316 20.8493 7.14102 20.8493C4.47888 20.8493 3.393 19.3952 3.393 15.8306V8.36778C3.393 7.4373 2.8116 6.85913 1.87582 6.85913H1.51723C0.581398 6.85913 0 7.4373 0 8.36778V15.8529C0 21.259 2.40265 24.0001 7.14102 24.0001C11.8794 24.0001 14.2819 21.259 14.2819 15.8529V8.36778C14.2819 7.4373 13.7005 6.85913 12.7647 6.85913Z" fill="white" />
+      </svg>
     </div>
   );
 }
@@ -66,12 +66,14 @@ function UiPathLogo({ className }: { className?: string }) {
 function ExpandedNavItem({
   item,
   isOpen,
+  isActive,
   onToggle,
   selectedChildId,
   onChildSelect,
 }: {
   item: NavItem;
   isOpen: boolean;
+  isActive: boolean;
   onToggle: () => void;
   selectedChildId?: string;
   onChildSelect?: (childId: string) => void;
@@ -82,13 +84,16 @@ function ExpandedNavItem({
     return (
       <button
         type="button"
-        className="flex h-10 w-full items-center gap-2 rounded-2xl px-1 text-foreground-muted transition-colors hover:bg-surface-hover"
+        className={cn(
+          'flex h-10 w-full items-center gap-2 rounded-2xl px-1 text-foreground-hover transition-colors hover:bg-surface-hover hover:text-foreground',
+          isActive && 'bg-surface-hover text-foreground'
+        )}
         onClick={onToggle}
       >
         <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg">
           {item.icon}
         </div>
-        <span className="text-sm font-semibold">{item.label}</span>
+        <span className="text-sm font-medium">{item.label}</span>
       </button>
     );
   }
@@ -98,13 +103,16 @@ function ExpandedNavItem({
       <CollapsibleTrigger asChild>
         <button
           type="button"
-          className="flex h-10 w-full items-center justify-between rounded-2xl px-1 text-foreground-muted transition-colors hover:bg-surface-hover"
+          className={cn(
+            'flex h-10 w-full items-center justify-between rounded-2xl px-1 text-foreground-hover transition-colors hover:bg-surface-hover hover:text-foreground',
+            isActive && 'bg-surface-hover text-foreground'
+          )}
         >
           <div className="flex items-center gap-2">
             <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg">
               {item.icon}
             </div>
-            <span className="text-sm font-semibold">{item.label}</span>
+            <span className="text-sm font-medium">{item.label}</span>
           </div>
           <div className="flex h-9 w-9 shrink-0 items-center justify-center">
             <ChevronDown
@@ -114,14 +122,14 @@ function ExpandedNavItem({
         </button>
       </CollapsibleTrigger>
       <CollapsibleContent>
-        <div className="flex flex-col">
+        <div className="flex flex-col gap-1 pt-1">
           {item.children?.map((child) => (
             <button
               type="button"
               key={child.id}
               className={cn(
-                'flex h-10 items-center rounded-2xl pl-12 pr-3 text-sm font-medium text-foreground-muted transition-colors hover:bg-surface-hover',
-                selectedChildId === child.id && 'bg-surface-hover text-foreground-on-accent'
+                'flex h-10 items-center rounded-2xl pl-12 pr-3 text-sm font-normal text-foreground-hover transition-colors hover:bg-surface-hover hover:text-foreground',
+                selectedChildId === child.id && 'bg-surface-hover text-foreground'
               )}
               onClick={() => onChildSelect?.(child.id)}
             >
@@ -149,19 +157,18 @@ function CollapsedNavItem({
       <TooltipTrigger asChild>
         <button
           type="button"
-          className={cn(
-            'flex h-12 w-full items-center justify-center text-foreground-muted transition-colors hover:text-foreground',
-            isActive && 'text-brand-foreground'
-          )}
+          className="group flex h-12 w-full items-center justify-center"
           onClick={onClick}
         >
           <div
             className={cn(
-              'flex h-9 w-9 items-center justify-center rounded-lg transition-colors',
-              isActive && 'bg-brand-subtle'
+              'flex h-9 w-9 items-center justify-center rounded-lg text-foreground-muted group-hover:bg-surface-hover group-hover:text-foreground-hover',
+              isActive && 'bg-surface-hover text-foreground-hover'
             )}
           >
-            {item.icon}
+            <div className="h-5 w-5 group-hover:scale-[1.2]">
+              {item.icon}
+            </div>
           </div>
         </button>
       </TooltipTrigger>
@@ -229,7 +236,7 @@ export function DelegatePanel({
     <TooltipProvider delayDuration={300}>
       <div
         className={cn(
-          'flex flex-col justify-between bg-surface-overlay shadow-[0px_4px_24px_0px_rgba(0,0,0,0.25)] transition-[width] duration-300 ease-in-out',
+          'flex h-full flex-col justify-between bg-surface-overlay transition-[width] duration-300 ease-in-out',
           panelOpen ? 'w-80' : 'w-[60px]',
           className
         )}
@@ -251,17 +258,17 @@ export function DelegatePanel({
             {/* Header actions (expanded only) */}
             {panelOpen && (
               <div className="flex flex-1 items-center justify-between">
-                <div className="flex items-center gap-[18px]">
+                <div className="flex items-center gap-1">
                   <button
                     type="button"
-                    className="text-foreground-muted transition-colors hover:text-foreground"
+                    className="flex h-8 w-8 items-center justify-center rounded-lg text-foreground-muted transition-colors hover:bg-surface-hover hover:text-foreground"
                     aria-label="New conversation"
                   >
                     <MessageCirclePlus className="h-5 w-5" />
                   </button>
                   <button
                     type="button"
-                    className="text-foreground-muted transition-colors hover:text-foreground"
+                    className="flex h-8 w-8 items-center justify-center rounded-lg text-foreground-muted transition-colors hover:bg-surface-hover hover:text-foreground"
                     aria-label="Picture in picture"
                   >
                     <PictureInPicture2 className="h-5 w-5" />
@@ -269,7 +276,7 @@ export function DelegatePanel({
                 </div>
                 <button
                   type="button"
-                  className="text-foreground-muted transition-colors hover:text-foreground"
+                  className="flex h-8 w-8 items-center justify-center rounded-lg text-foreground-muted transition-colors hover:bg-surface-hover hover:text-foreground"
                   onClick={() => setPanelOpen(false)}
                   aria-label="Collapse panel"
                 >
@@ -289,6 +296,7 @@ export function DelegatePanel({
                     key={item.id}
                     item={item}
                     isOpen={openSections[item.id] ?? false}
+                    isActive={activeNavId === item.id && !item.children?.some((c) => c.id === selectedChildId)}
                     onToggle={() => {
                       if (item.children?.length) {
                         toggleSection(item.id);
@@ -301,24 +309,8 @@ export function DelegatePanel({
                 ))}
               </nav>
             ) : (
-              /* Collapsed navigation */
-              <nav className="flex flex-col items-center pt-[18px]">
-                {/* Expand button */}
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <button
-                      type="button"
-                      className="flex h-12 w-full items-center justify-center text-foreground-muted transition-colors hover:text-foreground"
-                      onClick={() => setPanelOpen(true)}
-                    >
-                      <div className="flex h-9 w-9 items-center justify-center rounded-lg">
-                        <PanelRightOpen className="h-5 w-5 -scale-x-100" />
-                      </div>
-                    </button>
-                  </TooltipTrigger>
-                  <TooltipContent side="right">Expand panel</TooltipContent>
-                </Tooltip>
-
+              /* Collapsed navigation — click any item to expand */
+              <nav className="flex flex-col items-center gap-1 pt-[18px]">
                 {navItems.map((item) => (
                   <CollapsedNavItem
                     key={item.id}

--- a/packages/apollo-wind/src/components/custom/panel-flow.stories.tsx
+++ b/packages/apollo-wind/src/components/custom/panel-flow.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import * as React from 'react';
 import { FlowPanel, defaultFlowNavItems } from './panel-flow';
 
 const meta = {
@@ -13,38 +14,86 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 const sampleMessages = [
-  { id: '1', role: 'user' as const, content: 'Build an invoice processing workflow' },
-  { id: '2', role: 'assistant' as const, content: 'I\'ll create a workflow that extracts data from invoices using Document Understanding, validates the amounts, and routes them for approval.' },
-  { id: '3', role: 'user' as const, content: 'Add error handling for invalid formats' },
+  {
+    id: '1',
+    role: 'user' as const,
+    content:
+      'Tell me what tools the Excel agent is using',
+  },
+  {
+    id: '2',
+    role: 'assistant' as const,
+    traceLabel: 'Chain of thought',
+    toolCard: {
+      title: 'Excel Agent',
+      items: [
+        {
+          icon: 'search' as const,
+          title: 'WebSearchTool',
+          description:
+            'Searching and analyzing multiple cells in this spreadsheet to create a summary for planning next steps.',
+        },
+        {
+          icon: 'bot' as const,
+          title: 'Excel Agent',
+          description: 'Editing current column with additional information.',
+        },
+        {
+          icon: 'search' as const,
+          title: 'WebSearchTool',
+          description:
+            'Checking categorized tabs to better understand spam and volume sources.',
+        },
+        {
+          icon: 'bot' as const,
+          title: 'Currency conversion',
+          description:
+            'Performing currency conversion using current market rates to ensure accurate calculations.',
+        },
+      ],
+    },
+  },
 ];
 
 export const Default: Story = {
-  render: () => (
-    <div className="flex h-[600px] bg-surface">
-      <FlowPanel
-        open
-        navItems={defaultFlowNavItems}
-        activeNavId="chat"
-        chatMessages={sampleMessages}
-      />
-      <div className="flex flex-1 items-center justify-center text-sm text-foreground-muted">
-        Canvas area
+  render: () => {
+    const [open, setOpen] = React.useState(true);
+    const [activeNavId, setActiveNavId] = React.useState('chat');
+    return (
+      <div className="flex h-screen bg-surface">
+        <FlowPanel
+          open={open}
+          onOpenChange={setOpen}
+          navItems={defaultFlowNavItems}
+          activeNavId={activeNavId}
+          onNavChange={setActiveNavId}
+          chatMessages={sampleMessages}
+        />
+        <div className="flex flex-1 items-center justify-center text-sm text-foreground-muted">
+          Canvas area
+        </div>
       </div>
-    </div>
-  ),
+    );
+  },
 };
 
 export const Collapsed: Story = {
-  render: () => (
-    <div className="flex h-[600px] bg-surface">
-      <FlowPanel
-        open={false}
-        navItems={defaultFlowNavItems}
-        activeNavId="chat"
-      />
-      <div className="flex flex-1 items-center justify-center text-sm text-foreground-muted">
-        Canvas area
+  render: () => {
+    const [open, setOpen] = React.useState(false);
+    const [activeNavId, setActiveNavId] = React.useState('chat');
+    return (
+      <div className="flex h-screen bg-surface">
+        <FlowPanel
+          open={open}
+          onOpenChange={setOpen}
+          navItems={defaultFlowNavItems}
+          activeNavId={activeNavId}
+          onNavChange={setActiveNavId}
+        />
+        <div className="flex flex-1 items-center justify-center text-sm text-foreground-muted">
+          Canvas area
+        </div>
       </div>
-    </div>
-  ),
+    );
+  },
 };

--- a/packages/apollo-wind/src/components/custom/panel-flow.tsx
+++ b/packages/apollo-wind/src/components/custom/panel-flow.tsx
@@ -1,8 +1,23 @@
-import { CornerDownLeft, House, MessageCircle, PanelRightOpen, Plus, Workflow } from 'lucide-react';
+import {
+  Bot,
+  Brain,
+  ChevronUp,
+  Copy,
+  House,
+  MessageCircle,
+  PanelRightOpen,
+  RefreshCcw,
+  Search,
+  ThumbsDown,
+  ThumbsUp,
+  Workflow,
+} from 'lucide-react';
 import * as React from 'react';
 import { Avatar, AvatarFallback } from '@/components/ui/avatar';
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import { cn } from '@/lib';
+import { ChatComposer } from '@/components/custom/chat-composer';
 
 // ============================================================================
 // Types
@@ -14,10 +29,26 @@ export interface FlowPanelNavItem {
   icon: React.ReactNode;
 }
 
+export interface FlowPanelToolItem {
+  icon: 'search' | 'bot';
+  title: string;
+  description: string;
+}
+
+export interface FlowPanelToolCard {
+  title: string;
+  items: FlowPanelToolItem[];
+}
+
 export interface FlowPanelChatMessage {
   id: string;
   role: 'user' | 'assistant';
-  content: string;
+  /** Text content — user bubble or simple assistant text */
+  content?: string;
+  /** Collapsible reasoning trace label shown above tool card */
+  traceLabel?: string;
+  /** Expandable tool/agent card */
+  toolCard?: FlowPanelToolCard;
 }
 
 export interface FlowPanelProps {
@@ -44,8 +75,35 @@ export interface FlowPanelProps {
 
 function UiPathLogo() {
   return (
-    <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-brand shadow-sm">
-      <span className="text-xs font-bold text-foreground-on-accent select-none">Ui</span>
+    <div className="flex h-9 w-9 items-center justify-center overflow-clip rounded-lg bg-[#0092b8] shadow-sm">
+      <svg
+        viewBox="0 0 24 24"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+        className="h-[22px] w-[22px]"
+        aria-hidden="true"
+      >
+        {/* i — vertical bar */}
+        <path
+          d="M18.57 11.4014H18.273C17.3139 11.4014 16.7183 12.002 16.7183 12.9686V22.4331C16.7183 23.3997 17.3139 24.0003 18.273 24.0003H18.57C19.5289 24.0003 20.1246 23.3997 20.1246 22.4331V12.9686C20.1246 12.002 19.5289 11.4014 18.57 11.4014Z"
+          fill="white"
+        />
+        {/* ✦ sparkle — large */}
+        <path
+          d="M22.689 5.54073C20.5215 5.19295 18.8111 3.48437 18.463 1.31918C18.4564 1.27831 18.4034 1.27831 18.3968 1.31918C18.0487 3.48437 16.3383 5.19295 14.1708 5.54073C14.1299 5.54728 14.1299 5.60028 14.1708 5.60683C16.3383 5.95453 18.0487 7.66319 18.3968 9.82838C18.4034 9.86925 18.4564 9.86925 18.463 9.82838C18.8111 7.66319 20.5215 5.95453 22.689 5.60683C22.73 5.60028 22.73 5.54728 22.689 5.54073ZM20.5595 5.59031C19.4757 5.76416 18.6205 6.61848 18.4465 7.70108C18.4432 7.72151 18.4167 7.72151 18.4134 7.70108C18.2393 6.61848 17.3841 5.76416 16.3003 5.59031C16.2799 5.58703 16.2799 5.56053 16.3003 5.55725C17.3841 5.38337 18.2393 4.52907 18.4134 3.44648C18.4167 3.42604 18.4432 3.42604 18.4465 3.44648C18.6205 4.52907 19.4757 5.38337 20.5595 5.55725C20.5799 5.56053 20.5799 5.58703 20.5595 5.59031Z"
+          fill="white"
+        />
+        {/* ✦ sparkle — small */}
+        <path
+          d="M23.9846 2.15915C22.9008 2.33301 22.0456 3.18733 21.8716 4.26993C21.8683 4.29036 21.8418 4.29036 21.8385 4.26993C21.6645 3.18733 20.8092 2.33301 19.7255 2.15915C19.705 2.15588 19.705 2.12938 19.7255 2.1261C20.8092 1.95221 21.6645 1.09792 21.8385 0.0153254C21.8418 -0.00510845 21.8683 -0.00510845 21.8716 0.0153254C22.0456 1.09792 22.9008 1.95221 23.9846 2.1261C24.0051 2.12938 24.0051 2.15588 23.9846 2.15915Z"
+          fill="white"
+        />
+        {/* U */}
+        <path
+          d="M12.7647 6.85913H12.4063C11.4704 6.85913 10.889 7.4373 10.889 8.36778V15.8529C10.889 19.4018 9.80316 20.8493 7.14102 20.8493C4.47888 20.8493 3.393 19.3952 3.393 15.8306V8.36778C3.393 7.4373 2.8116 6.85913 1.87582 6.85913H1.51723C0.581398 6.85913 0 7.4373 0 8.36778V15.8529C0 21.259 2.40265 24.0001 7.14102 24.0001C11.8794 24.0001 14.2819 21.259 14.2819 15.8529V8.36778C14.2819 7.4373 13.7005 6.85913 12.7647 6.85913Z"
+          fill="white"
+        />
+      </svg>
     </div>
   );
 }
@@ -58,11 +116,13 @@ function IconRail({
   navItems,
   activeId,
   onNavClick,
+  onLogoClick,
   hasShadow,
 }: {
   navItems: FlowPanelNavItem[];
   activeId: string;
   onNavClick: (id: string) => void;
+  onLogoClick: () => void;
   hasShadow?: boolean;
 }) {
   return (
@@ -75,27 +135,38 @@ function IconRail({
       {/* Top: logo + nav */}
       <div className="flex flex-col">
         <div className="flex h-[60px] w-[60px] shrink-0 items-center justify-center">
-          <UiPathLogo />
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                onClick={onLogoClick}
+                aria-label="UiPath"
+                className="rounded-lg transition-opacity hover:opacity-80"
+              >
+                <UiPathLogo />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent side="right">UiPath</TooltipContent>
+          </Tooltip>
         </div>
-        <nav className="flex flex-col items-center pt-[18px]">
+        <nav className="flex flex-col items-center gap-1 pt-[18px]">
           {navItems.map((item) => (
             <Tooltip key={item.id}>
               <TooltipTrigger asChild>
                 <button
                   type="button"
-                  className={cn(
-                    'flex h-12 w-full items-center justify-center text-foreground-muted transition-colors hover:text-foreground',
-                    activeId === item.id && 'text-brand-foreground'
-                  )}
+                  className="group flex h-12 w-full items-center justify-center"
                   onClick={() => onNavClick(item.id)}
                 >
                   <div
                     className={cn(
-                      'flex h-9 w-9 items-center justify-center rounded-lg transition-colors',
-                      activeId === item.id && 'bg-surface-hover'
+                      'flex h-9 w-9 items-center justify-center rounded-lg text-foreground-muted group-hover:bg-surface-hover group-hover:text-foreground-hover',
+                      activeId === item.id && 'bg-surface-hover text-foreground-hover'
                     )}
                   >
-                    {item.icon}
+                    <div className="h-5 w-5 group-hover:scale-[1.2]">
+                      {item.icon}
+                    </div>
                   </div>
                 </button>
               </TooltipTrigger>
@@ -118,69 +189,139 @@ function IconRail({
 }
 
 // ============================================================================
-// Internal: Default chat content for expanded panel
+// Internal: Chat message components
 // ============================================================================
 
-function DefaultChatContent({ chatMessages }: { chatMessages: FlowPanelChatMessage[] }) {
+const toolIconMap = { search: Search, bot: Bot } as const;
+
+function ToolCard({ card }: { card: FlowPanelToolCard }) {
+  const [open, setOpen] = React.useState(true);
   return (
-    <div className="flex flex-1 flex-col justify-end gap-7 overflow-y-auto">
-      {chatMessages.map((msg) =>
-        msg.role === 'user' ? (
-          <div key={msg.id} className="flex flex-col items-end pr-6">
-            <div className="max-w-[360px] rounded-tl-2xl rounded-tr-2xl rounded-bl-2xl rounded-br-[4px] bg-surface-raised px-6 py-4">
-              <p className="text-base leading-6 tracking-[-0.4px] text-foreground">{msg.content}</p>
+    <Collapsible open={open} onOpenChange={setOpen}>
+      <div className="overflow-hidden rounded-2xl border border-surface-hover">
+        {/* Header */}
+        <CollapsibleTrigger asChild>
+          <button
+            type="button"
+            className="flex w-full items-center justify-between border-b border-surface-hover p-4"
+          >
+            <span className="whitespace-nowrap text-sm font-normal leading-5 text-foreground">
+              {card.title}
+            </span>
+            <ChevronUp className={cn('h-4 w-4 shrink-0 text-foreground-muted transition-transform duration-200', !open && 'rotate-180')} />
+          </button>
+        </CollapsibleTrigger>
+        {/* Body */}
+        <CollapsibleContent className="overflow-hidden data-[state=open]:animate-collapsible-down data-[state=closed]:animate-collapsible-up">
+          <div className="flex flex-col gap-2 pb-4 pt-1">
+            <p className="px-4 py-[5px] text-xs text-foreground-muted">
+              Agents and tools used
+            </p>
+            <div className="flex flex-col gap-3">
+              {card.items.map((item, i) => {
+                const Icon = toolIconMap[item.icon];
+                return (
+                  // biome-ignore lint/suspicious/noArrayIndexKey: static display list
+                  <div key={i} className="flex items-start gap-2.5 pl-4 pr-9">
+                    <div className="flex h-5 w-5 shrink-0 items-center justify-center">
+                      <Icon className="h-4 w-4 text-foreground-secondary" />
+                    </div>
+                    <div className="flex flex-col gap-0.5">
+                      <p className="text-sm font-normal leading-4 text-foreground">{item.title}</p>
+                      <p className="text-sm font-normal leading-5 text-foreground-muted">
+                        {item.description}
+                      </p>
+                    </div>
+                  </div>
+                );
+              })}
             </div>
           </div>
-        ) : (
-          <div key={msg.id} className="flex items-center gap-2">
-            <p className="text-base font-medium leading-5 text-foreground-muted">{msg.content}</p>
-          </div>
-        )
-      )}
+        </CollapsibleContent>
+      </div>
+    </Collapsible>
+  );
+}
+
+function MessageActions() {
+  return (
+    <div className="flex items-center gap-2">
+      {(
+        [
+          { icon: RefreshCcw, label: 'Refresh' },
+          { icon: ThumbsUp, label: 'Thumbs up' },
+          { icon: ThumbsDown, label: 'Thumbs down' },
+          { icon: Copy, label: 'Copy' },
+        ] as const
+      ).map(({ icon: Icon, label }) => (
+        <button
+          key={label}
+          type="button"
+          aria-label={label}
+          className="flex h-6 w-6 items-center justify-center overflow-hidden rounded text-foreground-muted hover:text-foreground"
+        >
+          <Icon className="h-4 w-4" />
+        </button>
+      ))}
     </div>
   );
 }
 
-// ============================================================================
-// Internal: Chat input
-// ============================================================================
+function DefaultChatContent({ chatMessages }: { chatMessages: FlowPanelChatMessage[] }) {
+  const [openTraces, setOpenTraces] = React.useState<Record<string, boolean>>({});
 
-function ChatInput() {
+  const isTraceOpen = (id: string) => openTraces[id] ?? true;
+
+  const toggleTrace = (id: string) => {
+    setOpenTraces((prev) => ({ ...prev, [id]: !isTraceOpen(id) }));
+  };
+
   return (
-    <div className="flex flex-col gap-3">
-      <div className="flex h-12 items-center rounded-2xl border border-border bg-surface-raised px-4">
-        <input
-          type="text"
-          placeholder="Ask me to help build your Flow"
-          className="flex-1 bg-transparent text-sm text-foreground placeholder:text-foreground-subtle outline-none"
-          readOnly
-        />
-      </div>
-      <div className="flex items-center justify-between">
-        <div className="flex items-center gap-2">
-          <button
-            type="button"
-            className="flex h-8 w-8 items-center justify-center rounded-lg text-foreground-muted hover:text-foreground"
-            aria-label="Add attachment"
-          >
-            <Plus className="h-5 w-5" />
-          </button>
-          <button
-            type="button"
-            className="flex h-8 w-8 items-center justify-center rounded-lg text-foreground-muted hover:text-foreground"
-            aria-label="Add workflow"
-          >
-            <Workflow className="h-5 w-5" />
-          </button>
-        </div>
-        <button
-          type="button"
-          className="flex h-8 w-8 items-center justify-center rounded-full bg-brand text-foreground-on-accent"
-          aria-label="Submit message"
-        >
-          <CornerDownLeft className="h-4 w-4" />
-        </button>
-      </div>
+    <div className="flex flex-1 flex-col justify-end gap-7 overflow-y-auto py-2">
+      {chatMessages.map((msg) => {
+        if (msg.role === 'user') {
+          return (
+            <div key={msg.id} className="flex flex-col items-end pl-4 w-full">
+              <div className="max-w-[360px] rounded-tl-2xl rounded-tr-2xl rounded-bl-2xl rounded-br-[4px] bg-surface-raised pl-6 pr-9 py-4">
+                <p className="text-sm font-normal leading-6 text-foreground-secondary">
+                  {msg.content}
+                </p>
+              </div>
+            </div>
+          );
+        }
+
+        const traceOpen = isTraceOpen(msg.id);
+
+        return (
+          <div key={msg.id} className="flex flex-col gap-4">
+            {msg.traceLabel && (
+              <Collapsible open={traceOpen} onOpenChange={() => toggleTrace(msg.id)}>
+                <CollapsibleTrigger asChild>
+                  <button type="button" className="flex items-center gap-2 text-left">
+                    <Brain className="h-4 w-4 shrink-0 text-foreground-muted" />
+                    <span className="text-sm font-medium leading-5 text-foreground-muted">
+                      {msg.traceLabel}
+                    </span>
+                    <ChevronUp className={cn('h-4 w-4 shrink-0 text-foreground-muted transition-transform duration-200', !traceOpen && 'rotate-180')} />
+                  </button>
+                </CollapsibleTrigger>
+                {msg.toolCard && (
+                  <CollapsibleContent className="overflow-hidden data-[state=open]:animate-collapsible-down data-[state=closed]:animate-collapsible-up">
+                    <div className="flex flex-col gap-2 pt-4">
+                      <ToolCard card={msg.toolCard} />
+                      <MessageActions />
+                    </div>
+                  </CollapsibleContent>
+                )}
+              </Collapsible>
+            )}
+            {msg.content && (
+              <p className="text-sm font-normal leading-5 text-foreground-muted">{msg.content}</p>
+            )}
+          </div>
+        );
+      })}
     </div>
   );
 }
@@ -200,15 +341,14 @@ function ExpandedPanel({
 }) {
   return (
     <div className="flex h-full w-[420px] shrink-0 flex-col justify-between overflow-hidden bg-surface-overlay px-4 pb-4 pt-3">
-      {/* Header: Flow / Autopilot tabs + close */}
+      {/* Header */}
       <div className="flex items-center justify-between">
-        <div className="flex items-center gap-4 text-base tracking-[-0.6px] leading-9">
-          <span className="font-bold text-foreground">Flow</span>
-          <span className="font-medium text-foreground-subtle">Autopilot</span>
-        </div>
+        <span className="text-base font-bold leading-9 tracking-tight text-foreground">
+          Flow
+        </span>
         <button
           type="button"
-          className="text-foreground-muted transition-colors hover:text-foreground"
+          className="flex h-8 w-8 items-center justify-center rounded-lg text-foreground-muted transition-colors hover:bg-surface-hover hover:text-foreground"
           onClick={onClose}
           aria-label="Close panel"
         >
@@ -219,8 +359,10 @@ function ExpandedPanel({
       {/* Chat content */}
       {expandedContent ?? <DefaultChatContent chatMessages={chatMessages} />}
 
-      {/* Chat input */}
-      <ChatInput />
+      {/* Composer */}
+      <div className="pt-12">
+        <ChatComposer placeholder="Ask me to help build your Flow" />
+      </div>
     </div>
   );
 }
@@ -234,8 +376,8 @@ function ExpandedPanel({
  * chat panel.
  *
  * - **Collapsed**: 60px icon rail with logo, nav icons, and avatar
- * - **Expanded**: Icon rail + 420px chat panel with Flow/Autopilot tabs,
- *   chat messages, and input field
+ * - **Expanded**: Icon rail + 420px chat panel with Flow title,
+ *   chat messages, and composer input
  */
 export function FlowPanel({
   className,
@@ -253,8 +395,11 @@ export function FlowPanel({
   const handleNavClick = (id: string) => {
     setInternalActiveId(id);
     onNavChange?.(id);
-    // Clicking a nav item opens the expanded panel
     onOpenChange?.(true);
+  };
+
+  const handleLogoClick = () => {
+    onOpenChange?.(!open);
   };
 
   return (
@@ -264,15 +409,22 @@ export function FlowPanel({
           navItems={navItems}
           activeId={activeId}
           onNavClick={handleNavClick}
+          onLogoClick={handleLogoClick}
           hasShadow={open}
         />
-        {open && (
+        <div
+          className="overflow-hidden shrink-0"
+          style={{
+            width: open ? 420 : 0,
+            transition: 'width 300ms ease-out',
+          }}
+        >
           <ExpandedPanel
             chatMessages={chatMessages}
             expandedContent={expandedContent}
             onClose={() => onOpenChange?.(false)}
           />
-        )}
+        </div>
       </div>
     </TooltipProvider>
   );
@@ -280,7 +432,7 @@ export function FlowPanel({
 
 // Default nav items matching Figma (Chat, Home, Flows)
 export const defaultFlowNavItems: FlowPanelNavItem[] = [
-  { id: 'chat', label: 'Chat', icon: <MessageCircle className="h-5 w-5" /> },
-  { id: 'home', label: 'Home', icon: <House className="h-5 w-5" /> },
-  { id: 'flows', label: 'Flows', icon: <Workflow className="h-5 w-5" /> },
+  { id: 'chat', label: 'Chat', icon: <MessageCircle className="h-full w-full" /> },
+  { id: 'home', label: 'Home', icon: <House className="h-full w-full" /> },
+  { id: 'flows', label: 'Flows', icon: <Workflow className="h-full w-full" /> },
 ];

--- a/packages/apollo-wind/src/components/custom/toolbar-canvas.stories.tsx
+++ b/packages/apollo-wind/src/components/custom/toolbar-canvas.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import * as React from 'react';
 import { FlowCanvasToolbar } from './toolbar-canvas';
 
 const meta = {
@@ -13,9 +14,12 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
-  render: () => (
-    <div className="bg-surface p-8">
-      <FlowCanvasToolbar activeMode="build" />
-    </div>
-  ),
+  render: () => {
+    const [activeMode, setActiveMode] = React.useState<'build' | 'evaluate'>('build');
+    return (
+      <div className="bg-surface p-8">
+        <FlowCanvasToolbar activeMode={activeMode} onModeChange={setActiveMode} />
+      </div>
+    );
+  },
 };

--- a/packages/apollo-wind/src/components/custom/toolbar-canvas.tsx
+++ b/packages/apollo-wind/src/components/custom/toolbar-canvas.tsx
@@ -27,7 +27,7 @@ export interface CanvasToolbarProps {
 // ============================================================================
 
 function ToolbarSeparator() {
-  return <div className="h-8 w-px bg-border-subtle" />;
+  return <div className="h-8 w-px bg-surface-overlay" />;
 }
 
 // ============================================================================
@@ -35,21 +35,22 @@ function ToolbarSeparator() {
 // ============================================================================
 
 function ToolbarButton({
-  icon,
+  icon: Icon,
   label,
   onClick,
 }: {
-  icon: React.ReactNode;
+  icon: React.ElementType;
   label: string;
   onClick?: () => void;
 }) {
   return (
-    <button type="button"
-      className="flex h-8 w-8 items-center justify-center rounded-lg text-foreground-muted transition-colors hover:text-foreground"
+    <button
+      type="button"
+      className="group flex h-8 w-8 items-center justify-center rounded-lg text-foreground-muted hover:bg-surface-hover hover:text-foreground"
       onClick={onClick}
       aria-label={label}
     >
-      {icon}
+      <Icon className="h-5 w-5 group-hover:h-6 group-hover:w-6" />
     </button>
   );
 }
@@ -73,53 +74,65 @@ export function FlowCanvasToolbar({
   return (
     <div
       className={cn(
-        'flex h-[60px] items-center gap-2 rounded-3xl border border-border bg-surface-raised px-2.5',
+        'flex h-[60px] items-center gap-2 rounded-[24px] border border-surface-overlay bg-surface-raised px-2.5',
         className
       )}
     >
       {/* Build / Evaluate toggle */}
-      <div className="flex h-10 items-center rounded-xl border border-border-deep bg-surface-overlay p-1">
+      <div className="flex h-10 items-center gap-1 rounded-xl border border-surface-overlay p-1">
         {/* Build */}
-        <button type="button"
+        <button
+          type="button"
           className={cn(
-            'flex h-8 items-center gap-2 rounded-[10px] px-3 py-2 text-sm font-medium leading-5 transition-colors',
+            'flex h-8 items-center gap-2 rounded-[10px] px-3 py-2 text-sm font-medium leading-5',
             activeMode === 'build'
-              ? 'border border-border bg-surface text-foreground'
-              : 'text-foreground-subtle hover:text-foreground-hover'
+              ? 'border border-surface-hover bg-foreground-inverse text-foreground shadow-[0px_4px_4px_0px_rgba(0,0,0,0.05)] hover:border-transparent hover:bg-surface-hover hover:shadow-none'
+              : 'text-foreground-muted hover:bg-surface-hover hover:text-foreground'
           )}
           onClick={() => onModeChange?.('build')}
         >
-          <Workflow className="h-5 w-5" />
+          <Workflow
+            className={cn(
+              'h-5 w-5',
+              activeMode === 'build' ? 'text-foreground-accent' : ''
+            )}
+          />
           <span>Build</span>
         </button>
         {/* Evaluate */}
-        <button type="button"
+        <button
+          type="button"
           className={cn(
-            'flex h-8 items-center gap-2 rounded-[10px] px-3 py-2 text-sm font-medium leading-5 transition-colors',
+            'flex h-8 items-center gap-2 rounded-[10px] px-3 py-2 text-sm font-medium leading-5',
             activeMode === 'evaluate'
-              ? 'border border-border bg-surface text-foreground'
-              : 'text-foreground-subtle hover:text-foreground-hover'
+              ? 'border border-surface-hover bg-foreground-inverse text-foreground shadow-[0px_4px_4px_0px_rgba(0,0,0,0.05)] hover:border-transparent hover:bg-surface-hover hover:shadow-none'
+              : 'text-foreground-muted hover:bg-surface-hover hover:text-foreground'
           )}
           onClick={() => onModeChange?.('evaluate')}
         >
-          <ListChecks className="h-5 w-5" />
+          <ListChecks
+            className={cn(
+              'h-5 w-5',
+              activeMode === 'evaluate' ? 'text-foreground-accent' : ''
+            )}
+          />
           <span>Evaluate</span>
         </button>
       </div>
 
       <ToolbarSeparator />
 
-      <ToolbarButton icon={<Undo2 className="h-5 w-5" />} label="Undo" />
-      <ToolbarButton icon={<Redo2 className="h-5 w-5" />} label="Redo" />
+      <ToolbarButton icon={Undo2} label="Undo" />
+      <ToolbarButton icon={Redo2} label="Redo" />
 
       <ToolbarSeparator />
 
-      <ToolbarButton icon={<Play className="h-5 w-5" />} label="Run" />
+      <ToolbarButton icon={Play} label="Run" />
 
       <ToolbarSeparator />
 
-      <ToolbarButton icon={<Plus className="h-5 w-5" />} label="Add node" />
-      <ToolbarButton icon={<StickyNote className="h-5 w-5" />} label="Add note" />
+      <ToolbarButton icon={Plus} label="Add node" />
+      <ToolbarButton icon={StickyNote} label="Add note" />
     </div>
   );
 }

--- a/packages/apollo-wind/src/components/custom/toolbar-view.stories.tsx
+++ b/packages/apollo-wind/src/components/custom/toolbar-view.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import * as React from 'react';
 import { FlowViewToolbar } from './toolbar-view';
 
 const meta = {
@@ -13,9 +14,12 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
-  render: () => (
-    <div className="bg-surface p-8">
-      <FlowViewToolbar activeNodeSize="m" />
-    </div>
-  ),
+  render: () => {
+    const [activeNodeSize, setActiveNodeSize] = React.useState<'s' | 'm' | 'l'>('s');
+    return (
+      <div className="bg-surface p-8">
+        <FlowViewToolbar activeNodeSize={activeNodeSize} onNodeSizeChange={setActiveNodeSize} />
+      </div>
+    );
+  },
 };

--- a/packages/apollo-wind/src/components/custom/toolbar-view.tsx
+++ b/packages/apollo-wind/src/components/custom/toolbar-view.tsx
@@ -4,6 +4,7 @@ import {
   ZoomOut,
   Maximize2,
   LayoutGrid,
+  GitCommitHorizontal,
 } from 'lucide-react';
 import { cn } from '@/lib';
 
@@ -15,6 +16,8 @@ export interface ViewToolbarProps {
   className?: string;
   /** Active node size: 's' | 'm' | 'l' */
   activeNodeSize?: 's' | 'm' | 'l';
+  /** Callback when node size changes */
+  onNodeSizeChange?: (size: 's' | 'm' | 'l') => void;
   /** Callback for zoom/view actions */
   onAction?: (action: string) => void;
 }
@@ -24,45 +27,83 @@ export interface ViewToolbarProps {
 // ============================================================================
 
 function ViewButton({
-  icon,
+  icon: Icon,
   label,
-  isActive,
   onClick,
 }: {
-  icon: React.ReactNode;
+  icon: React.ElementType;
   label: string;
-  isActive?: boolean;
   onClick?: () => void;
 }) {
   return (
-    <button type="button"
-      className={cn(
-        'flex h-8 w-8 items-center justify-center rounded-lg text-foreground-muted transition-colors hover:text-foreground',
-        isActive && 'rounded-2xl border border-border bg-surface text-foreground'
-      )}
+    <button
+      type="button"
+      className="group flex h-8 w-8 items-center justify-center rounded-lg text-foreground-muted hover:bg-surface-hover hover:text-foreground"
       onClick={onClick}
       aria-label={label}
     >
-      {icon}
+      <Icon className="h-5 w-5 group-hover:h-6 group-hover:w-6" />
     </button>
   );
 }
 
 // ============================================================================
-// Node size labels
+// Node size icons (SVG)
 // ============================================================================
 
-function NodeSizeIcon({ size, isActive }: { size: 's' | 'm' | 'l'; isActive?: boolean }) {
-  const label = { s: 'S', m: 'M', l: 'L' }[size];
+function NodeSIcon() {
+  return <GitCommitHorizontal className="h-5 w-5" />;
+}
+
+function NodeMIcon() {
   return (
-    <button type="button"
+    <svg viewBox="0 0 20 20" className="h-5 w-5" fill="none" aria-hidden="true">
+      {/* Medium card: plain rounded rectangle */}
+      <rect x="3" y="5" width="14" height="10" rx="2.5" stroke="currentColor" strokeWidth="1.5" />
+    </svg>
+  );
+}
+
+function NodeLIcon() {
+  return (
+    <svg viewBox="0 0 20 20" className="h-5 w-5" fill="none" aria-hidden="true">
+      {/* Large card: rounded rectangle with header divider */}
+      <rect x="3" y="4" width="14" height="12" rx="2.5" stroke="currentColor" strokeWidth="1.5" />
+      <path d="M3 8.5h14" stroke="currentColor" strokeWidth="1.5" />
+    </svg>
+  );
+}
+
+const nodeSizeIcons = { s: NodeSIcon, m: NodeMIcon, l: NodeLIcon } as const;
+const nodeSizeLabels = { s: 'Small nodes', m: 'Medium nodes', l: 'Large nodes' } as const;
+
+// ============================================================================
+// Node size button
+// ============================================================================
+
+function NodeSizeButton({
+  size,
+  isActive,
+  onClick,
+}: {
+  size: 's' | 'm' | 'l';
+  isActive?: boolean;
+  onClick?: () => void;
+}) {
+  const Icon = nodeSizeIcons[size];
+  return (
+    <button
+      type="button"
       className={cn(
-        'flex h-8 w-8 items-center justify-center rounded-2xl text-xs font-bold text-foreground-muted transition-colors hover:text-foreground',
-        isActive && 'border border-border bg-surface text-foreground'
+        'flex h-8 w-8 items-center justify-center rounded-2xl',
+        isActive
+          ? 'border border-surface-hover bg-surface text-foreground-accent shadow-[0px_4px_4px_0px_rgba(0,0,0,0.05)] hover:border-transparent hover:bg-surface-hover hover:text-foreground hover:shadow-none'
+          : 'text-foreground-muted hover:bg-surface-hover hover:text-foreground'
       )}
-      aria-label={`Node size ${label}`}
+      onClick={onClick}
+      aria-label={nodeSizeLabels[size]}
     >
-      {label}
+      <Icon />
     </button>
   );
 }
@@ -80,40 +121,25 @@ function NodeSizeIcon({ size, isActive }: { size: 's' | 'm' | 'l'; isActive?: bo
 export function FlowViewToolbar({
   className,
   activeNodeSize = 's',
+  onNodeSizeChange,
   onAction,
 }: ViewToolbarProps) {
   return (
     <div className={cn('flex flex-col gap-4', className)}>
       {/* Zoom + view controls */}
-      <div className="flex w-10 flex-col items-center gap-1 rounded-xl bg-surface-raised p-1">
-        <ViewButton
-          icon={<ZoomIn className="h-5 w-5" />}
-          label="Zoom in"
-          onClick={() => onAction?.('zoom-in')}
-        />
-        <ViewButton
-          icon={<ZoomOut className="h-5 w-5" />}
-          label="Zoom out"
-          onClick={() => onAction?.('zoom-out')}
-        />
-        <div className="h-px w-6 bg-border-subtle" />
-        <ViewButton
-          icon={<Maximize2 className="h-5 w-5" />}
-          label="Fit to screen"
-          onClick={() => onAction?.('fit')}
-        />
-        <ViewButton
-          icon={<LayoutGrid className="h-5 w-5" />}
-          label="Toggle grid"
-          onClick={() => onAction?.('grid')}
-        />
+      <div className="flex w-10 flex-col items-center gap-1 rounded-xl border border-border-subtle bg-surface-raised p-1">
+        <ViewButton icon={ZoomIn} label="Zoom in" onClick={() => onAction?.('zoom-in')} />
+        <ViewButton icon={ZoomOut} label="Zoom out" onClick={() => onAction?.('zoom-out')} />
+        <div className="h-px w-6 bg-surface-overlay" />
+        <ViewButton icon={Maximize2} label="Fit to screen" onClick={() => onAction?.('fit')} />
+        <ViewButton icon={LayoutGrid} label="Toggle grid" onClick={() => onAction?.('grid')} />
       </div>
 
       {/* Node size selector */}
-      <div className="flex w-10 flex-col items-center gap-2 rounded-[20px] border border-border-deep bg-surface-raised p-1">
-        <NodeSizeIcon size="s" isActive={activeNodeSize === 's'} />
-        <NodeSizeIcon size="m" isActive={activeNodeSize === 'm'} />
-        <NodeSizeIcon size="l" isActive={activeNodeSize === 'l'} />
+      <div className="flex w-10 flex-col items-center gap-2 rounded-[20px] border border-border-subtle bg-surface-raised p-1">
+        <NodeSizeButton size="s" isActive={activeNodeSize === 's'} onClick={() => onNodeSizeChange?.('s')} />
+        <NodeSizeButton size="m" isActive={activeNodeSize === 'm'} onClick={() => onNodeSizeChange?.('m')} />
+        <NodeSizeButton size="l" isActive={activeNodeSize === 'l'} onClick={() => onNodeSizeChange?.('l')} />
       </div>
     </div>
   );

--- a/packages/apollo-wind/src/styles/tailwind.consumer.css
+++ b/packages/apollo-wind/src/styles/tailwind.consumer.css
@@ -1023,3 +1023,22 @@ body.light-hc {
 @utility bg-gradient-6 {
   background-image: var(--gradient-6);
 }
+
+/* ============================================================================
+ * Collapsible animations (Radix UI CollapsibleContent)
+ * ============================================================================ */
+
+@keyframes collapsible-down {
+  from { height: 0; opacity: 0; }
+  to { height: var(--radix-collapsible-content-height); opacity: 1; }
+}
+
+@keyframes collapsible-up {
+  from { height: var(--radix-collapsible-content-height); opacity: 1; }
+  to { height: 0; opacity: 0; }
+}
+
+@theme inline {
+  --animate-collapsible-down: collapsible-down 200ms ease-out;
+  --animate-collapsible-up: collapsible-up 200ms ease-out;
+}


### PR DESCRIPTION
## Summary
- Updated `panel-delegate` header buttons to 32×32 rounded-lg with `bg-surface-hover` fill on hover (Figma node 4387:102971)
- Updated `panel-flow` collapse button to match delegate panel style
- Embedded full `ChatComposer` into `FlowPanel` expanded panel (replacing static stub)
- Added `CanvasToolbar` (`toolbar-canvas`): Build/Evaluate toggle with selected/hover states, icon buttons scaling 20→24px on hover, instant hover response
- Added `ViewToolbar` (`toolbar-view`): Zoom/view controls and node size selector with `GitCommitHorizontal` for S, custom SVGs for M/L, `border-border-subtle` containers, instant hover

## Test plan
- [ ] Panel (Delegate) — expanded header buttons hover/collapse
- [ ] Panel (Flow) — embedded ChatComposer, collapse button
- [ ] Canvas Toolbar — Build/Evaluate toggle switches correctly, icon scale on hover
- [ ] View Toolbar — node size selection works, hover states are instant

🤖 Generated with [Claude Code](https://claude.com/claude-code)
