### PR TITLE
fix(apollo-wind): use surface-hover token for table row hover state

### DIFF
--- a/packages/apollo-wind/src/components/ui/table.tsx
+++ b/packages/apollo-wind/src/components/ui/table.tsx
@@ -44,7 +44,7 @@ const TableRow = React.forwardRef<HTMLTableRowElement, React.HTMLAttributes<HTML
     <tr
       ref={ref}
       className={cn(
-        'border-b transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted',
+        'border-b transition-colors hover:bg-surface-hover data-[state=selected]:bg-muted',
         className
       )}
       {...props}


### PR DESCRIPTION
## Summary

- Fixes missing row hover state in the Data Table across all Apollo Wind themes
- Root cause: `hover:bg-muted/50` was invisible in the `light` core theme because `--muted` resolves to `--surface-raised` (`#ffffff`) — the same value as `--background`
- Fix: replace with `hover:bg-surface-hover`, the token purpose-built for interactive hover states, which is visually distinct from the background in every theme

| Theme | `--surface-hover` value |
|---|---|
| `light` | `#e9f1fa` |
| `dark` | `#374652` |
| `future-light` | `zinc-300` |
| `future-dark` | `zinc-700` |

## Test plan

- [ ] Open Data Table → Basic story and verify row hover is visible in `light` theme
- [ ] Verify hover is visible in `dark`, `future-light`, and `future-dark` themes
- [ ] Confirm selected row state (`data-[state=selected]:bg-muted`) is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)