### PR TITLE
fix(apollo-react): add Warning state for stages and stage tasks

### DIFF
--- a/packages/apollo-react/src/canvas/components/Edges/EdgeUtils.tsx
+++ b/packages/apollo-react/src/canvas/components/Edges/EdgeUtils.tsx
@@ -14,6 +14,7 @@ export const edgeTargetStatusToEdgeColor: {
   NotExecuted: 'var(--color-canvas-element-border-color-default)',
   Paused: 'var(--color-warning-icon)',
   Terminated: 'var(--color-error-icon)',
+  Warning: 'var(--color-warning-icon)',
   UserCancelled: 'var(--color-info-icon)',
   WARNING: 'var(--color-warning-icon)',
   None: 'var(--color-canvas-element-border-color-default)',

--- a/packages/apollo-react/src/canvas/components/ExecutionStatusIcon/ExecutionStatusIcon.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/ExecutionStatusIcon/ExecutionStatusIcon.stories.tsx
@@ -18,6 +18,7 @@ const meta = {
         'Failed',
         'NotExecuted',
         'Terminated',
+        'Warning',
       ],
       description: 'The execution status to display',
     },
@@ -56,6 +57,7 @@ export const Default: Story = {
           { status: 'Cancelled', label: 'Cancelled', description: 'Execution cancelled' },
           { status: 'Terminated', label: 'Terminated', description: 'Forcefully stopped' },
           { status: 'NotExecuted', label: 'Not Executed', description: 'Not yet started' },
+          { status: 'Warning', label: 'Warning', description: 'Needs attention' },
         ].map(({ status, label, description }) => (
           <div
             key={status}

--- a/packages/apollo-react/src/canvas/components/ExecutionStatusIcon/ExecutionStatusIcon.tsx
+++ b/packages/apollo-react/src/canvas/components/ExecutionStatusIcon/ExecutionStatusIcon.tsx
@@ -10,6 +10,7 @@ export function getExecutionStatusColor(status: string | undefined): string {
     case 'Completed':
       return 'var(--color-success-icon)';
     case 'Paused':
+    case 'Warning':
       return 'var(--color-warning-icon)';
     case 'Cancelled':
       return 'var(--color-error-icon)';
@@ -52,6 +53,7 @@ export function ExecutionStatusIcon({
     | 'Failed'
     | 'NotExecuted'
     | 'Terminated'
+    | 'Warning'
     | string;
   size?: number;
 }) {
@@ -65,6 +67,8 @@ export function ExecutionStatusIcon({
         return <ApIcon color={color} name="check_circle" size={`${size}px`} />;
       case 'Paused':
         return <ApIcon color={color} name="pause" size={`${size}px`} />;
+      case 'Warning':
+        return <ApIcon color={color} name="warning" size={`${size}px`} />;
       case 'Failed':
         return <ApIcon color={color} name="error" size={`${size}px`} />;
       case 'Terminated':

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.stories.tsx
@@ -248,6 +248,34 @@ export const Default: Story = {
           },
         },
       },
+      {
+        id: '3',
+        type: 'stage',
+        position: { x: 1104, y: 96 },
+        width: 304,
+        data: {
+          stageDetails: {
+            label: 'Review - Warning',
+            isReadOnly: true,
+            tasks: [
+              [{ id: '1', label: 'Risk Assessment', icon: <VerificationIcon /> }],
+              [{ id: '2', label: 'Policy Review', icon: <DocumentIcon /> }],
+            ],
+          },
+          execution: {
+            stageStatus: {
+              label: 'Needs attention',
+              status: 'Warning',
+            },
+            taskStatus: {
+              '2': {
+                status: 'Warning',
+                message: 'Policy review requires manual intervention',
+              },
+            },
+          },
+        },
+      },
     ],
   },
   args: {},

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.styles.ts
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.styles.ts
@@ -48,7 +48,7 @@ export const StageContainer = styled.div<{
     `}
 
   ${({ status }) =>
-    status === 'Paused' &&
+    (status === 'Paused' || status === 'Warning') &&
     css`
       border-color: var(--uix-canvas-warning-icon);
     `}
@@ -208,7 +208,7 @@ export const StageTask = styled.div<{
     `}
 
   ${({ status }) =>
-    status === 'Paused' &&
+    (status === 'Paused' || status === 'Warning') &&
     css`
       border-color: var(--uix-canvas-warning-icon);
     `}

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.types.ts
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.types.ts
@@ -12,6 +12,7 @@ enum ElementStatusValues {
   NotExecuted = 'NotExecuted',
   Paused = 'Paused',
   Terminated = 'Terminated',
+  Warning = 'Warning',
 }
 
 export type StageStatus = `${ElementStatusValues}`;

--- a/packages/apollo-react/src/canvas/styles/execution-status.ts
+++ b/packages/apollo-react/src/canvas/styles/execution-status.ts
@@ -30,6 +30,7 @@ export const getExecutionStatusBorder = (executionStatus?: string) => {
         border-color: var(--uix-canvas-success-icon);
       `;
     case 'Paused':
+    case 'Warning':
     case 'WARNING': {
       return css`
         border-color: var(--uix-canvas-warning-icon);

--- a/packages/apollo-react/src/canvas/types/execution.ts
+++ b/packages/apollo-react/src/canvas/types/execution.ts
@@ -7,6 +7,7 @@ export const ElementStatusValues = {
   NotExecuted: 'NotExecuted',
   Paused: 'Paused',
   Terminated: 'Terminated',
+  Warning: 'Warning',
   None: 'None',
 } as const;
 export type ElementStatusValues = (typeof ElementStatusValues)[keyof typeof ElementStatusValues];


### PR DESCRIPTION
## Summary
- Adds a new `Warning` execution status for stages and stage tasks
- Uses the same warning colors as `Paused` (yellow/orange warning palette)
- Displays a triangle warning icon (`warning`) instead of the pause icon

## Changes
- **`execution.ts`** / **`StageNode.types.ts`**: Added `Warning` to `ElementStatusValues` enum
- **`ExecutionStatusIcon.tsx`**: Added `Warning` case with same color as `Paused` and triangle `warning` icon
- **`StageNode.styles.ts`**: Added `Warning` border color for both `StageContainer` and `StageTask` (same as `Paused`)
- **`execution-status.ts`**: Added `Warning` case to border status styling (same as `Paused`)
- **`EdgeUtils.tsx`**: Added `Warning` to edge color mapping
- **`ExecutionStatusIcon.stories.tsx`**: Added `Warning` to story options and status grid

## Demo
<img width="2216" height="759" alt="image" src="https://github.com/user-attachments/assets/efdcad79-aa01-4792-aa25-fe01653a8fb3" />


## Test plan
- [ ] Verify Warning state renders with triangle warning icon on stages
- [ ] Verify Warning state renders with triangle warning icon on stage tasks
- [ ] Verify Warning state uses same border colors as Paused state
- [ ] Verify Warning state appears in ExecutionStatusIcon storybook
- [ ] Verify existing Paused state is unaffected

https://claude.ai/code/session_017WC9SPQJDYtnpsUkSqHDX8