### PR TITLE
chore(apollo-vertex): enable type-aware linting in oxlint [AGVSOL-1969]

### DIFF
--- a/apps/apollo-vertex/lib/auth.ts
+++ b/apps/apollo-vertex/lib/auth.ts
@@ -212,7 +212,7 @@ export const ensureValidToken = async (
     try {
       await handleOAuthCallback(clientId, baseUrl, redirectPath);
     } catch {
-      queryClient.resetQueries({ queryKey: TOKEN_QUERY_KEY });
+      void queryClient.resetQueries({ queryKey: TOKEN_QUERY_KEY });
     }
   }
 
@@ -276,5 +276,5 @@ export const logout = (
   sessionStorage.removeItem(STORAGE_KEYS.CODE_VERIFIER);
   sessionStorage.removeItem(STORAGE_KEYS.STATE);
   sessionStorage.removeItem(STORAGE_KEYS.AUTH_RETURN_TO);
-  queryClient.resetQueries({ queryKey: TOKEN_QUERY_KEY });
+  void queryClient.resetQueries({ queryKey: TOKEN_QUERY_KEY });
 };

--- a/apps/apollo-vertex/lib/auth.ts
+++ b/apps/apollo-vertex/lib/auth.ts
@@ -221,9 +221,15 @@ export const ensureValidToken = async (
     return null;
   }
 
-  const { data: tokenData, success } = TokenDataSchema.safeParse(
-    JSON.parse(tokenDataStr),
-  );
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(tokenDataStr);
+  } catch {
+    clearTokenData();
+    return null;
+  }
+
+  const { data: tokenData, success } = TokenDataSchema.safeParse(parsed);
 
   if (!success) {
     clearTokenData();

--- a/apps/apollo-vertex/package.json
+++ b/apps/apollo-vertex/package.json
@@ -13,8 +13,8 @@
     "postbuild": "pagefind --site .next/server/app --output-path public/_pagefind",
     "format": "biome format --write",
     "format:check": "biome format",
-    "lint": "oxlint",
-    "lint:fix": "oxlint --fix",
+    "lint": "oxlint --type-aware",
+    "lint:fix": "oxlint --fix --type-aware",
     "lint:deps": "depcruise registry --config .dependency-cruiser.js",
     "typecheck": "tsc --noEmit"
   },
@@ -105,6 +105,7 @@
     "dependency-cruiser": "^17.3.6",
     "eslint-plugin-react": "^7.37.5",
     "oxlint": "^1.38.0",
+    "oxlint-tsgolint": "^0.18.1",
     "pagefind": "^1.4.0",
     "shadcn": "latest",
     "tw-animate-css": "^1.4.0"

--- a/apps/apollo-vertex/registry/ai-chat/adapters/conversational-agent/stream.ts
+++ b/apps/apollo-vertex/registry/ai-chat/adapters/conversational-agent/stream.ts
@@ -27,6 +27,7 @@ function createStreamQueue(): StreamQueue {
     if (done) return;
     done = true;
     for (const waiter of waiters) {
+      // eslint-disable-next-line typescript-eslint/no-unsafe-type-assertion -- iterator protocol: value is ignored when done
       waiter({ value: null as never, done: true });
     }
     waiters.length = 0;
@@ -40,6 +41,7 @@ function createStreamQueue(): StreamQueue {
           if (buffered)
             return Promise.resolve({ value: buffered, done: false });
           if (done)
+            // eslint-disable-next-line typescript-eslint/no-unsafe-type-assertion -- iterator protocol: value is ignored when done
             return Promise.resolve({ value: null as never, done: true });
 
           return new Promise((resolve) => {

--- a/apps/apollo-vertex/registry/card/card.tsx
+++ b/apps/apollo-vertex/registry/card/card.tsx
@@ -78,7 +78,7 @@ function Card({
         />
 
         <button
-          // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- div props spread to button; both are HTML elements with compatible props
+          // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- intentionally spreading div-typed props onto a button for API simplicity; div and button props are not fully equivalent (e.g. ref, disabled), but Card currently shares a single props type for both render modes
           {...(props as React.ComponentProps<"button">)}
           type="button"
           aria-pressed={selected}

--- a/apps/apollo-vertex/registry/card/card.tsx
+++ b/apps/apollo-vertex/registry/card/card.tsx
@@ -78,6 +78,7 @@ function Card({
         />
 
         <button
+          // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- div props spread to button; both are HTML elements with compatible props
           {...(props as React.ComponentProps<"button">)}
           type="button"
           aria-pressed={selected}

--- a/apps/apollo-vertex/registry/data-table/data-table-filters.tsx
+++ b/apps/apollo-vertex/registry/data-table/data-table-filters.tsx
@@ -14,7 +14,11 @@ export const dataTableGlobalFilterFn = (
     const meta = cell.column.columnDef.meta;
     const displayValue = meta?.getFilterValue
       ? meta.getFilterValue(value, row)
-      : String(value ?? "");
+      : typeof value === "string"
+        ? value
+        : typeof value === "number" || typeof value === "boolean"
+          ? String(value)
+          : "";
     return displayValue.toLowerCase().includes(searchStr);
   });
 };

--- a/apps/apollo-vertex/registry/data-table/data-table.tsx
+++ b/apps/apollo-vertex/registry/data-table/data-table.tsx
@@ -18,6 +18,7 @@ import {
   type RowSelectionState,
   type SortingState,
   type Table as TanstackTable,
+  type Updater,
   type VisibilityState,
 } from "@tanstack/react-table";
 import * as React from "react";
@@ -141,7 +142,7 @@ function DataTable<TData, TValue>({
     onColumnVisibilityChange,
     onColumnOrderChange,
     ...(isRowSelectionEnabled && { onRowSelectionChange }),
-    onGlobalFilterChange: (updater) => {
+    onGlobalFilterChange: (updater: Updater<string>) => {
       onGlobalFilterChange(updater);
       resetPageIndex();
     },

--- a/apps/apollo-vertex/registry/filter-dropdown/filter-dropdown.tsx
+++ b/apps/apollo-vertex/registry/filter-dropdown/filter-dropdown.tsx
@@ -95,9 +95,16 @@ function FilterDropdown<TData, TValue>({
     if (column) {
       const filterValue = column.getFilterValue();
       if (multiSelect) {
-        return Array.isArray(filterValue) ? filterValue : [];
+        return Array.isArray(filterValue)
+          ? filterValue.filter((v): v is string => typeof v === "string")
+          : [];
       }
-      return filterValue == null ? [] : [String(filterValue)];
+      if (Array.isArray(filterValue) && typeof filterValue[0] === "string") {
+        return [filterValue[0]];
+      }
+      if (typeof filterValue === "string") return [filterValue];
+      if (typeof filterValue === "number") return [String(filterValue)];
+      return [];
     }
     if (valueProp != null) {
       if (multiSelect) {

--- a/apps/apollo-vertex/registry/shell/shell-auth-provider.tsx
+++ b/apps/apollo-vertex/registry/shell/shell-auth-provider.tsx
@@ -84,8 +84,8 @@ export const useAccessToken = ({
 
   const { data: token, isLoading } = useQuery({
     queryKey: TOKEN_QUERY_KEY,
-    queryFn: async () =>
-      await ensureValidToken(queryClient, clientId, baseUrl, redirectPath),
+    queryFn: () =>
+      ensureValidToken(queryClient, clientId, baseUrl, redirectPath),
     refetchInterval: 60 * 1000,
     enabled: typeof window !== "undefined",
   });

--- a/apps/apollo-vertex/templates/AiChatTemplate.tsx
+++ b/apps/apollo-vertex/templates/AiChatTemplate.tsx
@@ -16,6 +16,9 @@ import {
   type ChatMode,
 } from "./ai-chat/ai-chat-example-utils";
 
+const isChatMode = (v: string): v is ChatMode =>
+  v === "agenthub" || v === "conversational-agent";
+
 const queryClient = new QueryClient();
 
 function AiChatWithConnection({
@@ -35,7 +38,9 @@ function AiChatWithConnection({
       <div className="flex items-center justify-end gap-4 pt-2">
         <RadioGroup
           value={mode}
-          onValueChange={(v) => setMode(v as ChatMode)}
+          onValueChange={(v) => {
+            if (isChatMode(v)) setMode(v);
+          }}
           className="flex flex-row gap-4"
         >
           <div className="flex items-center gap-2">

--- a/apps/apollo-vertex/templates/FilterDropdownTemplate.tsx
+++ b/apps/apollo-vertex/templates/FilterDropdownTemplate.tsx
@@ -69,7 +69,9 @@ function FilterDropdownTemplateContent() {
           title="Status"
           options={statusOptions}
           value={statusFilter}
-          onChange={(v) => setStatusFilter(v as string[])}
+          onChange={(v) => {
+            if (Array.isArray(v)) setStatusFilter(v);
+          }}
         />
       </div>
 
@@ -83,7 +85,9 @@ function FilterDropdownTemplateContent() {
           options={regionOptions}
           multiSelect={false}
           value={regionFilter}
-          onChange={(v) => setRegionFilter(v as string)}
+          onChange={(v) => {
+            if (typeof v === "string") setRegionFilter(v);
+          }}
         />
       </div>
 
@@ -96,7 +100,9 @@ function FilterDropdownTemplateContent() {
           title="Country"
           options={countryOptions}
           value={countryFilter}
-          onChange={(v) => setCountryFilter(v as string[])}
+          onChange={(v) => {
+            if (Array.isArray(v)) setCountryFilter(v);
+          }}
         />
       </div>
     </div>

--- a/apps/apollo-vertex/templates/ai-chat/AiChatAgentHubMode.tsx
+++ b/apps/apollo-vertex/templates/ai-chat/AiChatAgentHubMode.tsx
@@ -40,7 +40,9 @@ export function AgentHubChat({ accessToken, orgTenant }: AgentHubChatProps) {
     <AiChat
       messages={messages}
       isLoading={isLoading}
-      onSendMessage={(text) => sendMessage(text)}
+      onSendMessage={(text) => {
+        void sendMessage(text);
+      }}
       onStop={stop}
       onClearChat={clear}
       title={t("ai_assistant")}

--- a/apps/apollo-vertex/templates/ai-chat/AiChatConversationalAgentMode.tsx
+++ b/apps/apollo-vertex/templates/ai-chat/AiChatConversationalAgentMode.tsx
@@ -47,7 +47,9 @@ function ConversationalAgentChatInner({
     <AiChat
       messages={messages}
       isLoading={isLoading}
-      onSendMessage={(text) => sendMessage(text)}
+      onSendMessage={(text) => {
+        void sendMessage(text);
+      }}
       onStop={stop}
       onClearChat={clear}
       title={title}

--- a/apps/apollo-vertex/templates/ai-chat/AiChatLoginGate.tsx
+++ b/apps/apollo-vertex/templates/ai-chat/AiChatLoginGate.tsx
@@ -158,6 +158,7 @@ export function AiChatLoginGate({ children }: AiChatLoginGateProps) {
     let idToken: string | null = null;
     if (tokenDataStr) {
       try {
+        // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- JSON.parse returns unknown; shape validated by optional chaining below
         const parsed = JSON.parse(tokenDataStr) as { id_token?: unknown };
         if (typeof parsed.id_token === "string") {
           idToken = parsed.id_token;
@@ -201,7 +202,12 @@ export function AiChatLoginGate({ children }: AiChatLoginGateProps) {
         <p className="text-muted-foreground">
           Sign in to UiPath to use the AI Chat demo
         </p>
-        <Button className="cursor-pointer" onClick={login}>
+        <Button
+          className="cursor-pointer"
+          onClick={() => {
+            void login();
+          }}
+        >
           <LogIn className="size-4 mr-2" />
           Sign in
         </Button>

--- a/apps/apollo-vertex/templates/ai-chat/AiChatLoginGate.tsx
+++ b/apps/apollo-vertex/templates/ai-chat/AiChatLoginGate.tsx
@@ -158,9 +158,13 @@ export function AiChatLoginGate({ children }: AiChatLoginGateProps) {
     let idToken: string | null = null;
     if (tokenDataStr) {
       try {
-        // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- JSON.parse returns unknown; shape validated by optional chaining below
-        const parsed = JSON.parse(tokenDataStr) as { id_token?: unknown };
-        if (typeof parsed.id_token === "string") {
+        const parsed: unknown = JSON.parse(tokenDataStr);
+        if (
+          typeof parsed === "object" &&
+          parsed !== null &&
+          "id_token" in parsed &&
+          typeof parsed.id_token === "string"
+        ) {
           idToken = parsed.id_token;
         }
       } catch {

--- a/package.json
+++ b/package.json
@@ -101,7 +101,14 @@
       "undici": "^6.24.0",
       "picomatch": ">=4.0.4",
       "yaml": ">=2.8.3",
-      "flatted": ">=3.4.2"
+      "brace-expansion": ">=5.0.5",
+      "flatted": ">=3.4.2",
+      "happy-dom": ">=20.8.8",
+      "handlebars": ">=4.7.9",
+      "path-to-regexp": ">=8.4.0",
+      "@xmldom/xmldom": ">=0.9.9",
+      "hono": ">=4.12.12",
+      "@hono/node-server": ">=1.19.13"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,7 +12,14 @@ overrides:
   undici: ^6.24.0
   picomatch: '>=4.0.4'
   yaml: '>=2.8.3'
+  brace-expansion: '>=5.0.5'
   flatted: '>=3.4.2'
+  happy-dom: '>=20.8.8'
+  handlebars: '>=4.7.9'
+  path-to-regexp: '>=8.4.0'
+  '@xmldom/xmldom': '>=0.9.9'
+  hono: '>=4.12.12'
+  '@hono/node-server': '>=1.19.13'
 
 importers:
 
@@ -209,7 +216,7 @@ importers:
         version: 8.21.3(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@uipath/uipath-typescript':
         specifier: ^1.2.1
-        version: 1.2.1(@opentelemetry/api@1.9.0)(zod@4.3.5)
+        version: 1.2.2(@opentelemetry/api@1.9.0)(zod@4.3.5)
       '@vercel/analytics':
         specifier: ^1.5.0
         version: 1.5.0(next@16.1.7(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.94.2))(react@19.2.3)
@@ -333,13 +340,16 @@ importers:
         version: 7.37.5(eslint@9.39.3(jiti@2.6.1))
       oxlint:
         specifier: ^1.38.0
-        version: 1.50.0
+        version: 1.50.0(oxlint-tsgolint@0.18.1)
+      oxlint-tsgolint:
+        specifier: ^0.18.1
+        version: 0.18.1
       pagefind:
         specifier: ^1.4.0
         version: 1.4.0
       shadcn:
         specifier: latest
-        version: 4.1.2(@types/node@24.10.1)(babel-plugin-macros@3.1.0)(typescript@5.9.3)
+        version: 4.1.1(@types/node@24.10.1)(babel-plugin-macros@3.1.0)(typescript@5.9.3)
       tw-animate-css:
         specifier: ^1.4.0
         version: 1.4.0
@@ -797,7 +807,7 @@ importers:
         specifier: ^13.0.0
         version: 13.0.0
       happy-dom:
-        specifier: ^20.0.0
+        specifier: '>=20.8.8'
         version: 20.8.9
       react:
         specifier: 19.2.3
@@ -1138,7 +1148,7 @@ importers:
         specifier: ^4.1.0
         version: 4.1.0(vitest@4.1.0)
       happy-dom:
-        specifier: ^20.0.0
+        specifier: '>=20.8.8'
         version: 20.8.9
       source-map-explorer:
         specifier: ^2.5.3
@@ -2813,11 +2823,11 @@ packages:
       react: ^18 || ^19 || ^19.0.0-rc
       react-dom: ^18 || ^19 || ^19.0.0-rc
 
-  '@hono/node-server@1.19.10':
-    resolution: {integrity: sha512-hZ7nOssGqRgyV3FVVQdfi+U4q02uB23bpnYpdvNXkYTRRyWx84b7yf1ans+dnJ/7h41sGL3CeQTfO+ZGxuO+Iw==}
+  '@hono/node-server@1.19.13':
+    resolution: {integrity: sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
-      hono: ^4
+      hono: '>=4.12.12'
 
   '@hookform/resolvers@5.2.2':
     resolution: {integrity: sha512-A/IxlMLShx3KjV/HeTcTfaMxdwy690+L/ZADoeaTltLx+CVuzkeVIPuybK3jrRfw7YZnmdKsVVHAlEPIAEUNlA==}
@@ -3747,6 +3757,36 @@ packages:
   '@opentelemetry/semantic-conventions@1.40.0':
     resolution: {integrity: sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==}
     engines: {node: '>=14'}
+
+  '@oxlint-tsgolint/darwin-arm64@0.18.1':
+    resolution: {integrity: sha512-CxSd15ZwHn70UJFTXVvy76bZ9zwI097cVyjvUFmYRJwvkQF3VnrTf2oe1gomUacErksvtqLgn9OKvZhLMYwvog==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxlint-tsgolint/darwin-x64@0.18.1':
+    resolution: {integrity: sha512-LE7VW/T/VcKhl3Z1ev5BusrxdlQ3DWweSeOB+qpBeur2h8+vCWq+M7tCO29C7lveBDfx1+rNwj4aiUVlA+Qs+g==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxlint-tsgolint/linux-arm64@0.18.1':
+    resolution: {integrity: sha512-2AG8YIXVJJbnM0rcsJmzzWOjZXBu5REwowgUpbHZueF7OYM3wR7Xu8pXEpAojEHAtYYZ3X4rpPoetomkJx7kCw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@oxlint-tsgolint/linux-x64@0.18.1':
+    resolution: {integrity: sha512-f8vDYPEdiwpA2JaDEkadTXfuqIgweQ8zcL4SX75EN2kkW2oAynjN7cd8m86uXDgB0JrcyOywbRtwnXdiIzXn2A==}
+    cpu: [x64]
+    os: [linux]
+
+  '@oxlint-tsgolint/win32-arm64@0.18.1':
+    resolution: {integrity: sha512-fBdML05KMDAL9ebWeoHIzkyI86Eq6r9YH5UDRuXJ9vAIo1EnKo0ti7hLUxNdc2dy2FF/T4k98p5wkkXvLyXqfA==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxlint-tsgolint/win32-x64@0.18.1':
+    resolution: {integrity: sha512-cYZMhNrsq9ZZ3OUWHyawqiS+c8HfieYG0zuZP2LbEuWWPfdZM/22iAlo608J+27G1s9RXQhvgX6VekwWbXbD7A==}
+    cpu: [x64]
+    os: [win32]
 
   '@oxlint/binding-android-arm-eabi@1.50.0':
     resolution: {integrity: sha512-G7MRGk/6NCe+L8ntonRdZP7IkBfEpiZ/he3buLK6JkLgMHgJShXZ+BeOwADmspXez7U7F7L1Anf4xLSkLHiGTg==}
@@ -6031,8 +6071,8 @@ packages:
     peerDependencies:
       typescript: '*'
 
-  '@uipath/uipath-typescript@1.2.1':
-    resolution: {integrity: sha512-RVHSPrBB1SxhyJes4/r/UHf1lJJJaBxpkH1Xe1VeVU3AUseCbS9pAyLW+3yrgxDL1k5njc2G3MjU3GRRJnXcVA==, tarball: https://npm.pkg.github.com/download/@uipath/uipath-typescript/1.2.1/4cfddd9456137cf364127843f31a257f86b143e3}
+  '@uipath/uipath-typescript@1.2.2':
+    resolution: {integrity: sha512-wLi5P7m3k07C+JB3VXhRJlNslxCQ5R7N3SQ+Yoh6fw11s9kZOc8m4d9qteHwVL9eP3VW7T7Wd39DuJr40HnS/Q==, tarball: https://npm.pkg.github.com/download/@uipath/uipath-typescript/1.2.2/1042de9c613ce2bba6108b0498cfa040252dd004}
     peerDependencies:
       zod: ^4.2.1
 
@@ -7405,10 +7445,6 @@ packages:
     resolution: {integrity: sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ==}
     engines: {node: '>=0.3.1'}
 
-  diff@8.0.4:
-    resolution: {integrity: sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==}
-    engines: {node: '>=0.3.1'}
-
   dir-glob@3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
     engines: {node: '>=8'}
@@ -8340,8 +8376,8 @@ packages:
     resolution: {integrity: sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==}
     engines: {node: '>=0.10.0'}
 
-  hono@4.12.7:
-    resolution: {integrity: sha512-jq9l1DM0zVIvsm3lv9Nw9nlJnMNPOcAtsbsgiUhWcFzPE99Gvo6yRTlszSLLYacMeQ6quHD6hMfId8crVHvexw==}
+  hono@4.12.12:
+    resolution: {integrity: sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==}
     engines: {node: '>=16.9.0'}
 
   hook-std@4.0.0:
@@ -9617,10 +9653,6 @@ packages:
     resolution: {integrity: sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==}
     engines: {node: 18 || 20 || >=22}
 
-  minimatch@10.2.5:
-    resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
-    engines: {node: 18 || 20 || >=22}
-
   minimist@1.2.7:
     resolution: {integrity: sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==}
 
@@ -10021,6 +10053,10 @@ packages:
     resolution: {integrity: sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==}
     engines: {node: '>= 0.4'}
 
+  oxlint-tsgolint@0.18.1:
+    resolution: {integrity: sha512-Hgb0wMfuXBYL0ddY+1hAG8IIfC40ADwPnBuUaC6ENAuCtTF4dHwsy7mCYtQ2e7LoGvfoSJRY0+kqQRiembJ/jQ==}
+    hasBin: true
+
   oxlint@1.50.0:
     resolution: {integrity: sha512-iSJ4IZEICBma8cZX7kxIIz9PzsYLF2FaLAYN6RKu7VwRVKdu7RIgpP99bTZaGl//Yao7fsaGZLSEo5xBrI5ReQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -10224,11 +10260,8 @@ packages:
     resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
     engines: {node: 18 || 20 || >=22}
 
-  path-to-regexp@6.3.0:
-    resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
-
-  path-to-regexp@8.4.2:
-    resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
+  path-to-regexp@8.4.0:
+    resolution: {integrity: sha512-PuseHIvAnz3bjrM2rGJtSgo1zjgxapTLZ7x2pjhzWwlp4SJQgK3f3iZIQwkpEnBaKz6seKBADpM4B4ySkuYypg==}
 
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
@@ -11351,8 +11384,8 @@ packages:
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
 
-  shadcn@4.1.2:
-    resolution: {integrity: sha512-qNQcCavkbYsgBj+X09tF2bTcwRd8abR880bsFkDU2kMqceMCLAm5c+cLg7kWDhfh1H9g08knpQ5ZEf6y/co16g==}
+  shadcn@4.1.1:
+    resolution: {integrity: sha512-nBj+7LYC9kzV9v9QmRPpoOhfW4KctJVQejywdAt/K+K+z4RYlJOcO2a4AaF7elrRWkfCbgXeGK02liV0KB9HvQ==}
     hasBin: true
 
   shallowequal@1.1.0:
@@ -11506,8 +11539,8 @@ packages:
   spdx-license-ids@3.0.22:
     resolution: {integrity: sha512-4PRT4nh1EImPbt2jASOKHX7PB7I+e4IWNLvkKFDxNhJlfjbYlleYQh285Z/3mPTHSAK/AvdMmw5BNNuYH8ShgQ==}
 
-  speech-rule-engine@4.1.3:
-    resolution: {integrity: sha512-SBMgkuJYvP4F62daRfBNwYC2nXTEhNXAfsBZ/BB7Ly85/KnbnjmKM7/45ZrFbH6jIMiAliDUDPSZFUuXDvcg6A==}
+  speech-rule-engine@4.1.2:
+    resolution: {integrity: sha512-S6ji+flMEga+1QU79NDbwZ8Ivf0S/MpupQQiIC0rTpU/ZTKgcajijJJb1OcByBQDjrXCN1/DJtGz4ZJeBMPGJw==}
     hasBin: true
 
   split2@1.0.0:
@@ -12432,7 +12465,7 @@ packages:
       '@vitest/browser-preview': 4.1.0
       '@vitest/browser-webdriverio': 4.1.0
       '@vitest/ui': 4.1.0
-      happy-dom: '*'
+      happy-dom: '>=20.8.8'
       jsdom: '*'
       vite: ^6.0.0 || ^7.0.0 || ^8.0.0-0
     peerDependenciesMeta:
@@ -14394,7 +14427,7 @@ snapshots:
     dependencies:
       '@eslint/object-schema': 2.1.7
       debug: 4.4.3
-      minimatch: 10.2.5
+      minimatch: 10.2.4
     transitivePeerDependencies:
       - supports-color
 
@@ -14415,7 +14448,7 @@ snapshots:
       ignore: 5.3.2
       import-fresh: 3.3.1
       js-yaml: 4.1.1
-      minimatch: 10.2.5
+      minimatch: 10.2.4
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
       - supports-color
@@ -14489,9 +14522,9 @@ snapshots:
       react-dom: 19.2.3(react@19.2.3)
       use-sync-external-store: 1.6.0(react@19.2.3)
 
-  '@hono/node-server@1.19.10(hono@4.12.7)':
+  '@hono/node-server@1.19.13(hono@4.12.12)':
     dependencies:
-      hono: 4.12.7
+      hono: 4.12.12
 
   '@hookform/resolvers@5.2.2(react-hook-form@7.66.1(react@19.2.3))':
     dependencies:
@@ -14908,9 +14941,9 @@ snapshots:
       '@rushstack/rig-package': 0.7.2
       '@rushstack/terminal': 0.22.3(@types/node@24.10.1)
       '@rushstack/ts-command-line': 5.3.3(@types/node@24.10.1)
-      diff: 8.0.4
+      diff: 8.0.3
       lodash: 4.18.1
-      minimatch: 10.2.5
+      minimatch: 10.2.4
       resolve: 1.22.11
       semver: 7.5.4
       source-map: 0.6.1
@@ -14932,7 +14965,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.26.0(zod@3.25.76)':
     dependencies:
-      '@hono/node-server': 1.19.10(hono@4.12.7)
+      '@hono/node-server': 1.19.13(hono@4.12.12)
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
       content-type: 1.0.5
@@ -14942,7 +14975,7 @@ snapshots:
       eventsource-parser: 3.0.6
       express: 5.2.1
       express-rate-limit: 8.3.1(express@5.2.1)
-      hono: 4.12.7
+      hono: 4.12.12
       jose: 6.1.3
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.0
@@ -15467,6 +15500,24 @@ snapshots:
       '@opentelemetry/resources': 2.1.0(@opentelemetry/api@1.9.0)
 
   '@opentelemetry/semantic-conventions@1.40.0': {}
+
+  '@oxlint-tsgolint/darwin-arm64@0.18.1':
+    optional: true
+
+  '@oxlint-tsgolint/darwin-x64@0.18.1':
+    optional: true
+
+  '@oxlint-tsgolint/linux-arm64@0.18.1':
+    optional: true
+
+  '@oxlint-tsgolint/linux-x64@0.18.1':
+    optional: true
+
+  '@oxlint-tsgolint/win32-arm64@0.18.1':
+    optional: true
+
+  '@oxlint-tsgolint/win32-x64@0.18.1':
+    optional: true
 
   '@oxlint/binding-android-arm-eabi@1.50.0':
     optional: true
@@ -17904,7 +17955,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@uipath/uipath-typescript@1.2.1(@opentelemetry/api@1.9.0)(zod@4.3.5)':
+  '@uipath/uipath-typescript@1.2.2(@opentelemetry/api@1.9.0)(zod@4.3.5)':
     dependencies:
       '@opentelemetry/sdk-logs': 0.204.0(@opentelemetry/api@1.9.0)
       socket.io-client: 4.8.3
@@ -19423,9 +19474,6 @@ snapshots:
 
   diff@8.0.3: {}
 
-  diff@8.0.4:
-    optional: true
-
   dir-glob@3.0.1:
     dependencies:
       path-type: 4.0.0
@@ -19885,7 +19933,7 @@ snapshots:
       is-glob: 4.0.3
       json-stable-stringify-without-jsonify: 1.0.1
       lodash.merge: 4.6.2
-      minimatch: 10.2.5
+      minimatch: 10.2.4
       natural-compare: 1.4.0
       optionator: 0.9.4
     optionalDependencies:
@@ -20736,7 +20784,7 @@ snapshots:
     dependencies:
       parse-passwd: 1.0.0
 
-  hono@4.12.7: {}
+  hono@4.12.12: {}
 
   hook-std@4.0.0: {}
 
@@ -21692,7 +21740,7 @@ snapshots:
       esm: 3.2.25
       mhchemparser: 4.2.1
       mj-context-menu: 0.6.1
-      speech-rule-engine: 4.1.3
+      speech-rule-engine: 4.1.2
 
   mathml-tag-names@2.1.3: {}
 
@@ -22252,10 +22300,6 @@ snapshots:
     dependencies:
       brace-expansion: 5.0.5
 
-  minimatch@10.2.5:
-    dependencies:
-      brace-expansion: 5.0.5
-
   minimist@1.2.7: {}
 
   minimist@1.2.8: {}
@@ -22317,7 +22361,7 @@ snapshots:
       headers-polyfill: 4.0.3
       is-node-process: 1.2.0
       outvariant: 1.4.3
-      path-to-regexp: 6.3.0
+      path-to-regexp: 8.4.0
       picocolors: 1.1.1
       rettime: 0.7.0
       statuses: 2.0.2
@@ -22676,7 +22720,16 @@ snapshots:
       object-keys: 1.1.1
       safe-push-apply: 1.0.0
 
-  oxlint@1.50.0:
+  oxlint-tsgolint@0.18.1:
+    optionalDependencies:
+      '@oxlint-tsgolint/darwin-arm64': 0.18.1
+      '@oxlint-tsgolint/darwin-x64': 0.18.1
+      '@oxlint-tsgolint/linux-arm64': 0.18.1
+      '@oxlint-tsgolint/linux-x64': 0.18.1
+      '@oxlint-tsgolint/win32-arm64': 0.18.1
+      '@oxlint-tsgolint/win32-x64': 0.18.1
+
+  oxlint@1.50.0(oxlint-tsgolint@0.18.1):
     optionalDependencies:
       '@oxlint/binding-android-arm-eabi': 1.50.0
       '@oxlint/binding-android-arm64': 1.50.0
@@ -22697,6 +22750,7 @@ snapshots:
       '@oxlint/binding-win32-arm64-msvc': 1.50.0
       '@oxlint/binding-win32-ia32-msvc': 1.50.0
       '@oxlint/binding-win32-x64-msvc': 1.50.0
+      oxlint-tsgolint: 0.18.1
 
   p-each-series@2.2.0: {}
 
@@ -22873,9 +22927,7 @@ snapshots:
       lru-cache: 11.2.6
       minipass: 7.1.3
 
-  path-to-regexp@6.3.0: {}
-
-  path-to-regexp@8.4.2: {}
+  path-to-regexp@8.4.0: {}
 
   path-type@4.0.0: {}
 
@@ -24040,7 +24092,7 @@ snapshots:
       depd: 2.0.0
       is-promise: 4.0.0
       parseurl: 1.3.3
-      path-to-regexp: 8.4.2
+      path-to-regexp: 8.4.0
     transitivePeerDependencies:
       - supports-color
 
@@ -24271,7 +24323,7 @@ snapshots:
 
   setprototypeof@1.2.0: {}
 
-  shadcn@4.1.2(@types/node@24.10.1)(babel-plugin-macros@3.1.0)(typescript@5.9.3):
+  shadcn@4.1.1(@types/node@24.10.1)(babel-plugin-macros@3.1.0)(typescript@5.9.3):
     dependencies:
       '@babel/core': 7.28.5
       '@babel/parser': 7.28.5
@@ -24522,7 +24574,7 @@ snapshots:
 
   spdx-license-ids@3.0.22: {}
 
-  speech-rule-engine@4.1.3:
+  speech-rule-engine@4.1.2:
     dependencies:
       '@xmldom/xmldom': 0.9.9
       commander: 13.1.0


### PR DESCRIPTION
Add --type-aware flag to lint and lint:fix scripts so oxlint enforces type-checked rules that were fixed in PR #400.

Also fix deadlock caused by awaiting invalidateQueries in ensureValidToken.