### PR TITLE
feat(apollo-vertex): make auth optional in shell component [AGVSOL-1824]

### DIFF
--- a/apps/apollo-vertex/app/vertex-components/shell/page.mdx
+++ b/apps/apollo-vertex/app/vertex-components/shell/page.mdx
@@ -3,7 +3,7 @@ import { PreviewFullScreen } from '@/app/components/preview-full-screen';
 
 # Shell
 
-A component that includes OAuth2 authentication and a collapsible sidebar.
+A component with a collapsible sidebar, theme and language toggles, and optional OAuth2 authentication.
 
 <PreviewFullScreen title="Shell preview">
     <ShellTemplate />
@@ -19,7 +19,7 @@ Use the `variant="minimal"` prop to render a horizontal header layout instead of
 
 ## Features
 
-- **OAuth2 Authentication**: Built-in authorization code flow with PKCE
+- **Optional OAuth2 Authentication**: Plug-and-play authorization code flow with PKCE
 - **Theme Toggle**: Built-in light/dark mode support
 - **Language Toggle**: Built-in language switcher for internationalization
 - **User Profile**: Dropdown menu with user information and sign-out
@@ -32,12 +32,42 @@ npx shadcn@latest add @uipath/shell
 
 ## Usage
 
-The `ApolloShell` component must be wrapped in a `QueryClientProvider` from `@tanstack/react-query`.
+The shell works out of the box without authentication. Just provide layout props:
+
+```tsx
+import { Home, Settings } from 'lucide-react';
+import { ApolloShell } from '@/components/ui/shell';
+
+const navItems = [
+  { path: '/dashboard', label: 'dashboard', icon: Home },
+  { path: '/settings', label: 'settings', icon: Settings },
+];
+
+function App() {
+  return (
+    <ApolloShell
+      companyName="Your Company"
+      productName="Your Product"
+      navItems={navItems}
+    >
+      <YourApp />
+    </ApolloShell>
+  );
+}
+```
+
+## Adding Authentication
+
+To enable built-in OAuth2 authentication with PKCE, wrap the shell with `ShellAuthProvider`.
+Both `ShellAuthProvider` and `ApolloShell` must be inside a `QueryClientProvider` from `@tanstack/react-query`.
+
+When a `ShellAuthProvider` is present, the shell automatically shows a login screen until the user is authenticated.
 
 ```tsx
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { Home, Settings } from 'lucide-react';
 import { ApolloShell } from '@/components/ui/shell';
+import { ShellAuthProvider } from '@/components/ui/shell-auth-provider';
 
 const queryClient = new QueryClient();
 
@@ -49,17 +79,19 @@ const navItems = [
 function App() {
   return (
     <QueryClientProvider client={queryClient}>
-      <ApolloShell
+      <ShellAuthProvider
         clientId="your-client-id"
         scope="openid profile email offline_access"
         baseUrl={window.location.origin}
-        companyName="Your Company"
-        productName="Your Product"
-        navItems={navItems}
       >
-        {/* your authenticated app content */}
-        <YourApp />
-      </ApolloShell>
+        <ApolloShell
+          companyName="Your Company"
+          productName="Your Product"
+          navItems={navItems}
+        >
+          <YourApp />
+        </ApolloShell>
+      </ShellAuthProvider>
     </QueryClientProvider>
   );
 }

--- a/apps/apollo-vertex/registry/shell/shell-auth-provider.tsx
+++ b/apps/apollo-vertex/registry/shell/shell-auth-provider.tsx
@@ -53,12 +53,20 @@ const decodeJWT = (token: string): UserInfo | null => {
 
 export const AuthContext = createContext<AuthContextValue | null>(null);
 
-export const useAuth = () => {
+const noAuthDefaults: AuthContextValue = {
+  user: null,
+  isAuthenticated: false,
+  isLoading: false,
+  // oxlint-disable-next-line no-empty-function
+  login: async () => {},
+  // oxlint-disable-next-line no-empty-function
+  logout: () => {},
+  accessToken: null,
+};
+
+export const useAuth = (): AuthContextValue => {
   const context = useContext(AuthContext);
-  if (context == null) {
-    throw new Error("useAuth must be used within an AuthProvider");
-  }
-  return context;
+  return context ?? noAuthDefaults;
 };
 
 interface UseAccessTokenProps {

--- a/apps/apollo-vertex/registry/shell/shell.tsx
+++ b/apps/apollo-vertex/registry/shell/shell.tsx
@@ -1,6 +1,7 @@
 import type { LucideIcon } from "lucide-react";
 import type { FC, PropsWithChildren } from "react";
-import { ShellAuthProvider, useAuth } from "./shell-auth-provider";
+import { useContext } from "react";
+import { AuthContext, useAuth } from "./shell-auth-provider";
 import { ShellLayout } from "./shell-layout";
 import { LocaleProvider } from "./shell-locale-provider";
 import { ShellLogin } from "./shell-login";
@@ -19,7 +20,7 @@ export interface ShellNavItem {
   icon: LucideIcon;
 }
 
-export interface ApolloShellComponentProps extends PropsWithChildren {
+export interface ApolloShellProps extends PropsWithChildren {
   companyName: string;
   productName: string;
   variant?: "minimal";
@@ -28,14 +29,7 @@ export interface ApolloShellComponentProps extends PropsWithChildren {
   loginDescription?: string;
 }
 
-interface ApolloShellProps extends ApolloShellComponentProps {
-  clientId: string;
-  scope: string;
-  baseUrl: string;
-  variant?: "minimal";
-}
-
-const ApolloShellComponent: FC<ApolloShellComponentProps> = ({
+const ApolloShellContent: FC<ApolloShellProps> = ({
   children,
   companyName,
   productName,
@@ -44,8 +38,10 @@ const ApolloShellComponent: FC<ApolloShellComponentProps> = ({
   navItems,
   loginDescription,
 }) => {
+  const authContext = useContext(AuthContext);
   const { accessToken } = useAuth();
-  if (!accessToken) {
+
+  if (authContext && !accessToken) {
     return <ShellLogin title={productName} description={loginDescription} />;
   }
 
@@ -65,9 +61,6 @@ const ApolloShellComponent: FC<ApolloShellComponentProps> = ({
 };
 
 export const ApolloShell: FC<ApolloShellProps> = ({
-  clientId,
-  scope,
-  baseUrl,
   children,
   companyName,
   productName,
@@ -77,19 +70,17 @@ export const ApolloShell: FC<ApolloShellProps> = ({
   loginDescription,
 }) => {
   return (
-    <ShellAuthProvider clientId={clientId} scope={scope} baseUrl={baseUrl}>
-      <LocaleProvider>
-        <ApolloShellComponent
-          companyName={companyName}
-          productName={productName}
-          companyLogo={companyLogo}
-          variant={variant}
-          navItems={navItems}
-          loginDescription={loginDescription}
-        >
-          {children}
-        </ApolloShellComponent>
-      </LocaleProvider>
-    </ShellAuthProvider>
+    <LocaleProvider>
+      <ApolloShellContent
+        companyName={companyName}
+        productName={productName}
+        companyLogo={companyLogo}
+        variant={variant}
+        navItems={navItems}
+        loginDescription={loginDescription}
+      >
+        {children}
+      </ApolloShellContent>
+    </LocaleProvider>
   );
 };

--- a/apps/apollo-vertex/templates/shell/ShellRoot.tsx
+++ b/apps/apollo-vertex/templates/shell/ShellRoot.tsx
@@ -42,9 +42,6 @@ export function ShellWrapper({
         alt: "UiPath logo",
       }}
       variant={variant}
-      clientId="e74e5981-cde0-4cd4-971c-6525cfba86b5"
-      scope="openid profile email offline_access"
-      baseUrl={typeof window === "undefined" ? "" : window.location.origin}
       navItems={variant === "minimal" ? minimalNavItems : navItems}
     >
       {children}


### PR DESCRIPTION
## Summary

Make authentication plug-and-play in the shell component. The shell is now auth-agnostic — it renders directly without requiring any auth configuration. Consumers who want built-in OAuth2 authentication wrap the shell with ShellAuthProvider externally.

// Without auth — just works
```
<ApolloShell companyName="..." navItems={navItems}>
  {children}
</ApolloShell>
```

// With auth — consumer wraps explicitly
```
<ShellAuthProvider clientId="..." scope="..." baseUrl="...">
  <ApolloShell companyName="..." navItems={navItems}>
    {children}
  </ApolloShell>
</ShellAuthProvider>
```
## Changes

Remove auth props from ApolloShell — shell no longer manages auth
useAuth() returns anonymous defaults when outside a ShellAuthProvider instead of throwing
Shell detects auth provider presence via context and shows login only when a provider exists but user is not authenticated
Remove auth config from shell template (runs in no-auth mode)
Update shell docs with usage examples for both modes