### PR TITLE
fix(ap-chat): use Unicode-safe base64 encoding for citation data [SRE-555606]

### DIFF
--- a/packages/apollo-react/src/material/components/ap-chat/components/message/markdown/parsers/citation-parser.tsx
+++ b/packages/apollo-react/src/material/components/ap-chat/components/message/markdown/parsers/citation-parser.tsx
@@ -34,7 +34,11 @@ export function citationPlugin() {
         const token = match[0];
         if (token.startsWith('[[cite-start:')) {
           try {
-            const decoded = atob(match[1] as string);
+            // Decode base64, then reverse percent-encoding for Unicode support.
+            // Data encoded before the Unicode fix used plain btoa (ASCII-only titles),
+            // so atob alone is sufficient as a fallback.
+            const raw = atob(match[1] as string);
+            const decoded = raw.startsWith('%5B') ? decodeURIComponent(raw) : raw;
             const citationsData = JSON.parse(decoded);
             citationStack.push({ citationsData });
 
@@ -147,7 +151,7 @@ export function contentPartsToMarkdown(messageId: string, contentParts: ContentP
           messageId,
         }));
 
-        const encodedData = btoa(JSON.stringify(citationsData));
+        const encodedData = btoa(encodeURIComponent(JSON.stringify(citationsData)));
         // Add a space before [[cite-end]] when text ends with a URL to prevent
         // link parser from absorbing [[cite-end]] into the URL and rendering it as part of the link.
         const endsWithUrl = /https?:\/\/\S+$/.test(text);


### PR DESCRIPTION
## Summary
- `btoa()` throws `InvalidCharacterError` when citation source titles contain non-Latin-1 Unicode characters (en dashes, em dashes, smart quotes, etc.) which silently breaks `contentPartsToMarkdown`, freezing the streamed response at the first citation boundary
- Wraps `JSON.stringify` output with `encodeURIComponent` before `btoa` so non-ASCII characters are percent-encoded to ASCII first
- Decoder detects new format via `%5B` prefix (percent-encoded `[`) and applies `decodeURIComponent`; old plain-`btoa` data passes through unchanged

## Context
Resolves [SRE-555606](https://uipath.atlassian.net/browse/SRE-555606) — Scottish Government customer consistently saw response truncation when their Finance Assistant cited SPFM documents with en dashes (`–`, U+2013) in titles (e.g. "SPFM – Fees and Charges"). The `btoa` failure prevented all subsequent `setContent` calls in the markdown renderer, freezing the display at whatever content was rendered before the first citation metadata arrived.


[SRE-555606]: https://uipath.atlassian.net/browse/SRE-555606

