### PR TITLE
fix(apollo-react): disable task drag-and-drop when stage is read-only [MST-8778]

### DIFF
--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.stories.tsx
@@ -1583,6 +1583,25 @@ const AddTaskLoadingStory = () => {
     }, 2000);
   }, []);
 
+  const handleTaskReorder = useCallback((nodeId: string, reorderedTasks: StageTaskItem[][]) => {
+    setNodesRef.current((nds) =>
+      nds.map((n) =>
+        n.id === nodeId
+          ? {
+              ...n,
+              data: {
+                ...n.data,
+                stageDetails: {
+                  ...(n.data as Record<string, any>).stageDetails,
+                  tasks: reorderedTasks,
+                },
+              },
+            }
+          : n
+      )
+    );
+  }, []);
+
   const initialNodes: Node[] = useMemo(
     () => [
       {
@@ -1599,6 +1618,9 @@ const AddTaskLoadingStory = () => {
           taskOptions: [] as ListItem[],
           onAddTaskFromToolbox: (taskItem: ListItem) => {
             handleAddTaskFromToolbox('loading-stage-empty', taskItem);
+          },
+          onTaskReorder: (reorderedTasks: StageTaskItem[][]) => {
+            handleTaskReorder('loading-stage-empty', reorderedTasks);
           },
           onTaskGroupModification: () => {},
         },
@@ -1617,6 +1639,9 @@ const AddTaskLoadingStory = () => {
           taskOptions: loadedTaskOptionsWithChildren,
           onAddTaskFromToolbox: (taskItem: ListItem) => {
             handleAddTaskFromToolbox('loading-stage-children', taskItem);
+          },
+          onTaskReorder: (reorderedTasks: StageTaskItem[][]) => {
+            handleTaskReorder('loading-stage-children', reorderedTasks);
           },
           onTaskGroupModification: () => {},
         },
@@ -1651,11 +1676,14 @@ const AddTaskLoadingStory = () => {
           onAddTaskFromToolbox: (taskItem: ListItem) => {
             handleAddTaskFromToolbox('loading-stage-tasks', taskItem);
           },
+          onTaskReorder: (reorderedTasks: StageTaskItem[][]) => {
+            handleTaskReorder('loading-stage-tasks', reorderedTasks);
+          },
           onTaskGroupModification: () => {},
         },
       },
     ],
-    [handleAddTaskFromToolbox]
+    [handleAddTaskFromToolbox, handleTaskReorder]
   );
 
   const [nodes, setNodes, onNodesChange] = useNodesState(initialNodes);
@@ -1716,11 +1744,32 @@ const AddTaskLoadingStory = () => {
     [setEdges]
   );
 
+  // Mark the stage read-only while tasks are loading so DnD is disabled mid-add
+  const nodesWithReadOnly = useMemo(
+    () =>
+      nodes.map((node) => {
+        const data = node.data as Record<string, any>;
+        const isLoading = ((data.loadingTaskIds as Set<string> | undefined)?.size ?? 0) > 0;
+        const existingIsReadOnly = Boolean(data.stageDetails?.isReadOnly);
+        return {
+          ...node,
+          data: {
+            ...data,
+            stageDetails: {
+              ...data.stageDetails,
+              isReadOnly: existingIsReadOnly || isLoading,
+            },
+          },
+        };
+      }),
+    [nodes]
+  );
+
   return (
     <div style={{ width: '100vw', height: '100vh' }}>
       <ReactFlowProvider>
         <BaseCanvas
-          nodes={nodes}
+          nodes={nodesWithReadOnly}
           edges={edges}
           onNodesChange={onNodesChange}
           onEdgesChange={onEdgesChange}

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.test.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.test.tsx
@@ -111,11 +111,13 @@ vi.mock('./DraggableTask', () => ({
     task,
     groupIndex,
     taskIndex,
+    isDragDisabled,
     getContextMenuItems,
   }: {
     task: StageTaskItem;
     groupIndex?: number;
     taskIndex?: number;
+    isDragDisabled?: boolean;
     getContextMenuItems?: (
       groupIndex: number,
       taskIndex: number
@@ -125,7 +127,10 @@ vi.mock('./DraggableTask', () => ({
       Array<{ id?: string; label?: string; onClick?: () => void }>
     >([]);
     return (
-      <div data-testid={`draggable-task-${task.id}`}>
+      <div
+        data-testid={`draggable-task-${task.id}`}
+        data-drag-disabled={isDragDisabled ? 'true' : 'false'}
+      >
         <div data-testid={`task-label-${task.id}`}>{task.label}</div>
         {getContextMenuItems && (
           <button
@@ -641,92 +646,51 @@ describe('StageNode - Replace Task Functionality', () => {
   });
 });
 
-describe('StageNode - Add Task Loading State', () => {
+describe('StageNode - DnD in read-only mode', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it('should set Toolbox loading to true when loadingTaskIds is non-empty', async () => {
-    const user = userEvent.setup();
-    const onAddTaskFromToolbox = vi.fn();
-    const { rerender } = renderStageNode({ onAddTaskFromToolbox, loadingTaskIds: new Set() });
+  const tasks: StageTaskItem[][] = [[createTask('task-1')], [createTask('task-2')]];
 
-    const addButton = screen.getByRole('button', { name: 'Add task' });
-    await user.click(addButton);
+  it('disables task drag when isReadOnly is true', () => {
+    renderStageNode({
+      stageDetails: { ...defaultProps.stageDetails, tasks, isReadOnly: true },
+      onTaskReorder: vi.fn(),
+    });
 
-    rerender(
-      <ReactFlowProvider>
-        <StageNode
-          {...defaultProps}
-          onAddTaskFromToolbox={onAddTaskFromToolbox}
-          loadingTaskIds={new Set(['task-1'])}
-        />
-      </ReactFlowProvider>
+    expect(screen.getByTestId('draggable-task-task-1')).toHaveAttribute(
+      'data-drag-disabled',
+      'true'
     );
-
-    const toolbox = screen.getByTestId('toolbox');
-    expect(toolbox).toHaveAttribute('data-loading', 'true');
-  });
-
-  it('should not pass loading to Toolbox when loadingTaskIds is empty', async () => {
-    const user = userEvent.setup();
-    const onAddTaskFromToolbox = vi.fn();
-    renderStageNode({ onAddTaskFromToolbox, loadingTaskIds: new Set() });
-
-    const addButton = screen.getByRole('button', { name: 'Add task' });
-    await user.click(addButton);
-
-    const toolbox = screen.getByTestId('toolbox');
-    expect(toolbox).toHaveAttribute('data-loading', 'false');
-  });
-
-  it('should disable the add button when loadingTaskIds is non-empty', () => {
-    const onAddTaskFromToolbox = vi.fn();
-    renderStageNode({ onAddTaskFromToolbox, loadingTaskIds: new Set(['task-1']) });
-
-    const addButton = screen.getByRole('button', { name: 'Add task' });
-    expect(addButton).toBeDisabled();
-  });
-
-  it('should not disable the add button when loadingTaskIds is empty', () => {
-    const onAddTaskFromToolbox = vi.fn();
-    renderStageNode({ onAddTaskFromToolbox, loadingTaskIds: new Set() });
-
-    const addButton = screen.getByRole('button', { name: 'Add task' });
-    expect(addButton).not.toBeDisabled();
-  });
-
-  it('should update Toolbox loading when loadingTaskIds changes to empty', async () => {
-    const user = userEvent.setup();
-    const onAddTaskFromToolbox = vi.fn();
-    const { rerender } = renderStageNode({ onAddTaskFromToolbox, loadingTaskIds: new Set() });
-
-    const addButton = screen.getByRole('button', { name: 'Add task' });
-    await user.click(addButton);
-
-    rerender(
-      <ReactFlowProvider>
-        <StageNode
-          {...defaultProps}
-          onAddTaskFromToolbox={onAddTaskFromToolbox}
-          loadingTaskIds={new Set(['task-1'])}
-        />
-      </ReactFlowProvider>
+    expect(screen.getByTestId('draggable-task-task-2')).toHaveAttribute(
+      'data-drag-disabled',
+      'true'
     );
+  });
 
-    expect(screen.getByTestId('toolbox')).toHaveAttribute('data-loading', 'true');
+  it('enables task drag when isReadOnly is false and onTaskReorder is provided', () => {
+    renderStageNode({
+      stageDetails: { ...defaultProps.stageDetails, tasks },
+      onTaskReorder: vi.fn(),
+    });
 
-    rerender(
-      <ReactFlowProvider>
-        <StageNode
-          {...defaultProps}
-          onAddTaskFromToolbox={onAddTaskFromToolbox}
-          loadingTaskIds={new Set()}
-        />
-      </ReactFlowProvider>
+    expect(screen.getByTestId('draggable-task-task-1')).toHaveAttribute(
+      'data-drag-disabled',
+      'false'
     );
+  });
 
-    expect(screen.getByTestId('toolbox')).toHaveAttribute('data-loading', 'false');
+  it('disables task drag when onTaskReorder is not provided', () => {
+    renderStageNode({
+      stageDetails: { ...defaultProps.stageDetails, tasks },
+      onTaskReorder: undefined,
+    });
+
+    expect(screen.getByTestId('draggable-task-task-1')).toHaveAttribute(
+      'data-drag-disabled',
+      'true'
+    );
   });
 });
 

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.tsx
@@ -102,8 +102,6 @@ const StageNodeInner = (props: StageNodeProps) => {
     loadingTaskIds,
   } = props;
 
-  const isAnyTaskLoading = loadingTaskIds != null && loadingTaskIds.size > 0;
-
   const taskWidth = width ? width - STAGE_CONTENT_INSET : undefined;
 
   const allTasks = useMemo(() => stageDetails?.tasks || [], [stageDetails?.tasks]);
@@ -657,14 +655,13 @@ const StageNodeInner = (props: StageNodeProps) => {
               </CanvasTooltip>
             )}
             {(onTaskAdd || onAddTaskFromToolbox) && !isReadOnly && (
-              <CanvasTooltip content={addTaskLabel} placement="top" hide={isAnyTaskLoading}>
+              <CanvasTooltip content={addTaskLabel} placement="top">
                 <Button
                   variant="ghost"
                   size="icon"
                   className="h-6 w-6"
                   onClick={handleTaskAddClick}
                   aria-label={addTaskLabel}
-                  disabled={isAnyTaskLoading}
                 >
                   <CanvasIcon icon="plus" size={20} />
                 </Button>
@@ -679,11 +676,8 @@ const StageNodeInner = (props: StageNodeProps) => {
               {(onTaskAdd || onAddTaskFromToolbox) && !isReadOnly ? (
                 <Button
                   variant="link"
-                  onClick={isAnyTaskLoading ? undefined : handleTaskAddClick}
-                  style={{
-                    maxWidth: 'fit-content',
-                    pointerEvents: isAnyTaskLoading ? 'none' : undefined,
-                  }}
+                  onClick={handleTaskAddClick}
+                  style={{ maxWidth: 'fit-content' }}
                 >
                   {defaultContent}
                 </Button>
@@ -734,7 +728,7 @@ const StageNodeInner = (props: StageNodeProps) => {
                                         ? projected.depth
                                         : undefined
                                     }
-                                    isDragDisabled={!onTaskReorder}
+                                    isDragDisabled={!onTaskReorder || isReadOnly}
                                     isTaskLoading={loadingTaskIds?.has(task.id)}
                                     {...(hasContextMenu &&
                                       !isReadOnly && {
@@ -796,7 +790,6 @@ const StageNodeInner = (props: StageNodeProps) => {
           <Toolbox
             title={addTaskLabel}
             initialItems={taskOptions}
-            loading={isAnyTaskLoading}
             onClose={() => setIsAddingTask(false)}
             onItemSelect={handleAddTaskToolboxItemSelected}
             onSearch={onTaskToolboxSearch}


### PR DESCRIPTION
## Summary
- Task DnD is now gated on `isReadOnly` in addition to `onTaskReorder`, so read-only stages block drag-to-reorder.
- Drops the implicit `loadingTaskIds`-based gating of the add-task button, tooltip, and Toolbox loading prop. Consumers set `stageDetails.isReadOnly` during async work to block interactions; `loadingTaskIds` continues to drive per-task indicators.
- `Add Task Loading State` story wires `onTaskReorder` and derives `isReadOnly` from `loadingTaskIds.size > 0` to demonstrate the consumer pattern.

## Demo

https://github.com/user-attachments/assets/d96930f8-d52d-4664-bdf5-310ceda6580d



## Test plan
- [ ] `Add Task Loading State` story: click **+**, verify DnD is blocked while the new task is loading and re-enables after.
- [ ] Read-only story (or any `isReadOnly: true` stage): verify tasks can't be dragged.
- [ ] Non-read-only stage with `onTaskReorder`: drag-to-reorder still works.
- [ ] Unit tests: `pnpm --filter @uipath/apollo-react test src/canvas/components/StageNode/StageNode.test.tsx`

[MST-8778]: https://uipath.atlassian.net/browse/MST-8778?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ