### PR TITLE
feat(apollo-react): add remark-breaks to sticky note markdown rendering, scroll improvements (3/3) [MST-7636]

### DIFF
--- a/packages/apollo-react/package.json
+++ b/packages/apollo-react/package.json
@@ -212,6 +212,7 @@
     "react-syntax-highlighter": "^16.1.0",
     "react-window": "^2.2.1",
     "rehype-katex": "^7.0.1",
+    "remark-breaks": "^4.0.0",
     "remark-gfm": "^4.0.1",
     "remark-math": "^6.0.0",
     "reselect": "^5.1.1",

--- a/packages/apollo-react/src/canvas/components/StickyNoteNode/StickyNoteNode.tsx
+++ b/packages/apollo-react/src/canvas/components/StickyNoteNode/StickyNoteNode.tsx
@@ -5,6 +5,7 @@ import { NodeResizeControl, useReactFlow } from '@uipath/apollo-react/canvas/xyf
 import { AnimatePresence } from 'motion/react';
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import ReactMarkdown from 'react-markdown';
+import remarkBreaks from 'remark-breaks';
 import remarkGfm from 'remark-gfm';
 import { GRID_SPACING } from '../../constants';
 import type { ToolbarAction } from '../Toolbar';
@@ -33,6 +34,7 @@ import type { StickyNoteColor, StickyNoteData, TextSelection } from './StickyNot
 import { STICKY_NOTE_COLORS, withAlpha } from './StickyNoteNode.types';
 import { preserveNewlines } from './StickyNoteNode.utils';
 import { useMarkdownShortcuts } from './useMarkdownShortcuts';
+import { useScrollCapture } from './useScrollCapture';
 
 export interface StickyNoteNodeProps extends NodeProps {
   data: StickyNoteData;
@@ -57,6 +59,7 @@ const StickyNoteNodeComponent = ({
   const [isColorPickerOpen, setIsColorPickerOpen] = useState(false);
   const [localContent, setLocalContent] = useState(data.content || '');
   const textAreaRef = useRef<HTMLTextAreaElement>(null);
+  const { ref: markdownRef, scrollCaptureProps } = useScrollCapture();
   const colorButtonRef = useRef<HTMLDivElement>(null);
   const [activeFormats, setActiveFormats] = useState<ActiveFormats>({
     bold: false,
@@ -353,16 +356,22 @@ const StickyNoteNodeComponent = ({
               />
             </>
           ) : (
-            <StickyNoteMarkdown>
+            <StickyNoteMarkdown ref={markdownRef} {...scrollCaptureProps}>
               {localContent ? (
-                <ReactMarkdown remarkPlugins={[remarkGfm]} components={markdownComponents}>
+                <ReactMarkdown
+                  remarkPlugins={[remarkGfm, remarkBreaks]}
+                  components={markdownComponents}
+                >
                   {preserveNewlines(localContent)}
                 </ReactMarkdown>
               ) : (
                 // Render placeholder if renderPlaceholderOnSelect is enabled, node is selected, and the content is empty
                 renderPlaceholderOnSelect &&
                 selected && (
-                  <ReactMarkdown remarkPlugins={[remarkGfm]} components={markdownComponents}>
+                  <ReactMarkdown
+                    remarkPlugins={[remarkGfm, remarkBreaks]}
+                    components={markdownComponents}
+                  >
                     {placeholder}
                   </ReactMarkdown>
                 )

--- a/packages/apollo-react/src/canvas/components/StickyNoteNode/useScrollCapture.ts
+++ b/packages/apollo-react/src/canvas/components/StickyNoteNode/useScrollCapture.ts
@@ -1,0 +1,53 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+const EVENT_START_POLL_INTERVAL = 150;
+
+/**
+ * Captures scroll (wheel) events on an overflowing element without hijacking
+ * an in-progress canvas zoom gesture.
+ *
+ * Returns a ref to attach to the scrollable element and props to spread onto it.
+ * Adds the `nowheel` class only when the pointer entered while no wheel gesture
+ * was active and the element has overflow.
+ */
+export function useScrollCapture<T extends HTMLElement = HTMLDivElement>() {
+  const ref = useRef<T>(null);
+  const [captureScroll, setCaptureScroll] = useState(false);
+  const wheelActiveRef = useRef(false);
+  const wheelTimeoutRef = useRef<ReturnType<typeof setTimeout>>(null);
+
+  // Track global wheel activity so we can distinguish "pointer entered while idle"
+  // from "pointer drifted over during a canvas zoom gesture".
+  useEffect(() => {
+    const onWheel = () => {
+      wheelActiveRef.current = true;
+      if (wheelTimeoutRef.current) clearTimeout(wheelTimeoutRef.current);
+      wheelTimeoutRef.current = setTimeout(() => {
+        wheelActiveRef.current = false;
+      }, EVENT_START_POLL_INTERVAL);
+    };
+    window.addEventListener('wheel', onWheel, { passive: true });
+    return () => window.removeEventListener('wheel', onWheel);
+  }, []);
+
+  const onMouseEnter = useCallback(() => {
+    if (wheelActiveRef.current) return;
+    const el = ref.current;
+    if (el && el.scrollHeight > el.clientHeight) {
+      setCaptureScroll(true);
+    }
+  }, []);
+
+  const onMouseLeave = useCallback(() => {
+    setCaptureScroll(false);
+  }, []);
+
+  return {
+    ref,
+    scrollCaptureProps: {
+      className: captureScroll ? 'nowheel' : undefined,
+      onMouseEnter,
+      onMouseLeave,
+    },
+  };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -665,6 +665,9 @@ importers:
       rehype-katex:
         specifier: ^7.0.1
         version: 7.0.1
+      remark-breaks:
+        specifier: ^4.0.0
+        version: 4.0.0
       remark-gfm:
         specifier: ^4.0.1
         version: 4.0.1
@@ -9345,6 +9348,9 @@ packages:
   mdast-util-mdxjs-esm@2.0.1:
     resolution: {integrity: sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==}
 
+  mdast-util-newline-to-break@2.0.0:
+    resolution: {integrity: sha512-MbgeFca0hLYIEx/2zGsszCSEJJ1JSCdiY5xQxRcLDDGa8EPvlLPupJ4DSajbMPAnC0je8jfb9TiUATnxxrHUog==}
+
   mdast-util-phrasing@4.1.0:
     resolution: {integrity: sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==}
 
@@ -10989,6 +10995,9 @@ packages:
 
   rehype-recma@1.0.0:
     resolution: {integrity: sha512-lqA4rGUf1JmacCNWWZx0Wv1dHqMwxzsDWYMTowuplHF3xH0N/MmrZ/G3BDZnzAkRmxDadujCjaKM2hqYdCBOGw==}
+
+  remark-breaks@4.0.0:
+    resolution: {integrity: sha512-IjEjJOkH4FuJvHZVIW0QCDWxcG96kCq7An/KVH2NfJe6rKZU2AsHeB3OEjPNRxi4QC34Xdx7I2KGYn6IpT7gxQ==}
 
   remark-frontmatter@5.0.0:
     resolution: {integrity: sha512-XTFYvNASMe5iPN0719nPrdItC9aU0ssC4v14mH1BCi1u0n1gAocqcujWUrByftZTbLhRtiKRyjYTSIOcr69UVQ==}
@@ -21723,6 +21732,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  mdast-util-newline-to-break@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-find-and-replace: 3.0.2
+
   mdast-util-phrasing@4.1.0:
     dependencies:
       '@types/mdast': 4.0.4
@@ -23690,6 +23704,12 @@ snapshots:
       hast-util-to-estree: 3.1.3
     transitivePeerDependencies:
       - supports-color
+
+  remark-breaks@4.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-newline-to-break: 2.0.0
+      unified: 11.0.5
 
   remark-frontmatter@5.0.0:
     dependencies:


### PR DESCRIPTION
There are two main changes in this PR:
- Line break rendering support
- Simpler scrolling on overflow

### 1. Line break rendering support
Adds `remark-breaks` (remark plugin) to turn soft line endings (enters) into hard breaks. This makes our line end behavior fall more closely in line with what a user would expect from a WYSIWYG editor (i.e. FigJam sticky notes)

### Before
![2026-03-31 10 33 08](https://github.com/user-attachments/assets/759f914f-2bce-4f9e-8340-0fea20a26ac1)

### After
![2026-03-31 10 32 07](https://github.com/user-attachments/assets/2643003f-5ccc-4d72-8bef-1993da6b4f06)

### 2. Simpler scrolling on overflow
Only adds `nowheel` class to the sticky note element when the `wheel` event starts on the sticky note. This prevents the sudden cancellation of canvas scroll inertia _(e.g. if the user starts scrolling outside the sticky note and their cursor ends up within the sticky note, we continue navigating on the canvas and ignore sticky note scroll behavior)_.

### Before
User has to manually drag the scrollbar to scroll on a sticky note w/ overflow

https://github.com/user-attachments/assets/94e80532-b5f5-41cd-9cbd-301017ca1871

### After
https://github.com/user-attachments/assets/92a39c77-2ea9-4c17-8295-ce71875e8b85

