### PR TITLE
fix(apollo-react): preserve task order when creating parallel group with task below [MST-7790]

### DIFF
--- a/packages/apollo-react/src/canvas/utils/GroupModificationUtils.test.ts
+++ b/packages/apollo-react/src/canvas/utils/GroupModificationUtils.test.ts
@@ -289,14 +289,14 @@ describe('GroupModificationUtils', () => {
   it('mergeGroupDown: should merge task with group below', () => {
     const tasks: TestItem[][] = [[createItem('1')], [createItem('2')], [createItem('3')]];
     const result = mergeGroupDown(tasks, 1, 0);
-    expect(result).toEqual([[createItem('1')], [createItem('3'), createItem('2')]]);
+    expect(result).toEqual([[createItem('1')], [createItem('2'), createItem('3')]]);
   });
 
   it('mergeGroupDown: should remove group if it becomes empty after merge', () => {
     const tasks: TestItem[][] = [[createItem('1')], [createItem('2')], [createItem('3')]];
     const result = mergeGroupDown(tasks, 1, 0);
     expect(result).toHaveLength(2);
-    expect(result[1]).toEqual([createItem('3'), createItem('2')]);
+    expect(result[1]).toEqual([createItem('2'), createItem('3')]);
   });
 
   it('mergeGroupDown: should merge into existing parallel group below', () => {
@@ -308,7 +308,7 @@ describe('GroupModificationUtils', () => {
     const result = mergeGroupDown(tasks, 1, 0);
     expect(result).toEqual([
       [createItem('1')],
-      [createItem('3'), createItem('4'), createItem('2')],
+      [createItem('2'), createItem('3'), createItem('4')],
     ]);
   });
 
@@ -340,7 +340,7 @@ describe('GroupModificationUtils', () => {
     expect(result).toEqual([
       [createItem('1')],
       [createItem('3')],
-      [createItem('4'), createItem('2')],
+      [createItem('2'), createItem('4')],
     ]);
   });
 

--- a/packages/apollo-react/src/canvas/utils/GroupModificationUtils.ts
+++ b/packages/apollo-react/src/canvas/utils/GroupModificationUtils.ts
@@ -190,7 +190,7 @@ export function mergeGroupDown<T>(tasks: T[][], groupIndex: number, taskIndex: n
 
   if (belowGroup) {
     // Add task to the group below
-    updatedTasks[groupIndex + 1] = [...belowGroup, task];
+    updatedTasks[groupIndex + 1] = [task, ...belowGroup];
 
     // Remove task from current group or remove group if empty
     if (currentGroupWithoutTask.length > 0) {


### PR DESCRIPTION
Before

https://github.com/user-attachments/assets/20d75372-4572-4e26-8b9f-e8d708d79f68




After

https://github.com/user-attachments/assets/f4c3285d-8324-40a4-984c-88a95610541d

