### PR TITLE
feat(apollo-react): add CasePlanIcon canvas icon

### DIFF
--- a/packages/apollo-react/src/canvas/icons/CasePlanIcon.tsx
+++ b/packages/apollo-react/src/canvas/icons/CasePlanIcon.tsx
@@ -1,0 +1,25 @@
+export const CasePlanIcon = ({ w = 22, h = 22 }: { w?: number | string; h?: number | string }) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    id="case-plan-icon"
+    width={w}
+    height={h}
+    fill="none"
+    viewBox="0 0 16 16"
+  >
+    <path
+      fillRule="evenodd"
+      clipRule="evenodd"
+      d="M9.333 2.5a.5.5 0 0 0-.5-.5H3.5a.5.5 0 0 0-.5.5v7.667a.5.5 0 0 0 .5.5h5.333a.5.5 0 0 0 .5-.5zm-6-1.5C2.597 1 2 1.597 2 2.333v8c0 .737.597 1.334 1.333 1.334H9c.736 0 1.333-.597 1.333-1.334v-8C10.333 1.597 9.736 1 9 1z"
+      fill="currentColor"
+    />
+    <path
+      d="M11 3c.736 0 1.333.597 1.333 1.333v8c0 .736-.597 1.334-1.333 1.334H5.333A1.334 1.334 0 0 1 4 12.333V11.6h1v.567a.5.5 0 0 0 .5.5h5.333a.5.5 0 0 0 .5-.5V4.5a.5.5 0 0 0-.5-.5H10.3V3z"
+      fill="currentColor"
+    />
+    <path
+      d="M13 5c.736 0 1.333.597 1.333 1.333v8c0 .736-.597 1.334-1.333 1.334H7.333A1.334 1.334 0 0 1 6 14.333V13.6h1v.567a.5.5 0 0 0 .5.5h5.333a.5.5 0 0 0 .5-.5V6.5a.5.5 0 0 0-.5-.5H12.3V5z"
+      fill="currentColor"
+    />
+  </svg>
+);

--- a/packages/apollo-react/src/canvas/icons/index.ts
+++ b/packages/apollo-react/src/canvas/icons/index.ts
@@ -7,6 +7,7 @@ export { ApiProject } from './ApiProject';
 export { AutonomousAgentIcon } from './AutonomousAgentIcon';
 export { BusinessProcessProject } from './BusinessProcessProject';
 export { CaseManagementProject } from './CaseManagementProject';
+export { CasePlanIcon } from './CasePlanIcon';
 export { CodedAgentIcon } from './CodedAgentIcon';
 export { ConnectorBuilderProject } from './ConnectorBuilderProject';
 export { ControlFlowIcon } from './ControlFlowIcon';


### PR DESCRIPTION
## Description

Add the case plan (stacked documents) icon as a hand-written canvas icon in `apollo-react`. This icon is currently a local SVG in PO.Frontend and needs to be a proper shared design system icon.

Added to `packages/apollo-react/src/canvas/icons/` following the same pattern as `CaseManagementProject` and other canvas icons.

## Demo

<img width="303" height="163" alt="image" src="https://github.com/user-attachments/assets/ba9002ac-449b-431d-9f61-08606d8b3430"/>