### PR TITLE
feat(apollo-vertex): add dismissible prop to Alert

### DIFF
--- a/apps/apollo-vertex/app/patterns/notifications/in-product/notification-examples.tsx
+++ b/apps/apollo-vertex/app/patterns/notifications/in-product/notification-examples.tsx
@@ -5,9 +5,8 @@ import {
   InfoIcon,
   OctagonXIcon,
   TriangleAlertIcon,
-  XIcon,
 } from "lucide-react";
-import { type ReactNode, useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 
 import { Alert, AlertDescription, AlertTitle } from "@/registry/alert/alert";
@@ -106,65 +105,37 @@ export function AlertExamples() {
   );
 }
 
-function DismissibleAlert({
-  children,
-  status,
-  visual = "outline",
-}: {
-  children: ReactNode;
-  status: "default" | "warning" | "error";
-  visual?: "outline" | "tinted";
-}) {
-  const [visible, setVisible] = useState(true);
-  if (!visible) return null;
-  return (
-    <div className="relative">
-      <Alert status={status} visual={visual}>
-        {children}
-      </Alert>
-      <button
-        type="button"
-        onClick={() => setVisible(false)}
-        className="absolute top-3 right-3 rounded-sm opacity-70 hover:opacity-100 transition-opacity"
-        aria-label="Dismiss"
-      >
-        <XIcon className="h-4 w-4" />
-      </button>
-    </div>
-  );
-}
-
 export function AlertOutlineExamples() {
   const [resetKey, setResetKey] = useState(0);
 
   return (
     <div className="space-y-3" key={resetKey}>
-      <DismissibleAlert status="default">
+      <Alert status="default" visual="outline" dismissible>
         <InfoIcon className="h-4 w-4" />
         <AlertTitle>New version available</AlertTitle>
         <AlertDescription>
           A new version of the platform is ready. Review the changelog for
           details.
         </AlertDescription>
-      </DismissibleAlert>
+      </Alert>
 
-      <DismissibleAlert status="warning">
+      <Alert status="warning" visual="outline" dismissible>
         <TriangleAlertIcon className="h-4 w-4" />
         <AlertTitle>API rate limit approaching</AlertTitle>
         <AlertDescription>
           You have used 90% of your monthly API quota. Consider upgrading your
           plan.
         </AlertDescription>
-      </DismissibleAlert>
+      </Alert>
 
-      <DismissibleAlert status="error">
+      <Alert status="error" visual="outline" dismissible>
         <OctagonXIcon className="h-4 w-4" />
         <AlertTitle>Connection failed</AlertTitle>
         <AlertDescription>
           Unable to reach the server. Check your network connection and try
           again.
         </AlertDescription>
-      </DismissibleAlert>
+      </Alert>
 
       <button
         type="button"

--- a/apps/apollo-vertex/app/shadcn-components/alert/page.mdx
+++ b/apps/apollo-vertex/app/shadcn-components/alert/page.mdx
@@ -61,6 +61,18 @@ import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
 </Alert>
 ```
 
+### Dismissible
+
+```tsx
+<Alert status="warning" visual="outline" dismissible onDismiss={() => console.log("dismissed")}>
+  <TriangleAlertIcon className="h-4 w-4" />
+  <AlertTitle>API rate limit approaching</AlertTitle>
+  <AlertDescription>
+    You have used 90% of your monthly API quota. Consider upgrading your plan.
+  </AlertDescription>
+</Alert>
+```
+
 ### Props
 
 | Prop | Type | Default | Description |
@@ -68,6 +80,8 @@ import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
 | `status` | `"default" \| "warning" \| "error"` | — | Sets the semantic status color |
 | `visual` | `"outline" \| "tinted"` | — | Sets the visual treatment |
 | `variant` | `"default" \| "destructive"` | `"default"` | Legacy shadcn variant (use `status` + `visual` instead) |
+| `dismissible` | `boolean` | `false` | Renders a close button and manages internal visibility |
+| `onDismiss` | `() => void` | — | Callback fired when the alert is dismissed |
 
 ## Complex alert patterns (edge cases)
 

--- a/apps/apollo-vertex/registry/alert/alert.tsx
+++ b/apps/apollo-vertex/registry/alert/alert.tsx
@@ -1,4 +1,7 @@
+"use client";
+
 import { cva, type VariantProps } from "class-variance-authority";
+import { XIcon } from "lucide-react";
 import * as React from "react";
 
 import { cn } from "@/lib/utils";
@@ -69,24 +72,51 @@ const alertVariants = cva(
 
 interface AlertProps
   extends React.ComponentProps<"div">,
-    VariantProps<typeof alertVariants> {}
+    VariantProps<typeof alertVariants> {
+  dismissible?: boolean;
+  onDismiss?: () => void;
+}
 
 function Alert({
   className,
   variant,
   status,
   visual,
+  dismissible,
+  onDismiss,
   children,
   ...props
 }: AlertProps) {
+  const [visible, setVisible] = React.useState(true);
+
+  if (!visible) return null;
+
   return (
     <div
       data-slot="alert"
       role="alert"
-      className={cn(alertVariants({ variant, status, visual }), className)}
+      className={cn(
+        alertVariants({ variant, status, visual }),
+        dismissible && "pr-10",
+        className,
+      )}
       {...props}
     >
       {children}
+      {dismissible && (
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation();
+            setVisible(false);
+            onDismiss?.();
+          }}
+          className="absolute top-3 right-3 rounded-sm opacity-70 transition-opacity hover:opacity-100"
+          aria-label="Dismiss"
+        >
+          <XIcon className="size-4" />
+        </button>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- Adds first-class `dismissible` boolean prop and `onDismiss` callback to the Alert registry component, replacing the external `DismissibleAlert` wrapper pattern used in notification-examples
- Dismiss button renders absolutely positioned with `pr-10` padding, internal visibility state, `aria-label="Dismiss"`, and `stopPropagation` to avoid bubbling to parent click handlers
- Component marked `"use client"` since `useState` is now used for visibility
- Updates the alert docs page with a dismissible code example and new props table entries
- Notification-examples simplified — removed the ~27-line `DismissibleAlert` wrapper in favor of the built-in prop

🤖 Generated with [Claude Code](https://claude.com/claude-code)