### PR TITLE
fix(apollo-react): expose canvas sizing variables

### DIFF
--- a/packages/apollo-react/src/canvas/components/AddNodePanel/AddNodeManager.tsx
+++ b/packages/apollo-react/src/canvas/components/AddNodePanel/AddNodeManager.tsx
@@ -2,7 +2,7 @@ import type { Edge, Node } from '@uipath/apollo-react/canvas/xyflow/react';
 import { useReactFlow } from '@uipath/apollo-react/canvas/xyflow/react';
 import type React from 'react';
 import { useCallback, useEffect, useRef } from 'react';
-import { PREVIEW_NODE_ID } from '../../constants';
+import { FLOATING_CANVAS_PANEL_OFFSET, PREVIEW_NODE_ID } from '../../constants';
 import { useOptionalNodeTypeRegistry } from '../../core';
 import { usePreviewNode } from '../../hooks/usePreviewNode';
 import { resolveCollisions } from '../../utils';
@@ -242,7 +242,7 @@ export const AddNodeManager: React.FC<AddNodeManagerProps> = ({
       open={!!previewNode}
       nodeId={PREVIEW_NODE_ID}
       placement="right-start"
-      offset={10}
+      offset={FLOATING_CANVAS_PANEL_OFFSET}
     >
       {CustomPanel ? (
         <CustomPanel onNodeSelect={(item) => handleNodeSelect(item)} onClose={handleClose} />

--- a/packages/apollo-react/src/canvas/components/Flow.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/Flow.stories.tsx
@@ -4,6 +4,7 @@ import type { Edge, Node, NodeProps } from '@uipath/apollo-react/canvas/xyflow/r
 import { Handle, Panel, Position, useReactFlow } from '@uipath/apollo-react/canvas/xyflow/react';
 import { Download, Plus, StickyNote } from 'lucide-react';
 import { type FC, memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { FLOATING_CANVAS_PANEL_OFFSET } from '../constants';
 import { useCanvasEvent, useExportCanvas } from '../hooks';
 import {
   createNode,
@@ -376,7 +377,7 @@ function DefaultStory({ useSmartHandles }: FlowStoryArgs) {
           anchorRect={addButtonRect}
           useFixedPosition
           placement="top"
-          offset={10}
+          offset={FLOATING_CANVAS_PANEL_OFFSET}
         >
           <AddNodePanel onNodeSelect={handleNodeSelect} onClose={handleCloseAddPanel} />
         </FloatingCanvasPanel>

--- a/packages/apollo-react/src/canvas/components/NodeInspector.tsx
+++ b/packages/apollo-react/src/canvas/components/NodeInspector.tsx
@@ -8,6 +8,7 @@ import {
   type XYPosition,
 } from '@uipath/apollo-react/canvas/xyflow/react';
 
+import { FLOATING_CANVAS_PANEL_OFFSET } from '../constants';
 import { FloatingCanvasPanel } from './FloatingCanvasPanel';
 
 function safeStringify(obj: unknown, indent = 2): string {
@@ -324,7 +325,7 @@ export function NodeInspector({
             nodeId={node.id}
             title="Node Inspector"
             placement="right-start"
-            offset={10}
+            offset={FLOATING_CANVAS_PANEL_OFFSET}
             onClose={showCloseButton ? onClose : undefined}
           >
             <NodeInfoContent
@@ -348,7 +349,7 @@ export function NodeInspector({
             nodeId={nodeId}
             title="Edge Inspector"
             placement="right-start"
-            offset={10 + (nodesToShow.length > 0 ? 420 : 0) + index * 420} // Offset multiple panels
+            offset={FLOATING_CANVAS_PANEL_OFFSET + (nodesToShow.length > 0 ? 420 : 0) + index * 420} // Offset multiple panels
             onClose={showCloseButton ? onClose : undefined}
           >
             <EdgeInfoContent edge={edge} />

--- a/packages/apollo-react/src/canvas/components/Toolbox/Toolbox.tsx
+++ b/packages/apollo-react/src/canvas/components/Toolbox/Toolbox.tsx
@@ -2,6 +2,13 @@ import { useNavigationStack } from '@uipath/apollo-react/canvas/hooks';
 import { Column } from '@uipath/apollo-react/canvas/layouts';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useListRef } from 'react-window';
+import {
+  TOOLBOX_GAP,
+  TOOLBOX_HEIGHT,
+  TOOLBOX_PADDING_X,
+  TOOLBOX_PADDING_Y,
+  TOOLBOX_WIDTH,
+} from '../../constants';
 import { Header } from './Header';
 import { type ListItem, ListView, type ListViewHandle, type RenderItem } from './ListView';
 import { SearchBox } from './SearchBox';
@@ -534,7 +541,13 @@ export function Toolbox<T>({
 
   return (
     <div ref={containerRef} data-testid="toolbox-container">
-      <Column px={20} py={12} gap={12} w={fullWidth ? '100%' : 320} h={fullHeight ? '100%' : 440}>
+      <Column
+        px={TOOLBOX_PADDING_X}
+        py={TOOLBOX_PADDING_Y}
+        gap={TOOLBOX_GAP}
+        w={fullWidth ? '100%' : TOOLBOX_WIDTH}
+        h={fullHeight ? '100%' : TOOLBOX_HEIGHT}
+      >
         <Header
           title={currentParentItem?.name || title}
           onBack={handleBackTransition}

--- a/packages/apollo-react/src/canvas/constants.ts
+++ b/packages/apollo-react/src/canvas/constants.ts
@@ -6,3 +6,24 @@ export const GRID_SPACING = 16;
 
 /** Canvas viewport width below which compact layout is used. */
 export const CANVAS_COMPACT_BREAKPOINT = 600;
+
+/** Fixed width of the Toolbox container (in px) when it isn't in `fullWidth` mode. */
+export const TOOLBOX_WIDTH = 320;
+/** Fixed height of the Toolbox container (in px) when it isn't in `fullHeight` mode. */
+export const TOOLBOX_HEIGHT = 440;
+/** Horizontal padding inside the Toolbox (in px; `px` prop on its outer `Column`). */
+export const TOOLBOX_PADDING_X = 20;
+/** Vertical padding inside the Toolbox (in px; `py` prop on its outer `Column`). */
+export const TOOLBOX_PADDING_Y = 12;
+/** Row gap between Toolbox sections (in px; `gap` prop on its outer `Column`). */
+export const TOOLBOX_GAP = 12;
+
+/**
+ * Default distance (in px) between a `FloatingCanvasPanel` and its anchor.
+ * Used as the `offset` prop at every canvas call site (add-node preview,
+ * node inspector, toolbar stories, etc.). The value is placement-agnostic:
+ * for `right-start` it's the horizontal gap, for `top` it's the vertical
+ * gap, and so on — the floating-ui `offset` middleware interprets it
+ * relative to the active placement.
+ */
+export const FLOATING_CANVAS_PANEL_OFFSET = 10;


### PR DESCRIPTION
## Summary

Expose the hardcoded sizing and offset values used by the canvas `Toolbox` and the `FloatingCanvasPanel` call sites as constants, so consumers (e.g. flow-workbench's pristine-state auto-centering) can compute layout math against authoritative values instead of duplicating magic numbers.

## Changes

### `packages/apollo-react/src/canvas/constants.ts`

Added six new constants alongside the existing `DEFAULT_NODE_SIZE` / `GRID_SPACING`. All values are in **pixels**:

| Constant | Value | Replaces |
| --- | --- | --- |
| `TOOLBOX_WIDTH` | `320` | Hardcoded `w={320}` on `Toolbox`'s outer `Column` |
| `TOOLBOX_HEIGHT` | `440` | Hardcoded `h={440}` on the same `Column` |
| `TOOLBOX_PADDING_X` | `20` | Hardcoded `px={20}` |
| `TOOLBOX_PADDING_Y` | `12` | Hardcoded `py={12}` |
| `TOOLBOX_GAP` | `12` | Hardcoded `gap={12}` |
| `FLOATING_CANVAS_PANEL_OFFSET` | `10` | `offset={10}` on `FloatingCanvasPanel` at each call site |

They're re-exported automatically via the existing `export * from './constants'` in `canvas/index.ts`.

`FLOATING_CANVAS_PANEL_OFFSET` is placement-agnostic — `floating-ui`'s `offset` middleware interprets it relative to the active `placement` (horizontal gap for `right-start`, vertical gap for `top`, etc.), so the same value works across all call sites regardless of anchor direction.

### Refactors (no behavior change)

- `components/Toolbox/Toolbox.tsx` — outer `Column` now reads all five `TOOLBOX_*` constants instead of hardcoded numbers.
- `components/AddNodePanel/AddNodeManager.tsx` — `offset={FLOATING_CANVAS_PANEL_OFFSET}`.
- `components/NodeInspector.tsx` — `offset={FLOATING_CANVAS_PANEL_OFFSET}`.
- `components/Flow.stories.tsx` — `offset={FLOATING_CANVAS_PANEL_OFFSET}`.

## Why

flow-workbench has a pristine-state auto-centering hook (`useInitialPristineState`) that centers the manual trigger plus a preview ghost and the Add Node Panel around the canvas viewport. The math requires knowing the panel's rendered width and the gap between the preview and the panel. Today those numbers (`320`, `10`) are duplicated as hardcoded constants on the consumer side, which means:

- If Apollo changes the Toolbox width or the default panel offset, consumer centering drifts silently.
- The consumer-side values are guesses — they're not derived from anywhere, they just happen to match what DevTools shows.

Exposing them makes the dependency explicit: consumers can import and stay in sync with whatever Apollo actually renders.

## Testing

- [x] `npx tsc --noEmit -p tsconfig.json` — clean.
- [x] `vitest run src/canvas/components/Toolbox src/canvas/components/AddNodePanel` — 81/81 pass across 4 files.
- [x] Visual: no change (pure constant extraction, same values as before).