### PR TITLE
feat(apollo-react): keydown event for stage node

### DIFF
--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.tsx
@@ -223,6 +223,11 @@ const StageNodeComponent = (props: StageNodeProps) => {
           onStageTitleChange(label);
         }
       }
+      // Prevent keyboard events from the title input from bubbling to xyflow
+      // and triggering canvas-level actions like node deletion or copy/paste.
+      if (e.key !== 'Escape') {
+        e.stopPropagation();
+      }
     },
     [onStageTitleChange, label]
   );


### PR DESCRIPTION
## Description 

Prevent keyboard events from input/contenteditable elements inside the stage (e.g. title input, toolbox search) from bubbling to xyflow and triggering canvas-level actions like node deletion or copy/paste.


## Demo 

https://github.com/user-attachments/assets/09d1cfc7-5fa8-4d1e-9303-5cd77cc2d748

