### PR TITLE
fix(apollo-vertex): opt data table components out of React Compiler

### DIFF
--- a/apps/apollo-vertex/registry/data-table/data-table-pagination.tsx
+++ b/apps/apollo-vertex/registry/data-table/data-table-pagination.tsx
@@ -28,6 +28,7 @@ function DataTablePagination<TData>({
   paginationSizes = [10, 20, 30, 40, 50],
   className,
 }: DataTablePaginationProps<TData>) {
+  "use no memo";
   const { t } = useTranslation();
   const { pageIndex, pageSize } = table.getState().pagination;
   const pageCount = table.getPageCount();

--- a/apps/apollo-vertex/registry/data-table/data-table-search.tsx
+++ b/apps/apollo-vertex/registry/data-table/data-table-search.tsx
@@ -13,6 +13,7 @@ function DataTableSearch<TData>({
   placeholder,
   className,
 }: DataTableSearchProps<TData>) {
+  "use no memo";
   const { t } = useTranslation();
   return (
     <div data-slot="data-table-search" className={className}>

--- a/apps/apollo-vertex/registry/data-table/data-table-toolbar.tsx
+++ b/apps/apollo-vertex/registry/data-table/data-table-toolbar.tsx
@@ -21,6 +21,7 @@ function DataTableToolbar<TData>({
   enableViewOptions,
   customContent,
 }: DataTableToolbarProps<TData>) {
+  "use no memo";
   if (!enableSearch && !enableViewOptions && !customContent) return null;
 
   return (

--- a/apps/apollo-vertex/registry/data-table/data-table-view-options.tsx
+++ b/apps/apollo-vertex/registry/data-table/data-table-view-options.tsx
@@ -23,6 +23,7 @@ function DataTableViewOptions<TData>({
   table,
   className,
 }: DataTableViewOptionsProps<TData>) {
+  "use no memo";
   const { t } = useTranslation();
 
   const allReorderableColumns = table

--- a/apps/apollo-vertex/registry/data-table/data-table.tsx
+++ b/apps/apollo-vertex/registry/data-table/data-table.tsx
@@ -146,6 +146,7 @@ function DataTable<TData, TValue>({
   onExpandedChange,
   renderExpandedRow,
 }: DataTableProps<TData, TValue>) {
+  "use no memo";
   const { t } = useTranslation();
 
   const isRowSelectionEnabled = !!(rowSelection && onRowSelectionChange);


### PR DESCRIPTION
## Summary

- Adds `"use no memo"` directive to `DataTable`, `DataTableSearch`, `DataTablePagination`, `DataTableToolbar`, and `DataTableViewOptions`
- The prior fix (useReactTableCompat wrapper) only created a fresh table object reference, but React Compiler still memoized `table.getState()` reads inside child components, causing search input and pagination controls to appear frozen
- Opting the full component tree out of React Compiler ensures all table state reads are fresh on every render