### PR TITLE
feat(apollo-vertex): ai-chat main component and examples [5/6]

### DIFF
--- a/apps/apollo-vertex/registry/ai-chat/components/ai-chat.tsx
+++ b/apps/apollo-vertex/registry/ai-chat/components/ai-chat.tsx
@@ -1,26 +1,76 @@
 "use client";
 
-import type { UIMessage } from "@tanstack/ai-client";
-import { AlertCircle, ArrowDown, Sparkles } from "lucide-react";
-import { type ReactNode, useState } from "react";
+import type { TextPart, UIMessage } from "@tanstack/ai-client";
+import {
+  AlertCircle,
+  ArrowDown,
+  MoreHorizontal,
+  RefreshCw,
+} from "lucide-react";
+import { type ReactNode, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/registry/alert-dialog/alert-dialog";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/registry/dropdown-menu/dropdown-menu";
 import { useStickyScroll } from "../hooks/use-sticky-scroll";
-import { AiChatInput } from "./ai-chat-input";
+import type { MessageFeedbackType } from "../types";
+import { AiChatInput, type AiChatInputHandle } from "./ai-chat-input";
 import { AiChatLoading } from "./ai-chat-loading";
+import { AiChatProvider } from "./ai-chat-provider";
+import { AutopilotGradientIcon } from "./icons/autopilot-gradient";
+
+const RETRY_LABEL = "Retry";
 
 export interface AiChatProps {
   messages: UIMessage[];
   isLoading: boolean;
-  onSendMessage: (content: string) => void;
+  onSendMessage: (content: string, attachments?: File[]) => void;
   onStop: () => void;
   onClearChat?: () => void;
+  onRetry?: () => void;
+  /** Callback when the user gives thumbs up/down feedback on an assistant message. */
+  onFeedback?: (messageId: string, type: MessageFeedbackType) => void;
+  /** Callback to regenerate the last assistant response. When provided, the "Try again" button appears in assistant message actions. */
+  onRegenerate?: () => void;
+  /** Callback when the user saves an edited user message. Receives the message ID and new content. */
+  onEditMessage?: (messageId: string, content: string) => void;
   children?: ReactNode;
   assistantName?: string;
+  assistantAvatar?: ReactNode;
+  userAvatar?: ReactNode;
   title?: string;
+  renderHeader?: ReactNode;
   emptyState?: ReactNode;
+  /** Quick-start suggestions shown below the input in the empty state */
+  suggestions?: string[];
+  /** Called when the user clicks a suggestion in the empty state */
+  onSuggestionClick?: (suggestion: string) => void;
   placeholder?: string;
   showClearButton?: boolean;
+  showTimestamps?: boolean;
+  showMessageActions?: boolean;
+  showCopyButton?: boolean;
   error?: Error | null;
+  /** Controlled input value */
+  value?: string;
+  /** Controlled input onChange */
+  onValueChange?: (value: string) => void;
+  /** When true, selecting text in an assistant message shows an "Ask AI assistant" button that quotes the selection into the input. */
+  enableTextSelection?: boolean;
 }
 
 export function AiChat({
@@ -29,25 +79,101 @@ export function AiChat({
   onSendMessage,
   onStop,
   onClearChat,
+  onRetry,
+  onFeedback,
+  onRegenerate,
+  onEditMessage,
   children,
   assistantName,
+  assistantAvatar,
+  userAvatar,
   title,
+  renderHeader,
   emptyState,
+  suggestions,
+  onSuggestionClick,
   placeholder,
   showClearButton = true,
+  showTimestamps = false,
+  showMessageActions = true,
+  showCopyButton = true,
   error,
+  value: controlledValue,
+  onValueChange,
+  enableTextSelection = false,
 }: AiChatProps) {
   const { t } = useTranslation();
-  const [input, setInput] = useState("");
+  const [internalInput, setInternalInput] = useState("");
+  const [quotedText, setQuotedText] = useState<string | null>(null);
   const { scrollRef, contentRef, isStuck, scrollToBottom } = useStickyScroll();
+  const inputRef = useRef<AiChatInputHandle>(null);
+
+  const isControlled = controlledValue != null;
+  const input = isControlled ? controlledValue : internalInput;
+  const setInput =
+    isControlled && onValueChange ? onValueChange : setInternalInput;
+
   const displayName = assistantName ?? t("ai_assistant");
 
-  const handleSubmit = () => {
-    if (!input.trim() || isLoading) return;
-    onSendMessage(input.trim());
+  const queuedMessageRef = useRef<{
+    content: string;
+    attachments?: File[];
+  } | null>(null);
+  const [conversationCopied, setConversationCopied] = useState(false);
+
+  const handleCopyConversation = async () => {
+    const text = messages
+      .map((m) => {
+        const content = m.parts
+          .filter((p): p is TextPart => p.type === "text")
+          .map((p) => p.content)
+          .join("");
+        if (!content) return null;
+        const label = m.role === "user" ? "You" : displayName;
+        return `${label}: ${content}`;
+      })
+      .filter(Boolean)
+      .join("\n\n");
+    await navigator.clipboard.writeText(text);
+    setConversationCopied(true);
+    setTimeout(() => setConversationCopied(false), 2000);
+  };
+
+  const handleSubmit = (attachments?: File[]) => {
+    if (!input.trim()) return;
+    const content = quotedText
+      ? `> ${quotedText}\n\n${input.trim()}`
+      : input.trim();
+    if (isLoading) {
+      queuedMessageRef.current = { content, attachments };
+      setInput("");
+      setQuotedText(null);
+      return;
+    }
+    onSendMessage(content, attachments);
     setInput("");
+    setQuotedText(null);
     scrollToBottom();
   };
+
+  const wasLoadingRef = useRef(false);
+  useEffect(() => {
+    if (wasLoadingRef.current && !isLoading) {
+      if (queuedMessageRef.current) {
+        const queued = queuedMessageRef.current;
+        queuedMessageRef.current = null;
+        onSendMessage(queued.content, queued.attachments);
+        scrollToBottom();
+      } else {
+        inputRef.current?.focus();
+      }
+    }
+    wasLoadingRef.current = isLoading;
+    // oxlint-disable-next-line react-hooks/exhaustive-deps -- onSendMessage/scrollToBottom are stable enough; adding them would retrigger on every render
+  }, [isLoading]);
+
+  const latestAssistantMessageId =
+    messages.findLast((m) => m.role === "assistant")?.id ?? null;
 
   const lastMessage = messages.at(-1);
   const lastAssistantHasText =
@@ -56,90 +182,224 @@ export function AiChat({
   const showLoadingIndicator = isLoading && !lastAssistantHasText;
 
   const defaultEmptyState = (
-    <div className="flex flex-col items-center justify-center h-full text-center text-muted-foreground">
-      <div className="size-16 flex items-center justify-center mb-4 rounded-full bg-primary">
-        <Sparkles
-          className="size-8 text-primary-foreground"
-          aria-hidden="true"
-        />
+    <div className="flex flex-col items-center justify-center h-full text-center">
+      <div className="flex flex-col items-center gap-1">
+        <h2 className="text-2xl font-semibold leading-tight tracking-tight text-foreground">
+          {"What are we tackling today?"}
+        </h2>
+        <p className="text-sm text-muted-foreground">
+          {"I can help you review, fix, or complete your work."}
+        </p>
       </div>
-      <p>{t("start_conversation_with", { name: displayName })}</p>
     </div>
   );
 
   return (
-    <div
-      className="flex flex-col h-full border rounded-lg bg-card"
-      data-slot="ai-chat"
+    <AiChatProvider
+      assistantName={displayName}
+      assistantAvatar={assistantAvatar}
+      userAvatar={userAvatar}
+      showTimestamps={showTimestamps}
+      showMessageActions={showMessageActions}
+      showCopyButton={showCopyButton}
+      isLoading={isLoading}
+      latestAssistantMessageId={latestAssistantMessageId}
+      onFeedback={onFeedback}
+      onRegenerate={onRegenerate}
+      onEditMessage={onEditMessage}
+      {...(enableTextSelection
+        ? { onQuoteSelect: (text) => setQuotedText(text) }
+        : {})}
     >
-      {title && (
-        <div className="py-3 px-4">
-          <h3 className="flex items-center gap-2 text-base font-semibold">
-            <Sparkles className="size-4" aria-hidden="true" />
-            {title}
-          </h3>
-        </div>
-      )}
-
-      {error && (
-        <div
-          role="alert"
-          aria-live="assertive"
-          className="mx-4 mb-2 flex items-start gap-2 rounded-lg border border-destructive/50 bg-destructive/10 p-3 text-sm text-destructive max-h-16 overflow-y-auto"
-        >
-          <AlertCircle
-            className="h-4 w-4 flex-shrink-0 mt-0.5"
-            aria-hidden="true"
-          />
-          <span>{error.message}</span>
-        </div>
-      )}
-
-      <div className="relative flex-1 min-h-0">
-        <div
-          ref={scrollRef}
-          role="log"
-          aria-label={t("chat_messages")}
-          aria-live="polite"
-          aria-atomic="false"
-          className="h-full overflow-y-auto p-4"
-        >
-          {messages.length === 0 ? (
-            (emptyState ?? defaultEmptyState)
-          ) : (
-            <div ref={contentRef} className="space-y-4">
-              {children}
-
-              {showLoadingIndicator && (
-                <AiChatLoading assistantName={displayName} />
+      <div
+        className="flex flex-col h-full max-w-[680px] mx-auto bg-transparent text-ai-chat-foreground overflow-hidden"
+        data-slot="ai-chat"
+      >
+        {renderHeader ??
+          (title && (
+            <div className="relative z-10 py-3 px-4 flex items-center justify-between gap-2 bg-background">
+              <div className="flex items-center gap-1.5 min-w-0">
+                <AutopilotGradientIcon
+                  size={21}
+                  className="flex-shrink-0"
+                  aria-hidden="true"
+                />
+                <span className="text-sm font-bold tracking-tight bg-clip-text text-transparent truncate pt-[2px] [background-image:linear-gradient(97.73deg,#5D4ED0_8.79%,#1076A0_91.48%)] dark:[background-image:linear-gradient(97.73deg,#9485F5_8.79%,#69C7DD_91.48%)]">
+                  {title}
+                </span>
+              </div>
+              {messages.length > 0 && (
+                <AlertDialog>
+                  <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                      <button
+                        type="button"
+                        className="size-7 inline-flex items-center justify-center rounded-md hover:bg-ai-chat-muted transition-colors flex-shrink-0"
+                        aria-label="More options"
+                      >
+                        <MoreHorizontal
+                          className="size-4 text-ai-chat-muted-foreground"
+                          aria-hidden="true"
+                        />
+                      </button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent align="end">
+                      <DropdownMenuItem
+                        onClick={() => {
+                          void handleCopyConversation();
+                        }}
+                      >
+                        {conversationCopied ? "Copied!" : "Copy conversation"}
+                      </DropdownMenuItem>
+                      {onClearChat && showClearButton && (
+                        <AlertDialogTrigger asChild>
+                          <DropdownMenuItem>
+                            {"New conversation"}
+                          </DropdownMenuItem>
+                        </AlertDialogTrigger>
+                      )}
+                    </DropdownMenuContent>
+                  </DropdownMenu>
+                  <AlertDialogContent>
+                    <AlertDialogHeader>
+                      <AlertDialogTitle>
+                        {"Start a new conversation?"}
+                      </AlertDialogTitle>
+                      <AlertDialogDescription>
+                        {"This will clear all messages and cannot be undone."}
+                      </AlertDialogDescription>
+                    </AlertDialogHeader>
+                    <AlertDialogFooter>
+                      <AlertDialogCancel>{"Cancel"}</AlertDialogCancel>
+                      <AlertDialogAction onClick={() => onClearChat?.()}>
+                        {"New conversation"}
+                      </AlertDialogAction>
+                    </AlertDialogFooter>
+                  </AlertDialogContent>
+                </AlertDialog>
               )}
             </div>
-          )}
-        </div>
+          ))}
 
-        {!isStuck && (
-          <button
-            type="button"
-            onClick={scrollToBottom}
-            aria-label={t("scroll_to_bottom")}
-            className="absolute bottom-2 left-1/2 -translate-x-1/2 z-10 flex items-center justify-center size-8 rounded-full border bg-background shadow-md hover:bg-accent"
+        {messages.length === 0 ? (
+          <div className="flex-1 flex flex-col items-center justify-center min-h-0">
+            <div className="w-full">
+              <div className="px-4 text-center mb-7">
+                {emptyState ?? defaultEmptyState}
+              </div>
+              <AiChatInput
+                ref={inputRef}
+                value={input}
+                onChange={setInput}
+                onSubmit={(files) => handleSubmit(files)}
+                onStop={onStop}
+                isLoading={isLoading}
+                placeholder={placeholder}
+                hasMessages={false}
+              />
+              {suggestions && suggestions.length > 0 && (
+                <div className="mt-4 px-4 flex flex-wrap justify-center gap-2">
+                  {suggestions.map((suggestion) => (
+                    <button
+                      key={suggestion}
+                      type="button"
+                      className="py-2 px-4 text-xs font-semibold rounded-full border border-input bg-background text-foreground hover:bg-muted transition-colors"
+                      onClick={() => {
+                        if (onSuggestionClick) {
+                          onSuggestionClick(suggestion);
+                        } else {
+                          onSendMessage(suggestion);
+                        }
+                      }}
+                    >
+                      {suggestion}
+                    </button>
+                  ))}
+                </div>
+              )}
+            </div>
+          </div>
+        ) : (
+          <div className="relative flex-1 min-h-0">
+            <div
+              className="absolute top-0 left-0 right-0 h-6 z-10 pointer-events-none"
+              style={{
+                background:
+                  "linear-gradient(to bottom, var(--background) 0%, transparent 100%)",
+              }}
+              aria-hidden="true"
+            />
+            <div
+              ref={scrollRef}
+              role="log"
+              aria-label={t("chat_messages")}
+              aria-live="polite"
+              aria-atomic="false"
+              aria-busy={isLoading}
+              className="h-full overflow-y-auto py-4 pl-10 pr-10"
+            >
+              <div ref={contentRef} className="space-y-1">
+                {children}
+
+                {showLoadingIndicator && <AiChatLoading />}
+              </div>
+            </div>
+
+            {!isStuck && (
+              <button
+                type="button"
+                onClick={scrollToBottom}
+                aria-label={t("scroll_to_bottom")}
+                className="absolute bottom-2 left-1/2 -translate-x-1/2 z-10 flex items-center justify-center size-8 rounded-full border border-ai-chat-border bg-ai-chat shadow-md hover:bg-ai-chat-muted"
+              >
+                <ArrowDown className="size-4" />
+              </button>
+            )}
+          </div>
+        )}
+
+        {error && (
+          <div
+            role="alert"
+            aria-live="assertive"
+            className="relative z-0 mx-4 -mb-6 flex items-center gap-2 rounded-t-lg bg-destructive/10 px-[23px] pt-3 pb-6 text-sm text-destructive"
           >
-            <ArrowDown className="size-4" />
-          </button>
+            <AlertCircle className="h-4 w-4 flex-shrink-0" aria-hidden="true" />
+            <span className="flex-1">{error.message}</span>
+            {onRetry && (
+              <button
+                type="button"
+                onClick={onRetry}
+                className="flex-shrink-0 inline-flex items-center gap-1 text-xs font-medium hover:underline"
+                aria-label={RETRY_LABEL}
+              >
+                <RefreshCw className="size-3" aria-hidden="true" />
+                {RETRY_LABEL}
+              </button>
+            )}
+          </div>
+        )}
+
+        {messages.length > 0 && (
+          <div>
+            <AiChatInput
+              ref={inputRef}
+              value={input}
+              onChange={setInput}
+              onSubmit={handleSubmit}
+              onStop={onStop}
+              isLoading={isLoading}
+              placeholder={placeholder}
+              hasMessages
+              quotedText={quotedText}
+              onClearQuote={() => setQuotedText(null)}
+            />
+            <div className="pt-2 pb-3 px-4 text-xs leading-normal text-muted-foreground text-center">
+              {"AI-generated responses should be reviewed for accuracy."}
+            </div>
+          </div>
         )}
       </div>
-
-      <AiChatInput
-        value={input}
-        onChange={setInput}
-        onSubmit={handleSubmit}
-        onStop={onStop}
-        onClear={onClearChat}
-        isLoading={isLoading}
-        placeholder={placeholder}
-        showClearButton={showClearButton}
-        hasMessages={messages.length > 0}
-      />
-    </div>
+    </AiChatProvider>
   );
 }

--- a/apps/apollo-vertex/registry/ai-chat/examples/choices-tool.ts
+++ b/apps/apollo-vertex/registry/ai-chat/examples/choices-tool.ts
@@ -1,0 +1,71 @@
+import { toolDefinition } from "@tanstack/ai";
+import { clientTools } from "@tanstack/ai-client";
+import { z } from "zod";
+
+const choiceOptionSchema = z.object({
+  id: z.string().describe("Unique identifier for this option"),
+  label: z.string().describe("Button text shown to the user"),
+  value: z.string().optional().describe("Optional payload sent when selected"),
+  recommended: z
+    .boolean()
+    .optional()
+    .describe("Highlight this option as the recommended choice"),
+});
+
+const presentChoicesInput = z.object({
+  prompt: z.string().describe("Short label shown above the choice buttons"),
+  options: z
+    .array(choiceOptionSchema)
+    .min(2)
+    .max(6)
+    .describe("2 to 6 options for the user to pick from"),
+  step: z
+    .number()
+    .optional()
+    .describe(
+      "Current step number (1-based) — include when this is part of a multi-step flow",
+    ),
+  totalSteps: z
+    .number()
+    .optional()
+    .describe("Total number of steps in the flow — include alongside step"),
+  canSkip: z.boolean().optional().describe("Show a skip button for this step"),
+  canGoBack: z
+    .boolean()
+    .optional()
+    .describe(
+      "Show a back button to let the user revise their previous answer",
+    ),
+});
+
+const presentChoicesOutput = presentChoicesInput.extend({
+  type: z.literal("choices"),
+});
+
+const presentChoicesDef = toolDefinition({
+  name: "presentChoices",
+  description: `Present the user with clickable choices. Call this tool whenever the user needs to pick between alternatives, or when gathering information step by step. Mark one option as recommended when there is a clear best pick. For multi-step flows, include step/totalSteps and set canGoBack=true after the first step.`,
+  inputSchema: presentChoicesInput,
+  outputSchema: presentChoicesOutput,
+});
+
+const presentChoices = presentChoicesDef.client((input) =>
+  Object.assign({ type: "choices" as const }, input),
+);
+
+export const choicesTools = clientTools(presentChoices);
+
+export const CHOICES_TOOL_PROMPT = `
+You have a "presentChoices" tool.
+Use it when the user asks for choices, options, or when you need to gather information step by step before taking action.
+
+Single-step: call with 2–6 options, mark one as recommended when there is a clear best pick.
+
+Multi-step flows: when you need multiple pieces of information, call this tool once per step.
+- Set step (1-based) and totalSteps on every call in the flow.
+- Set canGoBack=true on step 2 and beyond so the user can revise previous answers.
+- Set canSkip=true on optional steps.
+- Always include a "Something else" option (id: "other") as the last choice so the user can type a custom answer.
+
+After calling the tool keep your text reply short — the UI renders the options as buttons so do NOT repeat them in prose.
+`.trim();

--- a/apps/apollo-vertex/registry/ai-chat/examples/flow-tool.ts
+++ b/apps/apollo-vertex/registry/ai-chat/examples/flow-tool.ts
@@ -1,0 +1,71 @@
+import { toolDefinition } from "@tanstack/ai";
+import { clientTools } from "@tanstack/ai-client";
+import { z } from "zod";
+
+const flowOptionSchema = z.object({
+  id: z.string().describe("Unique identifier for this option"),
+  label: z.string().describe("Button text shown to the user"),
+  value: z
+    .string()
+    .optional()
+    .describe("Optional payload value — defaults to label if omitted"),
+  recommended: z
+    .boolean()
+    .optional()
+    .describe("Highlight this as the recommended choice"),
+  freeText: z
+    .boolean()
+    .optional()
+    .describe(
+      "When true, selecting this option lets the user type a custom answer in the input instead of choosing a preset",
+    ),
+});
+
+const flowStepSchema = z.object({
+  id: z.string().describe("Unique identifier for this step"),
+  prompt: z.string().describe("The question shown to the user for this step"),
+  options: z.array(flowOptionSchema).min(2).max(6).describe("2 to 6 options"),
+  canSkip: z.boolean().optional().describe("Allow the user to skip this step"),
+});
+
+const presentFlowInput = z.object({
+  steps: z
+    .array(flowStepSchema)
+    .min(2)
+    .max(8)
+    .describe("Ordered list of steps — all defined upfront"),
+});
+
+const presentFlowOutput = presentFlowInput.extend({
+  type: z.literal("flow"),
+});
+
+const presentFlowDef = toolDefinition({
+  name: "presentFlow",
+  description: `Present the user with a multi-step guided flow. All steps are defined upfront and the user navigates them client-side — no round-trip between steps. Use this when you need 2–8 answers before you can take action. When the user completes the flow, a single message is sent with all their answers. Only include specific, concrete options per step — never add "Other", "Something else", or any catch-all fallback, as the text input is always available.`,
+  inputSchema: presentFlowInput,
+  outputSchema: presentFlowOutput,
+});
+
+const presentFlow = presentFlowDef.client((input) =>
+  Object.assign({ type: "flow" as const }, input),
+);
+
+export const flowTool = clientTools(presentFlow);
+
+export const FLOW_TOOL_PROMPT = `
+You have a "presentFlow" tool.
+Use it when you need to gather 2–8 pieces of information before taking action and the questions are independent (each answer doesn't change the next question).
+
+- Define all steps upfront in the steps array.
+- Each step has a prompt and 2–6 options. Only include concrete, specific choices. Do NOT add catch-all options like "Something else", "Other", "None of the above", or any similar fallback — the text input below the card is always available for the user to type a custom answer.
+- Mark one option as recommended when there is a clear best pick.
+- Set canSkip=true on optional steps.
+
+The user navigates all steps locally — no LLM round-trips between steps. When they finish, you receive a single message with all their answers formatted as:
+"Step 1 (prompt): answer, Step 2 (prompt): answer, ..."
+
+The user can also type a custom free-text answer at any step instead of clicking an option. If an answer doesn't match the options you defined, treat it as a valid custom response and proceed — never question or re-ask it.
+
+After calling the tool keep your text reply very short — do NOT list the questions in prose.
+`.trim();


### PR DESCRIPTION
## Summary

Adds the top-level `AiChat` orchestration component and example tool definitions (`choices-tool`, `flow-tool`).

## Stack

```
pr/1a-aichat-foundation  →  main          merged
pr/1b-aichat-display     →  1a            merged
pr/1c-aichat-input       →  1b            merged
pr/1d-aichat-messages    →  1c            merged
pr/1e-aichat-chat        →  1d            ← this PR, draft
pr/2-aichat-templates    →  1e            draft
```

Manual stack — do not review until #547 merges.

> Supersedes #542 / #511 — re-split to keep each PR under 800–1000 LoC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)