### PR TITLE
fix(apollo-react): `CasePlanIcon` default size to 16

### DIFF
--- a/packages/apollo-react/src/canvas/icons/CasePlanIcon.tsx
+++ b/packages/apollo-react/src/canvas/icons/CasePlanIcon.tsx
@@ -1,4 +1,4 @@
-export const CasePlanIcon = ({ w = 22, h = 22 }: { w?: number | string; h?: number | string }) => (
+export const CasePlanIcon = ({ w = 16, h = 16 }: { w?: number | string; h?: number | string }) => (
   <svg
     xmlns="http://www.w3.org/2000/svg"
     id="case-plan-icon"


### PR DESCRIPTION
Changes `CasePlanIcon` to fix [missed comment](https://github.com/UiPath/apollo-ui/pull/506#discussion_r3081253740) in 
- #506