### PR TITLE
fix(apollo-react): adds tooltip to add node panel list item

### DIFF
--- a/packages/apollo-react/src/canvas/components/AddNodePanel/AddNodePanel.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/AddNodePanel/AddNodePanel.stories.tsx
@@ -68,21 +68,22 @@ const NODE_OPTIONS: ListItem<NodeItemData>[] = [
     name: 'AI Agent long long long long long long name',
     icon: { name: 'smart_toy' },
     data: { type: 'ai-agent', category: 'AI' },
-    description: 'Autonomous AI assistant',
+    description: 'Autonomous AI assistant that processes complex multi-step workflows end to end',
   },
   {
     id: '5',
     name: 'OpenAI',
     icon: { name: 'psychology' },
     data: { type: 'openai', category: 'AI' },
-    description: 'GPT models integration',
+    description: 'GPT models integration for natural language processing and text generation tasks',
   },
   {
     id: '6',
     name: 'Data extractor',
     icon: { name: 'file_copy' },
     data: { type: 'data-extractor', category: 'Data' },
-    description: 'Extract data from documents',
+    description:
+      'Extract structured data from documents, PDFs, images, and scanned files automatically',
   },
   {
     id: '7',

--- a/packages/apollo-react/src/canvas/components/Toolbox/ListView.tsx
+++ b/packages/apollo-react/src/canvas/components/Toolbox/ListView.tsx
@@ -168,7 +168,7 @@ const ListViewRow = memo(
           {item.icon?.Component && <item.icon.Component />}
         </IconContainerMemoized>
         <Column flex={1} overflow="hidden">
-          <ApTooltip content={item.name} placement="top" smartTooltip>
+          <ApTooltip content={item.name} placement="right" smartTooltip>
             <ApTypography
               variant={FontVariantToken.fontSizeM}
               className="list-view-item-name"
@@ -178,13 +178,15 @@ const ListViewRow = memo(
             </ApTypography>
           </ApTooltip>
           {item.description && (
-            <ApTypography
-              variant={FontVariantToken.fontSizeXs}
-              className="list-view-item-name"
-              color="var(--uix-canvas-foreground-de-emp)"
-            >
-              {item.description}
-            </ApTypography>
+            <ApTooltip content={item.description} placement="right" smartTooltip>
+              <ApTypography
+                variant={FontVariantToken.fontSizeXs}
+                className="list-view-item-name"
+                color="var(--uix-canvas-foreground-de-emp)"
+              >
+                {item.description}
+              </ApTypography>
+            </ApTooltip>
           )}
         </Column>
         {!!item.children && (


### PR DESCRIPTION
Adds tooltip - open right (smart) for title and description...
<img width="716" height="491" alt="image" src="https://github.com/user-attachments/assets/0932c307-7b4d-48b0-a22e-f767c92a905b" />
