### PR TITLE
fix(apollo-react): separate Warning status styling from Paused status

### DIFF
--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.styles.ts
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.styles.ts
@@ -48,7 +48,7 @@ export const StageContainer = styled.div<{
     `}
 
   ${({ status }) =>
-    (status === 'Paused' || status === 'Warning') &&
+    status === 'Paused' &&
     css`
       border-color: var(--uix-canvas-warning-icon);
     `}
@@ -210,7 +210,7 @@ export const StageTask = styled.div<{
     `}
 
   ${({ status }) =>
-    (status === 'Paused' || status === 'Warning') &&
+    status === 'Paused' &&
     css`
       border-color: var(--uix-canvas-warning-icon);
     `}


### PR DESCRIPTION
## Summary
Updated execution status styling to differentiate between 'Paused' and 'Warning' statuses, removing the shared styling that previously grouped them together.

## Key Changes
- **StageNode.styles.ts**: Updated two styled components (StageContainer and StageTask) to only apply warning icon styling for 'Paused' status, removing 'Warning' from the conditional check

## Implementation Details
The changes ensure that Warning status items display with a de-emphasized appearance (using `--uix-canvas-border-de-emp`) rather than the animated warning icon styling, providing better visual distinction between paused and warning states in the canvas UI.

## Demo
<img width="559" height="312" alt="image" src="https://github.com/user-attachments/assets/7a7bcbc0-3260-48df-ac98-6c51398ce5d7" />


https://claude.ai/code/session_01L8FQaVQLtdZSxJWAe4eBP3