### PR TITLE
fix(apollo-wind): update storybook commands in Getting Started docs

### DIFF
--- a/packages/apollo-wind/src/getting-started/getting-started.stories.tsx
+++ b/packages/apollo-wind/src/getting-started/getting-started.stories.tsx
@@ -360,7 +360,7 @@ function ChooseYourPackageTab() {
         description="The modern UI component library for rapid prototyping and new product interfaces. Built with Tailwind CSS and shadcn/ui — includes 60+ components, page templates, and full theming support."
         bestFor="Prototyping, new product UIs, and any project using Tailwind CSS."
         consumerInstall="npm install @uipath/apollo-wind"
-        localDevCommands={`pnpm build\npnpm storybook:wind`}
+        localDevCommands={`pnpm build\npnpm storybook:dev`}
       />
 
       <PackageCard
@@ -369,7 +369,7 @@ function ChooseYourPackageTab() {
         description="The component library for UiPath workflows and automation products. Built on Material UI with Apollo theming — provides the components and patterns used across workflow-based experiences."
         bestFor="Workflow interfaces, automation products, and existing Material UI projects."
         consumerInstall="npm install @uipath/apollo-react"
-        localDevCommands={`pnpm build\npnpm storybook:all`}
+        localDevCommands={`pnpm build\npnpm storybook:dev`}
       />
 
       <PackageCard
@@ -602,7 +602,7 @@ pnpm install
 pnpm build
 
 # Start the Apollo Wind Storybook
-pnpm storybook:wind`}
+pnpm storybook:dev`}
       </CodeBlock>
 
       <CodeBlock label="Development">
@@ -610,7 +610,7 @@ pnpm storybook:wind`}
 pnpm dev
 
 # Run Storybook
-pnpm storybook
+pnpm storybook:dev
 
 # Lint all packages
 pnpm lint


### PR DESCRIPTION
## Summary

- Replaces the removed `pnpm storybook:wind` script with `pnpm storybook:dev` in the Apollo Wind and Contributing "Run locally" tabs
- Also fixes `pnpm storybook:all` (Apollo React card) and `pnpm storybook` (Contributing dev block), neither of which exist in the root `package.json`

All four references now point to `pnpm storybook:dev` (`turbo run storybook`), which is the correct command for running Storybook locally across the monorepo.

## Test plan

- [ ] Run `pnpm storybook:dev` locally and confirm Storybook starts
- [ ] Open the **Introduction / Getting Started** story → **Choose your package** → **Run locally** tab for Apollo Wind and Apollo React — commands should read `pnpm storybook:dev`
- [ ] Open **Contributing to Apollo** tab — setup and development blocks should both reference `pnpm storybook:dev`

🤖 Generated with [Claude Code](https://claude.com/claude-code)