### PR TITLE
feat(apollo-react): add canvas background for future [MST-8915]

### DIFF
--- a/packages/apollo-react/src/canvas/components/BaseCanvas/BaseCanvas.test.tsx
+++ b/packages/apollo-react/src/canvas/components/BaseCanvas/BaseCanvas.test.tsx
@@ -49,7 +49,9 @@ vi.mock('@uipath/apollo-react/canvas/xyflow/react', async () => {
         </div>
       );
     },
-    Background: ({ variant }: any) => <div data-testid="background" data-variant={variant} />,
+    Background: ({ variant, className }: any) => (
+      <div className={className} data-testid="background" data-variant={variant} />
+    ),
     Panel: ({ children, position }: any) => <div data-testid={`panel-${position}`}>{children}</div>,
     useReactFlow: () => mockReactFlowInstance,
   };
@@ -87,6 +89,11 @@ describe('BaseCanvas', () => {
     const background = screen.getByTestId('background');
     expect(background).toBeInTheDocument();
     expect(background).toHaveAttribute('data-variant', 'dots');
+  });
+
+  it('passes apollo-canvas-background className to Background', () => {
+    renderBaseCanvas();
+    expect(screen.getByTestId('background')).toHaveClass('apollo-canvas-background');
   });
 
   it('renders controls in default position', () => {

--- a/packages/apollo-react/src/canvas/components/BaseCanvas/CanvasBackground.tsx
+++ b/packages/apollo-react/src/canvas/components/BaseCanvas/CanvasBackground.tsx
@@ -18,6 +18,7 @@ export const CanvasBackground: React.FC<CanvasBackgroundProps> = ({
 }) => {
   return (
     <Background
+      className="apollo-canvas-background"
       color={color}
       bgColor={bgColor}
       variant={variant}

--- a/packages/apollo-react/src/canvas/styles/reactflow-reset.css
+++ b/packages/apollo-react/src/canvas/styles/reactflow-reset.css
@@ -32,3 +32,32 @@
   font-size: inherit !important;
   box-shadow: none !important;
 }
+
+/**
+ * Canvas pane gradient for future themes.
+ *
+ * <Background /> passes bgColor as `background-color`, which only accepts
+ * solid colors. We layer `background-image` on top of the same SVG to
+ * render a gradient — the dot pattern (SVG content) still paints above.
+ * The `.apollo-canvas-background` class is applied via <Background />'s
+ * documented `className` prop in CanvasBackground.tsx.
+ *
+ * FIXME: Inline gradients should become gradient tokens in apollo-wind's
+ * tailwind.consumer.css once a 135° / 0–100% variant is added — then
+ * these rules collapse to `background-image: var(--gradient-N)`.
+ */
+.future-dark .apollo-canvas-background {
+  background-image: linear-gradient(
+    135deg,
+    var(--canvas-background-overlay, var(--surface-overlay)) 0%,
+    var(--canvas-background, var(--surface)) 100%
+  );
+}
+
+.future-light .apollo-canvas-background {
+  background-image: linear-gradient(
+    135deg,
+    var(--canvas-background, var(--surface)) 0%,
+    var(--canvas-background-overlay, var(--surface-overlay)) 100%
+  );
+}


### PR DESCRIPTION
## Demo
https://github.com/user-attachments/assets/3ffa9b57-0c79-4271-8305-4e1cdae8970b

### Future Dark
<img width="1491" height="965" alt="image" src="https://github.com/user-attachments/assets/2d89934b-c519-4019-a0dc-96770d9c230f" />

### Future Light
<img width="1491" height="969" alt="image" src="https://github.com/user-attachments/assets/84f71d29-75ec-4f12-84e8-541b89a905c2" />


## Summary

  - Adds a diagonal gradient surface to the canvas pane in `future-dark` / `future-light` themes, matching the flow-prototype's canvas look (lighter top-left → darker bottom-right, 135°, 0% → 100%).
  - Non-future themes are unaffected — they keep the solid `--canvas-background-secondary` bg.

  ## Why

  React Flow's `<Background />` accepts a `bgColor` prop that maps to `background-color`, which only renders solid colors — gradients passed through it are silently dropped. To support gradients without forking or patching React Flow, we layer
  `background-image` on top of the same SVG via CSS.

  ## Implementation

  - `CanvasBackground.tsx`: attaches `className="apollo-canvas-background"` to `<Background />` via its documented `className` prop (public API — no reliance on React Flow internals like `.react-flow__background`).
  - `reactflow-reset.css`: adds `.future-dark .apollo-canvas-background` and `.future-light .apollo-canvas-background` rules that set `background-image` to the gradient. The dot pattern (rendered as SVG vector content) still paints above the gradient.

  Gradients are inlined for now; a `FIXME` notes they should become gradient tokens in `apollo-wind/tailwind.consumer.css` once a 135° / 0–100% variant is added, after which the rules collapse to `background-image: var(--gradient-N)`.

  ## Test plan

  - [ ] Storybook: Future Dark story — verify gradient is visible and smooth (no visible band).
  - [ ] Storybook: Future Light story — verify gradient is visible and smooth.
  - [ ] Storybook: Light / Dark / Light-HC / Dark-HC stories — verify solid background is unchanged.
  - [ ] Visual regression tests pass.
