### PR TITLE
fix(apollo-react): use camelCase JSX attributes in CaseManagementProject icon [MST-8113]

### DIFF
--- a/packages/apollo-react/src/canvas/icons/CaseManagementProject.tsx
+++ b/packages/apollo-react/src/canvas/icons/CaseManagementProject.tsx
@@ -16,9 +16,9 @@ export const CaseManagementProject = ({
     <path
       d="M16.466 7.5C15.643 4.237 13.952 2 12 2C9.239 2 7 6.477 7 12C7 17.523 9.239 22 12 22C12.342 22 12.677 21.931 13 21.8"
       stroke="currentColor"
-      stroke-width="2"
-      stroke-linecap="round"
-      stroke-linejoin="round"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
     />
     <path
       fill="currentColor"


### PR DESCRIPTION
The `CaseManagementProject` icon uses raw SVG attributes (`stroke-width`, `stroke-linecap`, `stroke-linejoin`) instead of React JSX camelCase equivalents (`strokeWidth`, `strokeLinecap`, `strokeLinejoin`). This was introduced in #418 when the icon was redesigned — the previous version had correct camelCase attributes.

This causes `console.error` warnings in React, which breaks tests in downstream consumers that treat `console.error` as a test failure. E.g.:
- UiPath/PO.Frontend#4535