### PR TITLE
fix(apollo-react): add list and table styles to sticky note markdown preview [MST-7613]

### DIFF
--- a/packages/apollo-react/src/canvas/components/StickyNoteNode/StickyNoteNode.styles.ts
+++ b/packages/apollo-react/src/canvas/components/StickyNoteNode/StickyNoteNode.styles.ts
@@ -150,6 +150,14 @@ export const StickyNoteMarkdown = styled.div`
     padding-left: 20px;
   }
 
+  ul {
+    list-style: disc;
+  }
+
+  ol {
+    list-style: decimal;
+  }
+
   li {
     margin: 4px 0;
   }
@@ -185,6 +193,29 @@ export const StickyNoteMarkdown = styled.div`
 
   h3 {
     font-size: 1.1em;
+  }
+
+  table {
+    border-collapse: collapse;
+    width: 100%;
+    margin: 8px 0;
+    font-size: 0.9em;
+  }
+
+  th,
+  td {
+    border: 1px solid rgba(0, 0, 0, 0.15);
+    padding: 6px 10px;
+    text-align: left;
+  }
+
+  th {
+    font-weight: 600;
+    background: rgba(0, 0, 0, 0.05);
+  }
+
+  tr:nth-of-type(even) {
+    background: rgba(0, 0, 0, 0.02);
   }
 
   blockquote {


### PR DESCRIPTION
## Summary

The global CSS reset (applied by Storybook's `GlobalStyles.tsx`) sets `list-style: none` on `ul/ol` and `* { padding: 0 }`, which strips bullet markers, numbering, and table structure from the ReactMarkdown preview in sticky notes. This PR adds explicit style overrides in `StickyNoteMarkdown` so lists and tables render correctly regardless of any upstream CSS reset.

### Before
<img width="416" height="450" alt="image" src="https://github.com/user-attachments/assets/a313d83a-0404-4848-b804-e6f314d5bc7f" />

### After
<img width="490" height="550" alt="image" src="https://github.com/user-attachments/assets/f3855099-323c-41ef-9060-a9a75a3b24e7" />

## Changes

- Added `list-style: disc` for `<ul>` and `list-style: decimal` for `<ol>` inside `StickyNoteMarkdown`
- Added full table styling: `border-collapse`, cell borders/padding, header background, and alternating row shading

## Flow

```mermaid
flowchart TD
    A[User types markdown in sticky note] --> B[Exits edit mode]
    B --> C[ReactMarkdown + remarkGfm parses content]
    C --> D[HTML rendered inside StickyNoteMarkdown]
    D --> E[Global CSS reset strips list-style & table styles]
    E --> F[StickyNoteMarkdown scoped overrides restore correct rendering]
```

## Testing

- [x] `pnpm run test` passes (65 suites, 1273 tests)
- [x] `pnpm run typecheck` passes
- [x] Manual testing performed
