### PR TITLE
fix(apollo-vertex): self-contain sonner toast styling

### DIFF
--- a/apps/apollo-vertex/app/globals.css
+++ b/apps/apollo-vertex/app/globals.css
@@ -14,17 +14,6 @@
   --x-color-nextra-bg: var(--background);
 }
 
-/* Sonner close button: right-aligned inside toast (Apollo default) */
-[data-sonner-toast] [data-close-button] {
-  left: unset !important;
-  right: 8px !important;
-  top: 8px !important;
-  transform: none !important;
-  border: none !important;
-  background: transparent !important;
-  border-radius: 4px !important;
-}
-
 .dark {
   /* Override Nextra's background to match our theme */
   --x-color-nextra-bg: var(--background);

--- a/apps/apollo-vertex/next-env.d.ts
+++ b/apps/apollo-vertex/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/apollo-vertex/next-env.d.ts
+++ b/apps/apollo-vertex/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/apollo-vertex/registry/sonner/sonner.tsx
+++ b/apps/apollo-vertex/registry/sonner/sonner.tsx
@@ -24,6 +24,8 @@ export const apolloToastClassNames: NonNullable<
   success: `!border-success !bg-secondary dark:!bg-[color-mix(in_srgb,var(--success)_25%,var(--popover)_75%)] [&>svg]:!text-[var(--success-fg)] dark:[&>svg]:!text-success ${iconAlign}`,
   warning: `!border-warning !bg-secondary dark:!bg-[color-mix(in_srgb,var(--warning)_25%,var(--popover)_75%)] [&>svg]:!text-warning-foreground dark:[&>svg]:!text-warning ${iconAlign}`,
   error: `!border-destructive !bg-secondary dark:!bg-[color-mix(in_srgb,var(--destructive)_25%,var(--popover)_75%)] [&>svg]:!text-[var(--destructive-fg)] dark:[&>svg]:!text-destructive ${iconAlign}`,
+  closeButton:
+    '!left-auto !right-2 !top-2 !transform-none !border-none !bg-transparent !rounded-sm',
 };
 
 const Toaster = ({ ...props }: ToasterProps) => {
@@ -34,6 +36,7 @@ const Toaster = ({ ...props }: ToasterProps) => {
       theme={theme as ToasterProps["theme"]}
       className="toaster group"
       position="top-center"
+      duration={5000}
       closeButton
       icons={{
         success: <CircleCheckIcon className="size-4" />,


### PR DESCRIPTION
## Summary

Move close button styling from globals.css into `apolloToastClassNames` export so consumers automatically get the correct Apollo styling without depending on global CSS. Add `duration={5000}` to Toaster component to align with design system guidance (5-second auto-dismiss).

## Changes

- **registry/sonner/sonner.tsx**: Added `closeButton` class string to `apolloToastClassNames` and `duration={5000}` prop to Toaster
- **app/globals.css**: Removed `[data-sonner-toast] [data-close-button]` override (now self-contained)
- **next-env.d.ts**: Updated by Next.js (types path change)

🤖 Generated with Claude Code