### PR TITLE
fix(apollo-vertex): hide empty nav dot and link company logo to home

### DIFF
--- a/apps/apollo-vertex/registry/shell/shell-company.tsx
+++ b/apps/apollo-vertex/registry/shell/shell-company.tsx
@@ -1,3 +1,4 @@
+import { Link } from "@tanstack/react-router";
 import { useLocalStorage } from "@mantine/hooks";
 import { AnimatePresence, motion } from "framer-motion";
 import { PanelLeft } from "lucide-react";
@@ -91,12 +92,14 @@ export const Company = ({
     defaultValue: false,
   });
   const iconElement = (
-    <motion.div
-      className="w-8 h-8 rounded-[4px] bg-primary-700 dark:bg-primary-400 flex items-center justify-center shrink-0"
-      {...(isCollapsed ? { whileHover: iconHoverScale } : {})}
-    >
-      <CompanyLogoIcon companyLogo={companyLogo} />
-    </motion.div>
+    <Link to="/">
+      <motion.div
+        className="w-8 h-8 rounded-[4px] bg-primary-700 dark:bg-primary-400 flex items-center justify-center shrink-0"
+        {...(isCollapsed ? { whileHover: iconHoverScale } : {})}
+      >
+        <CompanyLogoIcon companyLogo={companyLogo} />
+      </motion.div>
+    </Link>
   );
 
   return (

--- a/apps/apollo-vertex/registry/shell/shell-minimal-company.tsx
+++ b/apps/apollo-vertex/registry/shell/shell-minimal-company.tsx
@@ -1,3 +1,4 @@
+import { Link } from "@tanstack/react-router";
 import type { CompanyLogo } from "./shell";
 import { CompanyLogoIcon } from "./shell-company-logo";
 
@@ -14,9 +15,12 @@ export const MinimalCompany = ({
 }: MinimalCompanyProps) => {
   return (
     <div className="flex items-center gap-2">
-      <div className="w-8 h-8 rounded-[4px] bg-primary-700 dark:bg-primary-400 flex items-center justify-center shrink-0">
+      <Link
+        to="/"
+        className="w-8 h-8 rounded-[4px] bg-primary-700 dark:bg-primary-400 flex items-center justify-center shrink-0"
+      >
         <CompanyLogoIcon companyLogo={companyLogo} />
-      </div>
+      </Link>
       <div className="flex items-center gap-1.5">
         <span className="text-sm font-semibold text-foreground">
           {companyName}

--- a/apps/apollo-vertex/registry/shell/shell-sidebar.tsx
+++ b/apps/apollo-vertex/registry/shell/shell-sidebar.tsx
@@ -41,11 +41,17 @@ export const Sidebar = ({
           companyLogo={companyLogo}
         />
 
-        <nav className="absolute left-1/2 -translate-x-1/2 flex items-center bg-muted dark:bg-[oklch(0.24_0.033_254)] rounded-full p-1.5 overflow-x-auto scrollbar-thin">
-          {navItems.map((item) => (
-            <MinimalNavItem key={item.path} to={item.path} label={item.label} />
-          ))}
-        </nav>
+        {navItems.length > 0 && (
+          <nav className="absolute left-1/2 -translate-x-1/2 flex items-center bg-muted dark:bg-[oklch(0.24_0.033_254)] rounded-full p-1.5 overflow-x-auto scrollbar-thin">
+            {navItems.map((item) => (
+              <MinimalNavItem
+                key={item.path}
+                to={item.path}
+                label={item.label}
+              />
+            ))}
+          </nav>
+        )}
 
         <div className="flex items-center gap-2">
           <UserProfile isCollapsed />


### PR DESCRIPTION
We have a view in fins that renders the shell without nav items, leaving an empty container. I thought I'd fix that as well as make the company logo component into a link back to the main route, which should be expected behavior.