### PR TITLE
fix(apollo-react): fix tool call status text

### DIFF
--- a/packages/apollo-react/src/material/components/ap-tool-call/ApToolCall.tsx
+++ b/packages/apollo-react/src/material/components/ap-tool-call/ApToolCall.tsx
@@ -292,7 +292,7 @@ export const ApToolCall = React.forwardRef<HTMLDivElement, ApToolCallProps>((pro
       'tool';
 
     if (status === 'loading') {
-      return _(msg({ id: 'tool-call.running', message: `Running ${toolCallName}...` }));
+      return `Running '${toolCallName}'`;
     }
 
     // Calculate duration
@@ -303,10 +303,8 @@ export const ApToolCall = React.forwardRef<HTMLDivElement, ApToolCallProps>((pro
         ? (new Date(endTimeStamp).getTime() - new Date(startTimeStamp).getTime()) / 1000
         : 0;
 
-    return _(
-      msg({ id: 'tool-call.ran', message: `Ran ${toolCallName} (${duration.toFixed(2)}s)` })
-    );
-  }, [getStatus, toolName, span, startTime, endTime, _]);
+    return `Ran '${toolCallName}' for ${duration.toFixed(2)} seconds`;
+  }, [getStatus, toolName, span, startTime, endTime]);
 
   const handleKeyDown = useCallback(
     (event: React.KeyboardEvent) => {


### PR DESCRIPTION
- msg is a Lingui compile-time macro that extracts static strings for translation catalogs
- when template literals with dynamic variables (${toolCallName}) are passed into msg(), macro strips runtime
  values, leaving only the static text fragments — hence "Running ..." and "Ran (s)"


Before:
<img width="565" height="599" alt="Screenshot 2026-03-11 at 9 34 11 PM" src="https://github.com/user-attachments/assets/0c9fbe9d-a3fc-4c59-8081-800d8c34531b" />

After:
<img width="595" height="672" alt="Screenshot 2026-03-11 at 9 40 50 PM" src="https://github.com/user-attachments/assets/fb98d024-7cd2-4780-87ab-1e8146c08355" />
