### PR TITLE
feat(apollo-vertex): make row selection optional in data-table

### DIFF
--- a/apps/apollo-vertex/registry/data-table/data-table-pagination.tsx
+++ b/apps/apollo-vertex/registry/data-table/data-table-pagination.tsx
@@ -40,10 +40,11 @@ function DataTablePagination<TData>({
       className={cn("flex items-center justify-between px-2", className)}
     >
       <div className="text-muted-foreground flex-1 text-sm">
-        {t("rows_selected", {
-          selected: table.getFilteredSelectedRowModel().rows.length,
-          total: table.getFilteredRowModel().rows.length,
-        })}
+        {table.options.enableRowSelection &&
+          t("rows_selected", {
+            selected: table.getFilteredSelectedRowModel().rows.length,
+            total: table.getFilteredRowModel().rows.length,
+          })}
       </div>
       <div className="flex items-center space-x-6 lg:space-x-8">
         <div className="flex items-center space-x-2">

--- a/apps/apollo-vertex/registry/data-table/data-table.tsx
+++ b/apps/apollo-vertex/registry/data-table/data-table.tsx
@@ -96,8 +96,8 @@ interface DataTableProps<TData, TValue> {
   onColumnVisibilityChange: OnChangeFn<VisibilityState>;
   columnOrder: string[];
   onColumnOrderChange: OnChangeFn<string[]>;
-  rowSelection: RowSelectionState;
-  onRowSelectionChange: OnChangeFn<RowSelectionState>;
+  rowSelection?: RowSelectionState;
+  onRowSelectionChange?: OnChangeFn<RowSelectionState>;
   globalFilter: string;
   onGlobalFilterChange: OnChangeFn<string>;
   pagination: PaginationState;
@@ -137,14 +137,20 @@ function DataTable<TData, TValue>({
 }: DataTableProps<TData, TValue>) {
   const { t } = useTranslation();
 
+  const selectionEnabled = rowSelection != null || onRowSelectionChange != null;
+
+  const effectiveColumns = selectionEnabled
+    ? columns
+    : columns.filter((col) => col.id !== "select");
+
   const table = useReactTable({
     data,
-    columns,
+    columns: effectiveColumns,
     onSortingChange,
     onColumnFiltersChange,
     onColumnVisibilityChange,
     onColumnOrderChange,
-    onRowSelectionChange,
+    ...(selectionEnabled && { onRowSelectionChange }),
     onGlobalFilterChange,
     onPaginationChange,
     getCoreRowModel: getCoreRowModel(),
@@ -152,13 +158,14 @@ function DataTable<TData, TValue>({
     getSortedRowModel: getSortedRowModel(),
     getFilteredRowModel: getFilteredRowModel(),
     ...(globalFilterFn ? { globalFilterFn } : {}),
+    enableRowSelection: selectionEnabled,
     autoResetPageIndex: false,
     state: {
       sorting,
       columnFilters,
       columnVisibility,
       columnOrder,
-      rowSelection,
+      ...(selectionEnabled && { rowSelection }),
       globalFilter,
       pagination,
     },


### PR DESCRIPTION
## Summary

- Row selection in DataTable is now only enabled when `rowSelection` or `onRowSelectionChange` props are provided
- When both props are undefined, the table disables row selection state tracking and hides the selection count text
- Consumers can still optionally include `DataTableSelectColumn` in their columns; it just won't be functional without the selection props

## Test plan

- [x] DataTable without selection props shows no checkboxes or selection text
- [x] DataTable with selection props continues to work as before
- [x] TypeScript type checking passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)