### PR TITLE
fix(apollo-react): clamp node header and subheader text to prevent overflow [MST-8419]

### DIFF
--- a/packages/apollo-react/src/canvas/components/BaseNode/BaseNode.styles.ts
+++ b/packages/apollo-react/src/canvas/components/BaseNode/BaseNode.styles.ts
@@ -292,16 +292,19 @@ export const BaseHeader = styled.div<{ shape?: NodeShape; backgroundColor?: stri
     `}
   line-height: 1.4;
   margin-bottom: 2px;
+  overflow: hidden;
   ${({ shape }) =>
     shape === 'rectangle'
       ? css`
           width: 100%;
           white-space: nowrap;
-          overflow: hidden;
           text-overflow: ellipsis;
         `
       : css`
           word-break: break-word;
+          display: -webkit-box;
+          -webkit-box-orient: vertical;
+          -webkit-line-clamp: 3;
         `}
 `;
 
@@ -310,16 +313,18 @@ export const BaseSubHeader = styled.div<{ shape?: NodeShape }>`
   color: var(--uix-canvas-foreground-de-emp);
   line-height: 1.3;
   word-break: break-word;
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
   ${({ shape }) =>
     shape === 'rectangle'
       ? css`
           width: 100%;
-          display: -webkit-box;
-          -webkit-box-orient: vertical;
           -webkit-line-clamp: 2;
-          overflow: hidden;
         `
-      : ''}
+      : css`
+          -webkit-line-clamp: 5;
+`}
 `;
 
 export const EditableLabel = styled.textarea<{


### PR DESCRIPTION
## Summary

Adds `-webkit-line-clamp` truncation to `BaseHeader` (3 lines) and `BaseSubHeader` (5 lines) for square/circular shaped nodes. This prevents long labels from overflowing their containers and overlapping with other nodes below.

| Rectangular Node (unchanged) | Square/Circular Node |
| ------------- | ------------- |
| <img width="326" height="133" alt="image" src="https://github.com/user-attachments/assets/6b253aae-9ad9-4a31-a385-dac7a939853e" />  | <img width="175" height="288" alt="image" src="https://github.com/user-attachments/assets/e130a8f5-0239-4bcd-8225-c4e82af5ce5c" /> |

## Changes

- **BaseHeader**: Added `display: -webkit-box`, `-webkit-box-orient: vertical`, `-webkit-line-clamp: 3`, and `overflow: hidden` for non-diamond shapes
- **BaseSubHeader**: Replaced empty string fallback with the same line-clamp pattern (5 lines) for non-diamond shapes

## Testing

- [x] `pnpm run test` passes (70 suites, 1346 tests)
- [x] `pnpm run typecheck` passes (apollo-react)
- [x] Manual testing performed