### PR TITLE
fix(apollo-wind): have buttons be of type='button' by default

### DIFF
--- a/packages/apollo-wind/src/components/ui/button.tsx
+++ b/packages/apollo-wind/src/components/ui/button.tsx
@@ -40,7 +40,12 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
   ({ className, variant, size, asChild = false, ...props }, ref) => {
     const Comp = asChild ? Slot : 'button';
     return (
-      <Comp className={cn(buttonVariants({ variant, size, className }))} ref={ref} {...props} />
+      <Comp
+        className={cn(buttonVariants({ variant, size, className }))}
+        ref={ref}
+        type={Comp === 'button' ? 'button' : undefined}
+        {...props}
+      />
     );
   }
 );


### PR DESCRIPTION
Having buttons be of type `button` by default would prevent unwanted behavior when using them within forms.

Example: [MST-7445](https://uipath.atlassian.net/browse/MST-7445?atlOrigin=eyJpIjoiNjEzMjdlNTc0YWYzNGUzNTkzMmU5ZWNkODkwZDgzYjUiLCJwIjoiaiJ9)

Related PR: https://github.com/UiPath/flow-workbench/pull/629

#### Test Plan
- [x] Buttons used within forms don't exhibit submit behavior by default
- [x] Button type can be overridden (`submit`, `reset`)

[MST-7445]: https://uipath.atlassian.net/browse/MST-7445?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ