### PR TITLE
fix(apollo-react): disable task context menus in read-only mode [MST-8297]

### DIFF
--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.stories.tsx
@@ -1061,6 +1061,20 @@ const AddAndReplaceTasksStory = () => {
       data: {
         stageDetails: {
           label: 'Add, Replace, and Group Tasks',
+          isReadOnly: false,
+          tasks: initialTasksForAddReplace,
+        },
+        taskOptions: availableTaskOptions,
+      },
+    },
+    {
+      id: 'readonly-stage',
+      type: 'stage',
+      position: { x: 720, y: 96 },
+      data: {
+        stageDetails: {
+          label: 'ReadOnly Stage',
+          isReadOnly: true,
           tasks: initialTasksForAddReplace,
         },
         taskOptions: availableTaskOptions,

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.test.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.test.tsx
@@ -847,6 +847,42 @@ describe('StageNode - hideParallelOptions', () => {
   });
 });
 
+describe('StageNode - ReadOnly Mode', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should not render task kebab menu when isReadOnly is true', () => {
+    const onTaskGroupModification = vi.fn();
+    const tasks: StageTaskItem[][] = [
+      [createTask('task-1', 'Task 1')],
+      [createTask('task-2', 'Task 2')],
+    ];
+
+    renderStageNode({
+      onTaskGroupModification,
+      stageDetails: { ...defaultProps.stageDetails, tasks, isReadOnly: true },
+    });
+
+    expect(screen.queryByTestId('task-menu-button-task-1')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('task-menu-button-task-2')).not.toBeInTheDocument();
+  });
+
+  it('should not render adhoc task kebab menu when isReadOnly is true', () => {
+    const onTaskGroupModification = vi.fn();
+    const adhocTask = createTask('adhoc-1', 'Adhoc Task 1');
+    adhocTask.isAdhoc = true;
+    const tasks: StageTaskItem[][] = [[adhocTask]];
+
+    renderStageNode({
+      onTaskGroupModification,
+      stageDetails: { ...defaultProps.stageDetails, tasks, isReadOnly: true },
+    });
+
+    expect(screen.queryByTestId('task-menu-button-adhoc-1')).not.toBeInTheDocument();
+  });
+});
+
 describe('StageNode - Header Chips', () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.tsx
@@ -758,9 +758,10 @@ const StageNodeInner = (props: StageNodeProps) => {
                                         : undefined
                                     }
                                     isDragDisabled={!onTaskReorder}
-                                    {...(hasContextMenu && {
-                                      getContextMenuItems: buildContextMenuItems,
-                                    })}
+                                    {...(hasContextMenu &&
+                                      !isReadOnly && {
+                                        getContextMenuItems: buildContextMenuItems,
+                                      })}
                                   />
                                 );
                               })}
@@ -800,10 +801,11 @@ const StageNodeInner = (props: StageNodeProps) => {
                           isSelected={selectedTaskId === task.id}
                           onTaskClick={handleTaskClick}
                           onTaskPlay={onTaskPlay}
-                          {...((onTaskGroupModification || onReplaceTaskFromToolbox) && {
-                            getContextMenuItems: () =>
-                              getAdhocContextMenuItems(groupIndex, taskIndex, task.id),
-                          })}
+                          {...((onTaskGroupModification || onReplaceTaskFromToolbox) &&
+                            !isReadOnly && {
+                              getContextMenuItems: () =>
+                                getAdhocContextMenuItems(groupIndex, taskIndex, task.id),
+                            })}
                         />
                       );
                     })}


### PR DESCRIPTION
## Summary
This PR prevents task context menus (kebab menus) from being rendered when a stage is in read-only mode, ensuring users cannot modify tasks through the UI in read-only stages.

## Key Changes
- Modified `StageNode.tsx` to conditionally disable context menus for both regular and adhoc tasks when `isReadOnly` is true
- Added test coverage in `StageNode.test.tsx` to verify that task kebab menus are not rendered in read-only mode for both regular and adhoc tasks

## Implementation Details
- Updated the context menu rendering logic to check `!isReadOnly` in addition to existing conditions for both regular task menus and adhoc task menus
- Added two new test cases under the "StageNode - ReadOnly Mode" describe block to validate the behavior

## Demo
<img width="1421" height="731" alt="image" src="https://github.com/user-attachments/assets/2198600d-eab3-4e25-b8cc-af7e25514887" />


https://claude.ai/code/session_01D3AjfzFVHi7iNwFCJvmgYf