### PR TITLE
ci(repo): add PR size labeling workflow [AGVSOL-1846]

### DIFF
--- a/.github/workflows/pr-size.yml
+++ b/.github/workflows/pr-size.yml
@@ -1,0 +1,183 @@
+name: PR Size
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+      - converted_to_draft
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  prepare-config:
+    name: Prepare PR size config
+    runs-on: ubuntu-24.04
+    outputs:
+      labels_json: ${{ steps.config.outputs.labels_json }}
+    steps:
+      - id: config
+        name: Build PR size label config
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        with:
+          result-encoding: string
+          script: |
+            const managedLabels = [
+              { name: "size:XS", color: "0e8a16", description: "0-9 changed lines." },
+              { name: "size:S", color: "5ebd3e", description: "10-29 changed lines." },
+              { name: "size:M", color: "fbca04", description: "30-99 changed lines." },
+              { name: "size:L", color: "fe7d37", description: "100-499 changed lines." },
+              { name: "size:XL", color: "d93f0b", description: "500-999 changed lines." },
+              { name: "size:XXL", color: "b60205", description: "1,000+ changed lines." },
+            ];
+
+            core.setOutput("labels_json", JSON.stringify(managedLabels));
+  sync-label-definitions:
+    name: Sync PR size label definitions
+    needs: prepare-config
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Ensure PR size labels exist
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        env:
+          PR_SIZE_LABELS_JSON: ${{ needs.prepare-config.outputs.labels_json }}
+        with:
+          script: |
+            const managedLabels = JSON.parse(process.env.PR_SIZE_LABELS_JSON ?? "[]");
+
+            for (const label of managedLabels) {
+              try {
+                const { data: existing } = await github.rest.issues.getLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  name: label.name,
+                });
+
+                if (
+                  existing.color !== label.color ||
+                  (existing.description ?? "") !== label.description
+                ) {
+                  await github.rest.issues.updateLabel({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    name: label.name,
+                    color: label.color,
+                    description: label.description,
+                  });
+                }
+              } catch (error) {
+                if (error.status !== 404) {
+                  throw error;
+                }
+
+                try {
+                  await github.rest.issues.createLabel({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    name: label.name,
+                    color: label.color,
+                    description: label.description,
+                  });
+                } catch (createError) {
+                  if (createError.status !== 422) {
+                    throw createError;
+                  }
+                }
+              }
+            }
+  label:
+    name: Label PR size
+    needs: [prepare-config, sync-label-definitions]
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+    concurrency:
+      group: pr-size-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
+    steps:
+      - name: Sync PR size label
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        env:
+          PR_SIZE_LABELS_JSON: ${{ needs.prepare-config.outputs.labels_json }}
+        with:
+          script: |
+            const issueNumber = context.payload.pull_request.number;
+            const additions = context.payload.pull_request.additions ?? 0;
+            const deletions = context.payload.pull_request.deletions ?? 0;
+            const changedLines = additions + deletions;
+            const managedLabels = JSON.parse(process.env.PR_SIZE_LABELS_JSON ?? "[]");
+
+            const managedLabelNames = new Set(managedLabels.map((label) => label.name));
+
+            const resolveSizeLabel = (totalChangedLines) => {
+              if (totalChangedLines < 10) {
+                return "size:XS";
+              }
+
+              if (totalChangedLines < 30) {
+                return "size:S";
+              }
+
+              if (totalChangedLines < 100) {
+                return "size:M";
+              }
+
+              if (totalChangedLines < 500) {
+                return "size:L";
+              }
+
+              if (totalChangedLines < 1000) {
+                return "size:XL";
+              }
+
+              return "size:XXL";
+            };
+
+            const nextLabelName = resolveSizeLabel(changedLines);
+
+            const { data: currentLabels } = await github.rest.issues.listLabelsOnIssue({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber,
+              per_page: 100,
+            });
+
+            for (const label of currentLabels) {
+              if (!managedLabelNames.has(label.name) || label.name === nextLabelName) {
+                continue;
+              }
+
+              try {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issueNumber,
+                  name: label.name,
+                });
+              } catch (removeError) {
+                if (removeError.status !== 404) {
+                  throw removeError;
+                }
+              }
+            }
+
+            if (!currentLabels.some((label) => label.name === nextLabelName)) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+                labels: [nextLabelName],
+              });
+            }
+
+            core.info(`PR #${issueNumber}: ${changedLines} changed lines -> ${nextLabelName}`);


### PR DESCRIPTION
Adds size labels to PRs so reviewers can quickly see how big a change is.

Inspired from: https://github.com/UiPath/coded-agentic-process/blob/main/.github/workflows/pr-size.yml