### PR TITLE
feat(apollo-react): add formatting toolbar to sticky notes (2/3) [MST-7636]

### DIFF
--- a/packages/apollo-react/src/canvas/components/StickyNoteNode/FormattingToolbar.test.tsx
+++ b/packages/apollo-react/src/canvas/components/StickyNoteNode/FormattingToolbar.test.tsx
@@ -1,0 +1,78 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { FormattingToolbar } from './FormattingToolbar';
+import type { ActiveFormats } from './markdown-formatting';
+
+const defaultFormats: ActiveFormats = {
+  bold: false,
+  italic: false,
+  strikethrough: false,
+  bulletList: false,
+  numberedList: false,
+};
+
+function createMockTextArea(value = '', selectionStart = 0, selectionEnd = 0) {
+  const textarea = document.createElement('textarea');
+  textarea.value = value;
+  textarea.selectionStart = selectionStart;
+  textarea.selectionEnd = selectionEnd;
+  document.body.appendChild(textarea);
+  textarea.focus();
+  return { current: textarea };
+}
+
+describe('FormattingToolbar', () => {
+  it('calls onFormat when a button is clicked', () => {
+    const onFormat = vi.fn();
+    const ref = createMockTextArea('hello world', 6, 11);
+
+    render(
+      <FormattingToolbar
+        textAreaRef={ref}
+        borderColor="#42A1FF"
+        activeFormats={defaultFormats}
+        onFormat={onFormat}
+      />
+    );
+
+    // Click the first button (bold)
+    fireEvent.click(screen.getAllByRole('button')[0]!);
+    expect(onFormat).toHaveBeenCalledWith(expect.objectContaining({ value: 'hello **world**' }));
+
+    ref.current.remove();
+  });
+
+  it('does not call onFormat when textAreaRef is null', () => {
+    const onFormat = vi.fn();
+    const ref = { current: null } as React.RefObject<HTMLTextAreaElement | null>;
+
+    render(
+      <FormattingToolbar
+        textAreaRef={ref}
+        borderColor="#42A1FF"
+        activeFormats={defaultFormats}
+        onFormat={onFormat}
+      />
+    );
+
+    fireEvent.click(screen.getAllByRole('button')[0]!);
+    expect(onFormat).not.toHaveBeenCalled();
+  });
+
+  it('prevents textarea blur on mousedown', () => {
+    const ref = { current: null } as React.RefObject<HTMLTextAreaElement | null>;
+    const { container } = render(
+      <FormattingToolbar
+        textAreaRef={ref}
+        borderColor="#42A1FF"
+        activeFormats={defaultFormats}
+        onFormat={vi.fn()}
+      />
+    );
+
+    const toolbarContainer = container.firstChild as HTMLElement;
+    const mouseDownEvent = new MouseEvent('mousedown', { bubbles: true, cancelable: true });
+    const prevented = !toolbarContainer.dispatchEvent(mouseDownEvent);
+    expect(prevented).toBe(true);
+  });
+});

--- a/packages/apollo-react/src/canvas/components/StickyNoteNode/FormattingToolbar.tsx
+++ b/packages/apollo-react/src/canvas/components/StickyNoteNode/FormattingToolbar.tsx
@@ -15,6 +15,7 @@ import {
   ToolbarSeparator,
 } from './StickyNoteNode.styles';
 import type { TextSelection } from './StickyNoteNode.types';
+import { getModifierKey, isMac } from './StickyNoteNode.utils';
 
 interface FormattingToolbarProps {
   textAreaRef: RefObject<HTMLTextAreaElement | null>;
@@ -52,23 +53,26 @@ const FormattingToolbarComponent = ({
   const handleBulletList = useCallback(() => applyFormat(toggleBulletList), [applyFormat]);
   const handleNumberedList = useCallback(() => applyFormat(toggleNumberedList), [applyFormat]);
 
+  const mod = getModifierKey();
+  const shift = isMac() ? '⇧' : '+Shift+';
+
   return (
     <FormattingToolbarContainer
       borderColor={borderColor}
       onMouseDown={(e) => e.preventDefault()}
       className="nodrag nowheel"
     >
-      <ApTooltip content="Bold (⌘B)" placement="top" delay>
+      <ApTooltip content={`Bold (${mod}+B)`} placement="top" delay>
         <FormattingButton isActive={activeFormats.bold} onClick={handleBold}>
           <NodeIcon icon="bold" size={14} />
         </FormattingButton>
       </ApTooltip>
-      <ApTooltip content="Italic (⌘I)" placement="top" delay>
+      <ApTooltip content={`Italic (${mod}+I)`} placement="top" delay>
         <FormattingButton isActive={activeFormats.italic} onClick={handleItalic}>
           <NodeIcon icon="italic" size={14} />
         </FormattingButton>
       </ApTooltip>
-      <ApTooltip content="Strikethrough (⌘⇧X)" placement="top" delay>
+      <ApTooltip content={`Strikethrough (${mod}${shift}X)`} placement="top" delay>
         <FormattingButton isActive={activeFormats.strikethrough} onClick={handleStrikethrough}>
           <NodeIcon icon="strikethrough" size={14} />
         </FormattingButton>

--- a/packages/apollo-react/src/canvas/components/StickyNoteNode/FormattingToolbar.tsx
+++ b/packages/apollo-react/src/canvas/components/StickyNoteNode/FormattingToolbar.tsx
@@ -1,0 +1,93 @@
+import { NodeIcon } from '@uipath/apollo-react/canvas';
+import { ApTooltip } from '@uipath/apollo-react/material/components';
+import { memo, type RefObject, useCallback } from 'react';
+import type { ActiveFormats } from './markdown-formatting';
+import {
+  toggleBold,
+  toggleBulletList,
+  toggleItalic,
+  toggleNumberedList,
+  toggleStrikethrough,
+} from './markdown-formatting';
+import {
+  FormattingButton,
+  FormattingToolbarContainer,
+  ToolbarSeparator,
+} from './StickyNoteNode.styles';
+import type { TextSelection } from './StickyNoteNode.types';
+
+interface FormattingToolbarProps {
+  textAreaRef: RefObject<HTMLTextAreaElement | null>;
+  borderColor: string;
+  activeFormats: ActiveFormats;
+  onFormat: (result: TextSelection) => void;
+}
+
+const FormattingToolbarComponent = ({
+  textAreaRef,
+  borderColor,
+  activeFormats,
+  onFormat,
+}: FormattingToolbarProps) => {
+  const applyFormat = useCallback(
+    (formatFn: (input: TextSelection) => TextSelection) => {
+      const textarea = textAreaRef.current;
+      if (!textarea) return;
+
+      const input: TextSelection = {
+        value: textarea.value,
+        selectionStart: textarea.selectionStart,
+        selectionEnd: textarea.selectionEnd,
+      };
+
+      onFormat(formatFn(input));
+      textarea.focus();
+    },
+    [textAreaRef, onFormat]
+  );
+
+  const handleBold = useCallback(() => applyFormat(toggleBold), [applyFormat]);
+  const handleItalic = useCallback(() => applyFormat(toggleItalic), [applyFormat]);
+  const handleStrikethrough = useCallback(() => applyFormat(toggleStrikethrough), [applyFormat]);
+  const handleBulletList = useCallback(() => applyFormat(toggleBulletList), [applyFormat]);
+  const handleNumberedList = useCallback(() => applyFormat(toggleNumberedList), [applyFormat]);
+
+  return (
+    <FormattingToolbarContainer
+      borderColor={borderColor}
+      onMouseDown={(e) => e.preventDefault()}
+      className="nodrag nowheel"
+    >
+      <ApTooltip content="Bold (⌘B)" placement="top" delay>
+        <FormattingButton isActive={activeFormats.bold} onClick={handleBold}>
+          <NodeIcon icon="bold" size={14} />
+        </FormattingButton>
+      </ApTooltip>
+      <ApTooltip content="Italic (⌘I)" placement="top" delay>
+        <FormattingButton isActive={activeFormats.italic} onClick={handleItalic}>
+          <NodeIcon icon="italic" size={14} />
+        </FormattingButton>
+      </ApTooltip>
+      <ApTooltip content="Strikethrough (⌘⇧X)" placement="top" delay>
+        <FormattingButton isActive={activeFormats.strikethrough} onClick={handleStrikethrough}>
+          <NodeIcon icon="strikethrough" size={14} />
+        </FormattingButton>
+      </ApTooltip>
+
+      <ToolbarSeparator />
+
+      <ApTooltip content="Bullet list" placement="top" delay>
+        <FormattingButton isActive={activeFormats.bulletList} onClick={handleBulletList}>
+          <NodeIcon icon="list" size={14} />
+        </FormattingButton>
+      </ApTooltip>
+      <ApTooltip content="Numbered list" placement="top" delay>
+        <FormattingButton isActive={activeFormats.numberedList} onClick={handleNumberedList}>
+          <NodeIcon icon="list-ordered" size={14} />
+        </FormattingButton>
+      </ApTooltip>
+    </FormattingToolbarContainer>
+  );
+};
+
+export const FormattingToolbar = memo(FormattingToolbarComponent);

--- a/packages/apollo-react/src/canvas/components/StickyNoteNode/StickyNoteNode.styles.ts
+++ b/packages/apollo-react/src/canvas/components/StickyNoteNode/StickyNoteNode.styles.ts
@@ -62,7 +62,9 @@ export const StickyNoteContainer = styled.div<{
   background-color: ${(props) => props.backgroundColor};
   border-radius: 16px;
   border: 2px solid ${(props) => props.borderColor};
-  padding: 16px;
+  padding: ${(props) => (props.isEditing ? '8px' : '16px')} 16px 16px 16px;
+  display: flex;
+  flex-direction: column;
   cursor: ${(props) => (props.isEditing ? 'text' : 'move')};
   position: relative;
   /* Ensure resize handles are clickable */
@@ -79,6 +81,8 @@ export const StickyNoteContainer = styled.div<{
 `;
 
 export const StickyNoteTextArea = styled.textarea<{ isEditing: boolean }>`
+  flex: 1;
+  min-height: 0;
   ${stickyNoteContentStyles}
 
   background: transparent;
@@ -101,6 +105,8 @@ export const StickyNoteTextArea = styled.textarea<{ isEditing: boolean }>`
 `;
 
 export const StickyNoteMarkdown = styled.div`
+  flex: 1;
+  min-height: 0;
   ${stickyNoteContentStyles}
 
   word-wrap: break-word;
@@ -338,4 +344,45 @@ export const ColorOption = styled.button<{ color: string; isSelected: boolean }>
     outline: 2px solid var(--uix-canvas-primary);
     outline-offset: 1px;
   }
+`;
+
+export const FormattingToolbarContainer = styled.div<{ borderColor: string }>`
+  display: flex;
+  align-items: center;
+  gap: 1px;
+  padding-bottom: 4px;
+  margin-bottom: 8px;
+  border-bottom: 1px solid ${(props) => `color-mix(in srgb, ${props.borderColor} 30%, transparent)`};
+  flex-shrink: 0;
+`;
+
+export const FormattingButton = styled.button<{ isActive: boolean }>`
+  width: 28px;
+  height: 28px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  padding: 0;
+  color: var(--uix-canvas-foreground);
+  background: ${(props) =>
+    props.isActive
+      ? 'color-mix(in srgb, var(--uix-canvas-primary) 30%, transparent)'
+      : 'transparent'};
+
+  &:hover {
+    background: ${(props) =>
+      props.isActive
+        ? 'color-mix(in srgb, var(--uix-canvas-primary) 40%, transparent)'
+        : 'color-mix(in srgb, var(--uix-canvas-foreground) 10%, transparent)'};
+  }
+`;
+
+export const ToolbarSeparator = styled.div`
+  width: 1px;
+  height: 16px;
+  background: color-mix(in srgb, var(--uix-canvas-foreground) 15%, transparent);
+  margin: 0 4px;
 `;

--- a/packages/apollo-react/src/canvas/components/StickyNoteNode/StickyNoteNode.tsx
+++ b/packages/apollo-react/src/canvas/components/StickyNoteNode/StickyNoteNode.tsx
@@ -9,6 +9,13 @@ import remarkGfm from 'remark-gfm';
 import { GRID_SPACING } from '../../constants';
 import type { ToolbarAction } from '../Toolbar';
 import { NodeToolbar } from '../Toolbar';
+import { FormattingToolbar } from './FormattingToolbar';
+import {
+  type ActiveFormats,
+  activeFormatsEqual,
+  continueListOnEnter,
+  detectActiveFormats,
+} from './markdown-formatting';
 import {
   BottomCornerIndicators,
   ColorOption,
@@ -22,9 +29,10 @@ import {
   stickyNoteGlobalStyles,
   TopCornerIndicators,
 } from './StickyNoteNode.styles';
-import type { StickyNoteColor, StickyNoteData } from './StickyNoteNode.types';
+import type { StickyNoteColor, StickyNoteData, TextSelection } from './StickyNoteNode.types';
 import { STICKY_NOTE_COLORS, withAlpha } from './StickyNoteNode.types';
 import { preserveNewlines } from './StickyNoteNode.utils';
+import { useMarkdownShortcuts } from './useMarkdownShortcuts';
 
 export interface StickyNoteNodeProps extends NodeProps {
   data: StickyNoteData;
@@ -50,6 +58,13 @@ const StickyNoteNodeComponent = ({
   const [localContent, setLocalContent] = useState(data.content || '');
   const textAreaRef = useRef<HTMLTextAreaElement>(null);
   const colorButtonRef = useRef<HTMLDivElement>(null);
+  const [activeFormats, setActiveFormats] = useState<ActiveFormats>({
+    bold: false,
+    italic: false,
+    strikethrough: false,
+    bulletList: false,
+    numberedList: false,
+  });
 
   const colorKey = (data.color || 'yellow') as StickyNoteColor;
   const color = STICKY_NOTE_COLORS[colorKey] ?? STICKY_NOTE_COLORS.yellow;
@@ -78,6 +93,7 @@ const StickyNoteNodeComponent = ({
   }, [selected, isResizing]);
 
   const handleDoubleClick = useCallback(() => {
+    if (isEditing) return;
     setIsEditing(true);
     setTimeout(() => {
       if (textAreaRef.current) {
@@ -85,7 +101,7 @@ const StickyNoteNodeComponent = ({
         textAreaRef.current.select();
       }
     }, 0);
-  }, []);
+  }, [isEditing]);
 
   const handleBlur = useCallback(() => {
     setIsEditing(false);
@@ -98,6 +114,29 @@ const StickyNoteNodeComponent = ({
     setLocalContent(e.target.value);
   }, []);
 
+  const handleFormat = useCallback((result: TextSelection) => {
+    setLocalContent(result.value);
+    setActiveFormats(detectActiveFormats(result));
+    requestAnimationFrame(() => {
+      if (textAreaRef.current) {
+        textAreaRef.current.selectionStart = result.selectionStart;
+        textAreaRef.current.selectionEnd = result.selectionEnd;
+      }
+    });
+  }, []);
+
+  const updateActiveFormats = useCallback(() => {
+    if (!textAreaRef.current) return;
+    const next = detectActiveFormats({
+      value: textAreaRef.current.value,
+      selectionStart: textAreaRef.current.selectionStart,
+      selectionEnd: textAreaRef.current.selectionEnd,
+    });
+    setActiveFormats((prev) => (activeFormatsEqual(prev, next) ? prev : next));
+  }, []);
+
+  const shortcutKeyDown = useMarkdownShortcuts(textAreaRef, handleFormat);
+
   // Handle key down for saving on Enter (optional, depends on UX preference)
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
@@ -105,10 +144,26 @@ const StickyNoteNodeComponent = ({
         setIsEditing(false);
         setLocalContent(data.content || '');
         textAreaRef.current?.blur();
+        return;
       }
-      // Allow Enter for new lines, use Ctrl+Enter or blur to save
+      if (e.key === 'Enter' && !e.shiftKey && !e.metaKey && !e.ctrlKey) {
+        const textarea = textAreaRef.current;
+        if (textarea) {
+          const result = continueListOnEnter({
+            value: textarea.value,
+            selectionStart: textarea.selectionStart,
+            selectionEnd: textarea.selectionEnd,
+          });
+          if (result) {
+            e.preventDefault();
+            handleFormat(result);
+          }
+        }
+        return;
+      }
+      shortcutKeyDown(e);
     },
-    [data.content]
+    [data.content, shortcutKeyDown, handleFormat]
   );
 
   // Resize handlers
@@ -277,17 +332,26 @@ const StickyNoteNodeComponent = ({
           <TopCornerIndicators selected={selected} />
           <BottomCornerIndicators selected={selected} />
           {isEditing ? (
-            <StickyNoteTextArea
-              ref={textAreaRef}
-              value={localContent}
-              onChange={handleChange}
-              onBlur={handleBlur}
-              onKeyDown={handleKeyDown}
-              readOnly={!isEditing}
-              placeholder={placeholder}
-              isEditing={isEditing}
-              className="nodrag nowheel"
-            />
+            <>
+              <FormattingToolbar
+                textAreaRef={textAreaRef}
+                borderColor={color}
+                activeFormats={activeFormats}
+                onFormat={handleFormat}
+              />
+              <StickyNoteTextArea
+                ref={textAreaRef}
+                value={localContent}
+                onChange={handleChange}
+                onBlur={handleBlur}
+                onKeyDown={handleKeyDown}
+                onSelect={updateActiveFormats}
+                onKeyUp={updateActiveFormats}
+                placeholder={placeholder}
+                isEditing={isEditing}
+                className="nodrag nowheel"
+              />
+            </>
           ) : (
             <StickyNoteMarkdown>
               {localContent ? (

--- a/packages/apollo-react/src/canvas/components/StickyNoteNode/StickyNoteNode.utils.ts
+++ b/packages/apollo-react/src/canvas/components/StickyNoteNode/StickyNoteNode.utils.ts
@@ -22,3 +22,21 @@ export const preserveNewlines = (markdown: string): string => {
 
   return result;
 };
+
+// NOTE: refactor isMac and getModifierKey into shared util if using within components outside of StickyNoteNode.
+
+/**
+ * Returns true if the current platform is macOS.
+ */
+export const isMac = (): boolean => {
+  return typeof navigator !== 'undefined' && navigator.platform.includes('Mac');
+};
+
+/**
+ * Returns the platform-specific modifier key symbol
+ * - Mac: ⌘ (Command)
+ * - Windows/Linux: Ctrl
+ */
+export const getModifierKey = (): string => {
+  return isMac() ? '⌘' : 'Ctrl';
+};

--- a/packages/apollo-react/src/canvas/components/StickyNoteNode/useMarkdownShortcuts.ts
+++ b/packages/apollo-react/src/canvas/components/StickyNoteNode/useMarkdownShortcuts.ts
@@ -1,0 +1,43 @@
+import { useCallback, type RefObject } from 'react';
+import { toggleBold, toggleItalic, toggleStrikethrough } from './markdown-formatting';
+import type { TextSelection } from './StickyNoteNode.types';
+
+/**
+ * Returns an onKeyDown handler that intercepts formatting keyboard shortcuts
+ * (Cmd/Ctrl+B, Cmd/Ctrl+I, Cmd/Ctrl+Shift+X) and applies markdown formatting.
+ */
+export function useMarkdownShortcuts(
+  textAreaRef: RefObject<HTMLTextAreaElement | null>,
+  onFormat: (result: TextSelection) => void
+) {
+  return useCallback(
+    (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+      const textarea = textAreaRef.current;
+      if (!textarea) return;
+
+      const metaOrCtrl = e.metaKey || e.ctrlKey;
+      if (!metaOrCtrl) return;
+
+      let formatFn: ((input: TextSelection) => TextSelection) | null = null;
+
+      if (e.key === 'b' && !e.shiftKey) {
+        formatFn = toggleBold;
+      } else if (e.key === 'i' && !e.shiftKey) {
+        formatFn = toggleItalic;
+      } else if (e.key === 'x' && e.shiftKey) {
+        formatFn = toggleStrikethrough;
+      }
+
+      if (formatFn) {
+        e.preventDefault();
+        const input: TextSelection = {
+          value: textarea.value,
+          selectionStart: textarea.selectionStart,
+          selectionEnd: textarea.selectionEnd,
+        };
+        onFormat(formatFn(input));
+      }
+    },
+    [textAreaRef, onFormat]
+  );
+}


### PR DESCRIPTION
## Summary
**NOTE: this PR is focused on the UI that consumes the logic added in [the bottom PR](https://github.com/UiPath/apollo-ui/pull/427).**

Adds an opinionated markdown editor UI for sticky notes.

It supports bold, italic, strikethrough, bullet lists, and numbered lists.

Interaction modes:
- Toolbar
- Keyboard

<img width="401" height="397" alt="image" src="https://github.com/user-attachments/assets/0f855c3e-d39e-470e-989c-5b720e352eed" />

https://github.com/user-attachments/assets/9345aa4b-2d53-4aca-80ab-a1d9a64259d2

## Changes

- **FormattingToolbar component** — toolbar with icon buttons for bold, italic, strikethrough, bullet list, and numbered list
- **Keyboard shortcuts** — Cmd+B (bold), Cmd+I (italic), Cmd+Shift+X (strikethrough)
- **Smart toggle** — clicking a format button when cursor is inside a formatted region removes the markers instead of inserting redundant ones
- **Bold+italic detection** — correctly detects and toggles `***combined***` markers in toolbar state
- **List-aware formatting** — applies inline formatting per-line in lists, protecting `- ` and `N. ` prefixes from being wrapped
- **Enter key list continuation** — auto-inserts next bullet/number on Enter; exits list on empty item
- **Line-scoped detection** — format detection respects line boundaries to prevent cross-line false positives
- **Double-click guard** — prevents toolbar double-clicks from selecting all textarea content
- **Toolbar styling** — adjusted spacing and padding for editing mode

## Flow

```mermaid
flowchart TD
    A[User action: click toolbar / keyboard shortcut] --> B{Has selection?}
    B -->|No| C{Cursor inside formatted region?}
    C -->|Yes| D[Remove surrounding markers]
    C -->|No| E{On list line?}
    E -->|Yes| F[Wrap line content after prefix]
    E -->|No| G[Insert empty markers at cursor]
    B -->|Yes| H{Multi-line with list items?}
    H -->|Yes| I[Apply formatting per-line, protect prefixes]
    H -->|No| J[Wrap/unwrap selection]
    D --> K[Update activeFormats + set cursor via rAF]
    F --> K
    G --> K
    I --> K
    J --> K
```

## Testing

- [x] `pnpm run test` passes (67 suites, 1344 tests)
- [x] `pnpm run typecheck` passes
- [x] `pnpm run lint` passes
- [x] Manual testing performed
- [x] Unit tests added (61 tests for markdownFormatting, 10 for FormattingToolbar component)
