### PR TITLE
fix(apollo-react): task status icon tooltip [MST-7296]

### DIFF
--- a/packages/apollo-react/src/canvas/components/StageNode/DraggableTask.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/DraggableTask.tsx
@@ -4,6 +4,7 @@ import { FontVariantToken, Padding, Spacing } from '@uipath/apollo-core';
 import { Column, Row } from '@uipath/apollo-react/canvas/layouts';
 import {
   ApBadge,
+  ApIconButton,
   ApTooltip,
   ApTypography,
   BadgeSize,
@@ -76,7 +77,9 @@ export const TaskContent = memo(({ task, taskExecution, isDragging }: TaskConten
         {taskExecution?.status &&
           (taskExecution.message ? (
             <ApTooltip content={taskExecution.message} placement="top">
-              <ExecutionStatusIcon status={taskExecution.status} />
+              <ApIconButton size="small">
+                <ExecutionStatusIcon status={taskExecution.status} />
+              </ApIconButton>
             </ApTooltip>
           ) : (
             <ExecutionStatusIcon status={taskExecution.status} />
@@ -194,7 +197,6 @@ const DraggableTaskComponent = ({
       status={taskExecution?.status}
       isParallel={isParallel}
       isDragEnabled={!isDragDisabled}
-      isMenuOpen={isMenuOpen}
       onClick={handleClick}
       {...(contextMenuItems.length > 0 && { onContextMenu: handleContextMenu })}
     >

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.stories.tsx
@@ -219,6 +219,35 @@ export const Default: Story = {
           })),
         },
       },
+      {
+        id: '2',
+        type: 'stage',
+        position: { x: 752, y: 96 },
+        width: 304,
+        data: {
+          onReplaceTaskFromToolbox: () => {},
+          stageDetails: {
+            label: 'Validation - Failed',
+            isReadOnly: true,
+            tasks: [
+              [{ id: '1', label: 'Data Validation', icon: <VerificationIcon /> }],
+              [{ id: '2', label: 'Compliance Check', icon: <DocumentIcon /> }],
+            ],
+          },
+          execution: {
+            stageStatus: {
+              label: 'error message',
+              status: 'Failed',
+            },
+            taskStatus: {
+              '2': {
+                status: 'Failed',
+                message: 'Compliance requirements not met',
+              },
+            },
+          },
+        },
+      },
     ],
   },
   args: {},

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.styles.ts
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.styles.ts
@@ -171,7 +171,6 @@ export const StageTask = styled.div<{
   selected?: boolean;
   isParallel?: boolean;
   isDragEnabled?: boolean;
-  isMenuOpen?: boolean;
 }>`
   position: relative;
   display: flex;
@@ -193,10 +192,6 @@ export const StageTask = styled.div<{
   height: ${({ isDragEnabled }) => (isDragEnabled ? '100%' : 'auto')};
 
   .task-menu-icon-button {
-    display: ${({ isMenuOpen }) => (isMenuOpen ? 'flex' : 'none')};
-  }
-
-  &:hover .task-menu-icon-button {
     display: flex;
   }
 


### PR DESCRIPTION
three dot on tasks in cases will always be visible.
fix the status icon in tasks to show the tooltip

after

https://github.com/user-attachments/assets/108f0b5c-9f5d-491b-972a-b3d87b3c2b6f

before


https://github.com/user-attachments/assets/72a0fa24-949a-482d-9620-60ac60efccb2

