### PR TITLE
feat(apollo-react): expose fallbackPlacement prop on FloatingCanvasPanel

### DIFF
--- a/packages/apollo-react/src/canvas/components/FloatingCanvasPanel/FloatingCanvasPanel.tsx
+++ b/packages/apollo-react/src/canvas/components/FloatingCanvasPanel/FloatingCanvasPanel.tsx
@@ -32,6 +32,15 @@ export type FloatingCanvasPanelProps = {
   anchorRect?: AnchorRect;
   placement?: Placement;
   offset?: number;
+  /**
+   * Controls whether the panel should try fallback placements when the primary
+   * axis overflows in both directions (e.g. both top and bottom are out of bounds).
+   * - `'none'` (default): only flip on the main axis (e.g. bottom↔top)
+   * - `'start'`: fall back to the start of the cross axis (e.g. left in LTR)
+   * - `'end'`: fall back to the end of the cross axis (e.g. right in LTR)
+   * @see https://floating-ui.com/docs/flip#fallbackaxissidedirection
+   */
+  fallbackPlacement?: 'none' | 'start' | 'end';
   isPinned?: boolean;
   /**
    * When true, the panel uses fixed positioning and anchorRect is treated as screen-space
@@ -66,6 +75,7 @@ export function FloatingCanvasPanel({
   anchorRect,
   placement = 'right-start',
   offset = 20,
+  fallbackPlacement,
   isPinned = false,
   useFixedPosition = false,
   portalToBody = false,
@@ -84,6 +94,7 @@ export function FloatingCanvasPanel({
     anchorRect,
     placement,
     offset,
+    fallbackPlacement,
   });
 
   if (!open || !computedAnchor) return null;

--- a/packages/apollo-react/src/canvas/components/FloatingCanvasPanel/useFloatingPosition.ts
+++ b/packages/apollo-react/src/canvas/components/FloatingCanvasPanel/useFloatingPosition.ts
@@ -17,6 +17,7 @@ export interface UseFloatingPositionOptions {
   anchorRect?: AnchorRect;
   placement?: Placement;
   offset?: number;
+  fallbackPlacement?: 'none' | 'start' | 'end';
 }
 
 export interface UseFloatingPositionReturn {
@@ -35,6 +36,7 @@ export function useFloatingPosition({
   anchorRect,
   placement = 'right-start',
   offset: offsetValue = 20,
+  fallbackPlacement = 'none',
 }: UseFloatingPositionOptions): UseFloatingPositionReturn {
   const referenceRef = useRef<HTMLDivElement>(null);
   const internalNode = useInternalNode(nodeId || '');
@@ -57,7 +59,7 @@ export function useFloatingPosition({
   const { refs, floatingStyles, update } = useFloating({
     placement,
     open: !!open && !!computedAnchor,
-    middleware: [offset(offsetValue), flip()],
+    middleware: [offset(offsetValue), flip({ fallbackAxisSideDirection: fallbackPlacement })],
     whileElementsMounted: autoUpdate,
   });
 


### PR DESCRIPTION
## Summary
- Expose floating-ui's `fallbackPlacement` option as an optional prop on `FloatingCanvasPanel` and `useFloatingPosition`.
- When the primary axis (e.g. top/bottom) overflows in both directions, this allows the popover to fall back to cross-axis placements (left/right).
- Defaults to `'none'` (no behavior change for existing consumers)

## Changes
- `useFloatingPosition.ts`: Added `fallbackPlacement` to options interface and passed it to `flip()`.
- `FloatingCanvasPanel.tsx`: Added `fallbackPlacement` prop and forwarded it to `useFloatingPosition`.