### PR TITLE
feat(apollo-vertex): update Alert and Sonner styles and docs [AGVSOL-1995]

### DIFF
--- a/apps/apollo-vertex/app/patterns/notifications/in-product/notification-examples.tsx
+++ b/apps/apollo-vertex/app/patterns/notifications/in-product/notification-examples.tsx
@@ -76,20 +76,11 @@ export function SonnerExamples() {
 export function AlertExamples() {
   return (
     <div className="space-y-3">
-      <Alert status="info" visual="tinted">
+      <Alert status="default" visual="tinted">
         <InfoIcon className="h-4 w-4" />
         <AlertTitle>New version available</AlertTitle>
         <AlertDescription>
-          A new version of the platform is ready. Review the changelog for
-          details.
-        </AlertDescription>
-      </Alert>
-
-      <Alert status="success" visual="tinted">
-        <CircleCheckIcon className="h-4 w-4" />
-        <AlertTitle>Changes saved</AlertTitle>
-        <AlertDescription>
-          Your configuration has been updated successfully.
+          A new version of the platform is ready. Review the changelog for details.
         </AlertDescription>
       </Alert>
 
@@ -120,7 +111,7 @@ function DismissibleAlert({
   visual = "outline",
 }: {
   children: ReactNode;
-  status: "info" | "success" | "warning" | "error";
+  status: "default" | "warning" | "error";
   visual?: "outline" | "tinted" | "subtle";
 }) {
   const [visible, setVisible] = useState(true);
@@ -147,20 +138,12 @@ export function AlertOutlineExamples() {
 
   return (
     <div className="space-y-3" key={resetKey}>
-      <DismissibleAlert status="info">
+      <DismissibleAlert status="default">
         <InfoIcon className="h-4 w-4" />
         <AlertTitle>New version available</AlertTitle>
         <AlertDescription>
           A new version of the platform is ready. Review the changelog for
           details.
-        </AlertDescription>
-      </DismissibleAlert>
-
-      <DismissibleAlert status="success">
-        <CircleCheckIcon className="h-4 w-4" />
-        <AlertTitle>Changes saved</AlertTitle>
-        <AlertDescription>
-          Your configuration has been updated successfully.
         </AlertDescription>
       </DismissibleAlert>
 
@@ -189,55 +172,6 @@ export function AlertOutlineExamples() {
       >
         Reset dismissed alerts
       </button>
-    </div>
-  );
-}
-
-// Docs-only: subtle alerts use bg-secondary in light mode to distinguish from the page background
-const alertSubtleBgStyles = `
-  :root:not(.dark) .alert-subtle-bg [data-slot="alert"] {
-    background-color: var(--secondary) !important;
-  }
-`;
-
-export function AlertDefaultExamples() {
-  return (
-    <div className="alert-subtle-bg space-y-3">
-      <style>{alertSubtleBgStyles}</style>
-      <Alert status="info" visual="subtle">
-        <InfoIcon className="h-4 w-4" />
-        <AlertTitle>New version available</AlertTitle>
-        <AlertDescription>
-          A new version of the platform is ready. Review the changelog for
-          details.
-        </AlertDescription>
-      </Alert>
-
-      <Alert status="success" visual="subtle">
-        <CircleCheckIcon className="h-4 w-4" />
-        <AlertTitle>Changes saved</AlertTitle>
-        <AlertDescription>
-          Your configuration has been updated successfully.
-        </AlertDescription>
-      </Alert>
-
-      <Alert status="warning" visual="subtle">
-        <TriangleAlertIcon className="h-4 w-4" />
-        <AlertTitle>API rate limit approaching</AlertTitle>
-        <AlertDescription>
-          You have used 90% of your monthly API quota. Consider upgrading your
-          plan.
-        </AlertDescription>
-      </Alert>
-
-      <Alert status="error" visual="subtle">
-        <OctagonXIcon className="h-4 w-4" />
-        <AlertTitle>Connection failed</AlertTitle>
-        <AlertDescription>
-          Unable to reach the server. Check your network connection and try
-          again.
-        </AlertDescription>
-      </Alert>
     </div>
   );
 }
@@ -323,7 +257,7 @@ export function CollapsibleAlertExample() {
 
 export function ActionAlertExample() {
   return (
-    <Alert status="info" visual="outline">
+    <Alert status="default" visual="outline">
       <InfoIcon className="h-4 w-4" />
       <AlertTitle>12 documents unclassified</AlertTitle>
       <AlertDescription>

--- a/apps/apollo-vertex/app/patterns/notifications/in-product/notification-examples.tsx
+++ b/apps/apollo-vertex/app/patterns/notifications/in-product/notification-examples.tsx
@@ -80,7 +80,8 @@ export function AlertExamples() {
         <InfoIcon className="h-4 w-4" />
         <AlertTitle>New version available</AlertTitle>
         <AlertDescription>
-          A new version of the platform is ready. Review the changelog for details.
+          A new version of the platform is ready. Review the changelog for
+          details.
         </AlertDescription>
       </Alert>
 
@@ -112,7 +113,7 @@ function DismissibleAlert({
 }: {
   children: ReactNode;
   status: "default" | "warning" | "error";
-  visual?: "outline" | "tinted" | "subtle";
+  visual?: "outline" | "tinted";
 }) {
   const [visible, setVisible] = useState(true);
   if (!visible) return null;

--- a/apps/apollo-vertex/app/patterns/notifications/in-product/page.mdx
+++ b/apps/apollo-vertex/app/patterns/notifications/in-product/page.mdx
@@ -1,4 +1,4 @@
-import { SonnerExamples, AlertExamples, AlertOutlineExamples, AlertDefaultExamples, CollapsibleAlertExample, ActionAlertExample } from './notification-examples'
+import { SonnerExamples, AlertExamples, AlertOutlineExamples, CollapsibleAlertExample, ActionAlertExample } from './notification-examples'
 import { LayoutDiagram } from './layout-diagram'
 
 # In-product notification
@@ -123,22 +123,21 @@ Inline notifications may be persistent or dismissible depending on priority.
 
 ### Choosing a visual style
 
-Inline alerts support three visual styles. Choose based on the urgency and importance of the message — not personal preference. Do not mix styles within the same context.
+Inline alerts support two visual styles. Choose based on the urgency and importance of the message — not personal preference. Do not mix styles within the same context.
 
 | Style | Variant | When to use | Dismissible |
 |---|---|---|---|
-| Default | Subtle | Routine info, background updates, non-disruptive confirmations | Optional |
+| Default | Tinted | Routine info, background updates, blocking errors, unresolved issues | No |
 | Accent | Outline | Contextual warnings, guidance, acknowledged states, unresolved requirements | Context-dependent |
-| Bold | Tinted | Critical issues, blocking errors, authentication failures | No |
 
-> When unsure, start with **default**. Escalate only when the message demands immediate attention or blocks progress.
+> When unsure, start with **default**. Use Accent only when the message needs a distinct visual call-out.
 
-#### Default (subtle)
+#### Default (tinted)
 
-Neutral background with status color on the title and icon. Description text uses the standard muted color. Use for routine information, background updates, and non-disruptive feedback.
+Low-opacity status background with neutral title text. Use for critical messages that demand immediate attention or block progress.
 
 <div className="p-4 border rounded-lg mt-4">
-  <AlertDefaultExamples />
+  <AlertExamples />
 </div>
 
 #### Accent (outline)
@@ -147,14 +146,6 @@ Status color on the border and icon, with default text colors. Use for contextua
 
 <div className="p-4 border rounded-lg mt-4">
   <AlertOutlineExamples />
-</div>
-
-#### Bold (tinted)
-
-Full status-colored background with white text in dark mode. Use for critical messages that demand immediate attention or block progress.
-
-<div className="p-4 border rounded-lg mt-4">
-  <AlertExamples />
 </div>
 
 ### Complex alert patterns (edge cases)
@@ -241,15 +232,15 @@ Each notification has a status that communicates tone and urgency through color 
 
 Notification statuses align with the [Badge](/shadcn-components/badge) status system for consistent semantic meaning across the design system.
 
-| Status | Usage | Token | Color | Inline notes |
-|---|---|---|---|---|
-| `info` | General updates, FYIs | `--info` | `oklch(0.60 0.125 210)` | Best for passive or contextual information |
-| `success` | Confirmation of completed tasks | `--success` | `oklch(0.57 0.105 152)` | Inline only when tied to direct user action |
-| `warning` | Potential issues or unintended consequences | `--warning` | `oklch(0.80 0.1401 80.82)` | Appropriate for both persistent and action-related messages |
-| `error` | Failures, blockers, critical issues | `--destructive` | `oklch(0.62 0.150 18)` | Inline only when tied to validation or error resolution |
+| Status | Usage | Token | Color | Sonner | Alert |
+|---|---|---|---|---|---|
+| `info` | General updates, FYIs | `--info` | `oklch(0.60 0.125 210)` | `toast.info()` | Use `status="default"` |
+| `success` | Confirmation of completed tasks | `--success` | `oklch(0.57 0.105 152)` | `toast.success()` | Not available — Sonner only |
+| `warning` | Potential issues or unintended consequences | `--warning` | `oklch(0.80 0.1401 80.82)` | `toast.warning()` | `status="warning"` |
+| `error` | Failures, blockers, critical issues | `--destructive` | `oklch(0.62 0.150 18)` | `toast.error()` | `status="error"` |
 
-> Inline notifications should use **success** or **error** only when tied to a user-initiated action.
-> For persistent system guidance or background alerts, use **info** or **warning**.
+> The Alert component supports `status="default"`, `status="warning"`, and `status="error"`. Use Sonner for success confirmations.
+> For persistent system guidance or background alerts, use `default` or `warning` in Alert.
 
 ---
 
@@ -341,8 +332,7 @@ Avoid driving users away from their workflow unless necessary.
 
 | Question | Answer | Style |
 |---|---|---|
-| Is the message routine, informational, or non-disruptive? | Yes | Default (subtle) |
+| Is the message routine, informational, or requires immediate attention? | Yes | Default (tinted) |
 | Is the message contextual, a warning, or an unresolved requirement? | Yes | Accent (outline) |
-| Does the message block progress or require immediate action? | Yes | Bold (tinted) |
 
-> When unsure, start with **default** and escalate only if the message demands it.
+> When unsure, use **default**. Use Accent only when the message needs a distinct visual call-out.

--- a/apps/apollo-vertex/app/patterns/notifications/in-product/page.mdx
+++ b/apps/apollo-vertex/app/patterns/notifications/in-product/page.mdx
@@ -134,7 +134,7 @@ Inline alerts support two visual styles. Choose based on the urgency and importa
 
 #### Default (tinted)
 
-Low-opacity status background with neutral title text. Use for critical messages that demand immediate attention or block progress.
+Low-opacity status background with neutral title text. Use for persistent, non-dismissible messages, from routine updates and background info to blocking errors.
 
 <div className="p-4 border rounded-lg mt-4">
   <AlertExamples />
@@ -332,7 +332,7 @@ Avoid driving users away from their workflow unless necessary.
 
 | Question | Answer | Style |
 |---|---|---|
-| Is the message routine, informational, or requires immediate attention? | Yes | Default (tinted) |
+| Is the message routine, informational, or does it require immediate attention? | Yes | Default (tinted) |
 | Is the message contextual, a warning, or an unresolved requirement? | Yes | Accent (outline) |
 
 > When unsure, use **default**. Use Accent only when the message needs a distinct visual call-out.

--- a/apps/apollo-vertex/app/shadcn-components/alert/page.mdx
+++ b/apps/apollo-vertex/app/shadcn-components/alert/page.mdx
@@ -1,5 +1,5 @@
 import { Callout } from 'nextra/components'
-import { AlertDefaultExamples, AlertOutlineExamples, AlertExamples, CollapsibleAlertExample, ActionAlertExample } from '@/app/patterns/notifications/in-product/notification-examples'
+import { AlertOutlineExamples, AlertExamples, CollapsibleAlertExample, ActionAlertExample } from '@/app/patterns/notifications/in-product/notification-examples'
 
 # Alert
 
@@ -9,12 +9,12 @@ Displays a callout for user attention.
   For guidance on when to use Alert vs. Sonner, visual style selection, and content guidelines, see the [In-product notification](/patterns/notifications/in-product) pattern.
 </Callout>
 
-### Default (subtle)
+### Default (tinted)
 
-Neutral background with status color on the title and icon. Description text uses the standard muted color. Use for routine information, background updates, and non-disruptive feedback.
+Low-opacity status background with neutral title text. Use for critical messages that demand immediate attention.
 
 <div className="p-4 border rounded-lg mt-4">
-  <AlertDefaultExamples />
+  <AlertExamples />
 </div>
 
 ### Accent (outline)
@@ -23,14 +23,6 @@ Status-colored border and icon with default text. Dismissible. Use for contextua
 
 <div className="p-4 border rounded-lg mt-4">
   <AlertOutlineExamples />
-</div>
-
-### Bold (tinted)
-
-Full status-colored background. Use for critical messages that demand immediate attention.
-
-<div className="p-4 border rounded-lg mt-4">
-  <AlertExamples />
 </div>
 
 ## Installation
@@ -45,14 +37,14 @@ npx shadcn@latest add @uipath/alert
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
 ```
 
-### Subtle (default)
+### Tinted (default)
 
 ```tsx
-<Alert status="info" visual="subtle">
-  <InfoIcon className="h-4 w-4" />
-  <AlertTitle>New version available</AlertTitle>
+<Alert status="error" visual="tinted">
+  <OctagonXIcon className="h-4 w-4" />
+  <AlertTitle>Connection failed</AlertTitle>
   <AlertDescription>
-    A new version of the platform is ready. Review the changelog for details.
+    Unable to reach the server. Check your network connection and try again.
   </AlertDescription>
 </Alert>
 ```
@@ -69,104 +61,19 @@ import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
 </Alert>
 ```
 
-### Tinted
-
-```tsx
-<Alert status="error" visual="tinted">
-  <OctagonXIcon className="h-4 w-4" />
-  <AlertTitle>Connection failed</AlertTitle>
-  <AlertDescription>
-    Unable to reach the server. Check your network connection and try again.
-  </AlertDescription>
-</Alert>
-```
-
 ### Props
 
 | Prop | Type | Default | Description |
 |---|---|---|---|
-| `status` | `"info" \| "success" \| "warning" \| "error"` | — | Sets the semantic status color |
+| `status` | `"default" \| "warning" \| "error"` | — | Sets the semantic status color |
 | `visual` | `"outline" \| "tinted" \| "subtle"` | — | Sets the visual treatment |
 | `variant` | `"default" \| "destructive"` | `"default"` | Legacy shadcn variant (use `status` + `visual` instead) |
 
 ## Complex alert patterns (edge cases)
 
-The following patterns are for workflows that need inline items or embedded actions inside an alert. Use sparingly — standard alerts cover most cases.
+For guidance on when and how to use these patterns, see [In-product notification](/patterns/notifications/in-product#complex-alert-patterns-edge-cases).
 
-### Collapsible content
-
-When an alert references a list of items, show them as inline chips. If they overflow a single row, clip to one row and show a "Show all" link. Any `status` can be used with this pattern.
-
-<div className="p-4 border rounded-lg mt-4">
+<div className="p-4 border rounded-lg mt-4 space-y-3">
   <CollapsibleAlertExample />
-</div>
-
-```tsx
-import { useState, useRef, useEffect } from "react"
-import { Alert, AlertTitle, AlertDescription } from "@/components/ui/alert"
-import { Badge } from "@/components/ui/badge"
-
-export function CollapsibleAlertExample() {
-  const [expanded, setExpanded] = useState(false)
-  const [overflows, setOverflows] = useState(false)
-  const [rowHeight, setRowHeight] = useState(0)
-  const measureRef = useRef<HTMLDivElement>(null)
-
-  useEffect(() => {
-    const el = measureRef.current
-    if (!el) return
-    const firstChild = el.firstElementChild as HTMLElement | null
-    if (!firstChild) return
-    const singleRow = firstChild.offsetHeight + 6
-    setRowHeight(singleRow)
-    setOverflows(el.scrollHeight > singleRow)
-  }, [])
-
-  return (
-    <Alert status="warning" visual="outline">
-      <TriangleAlertIcon className="h-4 w-4" />
-      <AlertTitle className="line-clamp-none">
-        {items.length} required documents missing
-      </AlertTitle>
-      <AlertDescription>
-        <p>Upload these documents before completing quality check.</p>
-        <div ref={measureRef} style={{ position: "absolute", visibility: "hidden", left: 0, right: 0 }}
-          className="flex flex-wrap gap-1.5 mt-2">
-          {items.map((item) => <Badge key={item} variant="secondary" status="warning">{item}</Badge>)}
-        </div>
-        <div style={!expanded && overflows && rowHeight ? { maxHeight: rowHeight, overflow: "hidden" } : {}}
-          className="flex flex-wrap gap-1.5 mt-2">
-          {items.map((item) => <Badge key={item} variant="secondary" status="warning">{item}</Badge>)}
-        </div>
-        {overflows && (
-          <button type="button" onClick={() => setExpanded(!expanded)}
-            className="mt-1.5 text-xs font-medium text-primary hover:underline">
-            {expanded ? "Show less" : "Show all"}
-          </button>
-        )}
-      </AlertDescription>
-    </Alert>
-  )
-}
-```
-
-### Action button
-
-When an alert can trigger a direct action, place a single button inside the description area. Limit to one action per alert. Any `status` can be used with this pattern.
-
-<div className="p-4 border rounded-lg mt-4">
   <ActionAlertExample />
 </div>
-
-```tsx
-<Alert status="info" visual="outline">
-  <InfoIcon className="h-4 w-4" />
-  <AlertTitle>12 documents unclassified</AlertTitle>
-  <AlertDescription>
-    <p>Some documents could not be automatically classified.</p>
-    <Button variant="outline" size="sm" className="mt-1.5">
-      Filter unclassified
-    </Button>
-  </AlertDescription>
-</Alert>
-```

--- a/apps/apollo-vertex/app/shadcn-components/alert/page.mdx
+++ b/apps/apollo-vertex/app/shadcn-components/alert/page.mdx
@@ -11,7 +11,7 @@ Displays a callout for user attention.
 
 ### Default (tinted)
 
-Low-opacity status background with neutral title text. Use for critical messages that demand immediate attention.
+Low-opacity status background with neutral title text. Use for persistent messages, from routine updates to blocking errors.
 
 <div className="p-4 border rounded-lg mt-4">
   <AlertExamples />
@@ -66,7 +66,7 @@ import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
 | Prop | Type | Default | Description |
 |---|---|---|---|
 | `status` | `"default" \| "warning" \| "error"` | — | Sets the semantic status color |
-| `visual` | `"outline" \| "tinted" \| "subtle"` | — | Sets the visual treatment |
+| `visual` | `"outline" \| "tinted"` | — | Sets the visual treatment |
 | `variant` | `"default" \| "destructive"` | `"default"` | Legacy shadcn variant (use `status` + `visual` instead) |
 
 ## Complex alert patterns (edge cases)

--- a/apps/apollo-vertex/app/shadcn-components/sonner/page.mdx
+++ b/apps/apollo-vertex/app/shadcn-components/sonner/page.mdx
@@ -60,6 +60,35 @@ toast.error("Upload failed", {
 })
 ```
 
+## Toaster props
+
+| Prop | Type | Default | Description |
+|---|---|---|---|
+| `position` | `ToasterProps["position"]` | `"top-center"` | Position of the toast stack on screen |
+| `duration` | `number` | `5000` | Auto-dismiss delay in milliseconds |
+| `closeButton` | `boolean` | `true` | Show a close button on each toast |
+| `theme` | `"light" \| "dark" \| "system"` | `"system"` | Color theme — defaults to the current app theme via `next-themes` |
+| `toastOptions` | `ToastOptions` | — | Global options applied to all toasts (classNames, style, etc.) |
+
+## Toast function options
+
+```tsx
+toast.info("Title", {
+  description: "Supporting message.",
+  action: {
+    label: "Undo",
+    onClick: () => {},
+  },
+})
+```
+
+| Option | Type | Description |
+|---|---|---|
+| `description` | `string` | Secondary text below the title |
+| `action` | `{ label: string; onClick: () => void }` | Action button rendered inside the toast |
+| `onDismiss` | `(toast) => void` | Callback when the toast is dismissed |
+| `onAutoClose` | `(toast) => void` | Callback when the toast auto-closes |
+
 ## Custom toast styles
 
 If you need to apply the Apollo status styles to your own `Toaster` instance, import `apolloToastClassNames`:

--- a/apps/apollo-vertex/app/shadcn-components/sonner/page.mdx
+++ b/apps/apollo-vertex/app/shadcn-components/sonner/page.mdx
@@ -68,7 +68,7 @@ toast.error("Upload failed", {
 | `duration` | `number` | `5000` | Auto-dismiss delay in milliseconds |
 | `closeButton` | `boolean` | `true` | Show a close button on each toast |
 | `theme` | `"light" \| "dark" \| "system"` | `"system"` | Color theme — defaults to the current app theme via `next-themes` |
-| `toastOptions` | `ToastOptions` | — | Global options applied to all toasts (classNames, style, etc.) |
+| `toastOptions` | `ToasterProps["toastOptions"]` | — | Global options applied to all toasts (classNames, style, etc.) |
 
 ## Toast function options
 

--- a/apps/apollo-vertex/registry/alert/alert.tsx
+++ b/apps/apollo-vertex/registry/alert/alert.tsx
@@ -13,13 +13,12 @@ const alertVariants = cva(
           "text-destructive bg-card [&>svg]:text-current *:data-[slot=alert-description]:text-destructive/90",
       },
       status: {
-        info: "",
-        success: "",
+        default: "",
         warning: "",
         error: "",
       },
       visual: {
-        outline: "bg-transparent",
+        outline: "bg-card",
         tinted: "border-transparent",
         subtle: "",
       },
@@ -27,20 +26,14 @@ const alertVariants = cva(
     compoundVariants: [
       // outline — status-colored border + icon
       {
-        status: "info",
+        status: "default",
         visual: "outline",
-        className: "border-info [&>svg]:text-info",
-      },
-      {
-        status: "success",
-        visual: "outline",
-        className: "border-success [&>svg]:text-success",
+        className: "border-badge [&>svg]:text-foreground",
       },
       {
         status: "warning",
         visual: "outline",
-        className:
-          "border-warning [&>svg]:text-warning-foreground dark:[&>svg]:text-warning",
+        className: "border-warning [&>svg]:text-warning-foreground dark:[&>svg]:text-warning",
       },
       {
         status: "error",
@@ -48,42 +41,29 @@ const alertVariants = cva(
         className: "border-destructive [&>svg]:text-destructive",
       },
 
-      // tinted — colored background, text, icon; description inherits container color
+      // tinted — status-tinted background, foreground title, status-colored icon
       {
-        status: "info",
+        status: "default",
         visual: "tinted",
-        className:
-          "bg-info/15 dark:bg-info/25 text-[var(--info-fg)] dark:text-white [&>svg]:text-[var(--info-fg)] dark:[&>svg]:text-white *:data-[slot=alert-description]:text-inherit",
-      },
-      {
-        status: "success",
-        visual: "tinted",
-        className:
-          "bg-success/10 dark:bg-success/25 text-[var(--success-fg)] dark:text-white [&>svg]:text-[var(--success-fg)] dark:[&>svg]:text-white *:data-[slot=alert-description]:text-inherit",
+        className: "bg-badge/20 border-transparent text-foreground [&>svg]:text-foreground",
       },
       {
         status: "warning",
         visual: "tinted",
         className:
-          "bg-warning/15 dark:bg-warning/25 text-warning-foreground dark:text-white [&>svg]:text-warning-foreground dark:[&>svg]:text-warning *:data-[slot=alert-description]:text-inherit",
+          "bg-warning/15 dark:bg-warning/25 text-foreground [&>svg]:text-warning-foreground dark:[&>svg]:text-warning",
       },
       {
         status: "error",
         visual: "tinted",
-        className:
-          "bg-destructive/10 dark:bg-destructive/25 text-[var(--destructive-fg)] dark:text-white [&>svg]:text-[var(--destructive-fg)] dark:[&>svg]:text-white *:data-[slot=alert-description]:text-inherit",
+        className: "bg-destructive/10 dark:bg-destructive/25 text-foreground [&>svg]:text-destructive",
       },
 
-      // subtle — icon color via CVA; title color applied by AlertTitle via AlertContext
+      // subtle — status-colored icon + title (title color applied via AlertContext)
       {
-        status: "info",
+        status: "default",
         visual: "subtle",
-        className: "[&>svg]:text-[var(--info-fg)] dark:[&>svg]:text-info",
-      },
-      {
-        status: "success",
-        visual: "subtle",
-        className: "[&>svg]:text-[var(--success-fg)] dark:[&>svg]:text-success",
+        className: "[&>svg]:text-foreground",
       },
       {
         status: "warning",
@@ -93,8 +73,7 @@ const alertVariants = cva(
       {
         status: "error",
         visual: "subtle",
-        className:
-          "[&>svg]:text-[var(--destructive-fg)] dark:[&>svg]:text-destructive",
+        className: "[&>svg]:text-destructive",
       },
     ],
     defaultVariants: {
@@ -104,7 +83,7 @@ const alertVariants = cva(
 );
 
 interface AlertContextValue {
-  status?: "info" | "success" | "warning" | "error" | null;
+  status?: "default" | "warning" | "error" | null;
   visual?: "outline" | "tinted" | "subtle" | null;
 }
 
@@ -138,10 +117,9 @@ function Alert({
 
 // Title colors for the subtle visual variant, keyed by status
 const subtleTitleColors: Record<string, string> = {
-  info: "text-[var(--info-fg)] dark:text-info",
-  success: "text-[var(--success-fg)] dark:text-success",
+  default: "text-foreground",
   warning: "text-warning-foreground dark:text-warning",
-  error: "text-[var(--destructive-fg)] dark:text-destructive",
+  error: "text-destructive",
 };
 
 function AlertTitle({ className, ...props }: React.ComponentProps<"div">) {

--- a/apps/apollo-vertex/registry/alert/alert.tsx
+++ b/apps/apollo-vertex/registry/alert/alert.tsx
@@ -20,7 +20,6 @@ const alertVariants = cva(
       visual: {
         outline: "bg-card",
         tinted: "border-transparent",
-        subtle: "",
       },
     },
     compoundVariants: [
@@ -33,7 +32,8 @@ const alertVariants = cva(
       {
         status: "warning",
         visual: "outline",
-        className: "border-warning [&>svg]:text-warning-foreground dark:[&>svg]:text-warning",
+        className:
+          "border-warning [&>svg]:text-warning-foreground dark:[&>svg]:text-warning",
       },
       {
         status: "error",
@@ -45,7 +45,8 @@ const alertVariants = cva(
       {
         status: "default",
         visual: "tinted",
-        className: "bg-badge/20 border-transparent text-foreground [&>svg]:text-foreground",
+        className:
+          "bg-badge/20 border-transparent text-foreground [&>svg]:text-foreground",
       },
       {
         status: "warning",
@@ -56,24 +57,8 @@ const alertVariants = cva(
       {
         status: "error",
         visual: "tinted",
-        className: "bg-destructive/10 dark:bg-destructive/25 text-foreground [&>svg]:text-destructive",
-      },
-
-      // subtle — status-colored icon + title (title color applied via AlertContext)
-      {
-        status: "default",
-        visual: "subtle",
-        className: "[&>svg]:text-foreground",
-      },
-      {
-        status: "warning",
-        visual: "subtle",
-        className: "[&>svg]:text-warning-foreground dark:[&>svg]:text-warning",
-      },
-      {
-        status: "error",
-        visual: "subtle",
-        className: "[&>svg]:text-destructive",
+        className:
+          "bg-destructive/10 dark:bg-destructive/25 text-foreground [&>svg]:text-destructive",
       },
     ],
     defaultVariants: {
@@ -81,13 +66,6 @@ const alertVariants = cva(
     },
   },
 );
-
-interface AlertContextValue {
-  status?: "default" | "warning" | "error" | null;
-  visual?: "outline" | "tinted" | "subtle" | null;
-}
-
-const AlertContext = React.createContext<AlertContextValue>({});
 
 interface AlertProps
   extends React.ComponentProps<"div">,
@@ -102,36 +80,23 @@ function Alert({
   ...props
 }: AlertProps) {
   return (
-    <AlertContext.Provider value={{ status, visual }}>
-      <div
-        data-slot="alert"
-        role="alert"
-        className={cn(alertVariants({ variant, status, visual }), className)}
-        {...props}
-      >
-        {children}
-      </div>
-    </AlertContext.Provider>
+    <div
+      data-slot="alert"
+      role="alert"
+      className={cn(alertVariants({ variant, status, visual }), className)}
+      {...props}
+    >
+      {children}
+    </div>
   );
 }
 
-// Title colors for the subtle visual variant, keyed by status
-const subtleTitleColors: Record<string, string> = {
-  default: "text-foreground",
-  warning: "text-warning-foreground dark:text-warning",
-  error: "text-destructive",
-};
-
 function AlertTitle({ className, ...props }: React.ComponentProps<"div">) {
-  const { status, visual } = React.useContext(AlertContext);
-  const colorClass =
-    visual === "subtle" && status ? (subtleTitleColors[status] ?? "") : "";
   return (
     <div
       data-slot="alert-title"
       className={cn(
         "col-start-2 line-clamp-1 min-h-4 font-medium tracking-tight",
-        colorClass,
         className,
       )}
       {...props}

--- a/apps/apollo-vertex/registry/sonner/sonner.tsx
+++ b/apps/apollo-vertex/registry/sonner/sonner.tsx
@@ -14,18 +14,17 @@ import { Toaster as Sonner, type ToasterProps } from "sonner";
 const iconAlign = "[&>[data-icon]]:!items-start [&>[data-icon]>svg]:!mt-0.5";
 
 // Apollo status styles for Sonner toasts.
-// Light: solid secondary background with status-colored border and accessible icon.
-// Dark: status-tinted background blended with popover; standard status token for icon.
-// sRGB interpolation avoids hue shift when mixing with blue-gray popover.
+// Light: inverted card surface (info) or status-tinted background; matching icon color.
+// Dark: inverted secondary surface (info) or status-tinted color-mix with popover.
 export const apolloToastClassNames: NonNullable<
   NonNullable<ToasterProps["toastOptions"]>["classNames"]
 > = {
-  info: `!border-info !bg-secondary dark:!bg-[color-mix(in_srgb,var(--info)_25%,var(--popover)_75%)] [&>svg]:!text-[var(--info-fg)] dark:[&>svg]:!text-info ${iconAlign}`,
-  success: `!border-success !bg-secondary dark:!bg-[color-mix(in_srgb,var(--success)_25%,var(--popover)_75%)] [&>svg]:!text-[var(--success-fg)] dark:[&>svg]:!text-success ${iconAlign}`,
-  warning: `!border-warning !bg-secondary dark:!bg-[color-mix(in_srgb,var(--warning)_25%,var(--popover)_75%)] [&>svg]:!text-warning-foreground dark:[&>svg]:!text-warning ${iconAlign}`,
-  error: `!border-destructive !bg-secondary dark:!bg-[color-mix(in_srgb,var(--destructive)_25%,var(--popover)_75%)] [&>svg]:!text-[var(--destructive-fg)] dark:[&>svg]:!text-destructive ${iconAlign}`,
+  info: `!border-info !bg-card-foreground dark:!bg-card-foreground [&>[data-icon]>svg]:!text-primary-foreground [&_[data-title]]:!text-primary-foreground [&_[data-description]]:!text-primary-foreground [&_[data-close-button]]:!text-primary-foreground ${iconAlign}`,
+  success: `!border-success !bg-[color-mix(in_srgb,var(--success)_25%,var(--card)_75%)] dark:!bg-[color-mix(in_srgb,var(--success)_25%,var(--popover)_75%)] [&>[data-icon]>svg]:!text-[oklch(0.166_0.0283_203.34)] dark:[&>[data-icon]>svg]:!text-foreground [&_[data-title]]:!text-[oklch(0.166_0.0283_203.34)] dark:[&_[data-title]]:!text-foreground [&_[data-description]]:!text-[oklch(0.166_0.0283_203.34)] dark:[&_[data-description]]:!text-foreground [&_[data-close-button]]:!text-[oklch(0.166_0.0283_203.34)] dark:[&_[data-close-button]]:!text-foreground ${iconAlign}`,
+  warning: `!border-warning !bg-[color-mix(in_srgb,var(--warning)_60%,var(--card)_40%)] dark:!bg-[color-mix(in_srgb,var(--warning)_60%,var(--popover)_40%)] [&>[data-icon]>svg]:!text-[oklch(0.166_0.0283_203.34)] dark:[&>[data-icon]>svg]:!text-foreground [&_[data-title]]:!text-[oklch(0.166_0.0283_203.34)] dark:[&_[data-title]]:!text-foreground [&_[data-description]]:!text-[oklch(0.166_0.0283_203.34)] dark:[&_[data-description]]:!text-foreground [&_[data-close-button]]:!text-[oklch(0.166_0.0283_203.34)] dark:[&_[data-close-button]]:!text-foreground ${iconAlign}`,
+  error: `!border-destructive !bg-[color-mix(in_srgb,var(--destructive)_50%,var(--card)_50%)] dark:!bg-[color-mix(in_srgb,var(--destructive)_50%,var(--popover)_50%)] [&>[data-icon]>svg]:!text-[oklch(0.166_0.0283_203.34)] dark:[&>[data-icon]>svg]:!text-foreground [&_[data-title]]:!text-[oklch(0.166_0.0283_203.34)] dark:[&_[data-title]]:!text-foreground [&_[data-description]]:!text-[oklch(0.166_0.0283_203.34)] dark:[&_[data-description]]:!text-foreground [&_[data-close-button]]:!text-[oklch(0.166_0.0283_203.34)] dark:[&_[data-close-button]]:!text-foreground ${iconAlign}`,
   closeButton:
-    "!left-auto !right-2 !top-2 !transform-none !border-none !bg-transparent !rounded-sm",
+    '!left-auto !right-2 !top-2 !transform-none !border-none !bg-transparent !rounded-sm',
 };
 
 const Toaster = ({ ...props }: ToasterProps) => {

--- a/apps/apollo-vertex/registry/sonner/sonner.tsx
+++ b/apps/apollo-vertex/registry/sonner/sonner.tsx
@@ -10,21 +10,29 @@ import {
 import { useTheme } from "next-themes";
 import { Toaster as Sonner, type ToasterProps } from "sonner";
 
-// Shared icon alignment: top-align icons with the first line of toast text
+// Shared icon alignment: top-align icons with the first line of toast text.
 const iconAlign = "[&>[data-icon]]:!items-start [&>[data-icon]>svg]:!mt-0.5";
 
+// Text color for icon, title, description, and close button in status toasts.
+// Light: dark ink (oklch(0.166 0.0283 203.34)) on tinted background; Dark: foreground token.
+const statusTextClasses =
+  "[&>[data-icon]>svg]:!text-[oklch(0.166_0.0283_203.34)] dark:[&>[data-icon]>svg]:!text-foreground " +
+  "[&_[data-title]]:!text-[oklch(0.166_0.0283_203.34)] dark:[&_[data-title]]:!text-foreground " +
+  "[&_[data-description]]:!text-[oklch(0.166_0.0283_203.34)] dark:[&_[data-description]]:!text-foreground " +
+  "[&_[data-close-button]]:!text-[oklch(0.166_0.0283_203.34)] dark:[&_[data-close-button]]:!text-foreground";
+
 // Apollo status styles for Sonner toasts.
-// Light: inverted card surface (info) or status-tinted background; matching icon color.
-// Dark: inverted secondary surface (info) or status-tinted color-mix with popover.
+// Light: inverted card-foreground background (info) or status-tinted background; matching icon color.
+// Dark: inverted card-foreground background (info) or status-tinted color-mix with popover.
 export const apolloToastClassNames: NonNullable<
   NonNullable<ToasterProps["toastOptions"]>["classNames"]
 > = {
   info: `!border-info !bg-card-foreground dark:!bg-card-foreground [&>[data-icon]>svg]:!text-primary-foreground [&_[data-title]]:!text-primary-foreground [&_[data-description]]:!text-primary-foreground [&_[data-close-button]]:!text-primary-foreground ${iconAlign}`,
-  success: `!border-success !bg-[color-mix(in_srgb,var(--success)_25%,var(--card)_75%)] dark:!bg-[color-mix(in_srgb,var(--success)_25%,var(--popover)_75%)] [&>[data-icon]>svg]:!text-[oklch(0.166_0.0283_203.34)] dark:[&>[data-icon]>svg]:!text-foreground [&_[data-title]]:!text-[oklch(0.166_0.0283_203.34)] dark:[&_[data-title]]:!text-foreground [&_[data-description]]:!text-[oklch(0.166_0.0283_203.34)] dark:[&_[data-description]]:!text-foreground [&_[data-close-button]]:!text-[oklch(0.166_0.0283_203.34)] dark:[&_[data-close-button]]:!text-foreground ${iconAlign}`,
-  warning: `!border-warning !bg-[color-mix(in_srgb,var(--warning)_60%,var(--card)_40%)] dark:!bg-[color-mix(in_srgb,var(--warning)_60%,var(--popover)_40%)] [&>[data-icon]>svg]:!text-[oklch(0.166_0.0283_203.34)] dark:[&>[data-icon]>svg]:!text-foreground [&_[data-title]]:!text-[oklch(0.166_0.0283_203.34)] dark:[&_[data-title]]:!text-foreground [&_[data-description]]:!text-[oklch(0.166_0.0283_203.34)] dark:[&_[data-description]]:!text-foreground [&_[data-close-button]]:!text-[oklch(0.166_0.0283_203.34)] dark:[&_[data-close-button]]:!text-foreground ${iconAlign}`,
-  error: `!border-destructive !bg-[color-mix(in_srgb,var(--destructive)_50%,var(--card)_50%)] dark:!bg-[color-mix(in_srgb,var(--destructive)_50%,var(--popover)_50%)] [&>[data-icon]>svg]:!text-[oklch(0.166_0.0283_203.34)] dark:[&>[data-icon]>svg]:!text-foreground [&_[data-title]]:!text-[oklch(0.166_0.0283_203.34)] dark:[&_[data-title]]:!text-foreground [&_[data-description]]:!text-[oklch(0.166_0.0283_203.34)] dark:[&_[data-description]]:!text-foreground [&_[data-close-button]]:!text-[oklch(0.166_0.0283_203.34)] dark:[&_[data-close-button]]:!text-foreground ${iconAlign}`,
+  success: `!border-success !bg-[color-mix(in_srgb,var(--success)_25%,var(--card)_75%)] dark:!bg-[color-mix(in_srgb,var(--success)_25%,var(--popover)_75%)] ${statusTextClasses} ${iconAlign}`,
+  warning: `!border-warning !bg-[color-mix(in_srgb,var(--warning)_60%,var(--card)_40%)] dark:!bg-[color-mix(in_srgb,var(--warning)_60%,var(--popover)_40%)] ${statusTextClasses} ${iconAlign}`,
+  error: `!border-destructive !bg-[color-mix(in_srgb,var(--destructive)_50%,var(--card)_50%)] dark:!bg-[color-mix(in_srgb,var(--destructive)_50%,var(--popover)_50%)] ${statusTextClasses} ${iconAlign}`,
   closeButton:
-    '!left-auto !right-2 !top-2 !transform-none !border-none !bg-transparent !rounded-sm',
+    "!left-auto !right-2 !top-2 !transform-none !border-none !bg-transparent !rounded-sm",
 };
 
 const Toaster = ({ ...props }: ToasterProps) => {


### PR DESCRIPTION
Clean update from: https://github.com/UiPath/apollo-ui/pull/345
Remove the unused subtle Alert variant and its supporting code (AlertContext, subtleTitleColors). Update tinted style descriptions to match actual examples, which range from routine info to errors.