### PR TITLE
feat(apollo-react)!: canvas wind integration [MST-8290]

### DIFF
--- a/apps/storybook/.storybook/main.ts
+++ b/apps/storybook/.storybook/main.ts
@@ -1,7 +1,8 @@
-import type { StorybookConfig } from "@storybook/react-vite";
 import { readFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import type { StorybookConfig } from "@storybook/react-vite";
+import tailwindcss from "@tailwindcss/vite";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -30,6 +31,8 @@ const reactScanHook = isDev
     )
   : "";
 
+const apolloWindSrc = resolve(__dirname, "../../../packages/apollo-wind/src");
+
 const config: StorybookConfig = {
   stories: [
     // For now only include canvas stories
@@ -43,6 +46,42 @@ const config: StorybookConfig = {
   framework: {
     name: "@storybook/react-vite",
     options: {},
+  },
+
+  viteFinal: async (config) => {
+    config.plugins = config.plugins || [];
+    config.plugins.push(tailwindcss());
+
+    // Resolve apollo-wind to source for HMR in dev.
+    config.resolve = config.resolve || {};
+    config.resolve.alias = [
+      ...(Array.isArray(config.resolve.alias)
+        ? config.resolve.alias
+        : Object.entries(config.resolve.alias || {}).map(
+            ([find, replacement]) => ({
+              find,
+              replacement,
+            }),
+          )),
+      {
+        find: /^@uipath\/apollo-wind\/tailwind\.css$/,
+        replacement: resolve(apolloWindSrc, "styles/tailwind.consumer.css"),
+      },
+      {
+        find: /^@uipath\/apollo-wind$/,
+        replacement: resolve(apolloWindSrc, "index.ts"),
+      },
+      {
+        find: /^@uipath\/apollo-wind\/(?!.*\.css$)(.*)/,
+        replacement: `${apolloWindSrc}/$1`,
+      },
+      {
+        find: /^@\/(.*)/,
+        replacement: `${apolloWindSrc}/$1`,
+      },
+    ];
+
+    return config;
   },
 
   previewBody: isDev

--- a/apps/storybook/.storybook/preview.tsx
+++ b/apps/storybook/.storybook/preview.tsx
@@ -1,4 +1,3 @@
-import CssBaseline from "@mui/material/CssBaseline";
 import { ThemeProvider } from "@mui/material/styles";
 import type { Preview } from "@storybook/react";
 import {
@@ -9,7 +8,6 @@ import {
 } from "@uipath/apollo-react/material/theme";
 // biome-ignore lint/correctness/noUnusedImports: needed
 import React, { useEffect } from "react";
-import { GlobalStyles } from "./GlobalStyles";
 
 const isDev = import.meta.env.MODE !== "production";
 
@@ -28,10 +26,8 @@ import "@uipath/apollo-react/core/tokens/css/theme-variables.css";
 import "@uipath/apollo-react/core/fonts/font.css";
 
 import "@uipath/apollo-react/canvas/styles/variables.css";
+import "@uipath/apollo-react/canvas/styles/tailwind.canvas.css";
 import "@uipath/apollo-react/canvas/xyflow/style.css";
-
-// Import Apollo Wind pre-compiled styles for apollo-wind components used in stories
-import "@uipath/apollo-wind/styles.css";
 
 // Theme type definition
 type ThemeMode = "light" | "dark" | "light-hc" | "dark-hc";
@@ -153,8 +149,6 @@ const preview: Preview = {
 
       return (
         <ThemeProvider theme={muiTheme}>
-          <CssBaseline />
-          <GlobalStyles />
           <div
             style={{
               height: "100%",

--- a/apps/storybook/package.json
+++ b/apps/storybook/package.json
@@ -26,9 +26,11 @@
     "@storybook/addon-links": "^10.2.15",
     "@storybook/react": "^10.2.15",
     "@storybook/react-vite": "^10.2.15",
+    "@tailwindcss/vite": "^4.1.17",
     "prettier": "^3.8.1",
     "react-scan": "^0.5.3",
     "storybook": "^10.2.15",
+    "tailwindcss": "^4.1.17",
     "typescript": "^5.9.3",
     "vite": "^7.3.2"
   }

--- a/packages/apollo-react/README.md
+++ b/packages/apollo-react/README.md
@@ -165,6 +165,8 @@ import { Breadcrumb } from '@uipath/apollo-react/canvas/controls';
 import { ReactFlow, Panel } from '@uipath/apollo-react/canvas/xyflow/react';
 ```
 
+> Canvas components are styled with [apollo-wind](../apollo-wind) (Tailwind CSS v4). See the [Canvas Tailwind Integration Guide](./src/canvas/README.md) for how to wire up the required CSS in standard and Shadow DOM apps.
+
 ### ApChat Component
 
 ```typescript

--- a/packages/apollo-react/biome.json
+++ b/packages/apollo-react/biome.json
@@ -6,12 +6,7 @@
     "useIgnoreFile": true
   },
   "files": {
-    "includes": [
-      "**",
-      "!**/node_modules",
-      "!**/dist",
-      "!**/src/icons/**"
-    ]
+    "includes": ["**", "!**/node_modules", "!**/dist", "!**/src/icons/**"]
   },
   "formatter": {
     "enabled": true,
@@ -25,6 +20,11 @@
       "semicolons": "always",
       "trailingCommas": "es5",
       "arrowParentheses": "always"
+    }
+  },
+  "css": {
+    "parser": {
+      "tailwindDirectives": true
     }
   },
   "linter": {

--- a/packages/apollo-react/package.json
+++ b/packages/apollo-react/package.json
@@ -129,7 +129,8 @@
     "dist"
   ],
   "scripts": {
-    "build": "pnpm run build:icons && pnpm run i18n:compile && rslib build",
+    "build": "pnpm run build:icons && pnpm run i18n:compile && rslib build && pnpm run build:css:canvas",
+    "build:css:canvas": "tailwindcss -i ./src/canvas/styles/tailwind.canvas.css -o ./dist/canvas/styles/tailwind.canvas.css --minify",
     "build:analyze": "ANALYZE=true pnpm run build",
     "build:icons": "tsx scripts/icons-build.ts",
     "dev": "rslib build --watch",
@@ -223,6 +224,7 @@
     "zustand": "^5.0.9"
   },
   "devDependencies": {
+    "@tailwindcss/cli": "^4.1.17",
     "@lingui/cli": "^5.6.1",
     "@lingui/conf": "^5.6.1",
     "@lingui/format-json": "^5.6.1",

--- a/packages/apollo-react/src/canvas/README.md
+++ b/packages/apollo-react/src/canvas/README.md
@@ -1,0 +1,197 @@
+# Canvas Tailwind CSS — Consumer Integration Guide
+
+Apollo React canvas components use [apollo-wind](../../../apollo-wind) (Tailwind CSS v4) for styling. This guide covers how consumers should integrate the required CSS depending on their application architecture.
+
+## Background
+
+Canvas components import from `@uipath/apollo-wind` and use Tailwind utility classes (e.g., `p-4`, `bg-surface`, `text-foreground`, `border-border`). These utilities depend on:
+
+1. **Tailwind CSS v4 utility class definitions** — the actual `.p-4 { padding: 1rem }` rules
+2. **Apollo-core theme variables** (`--color-foreground`, `--color-border`, etc.) — defined per-theme on `body.light`, `body.dark`, etc.
+3. **Apollo-wind bridge variables** (`--surface`, `--brand`, `--foreground`, etc.) — map semantic names to core variables, also scoped to theme selectors
+
+### What apollo-react ships
+
+Apollo-react exports a pre-compiled CSS file at:
+
+```
+@uipath/apollo-react/canvas/styles/tailwind.canvas.css
+```
+
+This contains all three layers above, compiled and minified (~160KB). It is **not** auto-injected — consumers must explicitly integrate it based on their architecture.
+
+---
+
+## Integration Patterns
+
+### Pattern A: Standard App (no Shadow DOM)
+
+**Example:** PO.Frontend — Rsbuild app with SCSS, styled-components, and MUI.
+
+#### The challenge
+
+Tailwind v4 wraps all utility classes in `@layer utilities`. Per the CSS specification, **un-layered CSS always takes precedence over layered CSS**, regardless of source order or specificity. If your app has un-layered styles (MUI, styled-components, global SCSS), they will override Tailwind utilities on any conflicting properties.
+
+Simply importing the pre-compiled `tailwind.canvas.css` will not work — the utilities will be overridden by your existing styles.
+
+#### Solution: Set up Tailwind CSS processing via PostCSS
+
+By processing Tailwind at build time through PostCSS, Tailwind owns the CSS cascade from the top of your stylesheet. This ensures utility classes work correctly while your existing styles continue to function (un-layered styles still take precedence, which is desirable for your app's own components).
+
+**1. Install dependencies**
+
+```bash
+npm install @uipath/apollo-wind postcss
+```
+
+**2. Create `postcss.config.js`** (project root)
+
+```js
+import apolloWindConfig from "@uipath/apollo-wind/postcss";
+
+export default {
+  plugins: [...apolloWindConfig.plugins],
+};
+```
+
+Rsbuild automatically detects and uses `postcss.config.js` — no additional build config is needed.
+
+**3. Create a CSS entry point** (e.g., `src/tailwind.css`)
+
+```css
+@import "@uipath/apollo-wind/tailwind.css";
+
+/* Scan apollo-wind and apollo-react canvas components for Tailwind class usage */
+@source "../node_modules/@uipath/apollo-wind";
+@source "../node_modules/@uipath/apollo-react/dist/canvas";
+```
+
+The `@source` directives tell Tailwind which files to scan for class names. Only utilities actually used by these components are included in the output.
+
+**4. Import in your app entry** (e.g., `bootstrap.tsx`)
+
+```tsx
+import "./tailwind.css";
+```
+
+Import it early, before component code, so the CSS is available when components render.
+
+#### How specificity works after setup
+
+| Style source | Layered? | Priority |
+|---|---|---|
+| MUI / styled-components | No (un-layered) | Highest — always wins |
+| App SCSS / global CSS | No (un-layered) | High |
+| Tailwind `@layer utilities` | Yes | Normal — wins over other layers |
+| Tailwind `@layer base` | Yes | Low |
+| CSS reset (`@layer reset`) | Yes | Lowest |
+
+Apollo-wind components in the canvas use **only** Tailwind classes. As long as your app's MUI/styled-component styles don't target the same elements, there are no conflicts. The two styling systems coexist on separate parts of the DOM.
+
+---
+
+### Pattern B: Shadow DOM App
+
+**Example:** Agents/frontend-sw — Emotion/MUI app rendering canvas inside a Shadow DOM boundary.
+
+#### The challenge
+
+Shadow DOM provides style encapsulation — CSS from the outer document does not apply inside a shadow root. This creates two problems:
+
+1. **Utility classes must be injected into the shadow root.** Global `<style>` or `<link>` tags in the document head won't reach shadow DOM content.
+
+2. **Theme CSS variables must be available inside the shadow root.** The apollo-core theme variables (`--color-foreground`, `--color-border`, etc.) are defined on `body.light` / `body.dark` in the outer document. CSS custom properties **do inherit** through the shadow DOM boundary, so these are available. However, the **bridge variables** (`--surface`, `--brand`, `--foreground`, etc.) are scoped to `.light` / `.dark` selectors in the Tailwind CSS — these selectors won't match inside the shadow DOM.
+
+#### Solution: Inline CSS injection with theme class wrapper
+
+**1. Import the pre-compiled CSS as an inline string**
+
+Using your bundler's `?inline` query (Rsbuild/Vite):
+
+```tsx
+import TailwindCanvasCSS from "@uipath/apollo-react/canvas/styles/tailwind.canvas.css?inline";
+```
+
+**2. Ensure a theme class wrapper exists inside the shadow DOM**
+
+The bridge variables are defined under selectors like `body.light, .light { ... }` and `body.dark, .dark { ... }`. For these to activate inside the shadow DOM, an ancestor element within the shadow root must have the appropriate theme class.
+
+Add a wrapper element with `apollo-design` and the active theme class:
+
+```tsx
+// Inside your shadow DOM component
+<div className={`apollo-design ${theme}`}>
+  {/* Canvas and other content */}
+</div>
+```
+
+The compiled CSS includes selectors for both `body.light` and `.apollo-design.light` (and their dark/hc variants), so this wrapper activates all theme variable definitions.
+
+**3. Inject the CSS into the shadow root**
+
+Using Emotion's `<Global>` component (if your Emotion cache targets the shadow root):
+
+```tsx
+<Global styles={[TailwindCanvasCSS, /* other CSS */]} />
+```
+
+Or by creating a `<style>` element directly:
+
+```tsx
+const styleElement = document.createElement("style");
+styleElement.textContent = TailwindCanvasCSS;
+shadowRoot.prepend(styleElement);
+```
+
+#### Variable resolution chain inside Shadow DOM
+
+```
+Outer document: body.light { --color-foreground: #273139; ... }
+                          ↓ (CSS custom property inheritance)
+Shadow root:    <div class="apollo-design light">
+                  → .apollo-design.light { --color-foreground: #273139; }  (core vars, redundant but ensures availability)
+                  → .light { --surface: var(--color-background); ... }     (bridge vars, NOW active)
+                  → .bg-surface { background-color: var(--surface); }      (utility classes, NOW resolved)
+```
+
+#### Existing canvas variables
+
+If you already use `@uipath/apollo-react/canvas/styles/variables.css` with shadow DOM re-scoping (as in `canvas-styles.utils.ts`), that pattern continues to work alongside the Tailwind CSS. The canvas variables (`--uix-canvas-*`) and the bridge variables (`--surface`, `--brand`, etc.) are independent — both reference the same underlying `--color-*` tokens.
+
+---
+
+## Exported CSS files
+
+| Export path | Contents | Use case |
+|---|---|---|
+| `@uipath/apollo-react/canvas/styles/tailwind.canvas.css` | Pre-compiled Tailwind utilities + theme variables (~160KB) | Shadow DOM consumers (inline import) |
+| `@uipath/apollo-react/canvas/styles/variables.css` | Canvas-specific CSS variable mappings (`--uix-canvas-*`) | All consumers (canvas component theming) |
+| `@uipath/apollo-react/canvas/xyflow/style.css` | React Flow base styles | All consumers (canvas rendering) |
+| `@uipath/apollo-wind/tailwind.css` | Tailwind CSS v4 entry point with Apollo theme | Standard apps via PostCSS processing |
+| `@uipath/apollo-wind/postcss` | PostCSS plugin config export | Standard apps (postcss.config.js) |
+
+## Troubleshooting
+
+### Tailwind utility classes have no effect
+
+**Symptom:** Elements have Tailwind classes (e.g., `p-4`) but the styles don't appear in DevTools, or appear but are overridden.
+
+**Cause:** Un-layered CSS from MUI, styled-components, or global SCSS overrides `@layer utilities`.
+
+**Fix:** Use Pattern A (PostCSS setup). Do not import the pre-compiled CSS directly in non-shadow-DOM apps.
+
+### CSS variables are undefined inside Shadow DOM
+
+**Symptom:** Elements show `var(--surface)` or `var(--color-foreground)` as undefined in computed styles.
+
+**Cause:** Bridge variables are scoped to `.light` / `.dark` selectors that don't match inside the shadow root.
+
+**Fix:** Add a wrapper element with the theme class inside the shadow DOM (see Pattern B, step 2).
+
+### Borders or backgrounds look wrong
+
+**Symptom:** Unexpected border colors or missing backgrounds on canvas components.
+
+**Cause:** The Tailwind base layer includes `* { border-color: var(--color-border-de-emp) }` and `body { background-color: var(--background) }`. These may conflict with existing component styles.
+
+**Fix:** These rules are in `@layer base`, so they lose to un-layered styles. If conflicts persist in Shadow DOM, override with more specific selectors in your injected CSS.

--- a/packages/apollo-react/src/canvas/components/AddNodePanel/AddNodePreview.tsx
+++ b/packages/apollo-react/src/canvas/components/AddNodePanel/AddNodePreview.tsx
@@ -1,9 +1,10 @@
 import styled from '@emotion/styled';
 import type { NodeProps } from '@uipath/apollo-react/canvas/xyflow/react';
 import { Handle, Position } from '@uipath/apollo-react/canvas/xyflow/react';
-import { ApIcon } from '@uipath/apollo-react/material/components';
 import type React from 'react';
+
 import { DEFAULT_NODE_SIZE } from '../../constants';
+import { CanvasIcon } from '../../utils/icon-registry';
 
 const PreviewContainer = styled.div<{ selected?: boolean; width?: number; height?: number }>`
   width: ${(props) => props.width ?? DEFAULT_NODE_SIZE}px;
@@ -29,10 +30,10 @@ export interface AddNodePreviewData {
 
 const getIcon = (iconName?: string): React.ReactElement => {
   if (iconName) {
-    return <ApIcon color="var(--uix-canvas-foreground-de-emp)" name={iconName} size="40px" />;
+    return <CanvasIcon icon={iconName} size={40} color="var(--uix-canvas-foreground-de-emp)" />;
   }
 
-  return <ApIcon color="var(--uix-canvas-foreground-de-emp)" name="more_horiz" size="40px" />;
+  return <CanvasIcon icon="ellipsis" size={40} color="var(--uix-canvas-foreground-de-emp)" />;
 };
 
 export const AddNodePreview: React.FC<NodeProps> = ({ selected, data, width, height }) => {

--- a/packages/apollo-react/src/canvas/components/AgentCanvas/components/SuggestionGroupPanel.tsx
+++ b/packages/apollo-react/src/canvas/components/AgentCanvas/components/SuggestionGroupPanel.tsx
@@ -1,11 +1,11 @@
-import { useTheme } from '@mui/material';
-import { FontVariantToken, Spacing } from '@uipath/apollo-core';
+import { Spacing } from '@uipath/apollo-core';
 import { Column, Row } from '@uipath/apollo-react/canvas/layouts';
 import { useStore } from '@uipath/apollo-react/canvas/xyflow/react';
-import { ApButton, ApIcon, ApIconButton, ApTypography } from '@uipath/apollo-react/material';
+import { Button, cn } from '@uipath/apollo-wind';
 import { useState } from 'react';
-
+import { CANVAS_COMPACT_BREAKPOINT } from '../../../constants';
 import type { AgentFlowSuggestionGroup } from '../../../types';
+import { CanvasIcon } from '../../../utils/icon-registry';
 
 interface SuggestionGroupPanelProps {
   suggestionGroup?: AgentFlowSuggestionGroup | null;
@@ -23,25 +23,26 @@ interface AcceptRejectAllButtonProps {
 }
 
 const RejectAllButton = ({ suggestionGroup, onClick, compact }: AcceptRejectAllButtonProps) => (
-  <ApButton
-    variant="tertiary"
-    size="small"
-    label="Reject all"
-    startIcon={<ApIcon variant="outlined" name="close" />}
+  <Button
+    variant="ghost"
+    size="sm"
     onClick={() => onClick(suggestionGroup.id)}
-    sx={compact ? { fontSize: '0.75rem', minWidth: 'auto' } : undefined}
-  />
+    className={compact ? 'text-xs min-w-0' : undefined}
+  >
+    <CanvasIcon icon="x" size={16} />
+    Reject all
+  </Button>
 );
 
 const AcceptAllButton = ({ suggestionGroup, onClick, compact }: AcceptRejectAllButtonProps) => (
-  <ApButton
-    variant="primary"
-    size="small"
-    label="Accept all"
-    startIcon={<ApIcon variant="outlined" name="check" />}
+  <Button
+    size="sm"
     onClick={() => onClick(suggestionGroup.id)}
-    sx={compact ? { fontSize: '0.75rem', minWidth: 'auto' } : undefined}
-  />
+    className={compact ? 'text-xs min-w-0' : undefined}
+  >
+    <CanvasIcon icon="check" size={16} />
+    Accept all
+  </Button>
 );
 
 const Divider = () => (
@@ -72,7 +73,7 @@ const SuggestionGroupNavigator = ({
   const [isHoveringUp, setIsHoveringUp] = useState(false);
   const [isHoveringDown, setIsHoveringDown] = useState(false);
 
-  const iconSize = compact ? '16px' : '20px';
+  const iconSize = compact ? 16 : 20;
 
   return (
     <div
@@ -83,36 +84,39 @@ const SuggestionGroupNavigator = ({
         minWidth: compact ? '80px' : '100px',
       }}
     >
-      <ApIconButton
+      <Button
+        variant="ghost"
+        size="icon"
+        className="h-8 w-8"
         onMouseEnter={() => setIsHoveringUp(true)}
         onMouseLeave={() => setIsHoveringUp(false)}
         onClick={onNavigatePrevious}
       >
-        <ApIcon
-          name="keyboard_arrow_up"
+        <CanvasIcon
+          icon="chevron-up"
           color={isHoveringUp ? 'var(--uix-canvas-primary)' : 'var(--uix-canvas-foreground-de-emp)'}
           size={iconSize}
         />
-      </ApIconButton>
-      <ApTypography
-        variant={compact ? FontVariantToken.fontSizeSBold : FontVariantToken.fontSizeMBold}
-        color="var(--uix-canvas-foreground-de-emp)"
-      >
+      </Button>
+      <span className={cn('font-bold text-foreground-muted', compact ? 'text-xs' : 'text-sm')}>
         {currentIndex + 1} of {total}
-      </ApTypography>
-      <ApIconButton
+      </span>
+      <Button
+        variant="ghost"
+        size="icon"
+        className="h-8 w-8"
         onMouseEnter={() => setIsHoveringDown(true)}
         onMouseLeave={() => setIsHoveringDown(false)}
         onClick={onNavigateNext}
       >
-        <ApIcon
-          name="keyboard_arrow_down"
+        <CanvasIcon
+          icon="chevron-down"
           color={
             isHoveringDown ? 'var(--uix-canvas-primary)' : 'var(--uix-canvas-foreground-de-emp)'
           }
           size={iconSize}
         />
-      </ApIconButton>
+      </Button>
     </div>
   );
 };
@@ -125,10 +129,8 @@ export const SuggestionGroupPanel = ({
   onNavigateNext,
   onNavigatePrevious,
 }: SuggestionGroupPanelProps) => {
-  const theme = useTheme();
   const canvasWidth = useStore((state) => state.width);
-  const smBreakpoint = theme.breakpoints.values.sm;
-  const isCompact = canvasWidth < smBreakpoint;
+  const isCompact = canvasWidth < CANVAS_COMPACT_BREAKPOINT;
 
   // Filter out standalone suggestions - they are interactive placeholders that shouldn't appear in the panel
   const nonStandaloneSuggestions =

--- a/packages/apollo-react/src/canvas/components/AgentCanvas/components/TimelinePlayer.tsx
+++ b/packages/apollo-react/src/canvas/components/AgentCanvas/components/TimelinePlayer.tsx
@@ -1,7 +1,7 @@
-import { FontVariantToken, Spacing } from '@uipath/apollo-core';
+import { Spacing } from '@uipath/apollo-core';
 import * as Icons from '@uipath/apollo-react/canvas/icons';
 import { Column, Row } from '@uipath/apollo-react/canvas/layouts';
-import { ApIconButton, ApTypography } from '@uipath/apollo-react/material';
+import { Button } from '@uipath/apollo-wind';
 import { DateTime } from 'luxon';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
@@ -480,25 +480,25 @@ export const TimelinePlayer: React.FC<{
       }}
     >
       <Row align="center" gap={Spacing.SpacingXs}>
-        <ApIconButton size="large" onClick={handlePlayPause}>
+        <Button variant="ghost" size="icon" className="h-10 w-10" onClick={handlePlayPause}>
           {playing ? (
             <Icons.TimelinePauseIcon w={24} h={24} color="var(--uix-canvas-icon-default)" />
           ) : (
             <Icons.TimelinePlayIcon w={24} h={24} color="var(--uix-canvas-icon-default)" />
           )}
-        </ApIconButton>
+        </Button>
 
-        <ApTypography>
+        <span>
           {currentTimeFormatted} / {totalTimeFormatted}
-        </ApTypography>
+        </span>
 
-        <ApTypography>{mostActiveSpan?.Name}</ApTypography>
+        <span>{mostActiveSpan?.Name}</span>
 
         <div style={{ flex: 1 }} />
 
-        <ApIconButton size="large" onClick={handleSpeedChange}>
-          <ApTypography variant={FontVariantToken.fontSizeSBold}>{speedLevel}x</ApTypography>
-        </ApIconButton>
+        <Button variant="ghost" size="icon" className="h-10 w-10" onClick={handleSpeedChange}>
+          <span className="text-xs font-bold">{speedLevel}x</span>
+        </Button>
       </Row>
 
       <Row align="center" style={{ marginLeft: '15px' }}>

--- a/packages/apollo-react/src/canvas/components/AgentCanvas/nodes/AgentNode.tsx
+++ b/packages/apollo-react/src/canvas/components/AgentCanvas/nodes/AgentNode.tsx
@@ -1,15 +1,15 @@
 import * as Icons from '@uipath/apollo-react/canvas/icons';
 import type { Node, NodeProps } from '@uipath/apollo-react/canvas/xyflow/react';
 import { Position } from '@uipath/apollo-react/canvas/xyflow/react';
-import { ApIcon } from '@uipath/apollo-react/material/components';
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { FloatingCanvasPanel } from '../../FloatingCanvasPanel';
+import type { HandleGroupManifest } from '../../../schema/node-definition';
 import {
   type AgentNodeTranslations,
   DefaultSuggestionTranslations,
   type SuggestionTranslations,
   type SuggestionType,
 } from '../../../types';
+import { CanvasIcon } from '../../../utils/icon-registry';
 import { BaseNode } from '../../BaseNode/BaseNode';
 import type { BaseNodeData } from '../../BaseNode/BaseNode.types';
 import {
@@ -17,7 +17,7 @@ import {
   type BaseNodeOverrideConfig,
 } from '../../BaseNode/BaseNodeConfigContext';
 import type { ButtonHandleConfig, HandleActionEvent } from '../../ButtonHandle/ButtonHandle';
-import type { HandleGroupManifest } from '../../../schema/node-definition';
+import { FloatingCanvasPanel } from '../../FloatingCanvasPanel';
 import type { NodeToolbarConfig, ToolbarAction } from '../../Toolbar';
 import { ResourceNodeType } from '../AgentFlow.constants';
 import { useAgentFlowStore } from '../store/agent-flow-store';
@@ -413,7 +413,7 @@ const AgentNodeComponent = memo((props: NodeProps<Node<AgentNodeData>> & AgentNo
             onAddInstructions();
           }}
         >
-          <ApIcon name="add" size="14px" />
+          <CanvasIcon icon="plus" size={14} />
           {translations.addInstructions}
         </AddInstructionsButton>
       ),

--- a/packages/apollo-react/src/canvas/components/AgentCanvas/nodes/ResourceNode.tsx
+++ b/packages/apollo-react/src/canvas/components/AgentCanvas/nodes/ResourceNode.tsx
@@ -1,9 +1,9 @@
 import * as Icons from '@uipath/apollo-react/canvas/icons';
-import { NodeIcon } from '@uipath/apollo-react/canvas/utils';
 import { Row } from '@uipath/apollo-react/canvas/layouts';
+import { CanvasIcon } from '@uipath/apollo-react/canvas/utils';
 import { type NodeProps, Position } from '@uipath/apollo-react/canvas/xyflow/react';
-import { ApIcon } from '@uipath/apollo-react/material/components';
 import { memo, useCallback, useMemo } from 'react';
+import type { HandleGroupManifest } from '../../../schema/node-definition';
 import {
   type AgentFlowResourceNode,
   type AgentFlowResourceNodeData,
@@ -13,11 +13,10 @@ import {
 } from '../../../types';
 import { BaseNode } from '../../BaseNode/BaseNode';
 import {
-  BaseNodeOverrideConfigProvider,
   type BaseNodeOverrideConfig,
+  BaseNodeOverrideConfigProvider,
 } from '../../BaseNode/BaseNodeConfigContext';
 import type { ButtonHandleConfig } from '../../ButtonHandle';
-import type { HandleGroupManifest } from '../../../schema/node-definition';
 import { ExecutionStatusIcon } from '../../ExecutionStatusIcon/ExecutionStatusIcon';
 import type { NodeToolbarConfig, ToolbarAction } from '../../Toolbar';
 import { ToolResourceIcon } from '../components/ToolResourceIcon';
@@ -138,10 +137,10 @@ export const ResourceNode = memo(
       let icon: React.ReactNode | undefined;
       switch (data.type) {
         case 'context':
-          icon = <ApIcon name="description" size="40px" />;
+          icon = <CanvasIcon icon="file-text" size={40} />;
           break;
         case 'escalation':
-          icon = <ApIcon name="person" size="40px" />;
+          icon = <CanvasIcon icon="user" size={40} />;
           break;
         case 'memorySpace':
           icon = <Icons.MemoryIcon w={40} h={40} />;
@@ -175,7 +174,7 @@ export const ResourceNode = memo(
         if (suggestionGroupVersion === '0.0.1') return null;
         const rejectAction: ToolbarAction = {
           id: 'reject-suggestion',
-          icon: <NodeIcon icon="X" size={14} />,
+          icon: <CanvasIcon icon="X" size={14} />,
           label: suggestTranslations.reject,
           disabled: false,
           onAction: () => handleActOnSuggestion(suggestionId, 'reject'),
@@ -183,7 +182,7 @@ export const ResourceNode = memo(
 
         const acceptAction: ToolbarAction = {
           id: 'accept-suggestion',
-          icon: <NodeIcon icon="check" size={14} />,
+          icon: <CanvasIcon icon="check" size={14} />,
           label: suggestTranslations.accept,
           disabled: false,
           onAction: () => handleActOnSuggestion(suggestionId, 'accept'),
@@ -224,7 +223,7 @@ export const ResourceNode = memo(
 
       const removeAction: ToolbarAction = {
         id: 'remove',
-        icon: <NodeIcon icon="trash" size={14} />,
+        icon: <CanvasIcon icon="trash" size={14} />,
         label: translations?.remove ?? '',
         disabled: false,
         onAction: handleClickRemove,
@@ -363,7 +362,7 @@ export const ResourceNode = memo(
 
     const breakpointAdornment = useMemo((): React.ReactNode => {
       if (!hasBreakpoint) return undefined;
-      return <ApIcon variant="normal" name="circle" size="14px" color="#cc3d45" />;
+      return <CanvasIcon icon="circle" size={14} color="#cc3d45" />;
     }, [hasBreakpoint]);
 
     const statusAdornment = useMemo((): React.ReactNode => {
@@ -372,30 +371,23 @@ export const ResourceNode = memo(
 
     const guardrailsAdornment = useMemo((): React.ReactNode => {
       if (!hasGuardrails) return undefined;
-      return (
-        <ApIcon
-          variant="outlined"
-          name="gpp_good"
-          size="18px"
-          color="var(--uix-canvas-icon-default)"
-        />
-      );
+      return <CanvasIcon icon="shield-check" size={18} color="var(--uix-canvas-icon-default)" />;
     }, [hasGuardrails]);
 
     const suggestionAdornment = useMemo((): React.ReactNode => {
       if (!isSuggestion) return undefined;
-      let iconName = 'swap_horizontal_circle';
+      let iconName = 'arrow-left-right';
       let color = 'var(--uix-canvas-warning-icon)';
 
       if (suggestionType === 'add') {
-        iconName = 'add_circle';
+        iconName = 'circle-plus';
         color = 'var(--uix-canvas-success-icon)';
       } else if (suggestionType === 'delete') {
-        iconName = 'remove_circle';
+        iconName = 'circle-minus';
         color = 'var(--uix-canvas-error-icon)';
       }
 
-      return <ApIcon variant="normal" name={iconName} size="18px" color={color} />;
+      return <CanvasIcon icon={iconName} size={18} color={color} />;
     }, [isSuggestion, suggestionType]);
 
     const handleConfigurations = useMemo(

--- a/packages/apollo-react/src/canvas/components/BaseCanvas/CanvasProviders.tsx
+++ b/packages/apollo-react/src/canvas/components/BaseCanvas/CanvasProviders.tsx
@@ -1,5 +1,7 @@
 import type { Edge, Node } from '@uipath/apollo-react/canvas/xyflow/react';
+import { TooltipProvider } from '@uipath/apollo-wind/components/ui/tooltip';
 import type { ReactNode } from 'react';
+import { CanvasTooltipProviderMarker } from '../CanvasTooltip';
 import type { BaseCanvasProps } from './BaseCanvas.types';
 import { BaseCanvasModeProvider } from './BaseCanvasModeProvider';
 import { CanvasThemeProvider } from './CanvasThemeContext';
@@ -29,11 +31,15 @@ export function CanvasProviders({
 }: CanvasProvidersProps) {
   return (
     <CanvasThemeProvider isDarkMode={isDarkMode}>
-      <ConnectedHandlesProvider edges={edges}>
-        <BaseCanvasModeProvider mode={mode}>
-          <SelectionStateProvider nodes={nodes}>{children}</SelectionStateProvider>
-        </BaseCanvasModeProvider>
-      </ConnectedHandlesProvider>
+      <TooltipProvider delayDuration={200} skipDelayDuration={100}>
+        <CanvasTooltipProviderMarker>
+          <ConnectedHandlesProvider edges={edges}>
+            <BaseCanvasModeProvider mode={mode}>
+              <SelectionStateProvider nodes={nodes}>{children}</SelectionStateProvider>
+            </BaseCanvasModeProvider>
+          </ConnectedHandlesProvider>
+        </CanvasTooltipProviderMarker>
+      </TooltipProvider>
     </CanvasThemeProvider>
   );
 }

--- a/packages/apollo-react/src/canvas/components/BaseNode/BaseNode.styles.ts
+++ b/packages/apollo-react/src/canvas/components/BaseNode/BaseNode.styles.ts
@@ -1,6 +1,6 @@
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
-import { ApSkeleton } from '../../../material/components/ap-skeleton';
+import { Skeleton } from '@uipath/apollo-wind';
 import type { NodeShape } from '../../schema';
 import { getExecutionStatusBorder, pulseAnimation } from '../../styles/execution-status';
 import type { FooterVariant } from './BaseNode.types';
@@ -412,7 +412,7 @@ export const BaseBadgeSlot = styled.div<{
 /**
  * Skeleton icon used in loading state. Uses the same dimension calculations as BaseIconWrapper.
  */
-export const BaseSkeletonIcon = styled(ApSkeleton, {
+export const BaseSkeletonIcon = styled(Skeleton, {
   shouldForwardProp: (prop) => prop !== 'shape' && prop !== 'nodeHeight' && prop !== 'nodeWidth',
 })<{
   shape?: NodeShape;

--- a/packages/apollo-react/src/canvas/components/BaseNode/BaseNode.test.tsx
+++ b/packages/apollo-react/src/canvas/components/BaseNode/BaseNode.test.tsx
@@ -43,7 +43,9 @@ vi.mock('../ButtonHandle/SmartHandle', () => ({
 vi.mock('./BaseNodeConfigContext', () => ({ useBaseNodeOverrideConfig: () => ({}) }));
 vi.mock('../../utils/adornment-resolver', () => ({ resolveAdornments: () => ({}) }));
 vi.mock('../../utils/toolbar-resolver', () => ({ resolveToolbar: () => undefined }));
-vi.mock('@uipath/apollo-react/material/components', () => ({ ApIcon: () => null }));
+vi.mock('@uipath/apollo-wind', () => ({
+  Skeleton: (props: Record<string, unknown>) => <div {...props} />,
+}));
 vi.mock('@uipath/apollo-react/canvas/utils', () => ({
   cx: (...args: unknown[]) => args.filter(Boolean).join(' '),
 }));
@@ -93,10 +95,10 @@ describe('BaseNode', () => {
       render(<BaseNode {...defaultProps} data={data} />);
 
       if (expectSkeleton) {
-        expect(screen.getByTestId('ap-skeleton')).toBeInTheDocument();
+        expect(screen.getByTestId('skeleton-icon')).toBeInTheDocument();
         expect(screen.queryByTestId('node-icon')).not.toBeInTheDocument();
       } else {
-        expect(screen.queryByTestId('ap-skeleton')).not.toBeInTheDocument();
+        expect(screen.queryByTestId('skeleton-icon')).not.toBeInTheDocument();
         expect(screen.getByTestId('node-icon')).toBeInTheDocument();
       }
     });
@@ -104,7 +106,7 @@ describe('BaseNode', () => {
     it('still renders label when loading', () => {
       render(<BaseNode {...defaultProps} data={{ loading: true }} />);
 
-      expect(screen.getByTestId('ap-skeleton')).toBeInTheDocument();
+      expect(screen.getByTestId('skeleton-icon')).toBeInTheDocument();
       expect(screen.getByText('Test Node')).toBeInTheDocument();
     });
   });

--- a/packages/apollo-react/src/canvas/components/BaseNode/BaseNode.tsx
+++ b/packages/apollo-react/src/canvas/components/BaseNode/BaseNode.tsx
@@ -6,14 +6,14 @@ import {
   useStore,
   useUpdateNodeInternals,
 } from '@uipath/apollo-react/canvas/xyflow/react';
-import { ApIcon } from '@uipath/apollo-react/material/components';
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { DEFAULT_NODE_SIZE } from '../../constants';
 import { useNodeTypeRegistry } from '../../core';
 import { useElementValidationStatus, useNodeExecutionState } from '../../hooks';
 import type { HandleGroupManifest } from '../../schema/node-definition';
+import type { ExecutionState } from '../../types/execution';
 import { resolveAdornments } from '../../utils/adornment-resolver';
-import { getIcon } from '../../utils/icon-registry';
+import { CanvasIcon, getIcon } from '../../utils/icon-registry';
 import { resolveDisplay, resolveHandles } from '../../utils/manifest-resolver';
 import { resolveToolbar } from '../../utils/toolbar-resolver';
 import { useBaseCanvasMode } from '../BaseCanvas/BaseCanvasModeProvider';
@@ -33,7 +33,6 @@ import {
   BaseSubHeader,
   BaseTextContainer,
 } from './BaseNode.styles';
-import type { ExecutionState } from '../../types/execution';
 import type {
   BaseNodeData,
   FooterVariant,
@@ -461,7 +460,7 @@ const BaseNodeComponent = (props: NodeProps<Node<BaseNodeData>>) => {
             height={height}
             width={width ?? height}
           >
-            <ApIcon color="var(--uix-canvas-error-icon)" name="error" size="32px" />
+            <CanvasIcon icon="circle-alert" size={32} color="var(--uix-canvas-error-icon)" />
           </BaseIconWrapper>
 
           {/* TODO: localize */}
@@ -499,10 +498,9 @@ const BaseNodeComponent = (props: NodeProps<Node<BaseNodeData>>) => {
         aria-busy={data.loading || undefined}
       >
         {data.loading ? (
-          // Always use rectangle variant; border-radius is controlled via shape prop
-          // to avoid ApSkeleton's circle variant overriding dimensions with !important.
+          // border-radius is controlled via shape prop
           <BaseSkeletonIcon
-            variant="rectangle"
+            data-testid="skeleton-icon"
             shape={displayShape}
             nodeHeight={displayFooter ? undefined : height}
             nodeWidth={displayFooter ? undefined : (width ?? height)}

--- a/packages/apollo-react/src/canvas/components/BaseNode/NodeLabel.tsx
+++ b/packages/apollo-react/src/canvas/components/BaseNode/NodeLabel.tsx
@@ -1,6 +1,6 @@
-import { ApTooltip } from '@uipath/apollo-react/material/components';
 import { memo, useCallback, useEffect, useRef, useState } from 'react';
 import type { NodeShape } from '../../schema';
+import { CanvasTooltip } from '../CanvasTooltip';
 import {
   BaseHeader,
   BaseSubHeader,
@@ -34,9 +34,9 @@ const ConditionalTooltip = ({ content, children }: ConditionalTooltipProps) => {
   }
 
   return (
-    <ApTooltip delay placement="top" content={content} smartTooltip>
+    <CanvasTooltip delay placement="top" content={content} smartTooltip>
       {children}
-    </ApTooltip>
+    </CanvasTooltip>
   );
 };
 

--- a/packages/apollo-react/src/canvas/components/BlankCanvasNode/BlankCanvasNode.tsx
+++ b/packages/apollo-react/src/canvas/components/BlankCanvasNode/BlankCanvasNode.tsx
@@ -1,7 +1,7 @@
 import { type NodeProps, useStoreApi } from '@uipath/apollo-react/canvas/xyflow/react';
-import { ApIcon } from '@uipath/apollo-react/material/components';
 import { useCallback, useRef } from 'react';
 import { selectAddNode, selectRemoveNode, useCanvasStore } from '../../stores/canvasStore';
+import { CanvasIcon } from '../../utils/icon-registry';
 import { AddNodePanel, type NodeItemData } from '../AddNodePanel';
 import { FloatingCanvasPanel } from '../FloatingCanvasPanel';
 import { Header, IconWrapper, NodeContainer, TextContainer } from './BlankCanvasNode.styles';
@@ -35,7 +35,7 @@ export const BlankCanvasNode = (props: BlankCanvasNodeProps) => {
     <>
       <NodeContainer selected={selected} ref={nodeRef}>
         <IconWrapper>
-          <ApIcon name="add" size="48px" color="var(--uix-canvas-foreground-de-emp)" />
+          <CanvasIcon icon="plus" size={48} color="var(--uix-canvas-foreground-de-emp)" />
         </IconWrapper>
       </NodeContainer>
       {typeof label === 'string' && (

--- a/packages/apollo-react/src/canvas/components/ButtonHandle/ButtonHandle.tsx
+++ b/packages/apollo-react/src/canvas/components/ButtonHandle/ButtonHandle.tsx
@@ -1,12 +1,11 @@
-import { FontVariantToken } from '@uipath/apollo-core';
 import { Row } from '@uipath/apollo-react/canvas/layouts';
 import { Position } from '@uipath/apollo-react/canvas/xyflow/react';
-import { ApTypography } from '@uipath/apollo-react/material';
-import { ApIcon, ApTooltip } from '@uipath/apollo-react/material/components';
 import { AnimatePresence } from 'motion/react';
 import { memo, useCallback, useMemo, useState } from 'react';
 import type { HandleConfigurationSpecificPosition } from '../../schema/node-definition/handle';
 import { canvasEventBus } from '../../utils/CanvasEventBus';
+import { CanvasIcon } from '../../utils/icon-registry';
+import { CanvasTooltip } from '../CanvasTooltip';
 import {
   StyledAddButton,
   StyledHandle,
@@ -48,7 +47,7 @@ const AddButton = memo(({ onAction }: AddButtonProps) => {
         whileHover={{ scale: 1.05 }}
         onClick={handleClick}
       >
-        <ApIcon name="add" size="14px" />
+        <CanvasIcon icon="plus" size={14} />
       </StyledAddButton>
     </AnimatePresence>
   );
@@ -173,10 +172,9 @@ const ButtonHandleBase = ({
         >
           <Row align="center" gap={4}>
             {labelIcon}
-            <ApTypography
-              color="var(--uix-canvas-foreground-de-emp)"
-              variant={FontVariantToken.fontSizeSBold}
-              sx={
+            <span
+              className="text-xs font-bold text-foreground-muted"
+              style={
                 shouldTruncateLabel
                   ? {
                       overflow: 'hidden',
@@ -187,7 +185,7 @@ const ButtonHandleBase = ({
               }
             >
               {label}
-            </ApTypography>
+            </span>
           </Row>
         </StyledLabel>
       )}
@@ -198,11 +196,11 @@ const ButtonHandleBase = ({
             $selected={selected}
             $size={label ? '60px' : '16px'}
           />
-          <ApTooltip content="Add node" placement="bottom">
+          <CanvasTooltip content="Add node" placement="bottom">
             <div className="nodrag nopan" style={{ pointerEvents: 'auto' }}>
               <AddButton onAction={handleButtonClick} />
             </div>
-          </ApTooltip>
+          </CanvasTooltip>
         </StyledWrapper>
       )}
       <StyledNotch

--- a/packages/apollo-react/src/canvas/components/ButtonHandle/SmartHandle.tsx
+++ b/packages/apollo-react/src/canvas/components/ButtonHandle/SmartHandle.tsx
@@ -1,7 +1,4 @@
-import { FontVariantToken } from '@uipath/apollo-core';
 import { Row } from '@uipath/apollo-react/canvas/layouts';
-import { ApTypography } from '@uipath/apollo-react/material';
-import { ApIcon } from '@uipath/apollo-react/material/components';
 import {
   type Edge,
   Handle,
@@ -24,8 +21,8 @@ import {
   useRef,
   useState,
 } from 'react';
-
 import { canvasEventBus } from '../../utils/CanvasEventBus';
+import { CanvasIcon } from '../../utils/icon-registry';
 import type { HandleActionEvent } from './ButtonHandle';
 import {
   StyledAddButton,
@@ -165,7 +162,7 @@ const AddButton = memo(({ onAction }: AddButtonProps) => {
         whileHover={{ scale: 1.05 }}
         onClick={handleClick}
       >
-        <ApIcon name="add" size="14px" />
+        <CanvasIcon icon="plus" size={14} />
       </StyledAddButton>
     </AnimatePresence>
   );
@@ -775,12 +772,7 @@ export function SmartHandle({
             <StyledLabel $position={computedPosition} $backgroundColor={labelBackgroundColor}>
               <Row align="center" gap={4}>
                 {labelIcon}
-                <ApTypography
-                  color="var(--uix-canvas-foreground-de-emp)"
-                  variant={FontVariantToken.fontSizeSBold}
-                >
-                  {label}
-                </ApTypography>
+                <span className="text-xs font-bold text-foreground-muted">{label}</span>
               </Row>
             </StyledLabel>
           )}

--- a/packages/apollo-react/src/canvas/components/CanvasPositionControls.tsx
+++ b/packages/apollo-react/src/canvas/components/CanvasPositionControls.tsx
@@ -1,15 +1,16 @@
-import token from '@uipath/apollo-core';
 import * as Icons from '@uipath/apollo-react/canvas/icons';
 import { Column, Row } from '@uipath/apollo-react/canvas/layouts';
 import {
   type ViewportHelperFunctionOptions as BaseCanvasZoomOptions,
   useReactFlow,
 } from '@uipath/apollo-react/canvas/xyflow/react';
-import { ApIcon, ApIconButton, ApTooltip } from '@uipath/apollo-react/material';
+import { Button } from '@uipath/apollo-wind';
 import { memo, useCallback } from 'react';
 import type { CanvasTranslations } from '../types';
+import { CanvasIcon } from '../utils/icon-registry';
 import { BASE_CANVAS_DEFAULTS } from './BaseCanvas/BaseCanvas.constants';
 import type { BaseCanvasFitViewOptions } from './BaseCanvas/BaseCanvas.types';
+import { CanvasTooltip } from './CanvasTooltip';
 export type { BaseCanvasZoomOptions };
 
 export interface CanvasPositionControlsProps {
@@ -52,39 +53,51 @@ export const CanvasPositionControls = memo(
     return (
       <RootComponent data-testid="canvas-controls">
         {showOrganize && (
-          <ApTooltip
-            content={translations.organize}
-            placement={placement}
-            data-testid="organize-button"
-          >
-            <ApIconButton color="secondary" onClick={handleOrganize}>
+          <CanvasTooltip content={translations.organize} placement={placement}>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-8 w-8"
+              aria-label={translations.organize}
+              onClick={handleOrganize}
+            >
               <Icons.OrganizeIcon />
-            </ApIconButton>
-          </ApTooltip>
+            </Button>
+          </CanvasTooltip>
         )}
-        <ApTooltip content={translations.zoomIn} placement={placement} data-testid="zoom-in-button">
-          <ApIconButton color="secondary" onClick={handleZoomIn}>
-            <ApIcon name="add" size={token.Icon.IconXs} />
-          </ApIconButton>
-        </ApTooltip>
-        <ApTooltip
-          content={translations.zoomOut}
-          placement={placement}
-          data-testid="zoom-out-button"
-        >
-          <ApIconButton color="secondary" onClick={handleZoomOut}>
-            <ApIcon name="remove" size={token.Icon.IconXs} />
-          </ApIconButton>
-        </ApTooltip>
-        <ApTooltip
-          content={translations.zoomToFit}
-          placement={placement}
-          data-testid="fit-to-view-button"
-        >
-          <ApIconButton color="secondary" onClick={handleFitToView}>
+        <CanvasTooltip content={translations.zoomIn} placement={placement}>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-8 w-8"
+            aria-label={translations.zoomIn}
+            onClick={handleZoomIn}
+          >
+            <CanvasIcon icon="plus" size={16} />
+          </Button>
+        </CanvasTooltip>
+        <CanvasTooltip content={translations.zoomOut} placement={placement}>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-8 w-8"
+            aria-label={translations.zoomOut}
+            onClick={handleZoomOut}
+          >
+            <CanvasIcon icon="minus" size={16} />
+          </Button>
+        </CanvasTooltip>
+        <CanvasTooltip content={translations.zoomToFit} placement={placement}>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-8 w-8"
+            aria-label={translations.zoomToFit}
+            onClick={handleFitToView}
+          >
             <Icons.ZoomToFitIcon />
-          </ApIconButton>
-        </ApTooltip>
+          </Button>
+        </CanvasTooltip>
       </RootComponent>
     );
   }

--- a/packages/apollo-react/src/canvas/components/CanvasTooltip.tsx
+++ b/packages/apollo-react/src/canvas/components/CanvasTooltip.tsx
@@ -1,0 +1,157 @@
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipPortal,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@uipath/apollo-wind/components/ui/tooltip';
+import React, {
+  createContext,
+  type PropsWithChildren,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import { useTruncationDetection } from '../../material/components/ap-tooltip/useTruncationDetection';
+
+const HasTooltipProviderContext = createContext(false);
+
+/**
+ * Marks a subtree as having a TooltipProvider. Wrap this around a Radix
+ * `TooltipProvider` so that `CanvasTooltip` can skip adding its own fallback.
+ */
+export function CanvasTooltipProviderMarker({ children }: PropsWithChildren) {
+  return (
+    <HasTooltipProviderContext.Provider value={true}>{children}</HasTooltipProviderContext.Provider>
+  );
+}
+
+type TooltipPlacement = 'top' | 'bottom' | 'left' | 'right';
+
+interface CanvasTooltipProps extends PropsWithChildren {
+  /** Tooltip content (text or ReactNode). */
+  content: ReactNode;
+  /** Tooltip placement relative to the trigger. */
+  placement?: TooltipPlacement;
+  /** When true, only show tooltip if trigger text is overflowing. */
+  smartTooltip?: boolean;
+  /** When true, show the tooltip with a longer delay (700ms). */
+  delay?: boolean;
+  /** Controlled open state. */
+  isOpen?: boolean;
+  /** When true, hide the tooltip entirely. */
+  hide?: boolean;
+}
+
+/**
+ * Thin wrapper around apollo-wind's Radix Tooltip that preserves the
+ * simple imperative API used throughout the canvas package.
+ *
+ * Uses the same clone-element strategy as ApTooltip to avoid inserting
+ * extra wrapper elements into the DOM.
+ */
+export function CanvasTooltip({
+  content,
+  placement = 'top',
+  smartTooltip = false,
+  delay = false,
+  isOpen,
+  hide,
+  children,
+}: Readonly<CanvasTooltipProps>) {
+  const childElement = useMemo(
+    () => (React.isValidElement(children) ? children : <span>{children}</span>),
+    [children]
+  );
+
+  // Store childElement in a ref for callbacks that need access without re-creating
+  const childElementRef = useRef(childElement);
+  childElementRef.current = childElement;
+
+  const childRef = useRef<HTMLElement | null>(null);
+  const truncationDetection = useTruncationDetection(childRef);
+  const isTruncated = smartTooltip ? truncationDetection.isTruncated : true;
+
+  // Controlled hover state (Radix doesn't have MUI's "empty title hides" pattern)
+  const [hoverOpen, setHoverOpen] = useState(false);
+
+  // Stable ref callback that uses childElementRef to avoid dependency on childElement
+  const setChildRef = useCallback((node: HTMLElement | null) => {
+    childRef.current = node;
+
+    const childRefProp = childElementRef.current.props.ref;
+    if (typeof childRefProp === 'function') {
+      childRefProp(node);
+    } else if (childRefProp && typeof childRefProp === 'object') {
+      (childRefProp as React.RefObject<HTMLElement | null>).current = node;
+    }
+  }, []);
+
+  const handleMouseEnter = useCallback(
+    (e: React.MouseEvent<HTMLElement>) => {
+      truncationDetection.check();
+      const childProps = childElementRef.current.props;
+      childProps.onMouseEnter?.(e);
+    },
+    [truncationDetection.check]
+  );
+
+  const triggerWithSmartTooltipHandlers = useMemo(
+    () =>
+      React.cloneElement(childElement, {
+        ref: setChildRef,
+        onMouseEnter: handleMouseEnter,
+      }),
+    [childElement, setChildRef, handleMouseEnter]
+  );
+
+  const triggerWithHandlers = smartTooltip ? triggerWithSmartTooltipHandlers : childElement;
+
+  const handleOpenChange = useCallback(
+    (nextOpen: boolean) => {
+      if (nextOpen && smartTooltip) {
+        truncationDetection.check();
+      }
+      setHoverOpen(nextOpen);
+    },
+    [smartTooltip, truncationDetection.check]
+  );
+
+  // Priority ordering matches ApTooltip: isOpen > hide > smartTooltip
+  const isTooltipHidden = useMemo(() => {
+    if (isOpen != null) return !isOpen;
+    if (hide != null) return hide;
+    if (smartTooltip && !isTruncated) return true;
+    return false;
+  }, [isOpen, hide, smartTooltip, isTruncated]);
+
+  const effectiveOpen = isTooltipHidden ? false : (isOpen ?? hoverOpen);
+
+  const hasProvider = useContext(HasTooltipProviderContext);
+
+  const tooltip = (
+    <Tooltip open={effectiveOpen} onOpenChange={handleOpenChange} delayDuration={delay ? 700 : 200}>
+      <TooltipTrigger asChild>{triggerWithHandlers}</TooltipTrigger>
+      <TooltipPortal>
+        <TooltipContent side={placement} className="max-w-xs break-words">
+          {content}
+        </TooltipContent>
+      </TooltipPortal>
+    </Tooltip>
+  );
+
+  if (hasProvider) {
+    return tooltip;
+  }
+
+  return (
+    <TooltipProvider delayDuration={200} skipDelayDuration={100}>
+      {tooltip}
+    </TooltipProvider>
+  );
+}
+
+export type { CanvasTooltipProps };

--- a/packages/apollo-react/src/canvas/components/CodedAgent/CodedAgentFlow.tsx
+++ b/packages/apollo-react/src/canvas/components/CodedAgent/CodedAgentFlow.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled';
-import { FontVariantToken, Spacing } from '@uipath/apollo-core';
+import { Spacing } from '@uipath/apollo-core';
 import * as Icons from '@uipath/apollo-react/canvas/icons';
 import { Row } from '@uipath/apollo-react/canvas/layouts';
 import type { Edge, EdgeProps, Node, NodeProps } from '@uipath/apollo-react/canvas/xyflow/react';
@@ -13,7 +13,7 @@ import {
   useNodesState,
   useReactFlow,
 } from '@uipath/apollo-react/canvas/xyflow/react';
-import { ApCircularProgress, ApIcon, ApTypography } from '@uipath/apollo-react/material';
+import { Spinner } from '@uipath/apollo-wind';
 import React, {
   memo,
   type ReactElement,
@@ -24,21 +24,22 @@ import React, {
   useState,
 } from 'react';
 
+import { NodeRegistryProvider } from '../../core/NodeRegistryProvider';
+import type { HandleGroupManifest } from '../../schema/node-definition';
 import type { CanvasTranslations, CodedAgentNodeTranslations } from '../../types';
 import { DefaultCanvasTranslations, DefaultCodedAgentNodeTranslations } from '../../types';
 import { d3HierarchyLayout, type LayoutDirection } from '../../utils/coded-agents/d3-layout';
 import { mermaidToReactFlow } from '../../utils/coded-agents/mermaid-parser';
+import { CanvasIcon } from '../../utils/icon-registry';
 import type { BaseCanvasRef } from '../BaseCanvas';
 import { BaseCanvas } from '../BaseCanvas';
 import { BaseNode } from '../BaseNode/BaseNode';
 import type { BaseNodeData } from '../BaseNode/BaseNode.types';
 import {
-  BaseNodeOverrideConfigProvider,
   type BaseNodeOverrideConfig,
+  BaseNodeOverrideConfigProvider,
 } from '../BaseNode/BaseNodeConfigContext';
 import { CanvasPositionControls } from '../CanvasPositionControls';
-import type { HandleGroupManifest } from '../../schema/node-definition';
-import { NodeRegistryProvider } from '../../core/NodeRegistryProvider';
 import { codedAgentManifest } from './coded-agent.manifest';
 
 const LAYOUT_SPACING = [110, 80] as [number, number]; // Horizontal and vertical spacing for layout
@@ -161,11 +162,11 @@ const createCodedAgentNodeWrapper = (
 
     const statusAdornment = useMemo((): React.ReactNode => {
       if (nodeData.hasError)
-        return <ApIcon name="error" size="16px" color="var(--uix-canvas-error-icon)" />;
+        return <CanvasIcon icon="circle-alert" size={16} color="var(--uix-canvas-error-icon)" />;
       if (nodeData.hasSuccess && !nodeData.hasError)
-        return <ApIcon name="check_circle" size="16px" color="var(--uix-canvas-success-icon)" />;
+        return <CanvasIcon icon="circle-check" size={16} color="var(--uix-canvas-success-icon)" />;
       if (nodeData.hasRunning && !nodeData.hasError && !nodeData.hasSuccess)
-        return <ApCircularProgress size={20} />;
+        return <Spinner size="sm" />;
       return undefined;
     }, [nodeData.hasError, nodeData.hasSuccess, nodeData.hasRunning]);
 
@@ -224,24 +225,24 @@ const CodedResourceNodeElement = memo(({ data, selected, id, ...nodeProps }: Nod
     const resourceType = nodeData.type || '';
 
     if (resourceType === 'tool' || label.includes('tool') || label.includes('function')) {
-      return <ApIcon name="build" size="40px" />;
+      return <CanvasIcon icon="wrench" size={40} />;
     }
     if (resourceType === 'context' || label.includes('context') || label.includes('knowledge')) {
-      return <ApIcon name="account_tree" size="40px" />;
+      return <CanvasIcon icon="network" size={40} />;
     }
     if (resourceType === 'escalation' || label.includes('escalation') || label.includes('human')) {
-      return <ApIcon name="person" size="40px" />;
+      return <CanvasIcon icon="user" size={40} />;
     }
-    return <ApIcon name="chat" size="40px" />;
+    return <CanvasIcon icon="message-circle" size={40} />;
   }, [label, nodeData.type]);
 
   const statusAdornment = useMemo((): React.ReactNode => {
     if (nodeData.hasError)
-      return <ApIcon name="error" size="16px" color="var(--uix-canvas-error-icon)" />;
+      return <CanvasIcon icon="circle-alert" size={16} color="var(--uix-canvas-error-icon)" />;
     if (nodeData.hasSuccess && !nodeData.hasError)
-      return <ApIcon name="check_circle" size="16px" color="var(--uix-canvas-success-icon)" />;
+      return <CanvasIcon icon="circle-check" size={16} color="var(--uix-canvas-success-icon)" />;
     if (nodeData.hasRunning && !nodeData.hasError && !nodeData.hasSuccess)
-      return <ApCircularProgress size={13} />;
+      return <Spinner size="sm" />;
     return undefined;
   }, [nodeData.hasError, nodeData.hasSuccess, nodeData.hasRunning]);
 
@@ -281,7 +282,7 @@ const CodedResourceNodeElement = memo(({ data, selected, id, ...nodeProps }: Nod
         />
       </BaseNodeOverrideConfigProvider>
       <TextContainer>
-        <ApTypography color="var(--uix-canvas-foreground-de-emp)">{nodeData.label}</ApTypography>
+        <span className="text-foreground-muted">{nodeData.label}</span>
       </TextContainer>
     </div>
   );
@@ -319,12 +320,7 @@ const CodedFlowNodeElement = memo(({ data, selected, id, ...nodeProps }: NodePro
           />
         </BaseNodeOverrideConfigProvider>
         <TextContainer>
-          <ApTypography
-            variant={FontVariantToken.fontSizeS}
-            color="var(--uix-canvas-foreground-de-emp)"
-          >
-            {nodeData.label}
-          </ApTypography>
+          <span className="text-xs text-foreground-muted">{nodeData.label}</span>
         </TextContainer>
       </div>
     );
@@ -474,27 +470,17 @@ const CodedAgentFlowInner = (props: CodedAgentFlowProps): ReactElement => {
   if (parseError) {
     return (
       <CenteredDiv>
-        <ApTypography color="var(--uix-canvas-error)">Error: {parseError}</ApTypography>
+        <span className="text-error">Error: {parseError}</span>
       </CenteredDiv>
     );
   }
 
   if (isLoading) {
-    return (
-      <CenteredDiv>
-        <ApTypography color="var(--uix-canvas-foreground)">Loading...</ApTypography>
-      </CenteredDiv>
-    );
+    return <CenteredDiv>Loading...</CenteredDiv>;
   }
 
   if (nodes.length === 0) {
-    return (
-      <CenteredDiv>
-        <ApTypography color="var(--uix-canvas-foreground)">
-          {agentNodeTranslations.noDataToDisplay}
-        </ApTypography>
-      </CenteredDiv>
-    );
+    return <CenteredDiv>{agentNodeTranslations.noDataToDisplay}</CenteredDiv>;
   }
 
   return (
@@ -513,12 +499,7 @@ const CodedAgentFlowInner = (props: CodedAgentFlowProps): ReactElement => {
         <Panel position="top-left">
           <Row align="center" gap={Spacing.SpacingXs}>
             <Icons.AgentIcon w={20} h={20} />
-            <ApTypography
-              variant={FontVariantToken.fontSizeSBold}
-              color="var(--uix-canvas-foreground)"
-            >
-              Coded Agent
-            </ApTypography>
+            <span className="text-xs font-bold">Coded Agent</span>
           </Row>
         </Panel>
         <Panel position="bottom-right">

--- a/packages/apollo-react/src/canvas/components/ExecutionStatusIcon/ExecutionStatusIcon.tsx
+++ b/packages/apollo-react/src/canvas/components/ExecutionStatusIcon/ExecutionStatusIcon.tsx
@@ -1,5 +1,6 @@
-import { ApCircularProgress, ApIcon } from '@uipath/apollo-react/material/components';
+import { Spinner } from '@uipath/apollo-wind';
 import { useMemo } from 'react';
+import { CanvasIcon } from '../../utils/icon-registry';
 
 export function getExecutionStatusColor(status: string | undefined): string {
   switch (status) {
@@ -62,21 +63,26 @@ export function ExecutionStatusIcon({
 
     switch (status) {
       case 'InProgress':
-        return <ApCircularProgress size={size} style={{ backgroundColor: 'transparent' }} />;
+        return (
+          <Spinner
+            size="sm"
+            style={{ backgroundColor: 'transparent', width: size, height: size }}
+          />
+        );
       case 'Completed':
-        return <ApIcon color={color} name="check_circle" size={`${size}px`} />;
+        return <CanvasIcon icon="circle-check" size={size} color={color} />;
       case 'Paused':
-        return <ApIcon color={color} name="pause" size={`${size}px`} />;
+        return <CanvasIcon icon="circle-pause" size={size} color={color} />;
       case 'Warning':
-        return <ApIcon color={color} name="warning" size={`${size}px`} />;
+        return <CanvasIcon icon="triangle-alert" size={size} color={color} />;
       case 'Failed':
-        return <ApIcon color={color} name="error" size={`${size}px`} />;
+        return <CanvasIcon icon="circle-alert" size={size} color={color} />;
       case 'Terminated':
-        return <ApIcon color={color} name="close" size={`${size}px`} />;
+        return <CanvasIcon icon="circle-x" size={size} color={color} />;
       case 'Cancelled':
-        return <ApIcon color={color} name="block" size={`${size}px`} />;
+        return <CanvasIcon icon="circle-stop" size={size} color={color} />;
       case 'NotExecuted':
-        return <ApIcon color={color} name="hourglass_empty" size={`${size}px`} />;
+        return <CanvasIcon icon="circle-dashed" size={size} color={color} />;
       default:
         return null;
     }

--- a/packages/apollo-react/src/canvas/components/FloatingCanvasPanel/PanelChrome.tsx
+++ b/packages/apollo-react/src/canvas/components/FloatingCanvasPanel/PanelChrome.tsx
@@ -1,9 +1,10 @@
 import styled from '@emotion/styled';
-import { FontVariantToken } from '@uipath/apollo-core';
 import { Row } from '@uipath/apollo-react/canvas/layouts';
-import { ApIcon, ApIconButton, ApTypography } from '@uipath/apollo-react/material';
+import { Button } from '@uipath/apollo-wind';
 import type { ReactNode } from 'react';
 import { useEffect, useRef } from 'react';
+
+import { CanvasIcon } from '../../utils/icon-registry';
 
 const PanelHeader = styled.div`
   border-bottom: 1px solid var(--uix-canvas-border-de-emp);
@@ -68,18 +69,19 @@ export function PanelChrome({
         <PanelHeader>
           {header ?? (
             <Row gap={8} justify="between" align="center">
-              <ApTypography
-                color="var(--uix-canvas-foreground)"
-                variant={FontVariantToken.fontSizeLBold}
-              >
-                {title}
-              </ApTypography>
+              <span className="text-base font-bold">{title}</span>
               <Row gap={8} align="center">
                 {headerActions}
                 {onClose && (
-                  <ApIconButton color="secondary" onClick={onClose}>
-                    <ApIcon name="close" />
-                  </ApIconButton>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="h-6 w-6"
+                    aria-label="Close"
+                    onClick={onClose}
+                  >
+                    <CanvasIcon icon="x" size={16} />
+                  </Button>
                 )}
               </Row>
             </Row>

--- a/packages/apollo-react/src/canvas/components/GroupNode/GroupNode.tsx
+++ b/packages/apollo-react/src/canvas/components/GroupNode/GroupNode.tsx
@@ -1,8 +1,8 @@
 import type { NodeProps } from '@uipath/apollo-react/canvas/xyflow/react';
 import { NodeResizeControl, useReactFlow } from '@uipath/apollo-react/canvas/xyflow/react';
-import { ApIcon } from '@uipath/apollo-react/material/components';
 import { memo, useCallback } from 'react';
 import { GRID_SPACING } from '../../constants';
+import { CanvasIcon } from '../../utils/icon-registry';
 import {
   BottomCornerIndicators,
   GroupContainer,
@@ -162,7 +162,7 @@ const GroupNodeComponent = ({ id, data, selected }: GroupNodeProps) => {
         <GroupHeader>
           {iconName && (
             <GroupIconWrapper>
-              <ApIcon name={iconName} size="16px" />
+              <CanvasIcon icon={iconName} size={16} />
             </GroupIconWrapper>
           )}
           <GroupTitle>{title}</GroupTitle>
@@ -183,11 +183,7 @@ const GroupNodeComponent = ({ id, data, selected }: GroupNodeProps) => {
                   aria-label={collapsed ? 'Expand group' : 'Collapse group'}
                   title={collapsed ? 'Expand group' : 'Collapse group'}
                 >
-                  <ApIcon
-                    variant="outlined"
-                    name={collapsed ? 'expand_more' : 'expand_less'}
-                    size="16px"
-                  />
+                  <CanvasIcon icon={collapsed ? 'chevron-down' : 'chevron-up'} size={16} />
                 </GroupHeaderButton>
               </>
             )}
@@ -199,7 +195,7 @@ const GroupNodeComponent = ({ id, data, selected }: GroupNodeProps) => {
                 aria-label="More options"
                 title="More options"
               >
-                <ApIcon variant="outlined" name="more_vert" size="16px" />
+                <CanvasIcon icon="ellipsis-vertical" size={16} />
               </GroupHeaderButton>
             )}
           </GroupControls>

--- a/packages/apollo-react/src/canvas/components/HierarchicalCanvas/HierarchicalCanvas.tsx
+++ b/packages/apollo-react/src/canvas/components/HierarchicalCanvas/HierarchicalCanvas.tsx
@@ -17,7 +17,7 @@ import {
   type ReactFlowInstance,
   type Viewport,
 } from '@uipath/apollo-react/canvas/xyflow/react';
-import { ApIcon, ApProgressSpinner } from '@uipath/apollo-react/material/components';
+import { Spinner } from '@uipath/apollo-wind';
 import type React from 'react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { PREVIEW_EDGE_ID, PREVIEW_NODE_ID } from '../../constants';
@@ -47,6 +47,7 @@ import {
 import { viewportManager } from '../../stores/viewportManager';
 import { DefaultCanvasTranslations } from '../../types';
 import type { CanvasLevel } from '../../types/canvas.types';
+import { CanvasIcon } from '../../utils/icon-registry';
 import { prefersReducedMotion } from '../../utils/transitions';
 import { AddNodeManager } from '../AddNodePanel/AddNodeManager';
 import { AddNodePreview } from '../AddNodePanel/AddNodePreview';
@@ -397,7 +398,7 @@ export const HierarchicalCanvas: React.FC<HierarchicalCanvasProps> = ({
           justifyContent: 'center',
         }}
       >
-        <ApProgressSpinner />
+        <Spinner />
       </div>
     );
   }
@@ -430,9 +431,9 @@ export const HierarchicalCanvas: React.FC<HierarchicalCanvasProps> = ({
               label: crumb.name,
               onClick:
                 index < breadcrumbs.length - 1 ? () => handleNavigateToDepth(index) : undefined,
-              startAdornment: index === 0 ? <ApIcon name="home" /> : undefined,
+              startAdornment: index === 0 ? <CanvasIcon icon="house" size={16} /> : undefined,
             }))}
-            delimiter={<ApIcon name="chevron_right" />}
+            delimiter={<CanvasIcon icon="chevron-right" size={16} />}
           />
         </div>
       )}

--- a/packages/apollo-react/src/canvas/components/HierarchicalCanvas/HierarchicalCanvasWithControls.tsx
+++ b/packages/apollo-react/src/canvas/components/HierarchicalCanvas/HierarchicalCanvasWithControls.tsx
@@ -1,12 +1,10 @@
-import { FontVariantToken } from '@uipath/apollo-core';
 import {
   type Node,
   Panel,
   ReactFlowProvider,
   useReactFlow,
 } from '@uipath/apollo-react/canvas/xyflow/react';
-import { ApButton, ApTypography } from '@uipath/apollo-react/material';
-import { ApIcon } from '@uipath/apollo-react/material/components';
+import { Button } from '@uipath/apollo-wind';
 import type React from 'react';
 import { useCallback, useEffect, useState } from 'react';
 import { NodeRegistryProvider } from '../../core';
@@ -23,6 +21,7 @@ import {
 } from '../../stores/canvasStore';
 import type { CanvasLevel } from '../../types/canvas.types';
 import { canvasEventBus } from '../../utils/CanvasEventBus';
+import { CanvasIcon } from '../../utils/icon-registry';
 import { createAddNodePreview } from '../AddNodePanel/createAddNodePreview';
 import { HierarchicalCanvas } from './HierarchicalCanvas';
 
@@ -271,7 +270,7 @@ const workflowManifests: NodeManifest[] = [
     ],
     toolbarExtensions: {
       design: {
-        actions: [{ id: 'drill-in', icon: 'open_in_new', label: 'Open Sub-Process' }],
+        actions: [{ id: 'drill-in', icon: 'external-link', label: 'Open Sub-Process' }],
       },
     },
   },
@@ -418,55 +417,27 @@ const CanvasWithControlsContent: React.FC<CanvasWithControlsContentProps> = ({
             minWidth: '180px',
           }}
         >
-          <ApButton
-            variant="secondary"
-            label="Start"
-            size="small"
-            startIcon={<ApIcon variant="outlined" name="play_circle" />}
-            onClick={() => handleAddNode('start')}
-          />
-          <ApButton
-            variant="secondary"
-            size="small"
-            label="Process"
-            startIcon={<ApIcon variant="outlined" name="settings" />}
-            onClick={() => handleAddNode('process')}
-          />
-          <ApButton
-            variant="secondary"
-            size="small"
-            label="Decision"
-            startIcon={<ApIcon variant="outlined" name="help" />}
-            onClick={() => handleAddNode('decision')}
-          />
-          <ApButton
-            variant="secondary"
-            size="small"
-            label="Sub-Process"
-            startIcon={<ApIcon variant="outlined" name="folder" />}
-            onClick={() => handleAddNode('subprocess')}
-          />
-          <ApButton
-            variant="secondary"
-            size="small"
-            label="End"
-            startIcon={<ApIcon variant="outlined" name="stop_circle" />}
-            onClick={() => handleAddNode('end')}
-          />
-          <ApButton
-            variant="primary"
-            size="small"
-            label="Sample Workflow"
-            startIcon={<ApIcon variant="outlined" name="auto_awesome" />}
-            onClick={handleAddSampleWorkflow}
-          />
-          <ApButton
-            variant="secondary"
-            size="small"
-            label="Clear Canvas"
-            startIcon={<ApIcon name="clear" />}
-            onClick={handleClearCanvas}
-          />
+          <Button variant="secondary" size="sm" onClick={() => handleAddNode('start')}>
+            <CanvasIcon icon="circle-play" size={16} /> Start
+          </Button>
+          <Button variant="secondary" size="sm" onClick={() => handleAddNode('process')}>
+            <CanvasIcon icon="settings" size={16} /> Process
+          </Button>
+          <Button variant="secondary" size="sm" onClick={() => handleAddNode('decision')}>
+            <CanvasIcon icon="circle-question-mark" size={16} /> Decision
+          </Button>
+          <Button variant="secondary" size="sm" onClick={() => handleAddNode('subprocess')}>
+            <CanvasIcon icon="folder" size={16} /> Sub-Process
+          </Button>
+          <Button variant="secondary" size="sm" onClick={() => handleAddNode('end')}>
+            <CanvasIcon icon="circle-stop" size={16} /> End
+          </Button>
+          <Button size="sm" onClick={handleAddSampleWorkflow}>
+            <CanvasIcon icon="sparkles" size={16} /> Sample Workflow
+          </Button>
+          <Button variant="secondary" size="sm" onClick={handleClearCanvas}>
+            <CanvasIcon icon="x" size={16} /> Clear Canvas
+          </Button>
         </div>
       </Panel>
 
@@ -482,11 +453,11 @@ const CanvasWithControlsContent: React.FC<CanvasWithControlsContentProps> = ({
             fontSize: '12px',
           }}
         >
-          <ApTypography variant={FontVariantToken.fontSizeMBold}>Canvas Info</ApTypography>
+          <span className="text-sm font-bold">Canvas Info</span>
           <div>Nodes: {currentCanvas?.nodes?.length || 0}</div>
           <div>Edges: {currentCanvas?.edges?.length || 0}</div>
           <div>Level: {currentPathLength}</div>
-          <ApTypography variant={FontVariantToken.fontSizeMBold}>Instructions</ApTypography>
+          <span className="text-sm font-bold">Instructions</span>
           <div style={{ fontSize: '11px', lineHeight: '1.4' }}>
             1. Add nodes or drag to create
             <br />

--- a/packages/apollo-react/src/canvas/components/NodeContextMenu/NodeContextMenu.tsx
+++ b/packages/apollo-react/src/canvas/components/NodeContextMenu/NodeContextMenu.tsx
@@ -1,95 +1,18 @@
-import { ApIcon, ApIconButton, ApMenu } from '@uipath/apollo-react/material/components';
-import type React from 'react';
-import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { memo, useCallback, useState } from 'react';
+import { CanvasDropdownMenu } from '../shared/CanvasDropdownMenu';
 import { MenuButton } from './NodeContextMenu.styles';
 import type { NodeContextMenuProps, NodeMenuAction } from './NodeContextMenu.types';
 
 export const NodeContextMenu = memo(({ menuItems, isVisible = false }: NodeContextMenuProps) => {
   const [isOpen, setIsOpen] = useState(false);
-  const anchorRef = useRef<HTMLButtonElement>(null);
 
-  const handleMenuOpen = useCallback((event: React.MouseEvent) => {
-    event.stopPropagation();
-    event.preventDefault();
-    setIsOpen(true);
-  }, []);
-
-  const handleMenuClose = useCallback(() => {
-    setIsOpen(false);
-  }, []);
-
-  // Don't auto-close the menu when hover is lost if the menu is already open
-  // This allows users to click the menu button without it immediately closing
-
-  useEffect(() => {
-    if (!isOpen) {
+  const handleMenuItemClick = useCallback((item: NodeMenuAction) => {
+    if (item.disabled === true) {
       return;
     }
-
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape' || e.key === 'Esc') {
-        e.preventDefault();
-        e.stopPropagation();
-        setIsOpen(false);
-      }
-    };
-
-    const handleClickAway = (e: MouseEvent) => {
-      const target = e.target as Node;
-      // Don't close if clicking the menu button or the menu itself
-      if (anchorRef.current?.contains(target)) {
-        return;
-      }
-
-      // Check if clicking outside the menu
-      const menuElement = document.querySelector('[role="menu"]');
-      if (menuElement && !menuElement.contains(target)) {
-        setIsOpen(false);
-      }
-    };
-
-    window.addEventListener('keydown', handleKeyDown, true);
-    document.addEventListener('mousedown', handleClickAway);
-
-    return () => {
-      window.removeEventListener('keydown', handleKeyDown, true);
-      document.removeEventListener('mousedown', handleClickAway);
-    };
-  }, [isOpen]);
-
-  const handleMenuItemClick = useCallback(
-    (item: NodeMenuAction) => {
-      if (item.disabled === true) {
-        return;
-      }
-      item.onClick();
-      handleMenuClose();
-    },
-    [handleMenuClose]
-  );
-
-  const transformedMenuItems = useMemo(
-    () =>
-      menuItems?.map((item, index) => {
-        if ('type' in item && item.type === 'divider') {
-          return {
-            divider: true,
-            key: `divider-${index}`,
-            variant: 'separator' as const,
-          };
-        }
-        const actionItem = item as NodeMenuAction;
-        return {
-          key: actionItem.id,
-          title: actionItem.label,
-          startIcon: actionItem.icon,
-          disabled: actionItem.disabled,
-          onClick: () => handleMenuItemClick(actionItem),
-          variant: 'item' as const,
-        };
-      }) || [],
-    [menuItems, handleMenuItemClick]
-  );
+    item.onClick();
+    setIsOpen(false);
+  }, []);
 
   if (!menuItems || menuItems.length === 0) {
     return null;
@@ -100,30 +23,18 @@ export const NodeContextMenu = memo(({ menuItems, isVisible = false }: NodeConte
   }
 
   return (
-    <>
-      <MenuButton
-        $isVisible={isVisible || isOpen}
-        onClick={(e: React.MouseEvent) => e.stopPropagation()}
-        onMouseDown={(e: React.MouseEvent) => e.stopPropagation()}
-      >
-        <ApIconButton
-          ref={anchorRef}
-          size="small"
-          color="secondary"
-          onClick={handleMenuOpen}
-          onMouseDown={(e: React.MouseEvent) => e.stopPropagation()}
-        >
-          <ApIcon name="more_vert" size="16px" />
-        </ApIconButton>
-      </MenuButton>
-      {isOpen && anchorRef.current && (
-        <ApMenu
-          isOpen={isOpen}
-          anchorEl={anchorRef.current}
-          menuItems={transformedMenuItems}
-          onClose={handleMenuClose}
-        />
-      )}
-    </>
+    <MenuButton
+      $isVisible={isVisible || isOpen}
+      onClick={(e: React.MouseEvent) => e.stopPropagation()}
+      onMouseDown={(e: React.MouseEvent) => e.stopPropagation()}
+    >
+      <CanvasDropdownMenu
+        open={isOpen}
+        onOpenChange={setIsOpen}
+        menuItems={menuItems}
+        onItemClick={handleMenuItemClick}
+        triggerAriaLabel="Node context menu"
+      />
+    </MenuButton>
   );
 });

--- a/packages/apollo-react/src/canvas/components/NodeInspector.tsx
+++ b/packages/apollo-react/src/canvas/components/NodeInspector.tsx
@@ -1,4 +1,3 @@
-import { FontVariantToken } from '@uipath/apollo-core';
 import { Column, Row } from '@uipath/apollo-react/canvas/layouts';
 import {
   type Edge,
@@ -8,7 +7,6 @@ import {
   useReactFlow,
   type XYPosition,
 } from '@uipath/apollo-react/canvas/xyflow/react';
-import { ApTypography } from '@uipath/apollo-react/material';
 
 import { FloatingCanvasPanel } from './FloatingCanvasPanel';
 
@@ -77,46 +75,39 @@ function NodeInfoContent({
   return (
     <Column gap={4} pt={4} px={16}>
       <Row gap={4}>
-        <ApTypography variant={FontVariantToken.fontMonoM}>ID:</ApTypography>
-        <ApTypography variant={FontVariantToken.fontMonoMBold}>{id}</ApTypography>
+        <span className="text-sm font-mono">ID:</span>
+        <span className="text-sm font-mono font-bold">{id}</span>
       </Row>
 
       <Row gap={4}>
-        <ApTypography variant={FontVariantToken.fontMonoM}>Type:</ApTypography>
-        <ApTypography variant={FontVariantToken.fontMonoMBold}>{type || 'default'}</ApTypography>
+        <span className="text-sm font-mono">Type:</span>
+        <span className="text-sm font-mono font-bold">{type || 'default'}</span>
       </Row>
 
       <Row gap={4}>
-        <ApTypography variant={FontVariantToken.fontMonoM}>Selected:</ApTypography>
-        <ApTypography variant={FontVariantToken.fontMonoMBold}>
-          {selected ? 'Yes' : 'No'}
-        </ApTypography>
+        <span className="text-sm font-mono">Selected:</span>
+        <span className="text-sm font-mono font-bold">{selected ? 'Yes' : 'No'}</span>
       </Row>
 
       <Row gap={4}>
-        <ApTypography variant={FontVariantToken.fontMonoM}>Position:</ApTypography>
-        <ApTypography variant={FontVariantToken.fontMonoMBold}>
+        <span className="text-sm font-mono">Position:</span>
+        <span className="text-sm font-mono font-bold">
           ({position.x.toFixed(0)}, {position.y.toFixed(0)})
-        </ApTypography>
+        </span>
       </Row>
 
       {width !== undefined && height !== undefined && (
         <Row gap={4}>
-          <ApTypography variant={FontVariantToken.fontMonoM}>Size:</ApTypography>
-          <ApTypography variant={FontVariantToken.fontMonoMBold}>
+          <span className="text-sm font-mono">Size:</span>
+          <span className="text-sm font-mono font-bold">
             {width.toFixed(0)} × {height.toFixed(0)}
-          </ApTypography>
+          </span>
         </Row>
       )}
 
       {data && Object.keys(data).length > 0 && (
         <Column gap={4}>
-          <ApTypography
-            variant={FontVariantToken.fontMonoM}
-            color="var(--uix-canvas-foreground-de-emp)"
-          >
-            Data:
-          </ApTypography>
+          <span className="text-sm font-mono text-foreground-muted">Data:</span>
           <pre
             style={{
               fontFamily: 'monospace',
@@ -157,81 +148,72 @@ function EdgeInfoContent({ edge }: EdgeInfoContentProps) {
   return (
     <Column gap={4} pt={4} px={16}>
       <Row gap={4}>
-        <ApTypography variant={FontVariantToken.fontMonoM}>ID:</ApTypography>
-        <ApTypography variant={FontVariantToken.fontMonoMBold}>{id}</ApTypography>
+        <span className="text-sm font-mono">ID:</span>
+        <span className="text-sm font-mono font-bold">{id}</span>
       </Row>
 
       <Row gap={4}>
-        <ApTypography variant={FontVariantToken.fontMonoM}>Type:</ApTypography>
-        <ApTypography variant={FontVariantToken.fontMonoMBold}>{type || 'default'}</ApTypography>
+        <span className="text-sm font-mono">Type:</span>
+        <span className="text-sm font-mono font-bold">{type || 'default'}</span>
       </Row>
 
       <Row gap={4}>
-        <ApTypography variant={FontVariantToken.fontMonoM}>Selected:</ApTypography>
-        <ApTypography variant={FontVariantToken.fontMonoMBold}>
-          {selected ? 'Yes' : 'No'}
-        </ApTypography>
+        <span className="text-sm font-mono">Selected:</span>
+        <span className="text-sm font-mono font-bold">{selected ? 'Yes' : 'No'}</span>
       </Row>
 
       <Row gap={4}>
-        <ApTypography variant={FontVariantToken.fontMonoM}>Source:</ApTypography>
-        <ApTypography variant={FontVariantToken.fontMonoMBold}>{source}</ApTypography>
+        <span className="text-sm font-mono">Source:</span>
+        <span className="text-sm font-mono font-bold">{source}</span>
       </Row>
 
       <Row gap={4}>
-        <ApTypography variant={FontVariantToken.fontMonoM}>Target:</ApTypography>
-        <ApTypography variant={FontVariantToken.fontMonoMBold}>{target}</ApTypography>
+        <span className="text-sm font-mono">Target:</span>
+        <span className="text-sm font-mono font-bold">{target}</span>
       </Row>
 
       {sourceHandle && (
         <Row gap={4}>
-          <ApTypography variant={FontVariantToken.fontMonoM}>Source Handle:</ApTypography>
-          <ApTypography variant={FontVariantToken.fontMonoMBold}>{sourceHandle}</ApTypography>
+          <span className="text-sm font-mono">Source Handle:</span>
+          <span className="text-sm font-mono font-bold">{sourceHandle}</span>
         </Row>
       )}
 
       {targetHandle && (
         <Row gap={4}>
-          <ApTypography variant={FontVariantToken.fontMonoM}>Target Handle:</ApTypography>
-          <ApTypography variant={FontVariantToken.fontMonoMBold}>{targetHandle}</ApTypography>
+          <span className="text-sm font-mono">Target Handle:</span>
+          <span className="text-sm font-mono font-bold">{targetHandle}</span>
         </Row>
       )}
 
       {animated !== undefined && (
         <Row gap={4}>
-          <ApTypography variant={FontVariantToken.fontMonoM}>Animated:</ApTypography>
-          <ApTypography variant={FontVariantToken.fontMonoMBold}>
-            {animated ? 'Yes' : 'No'}
-          </ApTypography>
+          <span className="text-sm font-mono">Animated:</span>
+          <span className="text-sm font-mono font-bold">{animated ? 'Yes' : 'No'}</span>
         </Row>
       )}
 
       {label && (
         <Row gap={4}>
-          <ApTypography variant={FontVariantToken.fontMonoM}>Label:</ApTypography>
-          <ApTypography variant={FontVariantToken.fontMonoMBold}>
+          <span className="text-sm font-mono">Label:</span>
+          <span className="text-sm font-mono font-bold">
             {typeof label === 'string' ? label : '[React Element]'}
-          </ApTypography>
+          </span>
         </Row>
       )}
 
       {(markerStart || markerEnd) && (
         <Row gap={4}>
-          <ApTypography variant={FontVariantToken.fontMonoM}>Markers:</ApTypography>
-          <ApTypography variant={FontVariantToken.fontMonoMBold}>
+          <span className="text-sm font-mono">Markers:</span>
+          <span className="text-sm font-mono font-bold">
             {markerStart && markerEnd ? 'Both ends' : markerStart ? 'Start only' : 'End only'}
-          </ApTypography>
+          </span>
         </Row>
       )}
 
       {data && Object.keys(data).length > 0 && (
         <Column gap={4}>
-          <ApTypography
-            variant={FontVariantToken.fontMonoM}
-            color="var(--uix-canvas-foreground-de-emp)"
-          >
-            Data:
-          </ApTypography>
+          <span className="text-sm font-mono text-foreground-muted">Data:</span>
           <pre
             style={{
               fontFamily: 'monospace',

--- a/packages/apollo-react/src/canvas/components/NodePropertiesPanel/NodePropertiesPanel.tsx
+++ b/packages/apollo-react/src/canvas/components/NodePropertiesPanel/NodePropertiesPanel.tsx
@@ -1,7 +1,8 @@
 import { Column } from '@uipath/apollo-react/canvas/layouts';
 import { useReactFlow } from '@uipath/apollo-react/canvas/xyflow/react';
-import { ApIcon, ApIconButton } from '@uipath/apollo-react/material/components';
+import { Button } from '@uipath/apollo-wind';
 import { memo, useCallback, useEffect, useState } from 'react';
+import { CanvasIcon } from '../../utils/icon-registry';
 import { FloatingCanvasPanel } from '../FloatingCanvasPanel';
 import { CheckboxField, NumberField, SelectField, TextField } from './fields';
 import { useNodeConfiguration, useNodeSelection } from './hooks';
@@ -118,13 +119,15 @@ export const NodePropertiesPanel = memo(function NodePropertiesPanel({
   }
 
   const headerActions = (
-    <ApIconButton
-      color="secondary"
+    <Button
+      variant="ghost"
+      size="icon"
+      className="h-6 w-6"
       onClick={handleTogglePin}
       title={isPinned ? 'Unpin panel' : 'Pin panel'}
     >
-      <ApIcon name={isPinned ? 'unfold_less' : 'unfold_more'} />
-    </ApIconButton>
+      <CanvasIcon icon={isPinned ? 'shrink' : 'expand'} size={16} />
+    </Button>
   );
 
   return (

--- a/packages/apollo-react/src/canvas/components/StageNode/AdhocTask.test.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/AdhocTask.test.tsx
@@ -69,35 +69,6 @@ describe('AdhocTaskItem', () => {
       expect(onTaskClick).toHaveBeenCalledWith(expect.any(Object), 'adhoc-1');
     });
 
-    it('prevents task click when menu is open', async () => {
-      const user = userEvent.setup();
-      const onTaskClick = vi.fn();
-      const onRemove = vi.fn();
-      const menuItems = createMenuItems(onRemove);
-
-      render(
-        <AdhocTaskItem
-          {...defaultProps}
-          onTaskClick={onTaskClick}
-          getContextMenuItems={() => menuItems}
-        />
-      );
-
-      // Open menu
-      const menuButton = screen.getByTestId('stage-task-menu-adhoc-1');
-      await user.click(menuButton);
-
-      await waitFor(() => {
-        expect(screen.getByText('Replace task')).toBeInTheDocument();
-      });
-
-      // Try to click the task while menu is open
-      const task = screen.getByTestId('stage-task-adhoc-1');
-      await user.click(task);
-
-      expect(onTaskClick).not.toHaveBeenCalled();
-    });
-
     it('allows task click after menu is closed', async () => {
       const user = userEvent.setup();
       const onTaskClick = vi.fn();
@@ -191,9 +162,9 @@ describe('AdhocTaskItem', () => {
       const playButton = screen.getByTestId('stage-task-play-adhoc-1');
       await user.click(playButton);
 
-      // Should show circular progress while loading
+      // Should show spinner while loading
       await waitFor(() => {
-        expect(screen.getByTestId('ap-circular-progress')).toBeInTheDocument();
+        expect(screen.getByRole('status')).toBeInTheDocument();
       });
 
       // Resolve the play promise
@@ -201,7 +172,7 @@ describe('AdhocTaskItem', () => {
 
       // Loading indicator should disappear
       await waitFor(() => {
-        expect(screen.queryByTestId('ap-circular-progress')).not.toBeInTheDocument();
+        expect(screen.queryByRole('status')).not.toBeInTheDocument();
       });
     });
 

--- a/packages/apollo-react/src/canvas/components/StageNode/AdhocTask.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/AdhocTask.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback, useRef, useState } from 'react';
+import { memo, useCallback, useRef } from 'react';
 import type { NodeMenuItem } from '../NodeContextMenu';
 import { StageTask } from './StageNode.styles';
 import type { StageTaskExecution, StageTaskItem } from './StageNode.types';
@@ -22,21 +22,15 @@ const AdhocTaskItemComponent = ({
   onTaskClick,
   onTaskPlay,
 }: AdhocTaskItemProps) => {
-  const [isMenuOpen, setIsMenuOpen] = useState(false);
   const taskRef = useRef<HTMLDivElement>(null);
   const menuRef = useRef<TaskMenuHandle>(null);
 
   const handleClick = useCallback(
     (e: React.MouseEvent) => {
-      if (isMenuOpen) return;
       onTaskClick(e, task.id);
     },
-    [isMenuOpen, onTaskClick, task.id]
+    [onTaskClick, task.id]
   );
-
-  const handleMenuOpenChange = useCallback((isOpen: boolean) => {
-    setIsMenuOpen(isOpen);
-  }, []);
 
   const handleContextMenu = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
     menuRef.current?.handleContextMenu(e);
@@ -53,13 +47,7 @@ const AdhocTaskItemComponent = ({
     >
       <TaskContent task={task} taskExecution={taskExecution} onTaskPlay={onTaskPlay} />
       {getContextMenuItems && (
-        <TaskMenu
-          ref={menuRef}
-          taskId={task.id}
-          getContextMenuItems={getContextMenuItems}
-          onMenuOpenChange={handleMenuOpenChange}
-          taskRef={taskRef}
-        />
+        <TaskMenu ref={menuRef} taskId={task.id} getContextMenuItems={getContextMenuItems} />
       )}
     </StageTask>
   );

--- a/packages/apollo-react/src/canvas/components/StageNode/DraggableTask.test.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/DraggableTask.test.tsx
@@ -167,38 +167,6 @@ describe('DraggableTask', () => {
       // Task click should NOT be called
       expect(onTaskClick).not.toHaveBeenCalled();
     });
-
-    it('prevents task selection when menu is open', async () => {
-      const user = userEvent.setup();
-      const onTaskClick = vi.fn();
-      const onRemove = vi.fn();
-      const menuItems = createMenuItems(onRemove);
-
-      render(
-        <DraggableTask
-          {...defaultProps}
-          onTaskClick={onTaskClick}
-          groupIndex={0}
-          taskIndex={0}
-          getContextMenuItems={() => menuItems}
-        />
-      );
-
-      // Open menu
-      const menuButton = screen.getByTestId('stage-task-menu-task-1');
-      await user.click(menuButton);
-
-      await waitFor(() => {
-        expect(screen.getByText('Move Up')).toBeInTheDocument();
-      });
-
-      // Try to click on task
-      const task = screen.getByTestId('stage-task-task-1');
-      await user.click(task);
-
-      // Task click should still not be called (menu is open)
-      expect(onTaskClick).not.toHaveBeenCalled();
-    });
   });
 
   describe('Menu Item Interaction', () => {

--- a/packages/apollo-react/src/canvas/components/StageNode/DraggableTask.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/DraggableTask.tsx
@@ -1,9 +1,9 @@
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import { useStore } from '@uipath/apollo-react/canvas/xyflow/react';
-import { ApTooltip } from '@uipath/apollo-react/material';
-import { memo, useCallback, useMemo, useRef, useState } from 'react';
+import { memo, useCallback, useMemo, useRef } from 'react';
 import { EntryConditionIcon } from '../../icons';
+import { CanvasTooltip } from '../CanvasTooltip';
 import type { DraggableTaskProps } from './DraggableTask.types';
 import {
   INDENTATION_WIDTH,
@@ -27,25 +27,16 @@ const DraggableTaskComponent = ({
   isDragDisabled,
   projectedDepth,
 }: DraggableTaskProps) => {
-  const [isMenuOpen, setIsMenuOpen] = useState(false);
   const zoom = useStore((s) => s.transform[2]);
   const taskRef = useRef<HTMLDivElement>(null);
   const menuRef = useRef<TaskMenuHandle>(null);
 
   const handleClick = useCallback(
     (e: React.MouseEvent) => {
-      // If any menu is open, prevent task selection
-      if (isMenuOpen) {
-        return;
-      }
       onTaskClick(e, task.id);
     },
-    [isMenuOpen, onTaskClick, task.id]
+    [onTaskClick, task.id]
   );
-
-  const handleMenuOpenChange = useCallback((isOpen: boolean) => {
-    setIsMenuOpen(isOpen);
-  }, []);
 
   const handleContextMenu = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
     menuRef.current?.handleContextMenu(e);
@@ -108,7 +99,7 @@ const DraggableTaskComponent = ({
       <TaskContent task={task} taskExecution={taskExecution} />
 
       {task.hasEntryCondition && (
-        <ApTooltip content="Entry condition" placement="top">
+        <CanvasTooltip content="Entry condition" placement="top">
           <span
             style={{
               display: 'flex',
@@ -119,16 +110,10 @@ const DraggableTaskComponent = ({
           >
             <EntryConditionIcon w={20} h={20} />
           </span>
-        </ApTooltip>
+        </CanvasTooltip>
       )}
       {getContextMenuItems && (
-        <TaskMenu
-          ref={menuRef}
-          taskId={task.id}
-          getContextMenuItems={handleGetContextMenuItems}
-          onMenuOpenChange={handleMenuOpenChange}
-          taskRef={taskRef}
-        />
+        <TaskMenu ref={menuRef} taskId={task.id} getContextMenuItems={handleGetContextMenuItems} />
       )}
     </StageTask>
   );

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.stories.utils.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.stories.utils.tsx
@@ -9,6 +9,27 @@ type StageNodeWrapperProps = Omit<NodeProps, 'data'> & {
 
 export const StageNodeWrapper = memo(
   ({ id, selected, dragging, width, data }: StageNodeWrapperProps) => {
-    return <StageNode id={id} selected={selected} dragging={dragging} width={width} {...data} />;
+    return (
+      <StageNode
+        id={id}
+        selected={selected}
+        dragging={dragging}
+        width={width}
+        {...data}
+        menuItems={[
+          {
+            id: 'menu-item-1',
+            label: 'Menu Item 1',
+            onClick: () => alert('Menu Item 1 clicked'),
+          },
+          {
+            id: 'menu-item-2',
+
+            label: 'Menu Item 2',
+            onClick: () => alert('Menu Item 2 clicked'),
+          },
+        ]}
+      />
+    );
   }
 );

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.tsx
@@ -15,16 +15,10 @@ import {
   sortableKeyboardCoordinates,
   verticalListSortingStrategy,
 } from '@dnd-kit/sortable';
-import { FontVariantToken, Icon, Padding, Spacing } from '@uipath/apollo-core';
+import { Icon, Padding, Spacing } from '@uipath/apollo-core';
 import { Column, Row } from '@uipath/apollo-react/canvas/layouts';
 import { Position, useStore, useStoreApi } from '@uipath/apollo-react/canvas/xyflow/react';
-import {
-  ApIcon,
-  ApIconButton,
-  ApLink,
-  ApTooltip,
-  ApTypography,
-} from '@uipath/apollo-react/material';
+import { Button, cn } from '@uipath/apollo-wind';
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { EntryConditionIcon, ExitConditionIcon, ReturnToOriginIcon } from '../../icons';
 import type { HandleGroupManifest } from '../../schema/node-definition';
@@ -33,8 +27,10 @@ import {
   moveGroupDown,
   moveGroupUp,
 } from '../../utils/GroupModificationUtils';
+import { CanvasIcon } from '../../utils/icon-registry';
 import { useConnectedHandles } from '../BaseCanvas/ConnectedHandlesContext';
 import { useButtonHandles } from '../ButtonHandle/useButtonHandles';
+import { CanvasTooltip } from '../CanvasTooltip';
 import { ExecutionStatusIcon } from '../ExecutionStatusIcon';
 import { FloatingCanvasPanel } from '../FloatingCanvasPanel';
 import { NodeContextMenu, type NodeMenuItem } from '../NodeContextMenu';
@@ -75,8 +71,8 @@ const CHIP_ICONS: Record<StageHeaderChipType, React.ReactElement> = {
   [StageHeaderChipType.Entry]: <EntryConditionIcon w={Icon.IconXs} h={Icon.IconXs} />,
   [StageHeaderChipType.Exit]: <ExitConditionIcon w={Icon.IconXs} h={Icon.IconXs} />,
   [StageHeaderChipType.ReturnToOrigin]: <ReturnToOriginIcon w={Icon.IconXs} h={Icon.IconXs} />,
-  [StageHeaderChipType.CaseExit]: <ApIcon name="close" size={Icon.IconXs} />,
-  [StageHeaderChipType.CaseCompletion]: <ApIcon name="check-mark" size={Icon.IconXs} />,
+  [StageHeaderChipType.CaseExit]: <CanvasIcon icon="x" size={16} />,
+  [StageHeaderChipType.CaseCompletion]: <CanvasIcon icon="check" size={16} />,
 };
 
 const StageNodeInner = (props: StageNodeProps) => {
@@ -597,13 +593,8 @@ const StageNodeInner = (props: StageNodeProps) => {
           <Row gap={Spacing.SpacingMicro} align="center" flex={1} minW={0}>
             {icon}
             <Column py={2} flex={1} minW={0}>
-              <ApTypography
-                variant={
-                  isStageTitleEditing ? FontVariantToken.fontSizeM : FontVariantToken.fontSizeMBold
-                }
-                color="var(--uix-canvas-foreground)"
-              >
-                <ApTooltip content={label} placement="top" delay>
+              <span className={cn('text-sm', !isStageTitleEditing && 'font-bold')}>
+                <CanvasTooltip content={label} placement="top" delay>
                   <StageTitleContainer isEditing={isStageTitleEditing}>
                     <StageTitleInput
                       name="Stage Title"
@@ -620,15 +611,10 @@ const StageNodeInner = (props: StageNodeProps) => {
                       readOnly={!isStageTitleEditable}
                     />
                   </StageTitleContainer>
-                </ApTooltip>
-              </ApTypography>
+                </CanvasTooltip>
+              </span>
               {stageDuration && (
-                <ApTypography
-                  variant={FontVariantToken.fontSizeS}
-                  color="var(--uix-canvas-foreground-de-emp)"
-                >
-                  {stageDuration}
-                </ApTypography>
+                <span className="text-xs text-foreground-muted">{stageDuration}</span>
               )}
               {stageDetails.headerChips && stageDetails.headerChips.length > 0 && (
                 <StageHeaderChipsRow>
@@ -644,18 +630,14 @@ const StageNodeInner = (props: StageNodeProps) => {
                         }}
                       >
                         {CHIP_ICONS[chip.type]}
-                        {chip.count !== undefined && (
-                          <ApTypography variant={FontVariantToken.fontSizeS}>
-                            {chip.count}
-                          </ApTypography>
-                        )}
+                        {chip.count !== undefined && <span className="text-xs">{chip.count}</span>}
                       </StageChip>
                     );
                     if (chip.tooltip) {
                       return (
-                        <ApTooltip key={chip.type} placement="bottom" content={chip.tooltip}>
+                        <CanvasTooltip key={chip.type} placement="bottom" content={chip.tooltip}>
                           {button}
-                        </ApTooltip>
+                        </CanvasTooltip>
                       );
                     }
                     return button;
@@ -666,25 +648,25 @@ const StageNodeInner = (props: StageNodeProps) => {
           </Row>
           <Row gap={Spacing.SpacingMicro} align="start" py={Padding.PadS}>
             {status && (
-              <ApTooltip content={statusLabel} placement="top">
-                <ApIconButton size="small">
+              <CanvasTooltip content={statusLabel} placement="top">
+                <Button variant="ghost" size="icon" className="h-6 w-6" aria-label={statusLabel}>
                   <ExecutionStatusIcon status={status} size={20} />
-                </ApIconButton>
-              </ApTooltip>
+                </Button>
+              </CanvasTooltip>
             )}
             {(onTaskAdd || onAddTaskFromToolbox) && !isReadOnly && (
-              <ApTooltip content={addTaskLabel} placement="top" hide={addTaskLoading}>
-                <span>
-                  <ApIconButton
-                    onClick={handleTaskAddClick}
-                    size="small"
-                    label={addTaskLabel}
-                    disabled={addTaskLoading}
-                  >
-                    <ApIcon name="add" size="20px" />
-                  </ApIconButton>
-                </span>
-              </ApTooltip>
+              <CanvasTooltip content={addTaskLabel} placement="top" hide={addTaskLoading}>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-6 w-6"
+                  onClick={handleTaskAddClick}
+                  aria-label={addTaskLabel}
+                  disabled={addTaskLoading}
+                >
+                  <CanvasIcon icon="plus" size={20} />
+                </Button>
+              </CanvasTooltip>
             )}
           </Row>
         </StageHeader>
@@ -693,23 +675,18 @@ const StageNodeInner = (props: StageNodeProps) => {
           {tasks.length === 0 && adhocTasks.length === 0 ? (
             <Column py={2}>
               {(onTaskAdd || onAddTaskFromToolbox) && !isReadOnly ? (
-                <ApLink
+                <Button
+                  variant="link"
                   onClick={addTaskLoading ? undefined : handleTaskAddClick}
-                  variant={FontVariantToken.fontSizeS}
                   style={{
                     maxWidth: 'fit-content',
                     pointerEvents: addTaskLoading ? 'none' : undefined,
                   }}
                 >
                   {defaultContent}
-                </ApLink>
+                </Button>
               ) : (
-                <ApTypography
-                  variant={FontVariantToken.fontSizeS}
-                  color="var(--uix-canvas-foreground-de-emp)"
-                >
-                  {defaultContent}
-                </ApTypography>
+                <span className="text-xs text-foreground-muted">{defaultContent}</span>
               )}
             </Column>
           ) : (
@@ -735,9 +712,7 @@ const StageNodeInner = (props: StageNodeProps) => {
                             <StageTaskGroup isParallel={isParallel}>
                               {isParallel && (
                                 <StageParallelLabel>
-                                  <ApTypography variant={FontVariantToken.fontSizeS}>
-                                    Parallel
-                                  </ApTypography>
+                                  <span className="text-xs">Parallel</span>
                                 </StageParallelLabel>
                               )}
                               {taskGroup.map((task, taskIndex) => {
@@ -783,12 +758,7 @@ const StageNodeInner = (props: StageNodeProps) => {
                   style={{ marginTop: tasks.length > 0 ? Spacing.SpacingS : '0px' }}
                 >
                   <StageAdhocHeaderSection>
-                    <ApTypography
-                      variant={FontVariantToken.fontSizeSBold}
-                      color="var(--uix-canvas-foreground-de-emp)"
-                    >
-                      Ad hoc tasks
-                    </ApTypography>
+                    <span className="text-xs font-bold text-foreground-muted">Ad hoc tasks</span>
                   </StageAdhocHeaderSection>
                   <StageTaskList>
                     {adhocTasks.map(({ task, groupIndex, taskIndex }) => {

--- a/packages/apollo-react/src/canvas/components/StageNode/TaskContent.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/TaskContent.tsx
@@ -1,22 +1,15 @@
-import { FontVariantToken, Padding, Spacing } from '@uipath/apollo-core';
+import { Padding, Spacing } from '@uipath/apollo-core';
 import { Column, Row } from '@uipath/apollo-react/canvas/layouts';
-import {
-  ApBadge,
-  ApCircularProgress,
-  ApIconButton,
-  ApTooltip,
-  ApTypography,
-  BadgeSize,
-  type StatusTypes,
-} from '@uipath/apollo-react/material';
+import { Badge, Button, Spinner } from '@uipath/apollo-wind';
 import debounce from 'debounce';
 import { memo, useCallback, useMemo, useState } from 'react';
 import { TimelinePlayIcon } from '../../icons';
+import { CanvasTooltip } from '../CanvasTooltip';
 import { ExecutionStatusIcon } from '../ExecutionStatusIcon';
 import { StageTaskIcon, StageTaskRetryDuration } from './StageNode.styles';
 import type { StageTaskExecution, StageTaskItem } from './StageNode.types';
 
-const ProcessNodeIcon = () => (
+const ProcessCanvasIcon = () => (
   <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
     <rect x="3" y="3" width="7" height="7" rx="1" />
     <rect x="14" y="3" width="7" height="7" rx="1" />
@@ -79,29 +72,31 @@ const TaskPlayButton = memo(
     const buttonSize = small ? '20px' : Spacing.SpacingL;
 
     return (
-      <ApTooltip content="Trigger task" placement="top">
-        <ApIconButton
+      <CanvasTooltip content="Trigger task" placement="top">
+        <Button
+          variant="ghost"
+          size="icon"
           data-testid={`stage-task-play-${taskId}`}
           onClick={handlePlayClick}
           onMouseDown={(e: React.MouseEvent) => e.stopPropagation()}
           onKeyDown={(e: React.KeyboardEvent) => e.stopPropagation()}
           className="task-menu-icon-button"
-          sx={{
-            color: 'var(--uix-canvas-icon-default) !important',
-            minWidth: 'unset !important',
-            width: `${buttonSize} !important`,
-            height: `${buttonSize} !important`,
-            padding: '0 !important',
+          style={{
+            color: 'var(--uix-canvas-icon-default)',
+            minWidth: 'unset',
+            width: buttonSize,
+            height: buttonSize,
+            padding: 0,
             ...(small && { marginRight: '-2px' }),
           }}
         >
           {playLoading ? (
-            <ApCircularProgress size={iconSize - 2} />
+            <Spinner size="sm" style={{ width: iconSize - 2, height: iconSize - 2 }} />
           ) : (
             <TimelinePlayIcon w={iconSize} h={iconSize} />
           )}
-        </ApIconButton>
-      </ApTooltip>
+        </Button>
+      </CanvasTooltip>
     );
   }
 );
@@ -135,30 +130,29 @@ export const TaskContent = memo(
               align="center"
               style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
             >
-              <StageTaskIcon>{task.icon ?? <ProcessNodeIcon />}</StageTaskIcon>
-              <ApTooltip
+              <StageTaskIcon>{task.icon ?? <ProcessCanvasIcon />}</StageTaskIcon>
+              <CanvasTooltip
                 content={task.label}
                 placement="top"
                 smartTooltip
                 {...(isDragging && { isOpen: false })}
               >
-                <ApTypography
-                  variant={FontVariantToken.fontSizeM}
-                  color="var(--uix-canvas-foreground)"
-                  style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
-                >
-                  {task.label}
-                </ApTypography>
-              </ApTooltip>
+                <span className="text-sm truncate">{task.label}</span>
+              </CanvasTooltip>
             </Row>
             <Row align="center" gap={Spacing.SpacingXs} style={{ flexShrink: 0 }}>
               {hasExecutionStatus &&
                 (taskExecution.message ? (
-                  <ApTooltip content={taskExecution.message} placement="top">
-                    <ApIconButton size="small">
+                  <CanvasTooltip content={taskExecution.message} placement="top">
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="h-6 w-6"
+                      aria-label={taskExecution.message}
+                    >
                       <ExecutionStatusIcon status={taskExecution.status} />
-                    </ApIconButton>
-                  </ApTooltip>
+                    </Button>
+                  </CanvasTooltip>
                 ) : (
                   <ExecutionStatusIcon status={taskExecution.status} />
                 ))}
@@ -174,28 +168,19 @@ export const TaskContent = memo(
             <Row align="center" justify="space-between">
               <Row gap={'2px'}>
                 {taskExecution?.duration && (
-                  <ApTypography
-                    variant={FontVariantToken.fontSizeS}
-                    color="var(--uix-canvas-foreground-de-emp)"
-                  >
-                    {taskExecution.duration}
-                  </ApTypography>
+                  <span className="text-xs text-foreground-muted">{taskExecution.duration}</span>
                 )}
                 {taskExecution?.retryDuration && (
                   <StageTaskRetryDuration status={taskExecution.badgeStatus ?? 'warning'}>
-                    <ApTypography variant={FontVariantToken.fontSizeS} color="inherit">
-                      {`(+${taskExecution.retryDuration})`}
-                    </ApTypography>
+                    <span className="text-xs">{`(+${taskExecution.retryDuration})`}</span>
                   </StageTaskRetryDuration>
                 )}
               </Row>
               <Row align="center" gap={Spacing.SpacingXs}>
                 {taskExecution?.badge && (
-                  <ApBadge
-                    size={BadgeSize.SMALL}
-                    status={taskExecution.badgeStatus as StatusTypes}
-                    label={generateBadgeText(taskExecution) ?? ''}
-                  />
+                  <Badge variant={taskExecution.badgeStatus}>
+                    {generateBadgeText(taskExecution) ?? ''}
+                  </Badge>
                 )}
                 {showPlayButtonSmall && (
                   <TaskPlayButton taskId={task.id} onTaskPlay={onTaskPlay} small />

--- a/packages/apollo-react/src/canvas/components/StageNode/TaskMenu.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/TaskMenu.tsx
@@ -1,8 +1,6 @@
-import token, { Spacing } from '@uipath/apollo-core';
-import { ApIcon, ApIconButton, ApMenu } from '@uipath/apollo-react/material';
-import { forwardRef, memo, useCallback, useImperativeHandle, useRef, useState } from 'react';
+import { forwardRef, memo, useCallback, useImperativeHandle, useState } from 'react';
 import type { NodeMenuAction, NodeMenuItem } from '../NodeContextMenu';
-import { type TransformedMenuItem, transformMenuItems } from './StageNodeTaskUtilities';
+import { CanvasDropdownMenu } from '../shared/CanvasDropdownMenu';
 
 export interface TaskMenuHandle {
   handleContextMenu: (e: React.MouseEvent<HTMLElement>) => void;
@@ -11,122 +9,53 @@ export interface TaskMenuHandle {
 interface TaskMenuProps {
   taskId: string;
   getContextMenuItems: () => NodeMenuItem[];
-  onMenuOpenChange?: (isOpen: boolean) => void;
-  taskRef?: React.RefObject<HTMLElement | null>;
 }
 
 const TaskMenuComponent = (
-  { taskId, getContextMenuItems, onMenuOpenChange, taskRef }: TaskMenuProps,
+  { taskId, getContextMenuItems }: TaskMenuProps,
   ref: React.Ref<TaskMenuHandle>
 ) => {
-  const [anchorElement, setAnchorElement] = useState<HTMLElement | null>(null);
-  const menuAnchorRef = useRef<HTMLButtonElement>(null);
-  const isMenuOpen = anchorElement !== null;
+  const [isOpen, setIsOpen] = useState(false);
+  const [menuItems, setMenuItems] = useState<NodeMenuItem[]>([]);
 
-  const [menuItems, setMenuItems] = useState<TransformedMenuItem[]>([]);
-
-  const handleMenuClose = useCallback(() => {
-    setAnchorElement(null);
-    onMenuOpenChange?.(false);
-  }, [onMenuOpenChange]);
-
-  const handleMenuItemClick = useCallback(
-    (item: NodeMenuAction) => {
-      item.onClick();
-      handleMenuClose();
-    },
-    [handleMenuClose]
-  );
-
-  const openMenu = useCallback(
-    (anchor: HTMLElement | null) => {
-      if (!anchor) {
-        return;
+  const handleOpenChange = useCallback(
+    (open: boolean) => {
+      if (open) {
+        setMenuItems(getContextMenuItems());
       }
-
-      setAnchorElement(anchor);
-      setMenuItems(transformMenuItems(getContextMenuItems(), handleMenuItemClick));
-      onMenuOpenChange?.(true);
+      setIsOpen(open);
     },
-    [getContextMenuItems, handleMenuItemClick, onMenuOpenChange]
+    [getContextMenuItems]
   );
 
-  const handleMenuClick = useCallback(
-    (e: React.MouseEvent) => {
-      e.stopPropagation();
-      e.preventDefault();
-      if (isMenuOpen) {
-        handleMenuClose();
-      } else {
-        openMenu(menuAnchorRef.current);
-      }
-    },
-    [isMenuOpen, handleMenuClose, openMenu]
-  );
+  const handleMenuItemClick = useCallback((item: NodeMenuAction) => {
+    item.onClick();
+    setIsOpen(false);
+  }, []);
 
   const handleContextMenu = useCallback(
     (e: React.MouseEvent<HTMLElement>) => {
       e.stopPropagation();
       e.preventDefault();
-      const anchor = taskRef?.current || (e.currentTarget as HTMLElement);
-      openMenu(anchor);
+      handleOpenChange(true);
     },
-    [taskRef, openMenu]
+    [handleOpenChange]
   );
 
   useImperativeHandle(ref, () => ({
     handleContextMenu,
   }));
 
-  const handleMenuMouseDown = useCallback((e: React.MouseEvent) => {
-    e.stopPropagation();
-  }, []);
-
   return (
-    <>
-      <ApIconButton
-        ref={menuAnchorRef}
-        data-testid={`stage-task-menu-${taskId}`}
-        onClick={handleMenuClick}
-        onMouseDown={handleMenuMouseDown}
-        className="task-menu-icon-button"
-        sx={{
-          color: 'var(--colorIconDefault) !important',
-          minWidth: 'unset !important',
-          width: `${Spacing.SpacingL} !important`,
-          height: `${Spacing.SpacingL} !important`,
-          padding: '0 !important',
-        }}
-      >
-        <ApIcon name="more_vert" size="16px" />
-      </ApIconButton>
-      <ApMenu
-        isOpen={isMenuOpen}
-        menuItems={menuItems}
-        anchorEl={anchorElement}
-        onClose={handleMenuClose}
-        anchorOrigin={{
-          vertical: 'bottom',
-          horizontal: 'right',
-        }}
-        transformOrigin={{
-          vertical: 'top',
-          horizontal: 'right',
-        }}
-        width={300}
-        slotProps={{
-          paper: {
-            className: 'task-menu-paper',
-            sx: {
-              '&.task-menu-paper .MuiList-padding': {
-                paddingTop: token.Padding.PadL,
-                paddingBottom: token.Padding.PadL,
-              },
-            },
-          },
-        }}
-      />
-    </>
+    <CanvasDropdownMenu
+      open={isOpen}
+      onOpenChange={handleOpenChange}
+      menuItems={menuItems}
+      onItemClick={handleMenuItemClick}
+      triggerTestId={`stage-task-menu-${taskId}`}
+      triggerAriaLabel="Task actions"
+      contentClassName="w-[300px]"
+    />
   );
 };
 

--- a/packages/apollo-react/src/canvas/components/StickyNoteNode/FormattingToolbar.tsx
+++ b/packages/apollo-react/src/canvas/components/StickyNoteNode/FormattingToolbar.tsx
@@ -1,6 +1,6 @@
-import { NodeIcon } from '@uipath/apollo-react/canvas';
-import { ApTooltip } from '@uipath/apollo-react/material/components';
+import { CanvasIcon } from '@uipath/apollo-react/canvas';
 import { memo, type RefObject, useCallback } from 'react';
+import { CanvasTooltip } from '../CanvasTooltip';
 import type { ActiveFormats } from './markdown-formatting';
 import {
   toggleBold,
@@ -62,34 +62,34 @@ const FormattingToolbarComponent = ({
       onMouseDown={(e) => e.preventDefault()}
       className="nodrag nowheel"
     >
-      <ApTooltip content={`Bold (${mod}+B)`} placement="top" delay>
+      <CanvasTooltip content={`Bold (${mod}+B)`} placement="top" delay>
         <FormattingButton isActive={activeFormats.bold} onClick={handleBold}>
-          <NodeIcon icon="bold" size={14} />
+          <CanvasIcon icon="bold" size={14} />
         </FormattingButton>
-      </ApTooltip>
-      <ApTooltip content={`Italic (${mod}+I)`} placement="top" delay>
+      </CanvasTooltip>
+      <CanvasTooltip content={`Italic (${mod}+I)`} placement="top" delay>
         <FormattingButton isActive={activeFormats.italic} onClick={handleItalic}>
-          <NodeIcon icon="italic" size={14} />
+          <CanvasIcon icon="italic" size={14} />
         </FormattingButton>
-      </ApTooltip>
-      <ApTooltip content={`Strikethrough (${mod}${shift}X)`} placement="top" delay>
+      </CanvasTooltip>
+      <CanvasTooltip content={`Strikethrough (${mod}${shift}X)`} placement="top" delay>
         <FormattingButton isActive={activeFormats.strikethrough} onClick={handleStrikethrough}>
-          <NodeIcon icon="strikethrough" size={14} />
+          <CanvasIcon icon="strikethrough" size={14} />
         </FormattingButton>
-      </ApTooltip>
+      </CanvasTooltip>
 
       <ToolbarSeparator />
 
-      <ApTooltip content="Bullet list" placement="top" delay>
+      <CanvasTooltip content="Bullet list" placement="top" delay>
         <FormattingButton isActive={activeFormats.bulletList} onClick={handleBulletList}>
-          <NodeIcon icon="list" size={14} />
+          <CanvasIcon icon="list" size={14} />
         </FormattingButton>
-      </ApTooltip>
-      <ApTooltip content="Numbered list" placement="top" delay>
+      </CanvasTooltip>
+      <CanvasTooltip content="Numbered list" placement="top" delay>
         <FormattingButton isActive={activeFormats.numberedList} onClick={handleNumberedList}>
-          <NodeIcon icon="list-ordered" size={14} />
+          <CanvasIcon icon="list-ordered" size={14} />
         </FormattingButton>
-      </ApTooltip>
+      </CanvasTooltip>
     </FormattingToolbarContainer>
   );
 };

--- a/packages/apollo-react/src/canvas/components/StickyNoteNode/StickyNoteNode.tsx
+++ b/packages/apollo-react/src/canvas/components/StickyNoteNode/StickyNoteNode.tsx
@@ -1,5 +1,5 @@
 import { Global } from '@emotion/react';
-import { NodeIcon } from '@uipath/apollo-react/canvas';
+import { CanvasIcon } from '@uipath/apollo-react/canvas';
 import type { NodeProps } from '@uipath/apollo-react/canvas/xyflow/react';
 import { NodeResizeControl, useReactFlow } from '@uipath/apollo-react/canvas/xyflow/react';
 import type { ResizeDragEvent, ResizeParams } from '@uipath/apollo-react/canvas/xyflow/system';
@@ -248,13 +248,13 @@ const StickyNoteNodeComponent = ({
     const actions: ToolbarAction[] = [
       {
         id: 'delete',
-        icon: <NodeIcon icon="trash" size={14} />,
+        icon: <CanvasIcon icon="trash" size={14} />,
         label: 'Delete',
         onAction: handleDelete,
       },
       {
         id: 'edit',
-        icon: <NodeIcon icon="pencil" size={14} />,
+        icon: <CanvasIcon icon="pencil" size={14} />,
         label: 'Edit',
         onAction: handleEditClick,
       },

--- a/packages/apollo-react/src/canvas/components/Toolbar/NodeToolbar/NodeToolbar.tsx
+++ b/packages/apollo-react/src/canvas/components/Toolbar/NodeToolbar/NodeToolbar.tsx
@@ -1,6 +1,7 @@
-import { ApIcon, ApTooltip } from '@uipath/apollo-react/material/components';
 import { AnimatePresence } from 'motion/react';
 import { memo, useMemo } from 'react';
+import { CanvasIcon } from '../../../utils/icon-registry';
+import { CanvasTooltip } from '../../CanvasTooltip';
 import { StyledToolbarButton, ToolbarButton } from '../shared';
 import {
   StyledDropdownItem,
@@ -87,9 +88,9 @@ const NodeToolbarComponent = ({ nodeId, config, expanded, hidden }: NodeToolbarP
                   aria-expanded={isDropdownOpen}
                   aria-haspopup="menu"
                 >
-                  <ApTooltip content={config.overflowLabel} placement="top">
-                    <ApIcon variant="outlined" name="more_vert" size="16px" />
-                  </ApTooltip>
+                  <CanvasTooltip content={config.overflowLabel} placement="top">
+                    <CanvasIcon icon="ellipsis-vertical" size={16} />
+                  </CanvasTooltip>
                 </StyledToolbarButton>
                 <AnimatePresence>
                   {isDropdownOpen && (
@@ -130,12 +131,9 @@ const NodeToolbarComponent = ({ nodeId, config, expanded, hidden }: NodeToolbarP
                             $disabled={item.disabled}
                           >
                             {item.icon && typeof item.icon === 'string' && (
-                              <ApIcon
-                                style={{ flex: 'unset' }}
-                                variant="outlined"
-                                name={item.icon}
-                                size="16px"
-                              />
+                              <span style={{ flex: 'unset', display: 'inline-flex' }}>
+                                <CanvasIcon icon={item.icon} size={16} />
+                              </span>
                             )}
                             {item.icon && typeof item.icon !== 'string' && item.icon}
                             <span>{item.label}</span>

--- a/packages/apollo-react/src/canvas/components/Toolbar/shared/ToolbarButton.tsx
+++ b/packages/apollo-react/src/canvas/components/Toolbar/shared/ToolbarButton.tsx
@@ -1,6 +1,7 @@
 import { getLighterColor } from '@uipath/apollo-react/canvas/utils';
-import { ApIcon, ApTooltip } from '@uipath/apollo-react/material/components';
 import { memo } from 'react';
+import { CanvasIcon } from '../../../utils/icon-registry';
+import { CanvasTooltip } from '../../CanvasTooltip';
 import { StyledToolbarButton } from './ToolbarButton.styles';
 import type { ToolbarActionItem } from './toolbar.types';
 
@@ -30,7 +31,7 @@ export const ToolbarButton = memo(({ action, layoutId }: ToolbarButtonProps) => 
   };
 
   return (
-    <ApTooltip content={action.label} placement="top">
+    <CanvasTooltip content={action.label} placement="top">
       <StyledToolbarButton
         layout={layoutId ? true : undefined}
         layoutId={layoutId}
@@ -47,12 +48,12 @@ export const ToolbarButton = memo(({ action, layoutId }: ToolbarButtonProps) => 
         $hoverColor={hoverColor}
       >
         {action.icon && typeof action.icon === 'string' ? (
-          <ApIcon variant="outlined" name={action.icon} size="16px" color={action.color} />
+          <CanvasIcon icon={action.icon} size={16} color={action.color} />
         ) : (
           action.icon
         )}
       </StyledToolbarButton>
-    </ApTooltip>
+    </CanvasTooltip>
   );
 });
 

--- a/packages/apollo-react/src/canvas/components/Toolbar/shared/toolbar.types.ts
+++ b/packages/apollo-react/src/canvas/components/Toolbar/shared/toolbar.types.ts
@@ -1,7 +1,7 @@
 export interface ToolbarActionItem {
   /** Unique action identifier */
   id: string;
-  /** Can be passed as a string (ApIcon icon name) or a custom rendered React node */
+  /** Can be passed as a string (icon identifier resolved via the canvas icon registry) or a custom rendered React node */
   icon: React.ReactNode;
   label?: string;
   disabled?: boolean;

--- a/packages/apollo-react/src/canvas/components/Toolbox/Header.tsx
+++ b/packages/apollo-react/src/canvas/components/Toolbox/Header.tsx
@@ -1,7 +1,7 @@
-import { FontVariantToken } from '@uipath/apollo-core';
 import { Row } from '@uipath/apollo-react/canvas/layouts';
-import { ApIcon, ApIconButton, ApTypography } from '@uipath/apollo-react/material';
+import { Button } from '@uipath/apollo-wind';
 import { memo } from 'react';
+import { CanvasIcon } from '../../utils/icon-registry';
 
 interface HeaderProps {
   title: string;
@@ -26,28 +26,29 @@ export const Header = memo(function Header({ title, onBack, showBackButton }: He
         }}
       >
         {isBackButtonVisible && (
-          <ApIconButton
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-8 w-8"
             aria-label="Back"
-            color="secondary"
             onClick={onBack}
             style={{
               transition: 'transform 0.3s ease-in-out',
             }}
           >
-            <ApIcon name="chevron_left" size="20px" />
-          </ApIconButton>
+            <CanvasIcon icon="chevron-left" size={20} />
+          </Button>
         )}
       </div>
-      <ApTypography
-        variant={FontVariantToken.fontSizeLBold}
-        color="var(--uix-canvas-foreground-emp)"
+      <span
+        className="text-base font-bold"
         style={{
           transition: 'transform 0.3s ease-in-out, margin 0.3s ease-in-out',
           margin: 0,
         }}
       >
         {title}
-      </ApTypography>
+      </span>
     </Row>
   );
 });

--- a/packages/apollo-react/src/canvas/components/Toolbox/ListView.test.tsx
+++ b/packages/apollo-react/src/canvas/components/Toolbox/ListView.test.tsx
@@ -28,7 +28,7 @@ describe('ListView', () => {
     it('should show loading spinner when loading with no items', () => {
       render(<ListView {...defaultProps} items={[]} isLoading={true} />);
 
-      expect(screen.getAllByTestId('ap-skeleton').length).toBeGreaterThan(0);
+      expect(document.querySelectorAll('.animate-pulse').length).toBeGreaterThan(0);
       expect(screen.queryByText('No items found')).not.toBeInTheDocument();
     });
 
@@ -43,7 +43,7 @@ describe('ListView', () => {
 
       render(<ListView {...defaultProps} items={items} isLoading={true} />);
 
-      expect(screen.queryByTestId('ap-skeleton')).not.toBeInTheDocument();
+      expect(document.querySelector('.animate-pulse')).not.toBeInTheDocument();
       expect(screen.getByText('Item 1')).toBeInTheDocument();
     });
   });
@@ -99,10 +99,9 @@ describe('ListView', () => {
 
       render(<ListView {...defaultProps} items={items} />);
 
-      // Check for chevron_right icon
-      const icons = screen.getAllByTestId('ap-icon');
-      const chevronIcon = icons.find((icon) => icon.getAttribute('data-name') === 'chevron_right');
-      expect(chevronIcon).toBeDefined();
+      // Check for chevron-right icon
+      const chevronIcon = document.querySelector('.lucide-chevron-right');
+      expect(chevronIcon).toBeInTheDocument();
     });
 
     it('should render item with URL icon', () => {

--- a/packages/apollo-react/src/canvas/components/Toolbox/ListView.tsx
+++ b/packages/apollo-react/src/canvas/components/Toolbox/ListView.tsx
@@ -1,16 +1,15 @@
-import { FontVariantToken } from '@uipath/apollo-core';
 import { Column } from '@uipath/apollo-react/canvas/layouts';
-import { NodeIcon, partition } from '@uipath/apollo-react/canvas/utils';
-import { ApSkeleton, ApTypography } from '@uipath/apollo-react/material';
-import { ApIcon, ApTooltip } from '@uipath/apollo-react/material/components';
+import { CanvasIcon, partition } from '@uipath/apollo-react/canvas/utils';
+import { Skeleton } from '@uipath/apollo-wind';
 import { forwardRef, memo, useCallback, useImperativeHandle, useMemo } from 'react';
 import type { ListImperativeAPI, RowComponentProps } from 'react-window';
 import { useCanvasTheme } from '../BaseCanvas/CanvasThemeContext';
+import { CanvasTooltip } from '../CanvasTooltip';
 import { IconContainer, ListItemButton, SectionHeader, StyledList } from './ListView.styles';
 
 export interface ListItemIcon {
   /**
-   * icon name from ApIcon (Material Icons)
+   * Icon identifier resolved via the canvas icon registry (lucide kebab-case names or registered custom icons)
    */
   name?: string;
   /**
@@ -128,12 +127,7 @@ const ListViewRow = memo(
     if (renderItem.type === 'section') {
       return (
         <SectionHeader {...ariaAttributes} style={style}>
-          <ApTypography
-            variant={FontVariantToken.fontSizeS}
-            color="var(--uix-canvas-foreground-emp)"
-          >
-            {renderItem.sectionName}
-          </ApTypography>
+          <span className="text-xs">{renderItem.sectionName}</span>
         </SectionHeader>
       );
     }
@@ -164,38 +158,23 @@ const ListViewRow = memo(
           {item.icon?.url && (
             <img src={item.icon?.url} alt={item.name} style={{ width: 24, height: 24 }} />
           )}
-          {item.icon?.name && <NodeIcon icon={item.icon.name} size={24} />}
+          {item.icon?.name && <CanvasIcon icon={item.icon.name} size={24} />}
           {item.icon?.Component && <item.icon.Component />}
         </IconContainerMemoized>
         <Column flex={1} overflow="hidden">
-          <ApTooltip content={item.name} placement="right" smartTooltip>
-            <ApTypography
-              variant={FontVariantToken.fontSizeM}
-              className="list-view-item-name"
-              color="var(--uix-canvas-foreground-emp)"
-            >
-              {item.name}
-            </ApTypography>
-          </ApTooltip>
+          <CanvasTooltip content={item.name} placement="right" smartTooltip>
+            <span className="text-sm list-view-item-name">{item.name}</span>
+          </CanvasTooltip>
           {item.description && (
-            <ApTooltip content={item.description} placement="right" smartTooltip>
-              <ApTypography
-                variant={FontVariantToken.fontSizeXs}
-                className="list-view-item-name"
-                color="var(--uix-canvas-foreground-de-emp)"
-              >
+            <CanvasTooltip content={item.description} placement="right" smartTooltip>
+              <span className="text-xs list-view-item-name text-foreground-muted">
                 {item.description}
-              </ApTypography>
-            </ApTooltip>
+              </span>
+            </CanvasTooltip>
           )}
         </Column>
         {!!item.children && (
-          <ApIcon
-            name="chevron_right"
-            variant="outlined"
-            size="20px"
-            color="var(--uix-canvas-foreground-de-emp)"
-          />
+          <CanvasIcon icon="chevron-right" size={20} color="var(--uix-canvas-foreground-de-emp)" />
         )}
       </ListItemButton>
     );
@@ -226,7 +205,7 @@ const ListViewInner = forwardRef(function ListView<T extends ListItem>(
     onItemClick,
     onItemHover,
     emptyStateMessage = 'No items found',
-    emptyStateIcon = 'search_off',
+    emptyStateIcon = 'search-x',
     isLoading = false,
     enableSections = true,
   }: ListViewProps<T>,
@@ -251,7 +230,7 @@ const ListViewInner = forwardRef(function ListView<T extends ListItem>(
     return (
       <Column gap={8}>
         {[...Array(3)].map((_, index) => (
-          <ApSkeleton variant="rectangle" style={{ height: '32px', width: '100%' }} key={index} />
+          <Skeleton className="h-8 w-full" key={index} />
         ))}
       </Column>
     );
@@ -261,13 +240,8 @@ const ListViewInner = forwardRef(function ListView<T extends ListItem>(
   if (items.length === 0) {
     return (
       <Column align="center" justify="center" flex={1} gap={10} style={{ minHeight: '250px' }}>
-        <ApIcon name={emptyStateIcon} size="48px" color="var(--uix-canvas-foreground-de-emp)" />
-        <ApTypography
-          variant={FontVariantToken.fontSizeS}
-          color="var(--uix-canvas-foreground-de-emp)"
-        >
-          {emptyStateMessage}
-        </ApTypography>
+        <CanvasIcon icon={emptyStateIcon} size={48} color="var(--uix-canvas-foreground-de-emp)" />
+        <span className="text-xs text-foreground-muted">{emptyStateMessage}</span>
       </Column>
     );
   }

--- a/packages/apollo-react/src/canvas/components/Toolbox/SearchBox.tsx
+++ b/packages/apollo-react/src/canvas/components/Toolbox/SearchBox.tsx
@@ -1,6 +1,7 @@
 import { cx } from '@uipath/apollo-react/canvas/utils';
-import { ApIcon } from '@uipath/apollo-react/material/components';
 import { memo, useEffect, useRef } from 'react';
+
+import { CanvasIcon } from '../../utils/icon-registry';
 import { StyledSearchForm } from './SearchBox.styles';
 
 interface SearchBoxProps {
@@ -52,7 +53,7 @@ export const SearchBox = memo(function SearchBox({
     >
       <div className={cx(`searchbox-container`, { 'has-value': !!value })}>
         <span className="searchbox-icon">
-          <ApIcon name="search" size="16px" />
+          <CanvasIcon icon="search" size={16} />
         </span>
         <input
           ref={inputRef}
@@ -76,7 +77,7 @@ export const SearchBox = memo(function SearchBox({
             onClick={clear}
             onKeyDown={handleClearButtonKeyDown}
           >
-            <ApIcon name="close" size="16px" />
+            <CanvasIcon icon="x" size={16} />
           </button>
         )}
       </div>

--- a/packages/apollo-react/src/canvas/components/TriggerNode/TriggerNode.tsx
+++ b/packages/apollo-react/src/canvas/components/TriggerNode/TriggerNode.tsx
@@ -1,9 +1,10 @@
 import { Position, useStore } from '@uipath/apollo-react/canvas/xyflow/react';
-import { ApIcon, ApTooltip } from '@uipath/apollo-react/material/components';
 import { memo, useCallback, useMemo, useState } from 'react';
 import type { HandleGroupManifest } from '../../schema/node-definition';
+import { CanvasIcon } from '../../utils/icon-registry';
 import { useConnectedHandles } from '../BaseCanvas/ConnectedHandlesContext';
 import { useButtonHandles } from '../ButtonHandle/useButtonHandles';
+import { CanvasTooltip } from '../CanvasTooltip';
 import { TriggerContainer, TriggerIconWrapper } from './TriggerNode.styles';
 import type { TriggerNodeProps } from './TriggerNode.types';
 
@@ -46,9 +47,7 @@ const TriggerNodeComponent = (props: TriggerNodeProps) => {
 
   const triggerContent = (
     <TriggerContainer selected={!!selected} status={status}>
-      <TriggerIconWrapper status={status}>
-        {icon || <ApIcon name="bolt" variant="outlined" size="30px" />}
-      </TriggerIconWrapper>
+      <TriggerIconWrapper status={status}>{icon || <CanvasIcon icon="zap" />}</TriggerIconWrapper>
     </TriggerContainer>
   );
 
@@ -59,9 +58,9 @@ const TriggerNodeComponent = (props: TriggerNodeProps) => {
       onMouseLeave={handleMouseLeave}
     >
       {tooltip ? (
-        <ApTooltip content={tooltip} placement="top" style={{ width: '100%', height: '100%' }}>
+        <CanvasTooltip content={tooltip} placement="top">
           {triggerContent}
-        </ApTooltip>
+        </CanvasTooltip>
       ) : (
         triggerContent
       )}

--- a/packages/apollo-react/src/canvas/components/shared/CanvasDropdownMenu.tsx
+++ b/packages/apollo-react/src/canvas/components/shared/CanvasDropdownMenu.tsx
@@ -1,0 +1,77 @@
+import {
+  Button,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@uipath/apollo-wind';
+import type React from 'react';
+import { CanvasIcon } from '../../utils/icon-registry';
+import type { NodeMenuAction, NodeMenuItem } from '../NodeContextMenu';
+
+interface CanvasDropdownMenuProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  menuItems: NodeMenuItem[];
+  onItemClick: (item: NodeMenuAction) => void;
+  triggerTestId?: string;
+  triggerAriaLabel?: string;
+  contentClassName?: string;
+}
+
+/**
+ * Wraps the DropdownMenu component from @uipath/apollo-wind to provide a consistent dropdown menu for canvas nodes.
+ * It renders a trigger button (three vertical dots) and displays the provided menu items when clicked.
+ * Menu items can be either actions or dividers, and clicking an action will call the provided onItemClick handler.
+ *
+ * Uses modal={false} to prevent multiple dropdowns from staying open simultaneously in the canvas.
+ * Radix's default modal overlay (pointer-events:none on body) doesn't block clicks inside
+ * React Flow's foreignObject, so we disable it and rely on document-level pointerdown
+ * listeners to detect outside interactions instead.
+ */
+export function CanvasDropdownMenu({
+  open,
+  onOpenChange,
+  menuItems,
+  onItemClick,
+  triggerTestId,
+  triggerAriaLabel = 'Dropdown menu',
+  contentClassName,
+}: CanvasDropdownMenuProps) {
+  return (
+    <DropdownMenu open={open} onOpenChange={onOpenChange} modal={false}>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-6 w-6"
+          data-testid={triggerTestId}
+          aria-label={triggerAriaLabel}
+          onClick={(e: React.MouseEvent) => e.stopPropagation()}
+          onPointerDown={(e: React.PointerEvent) => e.stopPropagation()}
+        >
+          <CanvasIcon icon="ellipsis-vertical" size={16} />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" sideOffset={4} className={contentClassName}>
+        {menuItems.map((item, index) => {
+          if ('type' in item && item.type === 'divider') {
+            return <DropdownMenuSeparator key={`divider-${index}`} />;
+          }
+          const actionItem = item as NodeMenuAction;
+          return (
+            <DropdownMenuItem
+              key={actionItem.id}
+              disabled={actionItem.disabled}
+              onSelect={() => onItemClick(actionItem)}
+            >
+              {actionItem.icon}
+              {actionItem.label}
+            </DropdownMenuItem>
+          );
+        })}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/packages/apollo-react/src/canvas/constants.ts
+++ b/packages/apollo-react/src/canvas/constants.ts
@@ -3,3 +3,6 @@ export const PREVIEW_EDGE_ID = 'preview-edge-id';
 export const DEFAULT_NODE_SIZE = 96; // px
 
 export const GRID_SPACING = 16;
+
+/** Canvas viewport width below which compact layout is used. */
+export const CANVAS_COMPACT_BREAKPOINT = 600;

--- a/packages/apollo-react/src/canvas/controls/Breadcrumb/Breadcrumb.tsx
+++ b/packages/apollo-react/src/canvas/controls/Breadcrumb/Breadcrumb.tsx
@@ -1,8 +1,8 @@
 import styled from '@emotion/styled';
-import { FontVariantToken, Spacing } from '@uipath/apollo-core';
-import { ApTooltip, ApTypography } from '@uipath/apollo-react/material';
+import { Spacing } from '@uipath/apollo-core';
 import type React from 'react';
 import { memo } from 'react';
+import { CanvasTooltip } from '../../components/CanvasTooltip';
 
 import { Row } from '../../layouts';
 
@@ -35,13 +35,7 @@ const LiStyled = styled.li`
 
 export const Breadcrumb: React.FC<BreadcrumbProps> = memo(({ items, delimiter = '>' }) => {
   const delimiterNode =
-    typeof delimiter === 'string' ? (
-      <ApTypography aria-hidden="true" color="var(--color-foreground-de-emp)">
-        {delimiter}
-      </ApTypography>
-    ) : (
-      delimiter
-    );
+    typeof delimiter === 'string' ? <span aria-hidden="true">{delimiter}</span> : delimiter;
 
   return (
     <Row
@@ -73,19 +67,14 @@ export const Breadcrumb: React.FC<BreadcrumbProps> = memo(({ items, delimiter = 
                   aria-current={index === items.length - 1 ? 'page' : undefined}
                 >
                   {item.startAdornment}
-                  <ApTooltip smartTooltip content={item.label}>
-                    <ApTypography
-                      variant={
-                        index === items.length - 1
-                          ? FontVariantToken.fontSizeMBold
-                          : FontVariantToken.fontSizeM
-                      }
-                      style={{ textOverflow: 'ellipsis', overflow: 'hidden', whiteSpace: 'nowrap' }}
+                  <CanvasTooltip smartTooltip content={item.label}>
+                    <span
+                      className={`${index === items.length - 1 ? 'text-sm font-bold' : 'text-sm'} truncate`}
                       data-testid={`breadcrumb-item-${item.label}`}
                     >
                       {item.label}
-                    </ApTypography>
-                  </ApTooltip>
+                    </span>
+                  </CanvasTooltip>
                   {item.endAdornment}
                 </Row>
               </button>
@@ -97,19 +86,14 @@ export const Breadcrumb: React.FC<BreadcrumbProps> = memo(({ items, delimiter = 
                 aria-current={index === items.length - 1 ? 'page' : undefined}
               >
                 {item.startAdornment}
-                <ApTooltip smartTooltip content={item.label}>
-                  <ApTypography
-                    variant={
-                      index === items.length - 1
-                        ? FontVariantToken.fontSizeMBold
-                        : FontVariantToken.fontSizeM
-                    }
-                    style={{ textOverflow: 'ellipsis', overflow: 'hidden', whiteSpace: 'nowrap' }}
+                <CanvasTooltip smartTooltip content={item.label}>
+                  <span
+                    className={`${index === items.length - 1 ? 'text-sm font-bold' : 'text-sm'} truncate`}
                     data-testid={`breadcrumb-item-${item.label}`}
                   >
                     {item.label}
-                  </ApTypography>
-                </ApTooltip>
+                  </span>
+                </CanvasTooltip>
                 {item.endAdornment}
               </Row>
             )}

--- a/packages/apollo-react/src/canvas/storybook-utils/components/StoryInfoPanel.tsx
+++ b/packages/apollo-react/src/canvas/storybook-utils/components/StoryInfoPanel.tsx
@@ -1,8 +1,8 @@
-import { FontVariantToken } from '@uipath/apollo-core';
 import { Column, Row } from '@uipath/apollo-react/canvas/layouts';
 import { Panel } from '@uipath/apollo-react/canvas/xyflow/react';
-import { ApIcon, ApIconButton, ApTypography } from '@uipath/apollo-react/material';
+import { Button } from '@uipath/apollo-wind';
 import { useState } from 'react';
+import { CanvasIcon } from '../../utils/icon-registry';
 
 export interface StoryInfoPanelProps {
   /** Panel title */
@@ -46,15 +46,17 @@ export function StoryInfoPanel({
         }}
       >
         <Row justify="space-between" align="center" gap={12}>
-          <ApTypography variant={FontVariantToken.fontSizeH4Bold}>{title}</ApTypography>
+          <span className="text-lg font-bold">{title}</span>
           {collapsible && hasContent && (
-            <ApIconButton
-              size="small"
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-6 w-6"
               onClick={() => setIsCollapsed(!isCollapsed)}
               aria-label={isCollapsed ? 'Expand panel' : 'Collapse panel'}
             >
-              <ApIcon name={isCollapsed ? 'expand_more' : 'expand_less'} />
-            </ApIconButton>
+              <CanvasIcon icon={isCollapsed ? 'chevron-down' : 'chevron-up'} size={16} />
+            </Button>
           )}
         </Row>
 
@@ -68,14 +70,7 @@ export function StoryInfoPanel({
               marginTop: isCollapsed && collapsible ? 0 : undefined,
             }}
           >
-            {description && (
-              <ApTypography
-                variant={FontVariantToken.fontSizeS}
-                color="var(--uix-canvas-foreground-de-emp)"
-              >
-                {description}
-              </ApTypography>
-            )}
+            {description && <span className="text-xs text-foreground-muted">{description}</span>}
             {children}
           </div>
         )}

--- a/packages/apollo-react/src/canvas/storybook-utils/decorators.tsx
+++ b/packages/apollo-react/src/canvas/storybook-utils/decorators.tsx
@@ -6,8 +6,10 @@
 
 import type { Decorator } from '@storybook/react';
 import { ReactFlowProvider } from '@uipath/apollo-react/canvas/xyflow/react';
+import { TooltipProvider } from '@uipath/apollo-wind';
 import type React from 'react';
 import { useMemo } from 'react';
+import { CanvasTooltipProviderMarker } from '../components/CanvasTooltip';
 import { NodeRegistryProvider } from '../core';
 import {
   type ExecutionStateContextValue,
@@ -136,7 +138,11 @@ export function withCanvasProviders(options: CanvasProvidersOptions = {}): Decor
         <ExecutionStatusContext.Provider value={executions}>
           <ValidationStatusContext.Provider value={validations}>
             <ReactFlowProvider>
-              <Story />
+              <TooltipProvider>
+                <CanvasTooltipProviderMarker>
+                  <Story />
+                </CanvasTooltipProviderMarker>
+              </TooltipProvider>
             </ReactFlowProvider>
           </ValidationStatusContext.Provider>
         </ExecutionStatusContext.Provider>

--- a/packages/apollo-react/src/canvas/styles/tailwind.canvas.css
+++ b/packages/apollo-react/src/canvas/styles/tailwind.canvas.css
@@ -1,0 +1,16 @@
+/**
+ * Canvas-specific Tailwind CSS
+ *
+ * Pre-compiles only the Tailwind utility classes used by canvas components
+ * and their apollo-wind dependencies.
+ *
+ * Consumers will need to follow {@link ../README.md} to include the compiled CSS in their build process so that tailwind styling is available at runtime.
+ */
+
+@import "@uipath/apollo-wind/tailwind.css";
+
+/* Scan canvas component source files for inline Tailwind class usage */
+@source "../../canvas/**/*.{ts,tsx}";
+
+/* Scan apollo-wind compiled components for CVA class strings */
+@source "../../../node_modules/@uipath/apollo-wind/dist/**/*.js";

--- a/packages/apollo-react/src/canvas/utils/adornment-resolver.tsx
+++ b/packages/apollo-react/src/canvas/utils/adornment-resolver.tsx
@@ -1,8 +1,7 @@
-import { ExecutionStatusIcon, NodeIcon } from '@uipath/apollo-react/canvas';
-import { ApTooltip } from '@uipath/apollo-react/material';
-import { ApIcon } from '@uipath/apollo-react/material/components';
+import { CanvasIcon, ExecutionStatusIcon } from '@uipath/apollo-react/canvas';
 import { memo } from 'react';
 import type { NodeAdornments, NodeStatusContext } from '../components';
+import { CanvasTooltip } from '../components/CanvasTooltip';
 import { getExecutionStatusColor } from '../components/ExecutionStatusIcon/ExecutionStatusIcon';
 import { ValidationErrorSeverity } from '../types/validation';
 
@@ -60,11 +59,11 @@ function ExecutionStatusIndicatorInternal({ status, count }: { status?: string; 
 
 function SquareDashedIndicator() {
   return (
-    <ApTooltip content="Node output is mocked" placement="bottom">
+    <CanvasTooltip content="Node output is mocked" placement="bottom">
       <span style={{ display: 'inline-flex' }}>
-        <NodeIcon icon="square-dashed" size={16} color="var(--color-foreground-emp)" />
+        <CanvasIcon icon="square-dashed" size={16} color="var(--color-foreground-emp)" />
       </span>
-    </ApTooltip>
+    </CanvasTooltip>
   );
 }
 
@@ -72,21 +71,21 @@ export const ExecutionStatusIndicator = memo(ExecutionStatusIndicatorInternal);
 
 export function ValidationErrorIndicator({ message }: { message?: string }) {
   return (
-    <ApTooltip content={message || 'Validation error'} placement="bottom">
+    <CanvasTooltip content={message || 'Validation error'} placement="bottom">
       <span style={{ display: 'inline-flex' }}>
-        <ApIcon name="error" size="16px" color="var(--uix-canvas-error-icon)" />
+        <CanvasIcon icon="circle-alert" size={16} color="var(--uix-canvas-error-icon)" />
       </span>
-    </ApTooltip>
+    </CanvasTooltip>
   );
 }
 
 export function ValidationWarningIndicator({ message }: { message?: string }) {
   return (
-    <ApTooltip content={message || 'Validation warning'} placement="bottom">
+    <CanvasTooltip content={message || 'Validation warning'} placement="bottom">
       <span style={{ display: 'inline-flex' }}>
-        <ApIcon name="warning" size="16px" color="var(--uix-canvas-warning-icon)" />
+        <CanvasIcon icon="triangle-alert" size={16} color="var(--uix-canvas-warning-icon)" />
       </span>
-    </ApTooltip>
+    </CanvasTooltip>
   );
 }
 

--- a/packages/apollo-react/src/canvas/utils/icon-registry.tsx
+++ b/packages/apollo-react/src/canvas/utils/icon-registry.tsx
@@ -101,18 +101,21 @@ export function getIcon(iconId: string): IconComponent {
   return ({ w, h, color }) => <BoxIcon width={w ?? 24} height={h ?? 24} color={color} />;
 }
 
-export interface NodeIconProps {
+export interface CanvasIconProps {
   icon?: string;
   size?: number;
   color?: string;
 }
 
 /**
- * Memoized component for rendering icons from the registry
- * Use this instead of getIcon() to avoid creating components during render
+ * Memoized component for rendering icons from the registry.
+ * Use this instead of getIcon() to avoid creating components during render.
  */
-export const NodeIcon = memo(function NodeIcon({ icon, size = 16, color }: NodeIconProps) {
+export const CanvasIcon = memo(function CanvasIcon({ icon, size = 16, color }: CanvasIconProps) {
   const Icon = useMemo(() => (icon ? getIcon(icon) : null), [icon]);
   if (!Icon) return null;
   return <Icon w={size} h={size} color={color} />;
 });
+
+/** @deprecated Use `CanvasIcon` instead. */
+export const NodeIcon = CanvasIcon;

--- a/packages/apollo-react/src/test/canvas-mocks.ts
+++ b/packages/apollo-react/src/test/canvas-mocks.ts
@@ -294,6 +294,18 @@ vi.mock('@uipath/apollo-core', async (importOriginal) => {
   };
 });
 
+// Mock Radix tooltip (from apollo-wind) — removes TooltipProvider requirement
+vi.mock('@uipath/apollo-wind/components/ui/tooltip', () => ({
+  TooltipProvider: ({ children }: { children?: React.ReactNode }) => children,
+  Tooltip: ({ children }: { children?: React.ReactNode }) =>
+    React.createElement(React.Fragment, null, children),
+  TooltipTrigger: ({ children }: { children?: React.ReactNode; asChild?: boolean }) =>
+    React.createElement(React.Fragment, null, children),
+  TooltipContent: () => null,
+  TooltipPortal: ({ children }: { children?: React.ReactNode }) =>
+    React.createElement(React.Fragment, null, children),
+}));
+
 // Mock sanitize-html
 // Test mock only - simplified HTML stripping for test environment, not actual sanitization
 // Production code uses the real sanitize-html library with proper configuration

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,7 +84,7 @@ importers:
         version: 36.0.1(stylelint@16.25.0(typescript@5.9.3))
       stylelint-config-tailwindcss:
         specifier: ^1.0.0
-        version: 1.0.0(stylelint@16.25.0(typescript@5.9.3))(tailwindcss@4.1.17)
+        version: 1.0.0(stylelint@16.25.0(typescript@5.9.3))(tailwindcss@4.2.2)
       tsx:
         specifier: ^4.20.6
         version: 4.20.6
@@ -96,7 +96,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@24.10.1)(@vitest/ui@4.1.0)(happy-dom@20.8.9)(jsdom@27.3.0)(msw@2.12.3(@types/node@24.10.1)(typescript@5.9.3))(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(sass@1.94.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3))
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@24.10.1)(@vitest/ui@4.1.0)(happy-dom@20.8.9)(jsdom@27.3.0)(msw@2.12.3(@types/node@24.10.1)(typescript@5.9.3))(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.32.0)(sass@1.94.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3))
 
   apps/apollo-vertex:
     dependencies:
@@ -367,7 +367,7 @@ importers:
         version: 5.9.3
       vite:
         specifier: ^7.3.2
-        version: 7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(sass@1.94.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3)
+        version: 7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.32.0)(sass@1.94.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3)
 
   apps/react-playground:
     dependencies:
@@ -468,7 +468,7 @@ importers:
         version: 10.2.15(storybook@10.2.15(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
       '@storybook/addon-docs':
         specifier: ^10.2.15
-        version: 10.2.15(@types/react@19.2.8)(esbuild@0.27.3)(rollup@4.59.0)(storybook@10.2.15(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(sass@1.94.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.27.3))
+        version: 10.2.15(@types/react@19.2.8)(esbuild@0.27.3)(rollup@4.59.0)(storybook@10.2.15(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.32.0)(sass@1.94.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.27.3))
       '@storybook/addon-links':
         specifier: ^10.2.15
         version: 10.2.15(react@19.2.3)(storybook@10.2.15(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
@@ -477,7 +477,10 @@ importers:
         version: 10.2.15(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.2.15(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.9.3)
       '@storybook/react-vite':
         specifier: ^10.2.15
-        version: 10.2.15(esbuild@0.27.3)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.59.0)(storybook@10.2.15(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.9.3)(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(sass@1.94.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.27.3))
+        version: 10.2.15(esbuild@0.27.3)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.59.0)(storybook@10.2.15(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.9.3)(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.32.0)(sass@1.94.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.27.3))
+      '@tailwindcss/vite':
+        specifier: ^4.1.17
+        version: 4.2.2(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.32.0)(sass@1.94.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3))
       prettier:
         specifier: ^3.8.1
         version: 3.8.1
@@ -487,12 +490,15 @@ importers:
       storybook:
         specifier: ^10.2.15
         version: 10.2.15(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      tailwindcss:
+        specifier: ^4.1.17
+        version: 4.2.2
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
       vite:
         specifier: ^7.3.2
-        version: 7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(sass@1.94.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3)
+        version: 7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.32.0)(sass@1.94.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3)
 
   packages/apollo-core:
     devDependencies:
@@ -525,7 +531,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@24.10.1)(@vitest/ui@4.1.0)(happy-dom@20.8.9)(jsdom@27.3.0)(msw@2.12.3(@types/node@24.10.1)(typescript@5.9.3))(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(sass@1.94.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3))
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@24.10.1)(@vitest/ui@4.1.0)(happy-dom@20.8.9)(jsdom@27.3.0)(msw@2.12.3(@types/node@24.10.1)(typescript@5.9.3))(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.32.0)(sass@1.94.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3))
 
   packages/apollo-react:
     dependencies:
@@ -736,10 +742,13 @@ importers:
         version: 10.2.15(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.2.15(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.9.3)
       '@storybook/react-vite':
         specifier: ^10.2.15
-        version: 10.2.15(esbuild@0.27.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.59.0)(storybook@10.2.15(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.9.3)(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(sass@1.94.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.27.0))
+        version: 10.2.15(esbuild@0.27.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.59.0)(storybook@10.2.15(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.9.3)(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.32.0)(sass@1.94.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.27.0))
       '@svgr/webpack':
         specifier: ^8.1.0
         version: 8.1.0(typescript@5.9.3)
+      '@tailwindcss/cli':
+        specifier: ^4.1.17
+        version: 4.1.17
       '@testing-library/jest-dom':
         specifier: ^6.9.1
         version: 6.9.1
@@ -796,7 +805,7 @@ importers:
         version: 4.7.0(esbuild@0.27.0)
       '@vitejs/plugin-react':
         specifier: ^4.7.0
-        version: 4.7.0(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(sass@1.94.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3))
+        version: 4.7.0(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.32.0)(sass@1.94.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3))
       '@vitest/coverage-v8':
         specifier: ^4.1.0
         version: 4.1.0(vitest@4.1.0)
@@ -823,10 +832,10 @@ importers:
         version: 5.9.3
       vite-tsconfig-paths:
         specifier: ^5.1.4
-        version: 5.1.4(typescript@5.9.3)(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(sass@1.94.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3))
+        version: 5.1.4(typescript@5.9.3)(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.32.0)(sass@1.94.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3))
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@24.10.1)(@vitest/ui@4.1.0)(happy-dom@20.8.9)(jsdom@27.3.0)(msw@2.12.3(@types/node@24.10.1)(typescript@5.9.3))(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(sass@1.94.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3))
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@24.10.1)(@vitest/ui@4.1.0)(happy-dom@20.8.9)(jsdom@27.3.0)(msw@2.12.3(@types/node@24.10.1)(typescript@5.9.3))(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.32.0)(sass@1.94.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3))
       webpack-bundle-analyzer:
         specifier: ^5.0.1
         version: 5.0.1
@@ -1016,7 +1025,7 @@ importers:
         version: 10.2.15(storybook@10.2.15(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
       '@storybook/addon-docs':
         specifier: ^10.2.15
-        version: 10.2.15(@types/react@19.2.8)(esbuild@0.27.3)(rollup@4.59.0)(storybook@10.2.15(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(sass@1.94.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.27.3))
+        version: 10.2.15(@types/react@19.2.8)(esbuild@0.27.3)(rollup@4.59.0)(storybook@10.2.15(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.32.0)(sass@1.94.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.27.3))
       '@storybook/addon-links':
         specifier: ^10.2.15
         version: 10.2.15(react@19.2.3)(storybook@10.2.15(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
@@ -1025,7 +1034,7 @@ importers:
         version: 0.2.3(storybook@10.2.15(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.9.3)
       '@storybook/react-vite':
         specifier: ^10.2.15
-        version: 10.2.15(esbuild@0.27.3)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.59.0)(storybook@10.2.15(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.9.3)(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(sass@1.94.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.27.3))
+        version: 10.2.15(esbuild@0.27.3)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.59.0)(storybook@10.2.15(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.9.3)(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.32.0)(sass@1.94.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.27.3))
       '@tailwindcss/cli':
         specifier: ^4.1.17
         version: 4.1.17
@@ -1100,7 +1109,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@24.10.1)(@vitest/ui@4.1.0)(happy-dom@20.8.9)(jsdom@27.3.0)(msw@2.12.3(@types/node@24.10.1)(typescript@5.9.3))(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(sass@1.94.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3))
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@24.10.1)(@vitest/ui@4.1.0)(happy-dom@20.8.9)(jsdom@27.3.0)(msw@2.12.3(@types/node@24.10.1)(typescript@5.9.3))(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.32.0)(sass@1.94.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3))
 
   web-packages/ap-chat:
     dependencies:
@@ -1161,7 +1170,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@24.10.1)(@vitest/ui@4.1.0)(happy-dom@20.8.9)(jsdom@27.3.0)(msw@2.12.3(@types/node@24.10.1)(typescript@5.9.3))(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(sass@1.94.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3))
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@24.10.1)(@vitest/ui@4.1.0)(happy-dom@20.8.9)(jsdom@27.3.0)(msw@2.12.3(@types/node@24.10.1)(typescript@5.9.3))(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.32.0)(sass@1.94.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3))
       webpack-bundle-analyzer:
         specifier: ^5.0.1
         version: 5.0.1
@@ -5478,9 +5487,18 @@ packages:
   '@tailwindcss/node@4.1.17':
     resolution: {integrity: sha512-csIkHIgLb3JisEFQ0vxr2Y57GUNYh447C8xzwj89U/8fdW8LhProdxvnVH6U8M2Y73QKiTIH+LWbK3V2BBZsAg==}
 
+  '@tailwindcss/node@4.2.2':
+    resolution: {integrity: sha512-pXS+wJ2gZpVXqFaUEjojq7jzMpTGf8rU6ipJz5ovJV6PUGmlJ+jvIwGrzdHdQ80Sg+wmQxUFuoW1UAAwHNEdFA==}
+
   '@tailwindcss/oxide-android-arm64@4.1.17':
     resolution: {integrity: sha512-BMqpkJHgOZ5z78qqiGE6ZIRExyaHyuxjgrJ6eBO5+hfrfGkuya0lYfw8fRHG77gdTjWkNWEEm+qeG2cDMxArLQ==}
     engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [android]
+
+  '@tailwindcss/oxide-android-arm64@4.2.2':
+    resolution: {integrity: sha512-dXGR1n+P3B6748jZO/SvHZq7qBOqqzQ+yFrXpoOWWALWndF9MoSKAT3Q0fYgAzYzGhxNYOoysRvYlpixRBBoDg==}
+    engines: {node: '>= 20'}
     cpu: [arm64]
     os: [android]
 
@@ -5490,9 +5508,21 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@tailwindcss/oxide-darwin-arm64@4.2.2':
+    resolution: {integrity: sha512-iq9Qjr6knfMpZHj55/37ouZeykwbDqF21gPFtfnhCCKGDcPI/21FKC9XdMO/XyBM7qKORx6UIhGgg6jLl7BZlg==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@tailwindcss/oxide-darwin-x64@4.1.17':
     resolution: {integrity: sha512-gdhEPLzke2Pog8s12oADwYu0IAw04Y2tlmgVzIN0+046ytcgx8uZmCzEg4VcQh+AHKiS7xaL8kGo/QTiNEGRog==}
     engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@tailwindcss/oxide-darwin-x64@4.2.2':
+    resolution: {integrity: sha512-BlR+2c3nzc8f2G639LpL89YY4bdcIdUmiOOkv2GQv4/4M0vJlpXEa0JXNHhCHU7VWOKWT/CjqHdTP8aUuDJkuw==}
+    engines: {node: '>= 20'}
     cpu: [x64]
     os: [darwin]
 
@@ -5502,9 +5532,21 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
+  '@tailwindcss/oxide-freebsd-x64@4.2.2':
+    resolution: {integrity: sha512-YUqUgrGMSu2CDO82hzlQ5qSb5xmx3RUrke/QgnoEx7KvmRJHQuZHZmZTLSuuHwFf0DJPybFMXMYf+WJdxHy/nQ==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [freebsd]
+
   '@tailwindcss/oxide-linux-arm-gnueabihf@4.1.17':
     resolution: {integrity: sha512-k7jWk5E3ldAdw0cNglhjSgv501u7yrMf8oeZ0cElhxU6Y2o7f8yqelOp3fhf7evjIS6ujTI3U8pKUXV2I4iXHQ==}
     engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [linux]
+
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.2.2':
+    resolution: {integrity: sha512-FPdhvsW6g06T9BWT0qTwiVZYE2WIFo2dY5aCSpjG/S/u1tby+wXoslXS0kl3/KXnULlLr1E3NPRRw0g7t2kgaQ==}
+    engines: {node: '>= 20'}
     cpu: [arm]
     os: [linux]
 
@@ -5514,9 +5556,21 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@tailwindcss/oxide-linux-arm64-gnu@4.2.2':
+    resolution: {integrity: sha512-4og1V+ftEPXGttOO7eCmW7VICmzzJWgMx+QXAJRAhjrSjumCwWqMfkDrNu1LXEQzNAwz28NCUpucgQPrR4S2yw==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [linux]
+
   '@tailwindcss/oxide-linux-arm64-musl@4.1.17':
     resolution: {integrity: sha512-HvZLfGr42i5anKtIeQzxdkw/wPqIbpeZqe7vd3V9vI3RQxe3xU1fLjss0TjyhxWcBaipk7NYwSrwTwK1hJARMg==}
     engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@tailwindcss/oxide-linux-arm64-musl@4.2.2':
+    resolution: {integrity: sha512-oCfG/mS+/+XRlwNjnsNLVwnMWYH7tn/kYPsNPh+JSOMlnt93mYNCKHYzylRhI51X+TbR+ufNhhKKzm6QkqX8ag==}
+    engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
 
@@ -5526,14 +5580,38 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@tailwindcss/oxide-linux-x64-gnu@4.2.2':
+    resolution: {integrity: sha512-rTAGAkDgqbXHNp/xW0iugLVmX62wOp2PoE39BTCGKjv3Iocf6AFbRP/wZT/kuCxC9QBh9Pu8XPkv/zCZB2mcMg==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [linux]
+
   '@tailwindcss/oxide-linux-x64-musl@4.1.17':
     resolution: {integrity: sha512-k7f+pf9eXLEey4pBlw+8dgfJHY4PZ5qOUFDyNf7SI6lHjQ9Zt7+NcscjpwdCEbYi6FI5c2KDTDWyf2iHcCSyyQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
 
+  '@tailwindcss/oxide-linux-x64-musl@4.2.2':
+    resolution: {integrity: sha512-XW3t3qwbIwiSyRCggeO2zxe3KWaEbM0/kW9e8+0XpBgyKU4ATYzcVSMKteZJ1iukJ3HgHBjbg9P5YPRCVUxlnQ==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [linux]
+
   '@tailwindcss/oxide-wasm32-wasi@4.1.17':
     resolution: {integrity: sha512-cEytGqSSoy7zK4JRWiTCx43FsKP/zGr0CsuMawhH67ONlH+T79VteQeJQRO/X7L0juEUA8ZyuYikcRBf0vsxhg==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+    bundledDependencies:
+      - '@napi-rs/wasm-runtime'
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+      - '@tybys/wasm-util'
+      - '@emnapi/wasi-threads'
+      - tslib
+
+  '@tailwindcss/oxide-wasm32-wasi@4.2.2':
+    resolution: {integrity: sha512-eKSztKsmEsn1O5lJ4ZAfyn41NfG7vzCg496YiGtMDV86jz1q/irhms5O0VrY6ZwTUkFy/EKG3RfWgxSI3VbZ8Q==}
     engines: {node: '>=14.0.0'}
     cpu: [wasm32]
     bundledDependencies:
@@ -5550,9 +5628,21 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@tailwindcss/oxide-win32-arm64-msvc@4.2.2':
+    resolution: {integrity: sha512-qPmaQM4iKu5mxpsrWZMOZRgZv1tOZpUm+zdhhQP0VhJfyGGO3aUKdbh3gDZc/dPLQwW4eSqWGrrcWNBZWUWaXQ==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [win32]
+
   '@tailwindcss/oxide-win32-x64-msvc@4.1.17':
     resolution: {integrity: sha512-SKWM4waLuqx0IH+FMDUw6R66Hu4OuTALFgnleKbqhgGU30DY20NORZMZUKgLRjQXNN2TLzKvh48QXTig4h4bGw==}
     engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@tailwindcss/oxide-win32-x64-msvc@4.2.2':
+    resolution: {integrity: sha512-1T/37VvI7WyH66b+vqHj/cLwnCxt7Qt3WFu5Q8hk65aOvlwAhs7rAp1VkulBJw/N4tMirXjVnylTR72uI0HGcA==}
+    engines: {node: '>= 20'}
     cpu: [x64]
     os: [win32]
 
@@ -5560,8 +5650,17 @@ packages:
     resolution: {integrity: sha512-F0F7d01fmkQhsTjXezGBLdrl1KresJTcI3DB8EkScCldyKp3Msz4hub4uyYaVnk88BAS1g5DQjjF6F5qczheLA==}
     engines: {node: '>= 10'}
 
+  '@tailwindcss/oxide@4.2.2':
+    resolution: {integrity: sha512-qEUA07+E5kehxYp9BVMpq9E8vnJuBHfJEC0vPC5e7iL/hw7HR61aDKoVoKzrG+QKp56vhNZe4qwkRmMC0zDLvg==}
+    engines: {node: '>= 20'}
+
   '@tailwindcss/postcss@4.1.17':
     resolution: {integrity: sha512-+nKl9N9mN5uJ+M7dBOOCzINw94MPstNR/GtIhz1fpZysxL/4a+No64jCBD6CPN+bIHWFx3KWuu8XJRrj/572Dw==}
+
+  '@tailwindcss/vite@4.2.2':
+    resolution: {integrity: sha512-mEiF5HO1QqCLXoNEfXVA1Tzo+cYsrqV7w9Juj2wdUFyW07JRenqMG225MvPwr3ZD9N1bFQj46X7r33iHxLUW0w==}
+    peerDependencies:
+      vite: ^5.2.0 || ^6 || ^7 || ^8
 
   '@tanstack/ai-client@0.7.2':
     resolution: {integrity: sha512-vpmuopa7AcwcYZehgaX4y5gqrSORNHLBgc7MvSFBMRo6rKPw2Y0kdpjd/WzI6zieSL4UXgTtPvqj2/Bvqkn1Iw==}
@@ -9134,8 +9233,20 @@ packages:
     cpu: [arm64]
     os: [android]
 
+  lightningcss-android-arm64@1.32.0:
+    resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
   lightningcss-darwin-arm64@1.30.2:
     resolution: {integrity: sha512-ylTcDJBN3Hp21TdhRT5zBOIi73P6/W0qwvlFEk22fkdXchtNTOU4Qc37SkzV+EKYxLouZ6M4LG9NfZ1qkhhBWA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-arm64@1.32.0:
+    resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [darwin]
@@ -9146,8 +9257,20 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  lightningcss-darwin-x64@1.32.0:
+    resolution: {integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
   lightningcss-freebsd-x64@1.30.2:
     resolution: {integrity: sha512-c2bH6xTrf4BDpK8MoGG4Bd6zAMZDAXS569UxCAGcA7IKbHNMlhGQ89eRmvpIUGfKWNVdbhSbkQaWhEoMGmGslA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-freebsd-x64@1.32.0:
+    resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [freebsd]
@@ -9158,8 +9281,20 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
   lightningcss-linux-arm64-gnu@1.30.2:
     resolution: {integrity: sha512-UK65WJAbwIJbiBFXpxrbTNArtfuznvxAJw4Q2ZGlU8kPeDIWEX1dg3rn2veBVUylA2Ezg89ktszWbaQnxD/e3A==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
@@ -9170,8 +9305,20 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  lightningcss-linux-arm64-musl@1.32.0:
+    resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
   lightningcss-linux-x64-gnu@1.30.2:
     resolution: {integrity: sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
@@ -9182,8 +9329,20 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  lightningcss-linux-x64-musl@1.32.0:
+    resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
   lightningcss-win32-arm64-msvc@1.30.2:
     resolution: {integrity: sha512-FZn+vaj7zLv//D/192WFFVA0RgHawIcHqLX9xuWiQt7P0PtdFEVaxgF9rjM/IRYHQXNnk61/H/gb2Ei+kUQ4xQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [win32]
@@ -9194,8 +9353,18 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  lightningcss-win32-x64-msvc@1.32.0:
+    resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
   lightningcss@1.30.2:
     resolution: {integrity: sha512-utfs7Pr5uJyyvDETitgsaqSyjCb2qNRAtuqUeWIAKztsOYdcACf2KtARYXg2pSvhkt+9NfoaNY7fxjl6nuMjIQ==}
+    engines: {node: '>= 12.0.0'}
+
+  lightningcss@1.32.0:
+    resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
     engines: {node: '>= 12.0.0'}
 
   lilconfig@3.1.3:
@@ -11883,6 +12052,9 @@ packages:
 
   tailwindcss@4.1.17:
     resolution: {integrity: sha512-j9Ee2YjuQqYT9bbRTfTZht9W/ytp5H+jJpZKiYdP/bpnXARAuELt9ofP0lPnmHjbga7SNQIxdTAXCmtKVYjN+Q==}
+
+  tailwindcss@4.2.2:
+    resolution: {integrity: sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q==}
 
   tapable@2.3.0:
     resolution: {integrity: sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==}
@@ -14763,11 +14935,11 @@ snapshots:
       '@types/yargs': 17.0.35
       chalk: 4.1.2
 
-  '@joshwooding/vite-plugin-react-docgen-typescript@0.6.4(typescript@5.9.3)(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(sass@1.94.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3))':
+  '@joshwooding/vite-plugin-react-docgen-typescript@0.6.4(typescript@5.9.3)(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.32.0)(sass@1.94.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3))':
     dependencies:
       glob: 13.0.6
       react-docgen-typescript: 2.4.0(typescript@5.9.3)
-      vite: 7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(sass@1.94.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3)
+      vite: 7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.32.0)(sass@1.94.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3)
     optionalDependencies:
       typescript: 5.9.3
 
@@ -17064,10 +17236,10 @@ snapshots:
       axe-core: 4.11.0
       storybook: 10.2.15(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
 
-  '@storybook/addon-docs@10.2.15(@types/react@19.2.8)(esbuild@0.27.3)(rollup@4.59.0)(storybook@10.2.15(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(sass@1.94.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.27.3))':
+  '@storybook/addon-docs@10.2.15(@types/react@19.2.8)(esbuild@0.27.3)(rollup@4.59.0)(storybook@10.2.15(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.32.0)(sass@1.94.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.27.3))':
     dependencies:
       '@mdx-js/react': 3.1.1(@types/react@19.2.8)(react@19.2.3)
-      '@storybook/csf-plugin': 10.2.15(esbuild@0.27.3)(rollup@4.59.0)(storybook@10.2.15(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(sass@1.94.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.27.3))
+      '@storybook/csf-plugin': 10.2.15(esbuild@0.27.3)(rollup@4.59.0)(storybook@10.2.15(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.32.0)(sass@1.94.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.27.3))
       '@storybook/icons': 2.0.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@storybook/react-dom-shim': 10.2.15(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.2.15(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
       react: 19.2.3
@@ -17101,46 +17273,46 @@ snapshots:
       - '@tmcp/auth'
       - typescript
 
-  '@storybook/builder-vite@10.2.15(esbuild@0.27.0)(rollup@4.59.0)(storybook@10.2.15(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(sass@1.94.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.27.0))':
+  '@storybook/builder-vite@10.2.15(esbuild@0.27.0)(rollup@4.59.0)(storybook@10.2.15(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.32.0)(sass@1.94.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.27.0))':
     dependencies:
-      '@storybook/csf-plugin': 10.2.15(esbuild@0.27.0)(rollup@4.59.0)(storybook@10.2.15(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(sass@1.94.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.27.0))
+      '@storybook/csf-plugin': 10.2.15(esbuild@0.27.0)(rollup@4.59.0)(storybook@10.2.15(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.32.0)(sass@1.94.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.27.0))
       storybook: 10.2.15(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       ts-dedent: 2.2.0
-      vite: 7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(sass@1.94.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3)
+      vite: 7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.32.0)(sass@1.94.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3)
     transitivePeerDependencies:
       - esbuild
       - rollup
       - webpack
 
-  '@storybook/builder-vite@10.2.15(esbuild@0.27.3)(rollup@4.59.0)(storybook@10.2.15(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(sass@1.94.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.27.3))':
+  '@storybook/builder-vite@10.2.15(esbuild@0.27.3)(rollup@4.59.0)(storybook@10.2.15(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.32.0)(sass@1.94.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.27.3))':
     dependencies:
-      '@storybook/csf-plugin': 10.2.15(esbuild@0.27.3)(rollup@4.59.0)(storybook@10.2.15(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(sass@1.94.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.27.3))
+      '@storybook/csf-plugin': 10.2.15(esbuild@0.27.3)(rollup@4.59.0)(storybook@10.2.15(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.32.0)(sass@1.94.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.27.3))
       storybook: 10.2.15(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       ts-dedent: 2.2.0
-      vite: 7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(sass@1.94.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3)
+      vite: 7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.32.0)(sass@1.94.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3)
     transitivePeerDependencies:
       - esbuild
       - rollup
       - webpack
 
-  '@storybook/csf-plugin@10.2.15(esbuild@0.27.0)(rollup@4.59.0)(storybook@10.2.15(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(sass@1.94.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.27.0))':
+  '@storybook/csf-plugin@10.2.15(esbuild@0.27.0)(rollup@4.59.0)(storybook@10.2.15(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.32.0)(sass@1.94.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.27.0))':
     dependencies:
       storybook: 10.2.15(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       unplugin: 2.3.10
     optionalDependencies:
       esbuild: 0.27.0
       rollup: 4.59.0
-      vite: 7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(sass@1.94.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3)
+      vite: 7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.32.0)(sass@1.94.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3)
       webpack: 5.105.4(esbuild@0.27.0)
 
-  '@storybook/csf-plugin@10.2.15(esbuild@0.27.3)(rollup@4.59.0)(storybook@10.2.15(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(sass@1.94.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.27.3))':
+  '@storybook/csf-plugin@10.2.15(esbuild@0.27.3)(rollup@4.59.0)(storybook@10.2.15(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.32.0)(sass@1.94.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.27.3))':
     dependencies:
       storybook: 10.2.15(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       unplugin: 2.3.10
     optionalDependencies:
       esbuild: 0.27.3
       rollup: 4.59.0
-      vite: 7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(sass@1.94.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3)
+      vite: 7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.32.0)(sass@1.94.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3)
       webpack: 5.105.4(esbuild@0.27.3)
 
   '@storybook/global@5.0.0': {}
@@ -17166,11 +17338,11 @@ snapshots:
       react-dom: 19.2.3(react@19.2.3)
       storybook: 10.2.15(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
 
-  '@storybook/react-vite@10.2.15(esbuild@0.27.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.59.0)(storybook@10.2.15(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.9.3)(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(sass@1.94.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.27.0))':
+  '@storybook/react-vite@10.2.15(esbuild@0.27.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.59.0)(storybook@10.2.15(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.9.3)(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.32.0)(sass@1.94.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.27.0))':
     dependencies:
-      '@joshwooding/vite-plugin-react-docgen-typescript': 0.6.4(typescript@5.9.3)(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(sass@1.94.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3))
+      '@joshwooding/vite-plugin-react-docgen-typescript': 0.6.4(typescript@5.9.3)(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.32.0)(sass@1.94.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3))
       '@rollup/pluginutils': 5.3.0(rollup@4.59.0)
-      '@storybook/builder-vite': 10.2.15(esbuild@0.27.0)(rollup@4.59.0)(storybook@10.2.15(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(sass@1.94.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.27.0))
+      '@storybook/builder-vite': 10.2.15(esbuild@0.27.0)(rollup@4.59.0)(storybook@10.2.15(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.32.0)(sass@1.94.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.27.0))
       '@storybook/react': 10.2.15(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.2.15(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.9.3)
       empathic: 2.0.0
       magic-string: 0.30.21
@@ -17180,7 +17352,7 @@ snapshots:
       resolve: 1.22.11
       storybook: 10.2.15(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       tsconfig-paths: 4.2.0
-      vite: 7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(sass@1.94.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3)
+      vite: 7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.32.0)(sass@1.94.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3)
     transitivePeerDependencies:
       - esbuild
       - rollup
@@ -17188,11 +17360,11 @@ snapshots:
       - typescript
       - webpack
 
-  '@storybook/react-vite@10.2.15(esbuild@0.27.3)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.59.0)(storybook@10.2.15(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.9.3)(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(sass@1.94.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.27.3))':
+  '@storybook/react-vite@10.2.15(esbuild@0.27.3)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.59.0)(storybook@10.2.15(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.9.3)(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.32.0)(sass@1.94.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.27.3))':
     dependencies:
-      '@joshwooding/vite-plugin-react-docgen-typescript': 0.6.4(typescript@5.9.3)(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(sass@1.94.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3))
+      '@joshwooding/vite-plugin-react-docgen-typescript': 0.6.4(typescript@5.9.3)(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.32.0)(sass@1.94.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3))
       '@rollup/pluginutils': 5.3.0(rollup@4.59.0)
-      '@storybook/builder-vite': 10.2.15(esbuild@0.27.3)(rollup@4.59.0)(storybook@10.2.15(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(sass@1.94.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.27.3))
+      '@storybook/builder-vite': 10.2.15(esbuild@0.27.3)(rollup@4.59.0)(storybook@10.2.15(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.32.0)(sass@1.94.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.27.3))
       '@storybook/react': 10.2.15(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.2.15(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.9.3)
       empathic: 2.0.0
       magic-string: 0.30.21
@@ -17202,7 +17374,7 @@ snapshots:
       resolve: 1.22.11
       storybook: 10.2.15(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       tsconfig-paths: 4.2.0
-      vite: 7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(sass@1.94.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3)
+      vite: 7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.32.0)(sass@1.94.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3)
     transitivePeerDependencies:
       - esbuild
       - rollup
@@ -17348,40 +17520,86 @@ snapshots:
       source-map-js: 1.2.1
       tailwindcss: 4.1.17
 
+  '@tailwindcss/node@4.2.2':
+    dependencies:
+      '@jridgewell/remapping': 2.3.5
+      enhanced-resolve: 5.20.0
+      jiti: 2.6.1
+      lightningcss: 1.32.0
+      magic-string: 0.30.21
+      source-map-js: 1.2.1
+      tailwindcss: 4.2.2
+
   '@tailwindcss/oxide-android-arm64@4.1.17':
+    optional: true
+
+  '@tailwindcss/oxide-android-arm64@4.2.2':
     optional: true
 
   '@tailwindcss/oxide-darwin-arm64@4.1.17':
     optional: true
 
+  '@tailwindcss/oxide-darwin-arm64@4.2.2':
+    optional: true
+
   '@tailwindcss/oxide-darwin-x64@4.1.17':
+    optional: true
+
+  '@tailwindcss/oxide-darwin-x64@4.2.2':
     optional: true
 
   '@tailwindcss/oxide-freebsd-x64@4.1.17':
     optional: true
 
+  '@tailwindcss/oxide-freebsd-x64@4.2.2':
+    optional: true
+
   '@tailwindcss/oxide-linux-arm-gnueabihf@4.1.17':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.2.2':
     optional: true
 
   '@tailwindcss/oxide-linux-arm64-gnu@4.1.17':
     optional: true
 
+  '@tailwindcss/oxide-linux-arm64-gnu@4.2.2':
+    optional: true
+
   '@tailwindcss/oxide-linux-arm64-musl@4.1.17':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm64-musl@4.2.2':
     optional: true
 
   '@tailwindcss/oxide-linux-x64-gnu@4.1.17':
     optional: true
 
+  '@tailwindcss/oxide-linux-x64-gnu@4.2.2':
+    optional: true
+
   '@tailwindcss/oxide-linux-x64-musl@4.1.17':
+    optional: true
+
+  '@tailwindcss/oxide-linux-x64-musl@4.2.2':
     optional: true
 
   '@tailwindcss/oxide-wasm32-wasi@4.1.17':
     optional: true
 
+  '@tailwindcss/oxide-wasm32-wasi@4.2.2':
+    optional: true
+
   '@tailwindcss/oxide-win32-arm64-msvc@4.1.17':
     optional: true
 
+  '@tailwindcss/oxide-win32-arm64-msvc@4.2.2':
+    optional: true
+
   '@tailwindcss/oxide-win32-x64-msvc@4.1.17':
+    optional: true
+
+  '@tailwindcss/oxide-win32-x64-msvc@4.2.2':
     optional: true
 
   '@tailwindcss/oxide@4.1.17':
@@ -17399,6 +17617,21 @@ snapshots:
       '@tailwindcss/oxide-win32-arm64-msvc': 4.1.17
       '@tailwindcss/oxide-win32-x64-msvc': 4.1.17
 
+  '@tailwindcss/oxide@4.2.2':
+    optionalDependencies:
+      '@tailwindcss/oxide-android-arm64': 4.2.2
+      '@tailwindcss/oxide-darwin-arm64': 4.2.2
+      '@tailwindcss/oxide-darwin-x64': 4.2.2
+      '@tailwindcss/oxide-freebsd-x64': 4.2.2
+      '@tailwindcss/oxide-linux-arm-gnueabihf': 4.2.2
+      '@tailwindcss/oxide-linux-arm64-gnu': 4.2.2
+      '@tailwindcss/oxide-linux-arm64-musl': 4.2.2
+      '@tailwindcss/oxide-linux-x64-gnu': 4.2.2
+      '@tailwindcss/oxide-linux-x64-musl': 4.2.2
+      '@tailwindcss/oxide-wasm32-wasi': 4.2.2
+      '@tailwindcss/oxide-win32-arm64-msvc': 4.2.2
+      '@tailwindcss/oxide-win32-x64-msvc': 4.2.2
+
   '@tailwindcss/postcss@4.1.17':
     dependencies:
       '@alloc/quick-lru': 5.2.0
@@ -17406,6 +17639,13 @@ snapshots:
       '@tailwindcss/oxide': 4.1.17
       postcss: 8.5.6
       tailwindcss: 4.1.17
+
+  '@tailwindcss/vite@4.2.2(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.32.0)(sass@1.94.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3))':
+    dependencies:
+      '@tailwindcss/node': 4.2.2
+      '@tailwindcss/oxide': 4.2.2
+      tailwindcss: 4.2.2
+      vite: 7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.32.0)(sass@1.94.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3)
 
   '@tanstack/ai-client@0.7.2':
     dependencies:
@@ -18026,7 +18266,7 @@ snapshots:
       next: 16.1.7(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.94.2)
       react: 19.2.3
 
-  '@vitejs/plugin-react@4.7.0(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(sass@1.94.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3))':
+  '@vitejs/plugin-react@4.7.0(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.32.0)(sass@1.94.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3))':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.28.5)
@@ -18034,7 +18274,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.27
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
-      vite: 7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(sass@1.94.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3)
+      vite: 7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.32.0)(sass@1.94.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -18050,7 +18290,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.0.0
       tinyrainbow: 3.0.3
-      vitest: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@24.10.1)(@vitest/ui@4.1.0)(happy-dom@20.8.9)(jsdom@27.3.0)(msw@2.12.3(@types/node@24.10.1)(typescript@5.9.3))(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(sass@1.94.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3))
+      vitest: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@24.10.1)(@vitest/ui@4.1.0)(happy-dom@20.8.9)(jsdom@27.3.0)(msw@2.12.3(@types/node@24.10.1)(typescript@5.9.3))(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.32.0)(sass@1.94.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3))
 
   '@vitest/expect@3.2.4':
     dependencies:
@@ -18069,14 +18309,14 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.0.3
 
-  '@vitest/mocker@4.1.0(msw@2.12.3(@types/node@24.10.1)(typescript@5.9.3))(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(sass@1.94.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3))':
+  '@vitest/mocker@4.1.0(msw@2.12.3(@types/node@24.10.1)(typescript@5.9.3))(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.32.0)(sass@1.94.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3))':
     dependencies:
       '@vitest/spy': 4.1.0
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
       msw: 2.12.3(@types/node@24.10.1)(typescript@5.9.3)
-      vite: 7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(sass@1.94.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3)
+      vite: 7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.32.0)(sass@1.94.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -18113,7 +18353,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vitest: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@24.10.1)(@vitest/ui@4.1.0)(happy-dom@20.8.9)(jsdom@27.3.0)(msw@2.12.3(@types/node@24.10.1)(typescript@5.9.3))(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(sass@1.94.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3))
+      vitest: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@24.10.1)(@vitest/ui@4.1.0)(happy-dom@20.8.9)(jsdom@27.3.0)(msw@2.12.3(@types/node@24.10.1)(typescript@5.9.3))(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.32.0)(sass@1.94.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3))
 
   '@vitest/utils@3.2.4':
     dependencies:
@@ -21547,34 +21787,67 @@ snapshots:
   lightningcss-android-arm64@1.30.2:
     optional: true
 
+  lightningcss-android-arm64@1.32.0:
+    optional: true
+
   lightningcss-darwin-arm64@1.30.2:
+    optional: true
+
+  lightningcss-darwin-arm64@1.32.0:
     optional: true
 
   lightningcss-darwin-x64@1.30.2:
     optional: true
 
+  lightningcss-darwin-x64@1.32.0:
+    optional: true
+
   lightningcss-freebsd-x64@1.30.2:
+    optional: true
+
+  lightningcss-freebsd-x64@1.32.0:
     optional: true
 
   lightningcss-linux-arm-gnueabihf@1.30.2:
     optional: true
 
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    optional: true
+
   lightningcss-linux-arm64-gnu@1.30.2:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.32.0:
     optional: true
 
   lightningcss-linux-arm64-musl@1.30.2:
     optional: true
 
+  lightningcss-linux-arm64-musl@1.32.0:
+    optional: true
+
   lightningcss-linux-x64-gnu@1.30.2:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.32.0:
     optional: true
 
   lightningcss-linux-x64-musl@1.30.2:
     optional: true
 
+  lightningcss-linux-x64-musl@1.32.0:
+    optional: true
+
   lightningcss-win32-arm64-msvc@1.30.2:
     optional: true
 
+  lightningcss-win32-arm64-msvc@1.32.0:
+    optional: true
+
   lightningcss-win32-x64-msvc@1.30.2:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.32.0:
     optional: true
 
   lightningcss@1.30.2:
@@ -21592,6 +21865,22 @@ snapshots:
       lightningcss-linux-x64-musl: 1.30.2
       lightningcss-win32-arm64-msvc: 1.30.2
       lightningcss-win32-x64-msvc: 1.30.2
+
+  lightningcss@1.32.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.32.0
+      lightningcss-darwin-arm64: 1.32.0
+      lightningcss-darwin-x64: 1.32.0
+      lightningcss-freebsd-x64: 1.32.0
+      lightningcss-linux-arm-gnueabihf: 1.32.0
+      lightningcss-linux-arm64-gnu: 1.32.0
+      lightningcss-linux-arm64-musl: 1.32.0
+      lightningcss-linux-x64-gnu: 1.32.0
+      lightningcss-linux-x64-musl: 1.32.0
+      lightningcss-win32-arm64-msvc: 1.32.0
+      lightningcss-win32-x64-msvc: 1.32.0
 
   lilconfig@3.1.3: {}
 
@@ -24892,10 +25181,10 @@ snapshots:
       stylelint: 16.25.0(typescript@5.9.3)
       stylelint-config-recommended: 14.0.1(stylelint@16.25.0(typescript@5.9.3))
 
-  stylelint-config-tailwindcss@1.0.0(stylelint@16.25.0(typescript@5.9.3))(tailwindcss@4.1.17):
+  stylelint-config-tailwindcss@1.0.0(stylelint@16.25.0(typescript@5.9.3))(tailwindcss@4.2.2):
     dependencies:
       stylelint: 16.25.0(typescript@5.9.3)
-      tailwindcss: 4.1.17
+      tailwindcss: 4.2.2
 
   stylelint@16.25.0(typescript@5.9.3):
     dependencies:
@@ -25040,6 +25329,8 @@ snapshots:
   tailwind-merge@3.4.0: {}
 
   tailwindcss@4.1.17: {}
+
+  tailwindcss@4.2.2: {}
 
   tapable@2.3.0: {}
 
@@ -25610,18 +25901,18 @@ snapshots:
       d3-time: 3.1.0
       d3-timer: 3.0.1
 
-  vite-tsconfig-paths@5.1.4(typescript@5.9.3)(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(sass@1.94.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3)):
+  vite-tsconfig-paths@5.1.4(typescript@5.9.3)(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.32.0)(sass@1.94.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3)):
     dependencies:
       debug: 4.4.3
       globrex: 0.1.2
       tsconfck: 3.1.6(typescript@5.9.3)
     optionalDependencies:
-      vite: 7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(sass@1.94.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3)
+      vite: 7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.32.0)(sass@1.94.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(sass@1.94.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3):
+  vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.32.0)(sass@1.94.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3):
     dependencies:
       esbuild: 0.27.3
       fdir: 6.5.0(picomatch@4.0.4)
@@ -25634,16 +25925,16 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.6.1
       less: 4.4.2
-      lightningcss: 1.30.2
+      lightningcss: 1.32.0
       sass: 1.94.2
       terser: 5.43.1
       tsx: 4.20.6
       yaml: 2.8.3
 
-  vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@24.10.1)(@vitest/ui@4.1.0)(happy-dom@20.8.9)(jsdom@27.3.0)(msw@2.12.3(@types/node@24.10.1)(typescript@5.9.3))(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(sass@1.94.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3)):
+  vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@24.10.1)(@vitest/ui@4.1.0)(happy-dom@20.8.9)(jsdom@27.3.0)(msw@2.12.3(@types/node@24.10.1)(typescript@5.9.3))(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.32.0)(sass@1.94.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3)):
     dependencies:
       '@vitest/expect': 4.1.0
-      '@vitest/mocker': 4.1.0(msw@2.12.3(@types/node@24.10.1)(typescript@5.9.3))(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(sass@1.94.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3))
+      '@vitest/mocker': 4.1.0(msw@2.12.3(@types/node@24.10.1)(typescript@5.9.3))(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.32.0)(sass@1.94.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3))
       '@vitest/pretty-format': 4.1.0
       '@vitest/runner': 4.1.0
       '@vitest/snapshot': 4.1.0
@@ -25660,7 +25951,7 @@ snapshots:
       tinyexec: 1.0.4
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vite: 7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(sass@1.94.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3)
+      vite: 7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.32.0)(sass@1.94.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.0


### PR DESCRIPTION
## Summary

Migrate the **canvas package** (`apollo-react/canvas`) from Material UI components to **apollo-wind** (Tailwind CSS + shadcn/Radix) primitives, eliminating the MUI runtime dependency from canvas components.

### What changed

**Icon system** — All `ApIcon` (Material Icons) usages replaced with `CanvasIcon` (Lucide icons via the canvas icon registry). `NodeIcon` renamed to `CanvasIcon` with a deprecated alias for backwards compatibility.

**Typography** — `ApTypography` with `FontVariantToken` replaced with plain `<span>` elements using Tailwind utility classes (`text-sm`, `font-bold`, `truncate`, etc.).

**Buttons** — `ApButton` and `ApIconButton` replaced with `Button` from `@uipath/apollo-wind` using appropriate `variant`/`size` props.

**Tooltips** — `ApTooltip` replaced with a new `CanvasTooltip` wrapper component around Radix Tooltip from apollo-wind. Preserves the existing API surface (`smartTooltip`, `delay`, `placement`, `hide`, `isOpen`). A `TooltipProvider` is now injected at the `CanvasProviders` level.

**Dropdown menus** — `ApMenu` replaced with a new `CanvasDropdownMenu` wrapper around Radix `DropdownMenu`. This significantly simplifies `NodeContextMenu` and `TaskMenu` — manual keyboard/click-away handling removed in favor of Radix's built-in behavior. Uses `modal={false}` to work correctly inside React Flow's `foreignObject`.

**Other component swaps:**

| MUI Component | apollo-wind Replacement |
|---|---|
| `ApSkeleton` | `Skeleton` |
| `ApCircularProgress` / `ApProgressSpinner` | `Spinner` |
| `ApBadge` | `Badge` |
| `ApLink` | `Button variant="link"` |
| `CssBaseline` / `GlobalStyles` | Removed (no longer needed) |

**MUI breakpoint removal** — `useTheme().breakpoints.values.sm` replaced with a new `CANVAS_COMPACT_BREAKPOINT` constant (600px), removing the last `useTheme()` call from canvas code.

### Tailwind build integration

- New `tailwind.canvas.css` entry point pre-compiles only the Tailwind utilities used by canvas components and their apollo-wind dependencies. Auto-imported via `canvas/index.ts` so consumers need no Tailwind setup.
- New `build:css:canvas` script uses `@tailwindcss/cli` to emit `dist/canvas/styles/tailwind.canvas.css` as part of the package build.
- Storybook configured with `@tailwindcss/vite` plugin and source-directory aliases for apollo-wind HMR during development.

### apollo-wind enhancements

- **Badge**: Added `error`, `warning`, `info`, `success` semantic variants with corresponding theme tokens.
- **Tooltip**: Exported `TooltipPortal` for portal-based rendering.
- **Skeleton / DropdownMenuSeparator**: Changed background from `bg-muted` to `bg-surface-overlay` for better theme consistency.
- **tailwind.consumer.css**: Added `--error-background`, `--info-background`, `--success-background`, `--warning-background` CSS custom properties.

### Test updates

- Assertions updated to match new component patterns (e.g., `skeleton-icon` test ID, `.animate-pulse` class, `role="status"` for spinners, `.lucide-chevron-right` selector).
- Removed tests for "prevents task click when menu is open" — Radix dropdown menus handle focus trapping and outside-click dismissal natively.