### PR TITLE
feat(apollo-wind): add xs size variant to toggle

### DIFF
--- a/packages/apollo-wind/src/components/ui/toggle-group.stories.tsx
+++ b/packages/apollo-wind/src/components/ui/toggle-group.stories.tsx
@@ -91,6 +91,17 @@ export const Large = {
   ),
 };
 
+export const ExtraSmall = {
+  args: {},
+  render: () => (
+    <ToggleGroup type="single" size="xs">
+      <ToggleGroupItem value="left">Left</ToggleGroupItem>
+      <ToggleGroupItem value="center">Center</ToggleGroupItem>
+      <ToggleGroupItem value="right">Right</ToggleGroupItem>
+    </ToggleGroup>
+  ),
+};
+
 export const Disabled = {
   args: {},
   render: () => (

--- a/packages/apollo-wind/src/components/ui/toggle.tsx
+++ b/packages/apollo-wind/src/components/ui/toggle.tsx
@@ -18,6 +18,7 @@ const toggleVariants = cva(
         default: 'h-10 px-3 min-w-10',
         sm: 'h-9 px-2.5 min-w-9',
         lg: 'h-11 px-5 min-w-11',
+        xs: 'h-6 px-2 min-w-6 text-xs',
       },
     },
     defaultVariants: {


### PR DESCRIPTION
## Summary

Adds a new `xs` size variant (`h-6`, `px-2`, `min-w-6`, `text-xs`) to the `toggleVariants` CVA in apollo-wind. Toggle and ToggleGroup consumers can now render compact 24px toggles without className overrides. ToggleGroup picks up the new size automatically through its existing `VariantProps` context, so no wiring changes were needed.  New ExtraSmall Storybook story included.

## Motivation

Downstream consumers currently hack compact toggle sizes with inline className overrides (e.g. `h-6 p-0.5` on lists and `h-5 px-1.5 text-xs` on triggers). Landing `size="xs"` as a first-class variant lets them drop the overrides.

## Changes

- `packages/apollo-wind/src/components/ui/toggle.tsx` — add `xs: 'h-6 px-2 min-w-6 text-xs'` to the size variants block.
- `packages/apollo-wind/src/components/ui/toggle-group.stories.tsx` — add `ExtraSmall` story mirroring the `Small` / `Large` shape.

No changes needed in `toggle-group.tsx` — it consumes `VariantProps<typeof toggleVariants>`, so `xs` flows through. Generated `.d.ts` union now reads `"default" | "lg" | "sm" | "xs"`.