### PR TITLE
fix(apollo-react): add readonly mode for node toolbar

### DIFF
--- a/packages/apollo-react/src/canvas/utils/toolbar-resolver.tsx
+++ b/packages/apollo-react/src/canvas/utils/toolbar-resolver.tsx
@@ -48,6 +48,9 @@ const DEFAULT_MODE_TOOLBARS: Record<string, ModeToolbarConfig> = {
   evaluation: {
     actions: [...DEFAULT_ACTIONS_FOR_ALL_MODES],
   },
+  readonly: {
+    actions: [],
+  },
 };
 
 // Stub toolbar registry - consumers can inject their own


### PR DESCRIPTION
getModeDefaults already returns { actions: [] } for any _unknown_ mode.
This PR adds `readonly` as new toolbar mode for explicitness