### PR TITLE
feat(apollo-vertex): add pointer cursor for all clickable elements

### DIFF
--- a/apps/apollo-vertex/app/globals.css
+++ b/apps/apollo-vertex/app/globals.css
@@ -40,4 +40,16 @@
   a {
     @apply text-primary-700 dark:text-primary-400;
   }
+
+  /* Ensure all clickable elements show pointer cursor */
+  button:not([disabled]),
+  [role="button"]:not([disabled]),
+  a[href],
+  select:not([disabled]),
+  summary,
+  input[type="checkbox"]:not([disabled]),
+  input[type="radio"]:not([disabled]),
+  [tabindex]:not([tabindex="-1"]):not([disabled]) {
+    cursor: pointer;
+  }
 }


### PR DESCRIPTION
Adding back in the pointer cursor to clickable elements (didn't do it for dropdown and select menus because seemed like a bigger override) because users have come to expect this visual cue when hovering clickable elements. 