### PR TITLE
fix(apollo-core): too generic theme name

### DIFF
--- a/packages/apollo-core/src/tokens/templates/css-theme-variables.template
+++ b/packages/apollo-core/src/tokens/templates/css-theme-variables.template
@@ -1,6 +1,6 @@
 @import "./variables.css";
 
-body.light, .light {
+body.light, .apollo-design.light {
 <% _.each(allProperties, function(property) { if (property.name.endsWith('light')) {
   const baseName = property.name.slice(0, -'-light'.length);
 %>  --<%= baseName %>: <%= property.value %>;
@@ -9,7 +9,7 @@ body.light, .light {
   color-scheme: light;
 }
 
-body.light-hc, .light-hc {
+body.light-hc, .apollo-design.light-hc {
 <% _.each(allProperties, function(property) { if (property.name.endsWith('light-hc')) {
   const baseName = property.name.slice(0, -'-light-hc'.length);
 %>  --<%= baseName %>: <%= property.value %>;
@@ -18,7 +18,7 @@ body.light-hc, .light-hc {
   color-scheme: light;
 }
 
-body.dark, .dark {
+body.dark, .apollo-design.dark {
 <% _.each(allProperties, function(property) { if (property.name.endsWith('dark')) {
   const baseName = property.name.slice(0, -'-dark'.length);
 %>  --<%= baseName %>: <%= property.value %>;
@@ -27,7 +27,7 @@ body.dark, .dark {
   color-scheme: dark;
 }
 
-body.dark-hc, .dark-hc {
+body.dark-hc, .apollo-design.dark-hc {
 <% _.each(allProperties, function(property) { if (property.name.endsWith('dark-hc')) {
   const baseName = property.name.slice(0, -'-dark-hc'.length);
 %>  --<%= baseName %>: <%= property.value %>;

--- a/packages/apollo-core/src/tokens/templates/theme-variables.template
+++ b/packages/apollo-core/src/tokens/templates/theme-variables.template
@@ -1,6 +1,6 @@
 @import "./variables";
 
-body.light, .light {
+body.light, .apollo-design.light {
 <% _.each(allProperties, function(property) { if (property.name.endsWith('light')) {
 %>  --<%= property.name.slice(0, -'-light'.length) %>: #{$<%= property.name %>};
 <% }}); %>
@@ -8,7 +8,7 @@ body.light, .light {
   color-scheme: light;
 }
 
-body.light-hc, .light-hc {
+body.light-hc, .apollo-design.light-hc {
 <% _.each(allProperties, function(property) { if (property.name.endsWith('light-hc')) {
 %>  --<%= property.name.slice(0, -'-light-hc'.length) %>: #{$<%= property.name %>};
 <% }}); %>
@@ -16,7 +16,7 @@ body.light-hc, .light-hc {
   color-scheme: light;
 }
 
-body.dark, .dark {
+body.dark, .apollo-design.dark {
 <% _.each(allProperties, function(property) { if (property.name.endsWith('dark')) {
 %>  --<%= property.name.slice(0, -'-dark'.length) %>: #{$<%= property.name %>};
 <% }}); %>
@@ -24,7 +24,7 @@ body.dark, .dark {
   color-scheme: dark;
 }
 
-body.dark-hc, .dark-hc {
+body.dark-hc, .apollo-design.dark-hc {
 <% _.each(allProperties, function(property) { if (property.name.endsWith('dark-hc')) {
 %>  --<%= property.name.slice(0, -'-dark-hc'.length) %>: #{$<%= property.name %>};
 <% }}); %>

--- a/packages/apollo-wind/src/getting-started/prototyping.stories.tsx
+++ b/packages/apollo-wind/src/getting-started/prototyping.stories.tsx
@@ -23,7 +23,15 @@ const meta: Meta<PrototypingArgs> = {
   argTypes: {
     tab: {
       control: 'select',
-      options: ['Overview', 'Skills', 'Prototype', 'w/ Figma', 'w/ Claude', 'w/ Cursor', 'Resources'],
+      options: [
+        'Overview',
+        'Skills',
+        'Prototype',
+        'w/ Figma',
+        'w/ Claude',
+        'w/ Cursor',
+        'Resources',
+      ],
     },
   },
 };
@@ -913,9 +921,7 @@ function ExternalSkillRow({ skill }: { skill: ExternalSkill }) {
               <SurfaceBadge key={s} surface={s} />
             ))}
           </div>
-          {skill.author && (
-            <span className="text-xs text-muted-foreground">by {skill.author}</span>
-          )}
+          {skill.author && <span className="text-xs text-muted-foreground">by {skill.author}</span>}
         </div>
         <p className="text-sm leading-6 text-muted-foreground">{skill.description}</p>
       </div>
@@ -969,15 +975,12 @@ function SkillsTab() {
           ))}
         </div>
 
+        {skillView === 'Internal' &&
+          SKILLS.map((skill) => <SkillRow key={skill.name} skill={skill} />)}
 
-
-        {skillView === 'Internal' && SKILLS.map((skill) => (
-          <SkillRow key={skill.name} skill={skill} />
-        ))}
-
-        {skillView === 'External' && EXTERNAL_SKILLS.length > 0 && EXTERNAL_SKILLS.map((skill) => (
-          <ExternalSkillRow key={skill.name} skill={skill} />
-        ))}
+        {skillView === 'External' &&
+          EXTERNAL_SKILLS.length > 0 &&
+          EXTERNAL_SKILLS.map((skill) => <ExternalSkillRow key={skill.name} skill={skill} />)}
 
         {skillView === 'External' && EXTERNAL_SKILLS.length === 0 && (
           <div className="px-4 py-10 text-center">

--- a/web-packages/ap-chat/package.json
+++ b/web-packages/ap-chat/package.json
@@ -26,7 +26,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "NODE_ENV=production rsbuild build",
+    "build": "NODE_ENV=production rsbuild build && tsc --project tsconfig.build.json",
     "build:analyze": "NODE_ENV=production BUNDLE_ANALYZE=true rsbuild build",
     "dev": "NODE_ENV=development rsbuild dev",
     "lint": "biome lint src",

--- a/web-packages/ap-chat/src/ap-chat-element.ts
+++ b/web-packages/ap-chat/src/ap-chat-element.ts
@@ -255,7 +255,7 @@ export class ApChat extends HTMLElement {
     const transformedThemeVariablesCSS = apolloThemeVariablesCSS
       .replace(/:root\s*\{/g, ':host {')
       .replace(
-        /body\.(light|dark|light-hc|dark-hc)(?:,\s*\.\1)?\s*\{/g,
+        /body\.(light|dark|light-hc|dark-hc)(?:,\s*\.apollo-design\.\1)?\s*\{/g,
         ':host(.$1), :host(.$1) * {'
       ); // Apply to host and all descendants
 

--- a/web-packages/ap-chat/tsconfig.build.json
+++ b/web-packages/ap-chat/tsconfig.build.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "emitDeclarationOnly": true,
+    "declarationMap": false,
+    "sourceMap": false,
+    "composite": false,
+    "incremental": false
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.spec.ts", "**/__tests__/**"]
+}


### PR DESCRIPTION
`.light` was too generic of a selector and in react canvas somewhere we use `.light` even on dark canvas, this prevents issues with parents that use `.light` theme, by adding the `apollo-design` required as well.

Also exports types for chat package, and runs format