### PR TITLE
fix(apollo-vertex): correct uipcli plugin docs link

### DIFF
--- a/apps/apollo-vertex/app/page.mdx
+++ b/apps/apollo-vertex/app/page.mdx
@@ -31,7 +31,7 @@ Vertical Solutions plugin for managing UiPath Vertical Solutions.
 
 Also supports flags, for more info `uip vss --help` or `uip vss [command] --help`.
 
-Plugin docs: https://github.com/UiPath/uipcli/tree/main/packages/vertical-solutions
+Plugin docs: https://github.com/UiPath/cli/tree/main/packages/vertical-solutions-tool
 
 - **Initialize a new vertical solution**
 


### PR DESCRIPTION
Fixes the vertical-solutions plugin documentation link on the landing page. The old URL (`UiPath/uipcli/.../vertical-solutions`) pointed to a non-existent repo/path. Updated to the correct location at `UiPath/cli/.../vertical-solutions-tool`.