### PR TITLE
fix(apollo-vertex): add nullish fallback for first_name indexed access

### DIFF
--- a/apps/apollo-vertex/registry/shell/shell-user-provider.tsx
+++ b/apps/apollo-vertex/registry/shell/shell-user-provider.tsx
@@ -44,7 +44,7 @@ export const ShellUserProvider: FC<PropsWithChildren> = ({ children }) => {
         id: authUser.sub,
         name: authUser.name,
         email: authUser.email,
-        first_name: nameParts[0],
+        first_name: nameParts[0] ?? authUser.name,
         last_name: nameParts.slice(1).join(" "),
       });
     } else {


### PR DESCRIPTION
Add `?? authUser.name` fallback to `nameParts[0]` so the code compiles in vertical projects with `noUncheckedIndexedAccess` enabled.