### PR TITLE
ci: rename maintenance branches to support/<pkg>@<major>.x

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -11,11 +11,11 @@ on:
   push:
     branches:
       - main
-      - 'release/**'
+      - 'support/**'
   pull_request:
     branches:
       - main
-      - 'release/**'
+      - 'support/**'
   schedule:
     - cron: '17 4 * * 5' # Weekly on Friday at 4:17 AM UTC
 

--- a/.github/workflows/dev-cleanup.yml
+++ b/.github/workflows/dev-cleanup.yml
@@ -5,7 +5,7 @@ on:
     types: [closed]
     branches:
       - main
-      - 'release/**'
+      - 'support/**'
 
 env:
   GH_NPM_REGISTRY_TOKEN: ${{ secrets.GH_NPM_REGISTRY_TOKEN }}

--- a/.github/workflows/dev-publish.yml
+++ b/.github/workflows/dev-publish.yml
@@ -9,7 +9,7 @@ on:
     types: [labeled, synchronize]
     branches:
       - main
-      - 'release/**'
+      - 'support/**'
 
 env:
   GH_NPM_REGISTRY_TOKEN: ${{ secrets.GH_NPM_REGISTRY_TOKEN }}

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches:
       - main
-      - 'release/**'
+      - 'support/**'
 
 env:
   GH_NPM_REGISTRY_TOKEN: ${{ secrets.GH_NPM_REGISTRY_TOKEN }}

--- a/.github/workflows/pr-size.yml
+++ b/.github/workflows/pr-size.yml
@@ -10,7 +10,7 @@ on:
       - converted_to_draft
     branches:
       - main
-      - 'release/**'
+      - 'support/**'
 
 permissions:
   contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-      - 'release/**'
+      - 'support/**'
 
 env:
   GH_NPM_REGISTRY_TOKEN: ${{ secrets.GH_NPM_REGISTRY_TOKEN }}

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -4,11 +4,11 @@ on:
   pull_request:
     branches:
       - main
-      - 'release/**'
+      - 'support/**'
   push:
     branches:
       - main
-      - 'release/**'
+      - 'support/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -350,9 +350,9 @@ Maintenance branches allow backporting fixes to older major versions after a new
 
 ### Branch Naming
 
-Maintenance branches are package-scoped: `release/<package-name>@<major>.x`
+Maintenance branches are package-scoped: `support/<package-name>@<major>.x`
 
-Examples: `release/apollo-react@3.x`, `release/apollo-core@5.x`
+Examples: `support/apollo-react@3.x`, `support/apollo-core@5.x`
 
 ### When to Create a Maintenance Branch
 
@@ -368,16 +368,16 @@ scripts/create-maintenance-branch.sh apollo-react 3
 
 This will:
 1. Find the latest `@uipath/apollo-react@3.*` tag
-2. Create `release/apollo-react@3.x` from that tag
+2. Create `support/apollo-react@3.x` from that tag
 3. Configure semantic-release on the new branch
 4. Print next steps
 
 After running the script:
-1. Push the maintenance branch: `git push -u origin 'release/apollo-react@3.x'`
+1. Push the maintenance branch: `git push -u origin 'support/apollo-react@3.x'`
 2. On `main`, update `packages/apollo-react/.releaserc.json` to add the maintenance branch entry **before** `"main"` in the `branches` array:
    ```json
    "branches": [
-     { "name": "release/apollo-react@3.x", "range": "3.x", "channel": "release-3.x" },
+     { "name": "support/apollo-react@3.x", "range": "3.x", "channel": "latest-v3" },
      "main"
    ]
    ```
@@ -387,10 +387,10 @@ After running the script:
 Cherry-pick from `main` or create a PR targeting the maintenance branch directly:
 
 ```bash
-git checkout release/apollo-react@3.x
+git checkout support/apollo-react@3.x
 git cherry-pick <sha>
 git push
-# → CI releases apollo-react@3.70.4 with dist-tag `release-3.x`
+# → CI releases apollo-react@3.70.4 with dist-tag `latest-v3`
 ```
 
 ### Installing Maintenance Releases
@@ -399,7 +399,7 @@ Maintenance releases publish under a dedicated npm dist-tag (not `latest`):
 
 ```bash
 # Install latest maintenance release for 3.x
-npm install @uipath/apollo-react@release-3.x
+npm install @uipath/apollo-react@latest-v3
 
 # Install a specific version
 npm install @uipath/apollo-react@3.70.4

--- a/scripts/create-maintenance-branch.sh
+++ b/scripts/create-maintenance-branch.sh
@@ -6,7 +6,7 @@
 #
 # This script:
 #   1. Finds the latest git tag for @uipath/<package>@<major>.*
-#   2. Creates release/<package>@<major>.x branch from that tag
+#   2. Creates support/<package>@<major>.x branch from that tag
 #   3. Updates the package's .releaserc.json with maintenance branch config
 #   4. Commits the config change
 #   5. Prints next steps (push, update main's .releaserc.json)
@@ -22,8 +22,8 @@ if ! [[ "$MAJOR" =~ ^[0-9]+$ ]]; then
 fi
 
 TAG_PATTERN="@uipath/${PACKAGE}@${MAJOR}.*"
-BRANCH="release/${PACKAGE}@${MAJOR}.x"
-CHANNEL="release-${MAJOR}.x"
+BRANCH="support/${PACKAGE}@${MAJOR}.x"
+CHANNEL="latest-v${MAJOR}"
 
 # Find package directory
 if [ -d "packages/${PACKAGE}" ]; then


### PR DESCRIPTION
## Summary
- Renames the maintenance branch convention from `release/<pkg>@<major>.x` to `support/<pkg>@<major>.x` across CI workflows, the helper script, and `CONTRIBUTING.md`.
- Switches the published npm dist-tag from `release-<major>.x` to `latest-v<major>` (e.g. `latest-v3`).
- Updates the seven workflow `branches:` filters (`release/**` → `support/**`), the `BRANCH`/`CHANNEL` variables in `scripts/create-maintenance-branch.sh`, and all examples in `CONTRIBUTING.md`.

## Test plan
- [ ] Verify each workflow's `branches:` filter still parses (YAML lint passes in CI).
- [ ] Dry-run `scripts/create-maintenance-branch.sh <pkg> <major>` to confirm the new branch name and channel are emitted.
- [ ] Spot-check `CONTRIBUTING.md` renders correctly on GitHub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)