### PR TITLE
fix(apollo-vertex): remove recursive resetQueries in ensureValidToken

### DIFF
--- a/apps/apollo-vertex/lib/auth.ts
+++ b/apps/apollo-vertex/lib/auth.ts
@@ -146,6 +146,17 @@ const exchangeCodeForToken = (
   return fetchTokenData(baseUrl, body);
 };
 
+const cleanupOAuthState = (targetPath?: string) => {
+  sessionStorage.removeItem(STORAGE_KEYS.CODE_VERIFIER);
+  sessionStorage.removeItem(STORAGE_KEYS.STATE);
+  sessionStorage.removeItem(STORAGE_KEYS.AUTH_RETURN_TO);
+  window.history.replaceState(
+    {},
+    document.title,
+    targetPath ?? window.location.pathname,
+  );
+};
+
 const handleOAuthCallback = async (
   clientId: string,
   baseUrl: string,
@@ -166,12 +177,16 @@ const handleOAuthCallback = async (
 
   const storedState = sessionStorage.getItem(STORAGE_KEYS.STATE);
   if (state !== storedState) {
-    throw new Error("State mismatch");
+    cleanupOAuthState();
+    toast.error("Authentication failed: State mismatch");
+    return;
   }
 
   const codeVerifier = sessionStorage.getItem(STORAGE_KEYS.CODE_VERIFIER);
   if (!codeVerifier) {
-    throw new Error("Code verifier not found");
+    cleanupOAuthState();
+    toast.error("Authentication failed: Code verifier not found");
+    return;
   }
 
   try {
@@ -182,25 +197,19 @@ const handleOAuthCallback = async (
       baseUrl,
       redirectPath,
     );
-    sessionStorage.removeItem(STORAGE_KEYS.CODE_VERIFIER);
-    sessionStorage.removeItem(STORAGE_KEYS.STATE);
     saveTokenData(tokenData);
     const returnTo = sessionStorage.getItem(STORAGE_KEYS.AUTH_RETURN_TO);
-    sessionStorage.removeItem(STORAGE_KEYS.AUTH_RETURN_TO);
-    const targetPath = returnTo ?? window.location.pathname;
-    window.history.replaceState({}, document.title, targetPath);
+    cleanupOAuthState(returnTo ?? window.location.pathname);
   } catch (authError) {
     clearTokenData();
-    sessionStorage.removeItem(STORAGE_KEYS.AUTH_RETURN_TO);
+    cleanupOAuthState();
     const message =
       authError instanceof Error ? authError.message : "Unknown error";
     toast.error(`Authentication failed: ${message}`);
-    throw authError;
   }
 };
 
 export const ensureValidToken = async (
-  queryClient: ReturnType<typeof useQueryClient>,
   clientId: string,
   baseUrl: string,
   redirectPath?: string,
@@ -209,11 +218,7 @@ export const ensureValidToken = async (
   const isInOAuthCallback = params.has("code") && params.has("state");
 
   if (isInOAuthCallback) {
-    try {
-      await handleOAuthCallback(clientId, baseUrl, redirectPath);
-    } catch {
-      void queryClient.resetQueries({ queryKey: TOKEN_QUERY_KEY });
-    }
+    await handleOAuthCallback(clientId, baseUrl, redirectPath);
   }
 
   const tokenDataStr = localStorage.getItem(STORAGE_KEYS.TOKEN);

--- a/apps/apollo-vertex/registry/shell/shell-auth-provider.tsx
+++ b/apps/apollo-vertex/registry/shell/shell-auth-provider.tsx
@@ -80,12 +80,9 @@ export const useAccessToken = ({
   baseUrl,
   redirectPath,
 }: UseAccessTokenProps) => {
-  const queryClient = useQueryClient();
-
   const { data: token, isLoading } = useQuery({
     queryKey: TOKEN_QUERY_KEY,
-    queryFn: () =>
-      ensureValidToken(queryClient, clientId, baseUrl, redirectPath),
+    queryFn: () => ensureValidToken(clientId, baseUrl, redirectPath),
     refetchInterval: 60 * 1000,
     enabled: typeof window !== "undefined",
   });


### PR DESCRIPTION
## Problem

`ensureValidToken` is the `queryFn` for `TOKEN_QUERY_KEY` (re-runs every 60s via `refetchInterval`). When `handleOAuthCallback` threw an error, the catch block called `resetQueries` on the same query key — re-invoking `ensureValidToken`, which failed again, reset again, and looped indefinitely. The page appeared blank with no errors.

Two issues made this worse:
1. `handleOAuthCallback` only cleaned the URL on success — OAuth params (`code`/`state`) stayed in the URL on failure, so every retry re-entered the callback path
2. Early validation errors (state mismatch, missing code verifier) threw before the inner try/catch, so no toast was shown

## Fix

1. **Remove `resetQueries`** from `ensureValidToken` — it was the direct cause of the loop and served no purpose (cleanup already happens inside `handleOAuthCallback`)
2. **Make `handleOAuthCallback` handle all failures internally** — every error path now cleans up session storage, strips OAuth params from the URL, and shows a toast instead of throwing

## Reproduction

> This bug affects vertical repos that consume the shell auth components, not apollo-vertex directly.

Navigate to any vertical app with `?code=x&state=x` in the URL → page stays blank indefinitely.

## Test plan

- [ ] Vertical app loads normally after successful OAuth flow
- [ ] Navigating with `?code=x&state=x` shows error toast and does not loop
- [ ] `logout()` still works (has its own `resetQueries`, unaffected)