### PR TITLE
feat(apollo-react): add markdown formatting utilities for sticky notes (1/3) [MST-7636]

### DIFF
--- a/packages/apollo-react/src/canvas/components/StickyNoteNode/StickyNoteNode.types.ts
+++ b/packages/apollo-react/src/canvas/components/StickyNoteNode/StickyNoteNode.types.ts
@@ -54,3 +54,13 @@ export function withAlpha(hex: string, alpha: number = STICKY_NOTE_BG_ALPHA): st
   const b = parseInt(normalized.slice(5, 7), 16);
   return `rgba(${r}, ${g}, ${b}, ${clampedAlpha})`;
 }
+
+/** Represents a textarea's value and cursor/selection positions */
+export type TextSelection = {
+  value: string;
+  selectionStart: number;
+  selectionEnd: number;
+};
+
+/** Available formatting actions for the toolbar and keyboard shortcuts */
+export type FormattingAction = 'bold' | 'italic' | 'strikethrough' | 'bulletList' | 'numberedList';

--- a/packages/apollo-react/src/canvas/components/StickyNoteNode/markdown-formatting/detectActiveFormats.test.ts
+++ b/packages/apollo-react/src/canvas/components/StickyNoteNode/markdown-formatting/detectActiveFormats.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest';
+import { detectActiveFormats } from './detectActiveFormats';
+
+describe('detectActiveFormats', () => {
+  it('detects bold when cursor is inside ** markers', () => {
+    const result = detectActiveFormats({
+      value: 'hello **world** end',
+      selectionStart: 10,
+      selectionEnd: 10,
+    });
+    expect(result.bold).toBe(true);
+    expect(result.italic).toBe(false);
+  });
+
+  it('detects italic when cursor is inside * markers', () => {
+    const result = detectActiveFormats({
+      value: 'hello *world* end',
+      selectionStart: 9,
+      selectionEnd: 9,
+    });
+    expect(result.italic).toBe(true);
+    expect(result.bold).toBe(false);
+  });
+
+  it('detects both bold and italic inside *** markers', () => {
+    const result = detectActiveFormats({
+      value: 'hello ***world*** end',
+      selectionStart: 11,
+      selectionEnd: 11,
+    });
+    expect(result.bold).toBe(true);
+    expect(result.italic).toBe(true);
+  });
+
+  it('detects bold and italic with separate nested markers', () => {
+    const result = detectActiveFormats({
+      value: 'hello **say *world* now** end',
+      selectionStart: 15,
+      selectionEnd: 15,
+    });
+    expect(result.bold).toBe(true);
+    expect(result.italic).toBe(true);
+  });
+
+  it('detects strikethrough when cursor is inside ~~ markers', () => {
+    const result = detectActiveFormats({
+      value: 'hello ~~world~~ end',
+      selectionStart: 10,
+      selectionEnd: 10,
+    });
+    expect(result.strikethrough).toBe(true);
+  });
+
+  it('does not detect formatting across line boundaries', () => {
+    expect(
+      detectActiveFormats({ value: '**hello\nworld**', selectionStart: 10, selectionEnd: 10 }).bold
+    ).toBe(false);
+    expect(
+      detectActiveFormats({ value: '*hello\nworld*', selectionStart: 9, selectionEnd: 9 }).italic
+    ).toBe(false);
+    expect(
+      detectActiveFormats({ value: '~~hello\nworld~~', selectionStart: 10, selectionEnd: 10 })
+        .strikethrough
+    ).toBe(false);
+  });
+
+  it('detects bullet list on current line', () => {
+    const result = detectActiveFormats({
+      value: '- hello world',
+      selectionStart: 5,
+      selectionEnd: 5,
+    });
+    expect(result.bulletList).toBe(true);
+    expect(result.numberedList).toBe(false);
+  });
+
+  it('detects numbered list on current line', () => {
+    const result = detectActiveFormats({
+      value: '1. hello world',
+      selectionStart: 5,
+      selectionEnd: 5,
+    });
+    expect(result.numberedList).toBe(true);
+    expect(result.bulletList).toBe(false);
+  });
+
+  it("returns all false when there's no formatting", () => {
+    const result = detectActiveFormats({ value: 'plain text', selectionStart: 5, selectionEnd: 5 });
+    expect(result.bold).toBe(false);
+    expect(result.italic).toBe(false);
+    expect(result.strikethrough).toBe(false);
+    expect(result.bulletList).toBe(false);
+    expect(result.numberedList).toBe(false);
+  });
+});

--- a/packages/apollo-react/src/canvas/components/StickyNoteNode/markdown-formatting/detectActiveFormats.ts
+++ b/packages/apollo-react/src/canvas/components/StickyNoteNode/markdown-formatting/detectActiveFormats.ts
@@ -1,0 +1,66 @@
+import type { TextSelection } from '../StickyNoteNode.types';
+import { BULLET_PREFIX, NUMBERED_PREFIX } from './listFormatting';
+
+export type ActiveFormats = {
+  bold: boolean;
+  italic: boolean;
+  strikethrough: boolean;
+  bulletList: boolean;
+  numberedList: boolean;
+};
+
+export function activeFormatsEqual(a: ActiveFormats, b: ActiveFormats): boolean {
+  return (
+    a.bold === b.bold &&
+    a.italic === b.italic &&
+    a.strikethrough === b.strikethrough &&
+    a.bulletList === b.bulletList &&
+    a.numberedList === b.numberedList
+  );
+}
+
+export function detectActiveFormats(input: TextSelection): ActiveFormats {
+  const { value, selectionStart } = input;
+
+  const lineStart = value.lastIndexOf('\n', selectionStart - 1) + 1;
+  let lineEnd = value.indexOf('\n', selectionStart);
+  if (lineEnd === -1) lineEnd = value.length;
+  const currentLine = value.slice(lineStart, lineEnd);
+
+  // Scope to current line only — inline markdown formatting never spans lines
+  const cursorInLine = selectionStart - lineStart;
+  const textBefore = currentLine.slice(0, cursorInLine);
+  const textAfter = currentLine.slice(cursorInLine);
+
+  // Bold: find ** before/after cursor on same line, allowing single * (from italic) in between
+  const bold =
+    /\*\*(?:[^*\n]|\*(?!\*))*$/.test(textBefore) && /^(?:[^*\n]|\*(?!\*))*\*\*/.test(textAfter);
+  const strikethrough = /~~[^~\n]*$/.test(textBefore) && /^[^~\n]*~~/.test(textAfter);
+
+  // Italic: find standalone * before/after cursor on same line, allowing ** (from bold) in between
+  const italicBefore = /(?<!\*)\*(?!\*)(?:[^*\n]|\*\*)*$/.test(textBefore);
+  const italicAfter = /^(?:[^*\n]|\*\*)*(?<!\*)\*(?!\*)/.test(textAfter);
+  let italic = italicBefore && italicAfter;
+
+  // Handle combined *** (bold+italic) markers where the italic * can't be isolated
+  if (!italic && bold) {
+    const beforeStars = /(\*{3,})[^*\n]*$/.exec(textBefore);
+    const afterStars = /^[^*\n]*(\*{3,})/.exec(textAfter);
+    if (
+      beforeStars &&
+      afterStars &&
+      beforeStars[1]!.length % 2 === 1 &&
+      afterStars[1]!.length % 2 === 1
+    ) {
+      italic = true;
+    }
+  }
+
+  return {
+    bold,
+    italic,
+    strikethrough,
+    bulletList: BULLET_PREFIX.test(currentLine),
+    numberedList: NUMBERED_PREFIX.test(currentLine),
+  };
+}

--- a/packages/apollo-react/src/canvas/components/StickyNoteNode/markdown-formatting/index.ts
+++ b/packages/apollo-react/src/canvas/components/StickyNoteNode/markdown-formatting/index.ts
@@ -1,0 +1,10 @@
+export { type ActiveFormats, activeFormatsEqual, detectActiveFormats } from './detectActiveFormats';
+export { toggleBold, toggleItalic, toggleStrikethrough } from './inlineFormatting';
+export {
+  BULLET_PREFIX,
+  continueListOnEnter,
+  NUMBERED_PREFIX,
+  NUMBERED_PREFIX_FULL,
+  toggleBulletList,
+  toggleNumberedList,
+} from './listFormatting';

--- a/packages/apollo-react/src/canvas/components/StickyNoteNode/markdown-formatting/inlineFormatting.test.ts
+++ b/packages/apollo-react/src/canvas/components/StickyNoteNode/markdown-formatting/inlineFormatting.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest';
+import { toggleBold, toggleItalic, toggleStrikethrough } from './inlineFormatting';
+
+// All three formats share toggleInlineWrap. Tests use toggleBold as the representative
+// unless a test covers behavior unique to a specific marker.
+
+describe('inline formatting (via toggleBold)', () => {
+  it('wraps selected text', () => {
+    const result = toggleBold({ value: 'hello world end', selectionStart: 6, selectionEnd: 11 });
+    expect(result.value).toBe('hello **world** end');
+    expect(result.selectionStart).toBe(8);
+    expect(result.selectionEnd).toBe(13);
+  });
+
+  it('unwraps already-wrapped selected text', () => {
+    const result = toggleBold({
+      value: 'hello **world** end',
+      selectionStart: 8,
+      selectionEnd: 13,
+    });
+    expect(result.value).toBe('hello world end');
+  });
+
+  it('inserts empty markers on a plain line with no selection', () => {
+    const result = toggleBold({ value: 'hello end', selectionStart: 6, selectionEnd: 6 });
+    expect(result.value).toBe('hello ****end');
+    expect(result.selectionStart).toBe(8);
+  });
+
+  it('removes markers when cursor is inside formatted region', () => {
+    const result = toggleBold({
+      value: 'hello **world** end',
+      selectionStart: 10,
+      selectionEnd: 10,
+    });
+    expect(result.value).toBe('hello world end');
+  });
+
+  it('wraps list line content with no selection', () => {
+    const result = toggleBold({ value: '1. hello', selectionStart: 5, selectionEnd: 5 });
+    expect(result.value).toBe('1. **hello**');
+  });
+
+  it('removes markers on a list line', () => {
+    const result = toggleBold({ value: '1. **hello**', selectionStart: 7, selectionEnd: 7 });
+    expect(result.value).toBe('1. hello');
+  });
+
+  it('wraps and unwraps each list line individually', () => {
+    const wrapped = toggleBold({
+      value: '1. hello\n2. world',
+      selectionStart: 0,
+      selectionEnd: 17,
+    });
+    expect(wrapped.value).toBe('1. **hello**\n2. **world**');
+
+    const unwrapped = toggleBold({
+      value: '1. **hello**\n2. **world**',
+      selectionStart: 0,
+      selectionEnd: 25,
+    });
+    expect(unwrapped.value).toBe('1. hello\n2. world');
+  });
+});
+
+describe('italic / bold boundary', () => {
+  it('does not unwrap bold markers when toggling italic', () => {
+    const result = toggleItalic({ value: '**world**', selectionStart: 2, selectionEnd: 7 });
+    expect(result.value).toBe('***world***');
+  });
+
+  it('unwraps italic from bold+italic list lines (***)', () => {
+    const result = toggleItalic({
+      value: '1. ***hello***\n2. ***world***',
+      selectionStart: 0,
+      selectionEnd: 29,
+    });
+    expect(result.value).toBe('1. **hello**\n2. **world**');
+  });
+
+  it('wraps italic onto bold-only list lines', () => {
+    const result = toggleItalic({
+      value: '1. **hello**\n2. **world**',
+      selectionStart: 0,
+      selectionEnd: 25,
+    });
+    expect(result.value).toBe('1. ***hello***\n2. ***world***');
+  });
+});
+
+describe('strikethrough uses ~~ marker', () => {
+  it('wraps and unwraps with ~~', () => {
+    const wrapped = toggleStrikethrough({
+      value: 'hello world end',
+      selectionStart: 6,
+      selectionEnd: 11,
+    });
+    expect(wrapped.value).toBe('hello ~~world~~ end');
+
+    const unwrapped = toggleStrikethrough({
+      value: 'hello ~~world~~ end',
+      selectionStart: 8,
+      selectionEnd: 13,
+    });
+    expect(unwrapped.value).toBe('hello world end');
+  });
+});

--- a/packages/apollo-react/src/canvas/components/StickyNoteNode/markdown-formatting/inlineFormatting.ts
+++ b/packages/apollo-react/src/canvas/components/StickyNoteNode/markdown-formatting/inlineFormatting.ts
@@ -1,0 +1,181 @@
+import type { TextSelection } from '../StickyNoteNode.types';
+import { BULLET_PREFIX, NUMBERED_PREFIX, NUMBERED_PREFIX_FULL } from './listFormatting';
+
+/**
+ * Toggles an inline markdown wrapper (e.g., **, *, ~~) around the selected text.
+ * If text is selected and already wrapped, unwraps it. Otherwise wraps it.
+ * If no text is selected and cursor is inside a formatted region, removes the markers.
+ * If no text is selected on a list line, wraps the line content after the prefix.
+ * Otherwise inserts empty markers and places cursor between them.
+ */
+function toggleInlineWrap(input: TextSelection, marker: string): TextSelection {
+  const { value, selectionStart, selectionEnd } = input;
+  const markerLen = marker.length;
+  const selectedText = value.slice(selectionStart, selectionEnd);
+  const hasSelection = selectionStart !== selectionEnd;
+
+  if (!hasSelection) {
+    // Check if cursor is inside an existing wrapped region — if so, remove the markers
+    const textBefore = value.slice(0, selectionStart);
+    const textAfter = value.slice(selectionStart);
+    const markerChar = marker[0]!;
+    const esc = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const me = esc(marker);
+    const ce = esc(markerChar);
+
+    // Find the nearest opening marker before cursor and closing marker after cursor,
+    // ensuring single-char markers (italic *) don't match multi-char markers (bold **)
+    const beforeRe =
+      markerLen === 1
+        ? new RegExp(`(?<!${ce})${me}(?!${ce})([^${ce}]*)$`)
+        : new RegExp(`${me}([^${ce}]*)$`);
+    const afterRe =
+      markerLen === 1
+        ? new RegExp(`^([^${ce}]*)(?<!${ce})${me}(?!${ce})`)
+        : new RegExp(`^([^${ce}]*)${me}`);
+
+    const bm = beforeRe.exec(textBefore);
+    const am = afterRe.exec(textAfter);
+
+    if (bm && am) {
+      const openStart = selectionStart - bm[0].length;
+      const closeEnd = selectionStart + am[0].length;
+
+      // For multi-char markers, verify boundary cleanliness (no extra same-char adjacent)
+      const boundaryClean =
+        markerLen === 1 || (value[openStart - 1] !== markerChar && value[closeEnd] !== markerChar);
+
+      if (boundaryClean) {
+        const newValue = value.slice(0, openStart) + bm[1] + am[1] + value.slice(closeEnd);
+        const newCursor = selectionStart - markerLen;
+        return { value: newValue, selectionStart: newCursor, selectionEnd: newCursor };
+      }
+    }
+
+    // On a list line — wrap the line's content (after prefix) instead of inserting empty markers
+    const lineStart = value.lastIndexOf('\n', selectionStart - 1) + 1;
+    let lineEnd = value.indexOf('\n', selectionStart);
+    if (lineEnd === -1) lineEnd = value.length;
+    const currentLine = value.slice(lineStart, lineEnd);
+    const bulletMatch = BULLET_PREFIX.exec(currentLine);
+    const numberedMatch = NUMBERED_PREFIX_FULL.exec(currentLine);
+    const prefixLen = bulletMatch?.[0].length ?? numberedMatch?.[0].length ?? 0;
+
+    if (prefixLen > 0) {
+      const content = currentLine.slice(prefixLen);
+      if (content.length > 0) {
+        const prefix = currentLine.slice(0, prefixLen);
+        const newLine = `${prefix}${marker}${content}${marker}`;
+        const newValue = value.slice(0, lineStart) + newLine + value.slice(lineEnd);
+        const newCursor = selectionStart + markerLen;
+        return { value: newValue, selectionStart: newCursor, selectionEnd: newCursor };
+      }
+    }
+
+    // Not inside a formatted region and not a list line — insert empty markers
+    const newValue = value.slice(0, selectionStart) + marker + marker + value.slice(selectionEnd);
+    const cursorPos = selectionStart + markerLen;
+    return { value: newValue, selectionStart: cursorPos, selectionEnd: cursorPos };
+  }
+
+  // Multi-line selection with list items — apply formatting per-line to protect prefixes
+  {
+    const lineStart = value.lastIndexOf('\n', selectionStart - 1) + 1;
+    let lineEnd = value.indexOf('\n', selectionEnd);
+    if (lineEnd === -1) lineEnd = value.length;
+    if (selectionEnd > lineStart && value[selectionEnd - 1] === '\n') {
+      lineEnd = selectionEnd - 1;
+    }
+
+    const lines = value.slice(lineStart, lineEnd).split('\n');
+
+    if (
+      lines.length >= 2 &&
+      lines.some((line) => BULLET_PREFIX.test(line) || NUMBERED_PREFIX.test(line))
+    ) {
+      const parsed = lines.map((line) => {
+        const bulletMatch = BULLET_PREFIX.exec(line);
+        const numberedMatch = NUMBERED_PREFIX.exec(line);
+        const prefix = bulletMatch?.[0] ?? numberedMatch?.[0] ?? '';
+        const content = line.slice(prefix.length);
+        return { prefix, content };
+      });
+
+      const isWrapped = (content: string): boolean => {
+        if (content.length < markerLen * 2) return false;
+        if (!content.startsWith(marker) || !content.endsWith(marker)) return false;
+        const mc = marker[0]!;
+        if (markerLen === 1) {
+          let leadingStars = 0;
+          while (content[leadingStars] === mc) leadingStars++;
+          let trailingStars = 0;
+          while (content[content.length - 1 - trailingStars] === mc) trailingStars++;
+          return leadingStars % 2 === 1 && trailingStars % 2 === 1;
+        }
+        return content[markerLen] !== mc && content[content.length - markerLen - 1] !== mc;
+      };
+
+      const allWrapped = parsed.every(({ content }) => isWrapped(content));
+
+      const newLines = allWrapped
+        ? parsed.map(
+            ({ prefix, content }) =>
+              `${prefix}${content.slice(markerLen, content.length - markerLen)}`
+          )
+        : parsed.map(({ prefix, content }) =>
+            content.length > 0 ? `${prefix}${marker}${content}${marker}` : `${prefix}${content}`
+          );
+
+      const newLinesText = newLines.join('\n');
+      const newValue = value.slice(0, lineStart) + newLinesText + value.slice(lineEnd);
+      const newSelectionEnd = lineStart + newLinesText.length;
+
+      return {
+        value: newValue,
+        selectionStart: lineStart,
+        selectionEnd: newSelectionEnd,
+      };
+    }
+  }
+
+  // Has selection — check if already wrapped and toggle accordingly
+  const before = value.slice(selectionStart - markerLen, selectionStart);
+  const after = value.slice(selectionEnd, selectionEnd + markerLen);
+
+  const markerChar = marker[0];
+  const outerBefore = value[selectionStart - markerLen - 1];
+  const outerAfter = value[selectionEnd + markerLen];
+  const isBoundaryClean = outerBefore !== markerChar && outerAfter !== markerChar;
+
+  if (before === marker && after === marker && isBoundaryClean) {
+    const newValue =
+      value.slice(0, selectionStart - markerLen) +
+      selectedText +
+      value.slice(selectionEnd + markerLen);
+    return {
+      value: newValue,
+      selectionStart: selectionStart - markerLen,
+      selectionEnd: selectionEnd - markerLen,
+    };
+  }
+
+  const newValue =
+    value.slice(0, selectionStart) + marker + selectedText + marker + value.slice(selectionEnd);
+  return {
+    value: newValue,
+    selectionStart: selectionStart + markerLen,
+    selectionEnd: selectionEnd + markerLen,
+  };
+}
+
+export function toggleBold(input: TextSelection): TextSelection {
+  return toggleInlineWrap(input, '**');
+}
+
+export function toggleItalic(input: TextSelection): TextSelection {
+  return toggleInlineWrap(input, '*');
+}
+
+export function toggleStrikethrough(input: TextSelection): TextSelection {
+  return toggleInlineWrap(input, '~~');
+}

--- a/packages/apollo-react/src/canvas/components/StickyNoteNode/markdown-formatting/listFormatting.test.ts
+++ b/packages/apollo-react/src/canvas/components/StickyNoteNode/markdown-formatting/listFormatting.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, it } from 'vitest';
+import { continueListOnEnter, toggleBulletList, toggleNumberedList } from './listFormatting';
+
+describe('toggleBulletList', () => {
+  it('adds bullet prefix to a line', () => {
+    const result = toggleBulletList({
+      value: 'eggs\nmilk\nbread',
+      selectionStart: 5,
+      selectionEnd: 5,
+    });
+    expect(result.value).toBe('eggs\n- milk\nbread');
+    expect(result.selectionStart).toBe(7);
+  });
+
+  it('removes bullet prefix when already present', () => {
+    const result = toggleBulletList({
+      value: 'eggs\n- milk\nbread',
+      selectionStart: 7,
+      selectionEnd: 7,
+    });
+    expect(result.value).toBe('eggs\nmilk\nbread');
+    expect(result.selectionStart).toBe(5);
+  });
+
+  it('adds bullet prefix to multiple selected lines', () => {
+    const result = toggleBulletList({
+      value: 'eggs\nmilk\nbread',
+      selectionStart: 5,
+      selectionEnd: 14,
+    });
+    expect(result.value).toBe('eggs\n- milk\n- bread');
+  });
+
+  it('removes bullet prefix from all lines when all have it', () => {
+    const result = toggleBulletList({
+      value: '- eggs\n- milk\n- bread',
+      selectionStart: 0,
+      selectionEnd: 20,
+    });
+    expect(result.value).toBe('eggs\nmilk\nbread');
+  });
+
+  it('switches from numbered list to bullet list', () => {
+    const result = toggleBulletList({
+      value: '1. eggs\n2. milk',
+      selectionStart: 0,
+      selectionEnd: 14,
+    });
+    expect(result.value).toBe('- eggs\n- milk');
+  });
+
+  it('does not treat * as a bullet prefix', () => {
+    const result = toggleBulletList({ value: '* milk', selectionStart: 2, selectionEnd: 2 });
+    expect(result.value).toBe('- * milk');
+  });
+});
+
+describe('toggleNumberedList', () => {
+  it('adds numbered prefix to a line', () => {
+    const result = toggleNumberedList({
+      value: 'eggs\nmilk\nbread',
+      selectionStart: 5,
+      selectionEnd: 5,
+    });
+    expect(result.value).toBe('eggs\n1. milk\nbread');
+    expect(result.selectionStart).toBe(8);
+  });
+
+  it('removes numbered prefix when already present', () => {
+    const result = toggleNumberedList({
+      value: 'eggs\n1. milk\nbread',
+      selectionStart: 8,
+      selectionEnd: 8,
+    });
+    expect(result.value).toBe('eggs\nmilk\nbread');
+    expect(result.selectionStart).toBe(5);
+  });
+
+  it('adds auto-incrementing numbers to multiple lines', () => {
+    const result = toggleNumberedList({
+      value: 'eggs\nmilk\nbread',
+      selectionStart: 0,
+      selectionEnd: 14,
+    });
+    expect(result.value).toBe('1. eggs\n2. milk\n3. bread');
+  });
+
+  it('removes numbered prefix from all lines when all have it', () => {
+    const result = toggleNumberedList({
+      value: '1. eggs\n2. milk\n3. bread',
+      selectionStart: 0,
+      selectionEnd: 23,
+    });
+    expect(result.value).toBe('eggs\nmilk\nbread');
+  });
+
+  it('switches from bullet list to numbered list', () => {
+    const result = toggleNumberedList({
+      value: '- eggs\n- milk',
+      selectionStart: 0,
+      selectionEnd: 12,
+    });
+    expect(result.value).toBe('1. eggs\n2. milk');
+  });
+});
+
+describe('continueListOnEnter', () => {
+  it('returns null when not on a list line', () => {
+    expect(
+      continueListOnEnter({ value: 'hello world', selectionStart: 5, selectionEnd: 5 })
+    ).toBeNull();
+  });
+
+  it('returns null when there is a selection', () => {
+    expect(
+      continueListOnEnter({ value: '- hello', selectionStart: 2, selectionEnd: 5 })
+    ).toBeNull();
+  });
+
+  it('continues bullet list with new item', () => {
+    const result = continueListOnEnter({ value: '- hello', selectionStart: 7, selectionEnd: 7 })!;
+    expect(result.value).toBe('- hello\n- ');
+    expect(result.selectionStart).toBe(10);
+  });
+
+  it('splits bullet list line at cursor', () => {
+    const result = continueListOnEnter({
+      value: '- hello world',
+      selectionStart: 7,
+      selectionEnd: 7,
+    })!;
+    expect(result.value).toBe('- hello\n-  world');
+    expect(result.selectionStart).toBe(10);
+  });
+
+  it('exits bullet list on empty item', () => {
+    const result = continueListOnEnter({
+      value: '- hello\n- ',
+      selectionStart: 10,
+      selectionEnd: 10,
+    })!;
+    expect(result.value).toBe('- hello\n');
+    expect(result.selectionStart).toBe(8);
+  });
+
+  it('continues numbered list with next number', () => {
+    const result = continueListOnEnter({ value: '1. hello', selectionStart: 8, selectionEnd: 8 })!;
+    expect(result.value).toBe('1. hello\n2. ');
+    expect(result.selectionStart).toBe(12);
+  });
+
+  it('auto-increments from higher numbers', () => {
+    const result = continueListOnEnter({
+      value: '1. first\n2. second',
+      selectionStart: 18,
+      selectionEnd: 18,
+    })!;
+    expect(result.value).toBe('1. first\n2. second\n3. ');
+    expect(result.selectionStart).toBe(22);
+  });
+
+  it('exits numbered list on empty item', () => {
+    const result = continueListOnEnter({
+      value: '1. hello\n2. ',
+      selectionStart: 12,
+      selectionEnd: 12,
+    })!;
+    expect(result.value).toBe('1. hello\n');
+    expect(result.selectionStart).toBe(9);
+  });
+
+  it('preserves indentation', () => {
+    const bullet = continueListOnEnter({ value: '  - hello', selectionStart: 9, selectionEnd: 9 })!;
+    expect(bullet.value).toBe('  - hello\n  - ');
+
+    const numbered = continueListOnEnter({
+      value: '  1. hello',
+      selectionStart: 10,
+      selectionEnd: 10,
+    })!;
+    expect(numbered.value).toBe('  1. hello\n  2. ');
+  });
+});

--- a/packages/apollo-react/src/canvas/components/StickyNoteNode/markdown-formatting/listFormatting.ts
+++ b/packages/apollo-react/src/canvas/components/StickyNoteNode/markdown-formatting/listFormatting.ts
@@ -1,0 +1,148 @@
+import type { TextSelection } from '../StickyNoteNode.types';
+
+/** Regex patterns for line prefix detection */
+export const BULLET_PREFIX = /^(\s*)-\s/;
+export const NUMBERED_PREFIX = /^(\s*)\d+\.\s/;
+export const NUMBERED_PREFIX_FULL = /^(\s*)(\d+)\.\s/;
+
+function getAffectedLines(
+  value: string,
+  selectionStart: number,
+  selectionEnd: number
+): { lineStart: number; lineEnd: number; lines: string[] } {
+  const lineStart = value.lastIndexOf('\n', selectionStart - 1) + 1;
+  let lineEnd = value.indexOf('\n', selectionEnd);
+  if (lineEnd === -1) lineEnd = value.length;
+  const linesText = value.slice(lineStart, lineEnd);
+  const lines = linesText.split('\n');
+  return { lineStart, lineEnd, lines };
+}
+
+export function toggleBulletList(input: TextSelection): TextSelection {
+  const { value, selectionStart, selectionEnd } = input;
+  const { lineStart, lineEnd, lines } = getAffectedLines(value, selectionStart, selectionEnd);
+
+  const allHaveBullet = lines.every((line) => BULLET_PREFIX.test(line));
+
+  let newLines: string[];
+  let prefixDelta: number;
+
+  if (allHaveBullet) {
+    newLines = lines.map((line) => line.replace(BULLET_PREFIX, '$1'));
+    prefixDelta = lines[0]!.length - newLines[0]!.length;
+  } else {
+    newLines = lines.map((line) => {
+      if (BULLET_PREFIX.test(line)) return line;
+      if (NUMBERED_PREFIX.test(line)) return line.replace(NUMBERED_PREFIX, '$1- ');
+      return `- ${line}`;
+    });
+    prefixDelta = newLines[0]!.length - lines[0]!.length;
+  }
+
+  const newLinesText = newLines.join('\n');
+  const newValue = value.slice(0, lineStart) + newLinesText + value.slice(lineEnd);
+
+  const totalLengthDelta = newLinesText.length - (lineEnd - lineStart);
+  const isMultiLine = lines.length > 1;
+  const newStart = allHaveBullet
+    ? Math.max(lineStart, selectionStart - prefixDelta)
+    : isMultiLine
+      ? selectionStart
+      : selectionStart + prefixDelta;
+  const newEnd = selectionEnd + totalLengthDelta;
+
+  return {
+    value: newValue,
+    selectionStart: newStart,
+    selectionEnd: Math.max(newStart, newEnd),
+  };
+}
+
+export function toggleNumberedList(input: TextSelection): TextSelection {
+  const { value, selectionStart, selectionEnd } = input;
+  const { lineStart, lineEnd, lines } = getAffectedLines(value, selectionStart, selectionEnd);
+
+  const allHaveNumbered = lines.every((line) => NUMBERED_PREFIX.test(line));
+
+  let newLines: string[];
+  let prefixDelta: number;
+
+  if (allHaveNumbered) {
+    newLines = lines.map((line) => line.replace(NUMBERED_PREFIX, '$1'));
+    prefixDelta = lines[0]!.length - newLines[0]!.length;
+  } else {
+    newLines = lines.map((line, i) => {
+      const num = `${i + 1}. `;
+      if (NUMBERED_PREFIX.test(line)) return line.replace(NUMBERED_PREFIX, `$1${num}`);
+      if (BULLET_PREFIX.test(line)) return line.replace(BULLET_PREFIX, `$1${num}`);
+      return `${num}${line}`;
+    });
+    prefixDelta = newLines[0]!.length - lines[0]!.length;
+  }
+
+  const newLinesText = newLines.join('\n');
+  const newValue = value.slice(0, lineStart) + newLinesText + value.slice(lineEnd);
+
+  const totalLengthDelta = newLinesText.length - (lineEnd - lineStart);
+  const newStart = allHaveNumbered
+    ? Math.max(lineStart, selectionStart - prefixDelta)
+    : selectionStart + prefixDelta;
+  const newEnd = selectionEnd + totalLengthDelta;
+
+  return {
+    value: newValue,
+    selectionStart: newStart,
+    selectionEnd: Math.max(newStart, newEnd),
+  };
+}
+
+/**
+ * Handles Enter key on a list line. Returns new TextSelection if on a list line, null otherwise.
+ * - Non-empty item: inserts newline with next list prefix
+ * - Empty item (just the prefix): removes the prefix to exit the list
+ */
+export function continueListOnEnter(input: TextSelection): TextSelection | null {
+  const { value, selectionStart, selectionEnd } = input;
+
+  if (selectionStart !== selectionEnd) return null;
+
+  const lineStart = value.lastIndexOf('\n', selectionStart - 1) + 1;
+  let lineEnd = value.indexOf('\n', selectionStart);
+  if (lineEnd === -1) lineEnd = value.length;
+  const currentLine = value.slice(lineStart, lineEnd);
+
+  const bulletMatch = BULLET_PREFIX.exec(currentLine);
+  if (bulletMatch) {
+    const indent = bulletMatch[1]!;
+    const prefix = `${indent}- `;
+    const contentAfterPrefix = currentLine.slice(bulletMatch[0].length);
+
+    if (contentAfterPrefix.trim() === '' && selectionStart === lineStart + currentLine.length) {
+      const newValue = value.slice(0, lineStart) + value.slice(lineEnd);
+      return { value: newValue, selectionStart: lineStart, selectionEnd: lineStart };
+    }
+
+    const newValue = `${value.slice(0, selectionStart)}\n${prefix}${value.slice(selectionStart)}`;
+    const newCursor = selectionStart + 1 + prefix.length;
+    return { value: newValue, selectionStart: newCursor, selectionEnd: newCursor };
+  }
+
+  const numberedMatch = NUMBERED_PREFIX_FULL.exec(currentLine);
+  if (numberedMatch) {
+    const indent = numberedMatch[1]!;
+    const currentNum = parseInt(numberedMatch[2]!, 10);
+    const contentAfterPrefix = currentLine.slice(numberedMatch[0].length);
+
+    if (contentAfterPrefix.trim() === '' && selectionStart === lineStart + currentLine.length) {
+      const newValue = value.slice(0, lineStart) + value.slice(lineEnd);
+      return { value: newValue, selectionStart: lineStart, selectionEnd: lineStart };
+    }
+
+    const prefix = `${indent}${currentNum + 1}. `;
+    const newValue = `${value.slice(0, selectionStart)}\n${prefix}${value.slice(selectionStart)}`;
+    const newCursor = selectionStart + 1 + prefix.length;
+    return { value: newValue, selectionStart: newCursor, selectionEnd: newCursor };
+  }
+
+  return null;
+}


### PR DESCRIPTION
## Summary
**NOTE: this PR is focused on the formatting/interaction logic that's consumed by the sticky note markdown toolbar in [the top PR](https://github.com/UiPath/apollo-ui/pull/429).**

Adds markdown editor logic to support bold, italic, strikethrough, bullet lists, and numbered lists.

Final UI (both PRs):
<img width="401" height="397" alt="image" src="https://github.com/user-attachments/assets/0f855c3e-d39e-470e-989c-5b720e352eed" />

https://github.com/user-attachments/assets/9345aa4b-2d53-4aca-80ab-a1d9a64259d2

## Changes
- **Smart toggle** — clicking a format button when cursor is inside a formatted region removes the markers instead of inserting redundant ones
- **Bold+italic detection** — correctly detects and toggles `***combined***` markers in toolbar state
- **List-aware formatting** — applies inline formatting per-line in lists, protecting `- ` and `N. ` prefixes from being wrapped
- **Enter key list continuation** — auto-inserts next bullet/number on Enter; exits list on empty item
- **Line-scoped detection** — format detection respects line boundaries to prevent cross-line false positives

## Flow

```mermaid
flowchart TD
    A[User action: click toolbar / keyboard shortcut] --> B{Has selection?}
    B -->|No| C{Cursor inside formatted region?}
    C -->|Yes| D[Remove surrounding markers]
    C -->|No| E{On list line?}
    E -->|Yes| F[Wrap line content after prefix]
    E -->|No| G[Insert empty markers at cursor]
    B -->|Yes| H{Multi-line with list items?}
    H -->|Yes| I[Apply formatting per-line, protect prefixes]
    H -->|No| J[Wrap/unwrap selection]
    D --> K[Update activeFormats + set cursor via rAF]
    F --> K
    G --> K
    I --> K
    J --> K
```

## Testing

- [x] `pnpm run test` passes (67 suites, 1344 tests)
- [x] `pnpm run typecheck` passes
- [x] `pnpm run lint` passes
- [x] Manual testing performed
- [x] Unit tests added (61 tests for markdownFormatting, 10 for FormattingToolbar component)
