### PR TITLE
feat(apollo-react): add node redesign [MST-8928]

### DIFF
--- a/packages/apollo-react/src/canvas/components/AddNodePanel/AddNodePreview.tsx
+++ b/packages/apollo-react/src/canvas/components/AddNodePanel/AddNodePreview.tsx
@@ -1,26 +1,17 @@
-import styled from '@emotion/styled';
 import type { NodeProps } from '@uipath/apollo-react/canvas/xyflow/react';
 import { Handle, Position } from '@uipath/apollo-react/canvas/xyflow/react';
 import type React from 'react';
+import { useMemo } from 'react';
 
-import { DEFAULT_NODE_SIZE } from '../../constants';
-import { CanvasIcon } from '../../utils/icon-registry';
-
-const PreviewContainer = styled.div<{ selected?: boolean; width?: number; height?: number }>`
-  width: ${(props) => props.width ?? DEFAULT_NODE_SIZE}px;
-  height: ${(props) => props.height ?? DEFAULT_NODE_SIZE}px;
-  border-radius: 16px;
-  background: var(--canvas-background-secondary);
-  border: 2px dashed
-    ${(props) =>
-      props.selected ? 'var(--canvas-selection-indicator)' : 'var(--canvas-border-de-emp)'};
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  text-align: center;
-  justify-content: center;
-  opacity: ${(props) => (props.selected ? 0.8 : 0.6)};
-`;
+import {
+  DEFAULT_NODE_SIZE,
+  NODE_CONTAINER_RADIUS_RATIO,
+  NODE_INNER_ICON_RATIO,
+  NODE_INNER_RADIUS_RATIO,
+  NODE_INNER_SHAPE_RATIO,
+} from '../../constants';
+import { getIcon } from '../../utils/icon-registry';
+import { BaseInnerShape } from '../BaseNode/BaseNodeInnerShape';
 
 export interface AddNodePreviewData {
   iconName?: string;
@@ -28,26 +19,52 @@ export interface AddNodePreviewData {
   outputHandlePosition?: Position;
 }
 
-const getIcon = (iconName?: string): React.ReactElement => {
-  if (iconName) {
-    return <CanvasIcon icon={iconName} size={40} color="var(--canvas-foreground-de-emp)" />;
-  }
-
-  return <CanvasIcon icon="ellipsis" size={40} color="var(--canvas-foreground-de-emp)" />;
-};
-
 export const AddNodePreview: React.FC<NodeProps> = ({ selected, data, width, height }) => {
   const nodeData = data as AddNodePreviewData;
-  const icon = getIcon(nodeData?.iconName);
+
+  const icon = useMemo(() => {
+    const IconComponent = getIcon(nodeData?.iconName ?? 'square-dashed');
+    return <IconComponent />;
+  }, [nodeData?.iconName]);
 
   const inputPosition = nodeData?.inputHandlePosition ?? Position.Left;
   const outputPosition = nodeData?.outputHandlePosition ?? Position.Right;
 
+  const containerWidth = width ?? DEFAULT_NODE_SIZE;
+  const containerHeight = height ?? DEFAULT_NODE_SIZE;
+
+  const containerStyle = useMemo((): React.CSSProperties => {
+    const basis = Math.min(containerWidth, containerHeight);
+    const gap = basis * (1 - NODE_INNER_SHAPE_RATIO);
+    const innerW = containerWidth - gap;
+    const innerH = containerHeight - gap;
+
+    return {
+      '--node-w': `${containerWidth}px`,
+      '--node-h': `${containerHeight}px`,
+      '--node-radius': `${basis * NODE_CONTAINER_RADIUS_RATIO}px`,
+      '--inner-w': `${innerW}px`,
+      '--inner-h': `${innerH}px`,
+      '--inner-radius': `${basis * NODE_INNER_RADIUS_RATIO}px`,
+      '--icon-size': `${basis * NODE_INNER_ICON_RATIO}px`,
+      borderColor: selected ? 'var(--canvas-selection-indicator)' : 'var(--canvas-border-de-emp)',
+      opacity: selected ? 0.8 : 0.6,
+      strokeWidth: 1.5,
+    } as React.CSSProperties;
+  }, [containerWidth, containerHeight, selected]);
+
   return (
     <>
-      <PreviewContainer selected={selected} width={width} height={height}>
-        {icon}
-      </PreviewContainer>
+      <div
+        className="
+          relative flex flex-col items-center justify-center bg-surface-overlay
+          w-(--node-w) h-(--node-h) rounded-(--node-radius)
+          border border-dashed
+        "
+        style={containerStyle}
+      >
+        <BaseInnerShape>{icon}</BaseInnerShape>
+      </div>
 
       <Handle
         type="target"


### PR DESCRIPTION
Redesign add node to match prototype:

| Theme | Before | After |
  |---|---|---|
  | Light | <img width="639" height="436" alt="image" src="https://github.com/user-attachments/assets/0fd7586d-8ccd-4669-b9cb-6a11cc37ebef" /> | <img width="647" height="507" alt="image" src="https://github.com/user-attachments/assets/bc932b7a-8467-454e-a54c-965dd03df8ae" /> |
  | Dark | <img width="637" height="426" alt="image" src="https://github.com/user-attachments/assets/28772368-c3b7-48a3-8c28-e7dd636f73a0" /> | <img width="644" height="462" alt="image" src="https://github.com/user-attachments/assets/e5f19e7c-8f3a-4c65-b05c-10ee1080a724" /> |
  | Future Light | <img width="621" height="440" alt="image" src="https://github.com/user-attachments/assets/bf3e09a4-af49-4f21-9e51-806e0f9bf23a" /> | <img width="628" height="469" alt="image" src="https://github.com/user-attachments/assets/337cb365-6069-4b54-9302-3a02299a35cd" /> |
  | Future Dark | <img width="666" height="428" alt="image" src="https://github.com/user-attachments/assets/6c98db9f-d3a4-4ae9-b63a-de27080eb0d8" /> | <img width="670" height="470" alt="image" src="https://github.com/user-attachments/assets/ffba54aa-6f19-4138-b566-5a89ebc1981a" /> |