### PR TITLE
chore: consolidate CODEOWNERS for apollo-vertex

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-/apps/apollo-vertex/ @ruudandriessen @frankkluijtmans @0xr3ngar @alincadariu @angeloaltamiranom

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -7,7 +7,7 @@ packages/apollo-react @UiPath/Apollo
 packages/apollo-wind
 
 # apps
-apps/apollo-vertex
+apps/apollo-vertex @UiPath/team-frontendhoven
 apps/react-playground @UiPath/Apollo
 apps/storybook
 


### PR DESCRIPTION
## Summary
- Removes the duplicate `.github/CODEOWNERS` file which listed individual users for `apps/apollo-vertex/`
- Consolidates ownership into the root `CODEOWNERS` file, assigning `@UiPath/team-frontendhoven` as code owners for `apps/apollo-vertex`
- GitHub prioritizes `.github/CODEOWNERS` over the root file, so having both caused confusion. Now only the root file is used.

🤖 Generated with [Claude Code](https://claude.com/claude-code)