### PR TITLE
chore(repo): support branch skill refactor

### DIFF
--- a/.claude/skills/cut-maintenance-branch/SKILL.md
+++ b/.claude/skills/cut-maintenance-branch/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cut-maintenance-branch
-description: Use when cutting a maintenance/support branch for an older major version of an apollo-ui package (e.g. apollo-react@3.x) so that fixes can keep shipping after main has moved to the next major. Orchestrates branch creation, workspace dep locking, lockfile regeneration, push, and the companion main-side .releaserc.json PR. Confirms commit messages and git actions with the user before executing them.
+description: Use when cutting a maintenance/support branch for an older major version of an apollo-ui package (e.g. apollo-react v3, v4, v5). Orchestrates branch creation, pushes it bare, then opens a PR with workspace dep locking, release config, and lockfile regeneration. Confirms commit messages and git actions with the user before executing them.
 ---
 
 # Cut Maintenance Branch
@@ -10,23 +10,26 @@ description: Use when cutting a maintenance/support branch for an older major ve
 Use when the user asks to:
 
 - "Cut a maintenance branch for `<package>@<major>`"
+- "Create a support branch for apollo-react v3" / "...v4" / "...v5"
 - "Set up a support branch for an older major version"
-- "Maintain `<package>@<old-major>` after the major bump"
+- "Maintain `<package>@<old-major>` independently"
 - Any phrasing equivalent to creating a `support/<package>@<major>.x` branch
+
+The user only needs to specify the package and major version. The skill finds the latest tag for that major. Main must already be on a newer major version.
 
 Do **not** use this skill for:
 - General release questions (covered by the package's `.releaserc.json`)
 - Backporting individual fixes to an existing maintenance branch (normal git workflow)
-- Cutting a branch for a major version that hasn't been published yet (no tags to branch from)
+- Cutting a branch for a major version that has no published tags (nothing to branch from)
 
 ## Architecture
 
 The skill owns all orchestration, user interaction, and git/network actions. It calls two small deterministic file-transform scripts:
 
-- [scripts/maintenance-branch/lock-workspace-deps.sh](../../../scripts/maintenance-branch/lock-workspace-deps.sh) — rewrites `workspace:*` deps in one `package.json` to concrete versioned ranges. Idempotent. No git, no network.
-- [scripts/maintenance-branch/update-releaserc.sh](../../../scripts/maintenance-branch/update-releaserc.sh) — adds a maintenance entry (or replaces an existing one with the same name) in one `.releaserc.json`'s `branches` array, before `"main"`. Idempotent.
+- [scripts/maintenance-branch/lock-workspace-deps.sh](../../../scripts/maintenance-branch/lock-workspace-deps.sh) — rewrites workspace deps in one `package.json` to exact pinned versions by default (e.g. `workspace:*` → `5.9.0`). Supports `--operator=^|~|=` to override. Idempotent. No git, no network.
+- [scripts/maintenance-branch/update-releaserc.sh](../../../scripts/maintenance-branch/update-releaserc.sh) — replaces `"main"` with a maintenance entry in one `.releaserc.json`'s `branches` array (the `"main"` entry is removed, not kept alongside). Each support branch owns its own release config; main's `.releaserc.json` is never modified. Idempotent.
 
-Everything else — finding the tag, creating the branch, committing, running `pnpm install`, pushing, opening the PR — is the skill's responsibility. **Confirm every commit message and every git/network action with the user before executing.**
+Everything else — finding the tag, creating the branch, pushing it bare, opening the configuration PR, running `pnpm install` — is the skill's responsibility. **Confirm every commit message and every git/network action with the user before executing.**
 
 ## Required inputs
 
@@ -34,7 +37,7 @@ Confirm with the user:
 
 - **Package name** — must exist in `packages/<name>/` or `web-packages/<name>/`. If ambiguous, list candidates from `ls packages/ web-packages/`.
 - **Major version** — must have at least one published tag matching `@uipath/<package>@<major>.*`.
-- **Lock operator** (only if the user wants something other than the default `^`) — options: `^`, `~`, `=`.
+- **Lock operator** — defaults to `=` (exact pin, e.g. `5.9.0`). Ask the user if they want exact pinning or a range (`^`, `~`). Mention that exact pinning is the default and recommended.
 
 Do not ask about anything else upfront — the rest is handled phase by phase with confirmations.
 
@@ -63,14 +66,20 @@ git fetch --tags
 ```
 
 ```bash
-# 4. gh CLI authenticated (only matters for the main-side PR)
+# 4. gh CLI authenticated (needed for PR creation)
 gh auth status
 ```
-If 401: surface the saved memory hint — `unset GITHUB_TOKEN && gh auth status`. The token may hold an SSH fingerprint in this environment.
-If unavailable, the skill can still cut the support branch — but the main-side PR step will fall back to printing instructions for manual creation. Tell the user this trade-off before proceeding.
+If 401: suggest `unset GITHUB_TOKEN && gh auth status` — the env var may hold an SSH fingerprint in this environment.
+If unavailable: **stop**. The skill requires `gh` to create the configuration PR.
 
 ```bash
-# 5. Find the latest matching tag
+# 5. Check remote branch does not already exist
+git ls-remote --heads origin "support/<package>@<major>.x"
+```
+If non-empty: **stop**. The support branch already exists on the remote. Tell the user — don't delete it.
+
+```bash
+# 6. Find the latest matching tag
 git tag --list "@uipath/<package>@<major>.*" --sort=-version:refname | head -1
 ```
 If empty: **stop**. Show the user the available tags for that package: `git tag --list "@uipath/<package>@*" --sort=-version:refname | head -10`.
@@ -82,28 +91,43 @@ Show the user a concrete preview before any mutation:
 - Tag the support branch will be cut from
 - Support branch name: `support/<package>@<major>.x`
 - Channel: `latest-v<major>`
-- Lock operator
 - Workspace deps that will be locked, with the version each will be locked to. Read sibling versions at the tag (not from main):
   ```bash
   git show "<tag>:packages/<sibling>/package.json" | jq -r .version
   ```
   For each `workspace:*` dep in the package's `package.json`, look up the sibling's version at the tag.
-- Companion main-side branch name: `ci/release-config-<package>@<major>.x`
-- Where the entry will be inserted in `<package>/.releaserc.json` on main
+- How `"main"` in `.releaserc.json` will be replaced with the support branch entry
+- PR branch name: `ci/configure-support-<package>@<major>.x`
 
 Get explicit user confirmation (e.g., "proceed?") before Phase 3.
 
-## Phase 3 — Create branch + apply transforms + commit (support branch)
+## Phase 3 — Create and push bare support branch
+
+Create the support branch at the tag and push it with no modifications. This establishes the branch on the remote so it can be targeted by a PR.
+
+**Confirm with the user** before creating and pushing.
 
 ```bash
 git checkout -b "support/<package>@<major>.x" "<tag>"
+git push -u origin "support/<package>@<major>.x"
 ```
 
-Run the two transforms:
+If the user declines the push: stop here. Print recovery instructions (the branch exists locally; they can push later).
+
+## Phase 4 — Create PR branch + apply transforms + commit
+
+Create a PR branch off the support branch:
 
 ```bash
-scripts/maintenance-branch/lock-workspace-deps.sh "<pkg-dir>/package.json" [--operator=...]
-scripts/maintenance-branch/update-releaserc.sh "<pkg-dir>/.releaserc.json" "support/<package>@<major>.x" <major>
+git checkout -b "ci/configure-support-<package>@<major>.x"
+```
+
+Run the two transforms from the repo root. **Important:** the scripts live on `main` and may not exist at the tag. Use `origin/main` (not local `main`) to ensure the latest version:
+
+```bash
+cd "$(git rev-parse --show-toplevel)"
+git show origin/main:scripts/maintenance-branch/lock-workspace-deps.sh | bash -s -- "<pkg-dir>/package.json" [--operator=<operator>]
+git show origin/main:scripts/maintenance-branch/update-releaserc.sh | bash -s -- "<pkg-dir>/.releaserc.json" "support/<package>@<major>.x" <major>
 ```
 
 Show the diff:
@@ -123,7 +147,7 @@ git add "<pkg-dir>/package.json" "<pkg-dir>/.releaserc.json"
 git commit -m "<approved message>"
 ```
 
-## Phase 4 — Regenerate lockfile
+## Phase 5 — Regenerate lockfile
 
 `pnpm install` is run automatically (no prompt) since the lockfile *must* match the locked `package.json` for the support branch to install cleanly. Stream output to the user.
 
@@ -149,102 +173,51 @@ git diff --quiet -- pnpm-lock.yaml || echo "changed"
   git commit -m "<approved message>"
   ```
 
-## Phase 5 — Push support branch
+## Phase 6 — Push PR branch and open PR
 
-**Confirm with the user** before pushing.
-
-```bash
-git push -u origin "support/<package>@<major>.x"
-```
-
-If the user declines: stop here. Print recovery instructions (the branch exists locally; they can push later). Skip Phase 6 (main-side PR is meaningless without a pushed support branch).
-
-## Phase 6 — Companion main-side PR (via worktree)
-
-This phase runs in a temporary git worktree so the user's working directory stays on the support branch undisturbed.
+**Confirm with the user** before pushing and opening the PR.
 
 ```bash
-git fetch origin main
-WORKTREE_DIR=$(mktemp -d -t apollo-maintenance-XXXXXX)
-git worktree add -b "ci/release-config-<package>@<major>.x" "$WORKTREE_DIR" origin/main
+git push -u origin "ci/configure-support-<package>@<major>.x"
 ```
-
-Set up cleanup: regardless of how the rest of the phase ends, the worktree must be removed:
-
-```bash
-git worktree remove --force "$WORKTREE_DIR" 2>/dev/null || true
-```
-
-Apply the transform inside the worktree:
-
-```bash
-scripts/maintenance-branch/update-releaserc.sh \
-  "$WORKTREE_DIR/<pkg-dir>/.releaserc.json" \
-  "support/<package>@<major>.x" \
-  <major>
-```
-
-Check whether anything changed:
-
-```bash
-git -C "$WORKTREE_DIR" diff --quiet -- "<pkg-dir>/.releaserc.json" || echo "changed"
-```
-
-- If unchanged: main's `.releaserc.json` already has the entry. Tell the user, clean up the worktree, skip to Phase 7.
-- If changed: propose commit message and **confirm**:
-
-  > `ci(<package>): add support/<package>@<major>.x to release branches`
-
-  Then:
-
-  ```bash
-  git -C "$WORKTREE_DIR" add "<pkg-dir>/.releaserc.json"
-  git -C "$WORKTREE_DIR" commit -m "<approved message>"
-  git -C "$WORKTREE_DIR" push -u origin "ci/release-config-<package>@<major>.x"
-  ```
 
 Propose PR title and body and **confirm with the user**. Suggested defaults:
 
-- **Title:** `ci(<package>): add support/<package>@<major>.x to release branches`
+- **Title:** `ci(<package>): configure support/<package>@<major>.x maintenance branch`
 - **Body** (write to a tempfile and pass via `--body-file`):
 
   ```markdown
-  Adds the `support/<package>@<major>.x` maintenance branch to `<pkg-dir>/.releaserc.json` so semantic-release on `main` is aware of the full release topology.
+  Configures the `support/<package>@<major>.x` maintenance branch for independent releases.
 
-  ## Why this matters
+  ## Changes
 
-  semantic-release reads the `branches` array from whichever branch it is running on, and uses the full topology to enforce release constraints. Without this entry on `main`:
+  - **Locked workspace deps** — workspace dependencies pinned to exact versions (e.g. `5.9.0`) so the branch installs independently of main's workspace
+  - **Release config** — `.releaserc.json` updated: `"main"` replaced with the support branch entry (`range: <major>.x`, `channel: latest-v<major>`)
+  - **Lockfile regenerated** — `pnpm-lock.yaml` updated to match locked dependencies (if applicable)
 
-  - **Range enforcement breaks.** With this entry declared *before* `"main"`, semantic-release infers the release range for main is `>=<NEXT_MAJOR>.0.0`. Without it, a stray patch/minor commit on main could in theory produce a `<major>.x.y` release, colliding with the maintenance branch.
-  - **Channel routing breaks.** main publishes to `latest`; the support branch publishes to `latest-v<major>`. Backports and merges between the two need both branch configs to agree on the topology to route to the right dist-tag.
-  - **Validation breaks.** semantic-release validates the branches config on every run. This entry is what lets it catch overlapping ranges or misconfigured backport branches.
+  ## Context
 
-  ## Companion change
-
-  Cut from tag `<tag>` on branch `support/<package>@<major>.x` (already pushed). That branch contains the same `.releaserc.json` entry plus locked `workspace:*` dependencies and a regenerated lockfile.
+  Branch cut from tag `<tag>`. After this PR is merged, the branch is ready to receive fix PRs and publish `<major>.x.y` releases to the `latest-v<major>` npm dist-tag.
   ```
 
 Open the PR:
 
 ```bash
 gh pr create \
-  --base main \
-  --head "ci/release-config-<package>@<major>.x" \
+  --base "support/<package>@<major>.x" \
+  --head "ci/configure-support-<package>@<major>.x" \
   --title "<approved title>" \
   --body-file "<tempfile>"
 ```
 
 Capture the PR URL.
 
-Clean up the worktree.
-
 ## Phase 7 — Report
 
 Surface to the user:
 
-- Support branch: `support/<package>@<major>.x` at SHA `<git rev-parse>` (pushed)
-- Lockfile: committed at SHA `<sha>` (or "no changes — skipped")
-- Main-side PR: `<url>` (or "skipped — already present on main", or "skipped — gh unavailable; manual instructions printed")
+- Support branch: `support/<package>@<major>.x` (pushed bare from `<tag>`)
+- Configuration PR: `<url>`
 
 Ask whether to switch back to `main`:
 
@@ -259,15 +232,14 @@ git checkout main
 | `Error: no tags found matching '...'` | Wrong major, or tags not fetched | `git fetch --tags`, re-confirm with user |
 | `Error: branch 'support/...' already exists` | Already cut | **Stop**. Don't delete — could destroy work. Tell user. |
 | Working tree not clean | Uncommitted changes | Tell user to commit/stash. Don't act on their behalf. |
-| `gh` 401 | `GITHUB_TOKEN` env var holds an SSH fingerprint | Suggest `unset GITHUB_TOKEN && gh auth status` (saved memory) |
+| `gh` 401 | `GITHUB_TOKEN` env var holds an SSH fingerprint | Suggest `unset GITHUB_TOKEN && gh auth status` |
 | `lock-workspace-deps.sh` errors with "no resolvable version" | `workspace:*` dep references a package not in `packages/*` or `web-packages/*` | Investigate manually — typo in `package.json`, removed package, or package in `apps/*` (which is excluded — apps are not published) |
-| `ci/release-config-...` branch already exists | Previous run partially completed | **Stop**. Tell user to clean up the stale branch before retrying. |
-| `pnpm install` fails | Locked sibling version not actually published, or registry issue | **Stop**. The support branch's `package.json` is committed but lockfile commit didn't happen. Tell user; they can investigate and either fix the lock manually or amend the dep-locking commit. |
-| Worktree creation fails | Disk space, permissions, or stale worktree from prior run | Try `git worktree prune`, then retry |
+| `ci/configure-support-...` branch already exists | Previous run partially completed | **Stop**. Tell user to clean up the stale branch before retrying. |
+| `pnpm install` fails | Locked sibling version not actually published, or registry issue | **Stop**. The PR branch has the `package.json` commit but lockfile commit didn't happen. Tell user; they can investigate and either fix the lock manually or amend the commit. |
 
 ## Things this skill explicitly does NOT do
 
 - **Does not delete sibling package source from the support branch.** The locked deps make publish output correct regardless. Source is left in place so local builds still work.
-- **Does not auto-merge the main-side PR.** Human review required.
+- **Does not modify main's `.releaserc.json`.** Each support branch owns its own release config. Main only has `"main"` in its branches array.
 - **Does not handle `peerDependencies` differently from `dependencies`** — they're rewritten the same way. If a package needs special peer-range strategy, handle manually.
 - **Does not amend or force-push commits** at any point. If something goes wrong mid-flow, leave artifacts in place and surface the state to the user.

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -80,7 +80,13 @@ jobs:
 
       - name: Run Check Dependency Consistency
         if: matrix.check == 'Check Dependency Consistency'
-        run: pnpm check:dependencies
+        run: |
+          if [[ "$BASE_REF" == support/* ]]; then
+            echo "Support branch detected - ignoring locked workspace deps"
+            pnpm exec check-dependency-version-consistency . --ignore-dep-pattern "^@uipath/"
+          else
+            pnpm check:dependencies
+          fi
 
       - name: Run Typecheck
         if: matrix.check == 'Typecheck'

--- a/.github/workflows/support-branch-scope.yml
+++ b/.github/workflows/support-branch-scope.yml
@@ -1,0 +1,188 @@
+name: Support Branch Scope Check
+
+on:
+  pull_request:
+    branches:
+      - 'support/**'
+
+concurrency:
+  group: support-scope-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  check-scope:
+    name: Check package scope
+    runs-on: ubuntu-latest
+    steps:
+      - name: Extract package from branch name
+        id: parse
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: |
+          # support/apollo-react@3.x → apollo-react
+          PACKAGE=$(echo "$BASE_REF" | sed -E 's|^support/(.+)@[0-9]+\.x$|\1|')
+          if [ "$PACKAGE" = "$BASE_REF" ]; then
+            echo "::error::Could not parse package name from branch '$BASE_REF'"
+            exit 1
+          fi
+          echo "package=$PACKAGE" >> "$GITHUB_OUTPUT"
+
+      - name: Sparse checkout base branch
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ github.event.pull_request.base.ref }}
+          sparse-checkout: |
+            packages
+            web-packages
+          sparse-checkout-cone-mode: true
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Resolve package directory
+        id: resolve
+        env:
+          PACKAGE: ${{ steps.parse.outputs.package }}
+        run: |
+          if [ -d "packages/${PACKAGE}" ]; then
+            echo "pkg_dir=packages/${PACKAGE}" >> "$GITHUB_OUTPUT"
+          elif [ -d "web-packages/${PACKAGE}" ]; then
+            echo "pkg_dir=web-packages/${PACKAGE}" >> "$GITHUB_OUTPUT"
+          else
+            echo "::error::Package '${PACKAGE}' not found in packages/ or web-packages/"
+            exit 1
+          fi
+
+      - name: Get changed files
+        id: changes
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: |
+          CHANGED=$(gh pr diff "$PR_URL" --name-only)
+          echo "files<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$CHANGED" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+
+      - name: Check scope
+        id: scope
+        env:
+          PKG_DIR: ${{ steps.resolve.outputs.pkg_dir }}
+          CHANGED_FILES: ${{ steps.changes.outputs.files }}
+        run: |
+          OUT_OF_SCOPE=""
+
+          while IFS= read -r file; do
+            [ -z "$file" ] && continue
+
+            case "$file" in
+              pnpm-lock.yaml) continue ;;
+              .npmrc) continue ;;
+              .github/*) continue ;;
+              ${PKG_DIR}/*) continue ;;
+            esac
+
+            OUT_OF_SCOPE="${OUT_OF_SCOPE}${file}\n"
+          done <<< "$CHANGED_FILES"
+
+          if [ -n "$OUT_OF_SCOPE" ]; then
+            echo "status=fail" >> "$GITHUB_OUTPUT"
+            echo "files<<EOF" >> "$GITHUB_OUTPUT"
+            echo -e "$OUT_OF_SCOPE" >> "$GITHUB_OUTPUT"
+            echo "EOF" >> "$GITHUB_OUTPUT"
+          else
+            echo "status=pass" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Post or update PR comment
+        if: steps.scope.outputs.status == 'fail'
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+        env:
+          PACKAGE: ${{ steps.parse.outputs.package }}
+          PKG_DIR: ${{ steps.resolve.outputs.pkg_dir }}
+          SCOPE_STATUS: ${{ steps.scope.outputs.status }}
+          OUT_OF_SCOPE_FILES: ${{ steps.scope.outputs.files }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+        with:
+          script: |
+            const marker = '<!-- support-branch-scope-check -->';
+            const pkg = process.env.PACKAGE;
+            const pkgDir = process.env.PKG_DIR;
+            const status = process.env.SCOPE_STATUS;
+            const outOfScope = (process.env.OUT_OF_SCOPE_FILES || '').trim();
+            const baseRef = process.env.BASE_REF;
+
+            let body = `${marker}\n`;
+            body += `## Support Branch Scope — \`${baseRef}\`\n\n`;
+            body += `> [!CAUTION]\n`;
+            body += `> This PR modifies files outside \`${pkgDir}/\`. Support branches should only contain changes scoped to their package.\n\n`;
+            body += `**Out-of-scope files:**\n`;
+            for (const f of outOfScope.split('\n').filter(Boolean)) {
+              body += `- \`${f}\`\n`;
+            }
+            body += `\n---\n\n`;
+
+            body += `### Need to update a workspace dependency (e.g. \`apollo-core\`)?\n\n`;
+            body += `This branch locks workspace deps to exact versions (e.g. \`5.9.0\` instead of \`workspace:*\`) `;
+            body += `and resolves them from the registry. `;
+            body += `Bumping the version in \`${pkgDir}/package.json\` and running \`pnpm install\` will fetch the new version.\n\n`;
+            body += `If your fix requires changes in a sibling package (e.g. \`apollo-core\`):\n\n`;
+            body += `1. **If the dependency is still on the same major on \`main\`** — land the fix on \`main\`, `;
+            body += `let it publish a new version, then bump the version in this branch's `;
+            body += `\`${pkgDir}/package.json\` and run \`pnpm install\` to update the lockfile.\n`;
+            body += `2. **If the dependency needs a support branch too** — cut a support branch for that package `;
+            body += `(e.g. \`support/apollo-core@5.x\`), publish the fix from there, then update the dependency version here.\n`;
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+
+            const existing = comments.find(c => c.body?.includes(marker));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }
+
+      - name: Remove comment if scope is clean
+        if: steps.scope.outputs.status != 'fail'
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+        with:
+          script: |
+            const marker = '<!-- support-branch-scope-check -->';
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const existing = comments.find(c => c.body?.includes(marker));
+            if (existing) {
+              await github.rest.issues.deleteComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+              });
+            }
+
+      - name: Fail if out of scope
+        if: steps.scope.outputs.status == 'fail'
+        run: |
+          echo "::error::PR contains changes outside the allowed package scope. See the PR comment for details."
+          exit 1

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,1 +1,5 @@
+# Allow fixup/squash commits locally (pre-push and CI reject them before merge)
+if head -1 "$1" | grep -qE '^(fixup|squash)! '; then
+  exit 0
+fi
 pnpm exec commitlint --edit "$1"

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,10 @@
+# Reject fixup/squash commits before push — they must be rebased first.
+REMOTE_REF=$(git rev-parse @{upstream} 2>/dev/null) || exit 0
+FIXUPS=$(git log --oneline "$REMOTE_REF"..HEAD --grep='^fixup! \|^squash! ' --format='%s' 2>/dev/null)
+if [ -n "$FIXUPS" ]; then
+  echo "Error: found fixup/squash commits that must be rebased before pushing:"
+  echo "$FIXUPS" | while read -r line; do echo "  - $line"; done
+  echo ""
+  echo "Run: git rebase -i --autosquash $REMOTE_REF"
+  exit 1
+fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -356,42 +356,37 @@ Examples: `support/apollo-react@3.x`, `support/apollo-core@5.x`
 
 ### When to Create a Maintenance Branch
 
-Create one when you ship a new major version and need to continue supporting the previous major for existing consumers.
+Create one when main has moved to a newer major and you need to continue shipping fixes for the previous major.
 
 ### Creating a Maintenance Branch
 
-Use the helper script:
+Use the Claude Code skill:
 
-```bash
-scripts/create-maintenance-branch.sh apollo-react 3
+```
+"Create a support branch for apollo-react v3"
 ```
 
-This will:
-1. Find the latest `@uipath/apollo-react@3.*` tag
-2. Create `support/apollo-react@3.x` from that tag
-3. Configure semantic-release on the new branch
-4. Print next steps
+The skill (`.claude/skills/cut-maintenance-branch/SKILL.md`) handles the full workflow:
+1. Finds the latest `@uipath/apollo-react@3.*` tag
+2. Creates and pushes `support/apollo-react@3.x` bare from that tag
+3. Opens a PR to the support branch that locks `workspace:*` deps to concrete versions, replaces `"main"` in `.releaserc.json` with the support branch entry, and regenerates the lockfile
 
-After running the script:
-1. Push the maintenance branch: `git push -u origin 'support/apollo-react@3.x'`
-2. On `main`, update `packages/apollo-react/.releaserc.json` to add the maintenance branch entry **before** `"main"` in the `branches` array:
-   ```json
-   "branches": [
-     { "name": "support/apollo-react@3.x", "range": "3.x", "channel": "latest-v3" },
-     "main"
-   ]
-   ```
+Each support branch owns its own `.releaserc.json` — main's `.releaserc.json` is never modified. The support branch's `branches` array contains only its own entry (not `"main"`).
 
 ### Backporting Fixes
 
-Cherry-pick from `main` or create a PR targeting the maintenance branch directly:
+Create a PR targeting the maintenance branch directly:
 
 ```bash
 git checkout support/apollo-react@3.x
-git cherry-pick <sha>
-git push
-# → CI releases apollo-react@3.70.4 with dist-tag `latest-v3`
+git checkout -b fix/my-fix
+# make changes
+git push -u origin fix/my-fix
+# open PR targeting support/apollo-react@3.x
+# → after merge, CI releases apollo-react@3.70.4 with dist-tag `latest-v3`
 ```
+
+A scope check workflow enforces that PRs to support branches only modify files within the target package's directory.
 
 ### Installing Maintenance Releases
 
@@ -405,9 +400,12 @@ npm install @uipath/apollo-react@latest-v3
 npm install @uipath/apollo-react@3.70.4
 ```
 
-### Cross-Package Fixes
+### Cross-Package Dependency Updates
 
-If a fix touches multiple packages (e.g., `apollo-core` and `apollo-react`), add the maintenance branch entry to each package's `.releaserc.json`. Both packages will be released from the same push.
+Support branches lock workspace deps to exact versions (e.g., `5.9.0` instead of `workspace:*`). If a fix requires a newer version of a sibling package:
+
+1. **If the dependency is still on the same major on `main`** — land the fix on `main`, let it publish, then bump the version in the support branch's `package.json` and run `pnpm install`.
+2. **If the dependency needs its own support branch** — cut one (e.g., `support/apollo-core@5.x`), publish the fix from there, then update the version here.
 
 ### How Other Packages Behave
 

--- a/packages/apollo-react/.releaserc.json
+++ b/packages/apollo-react/.releaserc.json
@@ -1,13 +1,6 @@
 {
   "extends": "semantic-release-monorepo",
-  "branches": [
-    {
-      "name": "support/apollo-react@3.x",
-      "range": "3.x",
-      "channel": "latest-v3"
-    },
-    "main"
-  ],
+  "branches": ["main"],
   "tagFormat": "@uipath/apollo-react@${version}",
   "plugins": [
     [

--- a/scripts/maintenance-branch/lock-workspace-deps.sh
+++ b/scripts/maintenance-branch/lock-workspace-deps.sh
@@ -1,15 +1,15 @@
 #!/bin/bash
-# Lock workspace:* dependencies in a single package.json to concrete versioned
-# ranges, sourced from sibling packages' version field.
+# Lock workspace dependencies in a single package.json to concrete versions,
+# sourced from sibling packages' version field.
 #
 # Usage:
 #   scripts/maintenance-branch/lock-workspace-deps.sh <package-json-path> [--operator=^|~|=]
 #
-# Behavior:
-#   workspace:*      → <operator><version>   (default operator: ^)
-#   workspace:^      → ^<version>
-#   workspace:~      → ~<version>
-#   workspace:X.Y.Z  → X.Y.Z                 (workspace: prefix dropped)
+# Behavior (default operator: = → exact pin):
+#   workspace:*      → <version>          (or <operator><version> with --operator)
+#   workspace:^      → <version>          (or <operator><version> with --operator)
+#   workspace:~      → <version>          (or <operator><version> with --operator)
+#   workspace:X.Y.Z  → X.Y.Z             (explicit version, workspace: prefix dropped)
 #
 # - Reads sibling versions from packages/*/package.json and web-packages/*/package.json.
 #   (apps/* are intentionally excluded — they are not published.)
@@ -22,7 +22,7 @@
 set -euo pipefail
 
 PACKAGE_JSON=""
-OPERATOR="^"
+OPERATOR="="
 
 for arg in "$@"; do
   case "$arg" in
@@ -86,9 +86,8 @@ jq --argjson siblings "$SIBLING_VERSIONS" --arg defaultOp "$OPERATOR" '
               error("workspace dep \($name) has no resolvable version in workspace")
             else
               .value = (
-                if $spec == "*" then "\($defaultOp)\($version)"
-                elif $spec == "^" then "^\($version)"
-                elif $spec == "~" then "~\($version)"
+                if $spec == "*" or $spec == "^" or $spec == "~" then
+                  (if $defaultOp == "=" then $version else "\($defaultOp)\($version)" end)
                 else $spec
                 end
               )

--- a/scripts/maintenance-branch/update-releaserc.sh
+++ b/scripts/maintenance-branch/update-releaserc.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-# Add (or replace) a maintenance-branch entry in a single .releaserc.json's
-# "branches" array, immediately before "main".
+# Replace "main" with a maintenance-branch entry in a single .releaserc.json's
+# "branches" array.
 #
 # Usage:
 #   scripts/maintenance-branch/update-releaserc.sh <releaserc-path> <branch-name> <major>
@@ -9,8 +9,9 @@
 #   scripts/maintenance-branch/update-releaserc.sh \
 #     packages/apollo-react/.releaserc.json support/apollo-react@3.x 3
 #
-# - Inserts {"name": <branch>, "range": "<major>.x", "channel": "latest-v<major>"}
-#   immediately before the "main" entry. Preserves order of all other entries.
+# - Replaces the "main" entry with {"name": <branch>, "range": "<major>.x",
+#   "channel": "latest-v<major>"}. Each support branch owns its own release
+#   config — main's .releaserc.json is never modified.
 # - Idempotent: if an entry with the same name already exists, it is replaced
 #   in place.
 # - If no "main" entry exists, the new entry is appended.
@@ -48,10 +49,11 @@ jq --arg name "$BRANCH" --arg range "${MAJOR}.x" --arg channel "$CHANNEL" '
   | { name: $name, range: $range, channel: $channel } as $entry
   | ($existing | map((type == "object" and .name == $name) or . == $name) | index(true)) as $existing_idx
   | ($existing | map((type == "object" and .name == "main") or . == "main") | index(true)) as $main_idx
-  | if $existing_idx != null then
-      .branches = ($existing | .[0:$existing_idx] + [$entry] + .[$existing_idx+1:])
+  | def remove_main: map(select(((type == "object" and .name == "main") or . == "main") | not));
+    if $existing_idx != null then
+      .branches = ($existing | .[0:$existing_idx] + [$entry] + .[$existing_idx+1:] | remove_main)
     elif $main_idx != null then
-      .branches = ($existing | .[0:$main_idx] + [$entry] + .[$main_idx:])
+      .branches = ($existing | .[0:$main_idx] + [$entry] + .[$main_idx+1:] | remove_main)
     else
       .branches = ($existing + [$entry])
     end


### PR DESCRIPTION
## Summary

Refactors the `cut-maintenance-branch` skill, supporting scripts, adds a scope enforcement workflow for support branches, and updates docs and git hooks.

### Skill and script changes

- **Self-contained release config** — `update-releaserc.sh` now *replaces* the `"main"` entry with the support branch entry instead of inserting before it. `remove_main` applied in both jq code paths to handle duplicate entries. Each support branch owns its own `.releaserc.json`; main is never modified.
- **Clean up main** — Removes the `support/apollo-react@3.x` entry from `packages/apollo-react/.releaserc.json` on main (added by #500), restoring it to `["main"]` only.
- **PR-based workflow** — The skill now pushes the support branch bare (at the tag point, no modifications), then opens a configuration PR targeting it. Previously, changes were committed directly to the support branch.
- **Exact version pinning** — `lock-workspace-deps.sh` now defaults to `=` (exact pin, e.g. `5.9.0`) instead of `^`. All workspace protocols (`workspace:*`, `workspace:^`, `workspace:~`) are pinned with the chosen operator. `--operator=^|~|=` is still supported to override. The skill prompts for the operator, defaulting to exact pin.
- **Any major version** — The skill works for any major that has published tags, not just during/after a major bump.
- **Scripts sourced from `origin/main`** — Phase 4 runs transform scripts via `git show origin/main:scripts/...` from the repo root, to handle tags that predate the scripts and avoid stale local refs.
- **Remote branch pre-check** — Added `git ls-remote` pre-flight step to detect if the support branch already exists on the remote.
- **Removed companion main-side PR** — The old Phase 6 (worktree-based PR to add the support entry to main's `.releaserc.json`) is eliminated entirely.

### Support branch scope check (new workflow)

New `support-branch-scope.yml` workflow that runs on PRs targeting `support/**` branches:

- Uses sparse checkout of the base branch to resolve the package directory (`packages/` or `web-packages/`)
- Parses the package name from the branch (e.g. `support/apollo-react@3.x` → `apollo-react`)
- Fails if the PR modifies files outside the package directory (lockfile, `.npmrc`, `.github/` are always allowed)
- Posts a PR comment on failure listing out-of-scope files and explaining how to update workspace dependencies
- Cleans up the comment when the scope issue is fixed

### Git hooks

- **`.husky/commit-msg`** — Allows `fixup!` and `squash!` commits locally (bypasses commitlint) so they can be used with `git rebase --autosquash`
- **`.husky/pre-push`** — Rejects any unpushed fixup/squash commits with a helpful message showing the rebase command

### Documentation

- **`CONTRIBUTING.md`** — Updated maintenance branch section to document the skill-based workflow, self-contained branches, scope check, and cross-package dependency guidance. Removed references to deleted helper script and old "insert before main" approach.

### Files changed

| File | What changed |
|---|---|
| `scripts/maintenance-branch/lock-workspace-deps.sh` | Default operator `=` (exact pin), all workspace protocols use chosen operator |
| `scripts/maintenance-branch/update-releaserc.sh` | Replaces `"main"`, `remove_main` in both code paths, explicit jq parens |
| `packages/apollo-react/.releaserc.json` | Removed support branch entry, back to `["main"]` |
| `.claude/skills/cut-maintenance-branch/SKILL.md` | 7-phase PR-based flow, `origin/main` scripts, operator prompt, exact pin default |
| `.github/workflows/support-branch-scope.yml` | New scope enforcement workflow (sparse checkout + case-based matching) |
| `.husky/commit-msg` | Allow fixup/squash commits locally |
| `.husky/pre-push` | Reject fixup/squash commits before push |
| `CONTRIBUTING.md` | Updated maintenance branch docs |

## Test plan

- [ ] Verify `update-releaserc.sh` replaces `"main"` correctly and handles duplicate "main" entries
- [ ] Verify `lock-workspace-deps.sh` pins to exact versions by default, respects `--operator=^`
- [ ] Verify `apollo-react/.releaserc.json` on main has only `["main"]` after merge
- [ ] Verify scope check workflow passes for in-scope changes and fails for out-of-scope
- [ ] Verify `git commit --fixup` works locally, `git push` rejects unsquashed fixups
- [ ] Run the skill end-to-end on a test package to confirm the 7-phase flow