### PR TITLE
feat(apollo-vertex): add expand row support to DataTable [AGVSOL-1577]

### DIFF
--- a/apps/apollo-vertex/registry/data-table/data-table.tsx
+++ b/apps/apollo-vertex/registry/data-table/data-table.tsx
@@ -3,9 +3,11 @@
 import {
   type ColumnDef,
   type ColumnFiltersState,
+  type ExpandedState,
   type FilterFn,
   flexRender,
   getCoreRowModel,
+  getExpandedRowModel,
   getFilteredRowModel,
   getPaginationRowModel,
   getSortedRowModel,
@@ -108,6 +110,9 @@ interface DataTableProps<TData, TValue> {
   toolbarContent?: (table: TanstackTable<TData>) => React.ReactNode;
   noResultsMessage?: string;
   stickyHeader?: boolean;
+  expanded?: ExpandedState;
+  onExpandedChange?: OnChangeFn<ExpandedState>;
+  renderExpandedRow?: (row: Row<TData>) => React.ReactNode;
 }
 
 function DataTable<TData, TValue>({
@@ -136,6 +141,9 @@ function DataTable<TData, TValue>({
   toolbarContent,
   noResultsMessage,
   stickyHeader = false,
+  expanded,
+  onExpandedChange,
+  renderExpandedRow,
 }: DataTableProps<TData, TValue>) {
   const { t } = useTranslation();
 
@@ -149,10 +157,14 @@ function DataTable<TData, TValue>({
     onRowSelectionChange,
     onGlobalFilterChange,
     onPaginationChange,
+    ...(onExpandedChange ? { onExpandedChange } : {}),
     getCoreRowModel: getCoreRowModel(),
     getPaginationRowModel: getPaginationRowModel(),
     getSortedRowModel: getSortedRowModel(),
     getFilteredRowModel: getFilteredRowModel(),
+    ...(renderExpandedRow
+      ? { getExpandedRowModel: getExpandedRowModel() }
+      : {}),
     ...(globalFilterFn ? { globalFilterFn } : {}),
     autoResetPageIndex: false,
     state: {
@@ -163,6 +175,7 @@ function DataTable<TData, TValue>({
       rowSelection,
       globalFilter,
       pagination,
+      ...(expanded ? { expanded } : {}),
     },
   });
 
@@ -209,27 +222,36 @@ function DataTable<TData, TValue>({
               />
             ) : rows.length > 0 ? (
               rows.map((row) => (
-                <TableRow
-                  key={row.id}
-                  data-state={row.getIsSelected() && "selected"}
-                  className={
-                    onRowClick
-                      ? "cursor-pointer hover:bg-gradient-to-r hover:from-primary/5 hover:to-secondary/5 transition-all border-l-2 border-transparent hover:border-l-primary"
-                      : ""
-                  }
-                  {...(onRowClick && {
-                    onClick: () => onRowClick(row.original),
-                  })}
-                >
-                  {row.getVisibleCells().map((cell) => (
-                    <TableCell key={cell.id}>
-                      {flexRender(
-                        cell.column.columnDef.cell,
-                        cell.getContext(),
-                      )}
-                    </TableCell>
-                  ))}
-                </TableRow>
+                <>
+                  <TableRow
+                    key={row.id}
+                    data-state={row.getIsSelected() && "selected"}
+                    className={
+                      onRowClick
+                        ? "cursor-pointer hover:bg-gradient-to-r hover:from-primary/5 hover:to-secondary/5 transition-all border-l-2 border-transparent hover:border-l-primary"
+                        : ""
+                    }
+                    {...(onRowClick && {
+                      onClick: () => onRowClick(row.original),
+                    })}
+                  >
+                    {row.getVisibleCells().map((cell) => (
+                      <TableCell key={cell.id}>
+                        {flexRender(
+                          cell.column.columnDef.cell,
+                          cell.getContext(),
+                        )}
+                      </TableCell>
+                    ))}
+                  </TableRow>
+                  {renderExpandedRow && row.getIsExpanded() && (
+                    <TableRow data-state="expanded" key={row.id}>
+                      <TableCell colSpan={row.getVisibleCells().length}>
+                        {renderExpandedRow(row)}
+                      </TableCell>
+                    </TableRow>
+                  )}
+                </>
               ))
             ) : (
               <TableRow>

--- a/apps/apollo-vertex/registry/data-table/index.ts
+++ b/apps/apollo-vertex/registry/data-table/index.ts
@@ -1,8 +1,10 @@
 export type {
   ColumnDef,
   ColumnFiltersState,
+  ExpandedState,
   OnChangeFn,
   PaginationState,
+  Row,
   RowSelectionState,
   SortingState,
   Table as TanstackTable,

--- a/apps/apollo-vertex/templates/DataTableTemplate.tsx
+++ b/apps/apollo-vertex/templates/DataTableTemplate.tsx
@@ -3,6 +3,7 @@
 import type {
   ColumnDef,
   ColumnFiltersState,
+  ExpandedState,
   PaginationState,
   RowSelectionState,
   SortingState,
@@ -10,6 +11,7 @@ import type {
 } from "@tanstack/react-table";
 import {
   CheckCircleIcon,
+  ChevronRightIcon,
   CircleDotIcon,
   ClockIcon,
   MoreHorizontalIcon,
@@ -137,6 +139,29 @@ const statusFilterOptions: DataTableFacetedFilterOption[] = [
 
 const columns: ColumnDef<Payment>[] = [
   {
+    id: "expand",
+    header: () => null,
+    cell: ({ row }) => (
+      <Button
+        variant="ghost"
+        size="icon-sm"
+        onClick={(e) => {
+          e.stopPropagation();
+          row.toggleExpanded();
+        }}
+      >
+        <ChevronRightIcon
+          className={`size-4 transition-transform ${row.getIsExpanded() ? "rotate-90" : ""}`}
+        />
+        <span className="sr-only">
+          {row.getIsExpanded() ? "Collapse row" : "Expand row"}
+        </span>
+      </Button>
+    ),
+    enableSorting: false,
+    enableHiding: false,
+  },
+  {
     id: "select",
     header: ({ table }) => (
       <Checkbox
@@ -223,7 +248,14 @@ const columns: ColumnDef<Payment>[] = [
   },
 ];
 
-const defaultColumnOrder = ["select", "status", "email", "amount", "actions"];
+const defaultColumnOrder = [
+  "expand",
+  "select",
+  "status",
+  "email",
+  "amount",
+  "actions",
+];
 
 export function DataTableTemplate() {
   const [sorting, setSorting] = useState<SortingState>([]);
@@ -231,6 +263,7 @@ export function DataTableTemplate() {
   const [columnVisibility, setColumnVisibility] = useState<VisibilityState>({});
   const [columnOrder, setColumnOrder] = useState<string[]>(defaultColumnOrder);
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
+  const [expanded, setExpanded] = useState<ExpandedState>({});
   const [globalFilter, setGlobalFilter] = useState("");
   const [pagination, setPagination] = useState<PaginationState>({
     pageIndex: 0,
@@ -252,6 +285,31 @@ export function DataTableTemplate() {
         onColumnOrderChange={setColumnOrder}
         rowSelection={rowSelection}
         onRowSelectionChange={setRowSelection}
+        expanded={expanded}
+        onExpandedChange={setExpanded}
+        renderExpandedRow={(row) => (
+          <div className="p-4 text-sm text-muted-foreground">
+            <p>
+              <span className="font-medium text-foreground">Payment ID:</span>{" "}
+              {row.original.id}
+            </p>
+            <p>
+              <span className="font-medium text-foreground">Email:</span>{" "}
+              {row.original.email}
+            </p>
+            <p>
+              <span className="font-medium text-foreground">Amount:</span>{" "}
+              {new Intl.NumberFormat("en-US", {
+                style: "currency",
+                currency: "USD",
+              }).format(row.original.amount)}
+            </p>
+            <p>
+              <span className="font-medium text-foreground">Status:</span>{" "}
+              {row.original.status}
+            </p>
+          </div>
+        )}
         globalFilter={globalFilter}
         onGlobalFilterChange={setGlobalFilter}
         pagination={pagination}


### PR DESCRIPTION

<img width="757" height="288" alt="Screenshot 2026-03-12 at 11 04 05" src="https://github.com/user-attachments/assets/26a65b3f-4458-4a6c-a518-64de4c4349fe" />


## Summary

DataTable now supports row expansion via optional `expanded`, `onExpandedChange`, and `renderExpandedRow` props. Consumers define their own expand toggle column (similar to the select column pattern) and provide a render callback for expanded content. The feature is fully opt-in and follows the same controlled-state pattern as selection and sorting.

## Changes

- Added `ExpandedState` and `getExpandedRowModel` from TanStack Table
- New optional props: `expanded`, `onExpandedChange`, `renderExpandedRow`
- Renders expanded content as a full-width row after expanded rows
- Updated DataTableTemplate with example expand column

🤖 Generated with Claude Code