### PR TITLE
fix(apollo-vertex): hide auth_callback from Nextra sidebar

### DIFF
--- a/apps/apollo-vertex/app/_meta.ts
+++ b/apps/apollo-vertex/app/_meta.ts
@@ -7,4 +7,10 @@ export default {
   "vertex-components": "Vertex Components",
   themes: "Themes",
   localization: "Localization",
+  auth_callback: {
+    display: "hidden",
+  },
+  portal_: {
+    display: "hidden",
+  },
 };


### PR DESCRIPTION
## Summary

The `auth_callback` OAuth route was appearing in the Nextra documentation sidebar because it wasn't listed in the root `_meta.ts`. This adds it with `display: "hidden"` so it no longer shows up in navigation while remaining functional for the OAuth flow.