### PR TITLE
fix(apollo-vertex): shell sidebar animations with React StrictMode [AGVSOL-1713]

### DIFF
--- a/apps/apollo-vertex/registry/shell/shell-company.tsx
+++ b/apps/apollo-vertex/registry/shell/shell-company.tsx
@@ -145,7 +145,7 @@ export const Company = ({
           iconElement
         )}
 
-        <AnimatePresence>
+        <AnimatePresence initial={false}>
           {!isCollapsed && (
             <motion.div
               key="company-text"
@@ -171,7 +171,7 @@ export const Company = ({
         </AnimatePresence>
       </div>
 
-      <AnimatePresence>
+      <AnimatePresence initial={false}>
         {!isCollapsed && (
           <motion.div
             variants={{

--- a/apps/apollo-vertex/registry/shell/shell-nav-item.tsx
+++ b/apps/apollo-vertex/registry/shell/shell-nav-item.tsx
@@ -47,7 +47,7 @@ export const NavItem = ({ to, icon: Icon, text }: NavItemProps) => {
       >
         <Icon className="w-4 h-4" />
       </motion.span>
-      <AnimatePresence>
+      <AnimatePresence initial={false}>
         {!isCollapsed && (
           <motion.span
             key="nav-text"

--- a/apps/apollo-vertex/registry/shell/shell-sidebar.tsx
+++ b/apps/apollo-vertex/registry/shell/shell-sidebar.tsx
@@ -75,10 +75,10 @@ export const Sidebar = ({
       />
       <nav className="flex-1 mt-10 space-y-1 pb-3">
         <NavItem to="/preview/shell" icon={Home} text="Dashboard" />
-        <NavItem to="/" icon={FolderOpen} text="Projects" />
-        <NavItem to="/" icon={BarChart3} text="Analytics" />
-        <NavItem to="/" icon={Users} text="Team" />
-        <NavItem to="/" icon={Settings} text="Settings" />
+        <NavItem to="/projects" icon={FolderOpen} text="Projects" />
+        <NavItem to="/analytics" icon={BarChart3} text="Analytics" />
+        <NavItem to="/team" icon={Users} text="Team" />
+        <NavItem to="/settings" icon={Settings} text="Settings" />
       </nav>
       <div
         className={cn("mt-auto", isCollapsed && "flex flex-col items-center")}


### PR DESCRIPTION
Add `initial={false}` to `AnimatePresence` in `shell-nav-item` and `shell-company` to prevent text from disappearing on mount in StrictMode environments (like [vertical-solutions-template](https://github.com/UiPath/vertical-solutions-template))
Update nav item routes to use distinct paths instead of all pointing to `/`