### PR TITLE
fix(apollo-wind): address theming gaps for apollo-react/canvas [MST-8290]

### DIFF
--- a/packages/apollo-wind/src/components/ui/badge.stories.tsx
+++ b/packages/apollo-wind/src/components/ui/badge.stories.tsx
@@ -30,11 +30,19 @@ export const Basic = {
 export const Variants = {
   name: 'Variants',
   render: () => (
-    <div className="flex flex-wrap items-center gap-3">
-      <Badge variant="default">Default</Badge>
-      <Badge variant="secondary">Secondary</Badge>
-      <Badge variant="destructive">Destructive</Badge>
-      <Badge variant="outline">Outline</Badge>
+    <div className="flex flex-col gap-3">
+      <div className="flex flex-wrap items-center gap-3">
+        <Badge variant="default">Default</Badge>
+        <Badge variant="secondary">Secondary</Badge>
+        <Badge variant="destructive">Destructive</Badge>
+        <Badge variant="outline">Outline</Badge>
+      </div>
+      <div className="flex flex-wrap items-center gap-3">
+        <Badge variant="success">Success</Badge>
+        <Badge variant="warning">Warning</Badge>
+        <Badge variant="error">Error</Badge>
+        <Badge variant="info">Info</Badge>
+      </div>
     </div>
   ),
 };

--- a/packages/apollo-wind/src/components/ui/badge.test.tsx
+++ b/packages/apollo-wind/src/components/ui/badge.test.tsx
@@ -33,6 +33,34 @@ describe('Badge', () => {
     expect(badge).toHaveClass('bg-destructive');
   });
 
+  it('applies error variant classes', () => {
+    render(<Badge variant="error">Error</Badge>);
+    const badge = screen.getByText('Error');
+    expect(badge).toHaveClass('bg-error-background');
+    expect(badge).toHaveClass('text-error');
+  });
+
+  it('applies warning variant classes', () => {
+    render(<Badge variant="warning">Warning</Badge>);
+    const badge = screen.getByText('Warning');
+    expect(badge).toHaveClass('bg-warning-background');
+    expect(badge).toHaveClass('text-warning');
+  });
+
+  it('applies info variant classes', () => {
+    render(<Badge variant="info">Info</Badge>);
+    const badge = screen.getByText('Info');
+    expect(badge).toHaveClass('bg-info-background');
+    expect(badge).toHaveClass('text-info');
+  });
+
+  it('applies success variant classes', () => {
+    render(<Badge variant="success">Success</Badge>);
+    const badge = screen.getByText('Success');
+    expect(badge).toHaveClass('bg-success-background');
+    expect(badge).toHaveClass('text-success');
+  });
+
   it('applies outline variant classes', () => {
     render(<Badge variant="outline">Outline</Badge>);
     const badge = screen.getByText('Outline');

--- a/packages/apollo-wind/src/components/ui/badge.tsx
+++ b/packages/apollo-wind/src/components/ui/badge.tsx
@@ -13,6 +13,12 @@ const badgeVariants = cva(
           'border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80',
         destructive:
           'border-transparent bg-destructive text-destructive-foreground hover:bg-destructive/80',
+        error: 'border-transparent bg-error-background text-error hover:bg-error-background/80',
+        warning:
+          'border-transparent bg-warning-background text-warning hover:bg-warning-background/80',
+        info: 'border-transparent bg-info-background text-info hover:bg-info-background/80',
+        success:
+          'border-transparent bg-success-background text-success hover:bg-success-background/80',
         outline: 'text-foreground',
       },
     },

--- a/packages/apollo-wind/src/components/ui/dropdown-menu.tsx
+++ b/packages/apollo-wind/src/components/ui/dropdown-menu.tsx
@@ -155,7 +155,7 @@ const DropdownMenuSeparator = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <DropdownMenuPrimitive.Separator
     ref={ref}
-    className={cn('-mx-1 my-1 h-px bg-muted', className)}
+    className={cn('-mx-1 my-1 h-px bg-surface-overlay', className)}
     {...props}
   />
 ));

--- a/packages/apollo-wind/src/components/ui/skeleton.test.tsx
+++ b/packages/apollo-wind/src/components/ui/skeleton.test.tsx
@@ -20,10 +20,10 @@ describe('Skeleton', () => {
     expect(skeleton).toHaveClass('rounded-md');
   });
 
-  it('applies bg-muted class', () => {
+  it('applies bg-surface-overlay class', () => {
     const { container } = render(<Skeleton />);
     const skeleton = container.firstChild;
-    expect(skeleton).toHaveClass('bg-muted');
+    expect(skeleton).toHaveClass('bg-surface-overlay');
   });
 
   it('applies custom className', () => {

--- a/packages/apollo-wind/src/components/ui/skeleton.tsx
+++ b/packages/apollo-wind/src/components/ui/skeleton.tsx
@@ -1,7 +1,9 @@
 import { cn } from '@/lib/index';
 
 function Skeleton({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
-  return <div className={cn('animate-pulse rounded-md bg-muted', className)} {...props} />;
+  return (
+    <div className={cn('animate-pulse rounded-md bg-surface-overlay', className)} {...props} />
+  );
 }
 
 export { Skeleton };

--- a/packages/apollo-wind/src/components/ui/tooltip.tsx
+++ b/packages/apollo-wind/src/components/ui/tooltip.tsx
@@ -9,6 +9,8 @@ const Tooltip = TooltipPrimitive.Root;
 
 const TooltipTrigger = TooltipPrimitive.Trigger;
 
+const TooltipPortal = TooltipPrimitive.Portal;
+
 const TooltipContent = React.forwardRef<
   React.ElementRef<typeof TooltipPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content>
@@ -25,4 +27,4 @@ const TooltipContent = React.forwardRef<
 ));
 TooltipContent.displayName = TooltipPrimitive.Content.displayName;
 
-export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider };
+export { Tooltip, TooltipTrigger, TooltipPortal, TooltipContent, TooltipProvider };

--- a/packages/apollo-wind/src/index.ts
+++ b/packages/apollo-wind/src/index.ts
@@ -212,6 +212,7 @@ export {
 export {
   Tooltip,
   TooltipContent,
+  TooltipPortal,
   TooltipProvider,
   TooltipTrigger,
 } from './components/ui/tooltip';

--- a/packages/apollo-wind/src/styles/tailwind.consumer.css
+++ b/packages/apollo-wind/src/styles/tailwind.consumer.css
@@ -57,9 +57,13 @@ body.dark, .dark {
 
   /* ── Status ──────────────────────────────────────────────────────────── */
   --error: var(--color-error-text, #ff8484);
+  --error-background: var(--color-error-background, #000000);
   --success: var(--color-success-icon, #74c94b);
+  --success-background: var(--color-success-background, #000000);
   --warning: var(--color-warning-icon, #ffbb27);
+  --warning-background: var(--color-warning-background, #000000);
   --info: var(--color-info-foreground, #42a1ff);
+  --info-background: var(--color-info-background, #000000);
 
   /* ── Ring / Focus ────────────────────────────────────────────────────── */
   --ring: var(--color-primary, #66adff);
@@ -134,9 +138,13 @@ body.dark-hc, .dark-hc {
 
   /* ── Status ──────────────────────────────────────────────────────────── */
   --error: var(--color-error-text, #ffadad);
+  --error-background: var(--color-error-background, #000000);
   --success: var(--color-success-icon, #74c94b);
+  --success-background: var(--color-success-background, #000000);
   --warning: var(--color-warning-icon, #ffbb27);
+  --warning-background: var(--color-warning-background, #000000);
   --info: var(--color-info-foreground, #42a1ff);
+  --info-background: var(--color-info-background, #000000);
 
   /* ── Ring / Focus ────────────────────────────────────────────────────── */
   --ring: var(--color-primary, #badaff);
@@ -211,9 +219,13 @@ body.light, .light {
 
   /* ── Status ──────────────────────────────────────────────────────────── */
   --error: var(--color-error-text, #a6040a);
+  --error-background: var(--color-error-background, #fff0f1);
   --success: var(--color-success-icon, #038108);
+  --success-background: var(--color-success-background, #eeffe5);
   --warning: var(--color-warning-text, #9e6100);
+  --warning-background: var(--color-warning-background, #fff3db);
   --info: var(--color-info-foreground, #1665b3);
+  --info-background: var(--color-info-background, #e9f1fa);
 
   /* ── Ring / Focus ────────────────────────────────────────────────────── */
   --ring: var(--color-primary, #0067df);
@@ -288,9 +300,13 @@ body.light-hc, .light-hc {
 
   /* ── Status ──────────────────────────────────────────────────────────── */
   --error: var(--color-error-text, #a6040a);
+  --error-background: var(--color-error-background, #fff0f1);
   --success: var(--color-success-icon, #005603);
+  --success-background: var(--color-success-background, #eeffe5);
   --warning: var(--color-warning-text, #273139);
+  --warning-background: var(--color-warning-background, #fff3db);
   --info: var(--color-info-foreground, #11508d);
+  --info-background: var(--color-info-background, #e9f1fa);
 
   /* ── Ring / Focus ────────────────────────────────────────────────────── */
   --ring: var(--color-primary, #00489d);
@@ -422,6 +438,16 @@ body.future-dark, .future-dark {
   --code-literal: var(--color-violet-400);
   /* booleans, null, undefined */
 
+  /* ── Status ──────────────────────────────────────────────────────────── */
+  --error: #ff8484;
+  --error-background:  #000000;
+  --success: #74c94b;
+  --success-background: #000000;
+  --warning: #ffbb27;
+  --warning-background: #000000;
+  --info: #42a1ff;
+  --info-background: #000000;
+
   /* ── shadcn aliases — maps to standard names for shadcn component compat ── */
   --background: var(--surface);
   --card: var(--surface-raised);
@@ -534,6 +560,16 @@ body.future-light, .future-light {
   --code-literal: var(--color-violet-600);
   /* booleans, null, undefined */
 
+  /* ── Status ──────────────────────────────────────────────────────────── */
+  --error:#a6040a;
+  --error-background: #fff0f1;
+  --success: #038108;
+  --success-background: #eeffe5;
+  --warning: #9e6100;
+  --warning-background: #fff3db;
+  --info: #1665b3;
+  --info-background: #e9f1fa;
+
   /* ── shadcn aliases ──────────────────────────────────────────────────── */
   --background: var(--surface);
   --card: var(--surface-raised);
@@ -605,6 +641,16 @@ body.wireframe, .wireframe {
   --gradient-4: none;
   --gradient-5: none;
   --gradient-6: none;
+
+  /* ── Status ──────────────────────────────────────────────────────────── */
+  --error: var(--foreground);
+  --error-background: var(--surface-overlay);
+  --success: var(--foreground);
+  --success-background:  var(--surface-overlay);
+  --warning: var(--foreground);
+  --warning-background:  var(--surface-overlay);
+  --info: var(--foreground);
+  --info-background:  var(--surface-overlay);
 
   /* ── shadcn aliases ──────────────────────────────────────────────────── */
   --background: var(--surface);
@@ -712,6 +758,16 @@ body.vertex, .vertex {
   --gradient-5: linear-gradient(180deg, oklch(0.21 0.03 258.5) 0%, oklch(0.233 0.036 254.7) 100%);
   --gradient-6: linear-gradient(106deg, oklch(0.692 0.1119 207.06) 28.08%, oklch(0.166 0.0283 203.34) 71.92%);
 
+  /* ── Status ──────────────────────────────────────────────────────────── */
+  --error: #ff8484;
+  --error-background:  #000000;
+  --success: #74c94b;
+  --success-background: #000000;
+  --warning: #ffbb27;
+  --warning-background: #000000;
+  --info: #42a1ff;
+  --info-background: #000000;
+
   /* ── shadcn aliases ──────────────────────────────────────────────────── */
   --background: var(--surface);
   --card: var(--surface-raised);
@@ -806,6 +862,16 @@ body.canvas, .canvas {
   --gradient-4: linear-gradient(180deg, #273139 0%, #334049 100%);
   --gradient-5: linear-gradient(180deg, #182027 0%, #273139 100%);
   --gradient-6: linear-gradient(106deg, #fa4616 28.08%, #3c2a1e 71.92%);
+
+  /* ── Status ──────────────────────────────────────────────────────────── */
+  --error: #ff8484;
+  --error-background:  #000000;
+  --success: #74c94b;
+  --success-background: #000000;
+  --warning: #ffbb27;
+  --warning-background: #000000;
+  --info: #42a1ff;
+  --info-background: #000000;
 
   /* ── shadcn aliases ──────────────────────────────────────────────────── */
   --background: var(--surface);
@@ -943,24 +1009,24 @@ body.canvas, .canvas {
   --color-chip-success-background: var(--color-chip-success-background);
   --color-error-icon: var(--color-error-icon);
   --color-error-icon-inverse: var(--color-error-icon-inverse);
-  --color-error-text: var(--color-error-text);
-  --color-error-background: var(--color-error-background);
+  --color-error-text: var(--error);
+  --color-error-background: var(--error-background);
   --color-error-foreground-inverse: var(--color-error-foreground-inverse);
   --color-info-foreground: var(--color-info-foreground);
   --color-info-icon: var(--color-info-icon);
   --color-info-icon-inverse: var(--color-info-icon-inverse);
-  --color-info-text: var(--color-info-text);
+  --color-info-text: var(--info);
   --color-info-foreground-inverse: var(--color-info-foreground-inverse);
-  --color-info-background: var(--color-info-background);
+  --color-info-background: var(--info-background);
   --color-success-icon: var(--color-success-icon);
   --color-success-icon-inverse: var(--color-success-icon-inverse);
-  --color-success-text: var(--color-success-text);
-  --color-success-background: var(--color-success-background);
+  --color-success-text: var(--success);
+  --color-success-background: var(--success-background);
   --color-success-foreground-inverse: var(--color-success-foreground-inverse);
   --color-warning-icon: var(--color-warning-icon);
   --color-warning-icon-inverse: var(--color-warning-icon-inverse);
-  --color-warning-text: var(--color-warning-text);
-  --color-warning-background: var(--color-warning-background);
+  --color-warning-text: var(--warning);
+  --color-warning-background: var(--warning-background);
   --color-warning-foreground-inverse: var(--color-warning-foreground-inverse);
   --color-icon-default: var(--color-icon-default);
   --color-icon-inverted-default: var(--color-icon-inverted-default);


### PR DESCRIPTION
- Skeleton + Dropdown item separator use surface-overlay and properly show in light theme
<img width="280" height="269" alt="Screenshot 2026-04-10 at 8 47 13 AM" src="https://github.com/user-attachments/assets/4be68571-3435-4ce9-8f28-34140b368b41" />

<img width="1038" height="585" alt="Screenshot 2026-04-10 at 8 46 50 AM" src="https://github.com/user-attachments/assets/c7905341-8f89-406e-9a11-3c7a5ccd0b5e" />

- Badge supports status variants, tailwind css updated to support status utility classes
<img width="1046" height="236" alt="Screenshot 2026-04-10 at 8 45 28 AM" src="https://github.com/user-attachments/assets/14af2a2a-cf65-4be3-b8a2-77f31d30ea14" />


- Export TooltipPortal primitive