### PR TITLE
feat(apollo-react): add hideParallelOptions prop to StageNode [MST-8113]

### DIFF
--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.test.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.test.tsx
@@ -699,114 +699,110 @@ describe('StageNode - Add Task Loading State', () => {
 
     expect(screen.getByTestId('toolbox')).toHaveAttribute('data-loading', 'false');
   });
+});
 
-  describe('hideParallelOptions', () => {
-    it('should show parallel options when hideParallelOptions is not set', () => {
-      const onTaskGroupModification = vi.fn();
-      const tasks: StageTaskItem[][] = [
-        [createTask('task-1', 'Task 1')],
-        [createTask('task-2', 'Task 2')],
-        [createTask('task-3', 'Task 3')],
-      ];
+describe('StageNode - hideParallelOptions', () => {
+  it('should show parallel options when hideParallelOptions is not set', () => {
+    const onTaskGroupModification = vi.fn();
+    const tasks: StageTaskItem[][] = [
+      [createTask('task-1', 'Task 1')],
+      [createTask('task-2', 'Task 2')],
+      [createTask('task-3', 'Task 3')],
+    ];
 
-      renderStageNode({
-        onTaskGroupModification,
-        stageDetails: { ...defaultProps.stageDetails, tasks },
-      });
-
-      const menuItems = screen.getByTestId('task-menu-items-task-2');
-      expect(
-        menuItems.querySelector('[data-testid="menu-item-task-2-move-up"]')
-      ).toBeInTheDocument();
-      expect(
-        menuItems.querySelector('[data-testid="menu-item-task-2-move-down"]')
-      ).toBeInTheDocument();
-      expect(
-        menuItems.querySelector('[data-testid="menu-item-task-2-group-with-up"]')
-      ).toBeInTheDocument();
-      expect(
-        menuItems.querySelector('[data-testid="menu-item-task-2-group-with-down"]')
-      ).toBeInTheDocument();
-      expect(
-        menuItems.querySelector('[data-testid="menu-item-task-2-remove-task"]')
-      ).toBeInTheDocument();
+    renderStageNode({
+      onTaskGroupModification,
+      stageDetails: { ...defaultProps.stageDetails, tasks },
     });
 
-    it('should hide parallel options but keep move and delete when hideParallelOptions is true', () => {
-      const onTaskGroupModification = vi.fn();
-      const tasks: StageTaskItem[][] = [
-        [createTask('task-1', 'Task 1')],
-        [createTask('task-2', 'Task 2')],
-        [createTask('task-3', 'Task 3')],
-      ];
+    const menuItems = screen.getByTestId('task-menu-items-task-2');
+    expect(menuItems.querySelector('[data-testid="menu-item-task-2-move-up"]')).toBeInTheDocument();
+    expect(
+      menuItems.querySelector('[data-testid="menu-item-task-2-move-down"]')
+    ).toBeInTheDocument();
+    expect(
+      menuItems.querySelector('[data-testid="menu-item-task-2-group-with-up"]')
+    ).toBeInTheDocument();
+    expect(
+      menuItems.querySelector('[data-testid="menu-item-task-2-group-with-down"]')
+    ).toBeInTheDocument();
+    expect(
+      menuItems.querySelector('[data-testid="menu-item-task-2-remove-task"]')
+    ).toBeInTheDocument();
+  });
 
-      renderStageNode({
-        onTaskGroupModification,
-        hideParallelOptions: true,
-        stageDetails: { ...defaultProps.stageDetails, tasks },
-      });
+  it('should hide parallel options but keep move and delete when hideParallelOptions is true', () => {
+    const onTaskGroupModification = vi.fn();
+    const tasks: StageTaskItem[][] = [
+      [createTask('task-1', 'Task 1')],
+      [createTask('task-2', 'Task 2')],
+      [createTask('task-3', 'Task 3')],
+    ];
 
-      const menuItems = screen.getByTestId('task-menu-items-task-2');
-      expect(
-        menuItems.querySelector('[data-testid="menu-item-task-2-move-up"]')
-      ).toBeInTheDocument();
-      expect(
-        menuItems.querySelector('[data-testid="menu-item-task-2-move-down"]')
-      ).toBeInTheDocument();
-      expect(
-        menuItems.querySelector('[data-testid="menu-item-task-2-remove-task"]')
-      ).toBeInTheDocument();
-      expect(
-        menuItems.querySelector('[data-testid="menu-item-task-2-group-with-up"]')
-      ).not.toBeInTheDocument();
-      expect(
-        menuItems.querySelector('[data-testid="menu-item-task-2-group-with-down"]')
-      ).not.toBeInTheDocument();
+    renderStageNode({
+      onTaskGroupModification,
+      hideParallelOptions: true,
+      stageDetails: { ...defaultProps.stageDetails, tasks },
     });
 
-    it('should hide ungroup/split options for parallel groups when hideParallelOptions is true', () => {
-      const onTaskGroupModification = vi.fn();
-      const tasks: StageTaskItem[][] = [
-        [createTask('task-1', 'Task 1'), createTask('task-2', 'Task 2')], // parallel group
-        [createTask('task-3', 'Task 3')],
-      ];
+    const menuItems = screen.getByTestId('task-menu-items-task-2');
+    expect(menuItems.querySelector('[data-testid="menu-item-task-2-move-up"]')).toBeInTheDocument();
+    expect(
+      menuItems.querySelector('[data-testid="menu-item-task-2-move-down"]')
+    ).toBeInTheDocument();
+    expect(
+      menuItems.querySelector('[data-testid="menu-item-task-2-remove-task"]')
+    ).toBeInTheDocument();
+    expect(
+      menuItems.querySelector('[data-testid="menu-item-task-2-group-with-up"]')
+    ).not.toBeInTheDocument();
+    expect(
+      menuItems.querySelector('[data-testid="menu-item-task-2-group-with-down"]')
+    ).not.toBeInTheDocument();
+  });
 
-      renderStageNode({
-        onTaskGroupModification,
-        hideParallelOptions: true,
-        stageDetails: { ...defaultProps.stageDetails, tasks },
-      });
+  it('should hide ungroup/split options for parallel groups when hideParallelOptions is true', () => {
+    const onTaskGroupModification = vi.fn();
+    const tasks: StageTaskItem[][] = [
+      [createTask('task-1', 'Task 1'), createTask('task-2', 'Task 2')], // parallel group
+      [createTask('task-3', 'Task 3')],
+    ];
 
-      const menuItems = screen.getByTestId('task-menu-items-task-1');
-      expect(
-        menuItems.querySelector('[data-testid="menu-item-task-1-remove-task"]')
-      ).toBeInTheDocument();
-      expect(
-        menuItems.querySelector('[data-testid="menu-item-task-1-ungroup"]')
-      ).not.toBeInTheDocument();
-      expect(
-        menuItems.querySelector('[data-testid="menu-item-task-1-split"]')
-      ).not.toBeInTheDocument();
-      expect(
-        menuItems.querySelector('[data-testid="menu-item-task-1-remove-group"]')
-      ).not.toBeInTheDocument();
+    renderStageNode({
+      onTaskGroupModification,
+      hideParallelOptions: true,
+      stageDetails: { ...defaultProps.stageDetails, tasks },
     });
 
-    it('should show only delete for a single task when hideParallelOptions is true', () => {
-      const onTaskGroupModification = vi.fn();
-      const tasks: StageTaskItem[][] = [[createTask('task-1', 'Task 1')]];
+    const menuItems = screen.getByTestId('task-menu-items-task-1');
+    expect(
+      menuItems.querySelector('[data-testid="menu-item-task-1-remove-task"]')
+    ).toBeInTheDocument();
+    expect(
+      menuItems.querySelector('[data-testid="menu-item-task-1-ungroup"]')
+    ).not.toBeInTheDocument();
+    expect(
+      menuItems.querySelector('[data-testid="menu-item-task-1-split"]')
+    ).not.toBeInTheDocument();
+    expect(
+      menuItems.querySelector('[data-testid="menu-item-task-1-remove-group"]')
+    ).not.toBeInTheDocument();
+  });
 
-      renderStageNode({
-        onTaskGroupModification,
-        hideParallelOptions: true,
-        stageDetails: { ...defaultProps.stageDetails, tasks },
-      });
+  it('should show only delete for a single task when hideParallelOptions is true', () => {
+    const onTaskGroupModification = vi.fn();
+    const tasks: StageTaskItem[][] = [[createTask('task-1', 'Task 1')]];
 
-      const menuItems = screen.getByTestId('task-menu-items-task-1');
-      const buttons = menuItems.querySelectorAll('button');
-      expect(buttons).toHaveLength(1);
-      expect(buttons[0]).toHaveTextContent('Delete task');
+    renderStageNode({
+      onTaskGroupModification,
+      hideParallelOptions: true,
+      stageDetails: { ...defaultProps.stageDetails, tasks },
     });
+
+    const menuItems = screen.getByTestId('task-menu-items-task-1');
+    const buttons = menuItems.querySelectorAll('button');
+    expect(buttons).toHaveLength(1);
+    expect(buttons[0]).toHaveTextContent('Delete task');
   });
 });
 

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.test.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.test.tsx
@@ -699,6 +699,115 @@ describe('StageNode - Add Task Loading State', () => {
 
     expect(screen.getByTestId('toolbox')).toHaveAttribute('data-loading', 'false');
   });
+
+  describe('hideParallelOptions', () => {
+    it('should show parallel options when hideParallelOptions is not set', () => {
+      const onTaskGroupModification = vi.fn();
+      const tasks: StageTaskItem[][] = [
+        [createTask('task-1', 'Task 1')],
+        [createTask('task-2', 'Task 2')],
+        [createTask('task-3', 'Task 3')],
+      ];
+
+      renderStageNode({
+        onTaskGroupModification,
+        stageDetails: { ...defaultProps.stageDetails, tasks },
+      });
+
+      const menuItems = screen.getByTestId('task-menu-items-task-2');
+      expect(
+        menuItems.querySelector('[data-testid="menu-item-task-2-move-up"]')
+      ).toBeInTheDocument();
+      expect(
+        menuItems.querySelector('[data-testid="menu-item-task-2-move-down"]')
+      ).toBeInTheDocument();
+      expect(
+        menuItems.querySelector('[data-testid="menu-item-task-2-group-with-up"]')
+      ).toBeInTheDocument();
+      expect(
+        menuItems.querySelector('[data-testid="menu-item-task-2-group-with-down"]')
+      ).toBeInTheDocument();
+      expect(
+        menuItems.querySelector('[data-testid="menu-item-task-2-remove-task"]')
+      ).toBeInTheDocument();
+    });
+
+    it('should hide parallel options but keep move and delete when hideParallelOptions is true', () => {
+      const onTaskGroupModification = vi.fn();
+      const tasks: StageTaskItem[][] = [
+        [createTask('task-1', 'Task 1')],
+        [createTask('task-2', 'Task 2')],
+        [createTask('task-3', 'Task 3')],
+      ];
+
+      renderStageNode({
+        onTaskGroupModification,
+        hideParallelOptions: true,
+        stageDetails: { ...defaultProps.stageDetails, tasks },
+      });
+
+      const menuItems = screen.getByTestId('task-menu-items-task-2');
+      expect(
+        menuItems.querySelector('[data-testid="menu-item-task-2-move-up"]')
+      ).toBeInTheDocument();
+      expect(
+        menuItems.querySelector('[data-testid="menu-item-task-2-move-down"]')
+      ).toBeInTheDocument();
+      expect(
+        menuItems.querySelector('[data-testid="menu-item-task-2-remove-task"]')
+      ).toBeInTheDocument();
+      expect(
+        menuItems.querySelector('[data-testid="menu-item-task-2-group-with-up"]')
+      ).not.toBeInTheDocument();
+      expect(
+        menuItems.querySelector('[data-testid="menu-item-task-2-group-with-down"]')
+      ).not.toBeInTheDocument();
+    });
+
+    it('should hide ungroup/split options for parallel groups when hideParallelOptions is true', () => {
+      const onTaskGroupModification = vi.fn();
+      const tasks: StageTaskItem[][] = [
+        [createTask('task-1', 'Task 1'), createTask('task-2', 'Task 2')], // parallel group
+        [createTask('task-3', 'Task 3')],
+      ];
+
+      renderStageNode({
+        onTaskGroupModification,
+        hideParallelOptions: true,
+        stageDetails: { ...defaultProps.stageDetails, tasks },
+      });
+
+      const menuItems = screen.getByTestId('task-menu-items-task-1');
+      expect(
+        menuItems.querySelector('[data-testid="menu-item-task-1-remove-task"]')
+      ).toBeInTheDocument();
+      expect(
+        menuItems.querySelector('[data-testid="menu-item-task-1-ungroup"]')
+      ).not.toBeInTheDocument();
+      expect(
+        menuItems.querySelector('[data-testid="menu-item-task-1-split"]')
+      ).not.toBeInTheDocument();
+      expect(
+        menuItems.querySelector('[data-testid="menu-item-task-1-remove-group"]')
+      ).not.toBeInTheDocument();
+    });
+
+    it('should show only delete for a single task when hideParallelOptions is true', () => {
+      const onTaskGroupModification = vi.fn();
+      const tasks: StageTaskItem[][] = [[createTask('task-1', 'Task 1')]];
+
+      renderStageNode({
+        onTaskGroupModification,
+        hideParallelOptions: true,
+        stageDetails: { ...defaultProps.stageDetails, tasks },
+      });
+
+      const menuItems = screen.getByTestId('task-menu-items-task-1');
+      const buttons = menuItems.querySelectorAll('button');
+      expect(buttons).toHaveLength(1);
+      expect(buttons[0]).toHaveTextContent('Delete task');
+    });
+  });
 });
 
 describe('StageNode - Header Chips', () => {

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.tsx
@@ -97,6 +97,7 @@ const StageNodeComponent = (props: StageNodeProps) => {
     onTaskReorder,
     onReplaceTaskFromToolbox,
     onTaskPlay,
+    hideParallelOptions,
   } = props;
 
   const taskWidth = width ? width - STAGE_CONTENT_INSET : undefined;
@@ -287,14 +288,22 @@ const StageNodeComponent = (props: StageNodeProps) => {
           taskGroupLength,
           isAboveParallel,
           isBelowParallel,
-          reGroupTaskFunction
+          reGroupTaskFunction,
+          hideParallelOptions
         );
         return [...items, ...reGroupOptions];
       }
 
       return items;
     },
-    [onReplaceTaskFromToolbox, onTaskClick, onTaskGroupModification, reGroupTaskFunction, tasks]
+    [
+      onReplaceTaskFromToolbox,
+      onTaskClick,
+      onTaskGroupModification,
+      reGroupTaskFunction,
+      tasks,
+      hideParallelOptions,
+    ]
   );
 
   const { setSelectedNodeId } = useNodeSelection();

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.types.ts
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.types.ts
@@ -86,6 +86,7 @@ export interface StageNodeProps extends NodeProps {
   onTaskReorder?: (reorderedTasks: StageTaskItem[][]) => void;
   onReplaceTaskFromToolbox?: (newTask: ListItem, groupIndex: number, taskIndex: number) => void;
   onTaskPlay?: (taskId: string) => Promise<void>;
+  hideParallelOptions?: boolean;
 }
 
 export interface StageTaskExecution {

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNodeTaskUtilities.ts
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNodeTaskUtilities.ts
@@ -16,7 +16,8 @@ export const getContextMenuItems = (
     groupModificationType: GroupModificationType,
     groupIndex: number,
     taskIndex: number
-  ) => void
+  ) => void,
+  hideParallelOptions = false
 ): NodeMenuItem[] => {
   const CONTEXT_MENU_ITEMS = {
     MOVE_UP: getMenuItem('move-up', 'Move up', () =>
@@ -67,7 +68,7 @@ export const getContextMenuItems = (
 
   if (items.length) items.push(CONTEXT_MENU_ITEMS.DIVIDER);
 
-  if (isParallelGroup) {
+  if (isParallelGroup && !hideParallelOptions) {
     items.push(
       CONTEXT_MENU_ITEMS.UNGROUP_ALL,
       CONTEXT_MENU_ITEMS.SPLIT_TASK,
@@ -75,7 +76,7 @@ export const getContextMenuItems = (
       CONTEXT_MENU_ITEMS.REMOVE_GROUP,
       CONTEXT_MENU_ITEMS.REMOVE_TASK
     );
-  } else {
+  } else if (!isParallelGroup && !hideParallelOptions) {
     if (groupIndex > 0) {
       items.push(
         isAboveParallel
@@ -94,6 +95,8 @@ export const getContextMenuItems = (
 
     if (items.length) items.push(CONTEXT_MENU_ITEMS.DIVIDER);
 
+    items.push(CONTEXT_MENU_ITEMS.REMOVE_TASK);
+  } else {
     items.push(CONTEXT_MENU_ITEMS.REMOVE_TASK);
   }
 


### PR DESCRIPTION
Currently the entire contents of the dropdown are hidden based on whether or not `onTaskGroupModification` is passed. But due to changes that make parallel grouping options not make sense we need to be able to hide only the parallel options.

This PR adds a `hideParallelOptions` prop to `StageNode` that, when true, removes the parallel-related menu items (create/add to/ungroup/split/remove parallel group) while keeping move up, move down, and delete.