### PR TITLE
chore(apollo-vertex): remove @uipath/proteus-client dependency

### DIFF
--- a/apps/apollo-vertex/package.json
+++ b/apps/apollo-vertex/package.json
@@ -101,7 +101,6 @@
     "@types/node": "^24.10.1",
     "@types/react": "^19.2.6",
     "@types/react-dom": "^19.2.2",
-    "@uipath/proteus-client": "^0.1.10",
     "babel-plugin-react-compiler": "^1.0.0",
     "dependency-cruiser": "^17.3.6",
     "eslint-plugin-react": "^7.37.5",

--- a/apps/apollo-vertex/types/optional-deps.d.ts
+++ b/apps/apollo-vertex/types/optional-deps.d.ts
@@ -10,6 +10,37 @@ declare module "@tanstack/react-db" {
   };
 }
 
+declare module "@uipath/proteus-client" {
+  export enum FeatureFlagKind {
+    Boolean = "Boolean",
+    String = "String",
+    Number = "Number",
+  }
+
+  export type FlagConfig = {
+    kind: FeatureFlagKind;
+    alias: string;
+  };
+
+  export type FlagMapping<TFlag extends string> = Record<TFlag, FlagConfig>;
+
+  export type FeatureFlagValues<TFlag extends string> = Record<TFlag, unknown>;
+
+  export type ProteusInstance<TFlag extends string> = {
+    featureFlagValue(key: TFlag): unknown;
+    defaultFeatureFlagValue(key: TFlag): unknown;
+    addFlagChangeListener(key: TFlag, cb: (value: unknown) => void): void;
+    removeFlagChangeListener(key: TFlag, cb: (value: unknown) => void): void;
+    identity(context: Record<string, string | undefined>): Promise<void>;
+  };
+
+  export function initializeProteus<TFlag extends string>(options: {
+    appName: string;
+    featureFlags: FlagMapping<TFlag>;
+    authTokenFactory: () => string;
+  }): ProteusInstance<TFlag>;
+}
+
 declare module "@uipath/vs-core" {
   export function useSolution(): {
     api: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -329,9 +329,6 @@ importers:
       '@types/react-dom':
         specifier: ^19.2.2
         version: 19.2.3(@types/react@19.2.8)
-      '@uipath/proteus-client':
-        specifier: ^0.1.10
-        version: 0.1.10(axios@1.15.0)
       babel-plugin-react-compiler:
         specifier: ^1.0.0
         version: 1.0.0
@@ -6103,11 +6100,6 @@ packages:
     peerDependencies:
       typescript: '*'
 
-  '@uipath/proteus-client@0.1.10':
-    resolution: {integrity: sha512-LfneUhb7wrLsJG0QT3Qt14NIfA1azVVKbQXNOa4gpf9eNvHpvS7O37kw4KZkgpXYzo/lm5HDTNF2ldi8TKLovQ==, tarball: https://npm.pkg.github.com/download/@uipath/proteus-client/0.1.10/9e33d99a1e615cedc805326de910a6f8468d792e}
-    peerDependencies:
-      axios: ^1.7.9
-
   '@uipath/uipath-typescript@1.2.2':
     resolution: {integrity: sha512-wLi5P7m3k07C+JB3VXhRJlNslxCQ5R7N3SQ+Yoh6fw11s9kZOc8m4d9qteHwVL9eP3VW7T7Wd39DuJr40HnS/Q==, tarball: https://npm.pkg.github.com/download/@uipath/uipath-typescript/1.2.2/1042de9c613ce2bba6108b0498cfa040252dd004}
     peerDependencies:
@@ -6488,9 +6480,6 @@ packages:
   async@3.2.6:
     resolution: {integrity: sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==}
 
-  asynckit@0.4.0:
-    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
-
   at-least-node@1.0.0:
     resolution: {integrity: sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==}
     engines: {node: '>= 4.0.0'}
@@ -6521,9 +6510,6 @@ packages:
   axe-core@4.11.0:
     resolution: {integrity: sha512-ilYanEU8vxxBexpJd8cWM4ElSQq4QctCLKih0TSfjIfCQTeyH/6zVrmIJfLPrKTKJRbiG+cfnZbQIjAlJmF1jQ==}
     engines: {node: '>=4'}
-
-  axios@1.15.0:
-    resolution: {integrity: sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==}
 
   babel-plugin-macros@3.1.0:
     resolution: {integrity: sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==}
@@ -6872,10 +6858,6 @@ packages:
   colors@1.0.3:
     resolution: {integrity: sha512-pFGrxThWcWQ2MsAz6RtgeWe4NK2kUE1WfsrvvlctdII745EW9I0yflqhe7++M5LEc7bV2c/9/5zc8sFcpL0Drw==}
     engines: {node: '>=0.1.90'}
-
-  combined-stream@1.0.8:
-    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
-    engines: {node: '>= 0.8'}
 
   comma-separated-tokens@2.0.3:
     resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
@@ -7438,10 +7420,6 @@ packages:
 
   delaunator@5.0.1:
     resolution: {integrity: sha512-8nvh+XBe96aCESrGOqMp/84b13H9cdKbG5P2ejQCh4d4sK9RL4371qou9drQjMhvnPmhWl5hnmqbEE0fXr9Xnw==}
-
-  delayed-stream@1.0.0:
-    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
-    engines: {node: '>=0.4.0'}
 
   depd@2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
@@ -8039,15 +8017,6 @@ packages:
     resolution: {integrity: sha512-Ik/6OCk9RQQ0T5Xw+hKNLWrjSMtv51dD4GRmJjbD5a58TIEpI5a5iXagKVl3Z5UuyslMCA8Xwnu76jQob62Yhg==}
     engines: {node: '>=10'}
 
-  follow-redirects@1.16.0:
-    resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
-    engines: {node: '>=4.0'}
-    peerDependencies:
-      debug: '*'
-    peerDependenciesMeta:
-      debug:
-        optional: true
-
   for-each@0.3.5:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
     engines: {node: '>= 0.4'}
@@ -8055,10 +8024,6 @@ packages:
   foreground-child@3.3.1:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
-
-  form-data@4.0.5:
-    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
-    engines: {node: '>= 6'}
 
   format@0.2.2:
     resolution: {integrity: sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==}
@@ -10815,10 +10780,6 @@ packages:
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
-
-  proxy-from-env@2.1.0:
-    resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
-    engines: {node: '>=10'}
 
   prr@1.0.1:
     resolution: {integrity: sha512-yPw4Sng1gWghHQWj0B3ZggWUm4qVbPwPFcRG8KyxiU7J2OHFSoEHKS+EZ3fv5l1t9CyCiop6l/ZYeWbrgoQejw==}
@@ -18106,11 +18067,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@uipath/proteus-client@0.1.10(axios@1.15.0)':
-    dependencies:
-      axios: 1.15.0
-      zod: 3.25.76
-
   '@uipath/uipath-typescript@1.2.2(@opentelemetry/api@1.9.0)(zod@4.3.5)':
     dependencies:
       '@opentelemetry/sdk-logs': 0.204.0(@opentelemetry/api@1.9.0)
@@ -18559,8 +18515,6 @@ snapshots:
 
   async@3.2.6: {}
 
-  asynckit@0.4.0: {}
-
   at-least-node@1.0.0: {}
 
   attr-accept@2.2.5: {}
@@ -18584,14 +18538,6 @@ snapshots:
   axe-core@4.10.2: {}
 
   axe-core@4.11.0: {}
-
-  axios@1.15.0:
-    dependencies:
-      follow-redirects: 1.16.0
-      form-data: 4.0.5
-      proxy-from-env: 2.1.0
-    transitivePeerDependencies:
-      - debug
 
   babel-plugin-macros@3.1.0:
     dependencies:
@@ -18981,10 +18927,6 @@ snapshots:
   colorette@2.0.20: {}
 
   colors@1.0.3: {}
-
-  combined-stream@1.0.8:
-    dependencies:
-      delayed-stream: 1.0.0
 
   comma-separated-tokens@2.0.3: {}
 
@@ -19596,8 +19538,6 @@ snapshots:
   delaunator@5.0.1:
     dependencies:
       robust-predicates: 3.0.2
-
-  delayed-stream@1.0.0: {}
 
   depd@2.0.0: {}
 
@@ -20452,8 +20392,6 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  follow-redirects@1.16.0: {}
-
   for-each@0.3.5:
     dependencies:
       is-callable: 1.2.7
@@ -20462,14 +20400,6 @@ snapshots:
     dependencies:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
-
-  form-data@4.0.5:
-    dependencies:
-      asynckit: 0.4.0
-      combined-stream: 1.0.8
-      es-set-tostringtag: 2.1.0
-      hasown: 2.0.2
-      mime-types: 2.1.35
 
   format@0.2.2: {}
 
@@ -23600,8 +23530,6 @@ snapshots:
     dependencies:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
-
-  proxy-from-env@2.1.0: {}
 
   prr@1.0.1:
     optional: true

--- a/scripts/check-licenses.ts
+++ b/scripts/check-licenses.ts
@@ -65,9 +65,6 @@ const excludedPackages: Record<string, string> = {
   // Missing license field in package.json. Actual license is MIT per GitHub repo
   // (https://github.com/fabiospampinato/khroma). Transitive dep of mermaid.
   'khroma': 'MIT per GitHub repo, missing license field in package.json',
-  // UiPath internal package with "Proprietary" license. Used as a devDependency
-  // in apollo-vertex for type-checking the feature flag registry items.
-  '@uipath/proteus-client': 'UiPath internal package, Proprietary license',
 };
 
 /**


### PR DESCRIPTION
Removes `@uipath/proteus-client` from `apps/apollo-vertex/package.json` as it is a private registry dependency that should not be listed. The lockfile has been regenerated accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)