### PR TITLE
feat(apollo-react): add necessary callbacks in sticky note node [MST-7963]

### DIFF
--- a/packages/apollo-react/src/canvas/components/StickyNoteNode/StickyNoteNode.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/StickyNoteNode/StickyNoteNode.stories.tsx
@@ -26,8 +26,49 @@ type Story = StoryObj<typeof meta>;
 // Helper Functions
 // ============================================================================
 
+// StickyNote wrapper with console logging for callbacks
+const StickyNoteWithCallbacks = (props: any) => {
+  const handleContentChange = (content: string) => {
+    console.log('📝 Content changed:', {
+      nodeId: props.id,
+      content,
+      timestamp: new Date().toISOString(),
+    });
+  };
+
+  const handleColorChange = (color: StickyNoteColor) => {
+    console.log('🎨 Color changed:', {
+      nodeId: props.id,
+      color,
+      timestamp: new Date().toISOString(),
+    });
+  };
+
+  const handleResize = (width: number, height: number) => {
+    console.log('📏 Resized:', {
+      nodeId: props.id,
+      width,
+      height,
+      timestamp: new Date().toISOString(),
+    });
+  };
+
+  return (
+    <StickyNoteNode
+      {...props}
+      onContentChange={handleContentChange}
+      onColorChange={handleColorChange}
+      onResize={handleResize}
+    />
+  );
+};
+
 const nodeTypes = {
   stickyNote: StickyNoteNode,
+};
+
+const nodeTypesWithCallbacks = {
+  stickyNote: StickyNoteWithCallbacks,
 };
 
 function createStickyNote(
@@ -376,6 +417,34 @@ function WithBaseNodesStory() {
   );
 }
 
+function WithCallbacksStory() {
+  const initialNodes = useMemo<Node<StickyNoteData>[]>(
+    () => [
+      createStickyNote(
+        'sticky-test-1',
+        'yellow',
+        '**Test Callbacks!**\n\n1. Double-click to edit content\n2. Click the color button to change color\n3. Drag corners to resize\n\nOpen the browser console to see logs! 🔍',
+        { x: 480, y: 480 },
+        { width: 320, height: 320 }
+      ),
+    ],
+    []
+  );
+
+  const { canvasProps } = useCanvasStory({
+    initialNodes,
+    additionalNodeTypes: nodeTypesWithCallbacks,
+  });
+
+  return (
+    <BaseCanvas {...canvasProps} mode="design">
+      <Panel position="bottom-right">
+        <CanvasPositionControls translations={DefaultCanvasTranslations} />
+      </Panel>
+    </BaseCanvas>
+  );
+}
+
 // ============================================================================
 // Exported Stories
 // ============================================================================
@@ -386,4 +455,8 @@ export const Default: Story = {
 
 export const WithBaseNodes: Story = {
   render: () => <WithBaseNodesStory />,
+};
+
+export const WithCallbacks: Story = {
+  render: () => <WithCallbacksStory />,
 };

--- a/packages/apollo-react/src/canvas/components/StickyNoteNode/StickyNoteNode.tsx
+++ b/packages/apollo-react/src/canvas/components/StickyNoteNode/StickyNoteNode.tsx
@@ -2,6 +2,7 @@ import { Global } from '@emotion/react';
 import { NodeIcon } from '@uipath/apollo-react/canvas';
 import type { NodeProps } from '@uipath/apollo-react/canvas/xyflow/react';
 import { NodeResizeControl, useReactFlow } from '@uipath/apollo-react/canvas/xyflow/react';
+import type { ResizeDragEvent, ResizeParams } from '@uipath/apollo-react/canvas/xyflow/system';
 import { AnimatePresence } from 'motion/react';
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import ReactMarkdown from 'react-markdown';
@@ -40,6 +41,9 @@ export interface StickyNoteNodeProps extends NodeProps {
   data: StickyNoteData;
   placeholder?: string;
   renderPlaceholderOnSelect?: boolean;
+  onContentChange?: (content: string) => void;
+  onColorChange?: (color: StickyNoteColor) => void;
+  onResize?: (width: number, height: number) => void;
 }
 
 const minWidth = GRID_SPACING * 8;
@@ -52,6 +56,9 @@ const StickyNoteNodeComponent = ({
   dragging,
   placeholder = 'Add text',
   renderPlaceholderOnSelect = false,
+  onContentChange,
+  onColorChange,
+  onResize,
 }: StickyNoteNodeProps) => {
   const { updateNodeData, deleteElements } = useReactFlow();
   const [isEditing, setIsEditing] = useState(data.autoFocus ?? false);
@@ -109,9 +116,10 @@ const StickyNoteNodeComponent = ({
   const handleBlur = useCallback(() => {
     setIsEditing(false);
     if (localContent !== data.content) {
+      onContentChange?.(localContent);
       updateNodeData(id, { content: localContent });
     }
-  }, [id, localContent, data.content, updateNodeData]);
+  }, [id, localContent, data.content, updateNodeData, onContentChange]);
 
   const handleChange = useCallback((e: React.ChangeEvent<HTMLTextAreaElement>) => {
     setLocalContent(e.target.value);
@@ -174,17 +182,22 @@ const StickyNoteNodeComponent = ({
     setIsResizing(true);
   }, []);
 
-  const handleResizeEnd = useCallback(() => {
-    setIsResizing(false);
-  }, []);
+  const handleResizeEnd = useCallback(
+    (_event: ResizeDragEvent, params: ResizeParams) => {
+      setIsResizing(false);
+      onResize?.(params.width, params.height);
+    },
+    [onResize]
+  );
 
   // Color change handler
   const handleColorChange = useCallback(
     (newColor: StickyNoteColor) => {
+      onColorChange?.(newColor);
       updateNodeData(id, { color: newColor });
       setIsColorPickerOpen(false);
     },
-    [id, updateNodeData]
+    [id, updateNodeData, onColorChange]
   );
 
   // Toggle color picker


### PR DESCRIPTION
We need the sticky node data whenever it gets updated with the help of callbacks so that we ca update nodes from po side as well and can save the state to history.

<img width="2536" height="1369" alt="Screenshot 2026-04-07 at 3 23 00 PM" src="https://github.com/user-attachments/assets/ca761471-62f3-4f30-a3d2-4fc7325829d0" />



