### PR TITLE
ci(apollo-react): register 3.x maintenance branch in release config

### DIFF
--- a/packages/apollo-react/.releaserc.json
+++ b/packages/apollo-react/.releaserc.json
@@ -1,6 +1,13 @@
 {
   "extends": "semantic-release-monorepo",
-  "branches": ["main"],
+  "branches": [
+    {
+      "name": "release/apollo-react@3.x",
+      "range": "3.x",
+      "channel": "release-3.x"
+    },
+    "main"
+  ],
   "tagFormat": "@uipath/apollo-react@${version}",
   "plugins": [
     [


### PR DESCRIPTION
## Summary

- Adds `release/apollo-react@3.x` to `packages/apollo-react/.releaserc.json` `branches` so semantic-release on main knows the 3.x maintenance line exists.
- This reserves the `3.x` range for the maintenance branch (preventing main from publishing a colliding `3.x.x` release) and resolves its npm dist-tag to `release-3.x`.

## Context

The maintenance branch [release/apollo-react@3.x](https://github.com/UiPath/apollo-ui/tree/release/apollo-react@3.x) was cut from tag `@uipath/apollo-react@3.71.0` using [scripts/create-maintenance-branch.sh](scripts/create-maintenance-branch.sh) in preparation for the upcoming `4.0.0` major bump on main.

## Test plan

- [ ] CI passes on this PR
- [ ] After merge, verify the next release on main bumps to `4.0.0` (requires a `BREAKING CHANGE:` commit)
- [ ] Verify a backport landed on `release/apollo-react@3.x` publishes under the `release-3.x` dist-tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)