### PR TITLE
Badge fix: rename Neutral section heading to Default

### DIFF
--- a/apps/apollo-vertex/app/shadcn-components/badge/page.mdx
+++ b/apps/apollo-vertex/app/shadcn-components/badge/page.mdx
@@ -13,7 +13,7 @@ Badges combine a `variant` appearance (primary, secondary, or outline). Icons ar
 
 <Badge variant="outline">Outline</Badge> badges are intended for low-emphasis or contextual use, such as inline references, filters, or selectable states. They provide clarity while maintaining a lightweight visual presence.
 
-### Neutral
+### Default
 
 <div className="p-4 border rounded-lg mt-4 flex flex-wrap gap-2">
   <Badge>Primary</Badge>


### PR DESCRIPTION
The "Neutral" heading on the badge component page was confusing and made it seem like a neutral status needed to be called. Relabeled for clarity.