### PR TITLE
fix(apollo-react): disable task three-dot menu while loading [MST-8171]

### DIFF
--- a/packages/apollo-react/src/canvas/components/StageNode/AdhocTask.test.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/AdhocTask.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
 import type { NodeMenuItem } from '../NodeContextMenu';
@@ -262,6 +262,78 @@ describe('AdhocTaskItem', () => {
       await waitFor(() => {
         expect(screen.queryByText('Delete task')).not.toBeInTheDocument();
       });
+    });
+  });
+
+  describe('Task Loading State', () => {
+    it('disables menu button when isTaskLoading is true', () => {
+      const onRemove = vi.fn();
+      const menuItems = createMenuItems(onRemove);
+
+      render(
+        <AdhocTaskItem
+          {...defaultProps}
+          getContextMenuItems={() => menuItems}
+          isTaskLoading={true}
+        />
+      );
+
+      const menuButton = screen.getByTestId('stage-task-menu-adhoc-1');
+      expect(menuButton).toBeDisabled();
+    });
+
+    it('does not disable menu button when isTaskLoading is false', () => {
+      const onRemove = vi.fn();
+      const menuItems = createMenuItems(onRemove);
+
+      render(
+        <AdhocTaskItem
+          {...defaultProps}
+          getContextMenuItems={() => menuItems}
+          isTaskLoading={false}
+        />
+      );
+
+      const menuButton = screen.getByTestId('stage-task-menu-adhoc-1');
+      expect(menuButton).not.toBeDisabled();
+    });
+
+    it('does not open menu when clicking a disabled menu button', () => {
+      const onRemove = vi.fn();
+      const menuItems = createMenuItems(onRemove);
+
+      render(
+        <AdhocTaskItem
+          {...defaultProps}
+          getContextMenuItems={() => menuItems}
+          isTaskLoading={true}
+        />
+      );
+
+      const menuButton = screen.getByTestId('stage-task-menu-adhoc-1');
+      expect(menuButton).toBeDisabled();
+
+      fireEvent.click(menuButton);
+      expect(screen.queryByText('Replace task')).not.toBeInTheDocument();
+    });
+
+    it('does not open menu on right-click when isTaskLoading is true', async () => {
+      const user = userEvent.setup();
+      const onRemove = vi.fn();
+      const menuItems = createMenuItems(onRemove);
+
+      render(
+        <AdhocTaskItem
+          {...defaultProps}
+          getContextMenuItems={() => menuItems}
+          isTaskLoading={true}
+        />
+      );
+
+      const task = screen.getByTestId('stage-task-adhoc-1');
+      await user.pointer({ keys: '[MouseRight]', target: task });
+
+      expect(screen.queryByText('Replace task')).not.toBeInTheDocument();
     });
   });
 });

--- a/packages/apollo-react/src/canvas/components/StageNode/AdhocTask.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/AdhocTask.tsx
@@ -12,6 +12,7 @@ interface AdhocTaskItemProps {
   getContextMenuItems?: () => NodeMenuItem[];
   onTaskClick: (e: React.MouseEvent, taskId: string) => void;
   onTaskPlay?: (taskId: string) => Promise<void>;
+  isTaskLoading?: boolean;
 }
 
 const AdhocTaskItemComponent = ({
@@ -21,6 +22,7 @@ const AdhocTaskItemComponent = ({
   getContextMenuItems,
   onTaskClick,
   onTaskPlay,
+  isTaskLoading,
 }: AdhocTaskItemProps) => {
   const taskRef = useRef<HTMLDivElement>(null);
   const menuRef = useRef<TaskMenuHandle>(null);
@@ -43,11 +45,16 @@ const AdhocTaskItemComponent = ({
       selected={isSelected}
       status={taskExecution?.status}
       onClick={handleClick}
-      {...(getContextMenuItems && { onContextMenu: handleContextMenu })}
+      {...(getContextMenuItems && !isTaskLoading && { onContextMenu: handleContextMenu })}
     >
       <TaskContent task={task} taskExecution={taskExecution} onTaskPlay={onTaskPlay} />
       {getContextMenuItems && (
-        <TaskMenu ref={menuRef} taskId={task.id} getContextMenuItems={getContextMenuItems} />
+        <TaskMenu
+          ref={menuRef}
+          taskId={task.id}
+          getContextMenuItems={getContextMenuItems}
+          disabled={isTaskLoading}
+        />
       )}
     </StageTask>
   );

--- a/packages/apollo-react/src/canvas/components/StageNode/DraggableTask.test.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/DraggableTask.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
 import type { NodeMenuItem } from '../NodeContextMenu';
@@ -311,6 +311,78 @@ describe('DraggableTask', () => {
       await user.click(task);
 
       expect(onTaskClick).toHaveBeenCalledWith(expect.any(Object), 'task-1');
+    });
+  });
+
+  describe('Task Loading State', () => {
+    it('disables menu button when isTaskLoading is true', () => {
+      const onRemove = vi.fn();
+      const menuItems = createMenuItems(onRemove);
+
+      render(
+        <DraggableTask
+          {...defaultProps}
+          getContextMenuItems={() => menuItems}
+          isTaskLoading={true}
+        />
+      );
+
+      const menuButton = screen.getByTestId('stage-task-menu-task-1');
+      expect(menuButton).toBeDisabled();
+    });
+
+    it('does not disable menu button when isTaskLoading is false', () => {
+      const onRemove = vi.fn();
+      const menuItems = createMenuItems(onRemove);
+
+      render(
+        <DraggableTask
+          {...defaultProps}
+          getContextMenuItems={() => menuItems}
+          isTaskLoading={false}
+        />
+      );
+
+      const menuButton = screen.getByTestId('stage-task-menu-task-1');
+      expect(menuButton).not.toBeDisabled();
+    });
+
+    it('does not open menu when clicking a disabled menu button', () => {
+      const onRemove = vi.fn();
+      const menuItems = createMenuItems(onRemove);
+
+      render(
+        <DraggableTask
+          {...defaultProps}
+          getContextMenuItems={() => menuItems}
+          isTaskLoading={true}
+        />
+      );
+
+      const menuButton = screen.getByTestId('stage-task-menu-task-1');
+      expect(menuButton).toBeDisabled();
+
+      fireEvent.click(menuButton);
+      expect(screen.queryByText('Move Up')).not.toBeInTheDocument();
+    });
+
+    it('does not open menu on right-click when isTaskLoading is true', async () => {
+      const user = userEvent.setup();
+      const onRemove = vi.fn();
+      const menuItems = createMenuItems(onRemove);
+
+      render(
+        <DraggableTask
+          {...defaultProps}
+          getContextMenuItems={() => menuItems}
+          isTaskLoading={true}
+        />
+      );
+
+      const task = screen.getByTestId('stage-task-task-1');
+      await user.pointer({ keys: '[MouseRight]', target: task });
+
+      expect(screen.queryByText('Move Up')).not.toBeInTheDocument();
     });
   });
 

--- a/packages/apollo-react/src/canvas/components/StageNode/DraggableTask.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/DraggableTask.tsx
@@ -26,6 +26,7 @@ const DraggableTaskComponent = ({
   onTaskClick,
   isDragDisabled,
   projectedDepth,
+  isTaskLoading,
 }: DraggableTaskProps) => {
   const zoom = useStore((s) => s.transform[2]);
   const taskRef = useRef<HTMLDivElement>(null);
@@ -94,7 +95,7 @@ const DraggableTaskComponent = ({
       isParallel={isParallel}
       isDragEnabled={!isDragDisabled}
       onClick={handleClick}
-      {...(getContextMenuItems && { onContextMenu: handleContextMenu })}
+      {...(getContextMenuItems && !isTaskLoading && { onContextMenu: handleContextMenu })}
     >
       <TaskContent task={task} taskExecution={taskExecution} />
 
@@ -113,7 +114,12 @@ const DraggableTaskComponent = ({
         </CanvasTooltip>
       )}
       {getContextMenuItems && (
-        <TaskMenu ref={menuRef} taskId={task.id} getContextMenuItems={handleGetContextMenuItems} />
+        <TaskMenu
+          ref={menuRef}
+          taskId={task.id}
+          getContextMenuItems={handleGetContextMenuItems}
+          disabled={isTaskLoading}
+        />
       )}
     </StageTask>
   );

--- a/packages/apollo-react/src/canvas/components/StageNode/DraggableTask.types.ts
+++ b/packages/apollo-react/src/canvas/components/StageNode/DraggableTask.types.ts
@@ -13,4 +13,5 @@ export interface DraggableTaskProps {
   onTaskPlay?: (taskId: string) => Promise<void>;
   isDragDisabled?: boolean;
   projectedDepth?: number;
+  isTaskLoading?: boolean;
 }

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.stories.tsx
@@ -1528,18 +1528,57 @@ const AddTaskLoadingStory = () => {
   const setNodesRef = useRef<React.Dispatch<React.SetStateAction<Node[]>>>(null!);
 
   // Inject per-node handlers — simulates loading state on add-task:
-  // 1. Set addTaskLoading=true so the + button is disabled
-  // 2. After 2s, set addTaskLoading=false to re-enable it
+  // 1. Set loadingTaskIds with a placeholder ID so the + button is disabled
+  // 2. After 2s, clear loadingTaskIds to re-enable it
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
 
-  const handleAddTaskFromToolbox = useCallback((nodeId: string, _taskItem: ListItem) => {
+  const handleAddTaskFromToolbox = useCallback((nodeId: string, taskItem: ListItem) => {
     clearTimeout(timeoutRef.current);
+    const newTaskId = `task-${Date.now()}`;
+    // Add the task to the stage and mark it as loading
     setNodesRef.current((nds) =>
-      nds.map((n) => (n.id === nodeId ? { ...n, data: { ...n.data, addTaskLoading: true } } : n))
+      nds.map((n) => {
+        if (n.id !== nodeId) return n;
+        const data = n.data as Record<string, any>;
+        const currentTasks: StageTaskItem[][] = data.stageDetails?.tasks ?? [];
+        const newTask: StageTaskItem = { id: newTaskId, label: taskItem.name };
+        const currentExecution = data.execution ?? {
+          stageStatus: { status: undefined },
+          taskStatus: {},
+        };
+        return {
+          ...n,
+          data: {
+            ...data,
+            stageDetails: { ...data.stageDetails, tasks: [...currentTasks, [newTask]] },
+            loadingTaskIds: new Set([...((data.loadingTaskIds as Set<string>) ?? []), newTaskId]),
+            execution: {
+              ...currentExecution,
+              taskStatus: { ...currentExecution.taskStatus, [newTaskId]: { status: 'InProgress' } },
+            },
+          },
+        };
+      })
     );
+    // After 2s, clear loading state and execution status
     timeoutRef.current = setTimeout(() => {
       setNodesRef.current((nds) =>
-        nds.map((n) => (n.id === nodeId ? { ...n, data: { ...n.data, addTaskLoading: false } } : n))
+        nds.map((n) => {
+          if (n.id !== nodeId) return n;
+          const data = n.data as Record<string, any>;
+          const { [newTaskId]: _, ...remainingTaskStatus } = data.execution?.taskStatus ?? {};
+          return {
+            ...n,
+            data: {
+              ...data,
+              loadingTaskIds: new Set(),
+              execution: {
+                ...data.execution,
+                taskStatus: remainingTaskStatus,
+              },
+            },
+          };
+        })
       );
     }, 2000);
   }, []);
@@ -1556,11 +1595,12 @@ const AddTaskLoadingStory = () => {
             label: 'Loading (+ disabled for 3s)',
             tasks: [],
           },
-          addTaskLoading: true,
+          loadingTaskIds: new Set(['loading-task']),
           taskOptions: [] as ListItem[],
           onAddTaskFromToolbox: (taskItem: ListItem) => {
             handleAddTaskFromToolbox('loading-stage-empty', taskItem);
           },
+          onTaskGroupModification: () => {},
         },
       },
       {
@@ -1573,11 +1613,45 @@ const AddTaskLoadingStory = () => {
             label: 'Async children (click +)',
             tasks: [[{ id: 'task-1', label: 'Existing Task', icon: <VerificationIcon /> }]],
           },
-          addTaskLoading: false,
+          loadingTaskIds: new Set(),
           taskOptions: loadedTaskOptionsWithChildren,
           onAddTaskFromToolbox: (taskItem: ListItem) => {
             handleAddTaskFromToolbox('loading-stage-children', taskItem);
           },
+          onTaskGroupModification: () => {},
+        },
+      },
+      {
+        id: 'loading-stage-tasks',
+        type: 'stage',
+        position: { x: 752, y: 96 },
+        width: 304,
+        data: {
+          stageDetails: {
+            label: 'Task loading (3-dot disabled)',
+            tasks: [
+              [{ id: 'loading-task-1', label: 'Loading Task (3-dot disabled)' }],
+              [
+                {
+                  id: 'ready-task-1',
+                  label: 'Ready Task (3-dot enabled)',
+                  icon: <VerificationIcon />,
+                },
+              ],
+            ],
+          },
+          loadingTaskIds: new Set(['loading-task-1']),
+          execution: {
+            stageStatus: { status: undefined },
+            taskStatus: {
+              'loading-task-1': { status: 'InProgress' },
+            },
+          },
+          taskOptions: loadedTaskOptionsWithChildren,
+          onAddTaskFromToolbox: (taskItem: ListItem) => {
+            handleAddTaskFromToolbox('loading-stage-tasks', taskItem);
+          },
+          onTaskGroupModification: () => {},
         },
       },
     ],
@@ -1598,7 +1672,7 @@ const AddTaskLoadingStory = () => {
                 ...node,
                 data: {
                   ...node.data,
-                  addTaskLoading: false,
+                  loadingTaskIds: new Set(),
                   taskOptions: loadedTaskOptionsWithChildren,
                 },
               }
@@ -1606,6 +1680,30 @@ const AddTaskLoadingStory = () => {
         )
       );
     }, 3000);
+    return () => clearTimeout(timeout);
+  }, [setNodes]);
+
+  // Simulate per-task loading — after 5 seconds, task finishes loading and 3-dot becomes enabled
+  useEffect(() => {
+    const timeout = setTimeout(() => {
+      setNodes((nds) =>
+        nds.map((node) =>
+          node.id === 'loading-stage-tasks'
+            ? {
+                ...node,
+                data: {
+                  ...node.data,
+                  loadingTaskIds: new Set(),
+                  execution: {
+                    stageStatus: { status: undefined },
+                    taskStatus: {},
+                  },
+                },
+              }
+            : node
+        )
+      );
+    }, 5000);
     return () => clearTimeout(timeout);
   }, [setNodes]);
 

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.test.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.test.tsx
@@ -646,10 +646,10 @@ describe('StageNode - Add Task Loading State', () => {
     vi.clearAllMocks();
   });
 
-  it('should pass addTaskLoading to Toolbox when toolbox is open', async () => {
+  it('should set Toolbox loading to true when loadingTaskIds is non-empty', async () => {
     const user = userEvent.setup();
     const onAddTaskFromToolbox = vi.fn();
-    const { rerender } = renderStageNode({ onAddTaskFromToolbox, addTaskLoading: false });
+    const { rerender } = renderStageNode({ onAddTaskFromToolbox, loadingTaskIds: new Set() });
 
     const addButton = screen.getByRole('button', { name: 'Add task' });
     await user.click(addButton);
@@ -659,7 +659,7 @@ describe('StageNode - Add Task Loading State', () => {
         <StageNode
           {...defaultProps}
           onAddTaskFromToolbox={onAddTaskFromToolbox}
-          addTaskLoading={true}
+          loadingTaskIds={new Set(['task-1'])}
         />
       </ReactFlowProvider>
     );
@@ -668,10 +668,10 @@ describe('StageNode - Add Task Loading State', () => {
     expect(toolbox).toHaveAttribute('data-loading', 'true');
   });
 
-  it('should not pass loading to Toolbox when addTaskLoading is false', async () => {
+  it('should not pass loading to Toolbox when loadingTaskIds is empty', async () => {
     const user = userEvent.setup();
     const onAddTaskFromToolbox = vi.fn();
-    renderStageNode({ onAddTaskFromToolbox, addTaskLoading: false });
+    renderStageNode({ onAddTaskFromToolbox, loadingTaskIds: new Set() });
 
     const addButton = screen.getByRole('button', { name: 'Add task' });
     await user.click(addButton);
@@ -680,26 +680,26 @@ describe('StageNode - Add Task Loading State', () => {
     expect(toolbox).toHaveAttribute('data-loading', 'false');
   });
 
-  it('should disable the add button when addTaskLoading is true', () => {
+  it('should disable the add button when loadingTaskIds is non-empty', () => {
     const onAddTaskFromToolbox = vi.fn();
-    renderStageNode({ onAddTaskFromToolbox, addTaskLoading: true });
+    renderStageNode({ onAddTaskFromToolbox, loadingTaskIds: new Set(['task-1']) });
 
     const addButton = screen.getByRole('button', { name: 'Add task' });
     expect(addButton).toBeDisabled();
   });
 
-  it('should not disable the add button when addTaskLoading is false', () => {
+  it('should not disable the add button when loadingTaskIds is empty', () => {
     const onAddTaskFromToolbox = vi.fn();
-    renderStageNode({ onAddTaskFromToolbox, addTaskLoading: false });
+    renderStageNode({ onAddTaskFromToolbox, loadingTaskIds: new Set() });
 
     const addButton = screen.getByRole('button', { name: 'Add task' });
     expect(addButton).not.toBeDisabled();
   });
 
-  it('should update Toolbox loading when addTaskLoading changes to false', async () => {
+  it('should update Toolbox loading when loadingTaskIds changes to empty', async () => {
     const user = userEvent.setup();
     const onAddTaskFromToolbox = vi.fn();
-    const { rerender } = renderStageNode({ onAddTaskFromToolbox, addTaskLoading: false });
+    const { rerender } = renderStageNode({ onAddTaskFromToolbox, loadingTaskIds: new Set() });
 
     const addButton = screen.getByRole('button', { name: 'Add task' });
     await user.click(addButton);
@@ -709,7 +709,7 @@ describe('StageNode - Add Task Loading State', () => {
         <StageNode
           {...defaultProps}
           onAddTaskFromToolbox={onAddTaskFromToolbox}
-          addTaskLoading={true}
+          loadingTaskIds={new Set(['task-1'])}
         />
       </ReactFlowProvider>
     );
@@ -721,7 +721,7 @@ describe('StageNode - Add Task Loading State', () => {
         <StageNode
           {...defaultProps}
           onAddTaskFromToolbox={onAddTaskFromToolbox}
-          addTaskLoading={false}
+          loadingTaskIds={new Set()}
         />
       </ReactFlowProvider>
     );

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.tsx
@@ -84,7 +84,6 @@ const StageNodeInner = (props: StageNodeProps) => {
     execution,
     stageDetails,
     addTaskLabel = 'Add task',
-    addTaskLoading = false,
     replaceTaskLabel = 'Replace task',
     taskOptions = [],
     menuItems,
@@ -100,7 +99,10 @@ const StageNodeInner = (props: StageNodeProps) => {
     onReplaceTaskFromToolbox,
     onTaskPlay,
     hideParallelOptions,
+    loadingTaskIds,
   } = props;
+
+  const isAnyTaskLoading = loadingTaskIds != null && loadingTaskIds.size > 0;
 
   const taskWidth = width ? width - STAGE_CONTENT_INSET : undefined;
 
@@ -655,14 +657,14 @@ const StageNodeInner = (props: StageNodeProps) => {
               </CanvasTooltip>
             )}
             {(onTaskAdd || onAddTaskFromToolbox) && !isReadOnly && (
-              <CanvasTooltip content={addTaskLabel} placement="top" hide={addTaskLoading}>
+              <CanvasTooltip content={addTaskLabel} placement="top" hide={isAnyTaskLoading}>
                 <Button
                   variant="ghost"
                   size="icon"
                   className="h-6 w-6"
                   onClick={handleTaskAddClick}
                   aria-label={addTaskLabel}
-                  disabled={addTaskLoading}
+                  disabled={isAnyTaskLoading}
                 >
                   <CanvasIcon icon="plus" size={20} />
                 </Button>
@@ -677,10 +679,10 @@ const StageNodeInner = (props: StageNodeProps) => {
               {(onTaskAdd || onAddTaskFromToolbox) && !isReadOnly ? (
                 <Button
                   variant="link"
-                  onClick={addTaskLoading ? undefined : handleTaskAddClick}
+                  onClick={isAnyTaskLoading ? undefined : handleTaskAddClick}
                   style={{
                     maxWidth: 'fit-content',
-                    pointerEvents: addTaskLoading ? 'none' : undefined,
+                    pointerEvents: isAnyTaskLoading ? 'none' : undefined,
                   }}
                 >
                   {defaultContent}
@@ -733,6 +735,7 @@ const StageNodeInner = (props: StageNodeProps) => {
                                         : undefined
                                     }
                                     isDragDisabled={!onTaskReorder}
+                                    isTaskLoading={loadingTaskIds?.has(task.id)}
                                     {...(hasContextMenu &&
                                       !isReadOnly && {
                                         getContextMenuItems: buildContextMenuItems,
@@ -771,6 +774,7 @@ const StageNodeInner = (props: StageNodeProps) => {
                           isSelected={selectedTaskId === task.id}
                           onTaskClick={handleTaskClick}
                           onTaskPlay={onTaskPlay}
+                          isTaskLoading={loadingTaskIds?.has(task.id)}
                           {...((onTaskGroupModification || onReplaceTaskFromToolbox) &&
                             !isReadOnly && {
                               getContextMenuItems: () =>
@@ -792,7 +796,7 @@ const StageNodeInner = (props: StageNodeProps) => {
           <Toolbox
             title={addTaskLabel}
             initialItems={taskOptions}
-            loading={addTaskLoading}
+            loading={isAnyTaskLoading}
             onClose={() => setIsAddingTask(false)}
             onItemSelect={handleAddTaskToolboxItemSelected}
             onSearch={onTaskToolboxSearch}

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.types.ts
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.types.ts
@@ -58,7 +58,6 @@ export interface StageNodeBaseProps {
     headerChips?: StageHeaderChip[];
   };
   addTaskLabel?: string;
-  addTaskLoading?: boolean;
   replaceTaskLabel?: string;
   taskOptions?: ListItem[];
   execution?: {
@@ -85,6 +84,7 @@ export interface StageNodeBaseProps {
   onReplaceTaskFromToolbox?: (newTask: ListItem, groupIndex: number, taskIndex: number) => void;
   onTaskPlay?: (taskId: string) => Promise<void>;
   hideParallelOptions?: boolean;
+  loadingTaskIds?: ReadonlySet<string>;
 }
 
 export interface StageNodeCanvasProps extends NodeProps, StageNodeBaseProps {}

--- a/packages/apollo-react/src/canvas/components/StageNode/TaskMenu.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/TaskMenu.tsx
@@ -9,10 +9,11 @@ export interface TaskMenuHandle {
 interface TaskMenuProps {
   taskId: string;
   getContextMenuItems: () => NodeMenuItem[];
+  disabled?: boolean;
 }
 
 const TaskMenuComponent = (
-  { taskId, getContextMenuItems }: TaskMenuProps,
+  { taskId, getContextMenuItems, disabled }: TaskMenuProps,
   ref: React.Ref<TaskMenuHandle>
 ) => {
   const [isOpen, setIsOpen] = useState(false);
@@ -20,12 +21,13 @@ const TaskMenuComponent = (
 
   const handleOpenChange = useCallback(
     (open: boolean) => {
+      if (disabled && open) return;
       if (open) {
         setMenuItems(getContextMenuItems());
       }
       setIsOpen(open);
     },
-    [getContextMenuItems]
+    [getContextMenuItems, disabled]
   );
 
   const handleMenuItemClick = useCallback((item: NodeMenuAction) => {
@@ -37,9 +39,10 @@ const TaskMenuComponent = (
     (e: React.MouseEvent<HTMLElement>) => {
       e.stopPropagation();
       e.preventDefault();
+      if (disabled) return;
       handleOpenChange(true);
     },
-    [handleOpenChange]
+    [handleOpenChange, disabled]
   );
 
   useImperativeHandle(ref, () => ({
@@ -55,6 +58,7 @@ const TaskMenuComponent = (
       triggerTestId={`stage-task-menu-${taskId}`}
       triggerAriaLabel="Task actions"
       contentClassName="w-[300px]"
+      disabled={disabled}
     />
   );
 };

--- a/packages/apollo-react/src/canvas/components/shared/CanvasDropdownMenu.tsx
+++ b/packages/apollo-react/src/canvas/components/shared/CanvasDropdownMenu.tsx
@@ -18,6 +18,7 @@ interface CanvasDropdownMenuProps {
   triggerTestId?: string;
   triggerAriaLabel?: string;
   contentClassName?: string;
+  disabled?: boolean;
 }
 
 /**
@@ -38,6 +39,7 @@ export function CanvasDropdownMenu({
   triggerTestId,
   triggerAriaLabel = 'Dropdown menu',
   contentClassName,
+  disabled,
 }: CanvasDropdownMenuProps) {
   return (
     <DropdownMenu open={open} onOpenChange={onOpenChange} modal={false}>
@@ -48,6 +50,7 @@ export function CanvasDropdownMenu({
           className="h-6 w-6"
           data-testid={triggerTestId}
           aria-label={triggerAriaLabel}
+          disabled={disabled}
           onClick={(e: React.MouseEvent) => e.stopPropagation()}
           onPointerDown={(e: React.PointerEvent) => e.stopPropagation()}
         >


### PR DESCRIPTION
## Summary
- Add `loadingTaskIds` prop to `StageNode` to track which tasks are currently loading
- Disable three-dot menu button on tasks that are in a loading state (prevents delete/actions during async operations)
- Apply same treatment to adhoc tasks
- Replace `addTaskLoading` with `loadingTaskIds` for per-task granularity
- Update tests and stories

## Demo

https://github.com/user-attachments/assets/51e04b29-2d36-4f91-9a6e-278c1aedc68c



## Test plan
- [ ] Verify three-dot menu button is disabled (greyed out) on loading tasks in storybook (`AddTaskLoading` story, third stage)
- [ ] Verify three-dot menu button is enabled on non-loading tasks in the same stage
- [ ] Verify right-click context menu is suppressed on loading tasks
- [ ] Verify loading state clears and menu re-enables after async operation completes
- [ ] Run `DraggableTask.test.tsx` — 4 new tests for loading state behavior
- [ ] Run `StageNode.test.tsx` — updated tests use `loadingTaskIds` instead of `addTaskLoading`