### PR TITLE
fix(apollo-react): added missing exports for stage header chips

### DIFF
--- a/packages/apollo-react/src/canvas/components/StageNode/index.ts
+++ b/packages/apollo-react/src/canvas/components/StageNode/index.ts
@@ -1,7 +1,9 @@
 export { StageConnectionEdge } from './StageConnectionEdge';
 export { StageEdge } from './StageEdge';
 export { StageNode } from './StageNode';
+export { StageHeaderChipType } from './StageNode.types';
 export type {
+  StageHeaderChip,
   StageNodeProps,
   StageStatus,
   StageTaskItem,


### PR DESCRIPTION
Exports for `StageHeaderChip` and `StageHeaderChipType` was missing.