### PR TITLE
fix(apollo-vertex): add useReactTableCompat to data-table registry

### DIFF
--- a/apps/apollo-vertex/registry.json
+++ b/apps/apollo-vertex/registry.json
@@ -567,6 +567,10 @@
         {
           "path": "registry/data-table/sortable-column-list.tsx",
           "type": "registry:ui"
+        },
+        {
+          "path": "registry/use-data-table/useReactTableCompat.ts",
+          "type": "registry:hook"
         }
       ]
     },


### PR DESCRIPTION
The hook added in https://github.com/UiPath/apollo-ui/pull/393 was missing from the data-table files array in registry.json, so external consumers installing via shadcn CLI would not receive it and have a missing dependency.

CC: @KokoMilev 
