### PR TITLE
feat(apollo-vertex): ai-chat alpha login and agenthub proxy [AGVSOL-1712]

### DIFF
--- a/apps/apollo-vertex/app/api/agenthub/[...path]/route.ts
+++ b/apps/apollo-vertex/app/api/agenthub/[...path]/route.ts
@@ -1,0 +1,42 @@
+import { type NextRequest, NextResponse } from "next/server";
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ path: string[] }> },
+) {
+  const authHeader = request.headers.get("authorization");
+  if (!authHeader) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { path } = await params;
+  const targetUrl = `https://alpha.uipath.com/${path.join("/")}`;
+  const body = await request.text();
+
+  const response = await fetch(targetUrl, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: authHeader,
+      "X-UiPath-LlmGateway-NormalizedApi-ModelName":
+        request.headers.get("x-uipath-llmgateway-normalizedapi-modelname") ??
+        "",
+    },
+    body,
+    signal: request.signal,
+  });
+
+  if (!response.ok || !response.body) {
+    const text = await response.text();
+    return new NextResponse(text, { status: response.status });
+  }
+
+  return new NextResponse(response.body, {
+    status: response.status,
+    headers: {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache",
+      Connection: "keep-alive",
+    },
+  });
+}

--- a/apps/apollo-vertex/app/portal_/cloudrpa/page.tsx
+++ b/apps/apollo-vertex/app/portal_/cloudrpa/page.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+/**
+ * Post-logout redirect page.
+ *
+ * This route exists solely as the `post_logout_redirect_uri` target for the
+ * UiPath Identity Server end-session flow. It should NOT be used for any other
+ * purpose. When the identity provider redirects here after logout, the page
+ * reads the stored return path and navigates the user back to where they were.
+ */
+
+import { useRouter } from "next/navigation";
+import { useEffect } from "react";
+import { STORAGE_KEYS } from "@/lib/auth";
+
+const FALLBACK_PATH = "/";
+
+export default function PostLogoutRedirect() {
+  const router = useRouter();
+
+  useEffect(() => {
+    const returnTo =
+      sessionStorage.getItem(STORAGE_KEYS.LOGOUT_RETURN_TO) ?? FALLBACK_PATH;
+    sessionStorage.removeItem(STORAGE_KEYS.LOGOUT_RETURN_TO);
+    router.replace(returnTo);
+  }, [router]);
+
+  return null;
+}

--- a/apps/apollo-vertex/app/vertex-components/ai-chat/page.mdx
+++ b/apps/apollo-vertex/app/vertex-components/ai-chat/page.mdx
@@ -35,22 +35,18 @@ npm install @tanstack/ai @tanstack/ai-client @tanstack/ai-react eventsource-pars
 ## Quick Start
 
 ```tsx
-import { stream, useChat } from '@tanstack/ai-react';
+import { useChat } from '@tanstack/ai-react';
 import { AiChat } from '@/components/ui/ai-chat/components/ai-chat';
 import { AiChatMessage } from '@/components/ui/ai-chat/components/ai-chat-message';
-import { createAgentHubStreamFactory } from '@/components/ui/ai-chat/adapters/agenthub/adapter';
+import { createAgentHubConnection } from '@/components/ui/ai-chat/adapters/agenthub/adapter';
 
 function BasicChat() {
-  const config = {
+  const connection = createAgentHubConnection({
     baseUrl: 'https://cloud.uipath.com/{org}/{tenant}/agenthub_/llm/api',
     model: { vendor: 'openai' as const, name: 'gpt-4o' },
     accessToken: () => getAccessToken(),
     systemPrompt: 'You are a helpful assistant.',
-  };
-
-  const connection = stream((messages) =>
-    createAgentHubStreamFactory(config)(messages),
-  );
+  });
 
   const { messages, sendMessage, isLoading, stop, clear, error } = useChat({
     connection,
@@ -137,9 +133,9 @@ function ChatWithTools() {
 The built-in adapter for the **UiPath AgentHub** normalized LLM endpoint. It converts TanStack AI `UIMessage` arrays to the AgentHub wire format, calls the endpoint, and parses the SSE response back into AG-UI `StreamChunk` events.
 
 ```tsx
-import { createAgentHubStreamFactory, type AgentHubAdapterConfig } from '@/components/ui/ai-chat/adapters/agenthub/adapter';
+import { createAgentHubConnection, type AgentHubAdapterConfig } from '@/components/ui/ai-chat/adapters/agenthub/adapter';
 
-const config: AgentHubAdapterConfig = {
+const connection = createAgentHubConnection({
   baseUrl: 'https://cloud.uipath.com/{org}/{tenant}/agenthub_/llm/api',
   model: { vendor: 'openai', name: 'gpt-4o' },
   accessToken: () => getAccessToken(),
@@ -147,11 +143,7 @@ const config: AgentHubAdapterConfig = {
   maxTokens: 2048,
   temperature: 0.7,
   tools: toolDefs,
-};
-
-const connection = stream((messages) =>
-  createAgentHubStreamFactory(config)(messages),
-);
+});
 ```
 
 The `model.vendor` field controls wire-format differences:
@@ -276,7 +268,7 @@ import type { ChoiceOption, ToolResultChoices } from '@/components/ui/ai-chat/ty
 
 // AgentHub adapter
 import {
-  createAgentHubStreamFactory,
+  createAgentHubConnection,
   type AgentHubAdapterConfig,
   type AgentHubVendor,
 } from '@/components/ui/ai-chat/adapters/agenthub/adapter';

--- a/apps/apollo-vertex/lib/auth.ts
+++ b/apps/apollo-vertex/lib/auth.ts
@@ -15,10 +15,12 @@ function generateRandomString(length: number): string {
     .join("");
 }
 
-const STORAGE_KEYS = {
+export const STORAGE_KEYS = {
   TOKEN: "uipath_token",
   CODE_VERIFIER: "uipath_code_verifier",
   STATE: "uipath_state",
+  AUTH_RETURN_TO: "auth_return_to",
+  LOGOUT_RETURN_TO: "logout_return_to",
 } as const;
 
 const TokenResponseSchema = z.object({
@@ -37,10 +39,14 @@ const getTokenEndpoint = (baseUrl: string) =>
   `${baseUrl}/identity_/connect/token`;
 const getAuthorizationEndpoint = (baseUrl: string) =>
   `${baseUrl}/identity_/connect/authorize`;
-const getRedirectUri = () =>
-  window.location.pathname === "/"
+const getRedirectUri = (redirectPath?: string) => {
+  if (redirectPath) {
+    return `${window.location.origin}${redirectPath}`;
+  }
+  return window.location.pathname === "/"
     ? window.location.origin
     : `${window.location.origin}${window.location.pathname}`;
+};
 
 export type TokenData = z.infer<typeof TokenDataSchema>;
 
@@ -127,11 +133,12 @@ const exchangeCodeForToken = (
   codeVerifier: string,
   clientId: string,
   baseUrl: string,
+  redirectPath?: string,
 ): Promise<TokenData> => {
   const body = new URLSearchParams({
     grant_type: "authorization_code",
     code,
-    redirect_uri: getRedirectUri(),
+    redirect_uri: getRedirectUri(redirectPath),
     client_id: clientId,
     code_verifier: codeVerifier,
   });
@@ -142,6 +149,7 @@ const exchangeCodeForToken = (
 const handleOAuthCallback = async (
   clientId: string,
   baseUrl: string,
+  redirectPath?: string,
 ): Promise<void> => {
   const params = new URLSearchParams(window.location.search);
   const code = params.get("code");
@@ -172,13 +180,18 @@ const handleOAuthCallback = async (
       codeVerifier,
       clientId,
       baseUrl,
+      redirectPath,
     );
     sessionStorage.removeItem(STORAGE_KEYS.CODE_VERIFIER);
     sessionStorage.removeItem(STORAGE_KEYS.STATE);
     saveTokenData(tokenData);
-    window.history.replaceState({}, document.title, window.location.pathname);
+    const returnTo = sessionStorage.getItem(STORAGE_KEYS.AUTH_RETURN_TO);
+    sessionStorage.removeItem(STORAGE_KEYS.AUTH_RETURN_TO);
+    const targetPath = returnTo ?? window.location.pathname;
+    window.history.replaceState({}, document.title, targetPath);
   } catch (authError) {
     clearTokenData();
+    sessionStorage.removeItem(STORAGE_KEYS.AUTH_RETURN_TO);
     const message =
       authError instanceof Error ? authError.message : "Unknown error";
     toast.error(`Authentication failed: ${message}`);
@@ -190,16 +203,16 @@ export const ensureValidToken = async (
   queryClient: ReturnType<typeof useQueryClient>,
   clientId: string,
   baseUrl: string,
+  redirectPath?: string,
 ): Promise<string | null> => {
   const params = new URLSearchParams(window.location.search);
   const isInOAuthCallback = params.has("code") && params.has("state");
 
   if (isInOAuthCallback) {
     try {
-      await handleOAuthCallback(clientId, baseUrl);
-      await queryClient.invalidateQueries({ queryKey: TOKEN_QUERY_KEY });
+      await handleOAuthCallback(clientId, baseUrl, redirectPath);
     } catch {
-      queryClient.setQueryData(TOKEN_QUERY_KEY, null);
+      queryClient.resetQueries({ queryKey: TOKEN_QUERY_KEY });
     }
   }
 
@@ -228,6 +241,7 @@ export const login = async (
   clientId: string,
   scope: string,
   baseUrl: string,
+  redirectPath?: string,
 ): Promise<void> => {
   const pkce = await PKCEChallenge();
   const state = generateRandomString(32);
@@ -235,9 +249,16 @@ export const login = async (
   sessionStorage.setItem(STORAGE_KEYS.CODE_VERIFIER, pkce.code_verifier);
   sessionStorage.setItem(STORAGE_KEYS.STATE, state);
 
+  if (redirectPath && window.location.pathname !== redirectPath) {
+    sessionStorage.setItem(
+      STORAGE_KEYS.AUTH_RETURN_TO,
+      window.location.pathname,
+    );
+  }
+
   const params = new URLSearchParams({
     client_id: clientId,
-    redirect_uri: getRedirectUri(),
+    redirect_uri: getRedirectUri(redirectPath),
     response_type: "code",
     scope: scope,
     state,
@@ -254,5 +275,6 @@ export const logout = (
   clearTokenData();
   sessionStorage.removeItem(STORAGE_KEYS.CODE_VERIFIER);
   sessionStorage.removeItem(STORAGE_KEYS.STATE);
-  queryClient.setQueryData(TOKEN_QUERY_KEY, null);
+  sessionStorage.removeItem(STORAGE_KEYS.AUTH_RETURN_TO);
+  queryClient.resetQueries({ queryKey: TOKEN_QUERY_KEY });
 };

--- a/apps/apollo-vertex/next.config.ts
+++ b/apps/apollo-vertex/next.config.ts
@@ -17,6 +17,10 @@ export default withNextra({
         source: "/identity_/:path*",
         destination: "https://alpha.uipath.com/identity_/:path*",
       },
+      {
+        source: "/_proxy/portal/:orgId/:path*",
+        destination: "https://alpha.uipath.com/:orgId/portal_/api/:path*",
+      },
     ];
   },
   headers() {

--- a/apps/apollo-vertex/registry/ai-chat/adapters/agenthub/adapter.ts
+++ b/apps/apollo-vertex/registry/ai-chat/adapters/agenthub/adapter.ts
@@ -1,5 +1,5 @@
-import type { ModelMessage, StreamChunk } from "@tanstack/ai";
-import type { UIMessage } from "@tanstack/ai-client";
+import type { ModelMessage } from "@tanstack/ai";
+import type { ConnectConnectionAdapter, UIMessage } from "@tanstack/ai-client";
 import { fetchAgentHubStream } from "./stream";
 import type { AgentHubAdapterConfig } from "./types";
 
@@ -12,21 +12,20 @@ function isUIMessages(
   return first != null && "parts" in first;
 }
 
-export function createAgentHubStreamFactory(
+export function createAgentHubConnection(
   config: AgentHubAdapterConfig,
-  signal?: AbortSignal,
-) {
-  return (
-    messages: Array<UIMessage> | Array<ModelMessage>,
-  ): AsyncIterable<StreamChunk> => {
-    if (messages.length === 0) {
-      return fetchAgentHubStream(config, [], signal);
-    }
-    if (!isUIMessages(messages)) {
-      throw new Error(
-        "AgentHub adapter requires UIMessages, received ModelMessages",
-      );
-    }
-    return fetchAgentHubStream(config, messages, signal);
+): ConnectConnectionAdapter {
+  return {
+    connect(messages, _data, abortSignal) {
+      if (messages.length === 0) {
+        return fetchAgentHubStream(config, [], abortSignal);
+      }
+      if (!isUIMessages(messages)) {
+        throw new Error(
+          "AgentHub adapter requires UIMessages, received ModelMessages",
+        );
+      }
+      return fetchAgentHubStream(config, messages, abortSignal);
+    },
   };
 }

--- a/apps/apollo-vertex/registry/ai-chat/adapters/agenthub/stream.ts
+++ b/apps/apollo-vertex/registry/ai-chat/adapters/agenthub/stream.ts
@@ -78,7 +78,7 @@ export async function* fetchAgentHubStream(
 const OpenAIChatStreamChunkSchema = z.object({
   choices: z.array(
     z.object({
-      finish_reason: z.string().nullable(),
+      finish_reason: z.string().nullable().optional(),
       delta: z.object({
         content: z.string().optional(),
         tool_calls: z

--- a/apps/apollo-vertex/registry/shell/shell-auth-provider.tsx
+++ b/apps/apollo-vertex/registry/shell/shell-auth-provider.tsx
@@ -72,40 +72,51 @@ export const useAuth = (): AuthContextValue => {
 interface UseAccessTokenProps {
   clientId: string;
   baseUrl: string;
+  redirectPath?: string;
 }
 
-export const useAccessToken = ({ clientId, baseUrl }: UseAccessTokenProps) => {
+export const useAccessToken = ({
+  clientId,
+  baseUrl,
+  redirectPath,
+}: UseAccessTokenProps) => {
   const queryClient = useQueryClient();
 
-  const { data: token } = useQuery({
+  const { data: token, isLoading } = useQuery({
     queryKey: TOKEN_QUERY_KEY,
-    queryFn: () => ensureValidToken(queryClient, clientId, baseUrl),
+    queryFn: async () =>
+      await ensureValidToken(queryClient, clientId, baseUrl, redirectPath),
     refetchInterval: 60 * 1000,
     enabled: typeof window !== "undefined",
   });
 
-  return token ?? null;
+  return { accessToken: token ?? null, isLoading };
 };
 
 interface ShellAuthProviderProps {
   clientId: string;
   scope: string;
   baseUrl: string;
+  redirectPath?: string;
 }
 
 export const ShellAuthProvider: FC<
   PropsWithChildren<ShellAuthProviderProps>
-> = ({ children, clientId, scope, baseUrl }) => {
+> = ({ children, clientId, scope, baseUrl, redirectPath }) => {
   const queryClient = useQueryClient();
-  const accessToken = useAccessToken({ clientId, baseUrl });
+  const { accessToken, isLoading } = useAccessToken({
+    clientId,
+    baseUrl,
+    redirectPath,
+  });
   const user = accessToken ? decodeJWT(accessToken) : null;
   const isAuthenticated = accessToken != null;
 
-  const contextValue = {
+  const contextValue: AuthContextValue = {
     user,
     isAuthenticated,
-    isLoading: false,
-    login: () => login(clientId, scope, baseUrl),
+    isLoading,
+    login: () => login(clientId, scope, baseUrl, redirectPath),
     logout: () => logout(queryClient),
     accessToken,
   };

--- a/apps/apollo-vertex/templates/AiChatLoginGate.tsx
+++ b/apps/apollo-vertex/templates/AiChatLoginGate.tsx
@@ -1,0 +1,219 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { jwtDecode } from "jwt-decode";
+import { LogIn, LogOut } from "lucide-react";
+import { type ReactNode, useCallback, useMemo } from "react";
+import { z } from "zod";
+import { Button } from "@/components/ui/button";
+import { STORAGE_KEYS } from "@/lib/auth";
+import { useAuth } from "@/registry/shell/shell-auth-provider";
+
+export interface OrgTenantInfo {
+  orgId: string;
+  orgName: string;
+  tenantId: string;
+  tenantName: string;
+}
+
+const TenantsAndOrgSchema = z.object({
+  organization: z.object({ id: z.string(), name: z.string() }),
+  tenants: z.array(z.object({ id: z.string(), name: z.string() })),
+});
+
+const PrtIdSchema = z.object({ prt_id: z.string() });
+
+async function fetchOrgTenant(
+  orgId: string,
+  accessToken: string,
+): Promise<OrgTenantInfo> {
+  const res = await fetch(
+    `/_proxy/portal/${orgId}/filtering/leftnav/tenantsAndOrganizationInfo`,
+    { headers: { Authorization: `Bearer ${accessToken}` } },
+  );
+  if (!res.ok) {
+    throw new Error(`Failed to fetch org tenant info (${res.status})`);
+  }
+
+  const data = TenantsAndOrgSchema.safeParse(await res.json());
+  if (!data.success) {
+    throw new Error("Invalid org tenant response");
+  }
+  if (data.data.tenants.length === 0) {
+    throw new Error("No tenants found for organization");
+  }
+
+  const { organization, tenants } = data.data;
+  const firstTenant = tenants[0];
+  return {
+    orgId: organization.id,
+    orgName: organization.name,
+    tenantId: firstTenant.id,
+    tenantName: firstTenant.name,
+  };
+}
+
+function useOrgTenant(accessToken: string | null) {
+  const orgId = useMemo(() => {
+    if (!accessToken) return null;
+    let decoded: unknown;
+    try {
+      decoded = jwtDecode(accessToken);
+    } catch {
+      return null;
+    }
+    const parsed = PrtIdSchema.safeParse(decoded);
+    return parsed.success ? parsed.data.prt_id : null;
+  }, [accessToken]);
+
+  const { data, isLoading, isError } = useQuery({
+    queryKey: ["orgTenant", orgId],
+    queryFn: () => {
+      if (!orgId || !accessToken)
+        throw new Error("Missing orgId or accessToken");
+      return fetchOrgTenant(orgId, accessToken);
+    },
+    enabled: !!accessToken && !!orgId,
+    staleTime: 5 * 60 * 1000,
+  });
+
+  return { orgTenant: data ?? null, isLoading: isLoading && !!orgId, isError };
+}
+
+function SignOutButton(
+  props: Omit<React.ComponentProps<typeof Button>, "onClick"> & {
+    onSignOut: () => void;
+  },
+) {
+  const { onSignOut, ...rest } = props;
+  return (
+    <Button
+      className="cursor-pointer"
+      variant="outline"
+      onClick={onSignOut}
+      {...rest}
+    >
+      <LogOut className="size-4 mr-2" />
+      Sign out
+    </Button>
+  );
+}
+
+interface AiChatLoginGateProps {
+  children: (props: {
+    accessToken: string;
+    orgTenant: OrgTenantInfo;
+  }) => ReactNode;
+}
+
+export function AiChatLoginGate({ children }: AiChatLoginGateProps) {
+  const { isAuthenticated, isLoading, login, logout, user, accessToken } =
+    useAuth();
+  const {
+    orgTenant,
+    isLoading: isOrgLoading,
+    isError: isOrgError,
+  } = useOrgTenant(accessToken);
+
+  const handleLogout = useCallback(() => {
+    const tokenDataStr = localStorage.getItem(STORAGE_KEYS.TOKEN);
+    let idToken: string | null = null;
+    if (tokenDataStr) {
+      try {
+        const parsed = JSON.parse(tokenDataStr) as { id_token?: unknown };
+        if (typeof parsed.id_token === "string") {
+          idToken = parsed.id_token;
+        }
+      } catch {
+        idToken = null;
+      }
+    }
+
+    sessionStorage.setItem(
+      STORAGE_KEYS.LOGOUT_RETURN_TO,
+      window.location.pathname,
+    );
+    logout();
+
+    const endSessionUrl = new URL(
+      "/identity_/connect/endsession",
+      window.location.origin,
+    );
+    if (idToken) {
+      endSessionUrl.searchParams.set("id_token_hint", idToken);
+    }
+    endSessionUrl.searchParams.set(
+      "post_logout_redirect_uri",
+      `${window.location.origin}/portal_/cloudrpa`,
+    );
+    window.location.href = endSessionUrl.toString();
+  }, [logout]);
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center h-[500px] text-muted-foreground">
+        Signing in...
+      </div>
+    );
+  }
+
+  if (!isAuthenticated) {
+    return (
+      <div className="flex flex-col items-center justify-center h-[500px] gap-4 border rounded-lg bg-card">
+        <p className="text-muted-foreground">
+          Sign in to UiPath to use the AI Chat demo
+        </p>
+        <Button className="cursor-pointer" onClick={login}>
+          <LogIn className="size-4 mr-2" />
+          Sign in
+        </Button>
+      </div>
+    );
+  }
+
+  if (isOrgError) {
+    return (
+      <div className="flex flex-col items-center justify-center h-[500px] gap-4 border rounded-lg bg-card">
+        <p className="text-muted-foreground">
+          We couldn&apos;t load your organization info. Please try signing out
+          and signing back in.
+        </p>
+        <SignOutButton onSignOut={handleLogout} />
+      </div>
+    );
+  }
+
+  if (isOrgLoading || !accessToken) {
+    return (
+      <div className="flex items-center justify-center h-[500px] text-muted-foreground">
+        Loading organization info...
+      </div>
+    );
+  }
+
+  if (!orgTenant) {
+    return (
+      <div className="flex flex-col items-center justify-center h-[500px] gap-4 border rounded-lg bg-card">
+        <p className="text-muted-foreground">
+          Unable to resolve your organization. Please try signing out and
+          signing back in.
+        </p>
+        <SignOutButton onSignOut={handleLogout} />
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex items-center justify-end gap-2">
+        {user && (
+          <span className="text-sm text-muted-foreground">
+            {user.name} \ {orgTenant.orgName} \ {orgTenant.tenantName}
+          </span>
+        )}
+        <SignOutButton onSignOut={handleLogout} size="sm" />
+      </div>
+      {children({ accessToken, orgTenant })}
+    </div>
+  );
+}

--- a/apps/apollo-vertex/templates/AiChatTemplate.tsx
+++ b/apps/apollo-vertex/templates/AiChatTemplate.tsx
@@ -1,178 +1,54 @@
 "use client";
 
-import type { UIMessage } from "@tanstack/ai-client";
-import { useCallback, useRef, useState } from "react";
+import { useChat } from "@tanstack/ai-react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
+import { createAgentHubConnection } from "@/registry/ai-chat/adapters/agenthub/adapter";
 import { AiChat } from "@/registry/ai-chat/components/ai-chat";
 import { AiChatMessage } from "@/registry/ai-chat/components/ai-chat-message";
+import { ShellAuthProvider } from "@/registry/shell/shell-auth-provider";
 import { LocaleProvider } from "@/registry/shell/shell-locale-provider";
+import { AiChatLoginGate, type OrgTenantInfo } from "./AiChatLoginGate";
 
-const delay = (ms: number): Promise<void> =>
-  new Promise((r) => {
-    setTimeout(r, ms);
-  });
+const queryClient = new QueryClient();
 
-function mockUIMessage(
-  role: "user" | "assistant",
-  parts: UIMessage["parts"],
-): UIMessage {
-  return { id: crypto.randomUUID(), role, parts };
-}
-
-function getMockResponses(userMessage: string): UIMessage[] {
-  const lower = userMessage.toLowerCase();
-
-  if (lower.includes("approve") || lower.includes("review")) {
-    return [
-      mockUIMessage("assistant", [
-        {
-          type: "text",
-          content:
-            "I've validated the data and checked your permissions. Everything looks good!",
-        },
-        {
-          type: "tool-result",
-          toolCallId: "tc1",
-          content: JSON.stringify({
-            type: "choices",
-            prompt: "How would you like to proceed?",
-            options: [
-              { id: "approve", label: "Approve Document", recommended: true },
-              { id: "reject", label: "Reject Document" },
-              { id: "request", label: "Request Changes" },
-            ],
-          }),
-          state: "complete",
-        },
-      ]),
-    ];
-  }
-
-  if (lower.includes("error") || lower.includes("fail")) {
-    return [{ id: "__error__", role: "assistant", parts: [] }];
-  }
-
-  if (lower.includes("markdown") || lower.includes("format")) {
-    return [
-      mockUIMessage("assistant", [
-        {
-          type: "text",
-          content: `# Markdown Rendering Demo
-
-This chat component supports **full markdown formatting** with *GitHub Flavored Markdown* extensions!
-
-## Text Formatting
-
-You can use **bold text**, *italic text*, and \`inline code\` in your responses.
-
-## Lists
-
-**Bullet lists:**
-- First item
-- Second item
-- Third item
-
-**Numbered lists:**
-1. Step one
-2. Step two
-3. Step three
-
-## Code Blocks
-
-\`\`\`typescript
-function greet(name: string): string {
-  return \`Hello, \${name}!\`;
-}
-\`\`\`
-
-## Tables
-
-| Feature | Status |
-|---------|--------|
-| Markdown | ✅ Supported |
-| Choices | ✅ Supported |
-| Error Display | ✅ Supported |
-
-> **Note:** All markdown elements are styled to match the Apollo Design System theme.`,
-        },
-      ]),
-    ];
-  }
-
-  return [
-    mockUIMessage("assistant", [
-      {
-        type: "text",
-        content: `I received: "${userMessage}". Try asking me to:\n\n• **approve** a document — shows suggestion buttons\n• Show **markdown** formatting — renders rich text\n• Simulate an **error** — shows the error banner`,
-      },
-    ]),
-  ];
-}
-
-function AiChatDemo() {
+function AiChatWithConnection({
+  accessToken,
+  orgTenant,
+}: {
+  accessToken: string;
+  orgTenant: OrgTenantInfo;
+}) {
   const { t } = useTranslation();
-  const [messages, setMessages] = useState<UIMessage[]>([]);
-  const [mockError, setMockError] = useState<Error | null>(null);
-  const [isMockLoading, setIsMockLoading] = useState(false);
-  const abortRef = useRef<AbortController | null>(null);
 
-  const handleSendMessage = useCallback(
-    async (content: string) => {
-      if (!content.trim() || isMockLoading) return;
-      setMockError(null);
-
-      const controller = new AbortController();
-      abortRef.current = controller;
-
-      const userMsg = mockUIMessage("user", [{ type: "text", content }]);
-
-      setMessages((prev) => [...prev, userMsg]);
-
-      setIsMockLoading(true);
-      try {
-        await delay(900);
-        if (controller.signal.aborted) return;
-
-        const responses = getMockResponses(content);
-
-        if (responses[0]?.id === "__error__") {
-          setMockError(
-            new Error("Connection failed: Unable to reach the AI service."),
-          );
-          return;
-        }
-
-        setMessages((prev) => [...prev, ...responses]);
-      } finally {
-        abortRef.current = null;
-        setIsMockLoading(false);
-      }
-    },
-    [isMockLoading],
+  const connection = useMemo(
+    () =>
+      createAgentHubConnection({
+        baseUrl: `/api/agenthub/${orgTenant.orgName}/${orgTenant.tenantName}/agenthub_/llm/api`,
+        model: { vendor: "openai", name: "gpt-4.1-mini-2025-04-14" },
+        accessToken: () => accessToken,
+        systemPrompt:
+          "You are a helpful assistant. Always respond using markdown format.",
+      }),
+    [accessToken, orgTenant],
   );
 
-  const handleClear = useCallback(() => {
-    setMessages([]);
-    setMockError(null);
-  }, []);
+  const { messages, sendMessage, isLoading, stop, clear, error } = useChat({
+    connection,
+  });
 
   return (
     <div className="h-[500px]">
       <AiChat
         messages={messages}
-        isLoading={isMockLoading}
-        // oxlint-disable-next-line typescript-eslint(no-misused-promises) -- async handler is intentional, AiChat manages the promise lifecycle
-        onSendMessage={handleSendMessage}
-        onStop={() => {
-          abortRef.current?.abort();
-          abortRef.current = null;
-          setIsMockLoading(false);
-        }}
-        onClearChat={handleClear}
+        isLoading={isLoading}
+        onSendMessage={(text) => sendMessage(text)}
+        onStop={stop}
+        onClearChat={clear}
         title={t("ai_assistant")}
-        placeholder="Try: approve · markdown · error"
         assistantName={t("assistant")}
-        error={mockError}
+        error={error ?? null}
       >
         {messages.map((message) => (
           <AiChatMessage
@@ -188,8 +64,24 @@ function AiChatDemo() {
 
 export function AiChatTemplate() {
   return (
-    <LocaleProvider>
-      <AiChatDemo />
-    </LocaleProvider>
+    <QueryClientProvider client={queryClient}>
+      <ShellAuthProvider
+        clientId="1119a927-10ab-4543-bd1a-ad6bfbbc27f4"
+        scope="openid profile offline_access"
+        baseUrl=""
+        redirectPath="/vertex-components/ai-chat"
+      >
+        <LocaleProvider>
+          <AiChatLoginGate>
+            {({ accessToken, orgTenant }) => (
+              <AiChatWithConnection
+                accessToken={accessToken}
+                orgTenant={orgTenant}
+              />
+            )}
+          </AiChatLoginGate>
+        </LocaleProvider>
+      </ShellAuthProvider>
+    </QueryClientProvider>
   );
 }


### PR DESCRIPTION
- login using uber client id through alpha
- logout both client and backend session for ai chat template
- fetch tenant after login to be able to proxy to agent hub endpoint

known issue, if you are already logged in to alpha, the ai chat login button will take you alpha for whatever reason. you need to log out first, and log in through the vertex ai chat page