### PR TITLE
fix(apollo-vertex): remove global anchor color override conflicting with Nextra

### DIFF
--- a/apps/apollo-vertex/app/globals.css
+++ b/apps/apollo-vertex/app/globals.css
@@ -26,7 +26,4 @@
   body {
     @apply bg-background text-foreground;
   }
-  a {
-    @apply text-primary-700 dark:text-primary-400;
-  }
 }


### PR DESCRIPTION
## Summary
- Removes the global `a` tag color override (`text-primary-700 dark:text-primary-400`) from `globals.css`
- This override was making the navbar header text, breadcrumbs, and other Nextra links appear brighter than the sidebar highlight color
- Nextra already handles its own link styling consistently, so the global rule was unnecessary and caused visual inconsistencies