### PR TITLE
fix(apollo-react): improve stage node performance [MST-8122]

### DIFF
--- a/packages/apollo-react/src/canvas/components/CanvasPerformance.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/CanvasPerformance.stories.tsx
@@ -1,0 +1,279 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import type { Connection, Edge, Node } from '@uipath/apollo-react/canvas/xyflow/react';
+import {
+  addEdge,
+  ConnectionMode,
+  Panel,
+  ReactFlowProvider,
+  useEdgesState,
+  useNodesState,
+} from '@uipath/apollo-react/canvas/xyflow/react';
+import { useCallback, useMemo, useState } from 'react';
+import { DefaultCanvasTranslations } from '../types';
+import { BaseCanvas } from './BaseCanvas';
+import { CanvasPositionControls } from './CanvasPositionControls';
+import { StageConnectionEdge } from './StageNode/StageConnectionEdge';
+import { StageEdge } from './StageNode/StageEdge';
+import { StageNodeWrapper } from './StageNode/StageNode.stories.utils';
+import type { StageTaskItem } from './StageNode/StageNode.types';
+
+const meta: Meta = {
+  title: 'Canvas/Performance',
+  parameters: {
+    layout: 'fullscreen',
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const PERFORMANCE_STAGE_NODE_WIDTH = 304;
+const PERFORMANCE_STAGE_SPACING_X = 400;
+const PERFORMANCE_STAGE_SPACING_Y = 384;
+const DEFAULT_STAGE_COUNT = 48;
+const MIN_STAGE_COUNT = 1;
+const MAX_STAGE_COUNT = 200;
+
+const VerificationIcon = () => (
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+    <path d="M9 11L12 14L20 6" />
+    <path d="M20 12V18C20 19.1046 19.1046 20 18 20H6C4.89543 20 4 19.1046 4 18V6C4 4.89543 4.89543 4 6 4H13" />
+  </svg>
+);
+
+const DocumentIcon = () => (
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+    <path d="M14 2H6C4.9 2 4 2.9 4 4V20C4 21.1 4.9 22 6 22H18C19.1 22 20 21.1 20 20V8L14 2Z" />
+    <path d="M14 2V8H20" />
+    <path d="M8 12H16" />
+    <path d="M8 16H16" />
+  </svg>
+);
+
+const ProcessIcon = () => (
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+    <rect x="3" y="3" width="7" height="7" rx="1" />
+    <rect x="14" y="3" width="7" height="7" rx="1" />
+    <rect x="3" y="14" width="7" height="7" rx="1" />
+    <rect x="14" y="14" width="7" height="7" rx="1" />
+  </svg>
+);
+
+function createPerformanceStageTasks(index: number): StageTaskItem[][] {
+  return [
+    [
+      {
+        id: `stage-${index}-task-intake`,
+        label: 'Intake Review',
+        icon: <VerificationIcon />,
+      },
+    ],
+    [
+      {
+        id: `stage-${index}-task-documents`,
+        label: 'Document Processing',
+        icon: <DocumentIcon />,
+      },
+    ],
+    [
+      {
+        id: `stage-${index}-task-risk`,
+        label: 'Risk Assessment',
+        icon: <VerificationIcon />,
+      },
+      {
+        id: `stage-${index}-task-policy`,
+        label: 'Policy Validation',
+        icon: <VerificationIcon />,
+      },
+    ],
+    [
+      {
+        id: `stage-${index}-task-review`,
+        label: 'Final Review',
+        icon: <ProcessIcon />,
+      },
+    ],
+  ];
+}
+
+function createPerformanceStageNodes(stageCount: number): Node[] {
+  const columns = Math.ceil(Math.sqrt(stageCount));
+
+  return Array.from({ length: stageCount }, (_, index) => {
+    const row = Math.floor(index / columns);
+    const col = index % columns;
+    const stageId = `performance-stage-${index}`;
+
+    return {
+      id: stageId,
+      type: 'stage',
+      position: {
+        x: col * PERFORMANCE_STAGE_SPACING_X,
+        y: row * PERFORMANCE_STAGE_SPACING_Y,
+      },
+      width: PERFORMANCE_STAGE_NODE_WIDTH,
+      data: {
+        stageDetails: {
+          label: `Performance Stage ${index + 1}`,
+          tasks: createPerformanceStageTasks(index),
+        },
+        execution: {
+          stageStatus: {
+            duration: `SLA: ${30 + (index % 5) * 15}m`,
+          },
+        },
+      },
+    };
+  });
+}
+
+function createPerformanceStageEdges(stageCount: number): Edge[] {
+  const columns = Math.ceil(Math.sqrt(stageCount));
+  const edges: Edge[] = [];
+
+  for (let index = 0; index < stageCount; index++) {
+    const col = index % columns;
+    const sourceId = `performance-stage-${index}`;
+
+    const rightIndex = index + 1;
+    if (col < columns - 1 && rightIndex < stageCount) {
+      const targetId = `performance-stage-${rightIndex}`;
+      edges.push({
+        id: `performance-edge-right-${index}`,
+        type: 'stage',
+        source: sourceId,
+        sourceHandle: `${sourceId}____source____right`,
+        target: targetId,
+        targetHandle: `${targetId}____target____left`,
+      });
+    }
+
+    const downIndex = index + columns;
+    if (downIndex < stageCount) {
+      const targetId = `performance-stage-${downIndex}`;
+      edges.push({
+        id: `performance-edge-down-${index}`,
+        type: 'stage',
+        source: sourceId,
+        sourceHandle: `${sourceId}____source____bottom`,
+        target: targetId,
+        targetHandle: `${targetId}____target____top`,
+      });
+    }
+  }
+
+  return edges;
+}
+
+const CanvasPerformanceStory = () => {
+  const nodeTypes = useMemo(() => ({ stage: StageNodeWrapper }), []);
+  const edgeTypes = useMemo(() => ({ stage: StageEdge }), []);
+  const defaultEdgeOptions = useMemo(() => ({ type: 'stage' }), []);
+  const [stageCount, setStageCount] = useState(DEFAULT_STAGE_COUNT);
+  const [nodes, setNodes, onNodesChange] = useNodesState(
+    createPerformanceStageNodes(DEFAULT_STAGE_COUNT)
+  );
+  const [edges, setEdges, onEdgesChange] = useEdgesState(
+    createPerformanceStageEdges(DEFAULT_STAGE_COUNT)
+  );
+
+  const onConnect = useCallback(
+    (connection: Connection) => setEdges((eds) => addEdge(connection, eds)),
+    [setEdges]
+  );
+
+  const handleStageCountChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const nextCount = Number.parseInt(e.target.value, 10);
+      setStageCount(nextCount);
+      setNodes(createPerformanceStageNodes(nextCount));
+      setEdges(createPerformanceStageEdges(nextCount));
+    },
+    [setEdges, setNodes]
+  );
+
+  return (
+    <div style={{ width: '100vw', height: '100vh' }}>
+      <ReactFlowProvider>
+        <BaseCanvas
+          nodes={nodes}
+          edges={edges}
+          onNodesChange={onNodesChange}
+          onEdgesChange={onEdgesChange}
+          onConnect={onConnect}
+          nodeTypes={nodeTypes}
+          edgeTypes={edgeTypes}
+          mode="design"
+          connectionMode={ConnectionMode.Strict}
+          defaultEdgeOptions={defaultEdgeOptions}
+          connectionLineComponent={StageConnectionEdge}
+          elevateEdgesOnSelect
+        >
+          <Panel position="top-left">
+            <div
+              className="nodrag nopan nowheel"
+              style={{
+                width: 240,
+                background: 'var(--uix-canvas-background)',
+                border: '1px solid var(--uix-canvas-border-de-emp)',
+                borderRadius: 16,
+                padding: 16,
+                boxShadow: '0 8px 32px rgba(15, 23, 42, 0.08)',
+              }}
+            >
+              <div style={{ fontWeight: 600, fontSize: 14 }}>Performance Test</div>
+              <div
+                style={{
+                  marginTop: 6,
+                  color: 'var(--uix-canvas-foreground-de-emp)',
+                  fontSize: 12,
+                  lineHeight: 1.4,
+                }}
+              >
+                Adjust the number of stage nodes to profile drag and pan performance.
+              </div>
+              <div
+                style={{
+                  display: 'flex',
+                  justifyContent: 'space-between',
+                  alignItems: 'center',
+                  marginTop: 12,
+                  marginBottom: 8,
+                  fontSize: 12,
+                }}
+              >
+                <span>Stage Count</span>
+                <strong style={{ fontSize: 14 }}>{stageCount}</strong>
+              </div>
+              <input
+                type="range"
+                min={MIN_STAGE_COUNT}
+                max={MAX_STAGE_COUNT}
+                value={stageCount}
+                onChange={handleStageCountChange}
+                style={{ width: '100%', cursor: 'pointer' }}
+              />
+            </div>
+          </Panel>
+          <Panel position="bottom-right">
+            <CanvasPositionControls translations={DefaultCanvasTranslations} />
+          </Panel>
+        </BaseCanvas>
+      </ReactFlowProvider>
+    </div>
+  );
+};
+
+export const StageWorkflow: Story = {
+  name: 'Stage Workflow',
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Standalone performance story with adjustable stage count. Use this to profile stage workflow drag and pan behavior under load.',
+      },
+    },
+  },
+  render: () => <CanvasPerformanceStory />,
+};

--- a/packages/apollo-react/src/canvas/components/CanvasPerformance.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/CanvasPerformance.stories.tsx
@@ -148,19 +148,6 @@ function createPerformanceStageEdges(stageCount: number): Edge[] {
         targetHandle: `${targetId}____target____left`,
       });
     }
-
-    const downIndex = index + columns;
-    if (downIndex < stageCount) {
-      const targetId = `performance-stage-${downIndex}`;
-      edges.push({
-        id: `performance-edge-down-${index}`,
-        type: 'stage',
-        source: sourceId,
-        sourceHandle: `${sourceId}____source____bottom`,
-        target: targetId,
-        targetHandle: `${targetId}____target____top`,
-      });
-    }
   }
 
   return edges;

--- a/packages/apollo-react/src/canvas/components/NodePropertiesPanel/hooks/index.ts
+++ b/packages/apollo-react/src/canvas/components/NodePropertiesPanel/hooks/index.ts
@@ -1,2 +1,2 @@
 export { useNodeConfiguration } from './useNodeConfiguration';
-export { useNodeSelection } from './useNodeSelection';
+export { useNodeSelection, useSetNodeSelection } from './useNodeSelection';

--- a/packages/apollo-react/src/canvas/components/NodePropertiesPanel/hooks/useNodeSelection.ts
+++ b/packages/apollo-react/src/canvas/components/NodePropertiesPanel/hooks/useNodeSelection.ts
@@ -1,3 +1,4 @@
+import type { Node } from '@uipath/apollo-react/canvas/xyflow/react';
 import {
   useNodes,
   useOnSelectionChange,
@@ -5,6 +6,14 @@ import {
 } from '@uipath/apollo-react/canvas/xyflow/react';
 import { useCallback, useEffect, useState } from 'react';
 import type { ConfigurableNode } from '../NodePropertiesPanel.types';
+
+function applySelection(nodes: Node[], nodeId: string): Node[] {
+  return nodes.map((node) => {
+    const shouldBeSelected = node.id === nodeId;
+    if (node.selected === shouldBeSelected) return node;
+    return { ...node, selected: shouldBeSelected };
+  });
+}
 
 export function useNodeSelection(nodeId?: string, maintainSelection = true) {
   const nodes = useNodes();
@@ -28,12 +37,7 @@ export function useNodeSelection(nodeId?: string, maintainSelection = true) {
 
   useEffect(() => {
     if (maintainSelection && selectedNodeId) {
-      setNodes((nds) =>
-        nds.map((node) => ({
-          ...node,
-          selected: node.id === selectedNodeId,
-        }))
-      );
+      setNodes((nds) => applySelection(nds, selectedNodeId));
     }
   }, [selectedNodeId, maintainSelection, setNodes]);
 
@@ -46,4 +50,22 @@ export function useNodeSelection(nodeId?: string, maintainSelection = true) {
     setSelectedNodeId,
     selectedNode,
   };
+}
+
+/**
+ * Lightweight hook that only provides setSelectedNodeId without subscribing
+ * to all nodes. Use this in node components that only need to trigger selection
+ * without reading the full nodes array.
+ */
+export function useSetNodeSelection() {
+  const { setNodes } = useReactFlow();
+
+  const setSelectedNodeId = useCallback(
+    (nodeId: string) => {
+      setNodes((nds) => applySelection(nds, nodeId));
+    },
+    [setNodes]
+  );
+
+  return { setSelectedNodeId };
 }

--- a/packages/apollo-react/src/canvas/components/StageNode/AdhocTask.test.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/AdhocTask.test.tsx
@@ -32,7 +32,6 @@ describe('AdhocTaskItem', () => {
     task: createTask('adhoc-1', 'Adhoc Task'),
     taskExecution: undefined,
     isSelected: false,
-    contextMenuItems: [] as NodeMenuItem[],
     onTaskClick: vi.fn(),
   };
 
@@ -77,7 +76,11 @@ describe('AdhocTaskItem', () => {
       const menuItems = createMenuItems(onRemove);
 
       render(
-        <AdhocTaskItem {...defaultProps} onTaskClick={onTaskClick} contextMenuItems={menuItems} />
+        <AdhocTaskItem
+          {...defaultProps}
+          onTaskClick={onTaskClick}
+          getContextMenuItems={() => menuItems}
+        />
       );
 
       // Open menu
@@ -102,7 +105,11 @@ describe('AdhocTaskItem', () => {
       const menuItems = createMenuItems(onRemove);
 
       render(
-        <AdhocTaskItem {...defaultProps} onTaskClick={onTaskClick} contextMenuItems={menuItems} />
+        <AdhocTaskItem
+          {...defaultProps}
+          onTaskClick={onTaskClick}
+          getContextMenuItems={() => menuItems}
+        />
       );
 
       // Open menu
@@ -219,13 +226,13 @@ describe('AdhocTaskItem', () => {
       const onRemove = vi.fn();
       const menuItems = createMenuItems(onRemove);
 
-      render(<AdhocTaskItem {...defaultProps} contextMenuItems={menuItems} />);
+      render(<AdhocTaskItem {...defaultProps} getContextMenuItems={() => menuItems} />);
 
       expect(screen.getByTestId('stage-task-menu-adhoc-1')).toBeInTheDocument();
     });
 
-    it('does not render menu button when contextMenuItems is empty', () => {
-      render(<AdhocTaskItem {...defaultProps} contextMenuItems={[]} />);
+    it('does not render menu button when getContextMenuItems is not provided', () => {
+      render(<AdhocTaskItem {...defaultProps} />);
 
       expect(screen.queryByTestId('stage-task-menu-adhoc-1')).not.toBeInTheDocument();
     });
@@ -235,7 +242,7 @@ describe('AdhocTaskItem', () => {
       const onRemove = vi.fn();
       const menuItems = createMenuItems(onRemove);
 
-      render(<AdhocTaskItem {...defaultProps} contextMenuItems={menuItems} />);
+      render(<AdhocTaskItem {...defaultProps} getContextMenuItems={() => menuItems} />);
 
       const menuButton = screen.getByTestId('stage-task-menu-adhoc-1');
       await user.click(menuButton);
@@ -251,7 +258,7 @@ describe('AdhocTaskItem', () => {
       const onRemove = vi.fn();
       const menuItems = createMenuItems(onRemove);
 
-      render(<AdhocTaskItem {...defaultProps} contextMenuItems={menuItems} />);
+      render(<AdhocTaskItem {...defaultProps} getContextMenuItems={() => menuItems} />);
 
       const menuButton = screen.getByTestId('stage-task-menu-adhoc-1');
       await user.click(menuButton);
@@ -270,7 +277,7 @@ describe('AdhocTaskItem', () => {
       const onRemove = vi.fn();
       const menuItems = createMenuItems(onRemove);
 
-      render(<AdhocTaskItem {...defaultProps} contextMenuItems={menuItems} />);
+      render(<AdhocTaskItem {...defaultProps} getContextMenuItems={() => menuItems} />);
 
       const menuButton = screen.getByTestId('stage-task-menu-adhoc-1');
       await user.click(menuButton);
@@ -284,24 +291,6 @@ describe('AdhocTaskItem', () => {
       await waitFor(() => {
         expect(screen.queryByText('Delete task')).not.toBeInTheDocument();
       });
-    });
-  });
-
-  describe('onMenuOpen callback', () => {
-    it('calls onMenuOpen when menu is opened', async () => {
-      const user = userEvent.setup();
-      const onMenuOpen = vi.fn();
-      const onRemove = vi.fn();
-      const menuItems = createMenuItems(onRemove);
-
-      render(
-        <AdhocTaskItem {...defaultProps} contextMenuItems={menuItems} onMenuOpen={onMenuOpen} />
-      );
-
-      const menuButton = screen.getByTestId('stage-task-menu-adhoc-1');
-      await user.click(menuButton);
-
-      expect(onMenuOpen).toHaveBeenCalled();
     });
   });
 });

--- a/packages/apollo-react/src/canvas/components/StageNode/AdhocTask.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/AdhocTask.tsx
@@ -68,20 +68,18 @@ interface AdhocTaskItemProps {
   task: StageTaskItem;
   taskExecution?: StageTaskExecution;
   isSelected: boolean;
-  contextMenuItems: NodeMenuItem[];
+  getContextMenuItems?: () => NodeMenuItem[];
   onTaskClick: (e: React.MouseEvent, taskId: string) => void;
   onTaskPlay?: (taskId: string) => Promise<void>;
-  onMenuOpen?: () => void;
 }
 
 const AdhocTaskItemComponent = ({
   task,
   taskExecution,
   isSelected,
-  contextMenuItems,
+  getContextMenuItems,
   onTaskClick,
   onTaskPlay,
-  onMenuOpen,
 }: AdhocTaskItemProps) => {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const taskRef = useRef<HTMLDivElement>(null);
@@ -110,17 +108,16 @@ const AdhocTaskItemComponent = ({
       selected={isSelected}
       status={taskExecution?.status}
       onClick={handleClick}
-      {...(contextMenuItems.length > 0 && { onContextMenu: handleContextMenu })}
+      {...(getContextMenuItems && { onContextMenu: handleContextMenu })}
     >
       <TaskContent task={task} taskExecution={taskExecution} />
       {onTaskPlay && <AdhocTaskPlayButton taskId={task.id} onTaskPlay={onTaskPlay} />}
-      {contextMenuItems.length > 0 && (
+      {getContextMenuItems && (
         <TaskMenu
           ref={menuRef}
           taskId={task.id}
-          contextMenuItems={contextMenuItems}
+          getContextMenuItems={getContextMenuItems}
           onMenuOpenChange={handleMenuOpenChange}
-          onMenuOpen={onMenuOpen}
           taskRef={taskRef}
         />
       )}

--- a/packages/apollo-react/src/canvas/components/StageNode/DraggableTask.test.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/DraggableTask.test.tsx
@@ -5,7 +5,11 @@ import type { NodeMenuItem } from '../NodeContextMenu';
 import { DraggableTask } from './DraggableTask';
 import type { DraggableTaskProps } from './DraggableTask.types';
 
-// Mock dnd-kit
+vi.mock('@uipath/apollo-react/canvas/xyflow/react', () => ({
+  useStore: (selector: (state: Record<string, unknown>) => unknown) =>
+    selector({ transform: [0, 0, 1] }),
+}));
+
 vi.mock('@dnd-kit/sortable', () => ({
   useSortable: () => ({
     attributes: {},
@@ -48,51 +52,66 @@ const defaultProps: DraggableTaskProps = {
   taskExecution: undefined,
   isSelected: false,
   isParallel: false,
-  contextMenuItems: [],
+  groupIndex: 0,
+  taskIndex: 0,
   onTaskClick: vi.fn(),
   isDragDisabled: false,
-  zoom: 1,
 };
 
 describe('DraggableTask', () => {
   describe('Menu Button Rendering', () => {
-    it('renders menu button with correct testid when onMenuOpen is provided', () => {
-      const onMenuOpen = vi.fn();
+    it('renders menu button with correct testid when getContextMenuItems is provided', () => {
       const onRemove = vi.fn();
       const menuItems = createMenuItems(onRemove);
 
       render(
-        <DraggableTask {...defaultProps} onMenuOpen={onMenuOpen} contextMenuItems={menuItems} />
+        <DraggableTask
+          {...defaultProps}
+          groupIndex={0}
+          taskIndex={0}
+          getContextMenuItems={() => menuItems}
+        />
       );
 
       const menuButton = screen.getByTestId('stage-task-menu-task-1');
       expect(menuButton).toBeInTheDocument();
     });
 
-    it('renders menu button when contextMenuItems are provided', () => {
+    it('renders menu button when getContextMenuItems are provided', () => {
       const onRemove = vi.fn();
       const menuItems = createMenuItems(onRemove);
 
-      render(<DraggableTask {...defaultProps} contextMenuItems={menuItems} />);
+      render(
+        <DraggableTask
+          {...defaultProps}
+          groupIndex={0}
+          taskIndex={0}
+          getContextMenuItems={() => menuItems}
+        />
+      );
 
       const menuButton = screen.getByTestId('stage-task-menu-task-1');
       expect(menuButton).toBeInTheDocument();
     });
 
-    it('does not render menu button when contextMenuItems is empty and onMenuOpen is not provided', () => {
-      render(<DraggableTask {...defaultProps} contextMenuItems={[]} />);
+    it('does not render menu button when getContextMenuItems is not provided', () => {
+      render(<DraggableTask {...defaultProps} />);
 
       const menuButton = screen.queryByTestId('stage-task-menu-task-1');
       expect(menuButton).not.toBeInTheDocument();
     });
 
     it('renders menu button with icon', () => {
-      const onMenuOpen = vi.fn();
       const onRemove = vi.fn();
       const menuItems = createMenuItems(onRemove);
 
       render(
-        <DraggableTask {...defaultProps} onMenuOpen={onMenuOpen} contextMenuItems={menuItems} />
+        <DraggableTask
+          {...defaultProps}
+          groupIndex={0}
+          taskIndex={0}
+          getContextMenuItems={() => menuItems}
+        />
       );
 
       const menuButton = screen.getByTestId('stage-task-menu-task-1');
@@ -105,12 +124,16 @@ describe('DraggableTask', () => {
   describe('Menu Opening and Closing', () => {
     it('opens menu when button is clicked', async () => {
       const user = userEvent.setup();
-      const onMenuOpen = vi.fn();
       const onRemove = vi.fn();
       const menuItems = createMenuItems(onRemove);
 
       render(
-        <DraggableTask {...defaultProps} onMenuOpen={onMenuOpen} contextMenuItems={menuItems} />
+        <DraggableTask
+          {...defaultProps}
+          groupIndex={0}
+          taskIndex={0}
+          getContextMenuItems={() => menuItems}
+        />
       );
 
       const menuButton = screen.getByTestId('stage-task-menu-task-1');
@@ -125,7 +148,6 @@ describe('DraggableTask', () => {
     it('does not trigger task click when menu button is clicked', async () => {
       const user = userEvent.setup();
       const onTaskClick = vi.fn();
-      const onMenuOpen = vi.fn();
       const onRemove = vi.fn();
       const menuItems = createMenuItems(onRemove);
 
@@ -133,8 +155,9 @@ describe('DraggableTask', () => {
         <DraggableTask
           {...defaultProps}
           onTaskClick={onTaskClick}
-          onMenuOpen={onMenuOpen}
-          contextMenuItems={menuItems}
+          groupIndex={0}
+          taskIndex={0}
+          getContextMenuItems={() => menuItems}
         />
       );
 
@@ -148,7 +171,6 @@ describe('DraggableTask', () => {
     it('prevents task selection when menu is open', async () => {
       const user = userEvent.setup();
       const onTaskClick = vi.fn();
-      const onMenuOpen = vi.fn();
       const onRemove = vi.fn();
       const menuItems = createMenuItems(onRemove);
 
@@ -156,8 +178,9 @@ describe('DraggableTask', () => {
         <DraggableTask
           {...defaultProps}
           onTaskClick={onTaskClick}
-          onMenuOpen={onMenuOpen}
-          contextMenuItems={menuItems}
+          groupIndex={0}
+          taskIndex={0}
+          getContextMenuItems={() => menuItems}
         />
       );
 
@@ -176,49 +199,21 @@ describe('DraggableTask', () => {
       // Task click should still not be called (menu is open)
       expect(onTaskClick).not.toHaveBeenCalled();
     });
+  });
 
-    it('prevents task selection when menu is open', async () => {
+  describe('Menu Item Interaction', () => {
+    it('triggers menu item onClick when menu item is clicked', async () => {
       const user = userEvent.setup();
-      const onTaskClick = vi.fn();
-      const onMenuOpen = vi.fn();
       const onRemove = vi.fn();
       const menuItems = createMenuItems(onRemove);
 
       render(
         <DraggableTask
           {...defaultProps}
-          onTaskClick={onTaskClick}
-          onMenuOpen={onMenuOpen}
-          contextMenuItems={menuItems}
+          groupIndex={0}
+          taskIndex={0}
+          getContextMenuItems={() => menuItems}
         />
-      );
-
-      // Open menu first
-      const menuButton = screen.getByTestId('stage-task-menu-task-1');
-      await user.click(menuButton);
-
-      await waitFor(() => {
-        expect(screen.getByText('Move Up')).toBeInTheDocument();
-      });
-
-      // Try to click on task while menu is open
-      const task = screen.getByTestId('stage-task-task-1');
-      await user.click(task);
-
-      // Task click should not be called (menu is open)
-      expect(onTaskClick).not.toHaveBeenCalled();
-    });
-  });
-
-  describe('Menu Item Interaction', () => {
-    it('triggers menu item onClick when menu item is clicked', async () => {
-      const user = userEvent.setup();
-      const onMenuOpen = vi.fn();
-      const onRemove = vi.fn();
-      const menuItems = createMenuItems(onRemove);
-
-      render(
-        <DraggableTask {...defaultProps} onMenuOpen={onMenuOpen} contextMenuItems={menuItems} />
       );
 
       // Open menu
@@ -239,12 +234,16 @@ describe('DraggableTask', () => {
 
     it('closes menu after menu item is clicked', async () => {
       const user = userEvent.setup();
-      const onMenuOpen = vi.fn();
       const onRemove = vi.fn();
       const menuItems = createMenuItems(onRemove);
 
       render(
-        <DraggableTask {...defaultProps} onMenuOpen={onMenuOpen} contextMenuItems={menuItems} />
+        <DraggableTask
+          {...defaultProps}
+          groupIndex={0}
+          taskIndex={0}
+          getContextMenuItems={() => menuItems}
+        />
       );
 
       // Open menu
@@ -267,12 +266,16 @@ describe('DraggableTask', () => {
 
     it('includes divider in menu items', async () => {
       const user = userEvent.setup();
-      const onMenuOpen = vi.fn();
       const onRemove = vi.fn();
       const menuItems = createMenuItems(onRemove);
 
       render(
-        <DraggableTask {...defaultProps} onMenuOpen={onMenuOpen} contextMenuItems={menuItems} />
+        <DraggableTask
+          {...defaultProps}
+          groupIndex={0}
+          taskIndex={0}
+          getContextMenuItems={() => menuItems}
+        />
       );
 
       // Open menu
@@ -306,7 +309,6 @@ describe('DraggableTask', () => {
     it('allows task click after menu is closed', async () => {
       const user = userEvent.setup();
       const onTaskClick = vi.fn();
-      const onMenuOpen = vi.fn();
       const onRemove = vi.fn();
       const menuItems = createMenuItems(onRemove);
 
@@ -314,8 +316,9 @@ describe('DraggableTask', () => {
         <DraggableTask
           {...defaultProps}
           onTaskClick={onTaskClick}
-          onMenuOpen={onMenuOpen}
-          contextMenuItems={menuItems}
+          groupIndex={0}
+          taskIndex={0}
+          getContextMenuItems={() => menuItems}
         />
       );
 

--- a/packages/apollo-react/src/canvas/components/StageNode/DraggableTask.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/DraggableTask.tsx
@@ -2,6 +2,7 @@ import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import { FontVariantToken, Padding, Spacing } from '@uipath/apollo-core';
 import { Column, Row } from '@uipath/apollo-react/canvas/layouts';
+import { useStore } from '@uipath/apollo-react/canvas/xyflow/react';
 import {
   ApBadge,
   ApIconButton,
@@ -124,14 +125,15 @@ const DraggableTaskComponent = ({
   taskExecution,
   isSelected,
   isParallel,
-  contextMenuItems,
+  groupIndex,
+  taskIndex,
+  getContextMenuItems,
   onTaskClick,
-  onMenuOpen,
   isDragDisabled,
   projectedDepth,
-  zoom = 1,
 }: DraggableTaskProps) => {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const zoom = useStore((s) => s.transform[2]);
   const taskRef = useRef<HTMLDivElement>(null);
   const menuRef = useRef<TaskMenuHandle>(null);
 
@@ -153,6 +155,13 @@ const DraggableTaskComponent = ({
   const handleContextMenu = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
     menuRef.current?.handleContextMenu(e);
   }, []);
+
+  const handleGetContextMenuItems = useCallback(() => {
+    if (!getContextMenuItems) {
+      return [];
+    }
+    return getContextMenuItems(groupIndex, taskIndex);
+  }, [getContextMenuItems, groupIndex, taskIndex]);
 
   const { attributes, listeners, setNodeRef, transition, transform, isDragging } = useSortable({
     id: task.id,
@@ -199,7 +208,7 @@ const DraggableTaskComponent = ({
       isParallel={isParallel}
       isDragEnabled={!isDragDisabled}
       onClick={handleClick}
-      {...(contextMenuItems.length > 0 && { onContextMenu: handleContextMenu })}
+      {...(getContextMenuItems && { onContextMenu: handleContextMenu })}
     >
       <TaskContent task={task} taskExecution={taskExecution} />
 
@@ -217,13 +226,12 @@ const DraggableTaskComponent = ({
           </span>
         </ApTooltip>
       )}
-      {contextMenuItems.length > 0 && (
+      {getContextMenuItems && (
         <TaskMenu
           ref={menuRef}
           taskId={task.id}
-          contextMenuItems={contextMenuItems}
+          getContextMenuItems={handleGetContextMenuItems}
           onMenuOpenChange={handleMenuOpenChange}
-          onMenuOpen={onMenuOpen}
           taskRef={taskRef}
         />
       )}

--- a/packages/apollo-react/src/canvas/components/StageNode/DraggableTask.types.ts
+++ b/packages/apollo-react/src/canvas/components/StageNode/DraggableTask.types.ts
@@ -12,11 +12,11 @@ export interface DraggableTaskProps {
   taskExecution?: StageTaskExecution;
   isSelected: boolean;
   isParallel: boolean;
-  contextMenuItems: NodeMenuItem[];
+  groupIndex: number;
+  taskIndex: number;
+  getContextMenuItems?: (groupIndex: number, taskIndex: number) => NodeMenuItem[];
   onTaskClick: (e: React.MouseEvent, taskId: string) => void;
-  onMenuOpen?: () => void;
   onTaskPlay?: (taskId: string) => Promise<void>;
   isDragDisabled?: boolean;
   projectedDepth?: number;
-  zoom?: number;
 }

--- a/packages/apollo-react/src/canvas/components/StageNode/StageEdge.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageEdge.tsx
@@ -1,10 +1,11 @@
 import styled from '@emotion/styled';
-import type { EdgeProps } from '@uipath/apollo-react/canvas/xyflow/react';
+import type { EdgeProps, ReactFlowState } from '@uipath/apollo-react/canvas/xyflow/react';
 import {
   EdgeLabelRenderer,
   getSmoothStepPath,
-  useInternalNode,
+  useStore,
 } from '@uipath/apollo-react/canvas/xyflow/react';
+import { memo } from 'react';
 
 export const StageEdgeLabel = styled.div`
   position: absolute;
@@ -30,6 +31,26 @@ type Props = EdgeProps & {
   arrowSize?: number;
 };
 
+interface StageEdgeGeometry {
+  sourceX: number;
+  sourceY: number;
+  targetX: number;
+  targetY: number;
+}
+
+interface StageEdgeInnerProps extends Omit<Props, 'sourceX' | 'sourceY' | 'targetX' | 'targetY'> {
+  geometry: StageEdgeGeometry;
+}
+
+function stageEdgeGeometryEquality(previous: StageEdgeGeometry, next: StageEdgeGeometry): boolean {
+  return (
+    previous.sourceX === next.sourceX &&
+    previous.sourceY === next.sourceY &&
+    previous.targetX === next.targetX &&
+    previous.targetY === next.targetY
+  );
+}
+
 function getArrowFromBezier(path: string, arrowSize: number) {
   const pathEl = document.createElementNS('http://www.w3.org/2000/svg', 'path');
   pathEl.setAttribute('d', path);
@@ -46,11 +67,8 @@ function getArrowFromBezier(path: string, arrowSize: number) {
   };
 }
 
-export function StageEdge({
-  sourceX,
-  sourceY,
-  targetX,
-  targetY,
+function StageEdgeInner({
+  geometry,
   sourcePosition,
   targetPosition,
   selected,
@@ -59,22 +77,13 @@ export function StageEdge({
   strokeWidth = 2,
   arrowSize = 8,
   ...rest
-}: Props) {
-  const sourceNode = useInternalNode(rest.source);
-  const targetNode = useInternalNode(rest.target);
-
-  const sourceNodeX = sourceNode
-    ? sourceNode.position.x + (sourceNode.measured?.width ?? 0)
-    : sourceX;
-  const sourceNodeY = sourceNode?.position.y ? sourceNode.position.y + 32 : sourceY;
-  const targetNodeX = targetNode?.position.x ?? targetX;
-  const targetNodeY = targetNode?.position.y ? targetNode.position.y + 32 : targetY;
+}: StageEdgeInnerProps) {
   const [pathData, labelX, labelY, _ex, _ey] = getSmoothStepPath({
-    sourceX: sourceNodeX,
-    sourceY: sourceNodeY,
+    sourceX: geometry.sourceX,
+    sourceY: geometry.sourceY,
     sourcePosition,
-    targetX: targetNodeX - 1,
-    targetY: targetNodeY,
+    targetX: geometry.targetX - 1,
+    targetY: geometry.targetY,
     targetPosition,
     borderRadius: 40,
   });
@@ -141,3 +150,48 @@ export function StageEdge({
     </>
   );
 }
+
+const StageEdgeInnerMemo = memo(StageEdgeInner);
+
+function StageEdgeComponent({
+  sourceX,
+  sourceY,
+  targetX,
+  targetY,
+  sourcePosition,
+  targetPosition,
+  selected,
+  style,
+  stroke,
+  strokeWidth,
+  arrowSize,
+  ...rest
+}: Props) {
+  const geometry = useStore((state: ReactFlowState): StageEdgeGeometry => {
+    const sourceNode = state.nodeLookup.get(rest.source);
+    const targetNode = state.nodeLookup.get(rest.target);
+
+    return {
+      sourceX: sourceNode ? sourceNode.position.x + (sourceNode.measured?.width ?? 0) : sourceX,
+      sourceY: sourceNode ? sourceNode.position.y + 32 : sourceY,
+      targetX: targetNode?.position.x ?? targetX,
+      targetY: targetNode ? targetNode.position.y + 32 : targetY,
+    };
+  }, stageEdgeGeometryEquality);
+
+  return (
+    <StageEdgeInnerMemo
+      geometry={geometry}
+      sourcePosition={sourcePosition}
+      targetPosition={targetPosition}
+      selected={selected}
+      style={style}
+      stroke={stroke}
+      strokeWidth={strokeWidth}
+      arrowSize={arrowSize}
+      {...rest}
+    />
+  );
+}
+
+export const StageEdge = memo(StageEdgeComponent);

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import type { Connection, Edge } from '@uipath/apollo-react/canvas/xyflow/react';
+import type { Connection, Edge, Node } from '@uipath/apollo-react/canvas/xyflow/react';
 import {
   addEdge,
   ConnectionMode,
@@ -24,7 +24,55 @@ import type { ListItem } from '../Toolbox';
 import { StageConnectionEdge } from './StageConnectionEdge';
 import { StageEdge } from './StageEdge';
 import { StageNode } from './StageNode';
+import { StageNodeWrapper } from './StageNode.stories.utils';
 import { StageHeaderChipType, type StageNodeProps, type StageTaskItem } from './StageNode.types';
+
+const DefaultCanvasDecorator = ({
+  initialNodes,
+  initialEdges = [],
+}: {
+  initialNodes: Node[];
+  initialEdges?: Edge[];
+}) => {
+  const [nodes, _setNodes, onNodesChange] = useNodesState(initialNodes);
+  const [edges, setEdges, onEdgesChange] = useEdgesState(initialEdges);
+
+  const onConnect = useCallback(
+    (connection: Connection) => {
+      setEdges((eds) => addEdge(connection, eds));
+    },
+    [setEdges]
+  );
+
+  const nodeTypes = useMemo(() => ({ stage: StageNodeWrapper }), []);
+  const edgeTypes = useMemo(() => ({ stage: StageEdge }), []);
+  const defaultEdgeOptions = useMemo(() => ({ type: 'stage' }), []);
+
+  return (
+    <div style={{ width: '100vw', height: '100vh' }}>
+      <ReactFlowProvider>
+        <BaseCanvas
+          nodes={nodes}
+          edges={edges}
+          onNodesChange={onNodesChange}
+          onEdgesChange={onEdgesChange}
+          onConnect={onConnect}
+          nodeTypes={nodeTypes}
+          edgeTypes={edgeTypes}
+          mode="design"
+          connectionMode={ConnectionMode.Strict}
+          defaultEdgeOptions={defaultEdgeOptions}
+          connectionLineComponent={StageConnectionEdge}
+          elevateEdgesOnSelect
+        >
+          <Panel position="bottom-right">
+            <CanvasPositionControls translations={DefaultCanvasTranslations} />
+          </Panel>
+        </BaseCanvas>
+      </ReactFlowProvider>
+    </div>
+  );
+};
 
 const meta: Meta<typeof StageNode> = {
   title: 'Canvas/StageNode',
@@ -34,16 +82,9 @@ const meta: Meta<typeof StageNode> = {
   },
   decorators: [
     (Story, context) => {
-      // Allow stories to use custom render
       if (context.parameters?.useCustomRender) {
         return <Story />;
       }
-
-      // Create a wrapper component that passes props correctly
-      const StageNodeWrapper = (props: any) => {
-        // React Flow passes node data in props.data, so we need to spread it
-        return <StageNode {...props} {...props.data} />;
-      };
 
       const initialNodes = context.parameters?.nodes || [
         {
@@ -63,44 +104,7 @@ const meta: Meta<typeof StageNode> = {
 
       const initialEdges = context.parameters?.edges || [];
 
-      const [nodes, _setNodes, onNodesChange] = useNodesState(initialNodes);
-      const [edges, setEdges, onEdgesChange] = useEdgesState(initialEdges);
-
-      const onConnect = useCallback(
-        (connection: Connection) => {
-          setEdges((eds) => addEdge(connection, eds));
-        },
-        [setEdges]
-      );
-
-      const nodeTypes = useMemo(() => ({ stage: StageNodeWrapper }), [StageNodeWrapper]);
-      const edgeTypes = useMemo(() => ({ stage: StageEdge }), []);
-      const defaultEdgeOptions = useMemo(() => ({ type: 'stage' }), []);
-
-      return (
-        <div style={{ width: '100vw', height: '100vh' }}>
-          <ReactFlowProvider>
-            <BaseCanvas
-              nodes={nodes}
-              edges={edges}
-              onNodesChange={onNodesChange}
-              onEdgesChange={onEdgesChange}
-              onConnect={onConnect}
-              nodeTypes={nodeTypes}
-              edgeTypes={edgeTypes}
-              mode="design"
-              connectionMode={ConnectionMode.Strict}
-              defaultEdgeOptions={defaultEdgeOptions}
-              connectionLineComponent={StageConnectionEdge}
-              elevateEdgesOnSelect
-            >
-              <Panel position="bottom-right">
-                <CanvasPositionControls translations={DefaultCanvasTranslations} />
-              </Panel>
-            </BaseCanvas>
-          </ReactFlowProvider>
-        </div>
-      );
+      return <DefaultCanvasDecorator initialNodes={initialNodes} initialEdges={initialEdges} />;
     },
   ],
   args: {
@@ -140,7 +144,7 @@ const VerificationIcon = () => (
 
 const DocumentIcon = () => (
   <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
-    <path d="M14 2H6C4.9 2 4 2.9 4 4V20C20 21.1 4.9 22 6 22H18C19.1 22 20 21.1 20 20V8L14 2Z" />
+    <path d="M14 2H6C4.9 2 4 2.9 4 4V20C4 21.1 4.9 22 6 22H18C19.1 22 20 21.1 20 20V8L14 2Z" />
     <path d="M14 2V8H20" />
     <path d="M8 12H16" />
     <path d="M8 16H16" />
@@ -870,15 +874,7 @@ const initialTasks: StageTaskItem[][] = [
 ];
 
 const DraggableTaskReorderingStory = () => {
-  const StageNodeWrapper = useMemo(
-    () =>
-      function StageNodeWrapperComponent(props: any) {
-        return <StageNode {...props} {...props.data} />;
-      },
-    []
-  );
-
-  const nodeTypes = useMemo(() => ({ stage: StageNodeWrapper }), [StageNodeWrapper]);
+  const nodeTypes = useMemo(() => ({ stage: StageNodeWrapper }), []);
   const edgeTypes = useMemo(() => ({ stage: StageEdge }), []);
 
   const [nodes, setNodes, onNodesChange] = useNodesState([
@@ -1013,15 +1009,7 @@ const availableTaskOptions: ListItem[] = [
 ];
 
 const AddAndReplaceTasksStory = () => {
-  const StageNodeWrapper = useMemo(
-    () =>
-      function StageNodeWrapperComponent(props: any) {
-        return <StageNode {...props} {...props.data} />;
-      },
-    []
-  );
-
-  const nodeTypes = useMemo(() => ({ stage: StageNodeWrapper }), [StageNodeWrapper]);
+  const nodeTypes = useMemo(() => ({ stage: StageNodeWrapper }), []);
   const edgeTypes = useMemo(() => ({ stage: StageEdge }), []);
 
   const [pendingReplaceTask, setPendingReplaceTask] = useState(false);
@@ -1319,22 +1307,38 @@ export const AddAndReplaceTasks: Story = {
 };
 
 const InlineTitleEditStory = () => {
-  const StageNodeWrapper = useMemo(
-    () =>
-      function StageNodeWrapperComponent(props: any) {
-        return <StageNode {...props} {...props.data} />;
-      },
+  const nodeTypes = useMemo(() => ({ stage: StageNodeWrapper }), []);
+  const edgeTypes = useMemo(() => ({ stage: StageEdge }), []);
+
+  const setNodesRef = useRef<React.Dispatch<React.SetStateAction<Node[]>>>(null!);
+
+  const createTitleChangeHandler = useCallback(
+    (nodeId: string) => (newTitle: string) => {
+      setNodesRef.current((nds) =>
+        nds.map((node) =>
+          node.id === nodeId
+            ? {
+                ...node,
+                data: {
+                  ...node.data,
+                  stageDetails: {
+                    ...(node.data.stageDetails as Record<string, unknown>),
+                    label: newTitle,
+                  },
+                },
+              }
+            : node
+        )
+      );
+    },
     []
   );
 
-  const nodeTypes = useMemo(() => ({ stage: StageNodeWrapper }), [StageNodeWrapper]);
-  const edgeTypes = useMemo(() => ({ stage: StageEdge }), []);
-
-  const initialNodes = useMemo(
+  const initialNodes: Node[] = useMemo(
     () => [
       {
         id: 'editable-stage',
-        type: 'stage' as const,
+        type: 'stage',
         position: { x: 48, y: 96 },
         width: 304,
         data: {
@@ -1348,11 +1352,12 @@ const InlineTitleEditStory = () => {
           onTaskAdd: () => {
             window.alert('Add task functionality - this would open a dialog to add a new task');
           },
+          onStageTitleChange: createTitleChangeHandler('editable-stage'),
         },
       },
       {
         id: 'long-title-stage',
-        type: 'stage' as const,
+        type: 'stage',
         position: { x: 400, y: 96 },
         width: 304,
         data: {
@@ -1363,49 +1368,17 @@ const InlineTitleEditStory = () => {
           onTaskAdd: () => {
             window.alert('Add task functionality - this would open a dialog to add a new task');
           },
+          onStageTitleChange: createTitleChangeHandler('long-title-stage'),
         },
       },
     ],
-    []
+    [createTitleChangeHandler]
   );
 
   const [nodes, setNodes, onNodesChange] = useNodesState(initialNodes);
+  setNodesRef.current = setNodes;
 
   const [edges, setEdges, onEdgesChange] = useEdgesState([]);
-
-  const createTitleChangeHandler = useCallback(
-    (nodeId: string) => (newTitle: string) => {
-      setNodes((nds) =>
-        nds.map((node) =>
-          node.id === nodeId
-            ? {
-                ...node,
-                data: {
-                  ...node.data,
-                  stageDetails: {
-                    ...node.data.stageDetails,
-                    label: newTitle,
-                  },
-                },
-              }
-            : node
-        )
-      );
-    },
-    [setNodes]
-  );
-
-  const nodesWithHandlers = useMemo(
-    () =>
-      nodes.map((node) => ({
-        ...node,
-        data: {
-          ...node.data,
-          onStageTitleChange: createTitleChangeHandler(node.id),
-        },
-      })),
-    [nodes, createTitleChangeHandler]
-  );
 
   const onConnect = useCallback(
     (connection: Connection) => setEdges((eds) => addEdge(connection, eds)),
@@ -1416,7 +1389,7 @@ const InlineTitleEditStory = () => {
     <div style={{ width: '100vw', height: '100vh' }}>
       <ReactFlowProvider>
         <BaseCanvas
-          nodes={nodesWithHandlers}
+          nodes={nodes}
           edges={edges}
           onNodesChange={onNodesChange}
           onEdgesChange={onEdgesChange}
@@ -1473,18 +1446,28 @@ const loadedTaskOptionsWithChildren: ListItem[] = [
 ];
 
 const AddTaskLoadingStory = () => {
-  const StageNodeWrapper = useMemo(
-    () =>
-      function StageNodeWrapperComponent(props: any) {
-        return <StageNode {...props} {...props.data} />;
-      },
-    []
-  );
-
-  const nodeTypes = useMemo(() => ({ stage: StageNodeWrapper }), [StageNodeWrapper]);
+  const nodeTypes = useMemo(() => ({ stage: StageNodeWrapper }), []);
   const edgeTypes = useMemo(() => ({ stage: StageEdge }), []);
+  const setNodesRef = useRef<React.Dispatch<React.SetStateAction<Node[]>>>(null!);
 
-  const initialNodes = useMemo(
+  // Inject per-node handlers — simulates loading state on add-task:
+  // 1. Set addTaskLoading=true so the + button is disabled
+  // 2. After 2s, set addTaskLoading=false to re-enable it
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+
+  const handleAddTaskFromToolbox = useCallback((nodeId: string, _taskItem: ListItem) => {
+    clearTimeout(timeoutRef.current);
+    setNodesRef.current((nds) =>
+      nds.map((n) => (n.id === nodeId ? { ...n, data: { ...n.data, addTaskLoading: true } } : n))
+    );
+    timeoutRef.current = setTimeout(() => {
+      setNodesRef.current((nds) =>
+        nds.map((n) => (n.id === nodeId ? { ...n, data: { ...n.data, addTaskLoading: false } } : n))
+      );
+    }, 2000);
+  }, []);
+
+  const initialNodes: Node[] = useMemo(
     () => [
       {
         id: 'loading-stage-empty',
@@ -1496,9 +1479,11 @@ const AddTaskLoadingStory = () => {
             label: 'Loading (+ disabled for 3s)',
             tasks: [],
           },
-          // Top-level loading: + button disabled until API returns items
           addTaskLoading: true,
           taskOptions: [] as ListItem[],
+          onAddTaskFromToolbox: (taskItem: ListItem) => {
+            handleAddTaskFromToolbox('loading-stage-empty', taskItem);
+          },
         },
       },
       {
@@ -1511,16 +1496,19 @@ const AddTaskLoadingStory = () => {
             label: 'Async children (click +)',
             tasks: [[{ id: 'task-1', label: 'Existing Task', icon: <VerificationIcon /> }]],
           },
-          // Children loading: items already available, level 2 loads on click
           addTaskLoading: false,
           taskOptions: loadedTaskOptionsWithChildren,
+          onAddTaskFromToolbox: (taskItem: ListItem) => {
+            handleAddTaskFromToolbox('loading-stage-children', taskItem);
+          },
         },
       },
     ],
-    []
+    [handleAddTaskFromToolbox]
   );
 
-  const [nodesState, setNodes, onNodesChange] = useNodesState(initialNodes);
+  const [nodes, setNodes, onNodesChange] = useNodesState(initialNodes);
+  setNodesRef.current = setNodes;
   const [edges, setEdges, onEdgesChange] = useEdgesState([]);
 
   // Simulate top-level API loading — after 3 seconds, items become available
@@ -1544,45 +1532,9 @@ const AddTaskLoadingStory = () => {
     return () => clearTimeout(timeout);
   }, [setNodes]);
 
-  // Inject per-node handlers — simulates loading state on add-task:
-  // 1. Set addTaskLoading=true so the + button is disabled
-  // 2. After 2s, set addTaskLoading=false to re-enable it
-  const timeoutRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
-
   useEffect(() => {
     return () => clearTimeout(timeoutRef.current);
   }, []);
-
-  const handleAddTaskFromToolbox = useCallback(
-    (nodeId: string, _taskItem: ListItem) => {
-      clearTimeout(timeoutRef.current);
-      setNodes((nds) =>
-        nds.map((n) => (n.id === nodeId ? { ...n, data: { ...n.data, addTaskLoading: true } } : n))
-      );
-      timeoutRef.current = setTimeout(() => {
-        setNodes((nds) =>
-          nds.map((n) =>
-            n.id === nodeId ? { ...n, data: { ...n.data, addTaskLoading: false } } : n
-          )
-        );
-      }, 2000);
-    },
-    [setNodes]
-  );
-
-  const nodesWithHandler = useMemo(
-    () =>
-      nodesState.map((node) => ({
-        ...node,
-        data: {
-          ...node.data,
-          onAddTaskFromToolbox: (taskItem: ListItem) => {
-            handleAddTaskFromToolbox(node.id, taskItem);
-          },
-        },
-      })),
-    [nodesState, handleAddTaskFromToolbox]
-  );
 
   const onConnect = useCallback(
     (connection: Connection) => setEdges((eds) => addEdge(connection, eds)),
@@ -1593,7 +1545,7 @@ const AddTaskLoadingStory = () => {
     <div style={{ width: '100vw', height: '100vh' }}>
       <ReactFlowProvider>
         <BaseCanvas
-          nodes={nodesWithHandler}
+          nodes={nodes}
           edges={edges}
           onNodesChange={onNodesChange}
           onEdgesChange={onEdgesChange}

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.stories.tsx
@@ -74,9 +74,9 @@ const DefaultCanvasDecorator = ({
   );
 };
 
-const meta: Meta<typeof StageNode> = {
+const meta: Meta<StageNodeProps> = {
   title: 'Canvas/StageNode',
-  component: StageNode as any,
+  component: StageNode,
   parameters: {
     layout: 'fullscreen',
   },
@@ -120,7 +120,7 @@ const meta: Meta<typeof StageNode> = {
       defaultValue: 'Add process',
     },
   },
-} satisfies Meta<StageNodeProps>;
+};
 
 export default meta;
 type Story = StoryObj<typeof meta>;
@@ -282,7 +282,6 @@ export const Default: Story = {
       },
     ],
   },
-  args: {},
 };
 
 export const WithTaskIcons: Story = {
@@ -354,7 +353,6 @@ export const WithTaskIcons: Story = {
       },
     ],
   },
-  args: {},
 };
 
 export const ExecutionStatus: Story = {
@@ -562,7 +560,6 @@ export const ExecutionStatus: Story = {
       },
     ] as Edge[],
   },
-  args: {},
 };
 
 export const InteractiveTaskManagement: Story = {
@@ -691,7 +688,6 @@ export const InteractiveTaskManagement: Story = {
       },
     ],
   },
-  args: {},
 };
 
 export const LoanProcessingWorkflow: Story = {
@@ -857,7 +853,6 @@ export const LoanProcessingWorkflow: Story = {
       },
     ] as Edge[],
   },
-  args: {} as any, // No args needed as we're using parameters
 };
 
 const initialTasks: StageTaskItem[][] = [
@@ -966,7 +961,6 @@ export const DraggableTaskReordering: Story = {
     useCustomRender: true,
   },
   render: () => <DraggableTaskReorderingStory />,
-  args: {},
 };
 
 const initialTasksForAddReplace: StageTaskItem[][] = [
@@ -1303,7 +1297,6 @@ export const AddAndReplaceTasks: Story = {
     useCustomRender: true,
   },
   render: () => <AddAndReplaceTasksStory />,
-  args: {},
 };
 
 const InlineTitleEditStory = () => {
@@ -1418,7 +1411,6 @@ export const EditableStageTitle: Story = {
     useCustomRender: true,
   },
   render: () => <InlineTitleEditStory />,
-  args: {},
 };
 
 // Simulate async children fetch (2s delay)
@@ -1574,7 +1566,6 @@ export const AddTaskLoading: Story = {
     useCustomRender: true,
   },
   render: () => <AddTaskLoadingStory />,
-  args: {},
 };
 
 export const AdhocTasks: Story = {
@@ -1703,7 +1694,6 @@ export const AdhocTasks: Story = {
       },
     ],
   },
-  args: {},
 };
 
 export const WithRulesTags: Story = {
@@ -1931,5 +1921,4 @@ export const WithRulesTags: Story = {
       },
     ],
   },
-  args: {},
 };

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.stories.utils.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.stories.utils.tsx
@@ -1,8 +1,14 @@
 import type { NodeProps } from '@uipath/apollo-react/canvas/xyflow/react';
 import { memo } from 'react';
 import { StageNode } from './StageNode';
-import type { StageNodeProps } from './StageNode.types';
+import type { StageNodeBaseProps } from './StageNode.types';
 
-export const StageNodeWrapper = memo((props: NodeProps) => {
-  return <StageNode {...(props as StageNodeProps)} {...props.data} />;
-});
+type StageNodeWrapperProps = Omit<NodeProps, 'data'> & {
+  data: StageNodeBaseProps;
+};
+
+export const StageNodeWrapper = memo(
+  ({ id, selected, dragging, width, data }: StageNodeWrapperProps) => {
+    return <StageNode id={id} selected={selected} dragging={dragging} width={width} {...data} />;
+  }
+);

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.stories.utils.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.stories.utils.tsx
@@ -1,0 +1,8 @@
+import type { NodeProps } from '@uipath/apollo-react/canvas/xyflow/react';
+import { memo } from 'react';
+import { StageNode } from './StageNode';
+import type { StageNodeProps } from './StageNode.types';
+
+export const StageNodeWrapper = memo((props: NodeProps) => {
+  return <StageNode {...(props as StageNodeProps)} {...props.data} />;
+});

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.test.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.test.tsx
@@ -211,7 +211,7 @@ const defaultProps = {
     { id: 'option-1', name: 'Option 1', data: {} },
     { id: 'option-2', name: 'Option 2', data: {} },
   ],
-} as StageNodeProps & { width?: number };
+} as StageNodeProps;
 
 const renderStageNode = (props: Partial<StageNodeProps> = {}) => {
   return render(

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.test.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.test.tsx
@@ -731,7 +731,8 @@ describe('StageNode - Add Task Loading State', () => {
 });
 
 describe('StageNode - hideParallelOptions', () => {
-  it('should show parallel options when hideParallelOptions is not set', () => {
+  it('should show parallel options when hideParallelOptions is not set', async () => {
+    const user = userEvent.setup();
     const onTaskGroupModification = vi.fn();
     const tasks: StageTaskItem[][] = [
       [createTask('task-1', 'Task 1')],
@@ -743,6 +744,8 @@ describe('StageNode - hideParallelOptions', () => {
       onTaskGroupModification,
       stageDetails: { ...defaultProps.stageDetails, tasks },
     });
+
+    await user.click(screen.getByTestId('task-menu-button-task-2'));
 
     const menuItems = screen.getByTestId('task-menu-items-task-2');
     expect(menuItems.querySelector('[data-testid="menu-item-task-2-move-up"]')).toBeInTheDocument();
@@ -760,7 +763,8 @@ describe('StageNode - hideParallelOptions', () => {
     ).toBeInTheDocument();
   });
 
-  it('should hide parallel options but keep move and delete when hideParallelOptions is true', () => {
+  it('should hide parallel options but keep move and delete when hideParallelOptions is true', async () => {
+    const user = userEvent.setup();
     const onTaskGroupModification = vi.fn();
     const tasks: StageTaskItem[][] = [
       [createTask('task-1', 'Task 1')],
@@ -774,6 +778,8 @@ describe('StageNode - hideParallelOptions', () => {
       stageDetails: { ...defaultProps.stageDetails, tasks },
     });
 
+    await user.click(screen.getByTestId('task-menu-button-task-2'));
+
     const menuItems = screen.getByTestId('task-menu-items-task-2');
     expect(menuItems.querySelector('[data-testid="menu-item-task-2-move-up"]')).toBeInTheDocument();
     expect(
@@ -790,7 +796,8 @@ describe('StageNode - hideParallelOptions', () => {
     ).not.toBeInTheDocument();
   });
 
-  it('should hide ungroup/split options for parallel groups when hideParallelOptions is true', () => {
+  it('should hide ungroup/split options for parallel groups when hideParallelOptions is true', async () => {
+    const user = userEvent.setup();
     const onTaskGroupModification = vi.fn();
     const tasks: StageTaskItem[][] = [
       [createTask('task-1', 'Task 1'), createTask('task-2', 'Task 2')], // parallel group
@@ -802,6 +809,8 @@ describe('StageNode - hideParallelOptions', () => {
       hideParallelOptions: true,
       stageDetails: { ...defaultProps.stageDetails, tasks },
     });
+
+    await user.click(screen.getByTestId('task-menu-button-task-1'));
 
     const menuItems = screen.getByTestId('task-menu-items-task-1');
     expect(
@@ -818,7 +827,8 @@ describe('StageNode - hideParallelOptions', () => {
     ).not.toBeInTheDocument();
   });
 
-  it('should show only delete for a single task when hideParallelOptions is true', () => {
+  it('should show only delete for a single task when hideParallelOptions is true', async () => {
+    const user = userEvent.setup();
     const onTaskGroupModification = vi.fn();
     const tasks: StageTaskItem[][] = [[createTask('task-1', 'Task 1')]];
 
@@ -827,6 +837,8 @@ describe('StageNode - hideParallelOptions', () => {
       hideParallelOptions: true,
       stageDetails: { ...defaultProps.stageDetails, tasks },
     });
+
+    await user.click(screen.getByTestId('task-menu-button-task-1'));
 
     const menuItems = screen.getByTestId('task-menu-items-task-1');
     const buttons = menuItems.querySelectorAll('button');

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.test.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { ReactFlowProvider } from '@uipath/apollo-react/canvas/xyflow/react';
+import React from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ListItem } from '../Toolbox';
 import { StageNode } from './StageNode';
@@ -108,36 +109,54 @@ vi.mock('../Toolbox', () => ({
 vi.mock('./DraggableTask', () => ({
   DraggableTask: ({
     task,
-    onMenuOpen,
-    contextMenuItems,
+    groupIndex,
+    taskIndex,
+    getContextMenuItems,
   }: {
     task: StageTaskItem;
-    onMenuOpen?: () => void;
-    contextMenuItems?: Array<{ id: string; label: string; onClick: () => void }>;
-  }) => (
-    <div data-testid={`draggable-task-${task.id}`}>
-      <div data-testid={`task-label-${task.id}`}>{task.label}</div>
-      {onMenuOpen && (
-        <button type="button" data-testid={`task-menu-button-${task.id}`} onClick={onMenuOpen}>
-          Open Menu
-        </button>
-      )}
-      {contextMenuItems && (
-        <div data-testid={`task-menu-items-${task.id}`}>
-          {contextMenuItems.map((item, index) => (
-            <button
-              key={item.id || index}
-              type="button"
-              data-testid={`menu-item-${task.id}-${item.id || index}`}
-              onClick={item.onClick}
-            >
-              {item.label}
-            </button>
-          ))}
-        </div>
-      )}
-    </div>
-  ),
+    groupIndex?: number;
+    taskIndex?: number;
+    getContextMenuItems?: (
+      groupIndex: number,
+      taskIndex: number
+    ) => Array<{ id?: string; label?: string; onClick?: () => void }>;
+  }) => {
+    const [menuItems, setMenuItems] = React.useState<
+      Array<{ id?: string; label?: string; onClick?: () => void }>
+    >([]);
+    return (
+      <div data-testid={`draggable-task-${task.id}`}>
+        <div data-testid={`task-label-${task.id}`}>{task.label}</div>
+        {getContextMenuItems && (
+          <button
+            type="button"
+            data-testid={`task-menu-button-${task.id}`}
+            onClick={() => {
+              if (groupIndex !== undefined && taskIndex !== undefined) {
+                setMenuItems(getContextMenuItems(groupIndex, taskIndex));
+              }
+            }}
+          >
+            Open Menu
+          </button>
+        )}
+        {menuItems.length > 0 && (
+          <div data-testid={`task-menu-items-${task.id}`}>
+            {menuItems.map((item, index) => (
+              <button
+                key={item.id || index}
+                type="button"
+                data-testid={`menu-item-${task.id}-${item.id || index}`}
+                onClick={item.onClick}
+              >
+                {item.label}
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+    );
+  },
   TaskContent: ({ task }: { task: StageTaskItem }) => <div>{task.label}</div>,
 }));
 
@@ -157,20 +176,20 @@ vi.mock('../ButtonHandle/useButtonHandles', () => ({
   useButtonHandles: () => null,
 }));
 
-// Mock useNodeSelection
-vi.mock('../NodePropertiesPanel/hooks', () => ({
-  useNodeSelection: () => ({
-    setSelectedNodeId: vi.fn(),
-  }),
-}));
-
-// Mock useViewport
 vi.mock('@uipath/apollo-react/canvas/xyflow/react', async () => {
   const actual = await vi.importActual('@uipath/apollo-react/canvas/xyflow/react');
   return {
     ...actual,
-    useViewport: () => ({ zoom: 1 }),
-    useStore: () => vi.fn(() => null),
+    useReactFlow: () => ({
+      setNodes: vi.fn(),
+    }),
+    useStore: (selector: (state: Record<string, unknown>) => unknown) => {
+      const mockState = {
+        transform: [0, 0, 1],
+        connectionClickStartHandle: null,
+      };
+      return selector(mockState);
+    },
   };
 });
 
@@ -475,15 +494,16 @@ describe('StageNode - Replace Task Functionality', () => {
     });
 
     it('should reset replace task state when node is deselected', async () => {
+      const user = userEvent.setup();
       const onReplaceTaskFromToolbox = vi.fn();
       const { rerender } = renderStageNode({ onReplaceTaskFromToolbox, selected: true });
 
       // Open replace task toolbox
       const taskMenuButton = screen.getByTestId('task-menu-button-task-1');
-      userEvent.click(taskMenuButton);
+      await user.click(taskMenuButton);
 
       const replaceMenuItem = screen.getByTestId('menu-item-task-1-replace-task');
-      userEvent.click(replaceMenuItem);
+      await user.click(replaceMenuItem);
 
       await waitFor(() => {
         expect(screen.getByTestId('toolbox')).toBeInTheDocument();
@@ -503,6 +523,7 @@ describe('StageNode - Replace Task Functionality', () => {
     });
 
     it('should reset both add task and replace task states when node is deselected', async () => {
+      const user = userEvent.setup();
       const onReplaceTaskFromToolbox = vi.fn();
       const onAddTaskFromToolbox = vi.fn();
       const { rerender } = renderStageNode({
@@ -513,10 +534,10 @@ describe('StageNode - Replace Task Functionality', () => {
 
       // Open replace task toolbox
       const taskMenuButton = screen.getByTestId('task-menu-button-task-1');
-      userEvent.click(taskMenuButton);
+      await user.click(taskMenuButton);
 
       const replaceMenuItem = screen.getByTestId('menu-item-task-1-replace-task');
-      userEvent.click(replaceMenuItem);
+      await user.click(replaceMenuItem);
 
       await waitFor(() => {
         expect(screen.getByTestId('toolbox')).toBeInTheDocument();

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.tsx
@@ -756,24 +756,17 @@ const StageNodeInner = (props: StageNodeInnerProps) => {
                   <StageTaskList>
                     {adhocTasks.map(({ task, groupIndex, taskIndex }) => {
                       const taskExecution = execution?.taskStatus?.[task.id];
-                      const menuItems = getAdhocContextMenuItems(groupIndex, taskIndex, task.id);
                       return (
                         <AdhocTaskItem
                           key={task.id}
                           task={task}
                           taskExecution={taskExecution}
                           isSelected={selectedTaskId === task.id}
-                          contextMenuItems={menuItems}
                           onTaskClick={handleTaskClick}
                           onTaskPlay={onTaskPlay}
                           {...((onTaskGroupModification || onReplaceTaskFromToolbox) && {
-                            onMenuOpen: () => {
-                              taskStateReference.current = {
-                                isParallel: false,
-                                groupIndex,
-                                taskIndex,
-                              };
-                            },
+                            getContextMenuItems: () =>
+                              getAdhocContextMenuItems(groupIndex, taskIndex, task.id),
                           })}
                         />
                       );
@@ -850,6 +843,7 @@ export const StageNode = ({
   onTaskReorder,
   onReplaceTaskFromToolbox,
   onTaskPlay,
+  hideParallelOptions,
 }: StageNodeProps) => {
   return (
     <StageNodeInnerMemo
@@ -875,6 +869,7 @@ export const StageNode = ({
       onTaskReorder={onTaskReorder}
       onReplaceTaskFromToolbox={onReplaceTaskFromToolbox}
       onTaskPlay={onTaskPlay}
+      hideParallelOptions={hideParallelOptions}
     />
   );
 };

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.tsx
@@ -55,7 +55,7 @@ import {
   StageTitleContainer,
   StageTitleInput,
 } from './StageNode.styles';
-import type { StageNodeInnerProps, StageNodeProps } from './StageNode.types';
+import type { StageNodeProps } from './StageNode.types';
 import { StageHeaderChipType } from './StageNode.types';
 import { flattenTasks, getProjection, reorderTasks } from './StageNode.utils';
 import { getContextMenuItems, getDivider, getMenuItem } from './StageNodeTaskUtilities';
@@ -75,7 +75,7 @@ const CHIP_ICONS: Record<StageHeaderChipType, React.ReactElement> = {
   [StageHeaderChipType.CaseCompletion]: <ApIcon name="check-mark" size={Icon.IconXs} />,
 };
 
-const StageNodeInner = (props: StageNodeInnerProps) => {
+const StageNodeInner = (props: StageNodeProps) => {
   const {
     dragging,
     selected,
@@ -813,63 +813,4 @@ const StageNodeInner = (props: StageNodeInnerProps) => {
   );
 };
 
-const StageNodeInnerMemo = memo(StageNodeInner);
-
-/**
- * Destructures to strip ReactFlow's internal NodeProps fields (e.g. positionAbsoluteX/Y,
- * zIndex, isConnectable) that change on every store update causing rerenders. Passing only
- * StageNodeBaseProps lets StageNodeInnerMemo's shallow comparison work effectively.
- */
-export const StageNode = ({
-  dragging,
-  selected,
-  id,
-  width,
-  execution,
-  stageDetails,
-  addTaskLabel,
-  addTaskLoading,
-  replaceTaskLabel,
-  taskOptions,
-  menuItems,
-  pendingReplaceTask,
-  onStageClick,
-  onTaskAdd,
-  onAddTaskFromToolbox,
-  onTaskToolboxSearch,
-  onTaskClick,
-  onTaskGroupModification,
-  onStageTitleChange,
-  onTaskReorder,
-  onReplaceTaskFromToolbox,
-  onTaskPlay,
-  hideParallelOptions,
-}: StageNodeProps) => {
-  return (
-    <StageNodeInnerMemo
-      dragging={dragging}
-      selected={selected}
-      id={id}
-      width={width}
-      execution={execution}
-      stageDetails={stageDetails}
-      addTaskLabel={addTaskLabel}
-      addTaskLoading={addTaskLoading}
-      replaceTaskLabel={replaceTaskLabel}
-      taskOptions={taskOptions}
-      menuItems={menuItems}
-      pendingReplaceTask={pendingReplaceTask}
-      onStageClick={onStageClick}
-      onTaskAdd={onTaskAdd}
-      onAddTaskFromToolbox={onAddTaskFromToolbox}
-      onTaskToolboxSearch={onTaskToolboxSearch}
-      onTaskClick={onTaskClick}
-      onTaskGroupModification={onTaskGroupModification}
-      onStageTitleChange={onStageTitleChange}
-      onTaskReorder={onTaskReorder}
-      onReplaceTaskFromToolbox={onReplaceTaskFromToolbox}
-      onTaskPlay={onTaskPlay}
-      hideParallelOptions={hideParallelOptions}
-    />
-  );
-};
+export const StageNode = memo(StageNodeInner);

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.tsx
@@ -18,7 +18,12 @@ import {
 } from '@dnd-kit/sortable';
 import { FontVariantToken, Icon, Padding, Spacing } from '@uipath/apollo-core';
 import { Column, Row } from '@uipath/apollo-react/canvas/layouts';
-import { Position, useStore, useViewport } from '@uipath/apollo-react/canvas/xyflow/react';
+import {
+  Position,
+  useStore,
+  useStoreApi,
+  useViewport,
+} from '@uipath/apollo-react/canvas/xyflow/react';
 import {
   ApIcon,
   ApIconButton,
@@ -36,7 +41,7 @@ import { useButtonHandles } from '../ButtonHandle/useButtonHandles';
 import { ExecutionStatusIcon } from '../ExecutionStatusIcon';
 import { FloatingCanvasPanel } from '../FloatingCanvasPanel';
 import { NodeContextMenu, type NodeMenuItem } from '../NodeContextMenu';
-import { useNodeSelection } from '../NodePropertiesPanel/hooks';
+import { useSetNodeSelection } from '../NodePropertiesPanel/hooks';
 import { type ListItem, Toolbox } from '../Toolbox';
 import { AdhocTaskItem } from './AdhocTask';
 import { DraggableTask, TaskContent } from './DraggableTask';
@@ -58,7 +63,11 @@ import {
   StageTitleContainer,
   StageTitleInput,
 } from './StageNode.styles';
-import type { StageNodeProps } from './StageNode.types';
+import type {
+  StageNodeInnerProps,
+  StageNodeProps,
+  StageTaskDragOverlayProps,
+} from './StageNode.types';
 import { StageHeaderChipType } from './StageNode.types';
 import { flattenTasks, getProjection, reorderTasks } from './StageNode.utils';
 import { getContextMenuItems, getDivider, getMenuItem } from './StageNodeTaskUtilities';
@@ -77,7 +86,39 @@ const CHIP_ICONS: Record<StageHeaderChipType, React.ReactElement> = {
   [StageHeaderChipType.CaseCompletion]: <ApIcon name="check-mark" size={Icon.IconXs} />,
 };
 
-const StageNodeComponent = (props: StageNodeProps) => {
+const StageTaskDragOverlay = memo(function StageTaskDragOverlay({
+  activeTask,
+  isActiveTaskParallel,
+  taskWidthStyle,
+}: StageTaskDragOverlayProps) {
+  const { zoom } = useViewport();
+  const dragOverlayStyle = useMemo<React.CSSProperties>(
+    () => ({
+      transform: `scale(${zoom})`,
+      transformOrigin: 'top left',
+    }),
+    [zoom]
+  );
+
+  return createPortal(
+    <DragOverlay>
+      {activeTask ? (
+        <div style={dragOverlayStyle}>
+          <StageTask
+            selected
+            isParallel={isActiveTaskParallel}
+            style={{ cursor: 'grabbing', ...taskWidthStyle }}
+          >
+            <TaskContent task={activeTask} isDragging />
+          </StageTask>
+        </div>
+      ) : null}
+    </DragOverlay>,
+    document.body
+  );
+});
+
+const StageNodeInner = (props: StageNodeInnerProps) => {
   const {
     dragging,
     selected,
@@ -136,10 +177,6 @@ const StageNodeComponent = (props: StageNodeProps) => {
   const status = execution?.stageStatus?.status;
   const statusLabel = execution?.stageStatus?.label;
   const stageDuration = execution?.stageStatus?.duration;
-  const reGroupTaskFunction = useMemo(
-    () => onTaskGroupModification || (() => {}),
-    [onTaskGroupModification]
-  );
 
   const isStageTitleEditable = !!onStageTitleChange && !isReadOnly;
 
@@ -158,6 +195,7 @@ const StageNodeComponent = (props: StageNodeProps) => {
     taskIndex: -1,
   });
   const isConnecting = useStore((state) => !!state.connectionClickStartHandle);
+  const storeApi = useStoreApi();
   const connectedHandleIds = useConnectedHandles(id);
 
   const [isAddingTask, setIsAddingTask] = useState(false);
@@ -194,8 +232,6 @@ const StageNodeComponent = (props: StageNodeProps) => {
     const group = tasks.find((g) => g.some((t) => t.id === activeDragId));
     return group ? group.length > 1 : false;
   }, [tasks, activeDragId]);
-
-  const { zoom } = useViewport();
 
   const projected = useMemo(() => {
     if (!activeDragId || !overId) return null;
@@ -276,22 +312,25 @@ const StageNodeComponent = (props: StageNodeProps) => {
     };
   }, [handleStageTitleClickToSave, isStageTitleEditing]);
 
-  const contextMenuItems = useCallback(
-    (
-      isParallel: boolean,
-      groupIndex: number,
-      taskIndex: number,
-      tasksLength: number,
-      taskGroupLength: number,
-      isAboveParallel: boolean,
-      isBelowParallel: boolean
-    ) => {
+  const hasContextMenu = !!(onReplaceTaskFromToolbox || onTaskGroupModification);
+
+  /** Lazily builds context menu items for a task. Called only when the menu opens,
+   * avoiding object allocation on every render for every task. */
+  const buildContextMenuItems = useCallback(
+    (groupIndex: number, taskIndex: number) => {
+      const taskGroup = tasks[groupIndex] ?? [];
+      const isParallel = taskGroup.length > 1;
       const items: NodeMenuItem[] = [];
 
       if (onReplaceTaskFromToolbox) {
         items.push(
           getMenuItem('replace-task', 'Replace task', () => {
-            const taskId = tasks[groupIndex]?.[taskIndex]?.id;
+            taskStateReference.current = {
+              isParallel,
+              groupIndex,
+              taskIndex,
+            };
+            const taskId = taskGroup[taskIndex]?.id;
             if (taskId) onTaskClick?.(taskId);
             setIsReplacingTask(true);
           })
@@ -303,12 +342,12 @@ const StageNodeComponent = (props: StageNodeProps) => {
         const reGroupOptions = getContextMenuItems(
           isParallel,
           groupIndex,
-          tasksLength,
+          tasks.length,
           taskIndex,
-          taskGroupLength,
-          isAboveParallel,
-          isBelowParallel,
-          reGroupTaskFunction,
+          taskGroup.length,
+          (tasks[groupIndex - 1]?.length ?? 0) > 1,
+          (tasks[groupIndex + 1]?.length ?? 0) > 1,
+          onTaskGroupModification,
           hideParallelOptions
         );
         return [...items, ...reGroupOptions];
@@ -316,14 +355,7 @@ const StageNodeComponent = (props: StageNodeProps) => {
 
       return items;
     },
-    [
-      onReplaceTaskFromToolbox,
-      onTaskClick,
-      onTaskGroupModification,
-      reGroupTaskFunction,
-      tasks,
-      hideParallelOptions,
-    ]
+    [onReplaceTaskFromToolbox, onTaskClick, onTaskGroupModification, tasks, hideParallelOptions]
   );
 
   const getAdhocContextMenuItems = useCallback(
@@ -348,17 +380,17 @@ const StageNodeComponent = (props: StageNodeProps) => {
         if (items.length > 0) items.push(getDivider());
         items.push(
           getMenuItem('remove-task', 'Delete task', () =>
-            reGroupTaskFunction(GroupModificationType.REMOVE_TASK, groupIndex, taskIndex)
+            onTaskGroupModification(GroupModificationType.REMOVE_TASK, groupIndex, taskIndex)
           )
         );
       }
 
       return items;
     },
-    [onReplaceTaskFromToolbox, onTaskClick, onTaskGroupModification, reGroupTaskFunction]
+    [onReplaceTaskFromToolbox, onTaskClick, onTaskGroupModification]
   );
 
-  const { setSelectedNodeId } = useNodeSelection();
+  const { setSelectedNodeId } = useSetNodeSelection();
   const handleStageClick = useCallback(() => {
     onStageClick?.();
   }, [onStageClick]);
@@ -495,9 +527,9 @@ const StageNodeComponent = (props: StageNodeProps) => {
 
   const handleDragMove = useCallback(
     (event: DragMoveEvent) => {
-      setOffsetLeft(event.delta.x / zoom);
+      setOffsetLeft(event.delta.x / storeApi.getState().transform[2]);
     },
-    [zoom]
+    [storeApi]
   );
 
   const handleDragOver = useCallback((event: DragOverEvent) => {
@@ -557,14 +589,6 @@ const StageNodeComponent = (props: StageNodeProps) => {
           } as React.CSSProperties)
         : undefined,
     [taskWidth]
-  );
-
-  const dragOverlayStyle = useMemo<React.CSSProperties>(
-    () => ({
-      transform: `scale(${zoom})`,
-      transformOrigin: 'top left',
-    }),
-    [zoom]
   );
 
   return (
@@ -732,15 +756,8 @@ const StageNodeComponent = (props: StageNodeProps) => {
                                     taskExecution={taskExecution}
                                     isSelected={selectedTaskId === task.id}
                                     isParallel={isParallel}
-                                    contextMenuItems={contextMenuItems(
-                                      isParallel,
-                                      groupIndex,
-                                      taskIndex,
-                                      tasks.length,
-                                      taskGroup.length,
-                                      (tasks[groupIndex - 1]?.length ?? 0) > 1,
-                                      (tasks[groupIndex + 1]?.length ?? 0) > 1
-                                    )}
+                                    groupIndex={groupIndex}
+                                    taskIndex={taskIndex}
                                     onTaskClick={handleTaskClick}
                                     projectedDepth={
                                       task.id === activeDragId && projected
@@ -748,15 +765,8 @@ const StageNodeComponent = (props: StageNodeProps) => {
                                         : undefined
                                     }
                                     isDragDisabled={!onTaskReorder}
-                                    zoom={zoom}
-                                    {...((onTaskGroupModification || onReplaceTaskFromToolbox) && {
-                                      onMenuOpen: () => {
-                                        taskStateReference.current = {
-                                          isParallel,
-                                          groupIndex,
-                                          taskIndex,
-                                        };
-                                      },
+                                    {...(hasContextMenu && {
+                                      getContextMenuItems: buildContextMenuItems,
                                     })}
                                   />
                                 );
@@ -767,22 +777,11 @@ const StageNodeComponent = (props: StageNodeProps) => {
                       })}
                     </StageTaskList>
                   </SortableContext>
-                  {createPortal(
-                    <DragOverlay>
-                      {activeTask ? (
-                        <div style={dragOverlayStyle}>
-                          <StageTask
-                            selected
-                            isParallel={isActiveTaskParallel}
-                            style={{ cursor: 'grabbing', ...taskWidthStyle }}
-                          >
-                            <TaskContent task={activeTask} isDragging />
-                          </StageTask>
-                        </div>
-                      ) : null}
-                    </DragOverlay>,
-                    document.body
-                  )}
+                  <StageTaskDragOverlay
+                    activeTask={activeTask}
+                    isActiveTaskParallel={isActiveTaskParallel}
+                    taskWidthStyle={taskWidthStyle}
+                  />
                 </DndContext>
               )}
               {adhocTasks.length > 0 && (
@@ -861,6 +860,65 @@ const StageNodeComponent = (props: StageNodeProps) => {
 
       {handleElements}
     </div>
+  );
+};
+
+const StageNodeInnerMemo = memo(StageNodeInner);
+
+/**
+ * Destructures to strip ReactFlow's internal NodeProps fields (e.g. positionAbsoluteX/Y,
+ * zIndex, isConnectable) that change on every store update causing rerenders. Passing only
+ * StageNodeBaseProps lets StageNodeInnerMemo's shallow comparison work effectively.
+ */
+const StageNodeComponent = ({
+  dragging,
+  selected,
+  id,
+  width,
+  execution,
+  stageDetails,
+  addTaskLabel,
+  addTaskLoading,
+  replaceTaskLabel,
+  taskOptions,
+  menuItems,
+  pendingReplaceTask,
+  onStageClick,
+  onTaskAdd,
+  onAddTaskFromToolbox,
+  onTaskToolboxSearch,
+  onTaskClick,
+  onTaskGroupModification,
+  onStageTitleChange,
+  onTaskReorder,
+  onReplaceTaskFromToolbox,
+  onTaskPlay,
+}: StageNodeProps) => {
+  return (
+    <StageNodeInnerMemo
+      dragging={dragging}
+      selected={selected}
+      id={id}
+      width={width}
+      execution={execution}
+      stageDetails={stageDetails}
+      addTaskLabel={addTaskLabel}
+      addTaskLoading={addTaskLoading}
+      replaceTaskLabel={replaceTaskLabel}
+      taskOptions={taskOptions}
+      menuItems={menuItems}
+      pendingReplaceTask={pendingReplaceTask}
+      onStageClick={onStageClick}
+      onTaskAdd={onTaskAdd}
+      onAddTaskFromToolbox={onAddTaskFromToolbox}
+      onTaskToolboxSearch={onTaskToolboxSearch}
+      onTaskClick={onTaskClick}
+      onTaskGroupModification={onTaskGroupModification}
+      onStageTitleChange={onStageTitleChange}
+      onTaskReorder={onTaskReorder}
+      onReplaceTaskFromToolbox={onReplaceTaskFromToolbox}
+      onTaskPlay={onTaskPlay}
+    />
   );
 };
 

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.tsx
@@ -4,7 +4,6 @@ import {
   type DragEndEvent,
   type DragMoveEvent,
   type DragOverEvent,
-  DragOverlay,
   type DragStartEvent,
   KeyboardSensor,
   PointerSensor,
@@ -18,12 +17,7 @@ import {
 } from '@dnd-kit/sortable';
 import { FontVariantToken, Icon, Padding, Spacing } from '@uipath/apollo-core';
 import { Column, Row } from '@uipath/apollo-react/canvas/layouts';
-import {
-  Position,
-  useStore,
-  useStoreApi,
-  useViewport,
-} from '@uipath/apollo-react/canvas/xyflow/react';
+import { Position, useStore, useStoreApi } from '@uipath/apollo-react/canvas/xyflow/react';
 import {
   ApIcon,
   ApIconButton,
@@ -32,7 +26,6 @@ import {
   ApTypography,
 } from '@uipath/apollo-react/material';
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { createPortal } from 'react-dom';
 import { EntryConditionIcon, ExitConditionIcon, ReturnToOriginIcon } from '../../icons';
 import type { HandleGroupManifest } from '../../schema/node-definition';
 import { GroupModificationType } from '../../utils/GroupModificationUtils';
@@ -44,7 +37,7 @@ import { NodeContextMenu, type NodeMenuItem } from '../NodeContextMenu';
 import { useSetNodeSelection } from '../NodePropertiesPanel/hooks';
 import { type ListItem, Toolbox } from '../Toolbox';
 import { AdhocTaskItem } from './AdhocTask';
-import { DraggableTask, TaskContent } from './DraggableTask';
+import { DraggableTask } from './DraggableTask';
 import {
   INDENTATION_WIDTH,
   STAGE_CONTENT_INSET,
@@ -57,20 +50,16 @@ import {
   StageHeaderChipsRow,
   StageParallelBracket,
   StageParallelLabel,
-  StageTask,
   StageTaskGroup,
   StageTaskList,
   StageTitleContainer,
   StageTitleInput,
 } from './StageNode.styles';
-import type {
-  StageNodeInnerProps,
-  StageNodeProps,
-  StageTaskDragOverlayProps,
-} from './StageNode.types';
+import type { StageNodeInnerProps, StageNodeProps } from './StageNode.types';
 import { StageHeaderChipType } from './StageNode.types';
 import { flattenTasks, getProjection, reorderTasks } from './StageNode.utils';
 import { getContextMenuItems, getDivider, getMenuItem } from './StageNodeTaskUtilities';
+import { StageTaskDragOverlay } from './StageTaskDragOverlay';
 
 interface TaskStateReference {
   isParallel: boolean;
@@ -85,38 +74,6 @@ const CHIP_ICONS: Record<StageHeaderChipType, React.ReactElement> = {
   [StageHeaderChipType.CaseExit]: <ApIcon name="close" size={Icon.IconXs} />,
   [StageHeaderChipType.CaseCompletion]: <ApIcon name="check-mark" size={Icon.IconXs} />,
 };
-
-const StageTaskDragOverlay = memo(function StageTaskDragOverlay({
-  activeTask,
-  isActiveTaskParallel,
-  taskWidthStyle,
-}: StageTaskDragOverlayProps) {
-  const { zoom } = useViewport();
-  const dragOverlayStyle = useMemo<React.CSSProperties>(
-    () => ({
-      transform: `scale(${zoom})`,
-      transformOrigin: 'top left',
-    }),
-    [zoom]
-  );
-
-  return createPortal(
-    <DragOverlay>
-      {activeTask ? (
-        <div style={dragOverlayStyle}>
-          <StageTask
-            selected
-            isParallel={isActiveTaskParallel}
-            style={{ cursor: 'grabbing', ...taskWidthStyle }}
-          >
-            <TaskContent task={activeTask} isDragging />
-          </StageTask>
-        </div>
-      ) : null}
-    </DragOverlay>,
-    document.body
-  );
-});
 
 const StageNodeInner = (props: StageNodeInnerProps) => {
   const {
@@ -870,7 +827,7 @@ const StageNodeInnerMemo = memo(StageNodeInner);
  * zIndex, isConnectable) that change on every store update causing rerenders. Passing only
  * StageNodeBaseProps lets StageNodeInnerMemo's shallow comparison work effectively.
  */
-const StageNodeComponent = ({
+export const StageNode = ({
   dragging,
   selected,
   id,
@@ -921,5 +878,3 @@ const StageNodeComponent = ({
     />
   );
 };
-
-export const StageNode = memo(StageNodeComponent);

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.types.ts
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.types.ts
@@ -41,7 +41,7 @@ export interface StageHeaderChip {
   onClick?: () => void;
 }
 
-export interface StageNodeProps extends NodeProps {
+export interface StageNodeBaseProps {
   dragging: boolean;
   selected: boolean;
   id: string;
@@ -90,6 +90,10 @@ export interface StageNodeProps extends NodeProps {
   hideParallelOptions?: boolean;
 }
 
+export interface StageNodeProps extends NodeProps, StageNodeBaseProps {}
+
+export type StageNodeInnerProps = StageNodeBaseProps & Pick<NodeProps, 'width'>;
+
 export interface StageTaskExecution {
   status?: StageTaskStatus;
   message?: string;
@@ -99,4 +103,10 @@ export interface StageTaskExecution {
   badge?: string;
   badgeStatus?: 'warning' | 'info' | 'error';
   retryCount?: number;
+}
+
+export interface StageTaskDragOverlayProps {
+  activeTask: StageTaskItem | undefined;
+  isActiveTaskParallel: boolean;
+  taskWidthStyle: React.CSSProperties | undefined;
 }

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.types.ts
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.types.ts
@@ -42,9 +42,6 @@ export interface StageHeaderChip {
 }
 
 export interface StageNodeBaseProps {
-  dragging: boolean;
-  selected: boolean;
-  id: string;
   pendingReplaceTask?: boolean;
   stageDetails: {
     label: string;
@@ -90,9 +87,9 @@ export interface StageNodeBaseProps {
   hideParallelOptions?: boolean;
 }
 
-export interface StageNodeProps extends NodeProps, StageNodeBaseProps {}
-
-export type StageNodeInnerProps = StageNodeBaseProps & Pick<NodeProps, 'width'>;
+export interface StageNodeCanvasProps extends NodeProps, StageNodeBaseProps {}
+export type StageNodeProps = StageNodeBaseProps &
+  Pick<NodeProps, 'id' | 'selected' | 'dragging' | 'width'>;
 
 export interface StageTaskExecution {
   status?: StageTaskStatus;

--- a/packages/apollo-react/src/canvas/components/StageNode/StageTaskDragOverlay.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageTaskDragOverlay.tsx
@@ -1,5 +1,5 @@
 import { DragOverlay } from '@dnd-kit/core';
-import { useViewport } from '@uipath/apollo-react/canvas/xyflow/react';
+import { useStore } from '@uipath/apollo-react/canvas/xyflow/react';
 import { useMemo } from 'react';
 import { createPortal } from 'react-dom';
 import { TaskContent } from './DraggableTask';
@@ -11,7 +11,7 @@ export const StageTaskDragOverlay = ({
   isActiveTaskParallel,
   taskWidthStyle,
 }: StageTaskDragOverlayProps) => {
-  const { zoom } = useViewport();
+  const zoom = useStore((state) => state.transform[2]);
   const dragOverlayStyle = useMemo<React.CSSProperties>(
     () => ({
       transform: `scale(${zoom})`,
@@ -20,19 +20,21 @@ export const StageTaskDragOverlay = ({
     [zoom]
   );
 
+  if (!activeTask) {
+    return null;
+  }
+
   return createPortal(
     <DragOverlay>
-      {activeTask ? (
-        <div style={dragOverlayStyle}>
-          <StageTask
-            selected
-            isParallel={isActiveTaskParallel}
-            style={{ cursor: 'grabbing', ...taskWidthStyle }}
-          >
-            <TaskContent task={activeTask} isDragging />
-          </StageTask>
-        </div>
-      ) : null}
+      <div style={dragOverlayStyle}>
+        <StageTask
+          selected
+          isParallel={isActiveTaskParallel}
+          style={{ cursor: 'grabbing', ...taskWidthStyle }}
+        >
+          <TaskContent task={activeTask} isDragging />
+        </StageTask>
+      </div>
     </DragOverlay>,
     document.body
   );

--- a/packages/apollo-react/src/canvas/components/StageNode/StageTaskDragOverlay.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageTaskDragOverlay.tsx
@@ -1,0 +1,39 @@
+import { DragOverlay } from '@dnd-kit/core';
+import { useViewport } from '@uipath/apollo-react/canvas/xyflow/react';
+import { useMemo } from 'react';
+import { createPortal } from 'react-dom';
+import { TaskContent } from './DraggableTask';
+import { StageTask } from './StageNode.styles';
+import type { StageTaskDragOverlayProps } from './StageNode.types';
+
+export const StageTaskDragOverlay = ({
+  activeTask,
+  isActiveTaskParallel,
+  taskWidthStyle,
+}: StageTaskDragOverlayProps) => {
+  const { zoom } = useViewport();
+  const dragOverlayStyle = useMemo<React.CSSProperties>(
+    () => ({
+      transform: `scale(${zoom})`,
+      transformOrigin: 'top left',
+    }),
+    [zoom]
+  );
+
+  return createPortal(
+    <DragOverlay>
+      {activeTask ? (
+        <div style={dragOverlayStyle}>
+          <StageTask
+            selected
+            isParallel={isActiveTaskParallel}
+            style={{ cursor: 'grabbing', ...taskWidthStyle }}
+          >
+            <TaskContent task={activeTask} isDragging />
+          </StageTask>
+        </div>
+      ) : null}
+    </DragOverlay>,
+    document.body
+  );
+};

--- a/packages/apollo-react/src/canvas/components/StageNode/TaskMenu.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/TaskMenu.tsx
@@ -1,16 +1,8 @@
 import token, { Spacing } from '@uipath/apollo-core';
 import { ApIcon, ApIconButton, ApMenu } from '@uipath/apollo-react/material';
-import {
-  forwardRef,
-  memo,
-  useCallback,
-  useImperativeHandle,
-  useMemo,
-  useRef,
-  useState,
-} from 'react';
+import { forwardRef, memo, useCallback, useImperativeHandle, useRef, useState } from 'react';
 import type { NodeMenuAction, NodeMenuItem } from '../NodeContextMenu';
-import { transformMenuItems } from './StageNodeTaskUtilities';
+import { TransformedMenuItem, transformMenuItems } from './StageNodeTaskUtilities';
 
 export interface TaskMenuHandle {
   handleContextMenu: (e: React.MouseEvent<HTMLElement>) => void;
@@ -18,34 +10,41 @@ export interface TaskMenuHandle {
 
 interface TaskMenuProps {
   taskId: string;
-  contextMenuItems: NodeMenuItem[];
+  getContextMenuItems: () => NodeMenuItem[];
   onMenuOpenChange?: (isOpen: boolean) => void;
-  onMenuOpen?: () => void;
   taskRef?: React.RefObject<HTMLElement | null>;
 }
 
 const TaskMenuComponent = (
-  { taskId, contextMenuItems, onMenuOpenChange, onMenuOpen, taskRef }: TaskMenuProps,
+  { taskId, getContextMenuItems, onMenuOpenChange, taskRef }: TaskMenuProps,
   ref: React.Ref<TaskMenuHandle>
 ) => {
-  const [isMenuOpen, setIsMenuOpen] = useState(false);
   const [anchorElement, setAnchorElement] = useState<HTMLElement | null>(null);
   const menuAnchorRef = useRef<HTMLButtonElement>(null);
+  const isMenuOpen = anchorElement !== null;
+
+  const [menuItems, setMenuItems] = useState<TransformedMenuItem[]>([]);
 
   const handleMenuClose = useCallback(() => {
-    setIsMenuOpen(false);
     setAnchorElement(null);
     onMenuOpenChange?.(false);
   }, [onMenuOpenChange]);
 
+  const handleMenuItemClick = useCallback(
+    (item: NodeMenuAction) => {
+      item.onClick();
+      handleMenuClose();
+    },
+    [handleMenuClose]
+  );
+
   const openMenu = useCallback(
     (anchor: HTMLElement | null) => {
       setAnchorElement(anchor);
-      setIsMenuOpen(true);
-      onMenuOpen?.();
+      setMenuItems(transformMenuItems(getContextMenuItems(), handleMenuItemClick));
       onMenuOpenChange?.(true);
     },
-    [onMenuOpen, onMenuOpenChange]
+    [getContextMenuItems, handleMenuItemClick, onMenuOpenChange]
   );
 
   const handleMenuClick = useCallback(
@@ -79,18 +78,6 @@ const TaskMenuComponent = (
     e.stopPropagation();
   }, []);
 
-  const handleMenuItemClick = useCallback(
-    (item: NodeMenuAction) => {
-      item.onClick();
-      handleMenuClose();
-    },
-    [handleMenuClose]
-  );
-
-  const transformedMenuItems = useMemo(() => {
-    return transformMenuItems(contextMenuItems, handleMenuItemClick);
-  }, [contextMenuItems, handleMenuItemClick]);
-
   return (
     <>
       <ApIconButton
@@ -111,7 +98,7 @@ const TaskMenuComponent = (
       </ApIconButton>
       <ApMenu
         isOpen={isMenuOpen}
-        menuItems={transformedMenuItems}
+        menuItems={menuItems}
         anchorEl={anchorElement}
         onClose={handleMenuClose}
         anchorOrigin={{

--- a/packages/apollo-react/src/canvas/components/StageNode/TaskMenu.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/TaskMenu.tsx
@@ -40,6 +40,10 @@ const TaskMenuComponent = (
 
   const openMenu = useCallback(
     (anchor: HTMLElement | null) => {
+      if (!anchor) {
+        return;
+      }
+
       setAnchorElement(anchor);
       setMenuItems(transformMenuItems(getContextMenuItems(), handleMenuItemClick));
       onMenuOpenChange?.(true);

--- a/packages/apollo-react/src/canvas/components/StageNode/index.ts
+++ b/packages/apollo-react/src/canvas/components/StageNode/index.ts
@@ -3,6 +3,7 @@ export { StageEdge } from './StageEdge';
 export { StageNode } from './StageNode';
 export type {
   StageHeaderChip,
+  StageNodeCanvasProps,
   StageNodeProps,
   StageStatus,
   StageTaskItem,


### PR DESCRIPTION
## Description

Improve StageNode rendering performance at scale by reducing unnecessary re-renders across the component tree.

Also added new [CanvasPerformance](https://apollo-canvas-qjqq1a8no-uipath.vercel.app/?path=/story/canvas-canvas-performance--stage-workflow) story with configurable stage count (1-200) for benchmarking render performance. 


**Key changes:**
- Wrap `StageNode`, `StageNodeInner`, `StageEdge`, `StageTaskDragOverlay`, and `TaskMenu` with `memo()` to prevent unnecessary re-renders
- Add `StageNodeComponent` wrapper that destructures only stable props, stripping ReactFlow internal fields (`positionAbsoluteX/Y`, `zIndex`, `isConnectable`) so `StageNodeInnerMemo`'s shallow comparison works effectively
- Add custom `stageEdgeGeometryEquality` selector to prevent `StageEdge` re-renders when edge geometry hasn't changed
- Introduce lightweight `useSetNodeSelection()` hook that provides only `setSelectedNodeId` without subscribing to all nodes
- Extract `StageTaskDragOverlay` as a separate memoized component rendered via `createPortal()` to isolate drag state
- Wrap `buildContextMenuItems` and `handleMenuItemClick` in `useCallback` to stabilize references
- Extract `StageNodeBaseProps` type separate from ReactFlow's `NodeProps` for cleaner prop boundaries
- Stories also updated to use memoized `nodeTypes`/`edgeTypes`/`defaultEdgeOptions`

## Testing

- All 1274 existing tests pass (65 test files)
- Updated `StageNode.test.tsx` and `DraggableTask.test.tsx` to match new component signatures
- Verify with `CanvasPerformance` story: panning and dragging should remain smooth at 200 nodes