### PR TITLE
feat(apollo-vertex): ai-chat display components [2/6]

### DIFF
--- a/apps/apollo-vertex/registry.json
+++ b/apps/apollo-vertex/registry.json
@@ -419,6 +419,18 @@
           "target": "components/ui/ai-chat/components/ai-chat-loading.tsx"
         },
         {
+          "path": "registry/ai-chat/components/ai-chat-thinking.tsx",
+          "type": "registry:component"
+        },
+        {
+          "path": "registry/ai-chat/components/ai-chat-code-block.tsx",
+          "type": "registry:component"
+        },
+        {
+          "path": "registry/ai-chat/components/ai-chat-empty-state.tsx",
+          "type": "registry:component"
+        },
+        {
           "path": "registry/ai-chat/components/ai-chat-input.tsx",
           "type": "registry:ui",
           "target": "components/ui/ai-chat/components/ai-chat-input.tsx"

--- a/apps/apollo-vertex/registry/ai-chat/components/ai-chat-code-block.tsx
+++ b/apps/apollo-vertex/registry/ai-chat/components/ai-chat-code-block.tsx
@@ -1,0 +1,164 @@
+"use client";
+
+import "highlight.js/styles/github.min.css";
+
+// Dark-mode override: github-dark-dimmed palette scoped to `.dark`
+const DARK_HLJS_STYLE = `
+.dark .hljs {
+  color: #adbac7;
+  background: transparent;
+}
+.dark .hljs-doctag,.dark .hljs-keyword,.dark .hljs-meta .hljs-keyword,.dark .hljs-template-tag,.dark .hljs-template-variable,.dark .hljs-type,.dark .hljs-variable.language_ {
+  color: #f47067;
+}
+.dark .hljs-title,.dark .hljs-title.class_,.dark .hljs-title.class_.inherited__,.dark .hljs-title.function_ {
+  color: #dcbdfb;
+}
+.dark .hljs-attr,.dark .hljs-attribute,.dark .hljs-literal,.dark .hljs-meta,.dark .hljs-number,.dark .hljs-operator,.dark .hljs-variable,.dark .hljs-selector-attr,.dark .hljs-selector-class,.dark .hljs-selector-id {
+  color: #6cb6ff;
+}
+.dark .hljs-regexp,.dark .hljs-string,.dark .hljs-meta .hljs-string {
+  color: #96d0ff;
+}
+.dark .hljs-built_in,.dark .hljs-symbol {
+  color: #f69d50;
+}
+.dark .hljs-comment,.dark .hljs-code,.dark .hljs-formula {
+  color: #768390;
+}
+.dark .hljs-name,.dark .hljs-quote,.dark .hljs-selector-tag,.dark .hljs-selector-pseudo {
+  color: #8ddb8c;
+}
+.dark .hljs-subst {
+  color: #adbac7;
+}
+.dark .hljs-section {
+  color: #316dca;
+  font-weight: bold;
+}
+.dark .hljs-bullet {
+  color: #eac55f;
+}
+.dark .hljs-emphasis {
+  color: #adbac7;
+  font-style: italic;
+}
+.dark .hljs-strong {
+  color: #adbac7;
+  font-weight: bold;
+}
+.dark .hljs-addition {
+  color: #b4f1b4;
+  background-color: #1b4721;
+}
+.dark .hljs-deletion {
+  color: #ffd8d3;
+  background-color: #78191b;
+}
+`;
+
+import hljs from "highlight.js/lib/core";
+import bash from "highlight.js/lib/languages/bash";
+import css from "highlight.js/lib/languages/css";
+import javascript from "highlight.js/lib/languages/javascript";
+import json from "highlight.js/lib/languages/json";
+import python from "highlight.js/lib/languages/python";
+import sql from "highlight.js/lib/languages/sql";
+import typescript from "highlight.js/lib/languages/typescript";
+import xml from "highlight.js/lib/languages/xml";
+import { Check, Copy } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/registry/tooltip/tooltip";
+
+hljs.registerLanguage("javascript", javascript);
+hljs.registerLanguage("js", javascript);
+hljs.registerLanguage("typescript", typescript);
+hljs.registerLanguage("ts", typescript);
+hljs.registerLanguage("tsx", typescript);
+hljs.registerLanguage("jsx", javascript);
+hljs.registerLanguage("python", python);
+hljs.registerLanguage("py", python);
+hljs.registerLanguage("bash", bash);
+hljs.registerLanguage("sh", bash);
+hljs.registerLanguage("shell", bash);
+hljs.registerLanguage("json", json);
+hljs.registerLanguage("css", css);
+hljs.registerLanguage("html", xml);
+hljs.registerLanguage("xml", xml);
+hljs.registerLanguage("sql", sql);
+
+const COPY_LABEL = "Copy code";
+const COPIED_LABEL = "Copied!";
+
+interface AiChatCodeBlockProps {
+  children: string;
+  language?: string;
+}
+
+export function AiChatCodeBlock({ children, language }: AiChatCodeBlockProps) {
+  const [copied, setCopied] = useState(false);
+  const codeRef = useRef<HTMLElement>(null);
+
+  const highlightedHtml =
+    language && hljs.getLanguage(language)
+      ? hljs.highlight(children, { language }).value
+      : hljs.highlightAuto(children).value;
+
+  useEffect(() => {
+    if (codeRef.current) {
+      codeRef.current.innerHTML = highlightedHtml;
+    }
+  }, [highlightedHtml]);
+
+  const handleCopy = async () => {
+    await navigator.clipboard.writeText(children);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  const copyLabel = copied ? COPIED_LABEL : COPY_LABEL;
+
+  return (
+    <>
+      <style>{DARK_HLJS_STYLE}</style>
+      <div className="relative group/codeblock mb-2 last:mb-0 rounded-lg bg-ai-chat-muted/50 overflow-hidden">
+        <div className="flex items-center justify-between px-3 py-1.5 border-b border-ai-chat-border">
+          {language && (
+            <span className="text-[11px] font-mono text-ai-chat-muted-foreground uppercase tracking-wider">
+              {language}
+            </span>
+          )}
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                onClick={() => {
+                  void handleCopy();
+                }}
+                className="ml-auto size-6 inline-flex items-center justify-center rounded-md opacity-0 group-hover/codeblock:opacity-100 transition-opacity hover:bg-ai-chat-border"
+                aria-label={copyLabel}
+              >
+                {copied ? (
+                  <Check className="size-3 text-success" aria-hidden="true" />
+                ) : (
+                  <Copy
+                    className="size-3 text-ai-chat-muted-foreground"
+                    aria-hidden="true"
+                  />
+                )}
+              </button>
+            </TooltipTrigger>
+            <TooltipContent>{copyLabel}</TooltipContent>
+          </Tooltip>
+        </div>
+        <pre className="p-3 overflow-x-auto">
+          <code ref={codeRef} className="hljs text-xs font-mono" />
+        </pre>
+      </div>
+    </>
+  );
+}

--- a/apps/apollo-vertex/registry/ai-chat/components/ai-chat-empty-state.tsx
+++ b/apps/apollo-vertex/registry/ai-chat/components/ai-chat-empty-state.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import type { ReactNode } from "react";
+
+interface AiChatEmptyStateProps {
+  title?: string;
+  description?: string;
+  icon?: ReactNode;
+}
+
+export function AiChatEmptyState({
+  title = "How can I help you?",
+  description,
+  icon,
+}: AiChatEmptyStateProps) {
+  return (
+    <div className="flex flex-col items-center justify-center h-full text-center text-ai-chat-muted-foreground gap-4">
+      {icon}
+      <div className="flex flex-col items-center gap-1">
+        <h2 className="text-2xl font-semibold leading-tight tracking-tight text-foreground">
+          {title}
+        </h2>
+        {description && (
+          <p className="text-sm text-muted-foreground max-w-sm">
+            {description}
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/apollo-vertex/registry/ai-chat/components/ai-chat-loading.tsx
+++ b/apps/apollo-vertex/registry/ai-chat/components/ai-chat-loading.tsx
@@ -1,33 +1,73 @@
 "use client";
 
-import { Sparkles } from "lucide-react";
-import { useTranslation } from "react-i18next";
+import { motion } from "framer-motion";
+import { AiChatThinking } from "./ai-chat-thinking";
 
-interface AiChatLoadingProps {
-  assistantName?: string;
-}
+// Quartic ease-out — same curve used inside AiChatThinking for consistency
+const ENTRANCE_EASE = [0.22, 1, 0.36, 1] as const;
+// Container slide-up + fade-in duration
+const ENTRANCE_DURATION = 0.5;
+// Text appears after the icon's morph completes (FORWARD_DURATION in AiChatThinking is 0.8s) plus a small gap
+const TEXT_DELAY = 0.9;
+const TEXT_DURATION = 0.3;
 
-export function AiChatLoading({ assistantName }: AiChatLoadingProps) {
-  const { t } = useTranslation();
-  const displayName = assistantName ?? t("ai_assistant");
+const shimmerStyle = {
+  display: "inline-block",
+  whiteSpace: "nowrap",
+  lineHeight: 1.3,
+  fontSize: "14px",
+  fontWeight: 500,
+  backgroundImage:
+    "linear-gradient(90deg, var(--muted-foreground) 0%, var(--muted-foreground) 30%, #6C5AEF 42%, var(--foreground) 50%, #69C7DD 58%, var(--muted-foreground) 70%, var(--muted-foreground) 100%)",
+  backgroundSize: "200% 100%",
+  backgroundClip: "text",
+  WebkitBackgroundClip: "text",
+  color: "transparent",
+  animation: "ap-chat-loading-shimmer 2.4s linear infinite",
+} as const;
 
+// TODO: Progressive thinking states
+// The indicator should become more informative as latency grows, and should
+// reflect what the agent is actually doing (not just that it is busy):
+//
+//   < 500ms   No indicator — avoids flicker on fast responses
+//   500ms–2s  Static "Thinking…" + shimmer (current)
+//   2s+       Contextual label — text reflects the current operation
+//               (e.g. "Reading document…", "Running automation…")
+//   4s+       Step-level UI — surfaces discrete agent actions as they occur,
+//               so the user understands what the agent is doing on their behalf
+//
+// Labels will be caller-supplied once the state model is defined, so the
+// component stays agnostic to the specific agent and its toolset.
+export function AiChatLoading() {
   return (
-    <div className="flex justify-start gap-3">
-      <div className="size-8 flex items-center justify-center flex-shrink-0 rounded-full bg-primary">
-        <Sparkles className="size-4 text-primary-foreground" />
+    <motion.div
+      className="flex justify-start py-2"
+      initial={{ opacity: 0, y: 8 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: ENTRANCE_DURATION, ease: ENTRANCE_EASE }}
+    >
+      <style>{`
+        @keyframes ap-chat-loading-shimmer {
+          0% { background-position: 200% 0; }
+          100% { background-position: -200% 0; }
+        }
+      `}</style>
+      <div className="flex items-center gap-0">
+        <AiChatThinking size={40} isThinking />
+        <motion.div
+          initial={{ opacity: 0, x: -8 }}
+          animate={{ opacity: 1, x: 0 }}
+          transition={{
+            duration: TEXT_DURATION,
+            delay: TEXT_DELAY,
+            ease: ENTRANCE_EASE,
+          }}
+          style={{ marginLeft: "-7px", display: "flex", alignItems: "center" }}
+        >
+          <span style={shimmerStyle}>{"Thinking\u2026"}</span>
+        </motion.div>
       </div>
-      <div className="flex flex-col gap-1">
-        <span className="text-xs text-muted-foreground font-medium">
-          {displayName}
-        </span>
-        <div className="px-4 py-3 rounded-lg bg-primary/10">
-          <div className="flex gap-1">
-            <span className="size-2 bg-primary rounded-full animate-bounce [animation-delay:-0.3s]" />
-            <span className="size-2 bg-primary rounded-full animate-bounce [animation-delay:-0.15s]" />
-            <span className="size-2 bg-primary rounded-full animate-bounce" />
-          </div>
-        </div>
-      </div>
-    </div>
+    </motion.div>
   );
 }

--- a/apps/apollo-vertex/registry/ai-chat/components/ai-chat-markdown.tsx
+++ b/apps/apollo-vertex/registry/ai-chat/components/ai-chat-markdown.tsx
@@ -3,73 +3,112 @@
 import type { ComponentProps, ReactNode } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
+import { AiChatCodeBlock } from "./ai-chat-code-block";
 
 type NodeProps = { children?: ReactNode };
 type AnchorProps = { children?: ReactNode; href?: string };
+type ImageProps = { src?: string | Blob; alt?: string; title?: string };
+
+function extractCodeProps(props: NodeProps & { className?: string }) {
+  const { className, children } = props;
+  const match = /language-(\w+)/.exec(className ?? "");
+  const language = match ? match[1] : "";
+  const code = (typeof children === "string" ? children : "").replace(
+    /\n$/,
+    "",
+  );
+  return { language, code };
+}
 
 const components: ComponentProps<typeof ReactMarkdown>["components"] = {
-  p: ({ children }: NodeProps) => <p className="mb-2 last:mb-0">{children}</p>,
+  p: ({ children }: NodeProps) => (
+    <p className="mt-5 mb-5 first:mt-0 last:mb-0">{children}</p>
+  ),
   ul: ({ children }: NodeProps) => (
-    <ul className="mb-2 last:mb-0 ml-4 list-disc">{children}</ul>
+    <ul className="mt-5 mb-5 first:mt-0 last:mb-0 ml-4 list-disc">
+      {children}
+    </ul>
   ),
   ol: ({ children }: NodeProps) => (
-    <ol className="mb-2 last:mb-0 ml-4 list-decimal">{children}</ol>
-  ),
-  li: ({ children }: NodeProps) => <li className="mb-1">{children}</li>,
-  pre: ({ children }: NodeProps) => (
-    <pre className="mb-2 last:mb-0 p-3 rounded bg-muted text-foreground font-mono text-xs overflow-x-auto">
+    <ol className="mt-5 mb-5 first:mt-0 last:mb-0 ml-4 list-decimal">
       {children}
-    </pre>
+    </ol>
   ),
+  li: ({ children }: NodeProps) => <li className="mb-3">{children}</li>,
+  pre: ({ children }: NodeProps) => <div>{children}</div>,
   code: ({
     children,
     className,
     ...props
-  }: NodeProps & { className?: string }) => (
-    <code
-      className={
-        className ??
-        "px-1.5 py-0.5 rounded bg-muted text-foreground font-mono text-xs"
-      }
+  }: NodeProps & { className?: string }) => {
+    const isBlock =
+      (className?.startsWith("language-") ?? false) ||
+      (typeof children === "string" && children.includes("\n"));
+
+    if (isBlock) {
+      const { language, code } = extractCodeProps({
+        className,
+        children,
+        ...props,
+      });
+      return <AiChatCodeBlock language={language}>{code}</AiChatCodeBlock>;
+    }
+
+    return (
+      <code className="px-1.5 py-0.5 rounded bg-ai-chat-muted text-ai-chat-foreground font-mono text-xs">
+        {children}
+      </code>
+    );
+  },
+  a: ({ children, ...props }: AnchorProps) => (
+    <a
+      className="text-primary-700 dark:text-primary-400 hover:underline"
       {...props}
     >
       {children}
-    </code>
-  ),
-  a: ({ children, ...props }: AnchorProps) => (
-    <a className="text-primary hover:underline" {...props}>
-      {children}
     </a>
+  ),
+  img: ({ src, alt, title }: ImageProps) => (
+    <img
+      src={typeof src === "string" ? src : ""}
+      alt={alt ?? ""}
+      title={title}
+      loading="lazy"
+      decoding="async"
+      className="block max-w-full max-h-[400px] object-contain rounded-lg border border-ai-chat-border"
+    />
   ),
   strong: ({ children }: NodeProps) => (
     <strong className="font-semibold">{children}</strong>
   ),
   em: ({ children }: NodeProps) => <em className="italic">{children}</em>,
   blockquote: ({ children }: NodeProps) => (
-    <blockquote className="border-l-2 border-muted-foreground/30 pl-3 italic my-2">
+    <blockquote className="border-l-2 border-ai-chat-accent pl-3 bg-ai-chat-accent/5 rounded-r italic my-2 py-1">
       {children}
     </blockquote>
   ),
   h1: ({ children }: NodeProps) => (
-    <h1 className="text-lg font-bold mb-2 mt-3 first:mt-0">{children}</h1>
+    <h1 className="text-2xl font-bold mb-3 mt-6 first:mt-0">{children}</h1>
   ),
   h2: ({ children }: NodeProps) => (
-    <h2 className="text-base font-bold mb-2 mt-3 first:mt-0">{children}</h2>
+    <h2 className="text-xl font-bold mb-2 mt-5 first:mt-0">{children}</h2>
   ),
   h3: ({ children }: NodeProps) => (
-    <h3 className="text-sm font-bold mb-2 mt-2 first:mt-0">{children}</h3>
+    <h3 className="text-lg font-bold mb-2 mt-4 first:mt-0">{children}</h3>
   ),
-  hr: () => <hr className="my-3 border-border" />,
+  hr: () => <hr className="my-3 border-ai-chat-border" />,
   table: ({ children }: NodeProps) => (
     <div className="overflow-x-auto my-2">
-      <table className="min-w-full divide-y divide-border">{children}</table>
+      <table className="min-w-full divide-y divide-ai-chat-border">
+        {children}
+      </table>
     </div>
   ),
   thead: ({ children }: NodeProps) => (
-    <thead className="bg-muted">{children}</thead>
+    <thead className="bg-ai-chat-muted">{children}</thead>
   ),
   tbody: ({ children }: NodeProps) => (
-    <tbody className="divide-y divide-border">{children}</tbody>
+    <tbody className="divide-y divide-ai-chat-border">{children}</tbody>
   ),
   tr: ({ children }: NodeProps) => <tr>{children}</tr>,
   th: ({ children }: NodeProps) => (
@@ -86,7 +125,7 @@ interface AiChatMarkdownProps {
 
 export function AiChatMarkdown({ children }: AiChatMarkdownProps) {
   return (
-    <div className="px-4 py-3 text-sm rounded-lg bg-primary/10 prose prose-sm dark:prose-invert max-w-none">
+    <div className="py-1 text-base leading-relaxed bg-transparent text-foreground prose dark:prose-invert max-w-none">
       <ReactMarkdown remarkPlugins={[remarkGfm]} components={components}>
         {children}
       </ReactMarkdown>

--- a/apps/apollo-vertex/registry/ai-chat/components/ai-chat-suggestions.tsx
+++ b/apps/apollo-vertex/registry/ai-chat/components/ai-chat-suggestions.tsx
@@ -1,37 +1,174 @@
 "use client";
 
-import { cn } from "@/lib/utils";
-import type { ChoiceOption } from "../tools/choices";
+import { ChevronLeft, ChevronRight, Loader2, X } from "lucide-react";
+import { motion } from "framer-motion";
+import type { ChoiceOption } from "../types";
+
+const ENTRANCE_EASE = [0.22, 1, 0.36, 1] as const;
+
+const containerVariants = {
+  hidden: { opacity: 0, y: 8 },
+  visible: {
+    opacity: 1,
+    y: 0,
+    transition: {
+      duration: 0.28,
+      ease: ENTRANCE_EASE,
+      delayChildren: 0.18,
+      staggerChildren: 0.05,
+    },
+  },
+};
+
+const buttonVariants = {
+  hidden: { opacity: 0, y: 6 },
+  visible: {
+    opacity: 1,
+    y: 0,
+    transition: { duration: 0.2, ease: ENTRANCE_EASE },
+  },
+};
 
 interface AiChatSuggestionsProps {
   prompt?: string;
   options: ChoiceOption[];
   onSelect: (option: ChoiceOption) => void;
+  step?: number;
+  totalSteps?: number;
+  canSkip?: boolean;
+  canGoBack?: boolean;
+  isLoading?: boolean;
+  onBack?: () => void;
+  onSkip?: () => void;
+  onDismiss?: () => void;
 }
 
 export function AiChatSuggestions({
   prompt,
   options,
   onSelect,
+  step,
+  totalSteps,
+  canSkip,
+  canGoBack,
+  isLoading = false,
+  onBack,
+  onSkip,
+  onDismiss,
 }: AiChatSuggestionsProps) {
+  const isMultiStep = step != null;
+
+  if (isMultiStep) {
+    return (
+      <motion.div
+        className="mt-4 rounded-xl border border-border bg-background shadow-sm overflow-hidden"
+        variants={containerVariants}
+        initial="hidden"
+        animate="visible"
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between px-4 pt-3 pb-2">
+          <div className="flex items-center gap-2">
+            {isLoading ? (
+              <Loader2
+                className="size-3.5 animate-spin text-muted-foreground"
+                aria-hidden="true"
+              />
+            ) : (
+              <>
+                {canGoBack && onBack && (
+                  <button
+                    type="button"
+                    onClick={onBack}
+                    className="size-6 inline-flex items-center justify-center rounded-md hover:bg-muted transition-colors text-muted-foreground"
+                    aria-label="Go back"
+                  >
+                    <ChevronLeft className="size-4" aria-hidden="true" />
+                  </button>
+                )}
+                {totalSteps && (
+                  <span className="text-xs text-muted-foreground">
+                    {step} <span className="opacity-40">{"/"}</span>{" "}
+                    {totalSteps}
+                  </span>
+                )}
+              </>
+            )}
+          </div>
+          <div className="flex items-center gap-1">
+            {canSkip && onSkip && (
+              <button
+                type="button"
+                onClick={onSkip}
+                className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors px-2 py-1 rounded-md hover:bg-muted"
+              >
+                {"Skip"}
+                <ChevronRight className="size-3" aria-hidden="true" />
+              </button>
+            )}
+            {onDismiss && (
+              <button
+                type="button"
+                onClick={onDismiss}
+                className="size-6 inline-flex items-center justify-center rounded-md hover:bg-muted transition-colors text-muted-foreground"
+                aria-label="Dismiss"
+              >
+                <X className="size-3.5" aria-hidden="true" />
+              </button>
+            )}
+          </div>
+        </div>
+
+        {/* Prompt */}
+        {prompt && (
+          <p className="px-4 pb-3 text-sm font-medium text-foreground">
+            {prompt}
+          </p>
+        )}
+
+        {/* Options */}
+        <div className="flex flex-col px-2 pb-3 gap-1">
+          {options.map((option) => (
+            <motion.button
+              key={option.id}
+              type="button"
+              variants={buttonVariants}
+              whileHover={isLoading ? {} : { x: 2 }}
+              disabled={isLoading}
+              className="w-full text-left px-3 py-2 rounded-lg text-sm transition-colors hover:bg-muted text-foreground disabled:opacity-40 disabled:cursor-not-allowed"
+              onClick={() => onSelect(option)}
+            >
+              {option.label}
+            </motion.button>
+          ))}
+        </div>
+      </motion.div>
+    );
+  }
+
+  // Single-step: original chip style
   return (
-    <div className="space-y-2">
+    <motion.div
+      className="mt-4 space-y-4"
+      variants={containerVariants}
+      initial="hidden"
+      animate="visible"
+    >
       {prompt && <p className="text-sm text-muted-foreground">{prompt}</p>}
       <div className="flex flex-wrap gap-2">
         {options.map((option) => (
-          <button
+          <motion.button
             key={option.id}
             type="button"
-            className={cn(
-              "h-auto py-2 px-3 text-left max-w-full text-sm rounded-lg border transition-colors hover:opacity-80",
-              option.recommended && "border-2 border-primary",
-            )}
+            variants={buttonVariants}
+            whileHover={{ scale: 1.02 }}
+            className="h-auto py-2 px-4 text-left max-w-full rounded-full text-xs font-semibold transition-colors border border-input bg-background text-foreground hover:bg-muted"
             onClick={() => onSelect(option)}
           >
-            <span className="font-medium truncate">{option.label}</span>
-          </button>
+            <span className="truncate">{option.label}</span>
+          </motion.button>
         ))}
       </div>
-    </div>
+    </motion.div>
   );
 }

--- a/apps/apollo-vertex/registry/ai-chat/components/ai-chat-thinking.tsx
+++ b/apps/apollo-vertex/registry/ai-chat/components/ai-chat-thinking.tsx
@@ -1,0 +1,220 @@
+"use client";
+
+import { motion } from "framer-motion";
+import { useId } from "react";
+
+interface AiChatThinkingProps {
+  size?: number;
+  className?: string;
+  /**
+   * When true, plays the forward sequence (idle → thinking) and holds
+   * the steady-state pulse. When false, plays the reverse back to idle.
+   * Defaults to true so existing usages auto-play on mount.
+   */
+  isThinking?: boolean;
+}
+
+// Timing
+const FORWARD_DURATION = 0.8;
+const REVERSE_DURATION = 0.4;
+const PULSE_DURATION = 1.8;
+
+// Single easing for both directions — quartic ease-in-out, smooth acceleration and deceleration
+const EASE = [0.83, 0, 0.17, 1] as const;
+
+// Circle radius in viewBox units. The 24×24 viewBox at 25% target = 6 units diameter = 3 units radius.
+const CIRCLE_RADIUS = 3;
+
+// Small sparkle geometric center within the 24×24 viewBox
+const SMALL_SPARKLE_CENTER_X = 17.82;
+const SMALL_SPARKLE_CENTER_Y = 6.35;
+const VIEWBOX_CENTER = 12;
+
+export function AiChatThinking({
+  size = 32,
+  className,
+  isThinking = true,
+}: AiChatThinkingProps) {
+  const gradientId = useId();
+
+  // Framer Motion's x/y on SVG elements are applied as CSS translate in CSS pixels.
+  // Convert viewBox-unit deltas into pixel values at the current render size.
+  const unit = size / 24;
+  const smallSparkleTargetX = (VIEWBOX_CENTER - SMALL_SPARKLE_CENTER_X) * unit;
+  const smallSparkleTargetY = (VIEWBOX_CENTER - SMALL_SPARKLE_CENTER_Y) * unit;
+
+  return (
+    <div
+      className={className}
+      style={{
+        position: "relative",
+        width: size,
+        height: size,
+        display: "inline-block",
+      }}
+      aria-hidden="true"
+    >
+      {/* Radiating glow ring — sized proportionally to the circle, fades in with it */}
+      <motion.div
+        style={{
+          position: "absolute",
+          top: "50%",
+          left: "50%",
+          width: "55%",
+          height: "55%",
+          marginTop: "-27.5%",
+          marginLeft: "-27.5%",
+          borderRadius: "50%",
+          background:
+            "radial-gradient(circle, rgba(108,90,239,0.4) 0%, rgba(105,199,221,0.18) 55%, transparent 75%)",
+          pointerEvents: "none",
+        }}
+        initial={{ opacity: 0, scale: 0.7 }}
+        animate={
+          isThinking
+            ? { opacity: [0.5, 0.9, 0.5], scale: [0.9, 1.1, 0.9] }
+            : { opacity: 0, scale: 0.7 }
+        }
+        transition={
+          isThinking
+            ? {
+                opacity: {
+                  duration: PULSE_DURATION,
+                  ease: "easeInOut",
+                  delay: FORWARD_DURATION * 0.5,
+                  repeat: Number.POSITIVE_INFINITY,
+                  repeatType: "loop",
+                },
+                scale: {
+                  duration: PULSE_DURATION,
+                  ease: "easeInOut",
+                  delay: FORWARD_DURATION * 0.5,
+                  repeat: Number.POSITIVE_INFINITY,
+                  repeatType: "loop",
+                },
+              }
+            : { duration: REVERSE_DURATION * 0.8, ease: EASE }
+        }
+      />
+
+      {/* SVG stage — holds both layers, no clipping */}
+      <svg
+        viewBox="0 0 24 24"
+        width="100%"
+        height="100%"
+        style={{
+          position: "absolute",
+          inset: 0,
+          display: "block",
+          overflow: "visible",
+        }}
+        aria-hidden="true"
+      >
+        <defs>
+          <linearGradient
+            id={gradientId}
+            x1="0"
+            y1="0.5"
+            x2="1"
+            y2="0.5"
+            gradientUnits="objectBoundingBox"
+          >
+            <stop offset="8.79%" stopColor="#6C5AEF" />
+            <stop offset="91.48%" stopColor="#69C7DD" />
+          </linearGradient>
+        </defs>
+
+        {/* Large sparkle — slow rotation (180°), fades out in place */}
+        <motion.g
+          style={{
+            transformBox: "fill-box",
+            transformOrigin: "center",
+          }}
+          initial={{ opacity: 1, rotate: 0 }}
+          animate={
+            isThinking ? { opacity: 0, rotate: 180 } : { opacity: 1, rotate: 0 }
+          }
+          transition={{
+            duration: isThinking ? FORWARD_DURATION : REVERSE_DURATION,
+            ease: EASE,
+          }}
+        >
+          <path
+            d="M19.4231 13.2391C15.2592 12.5335 11.9733 9.06719 11.3046 4.67449C11.292 4.59158 11.1901 4.59158 11.1775 4.67449C10.5088 9.06719 7.22293 12.5335 3.05898 13.2391C2.98034 13.2524 2.98034 13.3599 3.05898 13.3732C7.22293 14.0786 10.5088 17.5451 11.1775 21.9378C11.1901 22.0207 11.292 22.0207 11.3046 21.9378C11.9733 17.5451 15.2592 14.0786 19.4231 13.3732C19.5017 13.3599 19.5017 13.2524 19.4231 13.2391ZM15.3321 13.3397C13.2501 13.6924 11.6072 15.4256 11.2728 17.622C11.2665 17.6634 11.2156 17.6634 11.2093 17.622C10.8749 15.4256 9.23198 13.6924 7.15 13.3397C7.11069 13.333 7.11069 13.2793 7.15 13.2726C9.23198 12.9198 10.8749 11.1867 11.2093 8.99032C11.2156 8.94886 11.2665 8.94886 11.2728 8.99032C11.6072 11.1867 13.2501 12.9198 15.3321 13.2726C15.3714 13.2793 15.3714 13.333 15.3321 13.3397Z"
+            fill={`url(#${gradientId})`}
+          />
+        </motion.g>
+
+        {/* Small sparkle — fast independent rotation (720°), translates to center, scales up, fades out */}
+        <motion.g
+          style={{
+            transformBox: "fill-box",
+            transformOrigin: "center",
+          }}
+          initial={{ opacity: 1, rotate: 0, x: 0, y: 0, scale: 1 }}
+          animate={
+            isThinking
+              ? {
+                  opacity: 0,
+                  rotate: 720,
+                  x: smallSparkleTargetX,
+                  y: smallSparkleTargetY,
+                  scale: 1.8,
+                }
+              : { opacity: 1, rotate: 0, x: 0, y: 0, scale: 1 }
+          }
+          transition={{
+            duration: isThinking ? FORWARD_DURATION : REVERSE_DURATION,
+            ease: EASE,
+          }}
+        >
+          <path
+            d="M21.9179 6.38045C19.8359 6.73316 18.193 8.4664 17.8586 10.6628C17.8523 10.7042 17.8014 10.7042 17.7951 10.6628C17.4607 8.4664 15.8178 6.73316 13.7358 6.38045C13.6965 6.3738 13.6965 6.32005 13.7358 6.3134C15.8178 5.96062 17.4607 4.22744 17.7951 2.03109C17.8014 1.98964 17.8523 1.98964 17.8586 2.03109C18.193 4.22744 19.8359 5.96062 21.9179 6.3134C21.9572 6.32005 21.9572 6.3738 21.9179 6.38045Z"
+            fill={`url(#${gradientId})`}
+          />
+        </motion.g>
+
+        {/* Circle pulse wrapper — infinite breathing in steady state */}
+        <motion.g
+          style={{
+            transformBox: "fill-box",
+            transformOrigin: "center",
+          }}
+          initial={{ scale: 1 }}
+          animate={isThinking ? { scale: [1, 1.15, 1] } : { scale: 1 }}
+          transition={
+            isThinking
+              ? {
+                  duration: PULSE_DURATION,
+                  ease: "easeInOut",
+                  delay: FORWARD_DURATION,
+                  repeat: Number.POSITIVE_INFINITY,
+                  repeatType: "loop",
+                }
+              : { duration: REVERSE_DURATION, ease: EASE }
+          }
+        >
+          {/* Circle — grows from scale 0 / opacity 0 as the sparkle fades out */}
+          <motion.circle
+            cx={12}
+            cy={12}
+            r={CIRCLE_RADIUS}
+            fill={`url(#${gradientId})`}
+            style={{
+              transformBox: "fill-box",
+              transformOrigin: "center",
+            }}
+            initial={{ scale: 0, opacity: 0 }}
+            animate={
+              isThinking ? { scale: 1, opacity: 1 } : { scale: 0, opacity: 0 }
+            }
+            transition={{
+              duration: isThinking ? FORWARD_DURATION : REVERSE_DURATION,
+              ease: EASE,
+            }}
+          />
+        </motion.g>
+      </svg>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Adds passive/read-only rendering components: `ai-chat-loading`, `ai-chat-markdown`, `ai-chat-code-block`, `ai-chat-thinking`, `ai-chat-empty-state`, and `ai-chat-suggestions`.

## Stack

```
pr/1a-aichat-foundation  →  main          merged
pr/1b-aichat-display     →  1a            ← this PR, draft
pr/1c-aichat-input       →  1b            draft
pr/1d-aichat-messages    →  1c            draft
pr/1e-aichat-chat        →  1d            draft
pr/2-aichat-templates    →  1e            draft
```

Manual stack — do not review until #544 merges. After #544 merges: rebase this branch onto `main`, retarget to `main`, mark ready.

> Supersedes #542 / #511 — re-split to keep each PR under 800–1000 LoC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)