### PR TITLE
feat(apollo-react): add keyboard navigation and focus lock to Toolbox [AG-801]

### DIFF
--- a/packages/apollo-react/src/canvas/components/AddNodePanel/AddNodePanel.test.tsx
+++ b/packages/apollo-react/src/canvas/components/AddNodePanel/AddNodePanel.test.tsx
@@ -99,14 +99,14 @@ describe('AddNodePanel', () => {
     onClose: mockOnClose,
   };
 
-  it("should render with title 'Add Node'", () => {
+  it("should render with title 'Add node'", () => {
     render(
       <NodeRegistryProvider manifest={mockManifest}>
         <AddNodePanel {...defaultProps} />
       </NodeRegistryProvider>
     );
 
-    expect(screen.getByTestId('toolbox-title')).toHaveTextContent('Add Node');
+    expect(screen.getByTestId('toolbox-title')).toHaveTextContent('Add node');
   });
 
   it('should transform empty registry into empty list items', () => {

--- a/packages/apollo-react/src/canvas/components/AddNodePanel/AddNodePanel.tsx
+++ b/packages/apollo-react/src/canvas/components/AddNodePanel/AddNodePanel.tsx
@@ -78,7 +78,7 @@ export const AddNodePanel = memo(function AddNodePanel({
 
   return (
     <Toolbox
-      title={title ?? 'Add Node'}
+      title={title ?? 'Add node'}
       initialItems={nodeListOptions}
       loading={loading}
       onItemSelect={handleNodeListItemSelect}

--- a/packages/apollo-react/src/canvas/components/Toolbox/ListView.styles.ts
+++ b/packages/apollo-react/src/canvas/components/Toolbox/ListView.styles.ts
@@ -29,8 +29,14 @@ export const ListItemButton = styled(motion.button)`
   width: 100%;
   transition: all 0.15s ease;
 
-  &:hover {
+  &:hover,
+  &.active {
     background: var(--uix-canvas-background-hover);
+  }
+
+  &.active {
+    outline: 1px solid var(--uix-canvas-primary);
+    outline-offset: -1px;
   }
 `;
 

--- a/packages/apollo-react/src/canvas/components/Toolbox/ListView.test.tsx
+++ b/packages/apollo-react/src/canvas/components/Toolbox/ListView.test.tsx
@@ -245,8 +245,8 @@ describe('ListView', () => {
 
       render(<ListView {...defaultProps} items={items} isLoading={true} />);
 
-      const button = screen.getByRole('button');
-      expect(button).toBeDisabled();
+      const option = screen.getByRole('option');
+      expect(option).toBeDisabled();
     });
 
     it('should have loading class when isLoading is true', () => {
@@ -254,8 +254,8 @@ describe('ListView', () => {
 
       render(<ListView {...defaultProps} items={items} isLoading={true} />);
 
-      const button = screen.getByRole('button');
-      expect(button).toHaveClass('loading');
+      const option = screen.getByRole('option');
+      expect(option).toHaveClass('loading');
     });
   });
 

--- a/packages/apollo-react/src/canvas/components/Toolbox/ListView.tsx
+++ b/packages/apollo-react/src/canvas/components/Toolbox/ListView.tsx
@@ -3,8 +3,8 @@ import { Column } from '@uipath/apollo-react/canvas/layouts';
 import { NodeIcon, partition } from '@uipath/apollo-react/canvas/utils';
 import { ApSkeleton, ApTypography } from '@uipath/apollo-react/material';
 import { ApIcon, ApTooltip } from '@uipath/apollo-react/material/components';
-import { memo, useCallback, useMemo } from 'react';
-import type { RowComponentProps } from 'react-window';
+import { forwardRef, memo, useCallback, useImperativeHandle, useMemo } from 'react';
+import type { ListImperativeAPI, RowComponentProps } from 'react-window';
 import { useCanvasTheme } from '../BaseCanvas/CanvasThemeContext';
 import { IconContainer, ListItemButton, SectionHeader, StyledList } from './ListView.styles';
 
@@ -35,12 +35,55 @@ export type ListItem<T = any> = {
   children?: ListItem<T>[] | ((id: string, name: string) => Promise<ListItem<T>[]>);
 };
 
-type RenderItem<T extends ListItem> =
+export type RenderItem<T extends ListItem> =
   | { type: 'section'; sectionName: string }
   | { type: 'item'; item: T };
 
+export function buildRenderedItems<T extends ListItem>(
+  items: T[],
+  enableSections: boolean
+): RenderItem<T>[] {
+  const result: RenderItem<T>[] = [];
+
+  if (items.length === 0) return result;
+
+  if (!enableSections) {
+    // if sections are disabled, return all items as is
+    for (const item of items) {
+      result.push({ type: 'item', item });
+    }
+    return result;
+  }
+
+  const [itemsWithSection, itemsWithoutSection] = partition(items, (item) => !!item.section);
+
+  // process items without sections first
+  for (const item of itemsWithoutSection) {
+    result.push({ type: 'item', item });
+  }
+
+  // return early if no items with sections
+  if (itemsWithSection.length === 0) {
+    return result;
+  }
+
+  // process items with sections next
+  const sections = Array.from(new Set(itemsWithSection.map((item) => item.section)));
+
+  for (const section of sections) {
+    result.push({ type: 'section', sectionName: section as string });
+
+    for (const item of itemsWithSection.filter((item) => item.section === section)) {
+      result.push({ type: 'item', item });
+    }
+  }
+
+  return result;
+}
+
 export interface ListViewRowProps<T extends ListItem> {
   renderedItems: RenderItem<T>[];
+  activeIndex: number;
   isLoading?: boolean;
   isDarkMode?: boolean;
   onItemClick: (item: T) => void;
@@ -55,6 +98,7 @@ const ListViewRow = memo(
     style,
     ariaAttributes,
     renderedItems,
+    activeIndex,
     isLoading,
     isDarkMode,
     onItemClick,
@@ -97,13 +141,19 @@ const ListViewRow = memo(
     const item = renderItem.item;
     const bgColor = isDarkMode ? (item.colorDark ?? item.color) : item.color;
 
+    const isActive = index === activeIndex;
+
     return (
       <ListItemButton
         {...ariaAttributes}
+        tabIndex={-1}
+        id={`toolbox-item-${item.id}`}
+        role="option"
+        aria-selected={isActive}
         style={buttonStyle}
         onClick={handleButtonClick}
         onHoverStart={handleButtonHover}
-        className={isLoading ? 'loading' : ''}
+        className={`${isLoading ? 'loading' : ''} ${isActive ? 'active' : ''}`}
         disabled={isLoading}
       >
         <IconContainerMemoized
@@ -150,8 +200,14 @@ const ListViewRow = memo(
   }
 ) as <T extends ListItem>(props: RowComponentProps<ListViewRowProps<T>>) => React.ReactElement;
 
+export interface ListViewHandle<T extends ListItem = ListItem> {
+  renderedItems: RenderItem<T>[];
+}
+
 interface ListViewProps<T extends ListItem> {
   items: T[];
+  activeIndex?: number;
+  listRef?: React.RefObject<ListImperativeAPI | null>;
   onItemClick: (item: T) => void;
   onItemHover?: (item: T) => void;
   emptyStateMessage?: string;
@@ -160,59 +216,32 @@ interface ListViewProps<T extends ListItem> {
   enableSections?: boolean;
 }
 
-export const ListView = memo(function ListView<T extends ListItem>({
-  items,
-  onItemClick,
-  onItemHover,
-  emptyStateMessage = 'No items found',
-  emptyStateIcon = 'search_off',
-  isLoading = false,
-  enableSections = true,
-}: ListViewProps<T>) {
+const ListViewInner = forwardRef(function ListView<T extends ListItem>(
+  {
+    items,
+    activeIndex = -1,
+    listRef,
+    onItemClick,
+    onItemHover,
+    emptyStateMessage = 'No items found',
+    emptyStateIcon = 'search_off',
+    isLoading = false,
+    enableSections = true,
+  }: ListViewProps<T>,
+  ref: React.Ref<ListViewHandle<T>>
+) {
   const { isDarkMode } = useCanvasTheme();
 
-  const renderedItems = useMemo<RenderItem<T>[]>(() => {
-    const result: RenderItem<T>[] = [];
+  const renderedItems = useMemo(
+    () => buildRenderedItems(items, enableSections),
+    [items, enableSections]
+  );
 
-    if (items.length === 0) return result;
-
-    if (!enableSections) {
-      // if sections are disabled, return all items as is
-      for (const item of items) {
-        result.push({ type: 'item', item });
-      }
-      return result;
-    }
-
-    const [itemsWithSection, itemsWithoutSection] = partition(items, (item) => !!item.section);
-
-    // process items without sections first
-    for (const item of itemsWithoutSection) {
-      result.push({ type: 'item', item });
-    }
-
-    // return early if no items with sections
-    if (itemsWithSection.length === 0) {
-      return result;
-    }
-
-    // process items with sections next
-    const sections = Array.from(new Set(itemsWithSection.map((item) => item.section)));
-
-    for (const section of sections) {
-      result.push({ type: 'section', sectionName: section as string });
-
-      for (const item of itemsWithSection.filter((item) => item.section === section)) {
-        result.push({ type: 'item', item });
-      }
-    }
-
-    return result;
-  }, [items, enableSections]);
+  useImperativeHandle(ref, () => ({ renderedItems }), [renderedItems]);
 
   const rowProps = useMemo(
-    () => ({ renderedItems, isLoading, isDarkMode, onItemClick, onItemHover }),
-    [renderedItems, isLoading, isDarkMode, onItemClick, onItemHover]
+    () => ({ renderedItems, activeIndex, isLoading, isDarkMode, onItemClick, onItemHover }),
+    [renderedItems, activeIndex, isLoading, isDarkMode, onItemClick, onItemHover]
   );
 
   // Only show skeleton loaders when loading and no items exist
@@ -243,6 +272,9 @@ export const ListView = memo(function ListView<T extends ListItem>({
 
   return (
     <StyledList
+      id="toolbox-listbox"
+      role="listbox"
+      listRef={listRef}
       rowProps={rowProps}
       rowComponent={ListViewRow}
       rowCount={renderedItems.length}
@@ -251,3 +283,7 @@ export const ListView = memo(function ListView<T extends ListItem>({
     />
   );
 });
+
+export const ListView = memo(ListViewInner) as <T extends ListItem>(
+  props: ListViewProps<T> & { ref?: React.Ref<ListViewHandle<T>> }
+) => React.ReactElement | null;

--- a/packages/apollo-react/src/canvas/components/Toolbox/SearchBox.tsx
+++ b/packages/apollo-react/src/canvas/components/Toolbox/SearchBox.tsx
@@ -8,6 +8,9 @@ interface SearchBoxProps {
   onChange: (value: string) => void;
   clear: () => void;
   placeholder?: string;
+  inputRef?: React.RefObject<HTMLInputElement | null>;
+  onNavigationKeyDown?: (e: React.KeyboardEvent) => void;
+  activeDescendantId?: string;
 }
 
 export const SearchBox = memo(function SearchBox({
@@ -15,12 +18,16 @@ export const SearchBox = memo(function SearchBox({
   onChange,
   clear,
   placeholder = 'Search...',
+  inputRef: externalInputRef,
+  onNavigationKeyDown,
+  activeDescendantId,
 }: SearchBoxProps) {
-  const inputRef = useRef<HTMLInputElement>(null);
+  const internalRef = useRef<HTMLInputElement>(null);
+  const inputRef = externalInputRef ?? internalRef;
 
   useEffect(() => {
     inputRef.current?.focus();
-  }, []);
+  }, [inputRef]);
 
   return (
     <StyledSearchForm
@@ -36,10 +43,15 @@ export const SearchBox = memo(function SearchBox({
           ref={inputRef}
           autoComplete="off"
           type="text"
+          role="combobox"
+          aria-controls="toolbox-listbox"
+          aria-expanded={true}
           className="searchbox-input"
           placeholder={placeholder}
           value={value}
           onChange={(e) => onChange(e.target.value)}
+          onKeyDown={onNavigationKeyDown}
+          aria-activedescendant={activeDescendantId}
         />
         {value && (
           <button type="button" className="searchbox-clear" onClick={clear}>

--- a/packages/apollo-react/src/canvas/components/Toolbox/Toolbox.test.tsx
+++ b/packages/apollo-react/src/canvas/components/Toolbox/Toolbox.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { render, screen, type UserEvent, userEvent } from '../../utils/testing';
+import { act, render, screen, type UserEvent, userEvent } from '../../utils/testing';
 import type { ListItem } from './ListView';
 import { Toolbox } from './Toolbox';
 
@@ -58,7 +58,7 @@ describe('Toolbox', () => {
       render(<Toolbox {...defaultProps} loading={true} />);
 
       // ListView items should be disabled when loading
-      const items = screen.getAllByRole('button');
+      const items = screen.getAllByRole('option');
 
       for (const item of items) {
         expect(item).toBeDisabled();
@@ -284,6 +284,340 @@ describe('Toolbox', () => {
       // Should navigate back, not close
       expect(screen.getByText('Item 1')).toBeInTheDocument();
       expect(onClose).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Keyboard navigation', () => {
+    let user: UserEvent;
+
+    beforeEach(() => {
+      user = userEvent.setup();
+    });
+
+    const getActiveItem = () => document.querySelector('[aria-selected="true"]');
+
+    it('should move focus from search to first item on ArrowDown', async () => {
+      render(<Toolbox {...defaultProps} />);
+
+      const searchInput = screen.getByPlaceholderText('Search');
+      expect(searchInput).toHaveFocus();
+
+      // ArrowDown from search should highlight first item
+      await user.keyboard('{ArrowDown}');
+
+      const activeItem = getActiveItem();
+      expect(activeItem).toBeInTheDocument();
+      expect(activeItem).toHaveTextContent('Item 1');
+    });
+
+    it('should move focus back to search on ArrowUp from first item', async () => {
+      render(<Toolbox {...defaultProps} />);
+
+      const searchInput = screen.getByPlaceholderText('Search');
+
+      // Navigate to first item
+      await user.keyboard('{ArrowDown}');
+      expect(getActiveItem()).toHaveTextContent('Item 1');
+
+      // ArrowUp should return to search
+      await user.keyboard('{ArrowUp}');
+      expect(getActiveItem()).not.toBeInTheDocument();
+      expect(searchInput).toHaveFocus();
+    });
+
+    it('should navigate between items with ArrowDown/ArrowUp', async () => {
+      render(<Toolbox {...defaultProps} />);
+
+      // Navigate to first item
+      await user.keyboard('{ArrowDown}');
+      expect(getActiveItem()).toHaveTextContent('Item 1');
+
+      // Navigate to second item
+      await user.keyboard('{ArrowDown}');
+      expect(getActiveItem()).toHaveTextContent('Item 2');
+
+      // Navigate back to first item
+      await user.keyboard('{ArrowUp}');
+      expect(getActiveItem()).toHaveTextContent('Item 1');
+    });
+
+    it('should select item with Enter', async () => {
+      const onItemSelect = vi.fn();
+      render(<Toolbox {...defaultProps} onItemSelect={onItemSelect} />);
+
+      // Navigate to first item and press Enter
+      await user.keyboard('{ArrowDown}');
+      await user.keyboard('{Enter}');
+
+      expect(onItemSelect).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'item-1', name: 'Item 1' })
+      );
+    });
+
+    it('should navigate into children with Enter on item with children', async () => {
+      render(<Toolbox {...defaultProps} />);
+
+      // Navigate to Item 2 (has children) and press Enter
+      await user.keyboard('{ArrowDown}');
+      await user.keyboard('{ArrowDown}');
+      expect(getActiveItem()).toHaveTextContent('Item 2');
+
+      await user.keyboard('{Enter}');
+
+      // Should now show children
+      expect(screen.getByText('Child 1')).toBeInTheDocument();
+      expect(screen.queryByText('Item 1')).not.toBeInTheDocument();
+      // Active index should reset
+      expect(getActiveItem()).not.toBeInTheDocument();
+    });
+
+    it('should jump to first item on Home', async () => {
+      render(<Toolbox {...defaultProps} />);
+
+      // Navigate to second item
+      await user.keyboard('{ArrowDown}');
+      await user.keyboard('{ArrowDown}');
+      expect(getActiveItem()).toHaveTextContent('Item 2');
+
+      // Home should jump to first item
+      await user.keyboard('{Home}');
+      expect(getActiveItem()).toHaveTextContent('Item 1');
+    });
+
+    it('should jump to last item on End', async () => {
+      render(<Toolbox {...defaultProps} />);
+
+      // Navigate to first item
+      await user.keyboard('{ArrowDown}');
+      expect(getActiveItem()).toHaveTextContent('Item 1');
+
+      // End should jump to last item
+      await user.keyboard('{End}');
+      expect(getActiveItem()).toHaveTextContent('Item 2');
+    });
+
+    it('should reset active index when search query changes', async () => {
+      render(<Toolbox {...defaultProps} />);
+
+      // Navigate to an item
+      await user.keyboard('{ArrowDown}');
+      expect(getActiveItem()).toHaveTextContent('Item 1');
+
+      // Type in search — focus returns to input, active index resets
+      const searchInput = screen.getByPlaceholderText('Search');
+      await user.click(searchInput);
+      await user.type(searchInput, 'a');
+
+      expect(getActiveItem()).not.toBeInTheDocument();
+    });
+
+    it('should reset active index when navigating into children', async () => {
+      render(<Toolbox {...defaultProps} />);
+
+      // Highlight Item 2 (has children)
+      await user.keyboard('{ArrowDown}');
+      await user.keyboard('{ArrowDown}');
+      expect(getActiveItem()).toHaveTextContent('Item 2');
+
+      // Click to navigate into children — active index should reset
+      await user.click(screen.getByText('Item 2'));
+      expect(screen.getByText('Child 1')).toBeInTheDocument();
+      expect(getActiveItem()).not.toBeInTheDocument();
+    });
+
+    it('should skip section headers during navigation', async () => {
+      const itemsWithSections: ListItem[] = [
+        {
+          id: 'unsectioned',
+          name: 'Unsectioned Item',
+          data: {},
+          icon: { name: 'star' },
+        },
+        {
+          id: 'sectioned-1',
+          name: 'Sectioned Item 1',
+          data: {},
+          icon: { name: 'star' },
+          section: 'Group A',
+        },
+        {
+          id: 'sectioned-2',
+          name: 'Sectioned Item 2',
+          data: {},
+          icon: { name: 'star' },
+          section: 'Group A',
+        },
+      ];
+
+      render(<Toolbox {...defaultProps} initialItems={itemsWithSections} />);
+
+      // First ArrowDown: Unsectioned Item
+      await user.keyboard('{ArrowDown}');
+      expect(getActiveItem()).toHaveTextContent('Unsectioned Item');
+
+      // Second ArrowDown: should skip "Group A" header and land on Sectioned Item 1
+      await user.keyboard('{ArrowDown}');
+      expect(getActiveItem()).toHaveTextContent('Sectioned Item 1');
+
+      // Third ArrowDown: Sectioned Item 2
+      await user.keyboard('{ArrowDown}');
+      expect(getActiveItem()).toHaveTextContent('Sectioned Item 2');
+    });
+
+    it('should work with ArrowDown after search filters results', async () => {
+      render(<Toolbox {...defaultProps} />);
+
+      const searchInput = screen.getByPlaceholderText('Search');
+      await user.type(searchInput, 'Child');
+
+      // Wait for search results
+      expect(screen.getByText('Child 1')).toBeInTheDocument();
+
+      // ArrowDown from search into filtered results
+      await user.keyboard('{ArrowDown}');
+      expect(getActiveItem()).toHaveTextContent('Child 1');
+    });
+
+    it('should navigate into children with ArrowRight on item with children', async () => {
+      render(<Toolbox {...defaultProps} />);
+
+      // Navigate to Item 2 (has children)
+      await user.keyboard('{ArrowDown}');
+      await user.keyboard('{ArrowDown}');
+      expect(getActiveItem()).toHaveTextContent('Item 2');
+
+      // ArrowRight should drill into children
+      await user.keyboard('{ArrowRight}');
+      expect(screen.getByText('Child 1')).toBeInTheDocument();
+      expect(screen.queryByText('Item 1')).not.toBeInTheDocument();
+    });
+
+    it('should not navigate with ArrowRight on leaf item', async () => {
+      render(<Toolbox {...defaultProps} />);
+
+      // Navigate to Item 1 (no children)
+      await user.keyboard('{ArrowDown}');
+      expect(getActiveItem()).toHaveTextContent('Item 1');
+
+      // ArrowRight should do nothing
+      await user.keyboard('{ArrowRight}');
+      expect(screen.getByText('Item 1')).toBeInTheDocument();
+      expect(screen.getByText('Item 2')).toBeInTheDocument();
+    });
+
+    it('should navigate back with ArrowLeft when in nested view', async () => {
+      vi.useFakeTimers({ shouldAdvanceTime: true });
+      const timedUser = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+
+      render(<Toolbox {...defaultProps} />);
+
+      // Navigate to Item 2 and drill in with ArrowRight
+      await timedUser.keyboard('{ArrowDown}');
+      await timedUser.keyboard('{ArrowDown}');
+      await timedUser.keyboard('{ArrowRight}');
+      expect(screen.getByText('Child 1')).toBeInTheDocument();
+
+      // Advance past transition duration (150ms)
+      await act(() => vi.advanceTimersByTimeAsync(200));
+
+      // Highlight a child
+      await timedUser.keyboard('{ArrowDown}');
+      expect(getActiveItem()).toHaveTextContent('Child 1');
+
+      // ArrowLeft should go back to parent
+      await timedUser.keyboard('{ArrowLeft}');
+      expect(screen.getByText('Item 1')).toBeInTheDocument();
+      expect(screen.getByText('Item 2')).toBeInTheDocument();
+
+      vi.useRealTimers();
+    });
+
+    it('should wrap to first item when ArrowDown is pressed at last item', async () => {
+      render(<Toolbox {...defaultProps} />);
+
+      // Navigate to last item (Item 2)
+      await user.keyboard('{ArrowDown}');
+      await user.keyboard('{ArrowDown}');
+      expect(getActiveItem()).toHaveTextContent('Item 2');
+
+      // ArrowDown at last item should wrap to first
+      await user.keyboard('{ArrowDown}');
+      expect(getActiveItem()).toHaveTextContent('Item 1');
+    });
+
+    it('should move focus down with Tab and up with Shift+Tab', async () => {
+      render(<Toolbox {...defaultProps} />);
+
+      const searchInput = screen.getByPlaceholderText('Search');
+      expect(searchInput).toHaveFocus();
+
+      // Tab from search should highlight first item
+      await user.keyboard('{Tab}');
+      expect(getActiveItem()).toHaveTextContent('Item 1');
+
+      // Tab should move to next item
+      await user.keyboard('{Tab}');
+      expect(getActiveItem()).toHaveTextContent('Item 2');
+
+      // Shift+Tab should move back up
+      await user.keyboard('{Shift>}{Tab}{/Shift}');
+      expect(getActiveItem()).toHaveTextContent('Item 1');
+
+      // Shift+Tab from first item should return to search
+      await user.keyboard('{Shift>}{Tab}{/Shift}');
+      expect(getActiveItem()).not.toBeInTheDocument();
+      expect(searchInput).toHaveFocus();
+    });
+
+    it('should navigate back with ArrowLeft from empty search input in nested view', async () => {
+      vi.useFakeTimers({ shouldAdvanceTime: true });
+      const timedUser = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+
+      render(<Toolbox {...defaultProps} />);
+
+      // Navigate into children
+      await timedUser.keyboard('{ArrowDown}');
+      await timedUser.keyboard('{ArrowDown}');
+      await timedUser.keyboard('{ArrowRight}');
+      expect(screen.getByText('Child 1')).toBeInTheDocument();
+
+      // Advance past transition duration
+      await act(() => vi.advanceTimersByTimeAsync(200));
+
+      // Focus is on search input (activeIndex === -1), search is empty
+      // ArrowLeft should navigate back
+      await timedUser.keyboard('{ArrowLeft}');
+      expect(screen.getByText('Item 1')).toBeInTheDocument();
+      expect(screen.getByText('Item 2')).toBeInTheDocument();
+
+      vi.useRealTimers();
+    });
+
+    it('should not navigate back with ArrowLeft when search has text', async () => {
+      vi.useFakeTimers({ shouldAdvanceTime: true });
+      const timedUser = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+
+      render(<Toolbox {...defaultProps} />);
+
+      // Navigate into children
+      await timedUser.keyboard('{ArrowDown}');
+      await timedUser.keyboard('{ArrowDown}');
+      await timedUser.keyboard('{ArrowRight}');
+      expect(screen.getByText('Child 1')).toBeInTheDocument();
+
+      // Advance past transition duration
+      await act(() => vi.advanceTimersByTimeAsync(200));
+
+      // Type in search box
+      const searchInput = screen.getByPlaceholderText('Search');
+      await timedUser.type(searchInput, 'Child');
+
+      // ArrowLeft should not navigate back — allow cursor movement in search
+      await timedUser.keyboard('{ArrowLeft}');
+      expect(screen.queryByText('Item 1')).not.toBeInTheDocument();
+      expect(screen.getByText('Child 1')).toBeInTheDocument();
+
+      vi.useRealTimers();
     });
   });
 

--- a/packages/apollo-react/src/canvas/components/Toolbox/Toolbox.tsx
+++ b/packages/apollo-react/src/canvas/components/Toolbox/Toolbox.tsx
@@ -1,14 +1,16 @@
 import { useNavigationStack } from '@uipath/apollo-react/canvas/hooks';
 import { Column } from '@uipath/apollo-react/canvas/layouts';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useListRef } from 'react-window';
 import { Header } from './Header';
-import { type ListItem, ListView } from './ListView';
+import { type ListItem, ListView, type ListViewHandle, type RenderItem } from './ListView';
 import { SearchBox } from './SearchBox';
 import { AnimatedContainer, AnimatedContent } from './Toolbox.styles';
 
 type AnimationDirection = 'forward' | 'back';
 
 const TRANSITION_DURATION = 150;
+const SEARCH_BAR_INDEX = -1;
 
 /**
  * BFS for item by id.
@@ -58,6 +60,34 @@ export interface ToolboxProps<T> {
   onSearch?: ToolboxSearchHandler<T>;
 }
 
+function getNextSelectableIndex(
+  renderedItems: RenderItem<ListItem>[],
+  currentIndex: number,
+  direction: 'up' | 'down'
+): number {
+  const numericDirection = direction === 'up' ? -1 : 1;
+  let next = currentIndex + numericDirection;
+  while (next >= 0 && next < renderedItems.length) {
+    if (renderedItems[next]?.type === 'item') return next;
+    next += numericDirection;
+  }
+  return SEARCH_BAR_INDEX;
+}
+
+function getFirstSelectableIndex(renderedItems: RenderItem<ListItem>[]): number {
+  for (let i = 0; i < renderedItems.length; i++) {
+    if (renderedItems[i]?.type === 'item') return i;
+  }
+  return SEARCH_BAR_INDEX;
+}
+
+function getLastSelectableIndex(renderedItems: RenderItem<ListItem>[]): number {
+  for (let i = renderedItems.length - 1; i >= 0; i--) {
+    if (renderedItems[i]?.type === 'item') return i;
+  }
+  return SEARCH_BAR_INDEX;
+}
+
 function searchLeafItems<T>(items: ListItem<T>[], query: string): ListItem<T>[] {
   const results: ListItem<T>[] = [];
 
@@ -101,12 +131,22 @@ export function Toolbox<T>({
     parentItem: ListItem<T> | null;
   }>();
 
+  const [activeIndex, setActiveIndex] = useState(SEARCH_BAR_INDEX);
+
   const containerRef = useRef<HTMLDivElement>(null);
   const transitionTimeoutRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
   const searchIdRef = useRef(0);
   const initialItemsRef = useRef(initialItems);
+  const listRef = useListRef(null);
+  const listViewRef = useRef<ListViewHandle<ListItem<T>>>(null);
+  const searchInputRef = useRef<HTMLInputElement>(null);
 
   const isSearching = useMemo(() => search.length > 0, [search]);
+
+  const displayedItems = useMemo(
+    () => (isSearching && !isSearchingInitialItems ? searchedItems : items),
+    [isSearching, isSearchingInitialItems, searchedItems, items]
+  );
 
   const startTransition = useCallback((direction: AnimationDirection) => {
     if (transitionTimeoutRef.current) {
@@ -121,11 +161,26 @@ export function Toolbox<T>({
     }, TRANSITION_DURATION);
   }, []);
 
+  const navigateToIndex = useCallback(
+    (index: number) => {
+      setActiveIndex(index);
+
+      if (index === SEARCH_BAR_INDEX) {
+        searchInputRef.current?.focus();
+        return;
+      }
+
+      listRef.current?.scrollToRow({ index, align: 'auto' });
+    },
+    [listRef]
+  );
+
   const clearSearch = useCallback(() => {
     setSearch('');
     setSearchedItems([]);
     setSearchLoading(false);
     setIsSearchingInitialItems(true);
+    setActiveIndex(SEARCH_BAR_INDEX);
   }, []);
 
   const handleSearch = useCallback(
@@ -139,6 +194,7 @@ export function Toolbox<T>({
       }
 
       setSearch(query);
+      setActiveIndex(SEARCH_BAR_INDEX);
       searchIdRef.current += 1;
       const currentRequestId = searchIdRef.current;
 
@@ -162,6 +218,7 @@ export function Toolbox<T>({
 
   const handleBackTransition = useCallback(() => {
     startTransition('back');
+    setActiveIndex(SEARCH_BAR_INDEX);
 
     const previousState = navigationStack.pop();
 
@@ -195,6 +252,7 @@ export function Toolbox<T>({
       setItems(nestedItems);
       setCurrentParentItem(item);
       clearSearch();
+      setActiveIndex(SEARCH_BAR_INDEX);
       startTransition('forward');
       setChildrenLoading(false);
     },
@@ -283,6 +341,113 @@ export function Toolbox<T>({
     }
   }, [items]);
 
+  const activeDescendantId = useMemo(() => {
+    if (activeIndex < 0) return undefined;
+    const renderItem = listViewRef.current?.renderedItems[activeIndex];
+    if (renderItem?.type === 'item') return `toolbox-item-${renderItem.item.id}`;
+    return undefined;
+  }, [activeIndex]);
+
+  const handleNavigationKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (isTransitioning) return;
+
+      const renderedItems = listViewRef.current?.renderedItems ?? [];
+
+      const navigateDown = () => {
+        if (activeIndex === SEARCH_BAR_INDEX) {
+          const firstIndex = getFirstSelectableIndex(renderedItems);
+          if (firstIndex !== SEARCH_BAR_INDEX) navigateToIndex(firstIndex);
+        } else {
+          const nextIndex = getNextSelectableIndex(renderedItems, activeIndex, 'down');
+          if (nextIndex !== SEARCH_BAR_INDEX) {
+            navigateToIndex(nextIndex);
+          } else {
+            const firstIndex = getFirstSelectableIndex(renderedItems);
+            if (firstIndex !== SEARCH_BAR_INDEX) navigateToIndex(firstIndex);
+          }
+        }
+      };
+
+      const navigateUp = () => {
+        navigateToIndex(getNextSelectableIndex(renderedItems, activeIndex, 'up'));
+      };
+
+      switch (e.key) {
+        case 'ArrowDown': {
+          e.preventDefault();
+          navigateDown();
+          break;
+        }
+        case 'ArrowUp': {
+          e.preventDefault();
+          navigateUp();
+          break;
+        }
+        case 'Enter': {
+          if (activeIndex === SEARCH_BAR_INDEX) break;
+
+          const renderItem = renderedItems[activeIndex];
+          if (renderItem?.type === 'item') {
+            e.preventDefault();
+            handleItemSelect(renderItem.item);
+          }
+          break;
+        }
+        case 'ArrowRight': {
+          const renderItem = renderedItems[activeIndex];
+          if (renderItem?.type === 'item' && renderItem.item.children) {
+            e.preventDefault();
+            handleItemSelect(renderItem.item);
+          }
+          break;
+        }
+        case 'ArrowLeft': {
+          if (!navigationStack.canGoBack || (activeIndex === SEARCH_BAR_INDEX && search.length > 0))
+            return;
+
+          e.preventDefault();
+          handleBackTransition();
+          break;
+        }
+        case 'Tab': {
+          e.preventDefault();
+          if (e.shiftKey) {
+            navigateUp();
+          } else {
+            navigateDown();
+          }
+          break;
+        }
+        case 'Home': {
+          if (activeIndex === SEARCH_BAR_INDEX) break;
+
+          e.preventDefault();
+          const firstIndex = getFirstSelectableIndex(renderedItems);
+          if (firstIndex !== SEARCH_BAR_INDEX) navigateToIndex(firstIndex);
+          break;
+        }
+        case 'End': {
+          if (activeIndex === SEARCH_BAR_INDEX) break;
+
+          e.preventDefault();
+          const lastIndex = getLastSelectableIndex(renderedItems);
+          if (lastIndex !== SEARCH_BAR_INDEX) navigateToIndex(lastIndex);
+          break;
+        }
+      }
+    },
+    [
+      search,
+      isTransitioning,
+      activeIndex,
+      navigationStack.canGoBack,
+      navigateToIndex,
+      handleItemSelect,
+      handleBackTransition,
+    ]
+  );
+
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
       if (e.key === 'Escape') {
@@ -333,17 +498,23 @@ export function Toolbox<T>({
           onChange={handleSearch}
           clear={clearSearch}
           placeholder="Search"
+          inputRef={searchInputRef}
+          onNavigationKeyDown={handleNavigationKeyDown}
+          activeDescendantId={activeDescendantId}
         />
 
         <AnimatedContainer>
           <AnimatedContent entering={isTransitioning} direction={animationDirection}>
             <ListView
+              ref={listViewRef}
               isLoading={childrenLoading || searchLoading || loading}
-              items={isSearching && !isSearchingInitialItems ? searchedItems : items}
+              items={displayedItems}
+              activeIndex={activeIndex}
+              listRef={listRef}
               emptyStateMessage={isSearching ? 'No matching nodes found' : 'No nodes found'}
-              enableSections={!isSearching}
               onItemClick={handleItemSelect}
               onItemHover={onItemHover}
+              enableSections={!isSearching}
             />
           </AnimatedContent>
         </AnimatedContainer>

--- a/packages/apollo-react/src/test/canvas-mocks.ts
+++ b/packages/apollo-react/src/test/canvas-mocks.ts
@@ -328,6 +328,7 @@ vi.mock('react-window', () => ({
         )
       )
     ),
+  useListRef: () => React.useRef(null),
 }));
 
 // Mock @mui/x-tree-view to avoid ESM directory import issues


### PR DESCRIPTION
## Summary

Adds full keyboard navigation and ARIA-compliant focus locking to the Toolbox (AddNodePanel). Users can:
- navigate items vertically with up and down arrow keys (or tab/shift-tab)
- select with `Enter`
- drill into/out of categories with left and right arrow keys
- jump to first/last with `Home`/`End`

The search input acts as a combobox with `aria-activedescendant` pointing into the listbox, satisfying the WAI-ARIA spec ([condition 3](https://www.w3.org/WAI/ARIA/apg/practices/keyboard-interface/#kbd_focus_activedescendant:~:text=The%20focused%20referencing%20element%20has%20role,a%20descendant%20of%20the%20controlled%20element.)). Also refactors `renderedItems` ownership into ListView via `useImperativeHandle`, so Toolbox reads it from a ref instead of recomputing it.

https://github.com/user-attachments/assets/3737b90c-36c2-434d-aa15-a6d862a4156c

## Changes

- Add `onNavigationKeyDown` and `activeDescendantId` to `SearchBox` input
- Add `role="combobox"`, `aria-controls`, and `aria-expanded` to search input for ARIA compliance
- Add `id="toolbox-listbox"` to the virtualized list
- Add keyboard handler in `Toolbox` for ArrowDown/Up/Left/Right, Enter, Home, End
- Move `renderedItems` computation into `ListView`, expose via `useImperativeHandle`
- Add `ListViewHandle` interface and `enableSections` prop to `ListView`
- Add comprehensive keyboard navigation tests to `Toolbox.test.tsx`

## Flow

```mermaid
flowchart TD
    A[SearchBox input] -->|onKeyDown| B[Toolbox handleNavigationKeyDown]
    B -->|ArrowDown/Up| C[navigateToIndex]
    B -->|Enter/ArrowRight| D[handleItemSelect]
    B -->|ArrowLeft| E[handleBackTransition]
    C -->|scrollToRow| F[ListView ref]
    F -->|useImperativeHandle| G[renderedItems]
    A -->|aria-activedescendant| H[toolbox-item-id]
    A -->|aria-controls| I[toolbox-listbox]
```

## Testing

- [x] `pnpm run test` passes (64 suites, 1254 tests)
- [x] `pnpm run typecheck` passes
- [x] Manual testing
    - [x] Left/right arrows should navigate out of parents/into children respectively
    - [x] Navigate vertically and horizontally, then attempt typing (focus should still be on search bar). Repeat in reverse order
    - [x] Navigate with shift + tab/tab and then up/down arrow keys, sequentially
    - [x] Ensure client scrolls when selecting an element outside of current content area 
- [x] Try to tab out of `AddNodePanel`. Focus should remain within component
- [x] Other `Toolbox` consumers
   - [x] Ensure `StageNode`'s `FloatingCanvasPanel` functions as expected

https://github.com/user-attachments/assets/239412ff-4321-4677-992d-7586c751c6c6

- [x] Unit tests added/updated where relevant
