### PR TITLE
feat(apollo-react): add Queues and Tools variants to TaskIcon [MST-8108]

### DIFF
--- a/packages/apollo-react/src/canvas/components/TaskIcon/TaskIcon.styles.ts
+++ b/packages/apollo-react/src/canvas/components/TaskIcon/TaskIcon.styles.ts
@@ -18,6 +18,8 @@ export const TASK_ICON_GRADIENTS: Record<TaskItemTypeValues, string> = {
   [TaskItemTypeValues.ExternalAgent]: CategoryColor.Purple,
   [TaskItemTypeValues.Timer]: CategoryColor.Grey,
   [TaskItemTypeValues.CaseManagement]: CategoryColor.Purple,
+  [TaskItemTypeValues.Queues]: CategoryColor.Grey,
+  [TaskItemTypeValues.Tools]: CategoryColor.Grey,
 };
 
 interface TaskIconContainerProps {

--- a/packages/apollo-react/src/canvas/components/TaskIcon/TaskIcon.tsx
+++ b/packages/apollo-react/src/canvas/components/TaskIcon/TaskIcon.tsx
@@ -7,7 +7,7 @@ import {
   HumanIcon,
   RpaProject,
 } from '@uipath/apollo-react/canvas/icons';
-import { AutopilotIcon, DurationIcon } from '@uipath/apollo-react/icons';
+import { AutopilotIcon, ConfigurationIcon, DurationIcon, QueueIcon } from '@uipath/apollo-react/icons';
 import { TaskIconContainer } from './TaskIcon.styles';
 import { type TaskIconProps, type TaskIconSize, TaskItemTypeValues } from './TaskIcon.types';
 
@@ -38,6 +38,10 @@ const getIconForType = (type: TaskItemTypeValues, iconSize: number): React.React
       return <DurationIcon size={iconSize} />;
     case TaskItemTypeValues.CaseManagement:
       return <CaseManagementProject w={iconSize} h={iconSize} />;
+    case TaskItemTypeValues.Queues:
+      return <QueueIcon size={iconSize} />;
+    case TaskItemTypeValues.Tools:
+      return <ConfigurationIcon size={iconSize} />;
   }
 };
 

--- a/packages/apollo-react/src/canvas/components/TaskIcon/TaskIcon.tsx
+++ b/packages/apollo-react/src/canvas/components/TaskIcon/TaskIcon.tsx
@@ -7,7 +7,12 @@ import {
   HumanIcon,
   RpaProject,
 } from '@uipath/apollo-react/canvas/icons';
-import { AutopilotIcon, ConfigurationIcon, DurationIcon, QueueIcon } from '@uipath/apollo-react/icons';
+import {
+  AutopilotIcon,
+  ConfigurationIcon,
+  DurationIcon,
+  QueueIcon,
+} from '@uipath/apollo-react/icons';
 import { TaskIconContainer } from './TaskIcon.styles';
 import { type TaskIconProps, type TaskIconSize, TaskItemTypeValues } from './TaskIcon.types';
 

--- a/packages/apollo-react/src/canvas/components/TaskIcon/TaskIcon.types.ts
+++ b/packages/apollo-react/src/canvas/components/TaskIcon/TaskIcon.types.ts
@@ -8,6 +8,8 @@ export enum TaskItemTypeValues {
   Connector = 'connector',
   Timer = 'timer',
   CaseManagement = 'case_management',
+  Queues = 'queues',
+  Tools = 'tools',
 }
 
 export type TaskIconSize = 'sm' | 'md' | 'lg';


### PR DESCRIPTION
## Summary
- Add two new `TaskItemTypeValues` enum entries: `Queues` and `Tools`
- Map `Queues` to `QueueIcon` and `Tools` to `ConfigurationIcon`
- Both use grey gradient background (`CategoryColor.Grey`)

## Context
PO.Frontend's quick-add popover (MST-8108) uses `TaskIcon` to render category icons in the toolbox. The existing enum was missing entries for the **Queues** and **Tools** categories.

## Changes
- `TaskIcon.types.ts`: Added `Queues = 'queues'` and `Tools = 'tools'` to `TaskItemTypeValues`
- `TaskIcon.tsx`: Added icon mappings — `QueueIcon` for Queues, `ConfigurationIcon` for Tools
- `TaskIcon.styles.ts`: Added grey gradient entries for both new types

## Demo
<img width="520" height="686" alt="image" src="https://github.com/user-attachments/assets/c4716acb-1771-4156-a8f2-3ecbf16267b4" />
