### PR TITLE
docs: document apollo-vertex in repo guides

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,7 +53,7 @@ Use a **fixup/rebase workflow** to keep commits clean and meaningful.
 
 ## Project Overview
 
-Apollo v.4 is an open-source design system for UiPath, built to provide a unified component library for both internal and external consumers. This monorepo contains design tokens, utilities, and framework-specific implementations (React, Web Components).
+Apollo v.4 is UiPath's open-source design system monorepo. It houses multiple design systems used by different teams — from Material UI-based components to Tailwind/shadcn implementations — along with shared design tokens, utilities, and cross-framework components.
 
 ### Goals
 
@@ -83,6 +83,7 @@ This is the **UiPath/apollo-ui** public repository - the open-source design syst
 - **React**: Primary component library with Material UI theming
 - **Web Components**: Cross-framework components using standard web APIs
 - **Tailwind CSS + shadcn/ui**: Modern styling approach (apollo-wind package)
+- **shadcn Registry**: Installable components via `@uipath` registry (apollo-vertex app)
 
 ### Testing & Documentation
 
@@ -103,7 +104,8 @@ apollo-ui/
 │       ├── visual-regression.yml
 │       └── publish.yml         # NPM publishing
 │
-├── apps/                       # Development applications
+├── apps/                       # Applications
+│   ├── apollo-vertex/          # shadcn component registry + Next.js docs site
 │   ├── storybook/              # Storybook documentation
 │   ├── react-playground/       # React testing environment
 │
@@ -184,6 +186,27 @@ apollo-ui/
 - **Technology**: Web Components (Custom Elements)
 - **Exports**: `<ap-chat>` custom element
 
+### Apps
+
+#### `apollo-vertex`
+
+- **Purpose**: Design system for UiPath vertical solutions, distributed as a `@uipath` shadcn registry with a Next.js documentation site
+- **Location**: `apps/apollo-vertex/`
+- **Technology**: Next.js 16, Tailwind CSS 4, Radix UI, shadcn/ui, Nextra
+- **Standalone**: No dependencies on other monorepo packages
+- **Structure**:
+  ```
+  apollo-vertex/
+  ├── app/                    # Next.js app router pages
+  ├── registry/               # Component source (installed via npx shadcn add @uipath/...)
+  │   ├── button/
+  │   ├── checkbox/
+  │   └── [component]/
+  ├── templates/              # Page templates
+  └── lib/                    # Utilities (cn, etc.)
+  ```
+- **Key distinction**: The `registry/` directory is the source of truth for all `@uipath` shadcn components. Edits here are what consumers install via `npx shadcn@latest add @uipath/<component>`.
+
 ## Package Dependencies
 
 ```
@@ -192,6 +215,8 @@ apollo-core (tokens, icons, fonts)
 ├─→ apollo-react (React + MUI)
 │   └─→ ap-chat (Web Component)
 └─→ apollo-wind (Tailwind + shadcn)
+
+apollo-vertex (standalone — shadcn registry + docs app)
 ```
 
 ---
@@ -200,8 +225,9 @@ apollo-core (tokens, icons, fonts)
 
 ### Naming Conventions
 
-- **React components**: `Ap` prefix (e.g., `ApButton`, `ApTextField`)
+- **React components** (apollo-react): `Ap` prefix (e.g., `ApButton`, `ApTextField`)
 - **Web components**: `ap-` prefix (e.g., `<ap-chat>`)
+- **Vertex registry components**: PascalCase, no prefix (e.g., `Button`, `Checkbox`)
 
 ### Component Structure
 
@@ -219,20 +245,25 @@ apollo-core (tokens, icons, fonts)
 
 **Other packages** export only what's relevant to their purpose (e.g., web components export custom elements only).
 
-### Usage Pattern
+### Usage Patterns
 
+**apollo-react (Material UI):**
 ```typescript
-// Import CSS variables
 import '@uipath/apollo-react/core/theme.css';
-
-// Import components
 import { ApButton, ApTextField } from '@uipath/apollo-react/components';
-
-// Import tokens
 import { ColorOrange500, SpacingMd } from '@uipath/apollo-react/core';
-
-// Import theme
 import { apolloMaterialUiThemeDark } from '@uipath/apollo-react/theme';
+```
+
+**apollo-vertex (shadcn registry):**
+```bash
+# Install components into your project
+npx shadcn@latest add @uipath/button @uipath/checkbox
+```
+```typescript
+// Components are copied into your project and imported locally
+import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
 ```
 
 ---
@@ -269,6 +300,7 @@ import { apolloMaterialUiThemeDark } from '@uipath/apollo-react/theme';
 
 ### Adding a New Component
 
+**For apollo-react or web-packages:**
 1. Identify which package (apollo-react, or web-packages)
 2. Create component following naming conventions
 3. Use design tokens from apollo-core
@@ -276,6 +308,13 @@ import { apolloMaterialUiThemeDark } from '@uipath/apollo-react/theme';
 5. Add unit tests
 6. Add visual regression tests
 7. Document usage and API
+
+**For apollo-vertex (shadcn registry):**
+1. Create a new directory under `apps/apollo-vertex/registry/<component>/`
+2. Follow shadcn/ui patterns (Radix primitives, cva variants, `cn()` utility)
+3. Use `data-slot` attributes for styling hooks
+4. Preview in the dev app with `pnpm dev` (from `apps/apollo-vertex/`)
+5. Run `pnpm lint` and `pnpm format` before committing
 
 ### Package Structure Requirements
 
@@ -289,7 +328,8 @@ Each package must include:
 
 ### File Naming
 
-- Component files: PascalCase (e.g., `ApButton.tsx`)
+- Component files (apollo-react): PascalCase (e.g., `ApButton.tsx`)
+- Component files (apollo-vertex): kebab-case (e.g., `button.tsx`, `button-group.tsx`)
 - Utility files: camelCase (e.g., `formatDate.ts`)
 - Test files: `*.test.ts` or `*.spec.ts`
 - Story files: `*.stories.tsx`

--- a/README.md
+++ b/README.md
@@ -4,15 +4,15 @@
 [![pnpm](https://img.shields.io/badge/maintained%20with-pnpm-cc00ff.svg)](https://pnpm.io/)
 [![Turborepo](https://img.shields.io/badge/built%20with-Turborepo-ef4444.svg)](https://turbo.build/)
 
-Apollo v.4 is UiPath's open-source design system for building consistent user experiences across all UiPath products.
+Apollo v.4 is UiPath's open-source design system monorepo. It houses multiple design systems used by different teams across UiPath — from Material UI-based components to Tailwind/shadcn implementations — all in one place.
 
 ## Table of Contents
 - [✨ Features](#-features)
 - [📦 Package Dependency Graph](#-package-dependency-graph)
 - [📁 Repository Structure](#-repository-structure)
-- [📦 Packages](#-packages)
+- [📦 Packages & Design Systems](#-packages--design-systems)
   - [Core Foundation](#core-foundation)
-  - [Framework Implementations](#framework-implementations)
+  - [Design Systems](#design-systems)
   - [Web Components](#web-components)
 - [🎨 Live Demos](#-live-demos)
 - [📚 Documentation](#-documentation)
@@ -24,6 +24,7 @@ Apollo v.4 is UiPath's open-source design system for building consistent user ex
 - 🎨 **Design Tokens** - 1300+ icons, comprehensive color system, typography, spacing
 - ⚛️ **React Components** - Built on Material UI with Apollo theming
 - 🎐 **Tailwind CSS** - Modern utility-first styling with shadcn/ui
+- 🧩 **shadcn Registry** - Installable components via `npx shadcn add @uipath/...`
 - 🌐 **Web Components** - Cross-framework components for maximum flexibility
 - 📘 **TypeScript** - Full type safety across all packages
 - 📚 **Storybook** - Interactive component documentation
@@ -37,11 +38,13 @@ graph RL
     Wind["@uipath/apollo-wind<br/>Tailwind + shadcn/ui"] -->|requires| Core
     React -->|requires| Wind
     Chat["@uipath/ap-chat<br/>Chat Web Component"] -->|requires| React
+    Vertex["apollo-vertex<br/>Vertical Solutions Design System"]
 
     style Core fill:#374151,stroke:#ef4444,stroke-width:3px,color:#fff
     style React fill:#1e3a8a,stroke:#3b82f6,stroke-width:3px,color:#fff
     style Wind fill:#164e63,stroke:#06b6d4,stroke-width:3px,color:#fff
     style Chat fill:#064e3b,stroke:#10b981,stroke-width:3px,color:#fff
+    style Vertex fill:#4a1d96,stroke:#8b5cf6,stroke-width:3px,color:#fff
 ```
 
 ## 📁 Repository Structure
@@ -56,9 +59,9 @@ apollo-ui/
 ├── web-packages/          # Cross-framework web components
 │   └── ap-chat/           # 💬 Chat web component
 │
-└── apps/                  # Demo & development applications
-    ├── apollo-vertex/     # 🌟 Main Storybook hub
-    ├── storybook/         # 📚 Component documentation
+└── apps/                  # Applications
+    ├── apollo-vertex/     # 🧩 shadcn component registry + Next.js docs site
+    ├── storybook/         # 📚 Storybook component documentation
     └── react-playground/  # 🔬 React testing environment
 ```
 
@@ -101,7 +104,7 @@ Preview versions are published when the `dev-packages` label is added to a PR. R
 
 ---
 
-## 📦 Packages
+## 📦 Packages & Design Systems
 
 ### Core Foundation
 
@@ -109,19 +112,25 @@ Preview versions are published when the `dev-packages` label is added to a PR. R
 |---------|---------|-----------|
 | **[@uipath/apollo-core](./packages/apollo-core)** | [![npm](https://img.shields.io/npm/v/@uipath/apollo-core)](https://www.npmjs.com/package/@uipath/apollo-core) | [![downloads](https://img.shields.io/npm/dm/@uipath/apollo-core)](https://www.npmjs.com/package/@uipath/apollo-core) |
 
-Design tokens, 1300+ icons, and fonts. Framework-agnostic foundation for the design system.
+Design tokens, 1300+ icons, and fonts. Framework-agnostic foundation shared across design systems.
 
 ---
 
-### Framework Implementations
+### Design Systems
 
-| Package | Version | Downloads |
-|---------|---------|-----------|
-| **[@uipath/apollo-react](./packages/apollo-react)** | [![npm](https://img.shields.io/npm/v/@uipath/apollo-react)](https://www.npmjs.com/package/@uipath/apollo-react) | [![downloads](https://img.shields.io/npm/dm/@uipath/apollo-react)](https://www.npmjs.com/package/@uipath/apollo-react) |
-| **[@uipath/apollo-wind](./packages/apollo-wind)** | [![npm](https://img.shields.io/npm/v/@uipath/apollo-wind)](https://www.npmjs.com/package/@uipath/apollo-wind) | [![downloads](https://img.shields.io/npm/dm/@uipath/apollo-wind)](https://www.npmjs.com/package/@uipath/apollo-wind) |
+| System | Location | Tech | Consumed via |
+|--------|----------|------|--------------|
+| **[apollo-react](./packages/apollo-react)** | `packages/apollo-react` | React + Material UI | npm package |
+| **[apollo-wind](./packages/apollo-wind)** | `packages/apollo-wind` | Tailwind + shadcn/ui | npm package |
+| **[apollo-vertex](./apps/apollo-vertex)** | `apps/apollo-vertex` | Next.js + Tailwind + Radix | shadcn registry |
 
-- **apollo-react**: Canvas/workflow components, ApChat, icons, Material UI themes (Material UI in maintenance mode)
-- **apollo-wind**: Modern Tailwind CSS + shadcn/ui components (recommended for new development)
+- **apollo-react**: Canvas/workflow components, ApChat, icons, Material UI themes
+- **apollo-wind**: Tailwind CSS + shadcn/ui components published as an npm package
+- **apollo-vertex**: Design system for vertical solutions. Components are distributed via the `@uipath` shadcn registry and installed directly into consumer projects:
+
+```bash
+npx shadcn@latest add @uipath/button @uipath/checkbox @uipath/input
+```
 
 ---
 
@@ -141,7 +150,7 @@ Framework-agnostic AI chat interface web component for vanilla JS, Vue, Angular,
 
 Explore our components in interactive Storybook environments:
 
-- **[Apollo Vertex](https://apollo-vertex.vercel.app/)** - Complete design system showcase
+- **[Apollo Vertex](https://apollo-vertex.vercel.app/)** - Vertical solutions components and docs
 - **[Canvas Components](https://apollo-canvas.vercel.app/)** - Workflow and canvas demos
 - **[React Playground](https://apollo-ui-react.vercel.app/)** - Material UI components, design tokens, CSS vars, icons, and chat component
 - **[Wind Components](https://apollo-wind.vercel.app/)** - Tailwind CSS components
@@ -152,6 +161,7 @@ Explore our components in interactive Storybook environments:
 - **[@uipath/apollo-react](./packages/apollo-react/README.md)** - React components and canvas
 - **[@uipath/apollo-wind](./packages/apollo-wind/README.md)** - Tailwind components
 - **[@uipath/ap-chat](./web-packages/ap-chat/README.md)** - Chat web component
+- **[Apollo Vertex](./apps/apollo-vertex)** - Vertical solutions design system
 - **[Contributing Guide](./CONTRIBUTING.md)** - How to contribute
 
 ## 🚀 Contributing


### PR DESCRIPTION
## Summary
Update README and CLAUDE.md to document apollo-vertex as a full peer design system alongside apollo-react and apollo-wind. Clarify that the monorepo houses multiple design systems for different teams, with apollo-vertex serving vertical solutions via a shadcn registry.

## Changes
- Reframe repository as multi-system monorepo
- Add apollo-vertex to architecture docs and dependency graphs
- Document apollo-vertex stack, location, and usage (npx shadcn)
- Add naming conventions and workflow for apollo-vertex components
- Update component guidelines with apollo-vertex patterns

## Testing
Documentation-only changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)