### PR TITLE
feat(apollo-react): add line break support to sticky notes [MST-7431]

### DIFF
--- a/packages/apollo-react/src/canvas/components/StickyNoteNode/StickyNoteNode.styles.ts
+++ b/packages/apollo-react/src/canvas/components/StickyNoteNode/StickyNoteNode.styles.ts
@@ -5,6 +5,31 @@ import { motion } from 'motion/react';
 // Sticky notes must be below edges (z-index: 0). We use -10 instead of -1 to allow for future layers between sticky notes and edges if needed.
 export const STICKY_NOTE_BELOW_EDGE_Z_INDEX = -10;
 
+const stickyNoteContentStyles = `
+  width: 100%;
+  height: 100%;
+
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+  font-size: 14px;
+  line-height: 1.5;
+  color: var(--uix-canvas-foreground);
+
+  overflow-y: auto;
+
+  &::-webkit-scrollbar {
+    width: 6px;
+  }
+
+  &::-webkit-scrollbar-track {
+    background: transparent;
+  }
+
+  &::-webkit-scrollbar-thumb {
+    background: var(--uix-canvas-border);
+    border-radius: 4px;
+  }
+`;
+
 // Resize controls need to be above the sticky note content to be interactable
 export const RESIZE_CONTROL_Z_INDEX = 100;
 
@@ -54,21 +79,15 @@ export const StickyNoteContainer = styled.div<{
 `;
 
 export const StickyNoteTextArea = styled.textarea<{ isEditing: boolean }>`
-  width: 100%;
-  height: 100%;
+  ${stickyNoteContentStyles}
+
   background: transparent;
   border: none;
   outline: none;
   resize: none;
-  font-family:
-    -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
-  font-size: 14px;
-  line-height: 1.5;
-  color: var(--uix-canvas-foreground);
   cursor: ${(props) => (props.isEditing ? 'text' : 'move')};
   user-select: ${(props) => (props.isEditing ? 'text' : 'none')};
   pointer-events: ${(props) => (props.isEditing ? 'auto' : 'none')};
-  overflow-y: auto;
 
   &::placeholder {
     color: var(--uix-canvas-foreground-de-emp);
@@ -82,14 +101,8 @@ export const StickyNoteTextArea = styled.textarea<{ isEditing: boolean }>`
 `;
 
 export const StickyNoteMarkdown = styled.div`
-  width: 100%;
-  height: 100%;
-  overflow-y: auto;
-  font-family:
-    -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
-  font-size: 14px;
-  line-height: 1.5;
-  color: var(--uix-canvas-foreground);
+  ${stickyNoteContentStyles}
+
   word-wrap: break-word;
 
   /* Markdown styles */

--- a/packages/apollo-react/src/canvas/components/StickyNoteNode/StickyNoteNode.tsx
+++ b/packages/apollo-react/src/canvas/components/StickyNoteNode/StickyNoteNode.tsx
@@ -1,7 +1,7 @@
 import { Global } from '@emotion/react';
+import { NodeIcon } from '@uipath/apollo-react/canvas';
 import type { NodeProps } from '@uipath/apollo-react/canvas/xyflow/react';
 import { NodeResizeControl, useReactFlow } from '@uipath/apollo-react/canvas/xyflow/react';
-import { NodeIcon } from '@uipath/apollo-react/canvas';
 import { AnimatePresence } from 'motion/react';
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import ReactMarkdown from 'react-markdown';
@@ -24,6 +24,7 @@ import {
 } from './StickyNoteNode.styles';
 import type { StickyNoteColor, StickyNoteData } from './StickyNoteNode.types';
 import { STICKY_NOTE_COLORS, withAlpha } from './StickyNoteNode.types';
+import { preserveNewlines } from './StickyNoteNode.utils';
 
 export interface StickyNoteNodeProps extends NodeProps {
   data: StickyNoteData;
@@ -212,7 +213,7 @@ const StickyNoteNodeComponent = ({
       position: 'top' as const,
       align: 'center' as const,
     };
-  }, [handleEditClick, handleToggleColorPicker, color]);
+  }, [handleEditClick, handleToggleColorPicker, color, handleDelete]);
 
   return (
     <>
@@ -291,7 +292,7 @@ const StickyNoteNodeComponent = ({
             <StickyNoteMarkdown>
               {localContent ? (
                 <ReactMarkdown remarkPlugins={[remarkGfm]} components={markdownComponents}>
-                  {localContent}
+                  {preserveNewlines(localContent)}
                 </ReactMarkdown>
               ) : (
                 // Render placeholder if renderPlaceholderOnSelect is enabled, node is selected, and the content is empty

--- a/packages/apollo-react/src/canvas/components/StickyNoteNode/StickyNoteNode.utils.test.ts
+++ b/packages/apollo-react/src/canvas/components/StickyNoteNode/StickyNoteNode.utils.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import { preserveNewlines } from './StickyNoteNode.utils';
+
+describe('preserveNewlines', () => {
+  it('returns input unchanged when there are no newlines', () => {
+    expect(preserveNewlines('hello world')).toBe('hello world');
+  });
+
+  it('returns input unchanged for single newline', () => {
+    expect(preserveNewlines('hello\nworld')).toBe('hello\nworld');
+  });
+
+  it('returns input unchanged for double newline (standard paragraph break)', () => {
+    expect(preserveNewlines('hello\n\nworld')).toBe('hello\n\nworld');
+  });
+
+  it('preserves triple newline as paragraph break + one &nbsp; line', () => {
+    expect(preserveNewlines('hey\n\n\nhey')).toBe('hey\n\n&nbsp;\n\nhey');
+  });
+
+  it('preserves four newlines as paragraph break + two &nbsp; lines', () => {
+    expect(preserveNewlines('hey\n\n\n\nhey')).toBe('hey\n\n&nbsp;\n\n&nbsp;\n\nhey');
+  });
+
+  it('handles multiple groups of excess newlines', () => {
+    const input = 'a\n\n\nb\n\n\n\nc';
+    const result = preserveNewlines(input);
+    expect(result).toBe('a\n\n&nbsp;\n\nb\n\n&nbsp;\n\n&nbsp;\n\nc');
+  });
+
+  it('returns empty string unchanged', () => {
+    expect(preserveNewlines('')).toBe('');
+  });
+
+  it('does not modify newlines inside code blocks', () => {
+    const input = '```\nline1\n\n\n\nline2\n```';
+    const result = preserveNewlines(input);
+    // Code block content should not have &nbsp; inserted
+    expect(result).not.toContain('&nbsp;');
+    expect(result).toContain('line1\n\n\n\nline2');
+  });
+
+  it('preserves newlines outside code blocks but not inside', () => {
+    const input = 'before\n\n\ncode:\n```\na\n\n\n\nb\n```\n\n\nafter';
+    const result = preserveNewlines(input);
+    // Outside code block: \n\n\n → \n\n&nbsp;\n\n
+    // Inside code block: unchanged
+    expect(result).toContain('before\n\n&nbsp;\n\ncode:');
+    expect(result).toContain('```\na\n\n\n\nb\n```');
+    expect(result).toContain('\n\n&nbsp;\n\nafter');
+  });
+
+  it('handles multiple code blocks', () => {
+    const input = '```a```\n\n\n```b```';
+    const result = preserveNewlines(input);
+    expect(result).toContain('```a```');
+    expect(result).toContain('```b```');
+  });
+
+  it('preserves header formatting', () => {
+    expect(preserveNewlines('# Title\n\nContent')).toBe('# Title\n\nContent');
+    expect(preserveNewlines('## Subtitle\n\nContent')).toBe('## Subtitle\n\nContent');
+  });
+});

--- a/packages/apollo-react/src/canvas/components/StickyNoteNode/StickyNoteNode.utils.ts
+++ b/packages/apollo-react/src/canvas/components/StickyNoteNode/StickyNoteNode.utils.ts
@@ -1,0 +1,24 @@
+// Markdown collapses 3+ consecutive newlines into a single paragraph break.
+// Insert &nbsp; paragraphs to prevent markdown parser from collapsing consecutive newlines.
+export const preserveNewlines = (markdown: string): string => {
+  // Temporarily replace code blocks to prevent &nbsp; insertion
+  const codeBlocks: string[] = [];
+  let result = markdown.replace(/```[\s\S]*?```/g, (m) => {
+    codeBlocks.push(m);
+    return `\n%%CODE_BLOCK_${codeBlocks.length - 1}%%\n`;
+  });
+
+  // Replace runs of 3+ newlines (beyond the standard \n\n paragraph break)
+  // with \n\n followed by &nbsp;\n for each extra line
+  result = result.replace(/\n{3,}/g, (match) => {
+    const extraBreaks = match.length - 2;
+    return `\n\n${'&nbsp;\n\n'.repeat(extraBreaks)}`;
+  });
+
+  // Restore code blocks
+  result = result.replace(/%%CODE_BLOCK_(\d+)%%/g, (_, i) => {
+    return codeBlocks[Number(i)] ?? '';
+  });
+
+  return result;
+};


### PR DESCRIPTION
This PR adds support for preserving newlines for display in our markdown renderer within `StickyNoteNode`.

In markdown, newlines are treated as content delimiters (they mark separation between content blocks). As a result, the markdown parser collapses consecutive blank lines into a single paragraph break.

This method is a bit of a hack -- so much so that it's documented [here](https://www.markdownguide.org/hacks/). To preserve extra blank lines, we replace runs of 3+ `\n` with `\n\n`-separated `&nbsp;` characters so that the markdown renderer treats the `&nbsp;` as a standalone HTML element that is separated from other blocks by newlines.

**Additional changes**
- Sticky note scrollbar styled
    - scrollbar track made transparent

### Before
https://github.com/user-attachments/assets/d17dc503-82c1-42ab-b63b-65eed5fb39da


### After
https://github.com/user-attachments/assets/8a733b98-9dad-441d-91d2-663af12fb1b1


### Tests
- [x] Headings, lists, code blocks, and tables render as they did before w/o extra newlines
- [x] Newlines are preserved correctly within tables
- [x] Newlines are preserved correctly within code blocks

## Note
If we highly value features like newline preservation and text alignment in our sticky notes, it might be worth considering using a `WYSIWYG` editor instead.

# Available options/rationale
### Why preprocessing?
I went with string preprocessing over attempting writing a `remark` plugin because I don't want to formalize a workaround for an established spec. This solution works well for our needs at the moment.

**Option A (preprocessing)**
The method that's used in this PR.

- Take markdown typed in by user
- Replace runs of 3+ `\n` with `\n\n`-separated `&nbsp;` characters

| Pros | Cons |
| ------------- | ------------- |
| Easy to understand and debug | Uses `&nbsp;` HTML entity nodes instead of more understandable semantic break nodes  |              
| Does not depend on `micromark`'s API | |          

**Option B (`remark` plugin)**
This solution involves 3 steps at different layers of the parse pipeline:
1. `micromark` syntax extension — tokenize consecutive `\n` as a real token                                                             
2. `mdast` extension — map token to `{ type: 'extraBreaks', count: N }`                                                  
3. `hast` handler — convert node to `<br>` elements             
                                                                   
| Pros | Cons |
| ------------- | ------------- |
| Doesn't involve mutating input directly |  Harder to debug when something goes wrong  |              
| Safe for round-tripping (markdown → AST → markdown) | `micromark`'s API is sparsely documented and can change between versions |
| Publishable as a standalone package | |

