### PR TITLE
fix(apollo-wind): skip rendering null children on metadata form

### DIFF
--- a/packages/apollo-wind/src/components/forms/field-renderer.test.tsx
+++ b/packages/apollo-wind/src/components/forms/field-renderer.test.tsx
@@ -340,6 +340,57 @@ describe('FormFieldRenderer', () => {
       const wrapper = container.firstChild as HTMLElement;
       expect(wrapper).toHaveStyle({ gridColumn: 'span 1' });
     });
+
+    it('hides grid cell wrapper when custom component returns null', () => {
+      const NullComponent = () => null;
+
+      const field: FieldMetadata = {
+        name: 'null_custom',
+        type: 'custom',
+        label: 'Null Custom',
+        component: 'NullComponent',
+      };
+
+      const { container } = render(
+        <FormWrapper>
+          <FormFieldRenderer
+            field={field}
+            context={createMockContext()}
+            customComponents={{ NullComponent }}
+          />
+        </FormWrapper>
+      );
+
+      const wrapper = container.firstChild as HTMLElement;
+      expect(wrapper).toHaveClass('empty:hidden');
+      // The div should be empty since the custom component returned null
+      expect(wrapper.childNodes).toHaveLength(0);
+    });
+
+    it('does not hide grid cell wrapper when custom component renders content', () => {
+      const VisibleComponent = () => <div data-testid="custom-content">Hello</div>;
+
+      const field: FieldMetadata = {
+        name: 'visible_custom',
+        type: 'custom',
+        label: 'Visible Custom',
+        component: 'VisibleComponent',
+      };
+
+      const { container } = render(
+        <FormWrapper>
+          <FormFieldRenderer
+            field={field}
+            context={createMockContext()}
+            customComponents={{ VisibleComponent }}
+          />
+        </FormWrapper>
+      );
+
+      const wrapper = container.firstChild as HTMLElement;
+      expect(wrapper).toHaveClass('empty:hidden');
+      expect(screen.getByTestId('custom-content')).toBeInTheDocument();
+    });
   });
 
   describe('accessibility', () => {

--- a/packages/apollo-wind/src/components/forms/field-renderer.tsx
+++ b/packages/apollo-wind/src/components/forms/field-renderer.tsx
@@ -261,7 +261,7 @@ export function FormFieldRenderer({
   if (isCustomField(field) && customComponents[field.component]) {
     const CustomComponent = customComponents[field.component];
     return (
-      <div style={gridStyle}>
+      <div className="empty:hidden" style={gridStyle}>
         <Controller
           name={field.name}
           control={control}
@@ -282,7 +282,7 @@ export function FormFieldRenderer({
   }
 
   return (
-    <div style={gridStyle}>
+    <div className="empty:hidden" style={gridStyle}>
       <Controller
         name={field.name}
         control={control}


### PR DESCRIPTION
Addresses an issue where even if a field of the metadata form returned null to be hidden, gaps would still be formed around it
<img width="523" height="421" alt="image" src="https://github.com/user-attachments/assets/c029ad9d-d74b-456c-8e46-c241c3c3f2d8" />
<img width="659" height="570" alt="image" src="https://github.com/user-attachments/assets/da3c15b2-1d94-4695-9006-ac8d90dc5d00" />

