### PR TITLE
fix(apollo-react): remove react flow theme class

### DIFF
--- a/packages/apollo-react/src/canvas/components/BaseCanvas/BaseCanvas.tsx
+++ b/packages/apollo-react/src/canvas/components/BaseCanvas/BaseCanvas.tsx
@@ -1,4 +1,9 @@
-import type { Edge, Node, ReactFlowInstance } from '@uipath/apollo-react/canvas/xyflow/react';
+import type {
+  ColorMode,
+  Edge,
+  Node,
+  ReactFlowInstance,
+} from '@uipath/apollo-react/canvas/xyflow/react';
 import { ConnectionMode, ReactFlow } from '@uipath/apollo-react/canvas/xyflow/react';
 import {
   type CSSProperties,
@@ -147,6 +152,8 @@ const BaseCanvasInnerComponent = <NodeType extends Node = Node, EdgeType extends
     <CanvasProviders nodes={nodes} edges={edges} mode={mode} isDarkMode={isDarkMode}>
       <ReactFlow
         {...reactFlowProps}
+        // Purposely removing the reactFlow colorMode to prevent conflicts with custom theming implementation.
+        colorMode={'' as unknown as ColorMode}
         nodes={nodes}
         edges={edges}
         nodeTypes={nodeTypes}


### PR DESCRIPTION
ReactFlow adds a .light or .dark class to its wrapper (via the colorMode prop, which defaults to "light"). This wrapper class would matches our own theme selector and redefine every semantic token, overriding the body-level theme for all canvas descendants. This could also cause consumer stylesheets to apply and override our themes as well. So we are opting to fully  clear the ReactFlow class since we already control all of the theming for custom flow components.