### PR TITLE
feat(docs): What's New page, Overview nav, and URL-synced tabs

### DIFF
--- a/apps/apollo-docs/app/_meta.ts
+++ b/apps/apollo-docs/app/_meta.ts
@@ -1,6 +1,6 @@
 export default {
   index: { display: 'hidden' },
-  introduction: 'Introduction',
+  introduction: 'Overview',
   theme: 'Theme',
   components: 'Components',
   templates: 'Templates',

--- a/apps/apollo-docs/app/globals.css
+++ b/apps/apollo-docs/app/globals.css
@@ -98,3 +98,220 @@
   --input: var(--ap-wind-border);
   --x-color-nextra-bg: var(--background);
 }
+
+/* ─── Navbar layout ────────────────────────────────────────────────────────── */
+
+/*
+ * Nextra renders inside <nav>: [logo] [sidebar-nav-items-div.nextra-scrollbar.me-auto]
+ * [search-div.x:max-md:hidden] [our children: GitHub, Storybook] [hamburger]
+ *
+ * The search-div is the only <div> without "nextra-scrollbar" in its class.
+ * We use CSS order to push search after our nav links, giving the standard
+ * docs layout: [Logo] [Sections…] → [GitHub] [Storybook] [Search] [☰]
+ */
+.nextra-navbar nav > div:not([class*="nextra-scrollbar"]) {
+  order: 1;
+}
+.nextra-navbar .nextra-hamburger {
+  order: 2;
+}
+
+/* ─── Navbar links ─────────────────────────────────────────────────────────── */
+.nav-link {
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--foreground-muted);
+  text-decoration: none;
+  transition: color 0.15s;
+}
+.nav-link:hover { color: var(--foreground); }
+
+/* ─── What's New page ──────────────────────────────────────────────────────── */
+.whats-new-page { max-width: 52rem; }
+
+.whats-new-title {
+  font-size: 1.875rem;
+  font-weight: 700;
+  margin-bottom: 0.5rem;
+  color: var(--foreground);
+}
+
+.whats-new-subtitle {
+  color: var(--foreground-muted);
+  margin-bottom: 2rem;
+  font-size: 1rem;
+}
+
+/* Tabs */
+.wn-tab-bar {
+  display: flex;
+  border-bottom: 1px solid var(--ap-wind-border);
+  margin-bottom: 2rem;
+}
+
+.wn-tab-btn {
+  padding: 0 1rem 0.75rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+  cursor: pointer;
+  color: var(--foreground-muted);
+  background: none;
+  border: none;
+  border-bottom: 2px solid transparent;
+  margin-bottom: -1px;
+  transition: color 0.15s, border-color 0.15s;
+}
+.wn-tab-btn:hover { color: var(--foreground); }
+.wn-tab-btn--active {
+  color: var(--foreground);
+  border-bottom-color: var(--primary);
+}
+
+/* Release Notes */
+.releases-list { display: flex; flex-direction: column; gap: 1.25rem; }
+
+.releases-empty { color: var(--foreground-muted); font-size: 0.875rem; }
+.releases-empty a { color: var(--primary); }
+
+.release-card {
+  border: 1px solid var(--ap-wind-border);
+  border-radius: 0.625rem;
+  padding: 1.25rem 1.5rem;
+}
+
+.release-card__header {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.625rem;
+  margin-bottom: 0.875rem;
+}
+
+.release-badge {
+  font-size: 0.7rem;
+  font-weight: 600;
+  padding: 0.2rem 0.625rem;
+  border-radius: 9999px;
+  border: 1px solid;
+  letter-spacing: 0.02em;
+}
+.badge-wind  { background: color-mix(in srgb, #8b5cf6 12%, transparent); color: #a78bfa; border-color: color-mix(in srgb, #8b5cf6 25%, transparent); }
+.badge-react { background: color-mix(in srgb, #3b82f6 12%, transparent); color: #60a5fa; border-color: color-mix(in srgb, #3b82f6 25%, transparent); }
+.badge-core  { background: color-mix(in srgb, #10b981 12%, transparent); color: #34d399; border-color: color-mix(in srgb, #10b981 25%, transparent); }
+
+.release-date { font-size: 0.75rem; color: var(--foreground-muted); }
+
+.release-gh-link {
+  margin-left: auto;
+  font-size: 0.75rem;
+  color: var(--primary);
+  text-decoration: none;
+}
+.release-gh-link:hover { text-decoration: underline; }
+
+/* Package selector */
+.pkg-selector {
+  display: flex;
+  gap: 0.25rem;
+  background: color-mix(in srgb, var(--ap-wind-border) 35%, transparent);
+  border-radius: 0.5rem;
+  padding: 0.25rem;
+  width: fit-content;
+  margin-bottom: 1.5rem;
+}
+
+.pkg-btn {
+  padding: 0.375rem 0.875rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+  border-radius: 0.375rem;
+  cursor: pointer;
+  color: var(--foreground-muted);
+  background: none;
+  border: none;
+  transition: color 0.15s;
+}
+.pkg-btn:hover { color: var(--foreground); }
+.pkg-btn--active {
+  background: var(--surface-raised);
+  color: var(--foreground);
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.15);
+}
+
+/* Markdown rendering */
+.markdown-body {
+  font-size: 0.875rem;
+  line-height: 1.75;
+  color: var(--foreground-muted);
+}
+.markdown-body h1,
+.markdown-body h2 {
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--foreground);
+  margin: 1.5rem 0 0.5rem;
+}
+.markdown-body h3 {
+  font-size: 0.7rem;
+  font-weight: 700;
+  color: var(--foreground-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  margin: 1rem 0 0.375rem;
+}
+.markdown-body ul { list-style: disc; padding-left: 1.5rem; margin: 0.375rem 0; }
+.markdown-body li { margin: 0.2rem 0; }
+.markdown-body a { color: var(--primary); text-decoration: none; }
+.markdown-body a:hover { text-decoration: underline; }
+.markdown-body strong { color: var(--foreground); font-weight: 600; }
+.markdown-body code {
+  background: var(--surface-overlay);
+  padding: 0.1rem 0.375rem;
+  border-radius: 0.25rem;
+  font-size: 0.8em;
+  font-family: ui-monospace, monospace;
+}
+
+/* Changelog-specific: version headers get a divider */
+.changelog-body h2 {
+  border-bottom: 1px solid var(--ap-wind-border);
+  padding-bottom: 0.5rem;
+  margin-top: 2rem;
+}
+
+/* ─── LinkedTabs (URL-synced tabs for installation page) ───────────────────── */
+.linked-tabs__bar {
+  display: flex;
+  border-bottom: 1px solid var(--ap-wind-border);
+  margin-bottom: 1.5rem;
+}
+
+.linked-tabs__btn {
+  padding: 0 1rem 0.75rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+  cursor: pointer;
+  color: var(--foreground-muted);
+  background: none;
+  border: none;
+  border-bottom: 2px solid transparent;
+  margin-bottom: -1px;
+  transition: color 0.15s, border-color 0.15s;
+}
+.linked-tabs__btn:hover { color: var(--foreground); }
+.linked-tabs__btn--active {
+  color: var(--foreground);
+  border-bottom-color: var(--primary);
+}
+
+/* ─── Navbar version badge ─────────────────────────────────────────────────── */
+.nav-version {
+  font-size: 0.75rem;
+  font-weight: 600;
+  padding: 0.2rem 0.5rem;
+  border-radius: 9999px;
+  border: 1px solid var(--ap-wind-border);
+  color: var(--foreground-muted);
+  letter-spacing: 0.02em;
+  white-space: nowrap;
+}

--- a/apps/apollo-docs/app/introduction/_meta.ts
+++ b/apps/apollo-docs/app/introduction/_meta.ts
@@ -1,5 +1,6 @@
 export default {
   overview: 'What is Apollo?',
+  'whats-new': "What's New",
   installation: 'Installation',
   prototyping: 'Prototyping',
   cli: 'CLI',

--- a/apps/apollo-docs/app/introduction/installation/page.mdx
+++ b/apps/apollo-docs/app/introduction/installation/page.mdx
@@ -1,4 +1,4 @@
-import { Tabs } from 'nextra/components'
+import { LinkedTabs } from '../../../components/LinkedTabs';
 
 # Installation
 
@@ -12,65 +12,70 @@ Apollo v.4 is UiPath's open-source design system for building consistent user ex
 
 Apollo is split into focused packages. Pick the one that matches what you're building.
 
-<Tabs items={['apollo-core', 'apollo-wind', 'apollo-react']}>
-  <Tabs.Tab>
-    ### `@uipath/apollo-core`
+<LinkedTabs items={['apollo-core', 'apollo-wind', 'apollo-react']}>
+<div>
 
-    The shared foundation — design tokens, icons, fonts, and CSS variables. Both Apollo Wind and Apollo React depend on this package. Install it directly only if you need tokens without a component library.
+### `@uipath/apollo-core`
 
-    **Best for:** Custom builds that need design tokens, icons, or fonts without a full component library.
+The shared foundation — design tokens, icons, fonts, and CSS variables. Both Apollo Wind and Apollo React depend on this package. Install it directly only if you need tokens without a component library.
 
-    **Install**
+**Best for:** Custom builds that need design tokens, icons, or fonts without a full component library.
 
-    ```bash
-    npm install @uipath/apollo-core
-    ```
+**Install**
 
-    **Run locally**
+```bash
+npm install @uipath/apollo-core
+```
 
-    ```bash
-    pnpm build
-    ```
-  </Tabs.Tab>
-  <Tabs.Tab>
-    ### `@uipath/apollo-wind`
+**Run locally**
 
-    The modern UI component library for rapid prototyping and new product interfaces. Built with Tailwind CSS and shadcn/ui — includes 60+ components, page templates, and full theming support.
+```bash
+pnpm build
+```
 
-    **Best for:** Prototyping, new product UIs, and any project using Tailwind CSS.
+</div>
+<div>
 
-    **Install**
+### `@uipath/apollo-wind`
 
-    ```bash
-    npm install @uipath/apollo-wind
-    ```
+The modern UI component library for rapid prototyping and new product interfaces. Built with Tailwind CSS and shadcn/ui — includes 60+ components, page templates, and full theming support.
 
-    **Run locally** (after cloning the monorepo and running `pnpm install`)
+**Best for:** Prototyping, new product UIs, and any project using Tailwind CSS.
 
-    ```bash
-    pnpm build
-    pnpm storybook:wind
-    ```
-  </Tabs.Tab>
-  <Tabs.Tab>
-    ### `@uipath/apollo-react`
+**Install**
 
-    The component library for UiPath workflows and automation products. Built on Material UI with Apollo theming — provides the components and patterns used across workflow-based experiences.
+```bash
+npm install @uipath/apollo-wind
+```
 
-    **Best for:** Workflow interfaces, automation products, and existing Material UI projects.
+**Run locally** (after cloning the monorepo and running `pnpm install`)
 
-    **Install**
+```bash
+pnpm build
+pnpm storybook:dev
+```
 
-    ```bash
-    npm install @uipath/apollo-react
-    ```
+</div>
+<div>
 
-    **Run locally**
+### `@uipath/apollo-react`
 
-    ```bash
-    pnpm build
-    pnpm storybook:all
-    ```
-  </Tabs.Tab>
-</Tabs>
+The component library for UiPath workflows and automation products. Built on Material UI with Apollo theming — provides the components and patterns used across workflow-based experiences.
 
+**Best for:** Workflow interfaces, automation products, and existing Material UI projects.
+
+**Install**
+
+```bash
+npm install @uipath/apollo-react
+```
+
+**Run locally**
+
+```bash
+pnpm build
+pnpm storybook:dev
+```
+
+</div>
+</LinkedTabs>

--- a/apps/apollo-docs/app/introduction/whats-new/page.mdx
+++ b/apps/apollo-docs/app/introduction/whats-new/page.mdx
@@ -1,0 +1,8 @@
+import { WhatsNewPage } from '../../../components/WhatsNewPage';
+
+export const metadata = {
+  title: "What's New",
+  description: 'Apollo UI release notes and changelog across all packages.',
+};
+
+<WhatsNewPage />

--- a/apps/apollo-docs/app/layout.tsx
+++ b/apps/apollo-docs/app/layout.tsx
@@ -16,10 +16,26 @@ export const metadata = {
 
 const navbar = (
   <Navbar
-    logo={
-      <b style={{ fontWeight: 700, fontSize: '1.1rem' }}>Apollo UI</b>
-    }
-  />
+    logo={<b style={{ fontWeight: 700, fontSize: '1.1rem' }}>Apollo UI</b>}
+    align="left"
+  >
+    <a
+      href="https://github.com/UiPath/apollo-ui"
+      target="_blank"
+      rel="noopener noreferrer"
+      className="nav-link"
+    >
+      GitHub
+    </a>
+    <a
+      href="https://apollo-design.vercel.app"
+      target="_blank"
+      rel="noopener noreferrer"
+      className="nav-link"
+    >
+      Storybook
+    </a>
+  </Navbar>
 );
 
 const footer = (
@@ -27,6 +43,7 @@ const footer = (
 );
 
 export default async function RootLayout({ children }: { children: ReactNode }) {
+
   return (
     <html
       lang="en"

--- a/apps/apollo-docs/components/LinkedTabs.tsx
+++ b/apps/apollo-docs/components/LinkedTabs.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+import { Children, Suspense, type ReactNode } from 'react';
+
+interface LinkedTabsProps {
+  items: string[];
+  children: ReactNode;
+  /** URL search param key — defaults to "pkg" */
+  paramName?: string;
+}
+
+function LinkedTabsInner({ items, children, paramName = 'pkg' }: LinkedTabsProps) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  const activeId = searchParams.get(paramName) ?? items[0];
+  const activeIndex = Math.max(0, items.indexOf(activeId));
+
+  const panels = Children.toArray(children);
+
+  function setTab(item: string) {
+    const params = new URLSearchParams(searchParams.toString());
+    params.set(paramName, item);
+    router.push(`${pathname}?${params.toString()}`, { scroll: false });
+  }
+
+  return (
+    <div className="linked-tabs">
+      <div className="linked-tabs__bar">
+        {items.map((item) => (
+          <button
+            key={item}
+            type="button"
+            onClick={() => setTab(item)}
+            className={`linked-tabs__btn${activeId === item ? ' linked-tabs__btn--active' : ''}`}
+          >
+            {item}
+          </button>
+        ))}
+      </div>
+      <div className="linked-tabs__panel">
+        {panels[activeIndex]}
+      </div>
+    </div>
+  );
+}
+
+export function LinkedTabs(props: LinkedTabsProps) {
+  return (
+    <Suspense>
+      <LinkedTabsInner {...props} />
+    </Suspense>
+  );
+}

--- a/apps/apollo-docs/components/WhatsNewPage.tsx
+++ b/apps/apollo-docs/components/WhatsNewPage.tsx
@@ -1,0 +1,184 @@
+'use client';
+
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+import { Suspense, useEffect, useState } from 'react';
+import ReactMarkdown from 'react-markdown';
+
+export interface Release {
+  id: number;
+  tag_name: string;
+  name: string;
+  body: string;
+  published_at: string;
+  html_url: string;
+}
+
+const TABS = [
+  { id: 'release-notes', label: 'Release Notes' },
+  { id: 'changelog', label: 'Changelog' },
+] as const;
+
+const PACKAGES = ['apollo-wind', 'apollo-react', 'apollo-core'] as const;
+
+const CHANGELOG_URLS: Record<string, string> = {
+  'apollo-wind': 'https://raw.githubusercontent.com/UiPath/apollo-ui/main/packages/apollo-wind/CHANGELOG.md',
+  'apollo-react': 'https://raw.githubusercontent.com/UiPath/apollo-ui/main/packages/apollo-react/CHANGELOG.md',
+  'apollo-core': 'https://raw.githubusercontent.com/UiPath/apollo-ui/main/packages/apollo-core/CHANGELOG.md',
+};
+
+function packageBadgeClass(tag: string) {
+  if (tag.includes('apollo-wind')) return 'badge-wind';
+  if (tag.includes('apollo-react')) return 'badge-react';
+  return 'badge-core';
+}
+
+function formatDate(iso: string) {
+  return new Date(iso).toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  });
+}
+
+function WhatsNewContent() {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  const activeTab = searchParams.get('tab') ?? 'release-notes';
+  const activePkg = (searchParams.get('pkg') ?? 'apollo-wind') as typeof PACKAGES[number];
+
+  const [releases, setReleases] = useState<Release[]>([]);
+  const [changelogs, setChangelogs] = useState<Record<string, string>>({});
+  const [loadingReleases, setLoadingReleases] = useState(true);
+  const [loadingChangelog, setLoadingChangelog] = useState(false);
+
+  useEffect(() => {
+    fetch('https://api.github.com/repos/UiPath/apollo-ui/releases?per_page=30', {
+      headers: { Accept: 'application/vnd.github.v3+json' },
+    })
+      .then((r) => (r.ok ? r.json() : []))
+      .catch(() => [])
+      .then((data) => { setReleases(data); setLoadingReleases(false); });
+  }, []);
+
+  useEffect(() => {
+    if (activeTab !== 'changelog') return;
+    if (changelogs[activePkg]) return;
+    setLoadingChangelog(true);
+    fetch(CHANGELOG_URLS[activePkg])
+      .then((r) => (r.ok ? r.text() : ''))
+      .catch(() => '')
+      .then((text) => {
+        setChangelogs((prev) => ({ ...prev, [activePkg]: text }));
+        setLoadingChangelog(false);
+      });
+  }, [activeTab, activePkg, changelogs]);
+
+  function navigate(tab: string, pkg?: string) {
+    const params = new URLSearchParams(searchParams.toString());
+    params.set('tab', tab);
+    if (pkg) params.set('pkg', pkg);
+    router.push(`${pathname}?${params.toString()}`, { scroll: false });
+  }
+
+  return (
+    <div className="whats-new-page">
+      <h1 className="whats-new-title">What's New</h1>
+      <p className="whats-new-subtitle">
+        Stay up to date with the latest Apollo UI releases and changes.
+      </p>
+
+      {/* Tab bar */}
+      <div className="wn-tab-bar">
+        {TABS.map((tab) => (
+          <button
+            key={tab.id}
+            type="button"
+            onClick={() => navigate(tab.id)}
+            className={`wn-tab-btn${activeTab === tab.id ? ' wn-tab-btn--active' : ''}`}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </div>
+
+      {/* Release Notes tab */}
+      {activeTab === 'release-notes' && (
+        <div className="releases-list">
+          {loadingReleases ? (
+            <p className="releases-empty">Loading releases…</p>
+          ) : releases.length === 0 ? (
+            <p className="releases-empty">
+              Unable to load releases.{' '}
+              <a
+                href="https://github.com/UiPath/apollo-ui/releases"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                View on GitHub →
+              </a>
+            </p>
+          ) : (
+            releases.map((r) => (
+              <div key={r.id} className="release-card">
+                <div className="release-card__header">
+                  <span className={`release-badge ${packageBadgeClass(r.tag_name)}`}>
+                    {r.tag_name}
+                  </span>
+                  <span className="release-date">{formatDate(r.published_at)}</span>
+                  <a
+                    href={r.html_url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="release-gh-link"
+                  >
+                    View on GitHub →
+                  </a>
+                </div>
+                {r.body && (
+                  <div className="markdown-body">
+                    <ReactMarkdown>{r.body}</ReactMarkdown>
+                  </div>
+                )}
+              </div>
+            ))
+          )}
+        </div>
+      )}
+
+      {/* Changelog tab */}
+      {activeTab === 'changelog' && (
+        <div>
+          <div className="pkg-selector">
+            {PACKAGES.map((pkg) => (
+              <button
+                key={pkg}
+                type="button"
+                onClick={() => navigate('changelog', pkg)}
+                className={`pkg-btn${activePkg === pkg ? ' pkg-btn--active' : ''}`}
+              >
+                {pkg}
+              </button>
+            ))}
+          </div>
+          <div className="markdown-body changelog-body">
+            {loadingChangelog ? (
+              <p style={{ color: 'var(--foreground-muted)', fontSize: '0.875rem' }}>Loading…</p>
+            ) : (
+              <ReactMarkdown>{changelogs[activePkg] ?? 'No changelog available.'}</ReactMarkdown>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function WhatsNewPage() {
+  return (
+    <Suspense>
+      <WhatsNewContent />
+    </Suspense>
+  );
+}

--- a/apps/apollo-docs/next-env.d.ts
+++ b/apps/apollo-docs/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/apollo-docs/package.json
+++ b/apps/apollo-docs/package.json
@@ -18,6 +18,7 @@
     "@mui/material": "^5.18.0",
     "next": "16.2.3",
     "next-themes": "^0.4.6",
+    "react-markdown": "^10.1.0",
     "nextra": "^4.6.1",
     "nextra-theme-docs": "^4.6.1",
     "postcss": "^8.5.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -142,6 +142,9 @@ importers:
       react-dom:
         specifier: 19.2.3
         version: 19.2.3(react@19.2.3)
+      react-markdown:
+        specifier: ^10.1.0
+        version: 10.1.0(@types/react@19.2.8)(react@19.2.3)
       tailwindcss:
         specifier: ^4.1.17
         version: 4.1.17


### PR DESCRIPTION
## Summary

- **What's New page** — new page under Overview section with Release Notes (GitHub releases) and Changelog (per-package) tabs; data fetched client-side so it renders as a standard Nextra MDX page with full sidebar layout
- **Overview navigation** — renamed "Introduction" → "Overview" in the sidebar; What's New sits as the second item under Overview (after "What is Apollo?")
- **Navbar** — added GitHub and Storybook text links; search bar repositioned to the right via CSS `order` for standard docs layout
- **URL-synced tabs on Installation** — replaced Nextra's `<Tabs>` with a new `<LinkedTabs>` component that syncs active tab to `?pkg=` in the URL, making individual package tabs deep-linkable and shareable
- **Storybook command fix** — corrected `pnpm storybook:wind` and `pnpm storybook:all` → `pnpm storybook:dev` on the Installation page
- **Dependencies** — added `react-markdown@^10.1.0` for changelog rendering

## Test plan

- [ ] Navigate to Overview → What's New; confirm sidebar remains visible with full Overview section
- [ ] Switch between Release Notes and Changelog tabs; verify URL updates (`?tab=`, `?pkg=`)
- [ ] Copy a tab URL and paste in a new tab; confirm correct tab is pre-selected
- [ ] Navigate to Overview → Installation; select each package tab and confirm URL updates
- [ ] Confirm navbar shows GitHub and Storybook links with search on the right
- [ ] Confirm `pnpm storybook:dev` is the command shown for apollo-wind and apollo-react

🤖 Generated with [Claude Code](https://claude.com/claude-code)