### PR TITLE
fix(apollo-react): improve Toolbox keyboard nav with Space, Tab, and index restore

### DIFF
--- a/packages/apollo-react/src/canvas/components/Toolbox/ListView.test.tsx
+++ b/packages/apollo-react/src/canvas/components/Toolbox/ListView.test.tsx
@@ -236,7 +236,8 @@ describe('ListView', () => {
         expect.objectContaining({
           id: 'item-1',
           name: 'Item 1',
-        })
+        }),
+        0
       );
     });
 

--- a/packages/apollo-react/src/canvas/components/Toolbox/ListView.tsx
+++ b/packages/apollo-react/src/canvas/components/Toolbox/ListView.tsx
@@ -86,7 +86,7 @@ export interface ListViewRowProps<T extends ListItem> {
   activeIndex: number;
   isLoading?: boolean;
   isDarkMode?: boolean;
-  onItemClick: (item: T) => void;
+  onItemClick: (item: T, index: number) => void;
   onItemHover?: (item: T) => void;
 }
 
@@ -114,7 +114,7 @@ const ListViewRow = memo(
     const handleButtonClick = useCallback(() => {
       const clickTarget = renderedItems[index];
       if (clickTarget?.type === 'item') {
-        onItemClick(clickTarget.item);
+        onItemClick(clickTarget.item, index);
       }
     }, [onItemClick, renderedItems, index]);
 
@@ -208,7 +208,7 @@ interface ListViewProps<T extends ListItem> {
   items: T[];
   activeIndex?: number;
   listRef?: React.RefObject<ListImperativeAPI | null>;
-  onItemClick: (item: T) => void;
+  onItemClick: (item: T, index: number) => void;
   onItemHover?: (item: T) => void;
   emptyStateMessage?: string;
   emptyStateIcon?: string;

--- a/packages/apollo-react/src/canvas/components/Toolbox/SearchBox.tsx
+++ b/packages/apollo-react/src/canvas/components/Toolbox/SearchBox.tsx
@@ -9,7 +9,9 @@ interface SearchBoxProps {
   clear: () => void;
   placeholder?: string;
   inputRef?: React.RefObject<HTMLInputElement | null>;
+  clearButtonRef?: React.RefObject<HTMLButtonElement | null>;
   onNavigationKeyDown?: (e: React.KeyboardEvent) => void;
+  navigateToFirstItem?: () => void;
   activeDescendantId?: string;
 }
 
@@ -19,7 +21,9 @@ export const SearchBox = memo(function SearchBox({
   clear,
   placeholder = 'Search...',
   inputRef: externalInputRef,
+  clearButtonRef,
   onNavigationKeyDown,
+  navigateToFirstItem,
   activeDescendantId,
 }: SearchBoxProps) {
   const internalRef = useRef<HTMLInputElement>(null);
@@ -28,6 +32,17 @@ export const SearchBox = memo(function SearchBox({
   useEffect(() => {
     inputRef.current?.focus();
   }, [inputRef]);
+
+  const handleClearButtonKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Tab') {
+      e.preventDefault();
+      inputRef.current?.focus();
+
+      if (!e.shiftKey) {
+        navigateToFirstItem?.();
+      }
+    }
+  };
 
   return (
     <StyledSearchForm
@@ -54,7 +69,13 @@ export const SearchBox = memo(function SearchBox({
           aria-activedescendant={activeDescendantId}
         />
         {value && (
-          <button type="button" className="searchbox-clear" onClick={clear}>
+          <button
+            ref={clearButtonRef}
+            type="button"
+            className="searchbox-clear"
+            onClick={clear}
+            onKeyDown={handleClearButtonKeyDown}
+          >
             <ApIcon name="close" size="16px" />
           </button>
         )}

--- a/packages/apollo-react/src/canvas/components/Toolbox/Toolbox.test.tsx
+++ b/packages/apollo-react/src/canvas/components/Toolbox/Toolbox.test.tsx
@@ -642,6 +642,210 @@ describe('Toolbox', () => {
     });
   });
 
+  describe('Active index restoration on back navigation', () => {
+    const nestedItems: ListItem[] = [
+      {
+        id: 'item-1',
+        name: 'Item 1',
+        data: {},
+        icon: { name: 'star' },
+      },
+      {
+        id: 'item-2',
+        name: 'Item 2',
+        data: {},
+        icon: { name: 'star' },
+      },
+      {
+        id: 'category',
+        name: 'Category',
+        data: {},
+        icon: { name: 'folder' },
+        children: [
+          {
+            id: 'child-1',
+            name: 'Child 1',
+            data: {},
+            icon: { name: 'file' },
+          },
+          {
+            id: 'subcategory',
+            name: 'Subcategory',
+            data: {},
+            icon: { name: 'folder' },
+            children: [
+              {
+                id: 'grandchild-1',
+                name: 'Grandchild 1',
+                data: {},
+                icon: { name: 'file' },
+              },
+            ],
+          },
+        ],
+      },
+      {
+        id: 'item-3',
+        name: 'Item 3',
+        data: {},
+        icon: { name: 'star' },
+      },
+    ];
+
+    const getActiveItem = () => document.querySelector('[aria-selected="true"]');
+
+    it('should restore active index when navigating back via keyboard (ArrowLeft)', async () => {
+      vi.useFakeTimers({ shouldAdvanceTime: true });
+      const timedUser = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+
+      render(<Toolbox {...defaultProps} initialItems={nestedItems} />);
+
+      // Navigate to Category (3rd item)
+      await timedUser.keyboard('{ArrowDown}');
+      await timedUser.keyboard('{ArrowDown}');
+      await timedUser.keyboard('{ArrowDown}');
+      expect(getActiveItem()).toHaveTextContent('Category');
+
+      // Enter the category
+      await timedUser.keyboard('{ArrowRight}');
+      expect(screen.getByText('Child 1')).toBeInTheDocument();
+
+      // Wait for transition
+      await act(() => vi.advanceTimersByTimeAsync(200));
+
+      // Navigate back
+      await timedUser.keyboard('{ArrowLeft}');
+
+      // Should restore to Category (the item we entered from)
+      expect(getActiveItem()).toHaveTextContent('Category');
+
+      vi.useRealTimers();
+    });
+
+    it('should restore active index when navigating back via mouse click', async () => {
+      vi.useFakeTimers({ shouldAdvanceTime: true });
+      const timedUser = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+
+      render(<Toolbox {...defaultProps} initialItems={nestedItems} />);
+
+      // Click Category to enter it (mouse click)
+      await timedUser.click(screen.getByText('Category'));
+      expect(screen.getByText('Child 1')).toBeInTheDocument();
+
+      // Wait for transition
+      await act(() => vi.advanceTimersByTimeAsync(200));
+
+      // Click back button
+      await timedUser.click(screen.getByRole('button', { name: /back/i }));
+
+      // Should restore to Category
+      expect(getActiveItem()).toHaveTextContent('Category');
+
+      vi.useRealTimers();
+    });
+
+    it('should restore correct index through multiple levels of nesting', async () => {
+      vi.useFakeTimers({ shouldAdvanceTime: true });
+      const timedUser = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+
+      render(<Toolbox {...defaultProps} initialItems={nestedItems} />);
+
+      // Navigate to Category and enter it
+      await timedUser.keyboard('{ArrowDown}');
+      await timedUser.keyboard('{ArrowDown}');
+      await timedUser.keyboard('{ArrowDown}');
+      expect(getActiveItem()).toHaveTextContent('Category');
+      await timedUser.keyboard('{ArrowRight}');
+      await act(() => vi.advanceTimersByTimeAsync(200));
+
+      // Navigate to Subcategory and enter it
+      await timedUser.keyboard('{ArrowDown}');
+      await timedUser.keyboard('{ArrowDown}');
+      expect(getActiveItem()).toHaveTextContent('Subcategory');
+      await timedUser.keyboard('{ArrowRight}');
+      await act(() => vi.advanceTimersByTimeAsync(200));
+
+      // Should be in Subcategory now
+      expect(screen.getByText('Grandchild 1')).toBeInTheDocument();
+
+      // Go back to Category level — should restore Subcategory
+      await timedUser.keyboard('{ArrowLeft}');
+      await act(() => vi.advanceTimersByTimeAsync(200));
+      expect(getActiveItem()).toHaveTextContent('Subcategory');
+
+      // Go back to root — should restore Category
+      await timedUser.keyboard('{ArrowLeft}');
+      expect(getActiveItem()).toHaveTextContent('Category');
+
+      vi.useRealTimers();
+    });
+
+    it('should reset to search bar on back if search was active when entering', async () => {
+      vi.useFakeTimers({ shouldAdvanceTime: true });
+      const timedUser = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+
+      // Use onSearch that returns the category item so we can enter it from search
+      const categoryItem = nestedItems.find((i) => i.id === 'category')!;
+      const onSearch = vi.fn().mockResolvedValue([categoryItem]);
+
+      render(<Toolbox {...defaultProps} initialItems={nestedItems} onSearch={onSearch} />);
+
+      // Search for "Category"
+      const searchInput = screen.getByPlaceholderText('Search');
+      await timedUser.type(searchInput, 'cat');
+
+      // Navigate to Category result and enter it
+      await timedUser.keyboard('{ArrowDown}');
+      expect(getActiveItem()).toHaveTextContent('Category');
+      await timedUser.keyboard('{Enter}');
+      await act(() => vi.advanceTimersByTimeAsync(200));
+
+      expect(screen.getByText('Child 1')).toBeInTheDocument();
+
+      // Navigate back
+      await timedUser.keyboard('{ArrowLeft}');
+
+      // Should reset to search bar, not restore the search result index
+      expect(getActiveItem()).not.toBeInTheDocument();
+      expect(searchInput).toHaveFocus();
+
+      vi.useRealTimers();
+    });
+
+    it('should produce same restoration behavior for keyboard Enter and mouse click', async () => {
+      vi.useFakeTimers({ shouldAdvanceTime: true });
+      const timedUser = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+
+      // Test keyboard path
+      const { unmount } = render(<Toolbox {...defaultProps} initialItems={nestedItems} />);
+
+      await timedUser.keyboard('{ArrowDown}');
+      await timedUser.keyboard('{ArrowDown}');
+      await timedUser.keyboard('{ArrowDown}');
+      expect(getActiveItem()).toHaveTextContent('Category');
+      await timedUser.keyboard('{Enter}');
+      await act(() => vi.advanceTimersByTimeAsync(200));
+      await timedUser.keyboard('{ArrowLeft}');
+      const keyboardRestoredItem = getActiveItem();
+
+      unmount();
+
+      // Test mouse path
+      render(<Toolbox {...defaultProps} initialItems={nestedItems} />);
+
+      await timedUser.click(screen.getByText('Category'));
+      await act(() => vi.advanceTimersByTimeAsync(200));
+      await timedUser.click(screen.getByRole('button', { name: /back/i }));
+      const mouseRestoredItem = getActiveItem();
+
+      // Both should restore to Category
+      expect(keyboardRestoredItem).toHaveTextContent('Category');
+      expect(mouseRestoredItem).toHaveTextContent('Category');
+
+      vi.useRealTimers();
+    });
+  });
+
   describe('Smart item updates (initialItems prop changes)', () => {
     let user: UserEvent;
 

--- a/packages/apollo-react/src/canvas/components/Toolbox/Toolbox.tsx
+++ b/packages/apollo-react/src/canvas/components/Toolbox/Toolbox.tsx
@@ -129,6 +129,7 @@ export function Toolbox<T>({
   const navigationStack = useNavigationStack<{
     items: ListItem<T>[];
     parentItem: ListItem<T> | null;
+    activeIndex: number;
   }>();
 
   const [activeIndex, setActiveIndex] = useState(SEARCH_BAR_INDEX);
@@ -140,6 +141,7 @@ export function Toolbox<T>({
   const listRef = useListRef(null);
   const listViewRef = useRef<ListViewHandle<ListItem<T>>>(null);
   const searchInputRef = useRef<HTMLInputElement>(null);
+  const clearButtonRef = useRef<HTMLButtonElement>(null);
 
   const isSearching = useMemo(() => search.length > 0, [search]);
 
@@ -164,24 +166,30 @@ export function Toolbox<T>({
   const navigateToIndex = useCallback(
     (index: number) => {
       setActiveIndex(index);
+      searchInputRef.current?.focus();
 
-      if (index === SEARCH_BAR_INDEX) {
-        searchInputRef.current?.focus();
-        return;
+      if (index !== SEARCH_BAR_INDEX) {
+        requestAnimationFrame(() => {
+          listRef.current?.scrollToRow({ index, align: 'auto' });
+        });
       }
-
-      listRef.current?.scrollToRow({ index, align: 'auto' });
     },
     [listRef]
   );
+
+  const navigateToFirstItem = useCallback(() => {
+    const renderedItems = listViewRef.current?.renderedItems ?? [];
+    const firstIndex = getFirstSelectableIndex(renderedItems);
+    if (firstIndex !== SEARCH_BAR_INDEX) navigateToIndex(firstIndex);
+  }, [navigateToIndex]);
 
   const clearSearch = useCallback(() => {
     setSearch('');
     setSearchedItems([]);
     setSearchLoading(false);
     setIsSearchingInitialItems(true);
-    setActiveIndex(SEARCH_BAR_INDEX);
-  }, []);
+    navigateToIndex(SEARCH_BAR_INDEX);
+  }, [navigateToIndex]);
 
   const handleSearch = useCallback(
     async (query: string) => {
@@ -218,7 +226,6 @@ export function Toolbox<T>({
 
   const handleBackTransition = useCallback(() => {
     startTransition('back');
-    setActiveIndex(SEARCH_BAR_INDEX);
 
     const previousState = navigationStack.pop();
 
@@ -227,15 +234,20 @@ export function Toolbox<T>({
       setCurrentParentItem(previousState.data.parentItem);
     }
 
-    if (isSearching) {
-      clearSearch();
-    }
+    // Reset search state without calling clearSearch (which navigates to search bar).
+    setSearch('');
+    setSearchedItems([]);
+    setSearchLoading(false);
+    setIsSearchingInitialItems(true);
+
+    const restoredIndex = previousState?.data.activeIndex ?? SEARCH_BAR_INDEX;
+    navigateToIndex(restoredIndex);
 
     onBack?.();
-  }, [navigationStack, isSearching, onBack, clearSearch, startTransition]);
+  }, [navigationStack, onBack, startTransition, navigateToIndex]);
 
   const handleItemSelect = useCallback(
-    async (item: ListItem<T>) => {
+    async (item: ListItem<T>, index?: number) => {
       if (!item.children) {
         onItemSelect(item);
         return;
@@ -245,9 +257,14 @@ export function Toolbox<T>({
         typeof item.children === 'function'
           ? await item.children(item.id, item.name)
           : item.children;
+      const savedIndex = isSearching ? SEARCH_BAR_INDEX : (index ?? activeIndex);
       navigationStack.push({
         title: currentParentItem?.name || title,
-        data: { items, parentItem: currentParentItem },
+        data: {
+          items,
+          parentItem: currentParentItem,
+          activeIndex: savedIndex,
+        },
       });
       setItems(nestedItems);
       setCurrentParentItem(item);
@@ -256,7 +273,17 @@ export function Toolbox<T>({
       startTransition('forward');
       setChildrenLoading(false);
     },
-    [navigationStack, currentParentItem, title, items, clearSearch, startTransition, onItemSelect]
+    [
+      navigationStack,
+      currentParentItem,
+      title,
+      items,
+      activeIndex,
+      isSearching,
+      clearSearch,
+      startTransition,
+      onItemSelect,
+    ]
   );
 
   useEffect(() => {
@@ -303,6 +330,7 @@ export function Toolbox<T>({
           data: {
             items: newInitialItems,
             parentItem: null,
+            activeIndex: stackItem.data.activeIndex,
           },
         };
       }
@@ -320,6 +348,7 @@ export function Toolbox<T>({
         data: {
           items: updatedItems,
           parentItem: updatedParentItem,
+          activeIndex: stackItem.data.activeIndex,
         },
       };
     });
@@ -356,15 +385,13 @@ export function Toolbox<T>({
 
       const navigateDown = () => {
         if (activeIndex === SEARCH_BAR_INDEX) {
-          const firstIndex = getFirstSelectableIndex(renderedItems);
-          if (firstIndex !== SEARCH_BAR_INDEX) navigateToIndex(firstIndex);
+          navigateToFirstItem();
         } else {
           const nextIndex = getNextSelectableIndex(renderedItems, activeIndex, 'down');
           if (nextIndex !== SEARCH_BAR_INDEX) {
             navigateToIndex(nextIndex);
           } else {
-            const firstIndex = getFirstSelectableIndex(renderedItems);
-            if (firstIndex !== SEARCH_BAR_INDEX) navigateToIndex(firstIndex);
+            navigateToFirstItem();
           }
         }
       };
@@ -384,8 +411,9 @@ export function Toolbox<T>({
           navigateUp();
           break;
         }
+        case ' ':
         case 'Enter': {
-          if (activeIndex === SEARCH_BAR_INDEX) break;
+          if (activeIndex === SEARCH_BAR_INDEX) return;
 
           const renderItem = renderedItems[activeIndex];
           if (renderItem?.type === 'item') {
@@ -411,9 +439,25 @@ export function Toolbox<T>({
           break;
         }
         case 'Tab': {
+          // When on the search bar with text, defer behavior handling to SearchBox
+          if (activeIndex === SEARCH_BAR_INDEX && search.length > 0 && !e.shiftKey) {
+            break;
+          }
+
           e.preventDefault();
+
+          if (activeIndex === SEARCH_BAR_INDEX && e.shiftKey) {
+            break;
+          }
+
           if (e.shiftKey) {
             navigateUp();
+
+            // If the clear button is showing, allow shift+tab to focus it from the search bar
+            const nextUp = getNextSelectableIndex(renderedItems, activeIndex, 'up');
+            if (nextUp === SEARCH_BAR_INDEX && search.length > 0) {
+              clearButtonRef.current?.focus();
+            }
           } else {
             navigateDown();
           }
@@ -423,8 +467,7 @@ export function Toolbox<T>({
           if (activeIndex === SEARCH_BAR_INDEX) break;
 
           e.preventDefault();
-          const firstIndex = getFirstSelectableIndex(renderedItems);
-          if (firstIndex !== SEARCH_BAR_INDEX) navigateToIndex(firstIndex);
+          navigateToFirstItem();
           break;
         }
         case 'End': {
@@ -443,6 +486,7 @@ export function Toolbox<T>({
       activeIndex,
       navigationStack.canGoBack,
       navigateToIndex,
+      navigateToFirstItem,
       handleItemSelect,
       handleBackTransition,
     ]
@@ -499,7 +543,9 @@ export function Toolbox<T>({
           clear={clearSearch}
           placeholder="Search"
           inputRef={searchInputRef}
+          clearButtonRef={clearButtonRef}
           onNavigationKeyDown={handleNavigationKeyDown}
+          navigateToFirstItem={navigateToFirstItem}
           activeDescendantId={activeDescendantId}
         />
 


### PR DESCRIPTION
Fast-follow improvements for https://github.com/UiPath/apollo-ui/pull/354

## Summary

Improves keyboard navigation in the Toolbox component by:
- adding Space key support for item selection
- fixing Tab key cycling behavior (including search clear button handling)
- restoring the active item index when navigating back from a category (for both mouse and keyboard interactions)

https://github.com/user-attachments/assets/54f1b93b-7b5f-460d-84bc-2eda1ce3a3f6

## Changes

- **Space key selection**: Space now selects the active item, matching Enter/ArrowRight behavior
- **Tab cycling**: Tab/Shift+Tab cycles through the list; when search has text, Tab from search bar defers to SearchBox (clear button focus)
- **SearchBox clear button**: Tab on the clear button returns focus to the input or navigates to the first list item
- **Back-navigation index restore**: Saves `activeIndex` in the navigation stack on category entry; restores it on back navigation. If search was active when entering, resets to search bar instead (filtered index would be invalid)
- **Refactor**: Extracted `navigateToFirstItem` as a reusable callback, replacing inline duplicates

## Flow

```mermaid
flowchart TD
    A[User enters category] -->|push| B[Save items + parentItem + activeIndex to stack]
    C[User navigates back] -->|pop| D[Restore items + parentItem]
    D --> E{Was searching on entry?}
    E -->|Yes| F[Reset to search bar]
    E -->|No| G[Restore saved activeIndex]
```

## Testing

- [x] `pnpm run test` passes (64 suites, 1257 tests)
- [x] `pnpm run typecheck` passes
- [x] Manual testing performed
    - [x] Tabbing to/from search input with text in input -- focused on clear button in between list items and search
    - [x] Tabbing to/from search input without text in input -- did not focus on clear button
    - [x] List item index was preserved when navigating back to parent 
    - [x] Ensure same parent/child navigation results when using arrow keys/mouse