### PR TITLE
fix(apollo-react): no margin top when only adhoc tasks

### DIFF
--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.stories.tsx
@@ -1654,7 +1654,6 @@ export const AdhocTasks: Story = {
                   isAdhoc: true,
                 },
               ],
-              [{ id: '3', label: 'Regular Task', icon: <ProcessIcon /> }],
             ],
           },
           onTaskPlay: (taskId: string) => {

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.styles.ts
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.styles.ts
@@ -309,7 +309,6 @@ export const StageAdhocSection = styled.div`
   display: flex;
   flex-direction: column;
   gap: ${Spacing.SpacingS};
-  margin-top: ${Spacing.SpacingS};
 `;
 
 export const StageAdhocHeaderSection = styled.div`

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.tsx
@@ -803,7 +803,9 @@ const StageNodeComponent = (props: StageNodeProps) => {
                 </DndContext>
               )}
               {adhocTasks.length > 0 && (
-                <StageAdhocSection>
+                <StageAdhocSection
+                  style={{ marginTop: tasks.length > 0 ? Spacing.SpacingS : '0px' }}
+                >
                   <StageAdhocHeaderSection>
                     <ApTypography
                       variant={FontVariantToken.fontSizeSBold}


### PR DESCRIPTION
## Description
No margin top when only adhoc tasks
<img width="715" height="362" alt="Screenshot 2026-04-03 at 5 05 38 PM" src="https://github.com/user-attachments/assets/e0c46a9e-bea6-4a08-96cf-64ff9c969e05" />
