### PR TITLE
feat(apollo-react): add MoreElements and CreateNew TaskIcon types

### DIFF
--- a/packages/apollo-react/src/canvas/components/TaskIcon/TaskIcon.styles.ts
+++ b/packages/apollo-react/src/canvas/components/TaskIcon/TaskIcon.styles.ts
@@ -20,6 +20,8 @@ export const TASK_ICON_GRADIENTS: Record<TaskItemTypeValues, string> = {
   [TaskItemTypeValues.CaseManagement]: CategoryColor.Purple,
   [TaskItemTypeValues.Queues]: CategoryColor.Grey,
   [TaskItemTypeValues.Tools]: CategoryColor.Grey,
+  [TaskItemTypeValues.MoreElements]: CategoryColor.Grey,
+  [TaskItemTypeValues.CreateNew]: CategoryColor.Grey,
 };
 
 interface TaskIconContainerProps {

--- a/packages/apollo-react/src/canvas/components/TaskIcon/TaskIcon.test.tsx
+++ b/packages/apollo-react/src/canvas/components/TaskIcon/TaskIcon.test.tsx
@@ -1,6 +1,7 @@
 import { render } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 import { TaskIcon } from './TaskIcon';
+import { TASK_ICON_GRADIENTS } from './TaskIcon.styles';
 import { TaskItemTypeValues } from './TaskIcon.types';
 
 describe('TaskIcon', () => {
@@ -27,6 +28,42 @@ describe('TaskIcon', () => {
       const { container } = render(<TaskIcon type={TaskItemTypeValues.Agent} size="lg" />);
       const iconContainer = container.firstChild as HTMLElement;
       expect(iconContainer).toHaveStyle({ width: '72px', height: '72px', borderRadius: '8px' });
+    });
+  });
+
+  it('has a gradient mapping for every TaskItemTypeValues entry', () => {
+    for (const type of Object.values(TaskItemTypeValues)) {
+      expect(TASK_ICON_GRADIENTS[type]).toBeDefined();
+    }
+  });
+
+  describe('MoreElements type', () => {
+    it('renders with SVG icon', () => {
+      const { container } = render(<TaskIcon type={TaskItemTypeValues.MoreElements} />);
+      expect(container.querySelector('svg')).toBeInTheDocument();
+    });
+
+    it('renders at all sizes', () => {
+      for (const size of ['sm', 'md', 'lg'] as const) {
+        const { container } = render(
+          <TaskIcon type={TaskItemTypeValues.MoreElements} size={size} />
+        );
+        expect(container.firstChild).toBeInTheDocument();
+      }
+    });
+  });
+
+  describe('CreateNew type', () => {
+    it('renders with SVG icon', () => {
+      const { container } = render(<TaskIcon type={TaskItemTypeValues.CreateNew} />);
+      expect(container.querySelector('svg')).toBeInTheDocument();
+    });
+
+    it('renders at all sizes', () => {
+      for (const size of ['sm', 'md', 'lg'] as const) {
+        const { container } = render(<TaskIcon type={TaskItemTypeValues.CreateNew} size={size} />);
+        expect(container.firstChild).toBeInTheDocument();
+      }
     });
   });
 });

--- a/packages/apollo-react/src/canvas/components/TaskIcon/TaskIcon.tsx
+++ b/packages/apollo-react/src/canvas/components/TaskIcon/TaskIcon.tsx
@@ -10,7 +10,9 @@ import {
 import {
   AutopilotIcon,
   ConfigurationIcon,
+  CreateIcon,
   DurationIcon,
+  MoreIcon,
   QueueIcon,
 } from '@uipath/apollo-react/icons';
 import { TaskIconContainer } from './TaskIcon.styles';
@@ -47,6 +49,10 @@ const getIconForType = (type: TaskItemTypeValues, iconSize: number): React.React
       return <QueueIcon size={iconSize} />;
     case TaskItemTypeValues.Tools:
       return <ConfigurationIcon size={iconSize} />;
+    case TaskItemTypeValues.MoreElements:
+      return <MoreIcon size={iconSize} />;
+    case TaskItemTypeValues.CreateNew:
+      return <CreateIcon size={iconSize} />;
   }
 };
 

--- a/packages/apollo-react/src/canvas/components/TaskIcon/TaskIcon.types.ts
+++ b/packages/apollo-react/src/canvas/components/TaskIcon/TaskIcon.types.ts
@@ -10,6 +10,8 @@ export enum TaskItemTypeValues {
   CaseManagement = 'case_management',
   Queues = 'queues',
   Tools = 'tools',
+  MoreElements = 'more_elements',
+  CreateNew = 'create_new',
 }
 
 export type TaskIconSize = 'sm' | 'md' | 'lg';


### PR DESCRIPTION
## Summary
- Add `MoreElements` and `CreateNew` to `TaskItemTypeValues` enum for use in the canvas Toolbox quick-add popover
- `MoreElements` (three dots icon, grey background) — used for the "More BPMN elements" category row
- `CreateNew` (plus icon, grey background) — used for "Create new Agent", "Create new Case management", etc.
- Both use `CategoryColor.Grey` to match existing utility-style categories (Tools, Queues)

## Context
PO.Frontend's quick-add popover ([MST-8108](https://uipath.atlassian.net/browse/MST-8108)) needs styled icons for these two item types to match the existing category icons (Agent, Connector, Human Task, etc.).

[MST-8108]: https://uipath.atlassian.net/browse/MST-8108?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ