### PR TITLE
fix(apollo-react): stage title input fills available header width [MST-7791]

### DIFF
--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.stories.tsx
@@ -1290,6 +1290,136 @@ export const AddAndReplaceTasks: Story = {
   args: {},
 };
 
+const InlineTitleEditStory = () => {
+  const StageNodeWrapper = useMemo(
+    () =>
+      function StageNodeWrapperComponent(props: any) {
+        return <StageNode {...props} {...props.data} />;
+      },
+    []
+  );
+
+  const nodeTypes = useMemo(() => ({ stage: StageNodeWrapper }), [StageNodeWrapper]);
+  const edgeTypes = useMemo(() => ({ stage: StageEdge }), []);
+
+  const initialNodes = useMemo(
+    () => [
+      {
+        id: 'editable-stage',
+        type: 'stage' as const,
+        position: { x: 48, y: 96 },
+        width: 304,
+        data: {
+          stageDetails: {
+            label: 'Click to Edit Title',
+            tasks: [
+              [{ id: '1', label: 'KYC Verification', icon: <VerificationIcon /> }],
+              [{ id: '2', label: 'Document Review', icon: <DocumentIcon /> }],
+            ],
+          },
+          onTaskAdd: () => {
+            window.alert('Add task functionality - this would open a dialog to add a new task');
+          },
+        },
+      },
+      {
+        id: 'long-title-stage',
+        type: 'stage' as const,
+        position: { x: 400, y: 96 },
+        width: 304,
+        data: {
+          stageDetails: {
+            label: 'A Very Long Stage Title That Should Truncate With Ellipsis',
+            tasks: [[{ id: '1', label: 'Processing Task', icon: <ProcessIcon /> }]],
+          },
+          onTaskAdd: () => {
+            window.alert('Add task functionality - this would open a dialog to add a new task');
+          },
+        },
+      },
+    ],
+    []
+  );
+
+  const [nodes, setNodes, onNodesChange] = useNodesState(initialNodes);
+
+  const [edges, setEdges, onEdgesChange] = useEdgesState([]);
+
+  const createTitleChangeHandler = useCallback(
+    (nodeId: string) => (newTitle: string) => {
+      setNodes((nds) =>
+        nds.map((node) =>
+          node.id === nodeId
+            ? {
+                ...node,
+                data: {
+                  ...node.data,
+                  stageDetails: {
+                    ...node.data.stageDetails,
+                    label: newTitle,
+                  },
+                },
+              }
+            : node
+        )
+      );
+    },
+    [setNodes]
+  );
+
+  const nodesWithHandlers = useMemo(
+    () =>
+      nodes.map((node) => ({
+        ...node,
+        data: {
+          ...node.data,
+          onStageTitleChange: createTitleChangeHandler(node.id),
+        },
+      })),
+    [nodes, createTitleChangeHandler]
+  );
+
+  const onConnect = useCallback(
+    (connection: Connection) => setEdges((eds) => addEdge(connection, eds)),
+    [setEdges]
+  );
+
+  return (
+    <div style={{ width: '100vw', height: '100vh' }}>
+      <ReactFlowProvider>
+        <BaseCanvas
+          nodes={nodesWithHandlers}
+          edges={edges}
+          onNodesChange={onNodesChange}
+          onEdgesChange={onEdgesChange}
+          onConnect={onConnect}
+          nodeTypes={nodeTypes}
+          edgeTypes={edgeTypes}
+          mode="design"
+          connectionMode={ConnectionMode.Strict}
+          defaultEdgeOptions={{ type: 'stage' }}
+          connectionLineComponent={StageConnectionEdge}
+          elevateEdgesOnSelect
+          defaultViewport={{ x: 0, y: 0, zoom: 1.5 }}
+        >
+          <Panel position="bottom-right">
+            <CanvasPositionControls translations={DefaultCanvasTranslations} />
+          </Panel>
+        </BaseCanvas>
+      </ReactFlowProvider>
+    </div>
+  );
+};
+
+export const EditableStageTitle: Story = {
+  name: 'Editable Stage Title',
+  parameters: {
+    useCustomRender: true,
+  },
+  render: () => <InlineTitleEditStory />,
+  args: {},
+};
+
 // Simulate async children fetch (2s delay)
 const fetchChildren = (id: string): Promise<ListItem[]> =>
   new Promise((resolve) => {

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.styles.ts
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.styles.ts
@@ -78,9 +78,11 @@ export const StageHeader = styled.div<{ isException?: boolean }>`
 `;
 
 export const StageTitleContainer = styled.div<{ isEditing?: boolean }>`
-  display: inline-block;
+  display: block;
   border-radius: 4px;
   height: 100%;
+  width: 100%;
+  box-sizing: border-box;
   border: ${(props) => (props.isEditing ? '1px solid var(--uix-canvas-border-de-emp)' : 'none')};
 `;
 
@@ -97,9 +99,9 @@ export const StageTitleInput = styled.input<{
   background: transparent;
   text-overflow: ellipsis;
   border-radius: 2px;
+  width: 100%;
   min-width: 100px;
-  max-width: 220px;
-  padding: ${(props) => (props.isStageTitleEditable ? 'none' : `${Padding.PadS} 0px`)};
+  padding: ${(props) => (props.isStageTitleEditable ? '0' : `${Padding.PadS} 0px`)};
 
   &:focus {
     outline: none;

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.tsx
@@ -505,9 +505,9 @@ const StageNodeComponent = (props: StageNodeProps) => {
     >
       <StageContainer selected={selected} status={status} width={width} style={taskWidthStyle}>
         <StageHeader isException={isException}>
-          <Row gap={Spacing.SpacingMicro} align="center">
+          <Row gap={Spacing.SpacingMicro} align="center" flex={1} minW={0}>
             {icon}
-            <Column py={2}>
+            <Column py={2} flex={1} minW={0}>
               <ApTypography
                 variant={
                   isStageTitleEditing ? FontVariantToken.fontSizeM : FontVariantToken.fontSizeMBold


### PR DESCRIPTION
## Description 

  - Fix stage title input not expanding to fill the available width in the stage header

## Demo
Before

https://github.com/user-attachments/assets/67c243ed-4af7-45a2-8e31-c5d6a8297d61

After


https://github.com/user-attachments/assets/89e50ccd-5dd3-4e19-9599-cfc55800a6e2



  