### PR TITLE
refactor(apollo-vertex): decouple shell components from framework-specific routing []

### DIFF
--- a/apps/apollo-vertex/app/vertex-components/shell/page.mdx
+++ b/apps/apollo-vertex/app/vertex-components/shell/page.mdx
@@ -1,13 +1,9 @@
-import { ShellTemplate } from '@/templates/ShellTemplate';
-
 # Shell
 
 A component that includes OAuth2 authentication and a collapsible sidebar.
 
 <div className="not-prose my-8 rounded-lg overflow-hidden" style={{ height: '600px' }}>
-  <div className="[&_.h-screen]:!h-full h-full">
-    <ShellTemplate />
-  </div>
+  <iframe src="/preview/shell/dashboard" className="w-full h-full border-0" />
 </div>
 
 <a href="/preview/shell/dashboard" target="_blank" rel="noopener noreferrer">Open standalone preview ↗</a>
@@ -17,9 +13,7 @@ A component that includes OAuth2 authentication and a collapsible sidebar.
 Use the `variant="minimal"` prop to render a horizontal header layout instead of the default sidebar.
 
 <div className="not-prose my-8 rounded-lg overflow-hidden" style={{ height: '600px' }}>
-  <div className="[&_.h-screen]:!h-full h-full">
-    <ShellTemplate variant="minimal" />
-  </div>
+  <iframe src="/preview/shell-minimal" className="w-full h-full border-0" />
 </div>
 
 <a href="/preview/shell-minimal" target="_blank" rel="noopener noreferrer">Open standalone preview ↗</a>
@@ -43,6 +37,7 @@ The `ApolloShell` component must be wrapped in a `QueryClientProvider` from `@ta
 
 ```tsx
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { Link, useLocation } from '@tanstack/react-router';
 import { Home, Settings } from 'lucide-react';
 import { ApolloShell } from '@/components/ui/shell';
 
@@ -54,6 +49,8 @@ const navItems = [
 ];
 
 function App() {
+  const { pathname } = useLocation();
+
   return (
     <QueryClientProvider client={queryClient}>
       <ApolloShell
@@ -63,6 +60,8 @@ function App() {
         companyName="Your Company"
         productName="Your Product"
         navItems={navItems}
+        linkComponent={Link}
+        pathname={pathname}
       >
         {/* your authenticated app content */}
         <YourApp />

--- a/apps/apollo-vertex/package.json
+++ b/apps/apollo-vertex/package.json
@@ -55,7 +55,6 @@
     "@tailwindcss/postcss": "^4.1.17",
     "@tanstack/react-query": "^5.90.21",
     "@tanstack/react-table": "^8.21.3",
-    "@tanstack/react-router": "^1.132.31",
     "@uidotdev/usehooks": "^2.4.1",
     "@vercel/analytics": "^1.5.0",
     "class-variance-authority": "^0.7.1",

--- a/apps/apollo-vertex/registry.json
+++ b/apps/apollo-vertex/registry.json
@@ -871,6 +871,10 @@
       "files": [
         { "path": "registry/shell/shell.tsx", "type": "registry:ui" },
         {
+          "path": "registry/shell/shell-router-context.tsx",
+          "type": "registry:ui"
+        },
+        {
           "path": "registry/shell/shell-layout.tsx",
           "type": "registry:ui"
         },

--- a/apps/apollo-vertex/registry/shell/shell-minimal-nav-item.tsx
+++ b/apps/apollo-vertex/registry/shell/shell-minimal-nav-item.tsx
@@ -1,5 +1,5 @@
-import { Link, useLocation } from "@tanstack/react-router";
 import { cn } from "@/lib/utils";
+import { ShellLink, useShellPathname } from "./shell-router-context";
 import { Text } from "./shell-text";
 import type { TranslationKey } from "./shell-translation-key";
 
@@ -9,11 +9,11 @@ interface MinimalNavItemProps {
 }
 
 export const MinimalNavItem = ({ to, label }: MinimalNavItemProps) => {
-  const { pathname } = useLocation();
+  const pathname = useShellPathname();
   const isActive = pathname === to;
 
   return (
-    <Link
+    <ShellLink
       to={to}
       className={cn(
         "px-4 py-1.5 rounded-full text-sm font-medium transition-colors duration-200 shrink-0 whitespace-nowrap",
@@ -23,6 +23,6 @@ export const MinimalNavItem = ({ to, label }: MinimalNavItemProps) => {
       )}
     >
       <Text value={label} />
-    </Link>
+    </ShellLink>
   );
 };

--- a/apps/apollo-vertex/registry/shell/shell-nav-item.tsx
+++ b/apps/apollo-vertex/registry/shell/shell-nav-item.tsx
@@ -1,4 +1,3 @@
-import { Link, useLocation } from "@tanstack/react-router";
 import { useLocalStorage } from "@uidotdev/usehooks";
 import { AnimatePresence, motion } from "framer-motion";
 import type { LucideIcon } from "lucide-react";
@@ -15,6 +14,7 @@ import {
   textFadeVariants,
 } from "./shell-animations";
 import { SIDEBAR_COLLAPSED_KEY } from "./shell-constants";
+import { ShellLink, useShellPathname } from "./shell-router-context";
 import { Text } from "./shell-text";
 import type { TranslationKey } from "./shell-translation-key";
 
@@ -26,11 +26,11 @@ interface NavItemProps {
 
 export const NavItem = ({ to, icon: Icon, label }: NavItemProps) => {
   const [isCollapsed] = useLocalStorage(SIDEBAR_COLLAPSED_KEY, false);
-  const { pathname } = useLocation();
+  const pathname = useShellPathname();
   const isActive = pathname === to || pathname.startsWith(`${to}/`);
 
   const linkContent = (
-    <Link
+    <ShellLink
       to={to}
       className={cn(
         "flex items-center rounded-md transition-colors duration-200",
@@ -66,7 +66,7 @@ export const NavItem = ({ to, icon: Icon, label }: NavItemProps) => {
           </motion.span>
         )}
       </AnimatePresence>
-    </Link>
+    </ShellLink>
   );
 
   if (isCollapsed) {

--- a/apps/apollo-vertex/registry/shell/shell-router-context.tsx
+++ b/apps/apollo-vertex/registry/shell/shell-router-context.tsx
@@ -1,0 +1,54 @@
+import {
+  type AnchorHTMLAttributes,
+  type ComponentType,
+  createContext,
+  type PropsWithChildren,
+  useContext,
+} from "react";
+
+export type ShellLinkComponent = ComponentType<{
+  to: string;
+  href: string;
+  className?: string;
+  children?: React.ReactNode;
+}>;
+
+interface ShellLinkProps extends AnchorHTMLAttributes<HTMLAnchorElement> {
+  to: string;
+}
+
+const DefaultLink = ({ to, ...props }: ShellLinkProps) => (
+  <a href={to} {...props} />
+);
+
+interface ShellRouterContextValue {
+  LinkComponent: ShellLinkComponent;
+  pathname: string;
+}
+
+const ShellRouterContext = createContext<ShellRouterContextValue>({
+  LinkComponent: DefaultLink,
+  pathname: "/",
+});
+
+export const useShellPathname = () => useContext(ShellRouterContext).pathname;
+
+export const ShellLink = ({ to, href, ...props }: ShellLinkProps) => {
+  const { LinkComponent } = useContext(ShellRouterContext);
+  return <LinkComponent to={to} href={href ?? to} {...props} />;
+};
+
+interface ShellRouterProviderProps {
+  linkComponent: ShellLinkComponent;
+  pathname: string;
+}
+
+export const ShellRouterProvider = ({
+  linkComponent,
+  pathname,
+  children,
+}: PropsWithChildren<ShellRouterProviderProps>) => (
+  <ShellRouterContext value={{ LinkComponent: linkComponent, pathname }}>
+    {children}
+  </ShellRouterContext>
+);

--- a/apps/apollo-vertex/registry/shell/shell.tsx
+++ b/apps/apollo-vertex/registry/shell/shell.tsx
@@ -4,6 +4,10 @@ import { ShellAuthProvider, useAuth } from "./shell-auth-provider";
 import { ShellLayout } from "./shell-layout";
 import { LocaleProvider } from "./shell-locale-provider";
 import { ShellLogin } from "./shell-login";
+import {
+  type ShellLinkComponent,
+  ShellRouterProvider,
+} from "./shell-router-context";
 import type { TranslationKey } from "./shell-translation-key";
 import { ShellUserProvider } from "./shell-user-provider";
 
@@ -32,6 +36,8 @@ interface ApolloShellProps extends ApolloShellComponentProps {
   scope: string;
   baseUrl: string;
   variant?: "minimal";
+  linkComponent: ShellLinkComponent;
+  pathname: string;
 }
 
 const ApolloShellComponent: FC<ApolloShellComponentProps> = ({
@@ -72,20 +78,24 @@ export const ApolloShell: FC<ApolloShellProps> = ({
   companyLogo,
   variant,
   navItems,
+  linkComponent,
+  pathname,
 }) => {
   return (
-    <ShellAuthProvider clientId={clientId} scope={scope} baseUrl={baseUrl}>
-      <LocaleProvider>
-        <ApolloShellComponent
-          companyName={companyName}
-          productName={productName}
-          companyLogo={companyLogo}
-          variant={variant}
-          navItems={navItems}
-        >
-          {children}
-        </ApolloShellComponent>
-      </LocaleProvider>
-    </ShellAuthProvider>
+    <ShellRouterProvider linkComponent={linkComponent} pathname={pathname}>
+      <ShellAuthProvider clientId={clientId} scope={scope} baseUrl={baseUrl}>
+        <LocaleProvider>
+          <ApolloShellComponent
+            companyName={companyName}
+            productName={productName}
+            companyLogo={companyLogo}
+            variant={variant}
+            navItems={navItems}
+          >
+            {children}
+          </ApolloShellComponent>
+        </LocaleProvider>
+      </ShellAuthProvider>
+    </ShellRouterProvider>
   );
 };

--- a/apps/apollo-vertex/templates/ShellTemplate.tsx
+++ b/apps/apollo-vertex/templates/ShellTemplate.tsx
@@ -2,6 +2,8 @@
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BarChart3, FolderOpen, Home, Settings, Users } from "lucide-react";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
 import type { PropsWithChildren } from "react";
 import type { ShellNavItem } from "@/registry/shell/shell";
 import { ApolloShell } from "@/registry/shell/shell";
@@ -38,6 +40,8 @@ export function ShellTemplate({
   variant,
   children,
 }: PropsWithChildren<ShellTemplateProps>) {
+  const pathname = usePathname();
+
   return (
     <QueryClientProvider client={queryClient}>
       <ApolloShell
@@ -53,6 +57,8 @@ export function ShellTemplate({
         scope="openid profile email offline_access"
         baseUrl={baseUrl}
         navItems={variant === "minimal" ? minimalNavItems : navItems}
+        linkComponent={Link}
+        pathname={pathname}
       >
         {children}
       </ApolloShell>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -188,9 +188,6 @@ importers:
       '@tanstack/react-query':
         specifier: ^5.90.21
         version: 5.90.21(react@19.2.3)
-      '@tanstack/react-router':
-        specifier: ^1.132.31
-        version: 1.167.4(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@tanstack/react-table':
         specifier: ^8.21.3
         version: 8.21.3(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -5524,10 +5521,6 @@ packages:
   '@tailwindcss/postcss@4.1.17':
     resolution: {integrity: sha512-+nKl9N9mN5uJ+M7dBOOCzINw94MPstNR/GtIhz1fpZysxL/4a+No64jCBD6CPN+bIHWFx3KWuu8XJRrj/572Dw==}
 
-  '@tanstack/history@1.161.6':
-    resolution: {integrity: sha512-NaOGLRrddszbQj9upGat6HG/4TKvXLvu+osAIgfxPYA+eIvYKv8GKDJOrY2D3/U9MRnKfMWD7bU4jeD4xmqyIg==}
-    engines: {node: '>=20.19'}
-
   '@tanstack/query-core@5.90.20':
     resolution: {integrity: sha512-OMD2HLpNouXEfZJWcKeVKUgQ5n+n3A2JFmBaScpNDUqSrQSjiveC7dKMe53uJUg1nDG16ttFPz2xfilz6i2uVg==}
 
@@ -5535,19 +5528,6 @@ packages:
     resolution: {integrity: sha512-0Lu6y5t+tvlTJMTO7oh5NSpJfpg/5D41LlThfepTixPYkJ0sE2Jj0m0f6yYqujBwIXlId87e234+MxG3D3g7kg==}
     peerDependencies:
       react: ^18 || ^19
-
-  '@tanstack/react-router@1.167.4':
-    resolution: {integrity: sha512-VpbZh382zX3WF4+X2Z+EUyd8eJhJyjg9C6ByYwrVZiWbhgbMK4+zQQIG2+lCAlIlDi7SV8fDcGL09NA8Z2kpGQ==}
-    engines: {node: '>=20.19'}
-    peerDependencies:
-      react: '>=18.0.0 || >=19.0.0'
-      react-dom: '>=18.0.0 || >=19.0.0'
-
-  '@tanstack/react-store@0.9.2':
-    resolution: {integrity: sha512-Vt5usJE5sHG/cMechQfmwvwne6ktGCELe89Lmvoxe3LKRoFrhPa8OCKWs0NliG8HTJElEIj7PLtaBQIcux5pAQ==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   '@tanstack/react-table@8.21.3':
     resolution: {integrity: sha512-5nNMTSETP4ykGegmVkhjcS8tTLW6Vl4axfEGQN3v0zdHYbK4UfoqfPChclTrJ4EoK9QynqAu9oUf8VEmrpZ5Ww==}
@@ -5561,14 +5541,6 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-
-  '@tanstack/router-core@1.167.4':
-    resolution: {integrity: sha512-Gk5V9Zr5JFJ4SbLyCheQLJ3MnXddccENPA+DJRz+9g3QxtN8DJB8w8KCUCgDeYlWp4LvmO4nX3fy3tupqVP2Pw==}
-    engines: {node: '>=20.19'}
-    hasBin: true
-
-  '@tanstack/store@0.9.2':
-    resolution: {integrity: sha512-K013lUJEFJK2ofFQ/hZKJUmCnpcV00ebLyOyFOWQvyQHUOZp/iYO84BM6aOGiV81JzwbX0APTVmW8YI7yiG5oA==}
 
   '@tanstack/table-core@8.21.3':
     resolution: {integrity: sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg==}
@@ -6871,9 +6843,6 @@ packages:
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
-
-  cookie-es@2.0.0:
-    resolution: {integrity: sha512-RAj4E421UYRgqokKUmotqAwuplYw15qtdXfY+hGzgCJ/MBjCVZcSoHK/kH9kocfjRjcDME7IiDWR/1WX1TM2Pg==}
 
   cookie-signature@1.2.2:
     resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
@@ -8781,10 +8750,6 @@ packages:
 
   isarray@2.0.5:
     resolution: {integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==}
-
-  isbot@5.1.36:
-    resolution: {integrity: sha512-C/ZtXyJqDPZ7G7JPr06ApWyYoHjYexQbS6hPYD4WYCzpv2Qes6Z+CCEfTX4Owzf+1EJ933PoI2p+B9v7wpGZBQ==}
-    engines: {node: '>=18'}
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
@@ -11310,16 +11275,6 @@ packages:
     resolution: {integrity: sha512-uaW0WwXKpL9blXE2o0bRhoL2EGXIrZxQ2ZQ4mgcfoBxdFmQold+qWsD2jLrfZ0trjKL6vOw0j//eAwcALFjKSw==}
     engines: {node: '>= 18'}
 
-  seroval-plugins@1.5.1:
-    resolution: {integrity: sha512-4FbuZ/TMl02sqv0RTFexu0SP6V+ywaIe5bAWCCEik0fk17BhALgwvUDVF7e3Uvf9pxmwCEJsRPmlkUE6HdzLAw==}
-    engines: {node: '>=10'}
-    peerDependencies:
-      seroval: ^1.0
-
-  seroval@1.5.1:
-    resolution: {integrity: sha512-OwrZRZAfhHww0WEnKHDY8OM0U/Qs8OTfIDWhUD4BLpNJUfXK4cGmjiagGze086m+mhI+V2nD0gfbHEnJjb9STA==}
-    engines: {node: '>=10'}
-
   serve-static@2.2.0:
     resolution: {integrity: sha512-61g9pCh0Vnh7IutZjtLGGpTA355+OPn2TyDv/6ivP2h/AdAVX9azsoxmg2/M6nZeQZNYBEwIcsne1mJd9oQItQ==}
     engines: {node: '>= 18'}
@@ -11876,9 +11831,6 @@ packages:
 
   tiny-invariant@1.3.3:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
-
-  tiny-warning@1.0.3:
-    resolution: {integrity: sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==}
 
   tiny-worker@2.3.0:
     resolution: {integrity: sha512-pJ70wq5EAqTAEl9IkGzA+fN0836rycEuz2Cn6yeZ6FRzlVS5IDOkFHpIoEsksPRQV34GDqXm65+OlnZqUSyK2g==}
@@ -17321,32 +17273,12 @@ snapshots:
       postcss: 8.5.6
       tailwindcss: 4.1.17
 
-  '@tanstack/history@1.161.6': {}
-
   '@tanstack/query-core@5.90.20': {}
 
   '@tanstack/react-query@5.90.21(react@19.2.3)':
     dependencies:
       '@tanstack/query-core': 5.90.20
       react: 19.2.3
-
-  '@tanstack/react-router@1.167.4(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
-    dependencies:
-      '@tanstack/history': 1.161.6
-      '@tanstack/react-store': 0.9.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@tanstack/router-core': 1.167.4
-      isbot: 5.1.36
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
-      tiny-invariant: 1.3.3
-      tiny-warning: 1.0.3
-
-  '@tanstack/react-store@0.9.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
-    dependencies:
-      '@tanstack/store': 0.9.2
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
-      use-sync-external-store: 1.6.0(react@19.2.3)
 
   '@tanstack/react-table@8.21.3(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
@@ -17359,18 +17291,6 @@ snapshots:
       '@tanstack/virtual-core': 3.13.12
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
-
-  '@tanstack/router-core@1.167.4':
-    dependencies:
-      '@tanstack/history': 1.161.6
-      '@tanstack/store': 0.9.2
-      cookie-es: 2.0.0
-      seroval: 1.5.1
-      seroval-plugins: 1.5.1(seroval@1.5.1)
-      tiny-invariant: 1.3.3
-      tiny-warning: 1.0.3
-
-  '@tanstack/store@0.9.2': {}
 
   '@tanstack/table-core@8.21.3': {}
 
@@ -18828,8 +18748,6 @@ snapshots:
   convert-source-map@1.9.0: {}
 
   convert-source-map@2.0.0: {}
-
-  cookie-es@2.0.0: {}
 
   cookie-signature@1.2.2: {}
 
@@ -21089,8 +21007,6 @@ snapshots:
   isarray@1.0.0: {}
 
   isarray@2.0.5: {}
-
-  isbot@5.1.36: {}
 
   isexe@2.0.0: {}
 
@@ -24188,12 +24104,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  seroval-plugins@1.5.1(seroval@1.5.1):
-    dependencies:
-      seroval: 1.5.1
-
-  seroval@1.5.1: {}
-
   serve-static@2.2.0:
     dependencies:
       encodeurl: 2.0.0
@@ -24953,8 +24863,6 @@ snapshots:
       convert-hrtime: 5.0.0
 
   tiny-invariant@1.3.3: {}
-
-  tiny-warning@1.0.3: {}
 
   tiny-worker@2.3.0:
     dependencies:


### PR DESCRIPTION
Vertical repos must pass `linkComponent` and `pathname` to `ApolloShell` after syncing:

```tsx
import { Link, useLocation } from "@tanstack/react-router";
const { pathname } = useLocation();
<ApolloShell linkComponent={Link} pathname={pathname} ... />
```