### PR TITLE
fix(apollo-react): disable StageNode add-task button while loading [MST-8019]

### DIFF
--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.stories.tsx
@@ -10,7 +10,7 @@ import {
 } from '@uipath/apollo-react/canvas/xyflow/react';
 import { ApButton, ApMenu } from '@uipath/apollo-react/material/components';
 import type { IMenuItem } from '@uipath/apollo-react/material/components/ap-menu/ApMenu.types';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { DefaultCanvasTranslations } from '../../types';
 import {
   createGroupModificationHandlers,
@@ -1493,10 +1493,10 @@ const AddTaskLoadingStory = () => {
         width: 304,
         data: {
           stageDetails: {
-            label: 'Top-level loading (click +)',
+            label: 'Loading (+ disabled for 3s)',
             tasks: [],
           },
-          // Top-level loading: skeletons until API returns items
+          // Top-level loading: + button disabled until API returns items
           addTaskLoading: true,
           taskOptions: [] as ListItem[],
         },
@@ -1544,7 +1544,32 @@ const AddTaskLoadingStory = () => {
     return () => clearTimeout(timeout);
   }, [setNodes]);
 
-  // Inject per-node handlers
+  // Inject per-node handlers — simulates loading state on add-task:
+  // 1. Set addTaskLoading=true so the + button is disabled
+  // 2. After 2s, set addTaskLoading=false to re-enable it
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+
+  useEffect(() => {
+    return () => clearTimeout(timeoutRef.current);
+  }, []);
+
+  const handleAddTaskFromToolbox = useCallback(
+    (nodeId: string, _taskItem: ListItem) => {
+      clearTimeout(timeoutRef.current);
+      setNodes((nds) =>
+        nds.map((n) => (n.id === nodeId ? { ...n, data: { ...n.data, addTaskLoading: true } } : n))
+      );
+      timeoutRef.current = setTimeout(() => {
+        setNodes((nds) =>
+          nds.map((n) =>
+            n.id === nodeId ? { ...n, data: { ...n.data, addTaskLoading: false } } : n
+          )
+        );
+      }, 2000);
+    },
+    [setNodes]
+  );
+
   const nodesWithHandler = useMemo(
     () =>
       nodesState.map((node) => ({
@@ -1552,11 +1577,11 @@ const AddTaskLoadingStory = () => {
         data: {
           ...node.data,
           onAddTaskFromToolbox: (taskItem: ListItem) => {
-            window.alert(`Added task "${taskItem.name}" to ${node.id}`);
+            handleAddTaskFromToolbox(node.id, taskItem);
           },
         },
       })),
-    [nodesState]
+    [nodesState, handleAddTaskFromToolbox]
   );
 
   const onConnect = useCallback(

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.test.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.test.tsx
@@ -619,10 +619,20 @@ describe('StageNode - Add Task Loading State', () => {
   it('should pass addTaskLoading to Toolbox when toolbox is open', async () => {
     const user = userEvent.setup();
     const onAddTaskFromToolbox = vi.fn();
-    renderStageNode({ onAddTaskFromToolbox, addTaskLoading: true });
+    const { rerender } = renderStageNode({ onAddTaskFromToolbox, addTaskLoading: false });
 
     const addButton = screen.getByRole('button', { name: 'Add task' });
     await user.click(addButton);
+
+    rerender(
+      <ReactFlowProvider>
+        <StageNode
+          {...defaultProps}
+          onAddTaskFromToolbox={onAddTaskFromToolbox}
+          addTaskLoading={true}
+        />
+      </ReactFlowProvider>
+    );
 
     const toolbox = screen.getByTestId('toolbox');
     expect(toolbox).toHaveAttribute('data-loading', 'true');
@@ -640,9 +650,17 @@ describe('StageNode - Add Task Loading State', () => {
     expect(toolbox).toHaveAttribute('data-loading', 'false');
   });
 
-  it('should not disable the add button when addTaskLoading is true', () => {
+  it('should disable the add button when addTaskLoading is true', () => {
     const onAddTaskFromToolbox = vi.fn();
     renderStageNode({ onAddTaskFromToolbox, addTaskLoading: true });
+
+    const addButton = screen.getByRole('button', { name: 'Add task' });
+    expect(addButton).toBeDisabled();
+  });
+
+  it('should not disable the add button when addTaskLoading is false', () => {
+    const onAddTaskFromToolbox = vi.fn();
+    renderStageNode({ onAddTaskFromToolbox, addTaskLoading: false });
 
     const addButton = screen.getByRole('button', { name: 'Add task' });
     expect(addButton).not.toBeDisabled();
@@ -651,10 +669,20 @@ describe('StageNode - Add Task Loading State', () => {
   it('should update Toolbox loading when addTaskLoading changes to false', async () => {
     const user = userEvent.setup();
     const onAddTaskFromToolbox = vi.fn();
-    const { rerender } = renderStageNode({ onAddTaskFromToolbox, addTaskLoading: true });
+    const { rerender } = renderStageNode({ onAddTaskFromToolbox, addTaskLoading: false });
 
     const addButton = screen.getByRole('button', { name: 'Add task' });
     await user.click(addButton);
+
+    rerender(
+      <ReactFlowProvider>
+        <StageNode
+          {...defaultProps}
+          onAddTaskFromToolbox={onAddTaskFromToolbox}
+          addTaskLoading={true}
+        />
+      </ReactFlowProvider>
+    );
 
     expect(screen.getByTestId('toolbox')).toHaveAttribute('data-loading', 'true');
 

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.tsx
@@ -553,9 +553,14 @@ const StageNodeComponent = (props: StageNodeProps) => {
               </ApTooltip>
             )}
             {(onTaskAdd || onAddTaskFromToolbox) && !isReadOnly && (
-              <ApTooltip content={addTaskLabel} placement="top">
+              <ApTooltip content={addTaskLabel} placement="top" hide={addTaskLoading}>
                 <span>
-                  <ApIconButton onClick={handleTaskAddClick} size="small" label={addTaskLabel}>
+                  <ApIconButton
+                    onClick={handleTaskAddClick}
+                    size="small"
+                    label={addTaskLabel}
+                    disabled={addTaskLoading}
+                  >
                     <ApIcon name="add" size="20px" />
                   </ApIconButton>
                 </span>


### PR DESCRIPTION
## Summary
- Disable the "+" (add task) button on `StageNode` when `addTaskLoading` is `true`, preventing duplicate task additions while the API is processing
- Hide the tooltip on the disabled button to avoid showing an action hint for a non-interactive element
- Update tests to assert the button is disabled/enabled based on `addTaskLoading`
- Improve the Storybook story to simulate the real add-task flow (button disables for 2s, then re-enables)

## Demo

https://github.com/user-attachments/assets/241d875a-431e-442f-9c50-213fb11423b1



## Test plan
- [ ] Verify the add-task button is disabled and non-clickable while `addTaskLoading` is `true`
- [ ] Verify the button re-enables once `addTaskLoading` is set back to `false`
- [ ] Verify the tooltip is hidden while the button is disabled
- [ ] Confirm the "empty state" add-task link also remains non-clickable during loading
- [ ] Check the Storybook "Add Task Loading" story demonstrates the full flow