### PR TITLE
feat(ci): add automatic PR labeling by package/app

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,35 @@
+"pkg:apollo-core":
+  - changed-files:
+      - any-glob-to-any-file: "packages/apollo-core/**"
+
+"pkg:apollo-react":
+  - changed-files:
+      - any-glob-to-any-file: "packages/apollo-react/**"
+
+"pkg:apollo-wind":
+  - changed-files:
+      - any-glob-to-any-file: "packages/apollo-wind/**"
+
+"pkg:ap-chat":
+  - changed-files:
+      - any-glob-to-any-file: "web-packages/ap-chat/**"
+
+"app:apollo-vertex":
+  - changed-files:
+      - any-glob-to-any-file: "apps/apollo-vertex/**"
+
+"app:storybook":
+  - changed-files:
+      - any-glob-to-any-file: "apps/storybook/**"
+
+"app:landing":
+  - changed-files:
+      - any-glob-to-any-file: "apps/landing/**"
+
+"app:react-playground":
+  - changed-files:
+      - any-glob-to-any-file: "apps/react-playground/**"
+
+"ci":
+  - changed-files:
+      - any-glob-to-any-file: ".github/**"

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,0 +1,17 @@
+name: PR Labeler
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5
+        with:
+          sync-labels: true


### PR DESCRIPTION
## Summary
- Adds `actions/labeler@v5` workflow that automatically labels PRs based on changed file paths
- Configures labels for all packages (`pkg:apollo-core`, `pkg:apollo-react`, `pkg:apollo-wind`, `pkg:ap-chat`), apps (`app:apollo-vertex`, `app:storybook`, `app:landing`, `app:react-playground`), and CI (`.github/**`)
- Uses `sync-labels: true` so labels are removed when files are no longer part of the changeset

## Test plan
- [ ] Open a PR touching a single package and verify the correct label is applied
- [ ] Open a PR touching multiple packages/apps and verify all relevant labels appear
- [ ] Force-push to remove a file and verify the stale label is removed