### PR TITLE
fix(apollo-react): show "No tasks" message in read-only stage node

### DIFF
--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.tsx
@@ -96,7 +96,8 @@ const StageNodeComponent = (props: StageNodeProps) => {
   const isReadOnly = !!stageDetails?.isReadOnly;
   const icon = stageDetails?.icon;
   const selectedTaskId = stageDetails?.selectedTaskId;
-  const defaultContent = stageDetails?.defaultContent || 'Add first task';
+  const defaultContent =
+    stageDetails?.defaultContent || (isReadOnly ? 'No tasks' : 'Add first task');
 
   const status = execution?.stageStatus?.status;
   const statusLabel = execution?.stageStatus?.label;


### PR DESCRIPTION
## Summary
Updated the StageNode component to display a "No tasks" message when the stage is in read-only mode, instead of showing the default content.

## Key Changes
- Modified the empty state message in StageNode to conditionally render based on the `isReadOnly` prop
- When `isReadOnly` is true, displays "No tasks" text
- When `isReadOnly` is false, displays the original `defaultContent`

## Implementation Details
This change improves the user experience by providing clearer feedback in read-only stage nodes, making it immediately apparent that no tasks are available rather than showing generic placeholder content.

https://claude.ai/code/session_018gSnZEFPsSwaH5BxGny2aQ