### PR TITLE
ci(apollo-wind): configure support/apollo-wind@1.x maintenance branch

### DIFF
--- a/packages/apollo-wind/.releaserc.json
+++ b/packages/apollo-wind/.releaserc.json
@@ -1,6 +1,13 @@
 {
   "extends": "semantic-release-monorepo",
-  "branches": ["main"],
+  "branches": [
+    {
+      "name": "support/apollo-wind@1.x",
+      "range": "1.x",
+      "channel": "latest-v1"
+    },
+    "main"
+  ],
   "tagFormat": "@uipath/apollo-wind@${version}",
   "plugins": [
     [

--- a/packages/apollo-wind/package.json
+++ b/packages/apollo-wind/package.json
@@ -106,7 +106,7 @@
     "@radix-ui/react-tooltip": "^1.2.8",
     "@tailwindcss/postcss": "^4.1.17",
     "@tanstack/react-table": "^8.21.3",
-    "@uipath/apollo-core": "workspace:*",
+    "@uipath/apollo-core": "=5.8.1",
     "autoprefixer": "^10.4.22",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -916,8 +916,8 @@ importers:
         specifier: ^8.21.3
         version: 8.21.3(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@uipath/apollo-core':
-        specifier: workspace:*
-        version: link:../apollo-core
+        specifier: '=5.8.1'
+        version: 5.8.1
       autoprefixer:
         specifier: ^10.4.22
         version: 10.4.22(postcss@8.5.6)
@@ -5993,6 +5993,9 @@ packages:
     peerDependencies:
       react: '>=18.0.0'
       react-dom: '>=18.0.0'
+
+  '@uipath/apollo-core@5.8.1':
+    resolution: {integrity: sha512-2c4lbqH2+RJ/YR6gWs9WgInXyQnrkxosLLIYt0jzou/ohD13+Bm9lvKjJcOEPn4NnXjOLQvm/UsakcXUzhoKYg==, tarball: https://npm.pkg.github.com/download/@UiPath/apollo-core/5.8.1/dc987b5f24e764015c78f8681a810e63b6e835ea}
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
@@ -17807,6 +17810,8 @@ snapshots:
     dependencies:
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
+
+  '@uipath/apollo-core@5.8.1': {}
 
   '@ungap/structured-clone@1.3.0': {}
 


### PR DESCRIPTION
Configures the `support/apollo-wind@1.x` maintenance branch for independent releases.

## Changes

- **Locked workspace deps** — workspace dependencies pinned to exact versions (e.g. `5.8.1`) so the branch installs independently of main's workspace
- **Release config** — `.releaserc.json` updated: `"main"` replaced with the support branch entry (`range: 1.x`, `channel: latest-v1`)
- **Lockfile regenerated** — `pnpm-lock.yaml` updated to match locked dependencies

## Context

Branch cut from tag `@uipath/apollo-wind@1.5.0`. After this PR is merged, the branch is ready to receive fix PRs and publish `1.x.y` releases to the `latest-v1` npm dist-tag.
