### PR TITLE
fix(apollo-vertex): registry ci check [AGVSOL-2062]

### DIFF
--- a/.github/scripts/test-registry/test-registry.ts
+++ b/.github/scripts/test-registry/test-registry.ts
@@ -27,20 +27,21 @@ function testComponent(component: string, baseAppPath: string): TestResult {
     });
 
     // Install the component from registry
-    const addOutput = execFileSync('pnpm', ['exec', 'shadcn', 'add', `@uipath/${component}`], {
+    const addOutput = execFileSync('pnpm', ['exec', 'shadcn', 'add', `@uipath/${component}`, '--overwrite'], {
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'pipe'],
       cwd: testDir,
     });
 
-    // Run build to verify all imports resolve correctly
-    const buildOutput = execFileSync('pnpm', ['run', 'build'], {
+    // Type-check all files to verify all imports resolve correctly
+    // (next build only checks files in the build graph — components not imported by any page would be skipped)
+    const tscOutput = execFileSync('pnpm', ['exec', 'tsc', '--noEmit'], {
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'pipe'],
       cwd: testDir,
     });
 
-    return { component, success: true, output: `${addOutput}\n${buildOutput}` };
+    return { component, success: true, output: `${addOutput}\n${tscOutput}` };
   } catch (error) {
     if (error instanceof Error && 'stdout' in error && 'stderr' in error) {
       return { component, success: false, output: `${error.stdout}\n${error.stderr}` };

--- a/apps/apollo-vertex/AGENTS.md
+++ b/apps/apollo-vertex/AGENTS.md
@@ -188,6 +188,15 @@ Avoid near-duplicate components:
 - Extract common logic and styling into a base component or utility so multiple variants can reuse it.
 - Duplicate components make maintenance and accessibility fixes harder—reuse where possible.
 
+### Multi-file component gotchas
+
+shadcn has a known bug ([shadcn-ui/ui#7309](https://github.com/shadcn-ui/ui/issues/7309)) where barrel imports are rewritten to point at the main file instead of `index.ts`. For example, `@/components/ui/data-table` gets rewritten to `@/components/ui/data-table/data-table`, bypassing the barrel entirely.
+
+When working with multi-file registry components:
+- **Add `target` fields** to every file entry in `registry.json` to preserve subdirectory structure during installation.
+- **Re-export from the main file** anything that other registry components import via the barrel. The CI registry check (`tsc --noEmit`) will catch missed re-exports.
+- If a consumer registry component needs a symbol from a multi-file component, the safest import is from the specific subfile (e.g., `@/components/ui/data-table/data-table-column-header`), but be aware that shadcn may still rewrite this path.
+
 ## Git Workflow
 
 Follow conventional commits. Commit body lines must not be longer than 100 characters.

--- a/apps/apollo-vertex/registry.json
+++ b/apps/apollo-vertex/registry.json
@@ -566,55 +566,75 @@
         "@uipath/tooltip"
       ],
       "files": [
-        { "path": "registry/data-table/index.ts", "type": "registry:ui" },
-        { "path": "registry/data-table/data-table.tsx", "type": "registry:ui" },
+        {
+          "path": "registry/data-table/index.ts",
+          "type": "registry:ui",
+          "target": "components/ui/data-table/index.ts"
+        },
+        {
+          "path": "registry/data-table/data-table.tsx",
+          "type": "registry:ui",
+          "target": "components/ui/data-table/data-table.tsx"
+        },
         {
           "path": "registry/data-table/data-table-filters.tsx",
-          "type": "registry:ui"
+          "type": "registry:ui",
+          "target": "components/ui/data-table/data-table-filters.tsx"
         },
         {
           "path": "registry/data-table/data-table-row.tsx",
-          "type": "registry:ui"
+          "type": "registry:ui",
+          "target": "components/ui/data-table/data-table-row.tsx"
         },
         {
           "path": "registry/data-table/data-table-scroll-shadow.tsx",
-          "type": "registry:ui"
+          "type": "registry:ui",
+          "target": "components/ui/data-table/data-table-scroll-shadow.tsx"
         },
         {
           "path": "registry/data-table/data-table-column-header.tsx",
-          "type": "registry:ui"
+          "type": "registry:ui",
+          "target": "components/ui/data-table/data-table-column-header.tsx"
         },
         {
           "path": "registry/data-table/data-table-faceted-filter.tsx",
-          "type": "registry:ui"
+          "type": "registry:ui",
+          "target": "components/ui/data-table/data-table-faceted-filter.tsx"
         },
         {
           "path": "registry/data-table/data-table-pagination.tsx",
-          "type": "registry:ui"
+          "type": "registry:ui",
+          "target": "components/ui/data-table/data-table-pagination.tsx"
         },
         {
           "path": "registry/data-table/data-table-search.tsx",
-          "type": "registry:ui"
+          "type": "registry:ui",
+          "target": "components/ui/data-table/data-table-search.tsx"
         },
         {
           "path": "registry/data-table/data-table-skeleton.tsx",
-          "type": "registry:ui"
+          "type": "registry:ui",
+          "target": "components/ui/data-table/data-table-skeleton.tsx"
         },
         {
           "path": "registry/data-table/data-table-toolbar.tsx",
-          "type": "registry:ui"
+          "type": "registry:ui",
+          "target": "components/ui/data-table/data-table-toolbar.tsx"
         },
         {
           "path": "registry/data-table/data-table-view-options.tsx",
-          "type": "registry:ui"
+          "type": "registry:ui",
+          "target": "components/ui/data-table/data-table-view-options.tsx"
         },
         {
           "path": "registry/data-table/sortable-column-item.tsx",
-          "type": "registry:ui"
+          "type": "registry:ui",
+          "target": "components/ui/data-table/sortable-column-item.tsx"
         },
         {
           "path": "registry/data-table/sortable-column-list.tsx",
-          "type": "registry:ui"
+          "type": "registry:ui",
+          "target": "components/ui/data-table/sortable-column-list.tsx"
         },
         {
           "path": "registry/use-data-table/useReactTableCompat.ts",

--- a/apps/apollo-vertex/registry/data-table/data-table.tsx
+++ b/apps/apollo-vertex/registry/data-table/data-table.tsx
@@ -358,3 +358,4 @@ function DataTable<TData, TValue>({
 }
 export { DataTable };
 export type { DataTableProps };
+export { DataTableColumnHeader } from "./data-table-column-header";

--- a/apps/apollo-vertex/registry/data-table/index.ts
+++ b/apps/apollo-vertex/registry/data-table/index.ts
@@ -12,17 +12,17 @@ export type {
 } from "@tanstack/react-table";
 export type { DataTableProps } from "./data-table";
 export { DataTable } from "./data-table";
-export {
-  dataTableFacetedFilterFn,
-  dataTableGlobalFilterFn,
-} from "./data-table-filters";
-export { DataTableCell, DataTableRow } from "./data-table-row";
 export { DataTableColumnHeader } from "./data-table-column-header";
 export {
   DataTableFacetedFilter,
   type DataTableFacetedFilterOption,
 } from "./data-table-faceted-filter";
+export {
+  dataTableFacetedFilterFn,
+  dataTableGlobalFilterFn,
+} from "./data-table-filters";
 export { DataTablePagination } from "./data-table-pagination";
+export { DataTableCell, DataTableRow } from "./data-table-row";
 export { DataTableSearch } from "./data-table-search";
 export { DataTableSkeleton } from "./data-table-skeleton";
 export { DataTableToolbar } from "./data-table-toolbar";


### PR DESCRIPTION
## Summary

Prevents issues like #413 from happening again by automatically catching missing registry entries at build time.

- **Replace `next build` with `tsc --noEmit`** in the registry CI check — `next build` only type-checks files in the build graph, silently skipping components not imported by any page
- **Add `--overwrite` to `shadcn add`** — without it, shadcn silently skips installation on file conflicts, so `tsc --noEmit` runs against an empty app and always passes
- **Add explicit `target` paths for data-table registry files** — preserves the subdirectory structure during installation instead of flattening files into `components/ui/`
- **Re-export `DataTableColumnHeader` from `data-table.tsx`** — works around a known shadcn bug where barrel imports are rewritten to the main file

## shadcn barrel import bug

shadcn has a known bug ([shadcn-ui/ui#7309](https://github.com/shadcn-ui/ui/issues/7309)) where imports targeting a barrel `index.ts` in a multi-file component get rewritten to the main file instead. For example:

```ts
// Source code
import { DataTableColumnHeader } from "@/components/ui/data-table";

// After shadcn install — rewrites to the main file, bypassing index.ts
import { DataTableColumnHeader } from "@/components/ui/data-table/data-table";
```
Since data-table.tsx only exported DataTable and DataTableProps, the import broke. The fix is to re-export DataTableColumnHeader from data-table.tsx so both resolution paths work. This is documented in AGENTS.md for future contributors.