### PR TITLE
fix(apollo-vertex): fix stale data table controls with React Compiler [AGVSOL-1906]

### DIFF
--- a/apps/apollo-vertex/registry/data-table/data-table.tsx
+++ b/apps/apollo-vertex/registry/data-table/data-table.tsx
@@ -18,7 +18,6 @@ import {
   type RowSelectionState,
   type SortingState,
   type Table as TanstackTable,
-  useReactTable,
   type VisibilityState,
 } from "@tanstack/react-table";
 import * as React from "react";
@@ -40,8 +39,8 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
+import { useReactTableCompat } from "@/hooks/useReactTableCompat";
 import { cn } from "@/lib/utils";
-
 import { DataTablePagination } from "./data-table-pagination";
 import { DataTableSkeleton } from "./data-table-skeleton";
 import { DataTableToolbar } from "./data-table-toolbar";
@@ -151,7 +150,7 @@ function DataTable<TData, TValue>({
 
   const isRowSelectionEnabled = !!(rowSelection && onRowSelectionChange);
 
-  const table = useReactTable({
+  const table = useReactTableCompat({
     data,
     columns,
     onSortingChange,

--- a/apps/apollo-vertex/registry/use-data-table/useReactTableCompat.ts
+++ b/apps/apollo-vertex/registry/use-data-table/useReactTableCompat.ts
@@ -1,0 +1,23 @@
+"use client";
+
+import { type Table, useReactTable } from "@tanstack/react-table";
+
+/**
+ * React Compiler compatibility wrapper for useReactTable.
+ *
+ * useReactTable returns a mutable object with a stable reference. The React
+ * Compiler caches values by reference, so child components that receive the
+ * table instance never see a "change" and skip re-renders. Spreading into a
+ * new object on every render gives children a fresh reference while keeping
+ * all methods intact (they are closures, not prototype methods).
+ *
+ * @see https://github.com/facebook/react/pull/31820
+ */
+export function useReactTableCompat<TData>(
+  options: Parameters<typeof useReactTable<TData>>[0],
+): Table<TData> {
+  // eslint-disable-next-line no-warning-comments
+  // TODO: Remove after upgrading to @tanstack/react-table v9 (React Compiler compatible)
+  "use no memo";
+  return { ...useReactTable(options) } as Table<TData>;
+}

--- a/apps/apollo-vertex/tsconfig.json
+++ b/apps/apollo-vertex/tsconfig.json
@@ -86,8 +86,8 @@
       "@/components/ui/toggle-group": ["./registry/toggle-group/toggle-group"],
       "@/components/ui/tooltip": ["./registry/tooltip/tooltip"],
       "@/hooks/use-mobile": ["./registry/use-mobile/use-mobile"],
-      "@/hooks/use-local-storage": [
-        "./registry/use-local-storage/use-local-storage"
+      "@/hooks/useReactTableCompat": [
+        "./registry/use-data-table/useReactTableCompat"
       ],
       "@/components/theme-provider/theme-provider": [
         "./registry/theme-provider/theme-provider"


### PR DESCRIPTION
Data table toolbar controls (column visibility, search, pagination) were not updating in real time, only after a page refresh:

https://github.com/user-attachments/assets/8001b4fa-7473-4dc9-9b38-a649703e8509


Root cause is that React Compiler + `useReactTable` returning a mutable stable reference. The compiler treats unchanged references as unchanged data and skips re-renders: https://github.com/TanStack/virtual/issues/736

By adding`useReactTableCompat` wrapper that creates a fresh object reference per render so the compiler detects state changes: https://github.com/TanStack/virtual/issues/736#issuecomment-3065658277

https://github.com/user-attachments/assets/86f790be-2875-43f9-aa8c-effeea6458ba

