### PR TITLE
feat(apollo-wind): Skills tab UX improvements, skills library, and CLI scope

### DIFF
--- a/packages/apollo-wind/skills/apollo-install/SKILL.md
+++ b/packages/apollo-wind/skills/apollo-install/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: apollo-install
+description: Sets up and launches the Apollo Wind Storybook from scratch. Use when the user wants to run Apollo Wind, start Storybook, set up the apollo-ui repo, or says something like "get apollo running", "set up apollo", or "start apollo storybook".
+---
+
+# Apollo Install
+
+Fully sets up and launches the Apollo Wind Storybook in a single flow. Run each step in order — verify success before proceeding to the next.
+
+## Step 1 — Check prerequisites
+
+```bash
+node --version
+pnpm --version
+```
+
+**Node below 18 or missing:** Tell the user to install Node 18+ from https://nodejs.org and stop.
+
+**pnpm missing:** Install it, then continue.
+
+```bash
+npm install -g pnpm
+```
+
+## Step 2 — Clone the repository
+
+Check if the repo already exists before cloning.
+
+```bash
+ls ~/Desktop/apollo-ui
+```
+
+**If it does not exist**, clone it. Try SSH first:
+
+```bash
+cd ~/Desktop
+git clone git@github.com:UiPath/apollo-ui.git
+```
+
+**If SSH fails** (no key configured), fall back to HTTPS and let the user know:
+
+```bash
+cd ~/Desktop
+git clone https://github.com/UiPath/apollo-ui.git
+```
+
+## Step 3 — Navigate to the repo
+
+```bash
+cd ~/Desktop/apollo-ui
+```
+
+## Step 4 — Install dependencies
+
+```bash
+pnpm install
+```
+
+Wait for full completion before continuing.
+
+## Step 5 — Build all packages
+
+```bash
+pnpm build
+```
+
+Turborepo builds `apollo-core`, `apollo-react`, and `apollo-wind` in dependency order. Wait for completion.
+
+## Step 6 — Start Apollo Wind Storybook
+
+```bash
+pnpm storybook:wind
+```
+
+Storybook opens automatically at `http://localhost:6006`. If it does not open, tell the user to navigate there manually.
+
+## Success
+
+> Apollo Wind Storybook is running at http://localhost:6006. Browse components, templates, and tokens in the sidebar. To start prototyping, go to **Introduction → Prototyping**.
+
+## Common errors
+
+**`git@github.com: Permission denied`**
+SSH key not configured. Retry with HTTPS (see Step 2).
+
+**`ERR_PNPM_UNSUPPORTED_ENGINE`**
+Node version is too old. Ask the user to upgrade to Node 18+.
+
+**`Cannot find module` during build**
+Dependencies are incomplete. Re-run `pnpm install` then `pnpm build`.
+
+**Port 6006 already in use**
+Another Storybook instance is running. Tell the user to stop it or open http://localhost:6006 directly.

--- a/packages/apollo-wind/skills/apollo-repo-sync/SKILL.md
+++ b/packages/apollo-wind/skills/apollo-repo-sync/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: apollo-repo-sync
+description: Keeps apollo-wind up to date in a designer's prototype repo and ensures it is correctly configured. Use when the user wants to sync apollo-wind, update components, set up apollo-wind in their project, or at the start of any prototyping session to ensure they are on the latest version.
+---
+
+# Apollo Repo Sync
+
+Keeps `@uipath/apollo-wind` correctly configured and up to date in the user's prototype project. Run this at the start of each session or any time the user wants to pull in the latest components, styles, and templates.
+
+## Phase 1 — First-time setup
+
+Run this phase only if `@uipath/apollo-wind` is not yet in the project.
+
+### 1a — Install apollo-wind
+
+```bash
+pnpm add @uipath/apollo-wind
+```
+
+Or with npm:
+
+```bash
+npm install @uipath/apollo-wind
+```
+
+### 1b — Add the theme CSS import
+
+Add this to the project's root CSS file (e.g. `src/index.css` or `src/globals.css`):
+
+```css
+@import "@uipath/apollo-wind/styles";
+```
+
+### 1c — Wrap the app root with a theme class
+
+In the root component (e.g. `App.tsx` or `layout.tsx`), apply the theme class:
+
+```tsx
+<div className="future-dark min-h-screen bg-background text-foreground">
+  {/* your app */}
+</div>
+```
+
+Use `future-light` for the light theme. Tell the user they can switch themes by changing this class — no other changes needed.
+
+### 1d — Confirm setup
+
+Let the user know apollo-wind is installed and the theme is active. Tell them:
+
+> Apollo Wind is configured. Components are available from `@uipath/apollo-wind/components` and the `future-dark` theme is active on your root element.
+
+---
+
+## Phase 2 — Sync to latest (every session)
+
+Run this phase every time to ensure the project is on the latest version.
+
+### 2a — Check installed vs latest version
+
+```bash
+pnpm list @uipath/apollo-wind
+npm show @uipath/apollo-wind version
+```
+
+Compare the two. If they match, skip to the success message.
+
+### 2b — Update if behind
+
+```bash
+pnpm update @uipath/apollo-wind
+```
+
+Or with npm:
+
+```bash
+npm update @uipath/apollo-wind
+```
+
+### 2c — Rebuild the project
+
+```bash
+pnpm build
+```
+
+Or if there is a dev server already running, restart it so new components and styles are picked up.
+
+### 2d — Confirm sync
+
+Tell the user what changed:
+
+> Apollo Wind has been updated to vX.X.X. New components, styles, and templates are now available. You can start prototyping.
+
+If already on the latest version:
+
+> Apollo Wind is up to date (vX.X.X). No changes needed.
+
+---
+
+## Component imports
+
+After syncing, components are available at:
+
+```tsx
+import { Button } from '@uipath/apollo-wind/components';
+import { Card, CardContent } from '@uipath/apollo-wind/components';
+import { DataTable } from '@uipath/apollo-wind/components';
+```
+
+For theming tokens and utilities:
+
+```tsx
+import { cn } from '@uipath/apollo-wind/lib';
+```
+
+---
+
+## Common errors
+
+**`@uipath/apollo-wind` not found on npm registry**
+The package may not yet be published. Ask the user to check back or use the local monorepo setup via `apollo-install` instead.
+
+**Styles not applying after update**
+The CSS import may be missing. Re-check Phase 1b and ensure the import is at the top of the root CSS file.
+
+**Components not resolving after update**
+Re-run `pnpm build` or restart the dev server to pick up the updated package.

--- a/packages/apollo-wind/src/getting-started/getting-started.stories.tsx
+++ b/packages/apollo-wind/src/getting-started/getting-started.stories.tsx
@@ -404,8 +404,25 @@ function CLITab() {
       {/* Why CLI */}
       <div>
         <InfoCallout>
-          The Apollo registry is in development. Commands on this page reflect the target experience
-          and will work once the registry is published.
+          <p className="mb-2 font-medium text-foreground">Work in progress</p>
+          <p>
+            This is the <span className="font-medium text-foreground">Apollo Wind CLI</span> — a
+            frontend-specific tool for Tailwind-based projects using{' '}
+            <InlineCode>@uipath/apollo-wind</InlineCode>. The registry is not yet published;
+            commands on this page reflect the target experience and will work once it is.
+          </p>
+          <p className="mt-2">
+            Other teams at UiPath are also building CLIs for different parts of the stack. Check the{' '}
+            <a
+              href="https://github.com/UiPath"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="font-medium text-primary underline"
+            >
+              UiPath GitHub
+            </a>{' '}
+            for the full picture.
+          </p>
         </InfoCallout>
         <div className="mt-6">
           <SectionDescription>

--- a/packages/apollo-wind/src/getting-started/prototyping.stories.tsx
+++ b/packages/apollo-wind/src/getting-started/prototyping.stories.tsx
@@ -15,7 +15,7 @@ import { cn } from '@/lib';
 
 type PrototypingArgs = { tab: string };
 
-const meta = {
+const meta: Meta<PrototypingArgs> = {
   title: 'Introduction/Prototyping',
   parameters: {
     layout: 'fullscreen',
@@ -26,7 +26,7 @@ const meta = {
       options: ['Overview', 'Skills', 'Prototype', 'w/ Figma', 'w/ Claude', 'w/ Cursor', 'Resources'],
     },
   },
-} satisfies Meta<PrototypingArgs>;
+};
 
 export default meta;
 type Story = StoryObj<typeof meta>;
@@ -791,78 +791,77 @@ function UseCasesContent() {
 // Skills data
 // ============================================================================
 
-type SkillType = 'Cursor' | 'Claude Code';
+type SkillSurface = 'Cursor' | 'Claude Code';
 
 interface Skill {
   name: string;
-  types: SkillType[];
-  use: string;
+  description: string;
+  category: string;
+  surfaces: SkillSurface[];
   sourcePath: string;
 }
 
 const SKILLS: Skill[] = [
   {
+    name: 'apollo-install',
+    description:
+      'Sets up and launches the Apollo Wind Storybook from scratch — clones the repo, installs dependencies, builds, and starts the dev server.',
+    category: 'Setup',
+    surfaces: ['Cursor', 'Claude Code'],
+    sourcePath: 'packages/apollo-wind/skills/apollo-install/',
+  },
+  {
+    name: 'apollo-repo-sync',
+    description:
+      'Keeps apollo-wind up to date in a prototype repo — installs on first use and syncs to the latest version each session so new components and styles are always available.',
+    category: 'Setup',
+    surfaces: ['Cursor', 'Claude Code'],
+    sourcePath: 'packages/apollo-wind/skills/apollo-repo-sync/',
+  },
+  {
     name: 'apollo-prototype',
-    types: ['Cursor', 'Claude Code'],
-    use: 'Prototyping — encodes Apollo Wind design system rules so the AI applies tokens, components, and patterns automatically',
+    description:
+      'Encodes Apollo Wind design system rules so the AI applies tokens, components, and patterns automatically when prototyping.',
+    category: 'Prototype',
+    surfaces: ['Cursor', 'Claude Code'],
     sourcePath: 'packages/apollo-wind/skills/apollo-prototype/',
   },
 ];
 
 interface ExternalSkill {
   name: string;
-  types: SkillType[];
-  use: string;
+  description: string;
+  category: string;
+  surfaces: SkillSurface[];
   url: string;
   author?: string;
 }
 
 const EXTERNAL_SKILLS: ExternalSkill[] = [];
 
-const TYPE_COLORS: Record<SkillType, string> = {
+const SURFACE_COLORS: Record<SkillSurface, string> = {
   Cursor: 'bg-violet-500/10 text-violet-400 border-violet-500/20',
   'Claude Code': 'bg-orange-500/10 text-orange-400 border-orange-500/20',
 };
 
-function TypeBadge({ type }: { type: SkillType }) {
+function SurfaceBadge({ surface }: { surface: SkillSurface }) {
   return (
     <span
       className={cn(
         'inline-flex items-center rounded-full border px-2 py-0.5 text-xs font-medium',
-        TYPE_COLORS[type]
+        SURFACE_COLORS[surface]
       )}
     >
-      {type}
+      {surface}
     </span>
   );
 }
 
-function ExternalSkillRow({ skill }: { skill: ExternalSkill }) {
+function CategoryBadge({ category }: { category: string }) {
   return (
-    <div className="flex items-start gap-4 border-b border-border px-4 py-4 last:border-0">
-      <div className="min-w-0 flex-1">
-        <div className="mb-1.5 flex flex-wrap items-center gap-2">
-          <span className="text-sm font-medium text-foreground">{skill.name}</span>
-          <div className="flex flex-wrap gap-1.5">
-            {skill.types.map((t) => (
-              <TypeBadge key={t} type={t} />
-            ))}
-          </div>
-          {skill.author && (
-            <span className="text-xs text-muted-foreground">by {skill.author}</span>
-          )}
-        </div>
-        <p className="text-sm leading-6 text-muted-foreground">{skill.use}</p>
-      </div>
-      <a
-        href={skill.url}
-        target="_blank"
-        rel="noopener noreferrer"
-        className="shrink-0 rounded-md border border-border bg-muted/50 px-3 py-1.5 text-xs font-medium text-muted-foreground transition-colors hover:border-primary/40 hover:text-foreground"
-      >
-        View
-      </a>
-    </div>
+    <span className="inline-flex items-center rounded-full border border-border bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground">
+      {category}
+    </span>
   );
 }
 
@@ -882,13 +881,14 @@ function SkillRow({ skill }: { skill: Skill }) {
           <code className="rounded bg-muted px-1.5 py-0.5 text-sm font-medium text-foreground">
             {skill.name}
           </code>
+          <CategoryBadge category={skill.category} />
           <div className="flex flex-wrap gap-1.5">
-            {skill.types.map((t) => (
-              <TypeBadge key={t} type={t} />
+            {skill.surfaces.map((s) => (
+              <SurfaceBadge key={s} surface={s} />
             ))}
           </div>
         </div>
-        <p className="text-sm leading-6 text-muted-foreground">{skill.use}</p>
+        <p className="text-sm leading-6 text-muted-foreground">{skill.description}</p>
       </div>
       <button
         type="button"
@@ -897,6 +897,36 @@ function SkillRow({ skill }: { skill: Skill }) {
       >
         {copied ? 'Copied!' : 'Copy path'}
       </button>
+    </div>
+  );
+}
+
+function ExternalSkillRow({ skill }: { skill: ExternalSkill }) {
+  return (
+    <div className="flex items-start gap-4 border-b border-border px-4 py-4 last:border-0">
+      <div className="min-w-0 flex-1">
+        <div className="mb-1.5 flex flex-wrap items-center gap-2">
+          <span className="text-sm font-medium text-foreground">{skill.name}</span>
+          <CategoryBadge category={skill.category} />
+          <div className="flex flex-wrap gap-1.5">
+            {skill.surfaces.map((s) => (
+              <SurfaceBadge key={s} surface={s} />
+            ))}
+          </div>
+          {skill.author && (
+            <span className="text-xs text-muted-foreground">by {skill.author}</span>
+          )}
+        </div>
+        <p className="text-sm leading-6 text-muted-foreground">{skill.description}</p>
+      </div>
+      <a
+        href={skill.url}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="shrink-0 rounded-md border border-border bg-muted/50 px-3 py-1.5 text-xs font-medium text-muted-foreground transition-colors hover:border-primary/40 hover:text-foreground"
+      >
+        View
+      </a>
     </div>
   );
 }
@@ -920,29 +950,26 @@ function SkillsTab() {
 
       {/* Marketplace list */}
       <div className="overflow-hidden rounded-xl border border-border bg-card">
-        {/* List header with Internal / External toggle */}
-        <div className="flex items-center justify-between border-b border-border bg-muted/30 px-4 py-2.5">
-          <div className="inline-flex rounded-md border border-border bg-background p-0.5">
-            {(['Internal', 'External'] as const).map((view) => (
-              <button
-                key={view}
-                type="button"
-                onClick={() => setSkillView(view)}
-                className={cn(
-                  'cursor-pointer rounded px-3 py-1 text-xs font-medium transition-colors',
-                  skillView === view
-                    ? 'bg-primary text-primary-foreground'
-                    : 'text-muted-foreground hover:text-foreground'
-                )}
-              >
-                {view}
-              </button>
-            ))}
-          </div>
-          <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
-            {skillView === 'Internal' ? 'Install' : 'Link'}
-          </span>
+        {/* Internal / External toggle */}
+        <div className="flex gap-1 border-b border-border px-4">
+          {(['Internal', 'External'] as const).map((view) => (
+            <button
+              key={view}
+              type="button"
+              onClick={() => setSkillView(view)}
+              className={cn(
+                'cursor-pointer px-3 pb-3 pt-3 text-sm font-medium transition-colors',
+                skillView === view
+                  ? 'border-b-2 border-primary text-foreground'
+                  : 'text-muted-foreground hover:text-foreground'
+              )}
+            >
+              {view}
+            </button>
+          ))}
         </div>
+
+
 
         {skillView === 'Internal' && SKILLS.map((skill) => (
           <SkillRow key={skill.name} skill={skill} />
@@ -971,21 +998,23 @@ function SkillsTab() {
         )}
       </div>
 
-      <InfoCallout>
-        Want to contribute a skill? Add it to{' '}
-        <InlineCode>packages/apollo-wind/skills/</InlineCode> and open a PR. See the{' '}
-        <span className="font-medium text-foreground">Create Your Own Skill</span> section below for
-        what to include. If you can't open a PR, post your skill to the{' '}
-        <a
-          href="https://uipath.enterprise.slack.com/archives/C0172850BEH"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="font-medium text-primary underline"
-        >
-          #apollo
-        </a>{' '}
-        Slack channel and the team will handle it.
-      </InfoCallout>
+      <div className="border-l-2 border-primary pl-4 text-sm leading-6 text-muted-foreground">
+        <p className="mb-0.5 font-medium text-foreground">Want to contribute a skill?</p>
+        <p>
+          Add it to <InlineCode>packages/apollo-wind/skills/</InlineCode> and open a PR. See{' '}
+          <span className="font-medium text-foreground">Create Your Own Skill</span> below for what
+          to include. If you can't open a PR, post it to the{' '}
+          <a
+            href="https://uipath.enterprise.slack.com/archives/C0172850BEH"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="font-medium text-primary underline"
+          >
+            #apollo
+          </a>{' '}
+          Slack channel and the team will handle it.
+        </p>
+      </div>
 
       <Divider />
 

--- a/packages/apollo-wind/src/getting-started/prototyping.stories.tsx
+++ b/packages/apollo-wind/src/getting-started/prototyping.stories.tsx
@@ -13,12 +13,20 @@ import { cn } from '@/lib';
 // Meta
 // ============================================================================
 
+type PrototypingArgs = { tab: string };
+
 const meta = {
   title: 'Introduction/Prototyping',
   parameters: {
     layout: 'fullscreen',
   },
-} satisfies Meta;
+  argTypes: {
+    tab: {
+      control: 'select',
+      options: ['Overview', 'Skills', 'Prototype', 'w/ Figma', 'w/ Claude', 'w/ Cursor', 'Resources'],
+    },
+  },
+} satisfies Meta<PrototypingArgs>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
@@ -801,6 +809,16 @@ const SKILLS: Skill[] = [
   },
 ];
 
+interface ExternalSkill {
+  name: string;
+  types: SkillType[];
+  use: string;
+  url: string;
+  author?: string;
+}
+
+const EXTERNAL_SKILLS: ExternalSkill[] = [];
+
 const TYPE_COLORS: Record<SkillType, string> = {
   Cursor: 'bg-violet-500/10 text-violet-400 border-violet-500/20',
   'Claude Code': 'bg-orange-500/10 text-orange-400 border-orange-500/20',
@@ -816,6 +834,35 @@ function TypeBadge({ type }: { type: SkillType }) {
     >
       {type}
     </span>
+  );
+}
+
+function ExternalSkillRow({ skill }: { skill: ExternalSkill }) {
+  return (
+    <div className="flex items-start gap-4 border-b border-border px-4 py-4 last:border-0">
+      <div className="min-w-0 flex-1">
+        <div className="mb-1.5 flex flex-wrap items-center gap-2">
+          <span className="text-sm font-medium text-foreground">{skill.name}</span>
+          <div className="flex flex-wrap gap-1.5">
+            {skill.types.map((t) => (
+              <TypeBadge key={t} type={t} />
+            ))}
+          </div>
+          {skill.author && (
+            <span className="text-xs text-muted-foreground">by {skill.author}</span>
+          )}
+        </div>
+        <p className="text-sm leading-6 text-muted-foreground">{skill.use}</p>
+      </div>
+      <a
+        href={skill.url}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="shrink-0 rounded-md border border-border bg-muted/50 px-3 py-1.5 text-xs font-medium text-muted-foreground transition-colors hover:border-primary/40 hover:text-foreground"
+      >
+        View
+      </a>
+    </div>
   );
 }
 
@@ -859,6 +906,8 @@ function SkillRow({ skill }: { skill: Skill }) {
 // ============================================================================
 
 function SkillsTab() {
+  const [skillView, setSkillView] = React.useState<'Internal' | 'External'>('Internal');
+
   return (
     <div className="space-y-8">
       <div>
@@ -871,19 +920,55 @@ function SkillsTab() {
 
       {/* Marketplace list */}
       <div className="overflow-hidden rounded-xl border border-border bg-card">
-        {/* List header */}
-        <div className="grid grid-cols-[1fr_auto] border-b border-border bg-muted/30 px-4 py-2.5">
+        {/* List header with Internal / External toggle */}
+        <div className="flex items-center justify-between border-b border-border bg-muted/30 px-4 py-2.5">
+          <div className="inline-flex rounded-md border border-border bg-background p-0.5">
+            {(['Internal', 'External'] as const).map((view) => (
+              <button
+                key={view}
+                type="button"
+                onClick={() => setSkillView(view)}
+                className={cn(
+                  'cursor-pointer rounded px-3 py-1 text-xs font-medium transition-colors',
+                  skillView === view
+                    ? 'bg-primary text-primary-foreground'
+                    : 'text-muted-foreground hover:text-foreground'
+                )}
+              >
+                {view}
+              </button>
+            ))}
+          </div>
           <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
-            Skill
-          </span>
-          <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
-            Install
+            {skillView === 'Internal' ? 'Install' : 'Link'}
           </span>
         </div>
 
-        {SKILLS.map((skill) => (
+        {skillView === 'Internal' && SKILLS.map((skill) => (
           <SkillRow key={skill.name} skill={skill} />
         ))}
+
+        {skillView === 'External' && EXTERNAL_SKILLS.length > 0 && EXTERNAL_SKILLS.map((skill) => (
+          <ExternalSkillRow key={skill.name} skill={skill} />
+        ))}
+
+        {skillView === 'External' && EXTERNAL_SKILLS.length === 0 && (
+          <div className="px-4 py-10 text-center">
+            <p className="mb-1 text-sm font-medium text-foreground">No external skills yet</p>
+            <p className="text-sm text-muted-foreground">
+              Know a skill worth listing? Share it in the{' '}
+              <a
+                href="https://uipath.enterprise.slack.com/archives/C0172850BEH"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="font-medium text-primary underline"
+              >
+                #apollo
+              </a>{' '}
+              Slack channel.
+            </p>
+          </div>
+        )}
       </div>
 
       <InfoCallout>
@@ -1301,8 +1386,25 @@ const tabs = [
 ] as const;
 type TabId = (typeof tabs)[number];
 
-function PrototypingPage({ globalTheme }: { globalTheme: string }) {
-  const [activeTab, setActiveTab] = React.useState<TabId>('Overview');
+function PrototypingPage({
+  globalTheme,
+  initialTab = 'Overview',
+  onTabChange,
+}: {
+  globalTheme: string;
+  initialTab?: TabId;
+  onTabChange?: (tab: TabId) => void;
+}) {
+  const [activeTab, setActiveTab] = React.useState<TabId>(initialTab);
+
+  React.useEffect(() => {
+    setActiveTab(initialTab);
+  }, [initialTab]);
+
+  const handleTabChange = (tab: TabId) => {
+    setActiveTab(tab);
+    onTabChange?.(tab);
+  };
 
   const activeThemeClass = resolveThemeClass(globalTheme);
 
@@ -1334,7 +1436,7 @@ function PrototypingPage({ globalTheme }: { globalTheme: string }) {
                   ? 'border-b-2 border-primary text-foreground'
                   : 'text-muted-foreground hover:text-foreground'
               )}
-              onClick={() => setActiveTab(tab)}
+              onClick={() => handleTabChange(tab)}
             >
               {tab}
             </button>
@@ -1361,5 +1463,14 @@ function PrototypingPage({ globalTheme }: { globalTheme: string }) {
 // ============================================================================
 
 export const Default: Story = {
-  render: (_, { globals }) => <PrototypingPage globalTheme={globals.theme || 'future-dark'} />,
+  args: {
+    tab: 'Overview',
+  },
+  render: (args, { globals, updateArgs }) => (
+    <PrototypingPage
+      globalTheme={globals.theme || 'future-dark'}
+      initialTab={args.tab as TabId}
+      onTabChange={(tab) => updateArgs({ tab })}
+    />
+  ),
 };


### PR DESCRIPTION
## Summary

- **Skills tab UX** — Internal/External toggle using underline tab style for consistency; contribute callout replaced with left-accent design to distinguish it from the data table above
- **Skills library** — added `apollo-install` and `apollo-repo-sync` skills alongside the existing `apollo-prototype`, all registered in the Storybook marketplace
- **Linkable tabs** — tab state wired to Storybook args so active tab is reflected in the URL (`?args=tab:Skills`) and shareable
- **CLI page** — callout updated to communicate this is a frontend-specific (apollo-wind/Tailwind) CLI, WIP status, and link to UiPath GitHub for other team CLIs

## New skills

| Skill | Category | Purpose |
|---|---|---|
| `apollo-install` | Setup | One-time setup — clones repo, installs deps, builds, starts Storybook |
| `apollo-repo-sync` | Setup | Per-session — configures and keeps apollo-wind up to date in a prototype repo |
| `apollo-prototype` | Prototype | Ongoing — design system rules so the AI prototypes correctly |

## Test plan

- [ ] Storybook → Introduction/Prototyping → Skills tab renders with all 3 skills in the marketplace list
- [ ] Internal/External toggle uses underline style matching main page tabs
- [ ] Contribute callout renders as a left-accent strip, visually distinct from the table
- [ ] Clicking a tab updates the URL (`?args=tab:Skills`) and sharing that URL lands on the correct tab
- [ ] Storybook → Introduction/Getting Started → CLI tab shows the updated scope callout with UiPath GitHub link
- [ ] All three skill files present under `packages/apollo-wind/skills/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)