### PR TITLE
feat(apollo-vertex): ai-chat templates and documentation pages [2/2]

### DIFF
--- a/apps/apollo-vertex/app/_meta.ts
+++ b/apps/apollo-vertex/app/_meta.ts
@@ -12,6 +12,7 @@ export default {
   templates: "Templates",
   guidelines: "Guidelines",
   experiment: "Experiment",
+  "vertex-components": "Vertex Components",
   "data-querying": "Data Querying",
   localization: "Localization",
   mcp: "MCP Server",

--- a/apps/apollo-vertex/app/patterns/ai-chat/page.mdx
+++ b/apps/apollo-vertex/app/patterns/ai-chat/page.mdx
@@ -1,12 +1,15 @@
 import { AiChatTemplate } from '@/templates/AiChatTemplate';
+import { PreviewFullScreen } from '@/app/_components/preview-full-screen';
 
 # AI Chat
 
 A composable AI chat UI component for Apollo Vertex. Built with React, TypeScript, and Tailwind CSS. Designed to work with [TanStack AI](https://tanstack.com/ai) — you bring `useChat` and a connection adapter, the component handles the chrome (scroll, input, loading, suggestions, errors) while you control how messages and tool calls render.
 
-<div className="not-prose my-8">
-  <AiChatTemplate />
-</div>
+<PreviewFullScreen height={600} title="AI Chat">
+  <AiChatTemplate className="h-full flex w-full flex-col" />
+</PreviewFullScreen>
+
+> **All visual states and sub-components →** [Component Preview](/vertex-components/ai-chat/preview)
 
 ## Features
 

--- a/apps/apollo-vertex/app/vertex-components/ai-chat/preview/mock-data.ts
+++ b/apps/apollo-vertex/app/vertex-components/ai-chat/preview/mock-data.ts
@@ -1,0 +1,218 @@
+import type { UIMessage } from "@tanstack/ai-client";
+
+export const MOCK_MESSAGES_BASIC: UIMessage[] = [
+  {
+    id: "1",
+    role: "user",
+    parts: [{ type: "text", content: "What is Apollo Design System?" }],
+    createdAt: new Date(Date.now() - 120000),
+  },
+  {
+    id: "2",
+    role: "assistant",
+    parts: [
+      {
+        type: "text",
+        content:
+          "Apollo is UiPath's open-source design system. It provides a unified component library with **design tokens**, **React components**, and **Web Components** for building consistent user interfaces.",
+      },
+    ],
+    createdAt: new Date(Date.now() - 60000),
+  },
+];
+
+export const MOCK_MESSAGES_MARKDOWN: UIMessage[] = [
+  {
+    id: "1",
+    role: "user",
+    parts: [
+      {
+        type: "text",
+        content: "Show me all the markdown formatting you support.",
+      },
+    ],
+    createdAt: new Date(),
+  },
+  {
+    id: "2",
+    role: "assistant",
+    parts: [
+      {
+        type: "text",
+        content: `Here's a comprehensive demo of supported markdown:
+
+## Headings & Text
+
+This is a paragraph with **bold**, *italic*, and \`inline code\`.
+
+> This is a blockquote with some important information.
+
+---
+
+## Lists
+
+**Unordered list:**
+- First item
+- Second item with **bold**
+- Third item
+
+**Ordered list:**
+1. Step one
+2. Step two
+3. Step three
+
+## Code Block
+
+\`\`\`typescript
+interface AiChatProps {
+  messages: UIMessage[];
+  isLoading: boolean;
+  onSendMessage: (content: string) => void;
+}
+\`\`\`
+
+## Table
+
+| Component | Status | Description |
+|-----------|--------|-------------|
+| AiChat | Ready | Main chat shell |
+| AiChatMessage | Ready | Message renderer |
+| AiChatInput | Ready | Text input |
+| AiChatMarkdown | Ready | Markdown renderer |
+
+## Links
+
+Check [Apollo UI](https://github.com/UiPath/apollo-ui) for more info.`,
+      },
+    ],
+    createdAt: new Date(),
+  },
+];
+
+export const MOCK_MESSAGES_CONVERSATION: UIMessage[] = [
+  {
+    id: "1",
+    role: "user",
+    parts: [{ type: "text", content: "Can you help me set up a new project?" }],
+    createdAt: new Date(Date.now() - 300000),
+  },
+  {
+    id: "2",
+    role: "assistant",
+    parts: [
+      {
+        type: "text",
+        content:
+          "Of course! I'd be happy to help. What kind of project are you looking to create?",
+      },
+    ],
+    createdAt: new Date(Date.now() - 240000),
+  },
+  {
+    id: "3",
+    role: "user",
+    parts: [
+      {
+        type: "text",
+        content: "A React app with Tailwind CSS and TypeScript.",
+      },
+    ],
+    createdAt: new Date(Date.now() - 180000),
+  },
+  {
+    id: "4",
+    role: "assistant",
+    parts: [
+      {
+        type: "text",
+        content:
+          "Great choice! Here's how to get started:\n\n1. Run `npx create-next-app@latest`\n2. Select **TypeScript** and **Tailwind CSS** during setup\n3. Install Apollo components:\n\n```bash\nnpx shadcn@latest add @uipath/button\n```\n\nWould you like me to walk through any of these steps in detail?",
+      },
+    ],
+    createdAt: new Date(Date.now() - 120000),
+  },
+  {
+    id: "5",
+    role: "user",
+    parts: [{ type: "text", content: "Yes, explain step 3 please." }],
+    createdAt: new Date(Date.now() - 60000),
+  },
+  {
+    id: "6",
+    role: "assistant",
+    parts: [
+      {
+        type: "text",
+        content:
+          "The `shadcn` CLI copies component source code directly into your project. When you run the command, it will:\n\n- Create `components/ui/button.tsx` in your project\n- Add any required dependencies to `package.json`\n- Set up the `cn()` utility if not present\n\nYou own the code — modify it however you need.",
+      },
+    ],
+    createdAt: new Date(),
+  },
+];
+
+export const MOCK_MESSAGES_WITH_CHOICES: UIMessage[] = [
+  {
+    id: "1",
+    role: "user",
+    parts: [{ type: "text", content: "What presentation style should I use?" }],
+    createdAt: new Date(),
+  },
+  {
+    id: "2",
+    role: "assistant",
+    parts: [
+      {
+        type: "text",
+        content: "Here are some options based on your audience:",
+      },
+      {
+        type: "tool-call",
+        id: "call-1",
+        name: "presentChoices",
+        arguments: "{}",
+        state: "input-complete" as const,
+      },
+      {
+        type: "tool-result",
+        toolCallId: "call-1",
+        state: "complete" as const,
+        content: JSON.stringify({
+          type: "choices",
+          prompt: "Pick a presentation style:",
+          options: [
+            { id: "1", label: "Executive Summary", recommended: true },
+            { id: "2", label: "Technical Deep Dive" },
+            { id: "3", label: "Workshop Format" },
+          ],
+        }),
+      },
+    ],
+    createdAt: new Date(),
+  },
+];
+
+export const MOCK_SOURCES_BASIC: Record<
+  string,
+  { label: string; url: string }[]
+> = {
+  "2": [
+    { label: "Apollo UI GitHub", url: "https://github.com/UiPath/apollo-ui" },
+    { label: "Tailwind CSS", url: "https://tailwindcss.com" },
+    { label: "shadcn/ui", url: "https://ui.shadcn.com" },
+  ],
+};
+
+export const MOCK_ATTACHMENTS_BASIC: Record<
+  string,
+  { name: string; type: string; size: number }[]
+> = {
+  "1": [{ name: "Q4_Report.pdf", type: "application/pdf", size: 245000 }],
+};
+
+export const MOCK_CHOICE_OPTIONS = [
+  { id: "1", label: "Option A — Recommended", recommended: true },
+  { id: "2", label: "Option B — Alternative" },
+  { id: "3", label: "Option C — Experimental" },
+  { id: "4", label: "Option D — Conservative" },
+];

--- a/apps/apollo-vertex/app/vertex-components/ai-chat/preview/page.tsx
+++ b/apps/apollo-vertex/app/vertex-components/ai-chat/preview/page.tsx
@@ -1,0 +1,523 @@
+// oxlint-disable eslint/max-lines -- preview page documents many visual states
+"use client";
+
+import { Maximize2, Minimize2 } from "lucide-react";
+import { type ReactNode, useState } from "react";
+import { AiChat } from "@/registry/ai-chat/components/ai-chat";
+import { AiChatCodeBlock } from "@/registry/ai-chat/components/ai-chat-code-block";
+import { AiChatEmptyState } from "@/registry/ai-chat/components/ai-chat-empty-state";
+import { AiChatFlow } from "@/registry/ai-chat/components/ai-chat-flow";
+import { AiChatInput } from "@/registry/ai-chat/components/ai-chat-input";
+import { AiChatMarkdown } from "@/registry/ai-chat/components/ai-chat-markdown";
+import { AiChatMessage } from "@/registry/ai-chat/components/ai-chat-message";
+import { AiChatMessageActions } from "@/registry/ai-chat/components/ai-chat-message-actions";
+import { AiChatSuggestions } from "@/registry/ai-chat/components/ai-chat-suggestions";
+import type { ToolResultFlow } from "@/registry/ai-chat/utils/ai-chat-utils";
+import { Button } from "@/registry/button/button";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogTitle,
+  DialogTrigger,
+} from "@/registry/dialog/dialog";
+import {
+  MOCK_ATTACHMENTS_BASIC,
+  MOCK_CHOICE_OPTIONS,
+  MOCK_MESSAGES_BASIC,
+  MOCK_MESSAGES_CONVERSATION,
+  MOCK_MESSAGES_MARKDOWN,
+  MOCK_MESSAGES_WITH_CHOICES,
+  MOCK_SOURCES_BASIC,
+} from "./mock-data";
+import { ThinkingDemo } from "./thinking-demo";
+
+function noop(..._args: unknown[]) {
+  // no-op for preview
+}
+
+const MOCK_FLOW: ToolResultFlow = {
+  type: "flow",
+  steps: [
+    {
+      id: "step-1",
+      prompt: "What type of content are you creating?",
+      options: [
+        { id: "blog", label: "Blog post" },
+        { id: "email", label: "Email campaign" },
+        { id: "social", label: "Social media posts" },
+      ],
+    },
+    {
+      id: "step-2",
+      prompt: "Who is your target audience?",
+      options: [
+        { id: "developers", label: "Developers" },
+        { id: "business", label: "Business leaders" },
+        { id: "general", label: "General audience" },
+      ],
+      canSkip: true,
+    },
+    {
+      id: "step-3",
+      prompt: "What tone would you like?",
+      options: [
+        { id: "professional", label: "Professional" },
+        { id: "casual", label: "Casual & friendly" },
+        { id: "technical", label: "Technical & precise" },
+      ],
+    },
+  ],
+};
+
+function FlowDemo() {
+  const [flowKey, setFlowKey] = useState(0);
+  const [result, setResult] = useState<string | null>(null);
+
+  if (result !== null) {
+    return (
+      <div className="flex flex-col gap-3">
+        <p className="text-xs text-muted-foreground font-mono break-all">
+          {result}
+        </p>
+        <button
+          type="button"
+          className="self-start text-xs px-3 py-1.5 rounded-md border border-input bg-background hover:bg-muted transition-colors"
+          onClick={() => {
+            setResult(null);
+            setFlowKey((k) => k + 1);
+          }}
+        >
+          Reset
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <AiChatFlow
+      key={flowKey}
+      flow={MOCK_FLOW}
+      onComplete={(answers) => {
+        setResult(
+          answers.map((a, i) => `Step ${i + 1}: ${a.answer}`).join(" · "),
+        );
+      }}
+      onDismiss={() => {
+        setResult("(dismissed)");
+      }}
+    />
+  );
+}
+
+function SectionHeader({
+  title,
+  description,
+}: {
+  title: string;
+  description: string;
+}) {
+  return (
+    <div className="mb-4">
+      <h2 className="text-xl font-bold text-foreground">{title}</h2>
+      <p className="text-sm text-muted-foreground mt-1">{description}</p>
+    </div>
+  );
+}
+
+function PreviewCard({
+  children,
+  className,
+  title,
+}: {
+  children: ReactNode;
+  className?: string;
+  title?: string;
+}) {
+  const [isOpen, setIsOpen] = useState(false);
+  const baseClass = `border rounded-lg bg-background overflow-hidden ${className ?? ""}`;
+
+  if (!title) {
+    return <div className={baseClass}>{children}</div>;
+  }
+
+  return (
+    <Dialog open={isOpen} onOpenChange={setIsOpen}>
+      <div className={`relative group ${baseClass}`}>
+        {!isOpen && children}
+        <DialogTrigger asChild>
+          <Button
+            variant="outline"
+            size="icon-sm"
+            className="absolute top-2 right-2 z-10 opacity-0 group-hover:opacity-100 focus-visible:opacity-100 transition-opacity duration-300 bg-background/80 backdrop-blur-sm"
+            aria-label="Enter full screen"
+            title="Enter full screen"
+          >
+            <Maximize2 className="size-4" />
+          </Button>
+        </DialogTrigger>
+      </div>
+      <DialogContent fullscreen showCloseButton={false}>
+        <DialogTitle className="sr-only">{title}</DialogTitle>
+        <DialogClose asChild>
+          <Button
+            variant="outline"
+            size="icon-sm"
+            className="absolute top-4 right-4 z-20"
+            aria-label="Exit full screen"
+            title="Exit full screen"
+          >
+            <Minimize2 className="size-4" />
+          </Button>
+        </DialogClose>
+        <div className="h-full">{children}</div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function renderBasicMsg(msg: (typeof MOCK_MESSAGES_BASIC)[number]) {
+  return (
+    <AiChatMessage
+      key={msg.id}
+      message={msg}
+      sources={MOCK_SOURCES_BASIC[msg.id]}
+      attachments={MOCK_ATTACHMENTS_BASIC[msg.id]}
+    />
+  );
+}
+
+export default function AiChatPreviewPage() {
+  return (
+    <div className="max-w-6xl mx-auto p-8 space-y-12">
+      <div>
+        <h1 className="text-3xl font-bold text-foreground">
+          {"AI Chat — Component Preview"}
+        </h1>
+        <p className="text-muted-foreground mt-2">
+          {"All visual states and sub-components rendered with mock data."}
+        </p>
+      </div>
+
+      {/* ── 1. Empty State (default) ────────────────────────── */}
+      <section>
+        <SectionHeader
+          title="Empty State (Default)"
+          description="Default empty state with AI gradient icon."
+        />
+        <PreviewCard className="h-[400px]" title="Empty State (Default)">
+          <AiChat
+            messages={[]}
+            isLoading={false}
+            onSendMessage={noop}
+            onStop={noop}
+            title="Autopilot"
+          />
+        </PreviewCard>
+      </section>
+
+      {/* ── 2. Empty State (with suggestions) ──────────────── */}
+      <section>
+        <SectionHeader
+          title="Empty State (Custom with Suggestions)"
+          description="AiChatEmptyState component with quick-start prompts."
+        />
+        <PreviewCard
+          className="h-[400px]"
+          title="Empty State (Custom with Suggestions)"
+        >
+          <AiChat
+            messages={[]}
+            isLoading={false}
+            onSendMessage={noop}
+            onStop={noop}
+            title="Autopilot"
+            emptyState={
+              <AiChatEmptyState
+                title="What would you like to do?"
+                description="I can help you review, fix, or complete your work."
+              />
+            }
+            suggestions={["Create a React app", "Debug my code", "Write tests"]}
+          />
+        </PreviewCard>
+      </section>
+
+      {/* ── 3. Basic Conversation with timestamps ──────────── */}
+      <section>
+        <SectionHeader
+          title="Basic Conversation"
+          description="User/assistant exchange with avatars, timestamps, and hover actions."
+        />
+        <PreviewCard className="h-[400px]" title="Basic Conversation">
+          <AiChat
+            messages={MOCK_MESSAGES_BASIC}
+            isLoading={false}
+            onSendMessage={noop}
+            onStop={noop}
+            title="Autopilot"
+            showTimestamps
+            showMessageActions
+            enableTextSelection
+            onEditMessage={noop}
+            onFeedback={noop}
+            onRegenerate={noop}
+          >
+            {MOCK_MESSAGES_BASIC.map((msg) => renderBasicMsg(msg))}
+          </AiChat>
+        </PreviewCard>
+      </section>
+
+      {/* ── 4. Multi-turn Conversation ─────────────────────── */}
+      <section>
+        <SectionHeader
+          title="Multi-turn Conversation"
+          description="Longer back-and-forth with scrollable content and custom assistant name."
+        />
+        <PreviewCard className="h-[500px]" title="Multi-turn Conversation">
+          <AiChat
+            messages={MOCK_MESSAGES_CONVERSATION}
+            isLoading={false}
+            onSendMessage={noop}
+            onStop={noop}
+            title="Autopilot"
+            showTimestamps
+            onEditMessage={noop}
+          >
+            {MOCK_MESSAGES_CONVERSATION.map((msg) => (
+              <AiChatMessage key={msg.id} message={msg} />
+            ))}
+          </AiChat>
+        </PreviewCard>
+      </section>
+
+      {/* ── 5. Markdown + Code Block ───────────────────────── */}
+      <section>
+        <SectionHeader
+          title="Markdown Rendering"
+          description="All markdown elements including code blocks with copy button."
+        />
+        <PreviewCard className="h-[600px]" title="Markdown Rendering">
+          <AiChat
+            messages={MOCK_MESSAGES_MARKDOWN}
+            isLoading={false}
+            onSendMessage={noop}
+            onStop={noop}
+            title="Autopilot"
+            onEditMessage={noop}
+          >
+            {MOCK_MESSAGES_MARKDOWN.map((msg) => (
+              <AiChatMessage key={msg.id} message={msg} />
+            ))}
+          </AiChat>
+        </PreviewCard>
+      </section>
+
+      {/* ── 6. Loading State ───────────────────────────────── */}
+      <section>
+        <SectionHeader
+          title="Loading State"
+          description="Thinking indicator that appears while the assistant generates a response."
+        />
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+          <PreviewCard className="h-[300px]" title="Loading State">
+            <AiChat
+              messages={[MOCK_MESSAGES_BASIC[0]]}
+              isLoading
+              onSendMessage={noop}
+              onStop={noop}
+              title="Autopilot"
+              onEditMessage={noop}
+            >
+              {renderBasicMsg(MOCK_MESSAGES_BASIC[0])}
+            </AiChat>
+          </PreviewCard>
+          <PreviewCard className="p-6">
+            <h3 className="text-sm font-semibold text-muted-foreground mb-4 uppercase tracking-wide">
+              {"Thinking indicator (interactive)"}
+            </h3>
+            <ThinkingDemo />
+          </PreviewCard>
+        </div>
+      </section>
+
+      {/* ── 7. Error + Retry ───────────────────────────────── */}
+      <section>
+        <SectionHeader
+          title="Error State with Retry"
+          description="Inline error banner with retry button."
+        />
+        <PreviewCard className="h-[400px]" title="Error State with Retry">
+          <AiChat
+            messages={MOCK_MESSAGES_BASIC}
+            isLoading={false}
+            onSendMessage={noop}
+            onStop={noop}
+            onRetry={noop}
+            onEditMessage={noop}
+            title="Autopilot"
+            error={
+              new Error(
+                "Failed to connect to the AI service. Please check your network connection.",
+              )
+            }
+          >
+            {MOCK_MESSAGES_BASIC.map((msg) => renderBasicMsg(msg))}
+          </AiChat>
+        </PreviewCard>
+      </section>
+
+      {/* ── 8. Suggestion Buttons ──────────────────────────── */}
+      <section>
+        <SectionHeader
+          title="Suggestion Buttons"
+          description="Label and buttons"
+        />
+        <PreviewCard className="h-[400px]" title="Suggestion Buttons">
+          <AiChat
+            messages={MOCK_MESSAGES_WITH_CHOICES}
+            isLoading={false}
+            onSendMessage={noop}
+            onStop={noop}
+            onEditMessage={noop}
+            title="Autopilot"
+          >
+            {MOCK_MESSAGES_WITH_CHOICES.map((msg) => (
+              <AiChatMessage key={msg.id} message={msg} />
+            ))}
+          </AiChat>
+        </PreviewCard>
+      </section>
+
+      {/* ── 9. Message Actions ─────────────────────────────── */}
+      <section>
+        <SectionHeader
+          title="Message Actions"
+          description="Copy, thumbs up/down, regenerate (assistant) and edit (user)."
+        />
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+          <PreviewCard className="p-6">
+            <h3 className="text-sm font-semibold text-muted-foreground mb-4 uppercase tracking-wide">
+              {"Assistant actions"}
+            </h3>
+            <AiChatMessageActions
+              content="This is an assistant response."
+              messageRole="assistant"
+              isLatest
+              showCopy
+              onFeedback={noop}
+              onRegenerate={noop}
+            />
+          </PreviewCard>
+          <PreviewCard className="p-6">
+            <h3 className="text-sm font-semibold text-muted-foreground mb-4 uppercase tracking-wide">
+              {"User actions"}
+            </h3>
+            <AiChatMessageActions
+              content="This is a user message."
+              messageRole="user"
+              isLatest
+              showCopy
+              onEdit={noop}
+            />
+          </PreviewCard>
+        </div>
+      </section>
+
+      {/* ── 10. Edit Mode ──────────────────────────────────── */}
+      <section>
+        <SectionHeader
+          title="Edit Mode"
+          description="Inline edit flow — click the edit icon on a user message to revise and re-run."
+        />
+        <PreviewCard className="h-[400px]" title="Edit Mode">
+          <AiChat
+            messages={MOCK_MESSAGES_BASIC}
+            isLoading={false}
+            onSendMessage={noop}
+            onStop={noop}
+            title="Autopilot"
+            showMessageActions
+            onEditMessage={noop}
+            onRegenerate={noop}
+            onFeedback={noop}
+          >
+            {MOCK_MESSAGES_BASIC.map((msg) => renderBasicMsg(msg))}
+          </AiChat>
+        </PreviewCard>
+      </section>
+
+      {/* ── 11. Isolated Sub-Components ────────────────────── */}
+      <section>
+        <SectionHeader
+          title="Isolated Sub-Components"
+          description="Each sub-component rendered standalone."
+        />
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+          <PreviewCard className="p-6">
+            <h3 className="text-sm font-semibold text-muted-foreground mb-4 uppercase tracking-wide">
+              {"AiChatSuggestions (with recommended)"}
+            </h3>
+            <AiChatSuggestions
+              prompt="Choose your preferred approach:"
+              options={MOCK_CHOICE_OPTIONS}
+              onSelect={noop}
+            />
+          </PreviewCard>
+
+          <PreviewCard className="p-6">
+            <h3 className="text-sm font-semibold text-muted-foreground mb-4 uppercase tracking-wide">
+              {"AiChatFlow (multi-step)"}
+            </h3>
+            <FlowDemo />
+          </PreviewCard>
+
+          <PreviewCard className="p-0">
+            <h3 className="text-sm font-semibold text-muted-foreground px-6 pt-6 uppercase tracking-wide">
+              {"AiChatInput (with text + attachment)"}
+            </h3>
+            <AiChatInput
+              value="How do I install Apollo components?"
+              onChange={noop}
+              onSubmit={noop}
+              onStop={noop}
+              isLoading={false}
+              hasMessages
+              initialFiles={[
+                {
+                  uid: "preview-1",
+                  name: "design-spec.png",
+                  size: 84320,
+                  type: "image/png",
+                  file: new File([], "design-spec.png", { type: "image/png" }),
+                },
+              ]}
+            />
+          </PreviewCard>
+
+          <PreviewCard className="p-6">
+            <h3 className="text-sm font-semibold text-muted-foreground mb-4 uppercase tracking-wide">
+              {"AiChatCodeBlock"}
+            </h3>
+            <AiChatCodeBlock language="typescript">
+              {`import { AiChat } from "@/components/ui/ai-chat";
+
+function App() {
+  return <AiChat messages={[]} isLoading={false} />;
+}`}
+            </AiChatCodeBlock>
+          </PreviewCard>
+
+          <PreviewCard className="p-6">
+            <h3 className="text-sm font-semibold text-muted-foreground mb-4 uppercase tracking-wide">
+              {"AiChatMarkdown (standalone)"}
+            </h3>
+            <AiChatMarkdown>
+              {`Here's a quick example with **bold**, *italic*, \`code\`, and a [link](https://example.com).\n\n| Feature | Supported |\n|---------|----------|\n| Tables | Yes |\n| Code | Yes |`}
+            </AiChatMarkdown>
+          </PreviewCard>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/apps/apollo-vertex/app/vertex-components/ai-chat/preview/thinking-demo.tsx
+++ b/apps/apollo-vertex/app/vertex-components/ai-chat/preview/thinking-demo.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { AnimatePresence, motion } from "framer-motion";
+import { useState } from "react";
+import { AiChatThinking } from "@/registry/ai-chat/components/ai-chat-thinking";
+import { useThinkingLabel } from "@/registry/ai-chat/hooks/use-thinking-label";
+import { Button } from "@/registry/button/button";
+
+const ENTRANCE_EASE = [0.22, 1, 0.36, 1] as const;
+const LABEL_SLIDE = 6;
+
+const shimmerStyle = {
+  display: "inline-block",
+  whiteSpace: "nowrap",
+  lineHeight: 1.3,
+  fontSize: "14px",
+  fontWeight: 500,
+  backgroundImage:
+    "linear-gradient(90deg, var(--muted-foreground) 0%, var(--muted-foreground) 30%, #6C5AEF 42%, var(--foreground) 50%, #69C7DD 58%, var(--muted-foreground) 70%, var(--muted-foreground) 100%)",
+  backgroundSize: "200% 100%",
+  backgroundClip: "text",
+  WebkitBackgroundClip: "text",
+  color: "transparent",
+  animation: "ap-chat-shimmer-thinking 2.4s linear infinite",
+} as const;
+
+export function ThinkingDemo() {
+  const [isThinking, setIsThinking] = useState(false);
+  const { label, key: labelKey } = useThinkingLabel();
+
+  return (
+    <div className="flex flex-col items-center gap-6">
+      <style>{`
+        @keyframes ap-chat-shimmer-thinking {
+          0% { background-position: 200% 0; }
+          100% { background-position: -200% 0; }
+        }
+      `}</style>
+      <div className="flex items-center gap-0 h-14">
+        <AiChatThinking size={40} isThinking={isThinking} />
+        <motion.div
+          initial={{ opacity: 0, x: -8 }}
+          animate={{
+            opacity: isThinking ? 1 : 0,
+            x: isThinking ? 0 : -8,
+          }}
+          transition={{
+            duration: 0.3,
+            delay: isThinking ? 0.9 : 0,
+            ease: ENTRANCE_EASE,
+          }}
+          style={{ marginLeft: "-7px", display: "flex", alignItems: "center" }}
+        >
+          <AnimatePresence mode="wait">
+            <motion.span
+              key={isThinking ? labelKey : "idle"}
+              initial={{ opacity: 0, y: LABEL_SLIDE }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: -LABEL_SLIDE }}
+              transition={{ duration: 0.22, ease: ENTRANCE_EASE }}
+              style={shimmerStyle}
+            >
+              {isThinking ? label : "Thinking…"}
+            </motion.span>
+          </AnimatePresence>
+        </motion.div>
+      </div>
+      <Button
+        variant="outline"
+        size="sm"
+        onClick={() => setIsThinking((v) => !v)}
+      >
+        {isThinking ? "Stop thinking" : "Start thinking"}
+      </Button>
+    </div>
+  );
+}

--- a/apps/apollo-vertex/templates/AiChatTemplate.tsx
+++ b/apps/apollo-vertex/templates/AiChatTemplate.tsx
@@ -34,8 +34,8 @@ function AiChatWithConnection({
   });
 
   return (
-    <div className="flex flex-col gap-4">
-      <div className="flex items-center justify-end gap-4 pt-2">
+    <div className="flex flex-col gap-4 h-full min-h-0">
+      <div className="flex items-center justify-end gap-4 pt-2 flex-shrink-0">
         <RadioGroup
           value={mode}
           onValueChange={(v) => {
@@ -64,7 +64,7 @@ function AiChatWithConnection({
         </RadioGroup>
       </div>
 
-      <div className="h-[500px]">
+      <div className="flex-1 min-h-0 overflow-hidden">
         {mode === "agenthub" ? (
           <AgentHubChat accessToken={accessToken} orgTenant={orgTenant} />
         ) : (
@@ -78,9 +78,9 @@ function AiChatWithConnection({
   );
 }
 
-export function AiChatTemplate() {
+export function AiChatTemplate({ className }: { className?: string }) {
   return (
-    <div className="min-h-[600px] flex w-full flex-col justify-center">
+    <div className={className ?? "h-[600px] flex w-full flex-col"}>
       <QueryClientProvider client={queryClient}>
         <ShellAuthProvider
           clientId={AICHAT_CLIENT_ID}

--- a/apps/apollo-vertex/templates/ai-chat/AiChatAgentHubMode.tsx
+++ b/apps/apollo-vertex/templates/ai-chat/AiChatAgentHubMode.tsx
@@ -4,16 +4,25 @@ import { useChat } from "@tanstack/ai-react";
 import { useTranslation } from "react-i18next";
 import { createAgentHubConnection } from "@/registry/ai-chat/adapters/agenthub/adapter";
 import { AiChat } from "@/registry/ai-chat/components/ai-chat";
+import { AiChatEmptyState } from "@/registry/ai-chat/components/ai-chat-empty-state";
 import { AiChatMessage } from "@/registry/ai-chat/components/ai-chat-message";
 import {
   CHOICES_TOOL_PROMPT,
   choicesTools,
 } from "@/registry/ai-chat/examples/choices-tool";
+import {
+  FLOW_TOOL_PROMPT,
+  flowTool,
+} from "@/registry/ai-chat/examples/flow-tool";
 import type { OrgTenantInfo } from "./AiChatLoginGate";
+
+const allTools = [...choicesTools, ...flowTool];
 
 const systemPrompt = `You are a helpful assistant. Always respond using markdown format.
 
-${CHOICES_TOOL_PROMPT}`;
+${CHOICES_TOOL_PROMPT}
+
+${FLOW_TOOL_PROMPT}`;
 
 interface AgentHubChatProps {
   accessToken: string;
@@ -28,13 +37,14 @@ export function AgentHubChat({ accessToken, orgTenant }: AgentHubChatProps) {
     model: { vendor: "openai", name: "gpt-4.1-mini-2025-04-14" },
     accessToken: () => accessToken,
     systemPrompt,
-    tools: choicesTools,
+    tools: allTools,
   });
 
-  const { messages, sendMessage, isLoading, stop, clear, error } = useChat({
-    connection,
-    tools: choicesTools,
-  });
+  const { messages, sendMessage, isLoading, stop, clear, reload, error } =
+    useChat({
+      connection,
+      tools: allTools,
+    });
 
   return (
     <AiChat
@@ -45,16 +55,25 @@ export function AgentHubChat({ accessToken, orgTenant }: AgentHubChatProps) {
       }}
       onStop={stop}
       onClearChat={clear}
-      title={t("ai_assistant")}
+      onRegenerate={() => {
+        void reload();
+      }}
+      onEditMessage={(_id, content) => {
+        void sendMessage(content);
+      }}
+      title="Autopilot"
       assistantName={t("assistant")}
+      enableTextSelection
       error={error ?? null}
+      emptyState={<AiChatEmptyState title="What are we tackling today?" />}
+      suggestions={[
+        "Summarize a PDF",
+        "Create an executive brief",
+        "Draft a follow-up for my last meeting",
+      ]}
     >
       {messages.map((message) => (
-        <AiChatMessage
-          key={message.id}
-          message={message}
-          assistantName={t("assistant")}
-        />
+        <AiChatMessage key={message.id} message={message} />
       ))}
     </AiChat>
   );

--- a/apps/apollo-vertex/templates/ai-chat/AiChatConversationalAgentMode.tsx
+++ b/apps/apollo-vertex/templates/ai-chat/AiChatConversationalAgentMode.tsx
@@ -39,9 +39,10 @@ function ConversationalAgentChatInner({
     };
   }, [connection]);
 
-  const { messages, sendMessage, isLoading, stop, clear, error } = useChat({
-    connection,
-  });
+  const { messages, sendMessage, isLoading, stop, clear, reload, error } =
+    useChat({
+      connection,
+    });
 
   return (
     <AiChat
@@ -52,16 +53,16 @@ function ConversationalAgentChatInner({
       }}
       onStop={stop}
       onClearChat={clear}
+      onRegenerate={() => {
+        void reload();
+      }}
       title={title}
       assistantName={assistantName}
+      enableTextSelection
       error={error ?? null}
     >
       {messages.map((message) => (
-        <AiChatMessage
-          key={message.id}
-          message={message}
-          assistantName={assistantName}
-        />
+        <AiChatMessage key={message.id} message={message} />
       ))}
     </AiChat>
   );
@@ -151,7 +152,7 @@ export function ConversationalAgentChat({
           sdk={sdk}
           agentId={selectedAgentConfig.agentId}
           folderId={selectedAgentConfig.folderId}
-          title={t("ai_assistant")}
+          title="Autopilot"
           assistantName={t("assistant")}
         />
       </div>

--- a/apps/apollo-vertex/templates/ai-chat/AiChatLoginGate.tsx
+++ b/apps/apollo-vertex/templates/ai-chat/AiChatLoginGate.tsx
@@ -1,9 +1,9 @@
 "use client";
 
+import { useLocalStorage } from "@mantine/hooks";
 import { useQuery } from "@tanstack/react-query";
 import { jwtDecode } from "jwt-decode";
 import { ChevronRight, LogIn, LogOut } from "lucide-react";
-import { useLocalStorage } from "@mantine/hooks";
 import type { ReactNode } from "react";
 import { z } from "zod";
 import { Button } from "@/components/ui/button";
@@ -252,8 +252,8 @@ export function AiChatLoginGate({ children }: AiChatLoginGateProps) {
   }
 
   return (
-    <div className="flex flex-col gap-2">
-      <div className="flex items-center justify-end gap-2">
+    <div className="flex flex-col gap-2 h-full">
+      <div className="flex-shrink-0 flex items-center justify-end gap-2">
         <span className="flex items-center gap-1 text-sm text-muted-foreground">
           {user && (
             <>


### PR DESCRIPTION
## Summary

- Adds `AiChatTemplate`, `AiChatAgentHubMode`, `AiChatConversationalAgentMode`, and `AiChatLoginGate` page templates
- Adds full interactive preview page at `/vertex-components/ai-chat/preview` with mock data and thinking demo
- Adds `/patterns/ai-chat` documentation page
- Adds ai-chat entry to `app/_meta.ts` nav

## Stacking

This is **PR 2 of 2**. Targets [`pr/1-aichat-core`](#542) — merge PR 1 first, then re-target this PR to `main` before merging.

> Supersedes #511 — split into stacked PRs per reviewer request.

## Test plan

- [ ] `git checkout pr/2-aichat-templates && pnpm dev`
- [ ] Visit `http://localhost:3000/vertex-components/ai-chat/preview` — interactive AI chat preview loads with mock data
- [ ] Visit `http://localhost:3000/patterns/ai-chat` — documentation page renders
- [ ] "AI Chat" appears in the Vertex Components nav section

🤖 Generated with [Claude Code](https://claude.com/claude-code)