### PR TITLE
feat(apollo-vertex): add title and description props to ShellLogin

### DIFF
--- a/apps/apollo-vertex/registry/shell/shell-login.tsx
+++ b/apps/apollo-vertex/registry/shell/shell-login.tsx
@@ -1,7 +1,12 @@
 import { useTranslation } from "react-i18next";
 import { useAuth } from "./shell-auth-provider";
 
-export const ShellLogin = () => {
+export interface ShellLoginProps {
+  title?: string;
+  description?: string;
+}
+
+export const ShellLogin = ({ title, description }: ShellLoginProps) => {
   const { t } = useTranslation();
   const { login } = useAuth();
 
@@ -9,6 +14,18 @@ export const ShellLogin = () => {
     <div className="flex h-screen items-center justify-center bg-background">
       <div className="w-full max-w-md">
         <div className="bg-card rounded-lg shadow-lg p-8 border border-border">
+          {(title || description) && (
+            <div className="text-center mb-8">
+              {title && (
+                <h1 className="text-3xl font-bold text-foreground mb-2">
+                  {title}
+                </h1>
+              )}
+              {description && (
+                <p className="text-muted-foreground">{description}</p>
+              )}
+            </div>
+          )}
           <div className="space-y-6">
             <button
               type="button"

--- a/apps/apollo-vertex/registry/shell/shell-user-profile.tsx
+++ b/apps/apollo-vertex/registry/shell/shell-user-profile.tsx
@@ -36,7 +36,7 @@ export const UserProfile = ({ isCollapsed }: UserProfileProps) => {
           <DropdownMenuTrigger asChild>
             <motion.button
               type="button"
-              className="flex items-center justify-center cursor-pointer rounded-full"
+              className="flex items-center justify-center cursor-pointer rounded-full p-1"
               initial={{ opacity: 0, scale: 0.8 }}
               animate={{ opacity: 1, scale: 1 }}
               exit={{ opacity: 0, scale: 0.8 }}
@@ -76,7 +76,7 @@ export const UserProfile = ({ isCollapsed }: UserProfileProps) => {
             <motion.button
               type="button"
               key="expanded"
-              className="flex items-center gap-3 w-full min-w-0 cursor-pointer rounded-lg px-1 hover:bg-sidebar-accent transition-colors"
+              className="flex items-center gap-3 w-full min-w-0 cursor-pointer rounded-lg p-1 hover:bg-sidebar-accent transition-colors"
               initial={{ opacity: 0, x: -10 }}
               animate={{ opacity: 1, x: 0 }}
               exit={{ opacity: 0, x: -10 }}

--- a/apps/apollo-vertex/registry/shell/shell.tsx
+++ b/apps/apollo-vertex/registry/shell/shell.tsx
@@ -25,6 +25,7 @@ export interface ApolloShellComponentProps extends PropsWithChildren {
   variant?: "minimal";
   companyLogo?: CompanyLogo;
   navItems: ShellNavItem[];
+  loginDescription?: string;
 }
 
 interface ApolloShellProps extends ApolloShellComponentProps {
@@ -41,10 +42,11 @@ const ApolloShellComponent: FC<ApolloShellComponentProps> = ({
   companyLogo,
   variant,
   navItems,
+  loginDescription,
 }) => {
   const { accessToken } = useAuth();
   if (!accessToken) {
-    return <ShellLogin />;
+    return <ShellLogin title={productName} description={loginDescription} />;
   }
 
   return (
@@ -72,6 +74,7 @@ export const ApolloShell: FC<ApolloShellProps> = ({
   companyLogo,
   variant,
   navItems,
+  loginDescription,
 }) => {
   return (
     <ShellAuthProvider clientId={clientId} scope={scope} baseUrl={baseUrl}>
@@ -82,6 +85,7 @@ export const ApolloShell: FC<ApolloShellProps> = ({
           companyLogo={companyLogo}
           variant={variant}
           navItems={navItems}
+          loginDescription={loginDescription}
         >
           {children}
         </ApolloShellComponent>

--- a/apps/apollo-vertex/templates/ShellTemplate.tsx
+++ b/apps/apollo-vertex/templates/ShellTemplate.tsx
@@ -53,6 +53,7 @@ export function ShellTemplate({
         scope="openid profile email offline_access"
         baseUrl={baseUrl}
         navItems={variant === "minimal" ? minimalNavItems : navItems}
+        loginDescription="Sign in to access your workspace and manage your projects."
       >
         {children}
       </ApolloShell>


### PR DESCRIPTION
Main reason for this change was so we don't have have to update the login page everytime the shell get's updated 😅 

<img width="900" height="647" alt="Screenshot 2026-03-18 at 16 24 55" src="https://github.com/user-attachments/assets/cb6c9dec-08d3-4f47-bc6e-0392d151eab6" />


## Summary
- Add optional `title` and `description` props to `ShellLogin` component
- Pass `productName` as the login title and new `loginDescription` prop as subtitle
- Allows customizing the login screen with app-specific content
- Minor styling fixes to user profile button padding