### PR TITLE
feat(apollo-react): add new event-driven section for tasks in a case stage node

### DIFF
--- a/packages/apollo-react/src/canvas/components/StageNode/DraggableTask.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/DraggableTask.tsx
@@ -2,8 +2,6 @@ import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import { useStore } from '@uipath/apollo-react/canvas/xyflow/react';
 import { memo, useCallback, useMemo, useRef } from 'react';
-import { EntryConditionIcon } from '../../icons';
-import { CanvasTooltip } from '../CanvasTooltip';
 import type { DraggableTaskProps } from './DraggableTask.types';
 import {
   INDENTATION_WIDTH,
@@ -12,6 +10,7 @@ import {
   StageTaskDragPlaceholderWrapper,
   StageTaskWrapper,
 } from './StageNode.styles';
+import { StageTaskEntryConditionIcon } from './StageTaskEntryConditionIcon';
 import { TaskContent } from './TaskContent';
 import { TaskMenu, type TaskMenuHandle } from './TaskMenu';
 
@@ -99,20 +98,7 @@ const DraggableTaskComponent = ({
     >
       <TaskContent task={task} taskExecution={taskExecution} />
 
-      {task.hasEntryCondition && (
-        <CanvasTooltip content="Entry condition" placement="top">
-          <span
-            style={{
-              display: 'flex',
-              alignItems: 'center',
-              color: 'var(--color-icon-default)',
-              flexShrink: 0,
-            }}
-          >
-            <EntryConditionIcon w={20} h={20} />
-          </span>
-        </CanvasTooltip>
-      )}
+      <StageTaskEntryConditionIcon task={task} />
       {getContextMenuItems && (
         <TaskMenu
           ref={menuRef}

--- a/packages/apollo-react/src/canvas/components/StageNode/EventDrivenTask.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/EventDrivenTask.tsx
@@ -1,0 +1,64 @@
+import { memo, useCallback, useRef } from 'react';
+import type { NodeMenuItem } from '../NodeContextMenu';
+import { StageTask } from './StageNode.styles';
+import type { StageTaskExecution, StageTaskItem } from './StageNode.types';
+import { StageTaskEntryConditionIcon } from './StageTaskEntryConditionIcon';
+import { TaskContent } from './TaskContent';
+import { TaskMenu, type TaskMenuHandle } from './TaskMenu';
+
+interface EventDrivenTaskItemProps {
+  task: StageTaskItem;
+  taskExecution?: StageTaskExecution;
+  isSelected: boolean;
+  getContextMenuItems?: () => NodeMenuItem[];
+  onTaskClick: (e: React.MouseEvent, taskId: string) => void;
+  isTaskLoading?: boolean;
+}
+
+const EventDrivenTaskItemComponent = ({
+  task,
+  taskExecution,
+  isSelected,
+  getContextMenuItems,
+  onTaskClick,
+  isTaskLoading,
+}: EventDrivenTaskItemProps) => {
+  const taskRef = useRef<HTMLDivElement>(null);
+  const menuRef = useRef<TaskMenuHandle>(null);
+
+  const handleClick = useCallback(
+    (e: React.MouseEvent) => {
+      onTaskClick(e, task.id);
+    },
+    [onTaskClick, task.id]
+  );
+
+  const handleContextMenu = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
+    menuRef.current?.handleContextMenu(e);
+  }, []);
+
+  return (
+    <StageTask
+      ref={taskRef}
+      data-testid={`stage-task-${task.id}`}
+      selected={isSelected}
+      status={taskExecution?.status}
+      onClick={handleClick}
+      {...(getContextMenuItems && !isTaskLoading && { onContextMenu: handleContextMenu })}
+    >
+      <TaskContent task={task} taskExecution={taskExecution} />
+
+      <StageTaskEntryConditionIcon task={task} />
+      {getContextMenuItems && (
+        <TaskMenu
+          ref={menuRef}
+          taskId={task.id}
+          getContextMenuItems={getContextMenuItems}
+          disabled={isTaskLoading}
+        />
+      )}
+    </StageTask>
+  );
+};
+
+export const EventDrivenTaskItem = memo(EventDrivenTaskItemComponent);

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.stories.tsx
@@ -1992,6 +1992,281 @@ export const AdhocTasks: Story = {
   },
 };
 
+export const TasksBySection: Story = {
+  name: 'Tasks by section',
+  parameters: {
+    nodes: [
+      {
+        id: '0',
+        type: 'stage',
+        position: { x: 48, y: 96 },
+        width: 304,
+        data: {
+          stageDetails: {
+            label: 'With sequential tasks',
+            tasks: [
+              [
+                {
+                  id: '1',
+                  label: 'First task',
+                  icon: <VerificationIcon />,
+                  taskGroupType: 'sequential',
+                },
+              ],
+              [
+                {
+                  id: '2',
+                  label: 'Next task',
+                  icon: <DocumentIcon />,
+                  taskGroupType: 'sequential',
+                },
+              ],
+              [
+                {
+                  id: '3',
+                  label: 'Parallel task 1',
+                  icon: <DocumentIcon />,
+                  taskGroupType: 'sequential',
+                },
+                {
+                  id: '4',
+                  label: 'Parallel task 2',
+                  icon: <DocumentIcon />,
+                  taskGroupType: 'sequential',
+                },
+              ],
+              [
+                {
+                  id: '5',
+                  label: 'Last task',
+                  icon: <VerificationIcon />,
+                  taskGroupType: 'sequential',
+                },
+              ],
+            ],
+          },
+          onTaskPlay: (taskId: string) => {
+            return new Promise<void>((resolve) =>
+              setTimeout(() => {
+                resolve();
+                console.log(`Play task: ${taskId}`);
+              }, 5000)
+            );
+          },
+          onTaskClick: (taskId: string) => {
+            window.alert(`Task clicked: ${taskId}`);
+          },
+        },
+      },
+      {
+        id: '1',
+        type: 'stage',
+        position: { x: 400, y: 96 },
+        width: 304,
+        data: {
+          stageDetails: {
+            label: 'With adhoc tasks',
+            tasks: [
+              [
+                {
+                  id: '1',
+                  label: 'Ad hoc - Risk Assessment',
+                  icon: <VerificationIcon />,
+                  taskGroupType: 'adhoc',
+                },
+              ],
+              [
+                {
+                  id: '2',
+                  label: 'Ad hoc - Compliance Review',
+                  icon: <DocumentIcon />,
+                  taskGroupType: 'adhoc',
+                },
+              ],
+              [
+                {
+                  id: '3',
+                  label: 'Regular Task',
+                  icon: <ProcessIcon />,
+                  taskGroupType: 'sequential',
+                },
+              ],
+              [
+                {
+                  id: '4',
+                  label: 'Regular Task',
+                  icon: <DocumentIcon />,
+                  taskGroupType: 'sequential',
+                },
+              ],
+            ],
+          },
+          onTaskClick: (taskId: string) => {
+            window.alert(`Task clicked: ${taskId}`);
+          },
+          onTaskGroupModification: (type: string, groupIndex: number, taskIndex: number) => {
+            console.log(
+              `Task group modification: ${type}, group: ${groupIndex}, task: ${taskIndex}`
+            );
+          },
+          onReplaceTaskFromToolbox: (task: unknown, groupIndex: number, taskIndex: number) => {
+            console.log(`Replace task at group: ${groupIndex}, task: ${taskIndex}`, task);
+          },
+        },
+      },
+      {
+        id: '2',
+        type: 'stage',
+        position: { x: 752, y: 96 },
+        width: 304,
+        data: {
+          stageDetails: {
+            label: 'With event-driven tasks',
+            tasks: [
+              [
+                {
+                  id: '1',
+                  label: 'Waiting for specific condition',
+                  icon: <VerificationIcon />,
+                  taskGroupType: 'event-driven',
+                  hasEntryCondition: true,
+                },
+              ],
+              [
+                {
+                  id: '2',
+                  label: 'Regular Task',
+                  icon: <ProcessIcon />,
+                  taskGroupType: 'sequential',
+                },
+              ],
+              [
+                {
+                  id: '3',
+                  label: 'Wait for connector',
+                  icon: <DocumentIcon />,
+                  taskGroupType: 'event-driven',
+                  hasEntryCondition: true,
+                },
+              ],
+              [
+                {
+                  id: '4',
+                  label: 'Regular Task',
+                  icon: <DocumentIcon />,
+                  taskGroupType: 'sequential',
+                },
+              ],
+            ],
+          },
+          onTaskClick: (taskId: string) => {
+            window.alert(`Task clicked: ${taskId}`);
+          },
+          onTaskGroupModification: (type: string, groupIndex: number, taskIndex: number) => {
+            console.log(
+              `Task group modification: ${type}, group: ${groupIndex}, task: ${taskIndex}`
+            );
+          },
+          onReplaceTaskFromToolbox: (task: unknown, groupIndex: number, taskIndex: number) => {
+            console.log(`Replace task at group: ${groupIndex}, task: ${taskIndex}`, task);
+          },
+        },
+      },
+      {
+        id: '3',
+        type: 'stage',
+        position: { x: 1104, y: 96 },
+        width: 304,
+        data: {
+          stageDetails: {
+            label: 'All task sections',
+            isReadOnly: true,
+            tasks: [
+              [
+                {
+                  id: '1',
+                  label: 'Ad hoc - Verify Address',
+                  icon: <VerificationIcon />,
+                  taskGroupType: 'adhoc',
+                },
+              ],
+              [
+                {
+                  id: '2',
+                  label: 'Wait for connector',
+                  icon: <VerificationIcon />,
+                  taskGroupType: 'event-driven',
+                  hasEntryCondition: true,
+                },
+              ],
+              [
+                {
+                  id: '4',
+                  label: 'Task',
+                  icon: <DocumentIcon />,
+                  taskGroupType: 'sequential',
+                },
+              ],
+              [{ id: '5', label: 'Regular Processing', icon: <ProcessIcon /> }],
+            ],
+          },
+          execution: {
+            stageStatus: {
+              status: 'InProgress',
+              label: 'In progress',
+              duration: 'SLA: 3h 45m',
+            },
+            taskStatus: {
+              '1': {
+                status: 'Completed',
+                label: 'Verify Address',
+                duration: '1h 20m',
+                retryDuration: '35m',
+                badge: 'Reworked',
+                badgeStatus: 'warning',
+                retryCount: 2,
+              },
+              '2': {
+                status: 'Failed',
+                label: 'Verify Identity',
+                duration: '45m',
+                message: 'Identity verification failed - document expired',
+                badge: 'Action needed',
+                badgeStatus: 'error',
+              },
+              '3': {
+                status: 'InProgress',
+                label: 'Background Check',
+              },
+              '4': {
+                status: 'InProgress',
+                label: 'Review Docs',
+                duration: '30m',
+                retryDuration: '10m',
+                badge: 'Reworked',
+                badgeStatus: 'info',
+                retryCount: 1,
+              },
+              '5': {
+                status: 'InProgress',
+                label: 'Regular Processing',
+              },
+            },
+          },
+          onTaskPlay: (taskId: string) => {
+            return new Promise<void>((resolve) =>
+              setTimeout(() => {
+                resolve();
+                console.log(`Play task: ${taskId}`);
+              }, 5000)
+            );
+          },
+        },
+      },
+    ],
+  },
+};
+
 export const WithRulesTags: Story = {
   name: 'With Rules & Tags',
   parameters: {

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.styles.ts
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.styles.ts
@@ -130,7 +130,7 @@ export const StageTaskList = styled.div`
   gap: ${Spacing.SpacingS};
 `;
 
-export const StageTaskGroup = styled.div<{ isParallel?: boolean }>`
+export const StageTaskGroupContainer = styled.div<{ isParallel?: boolean }>`
   position: relative;
   display: flex;
   flex-direction: column;
@@ -305,13 +305,13 @@ export const StageChip = styled.button`
   }
 `;
 
-export const StageAdhocSection = styled.div`
+export const StageAdditionalTasksSection = styled.div`
   display: flex;
   flex-direction: column;
   gap: ${Spacing.SpacingS};
 `;
 
-export const StageAdhocHeaderSection = styled.div`
+export const StageAdditionalTasksHeaderSection = styled.div`
   height: 36px;
   display: flex;
   align-items: center;

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.tsx
@@ -1,79 +1,13 @@
-import {
-  closestCenter,
-  DndContext,
-  type DragEndEvent,
-  type DragMoveEvent,
-  type DragOverEvent,
-  type DragStartEvent,
-  KeyboardSensor,
-  PointerSensor,
-  useSensor,
-  useSensors,
-} from '@dnd-kit/core';
-import {
-  SortableContext,
-  sortableKeyboardCoordinates,
-  verticalListSortingStrategy,
-} from '@dnd-kit/sortable';
-import { Icon, Padding, Spacing } from '@uipath/apollo-core';
-import { Column, Row } from '@uipath/apollo-react/canvas/layouts';
-import { Position, useStore, useStoreApi } from '@uipath/apollo-react/canvas/xyflow/react';
-import { Button, cn } from '@uipath/apollo-wind';
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { EntryConditionIcon, ExitConditionIcon, ReturnToOriginIcon } from '../../icons';
-import type { HandleGroupManifest } from '../../schema/node-definition';
-import {
-  GroupModificationType,
-  moveGroupDown,
-  moveGroupUp,
-} from '../../utils/GroupModificationUtils';
-import { CanvasIcon } from '../../utils/icon-registry';
-import { useConnectedHandles } from '../BaseCanvas/ConnectedHandlesContext';
-import { useButtonHandles } from '../ButtonHandle/useButtonHandles';
-import { CanvasTooltip } from '../CanvasTooltip';
-import { ExecutionStatusIcon } from '../ExecutionStatusIcon';
 import { FloatingCanvasPanel } from '../FloatingCanvasPanel';
-import { NodeContextMenu, type NodeMenuItem } from '../NodeContextMenu';
+import { NodeContextMenu } from '../NodeContextMenu';
 import { useSetNodeSelection } from '../NodePropertiesPanel/hooks';
 import { type ListItem, Toolbox } from '../Toolbox';
-import { AdhocTaskItem } from './AdhocTask';
-import { DraggableTask } from './DraggableTask';
-import {
-  INDENTATION_WIDTH,
-  STAGE_CONTENT_INSET,
-  StageAdhocHeaderSection,
-  StageAdhocSection,
-  StageChip,
-  StageContainer,
-  StageContent,
-  StageHeader,
-  StageHeaderChipsRow,
-  StageParallelBracket,
-  StageParallelLabel,
-  StageTaskGroup,
-  StageTaskList,
-  StageTitleContainer,
-  StageTitleInput,
-} from './StageNode.styles';
-import type { StageNodeProps } from './StageNode.types';
-import { StageHeaderChipType } from './StageNode.types';
-import { flattenTasks, getProjection, reorderTasks } from './StageNode.utils';
-import { getContextMenuItems, getDivider, getMenuItem } from './StageNodeTaskUtilities';
-import { StageTaskDragOverlay } from './StageTaskDragOverlay';
-
-interface TaskStateReference {
-  isParallel: boolean;
-  groupIndex: number;
-  taskIndex: number;
-}
-
-const CHIP_ICONS: Record<StageHeaderChipType, React.ReactElement> = {
-  [StageHeaderChipType.Entry]: <EntryConditionIcon w={Icon.IconXs} h={Icon.IconXs} />,
-  [StageHeaderChipType.Exit]: <ExitConditionIcon w={Icon.IconXs} h={Icon.IconXs} />,
-  [StageHeaderChipType.ReturnToOrigin]: <ReturnToOriginIcon w={Icon.IconXs} h={Icon.IconXs} />,
-  [StageHeaderChipType.CaseExit]: <CanvasIcon icon="x" size={16} />,
-  [StageHeaderChipType.CaseCompletion]: <CanvasIcon icon="check" size={16} />,
-};
+import { INDENTATION_WIDTH, STAGE_CONTENT_INSET, StageContainer } from './StageNode.styles';
+import type { StageNodeProps, TaskStateReference } from './StageNode.types';
+import { StageNodeAllTaskGroups } from './StageNodeAllTaskGroups';
+import { StageNodeHandles } from './StageNodeHandles';
+import { StageNodeHeader } from './StageNodeHeader';
 
 const StageNodeInner = (props: StageNodeProps) => {
   const {
@@ -92,72 +26,27 @@ const StageNodeInner = (props: StageNodeProps) => {
     onTaskAdd,
     onAddTaskFromToolbox,
     onTaskToolboxSearch,
-    onTaskClick,
-    onTaskGroupModification,
-    onStageTitleChange,
-    onTaskReorder,
     onReplaceTaskFromToolbox,
-    onTaskPlay,
-    hideParallelOptions,
-    loadingTaskIds,
   } = props;
 
   const taskWidth = width ? width - STAGE_CONTENT_INSET : undefined;
 
   const allTasks = useMemo(() => stageDetails?.tasks || [], [stageDetails?.tasks]);
 
-  // Split tasks into regular (draggable) and ad hoc (separate section)
-  const tasks = useMemo(
-    () => allTasks.filter((group) => group.some((t) => !t.isAdhoc)),
-    [allTasks]
-  );
-  const adhocGroups = useMemo(
-    () => allTasks.filter((group) => group.every((t) => t.isAdhoc)),
-    [allTasks]
-  );
-  const adhocTasks = useMemo(
-    () =>
-      allTasks.flatMap((group, groupIndex) =>
-        group
-          .map((task, taskIndex) => ({ task, groupIndex, taskIndex }))
-          .filter(({ task }) => task.isAdhoc)
-      ),
-    [allTasks]
-  );
-
-  const flatTasks = useMemo(() => tasks.flat(), [tasks]);
-  const taskIds = useMemo(() => flatTasks.map((task) => task.id), [flatTasks]);
-
   const isException = stageDetails?.isException;
   const isReadOnly = !!stageDetails?.isReadOnly;
-  const icon = stageDetails?.icon;
   const selectedTaskId = stageDetails?.selectedTaskId;
-  const defaultContent =
-    stageDetails?.defaultContent || (isReadOnly ? 'No tasks' : 'Add first task');
-
   const status = execution?.stageStatus?.status;
-  const statusLabel = execution?.stageStatus?.label;
-  const stageDuration = execution?.stageStatus?.duration;
-
-  const isStageTitleEditable = !!onStageTitleChange && !isReadOnly;
 
   const [isHovered, setIsHovered] = useState(false);
-  const [label, setLabel] = useState(props.stageDetails.label);
+  const handleMouseEnter = useCallback(() => setIsHovered(true), []);
+  const handleMouseLeave = useCallback(() => setIsHovered(false), []);
 
-  useEffect(() => {
-    setLabel(props.stageDetails.label);
-  }, [props.stageDetails.label]);
-
-  const [isStageTitleEditing, setIsStageTitleEditing] = useState(false);
-  const stageTitleRef = useRef<HTMLInputElement>(null);
   const taskStateReference = useRef<TaskStateReference>({
     isParallel: false,
     groupIndex: -1,
     taskIndex: -1,
   });
-  const isConnecting = useStore((state) => !!state.connectionClickStartHandle);
-  const storeApi = useStoreApi();
-  const connectedHandleIds = useConnectedHandles(id);
 
   const [isAddingTask, setIsAddingTask] = useState(false);
   const [isReplacingTask, setIsReplacingTask] = useState(false);
@@ -179,26 +68,6 @@ const StageNodeInner = (props: StageNodeProps) => {
     }
   }, [pendingReplaceTask, selectedTaskId, allTasks]);
 
-  const [activeDragId, setActiveDragId] = useState<string | null>(null);
-  const [offsetLeft, setOffsetLeft] = useState(0);
-  const [overId, setOverId] = useState<string | null>(null);
-  const activeTask = useMemo(
-    () => flatTasks.find((t) => t.id === activeDragId),
-    [flatTasks, activeDragId]
-  );
-  const isActiveTaskParallel = useMemo(() => {
-    if (!activeDragId) {
-      return false;
-    }
-    const group = tasks.find((g) => g.some((t) => t.id === activeDragId));
-    return group ? group.length > 1 : false;
-  }, [tasks, activeDragId]);
-
-  const projected = useMemo(() => {
-    if (!activeDragId || !overId) return null;
-    return getProjection(tasks, activeDragId, overId, offsetLeft);
-  }, [tasks, activeDragId, overId, offsetLeft]);
-
   useEffect(() => {
     if (selected === false) {
       setIsAddingTask(false);
@@ -206,192 +75,14 @@ const StageNodeInner = (props: StageNodeProps) => {
     }
   }, [selected]);
 
-  const hasConnections = connectedHandleIds.size > 0;
-
-  const shouldShowHandles = useMemo(() => {
-    return !isReadOnly && (selected || isHovered || isConnecting || hasConnections);
-  }, [hasConnections, isConnecting, selected, isHovered, isReadOnly]);
-
-  const handleMouseEnter = useCallback(() => setIsHovered(true), []);
-  const handleMouseLeave = useCallback(() => setIsHovered(false), []);
-
   const shouldShowMenu = useMemo(() => {
     return menuItems && menuItems.length > 0 && (selected || isHovered) && !isReadOnly;
   }, [menuItems, selected, isHovered, isReadOnly]);
-
-  const handleStageTitleChange = useCallback((e: React.FormEvent<HTMLInputElement>) => {
-    setIsStageTitleEditing(true);
-    setLabel((e.target as HTMLInputElement).value);
-  }, []);
-
-  const handleStageTitleClickToSave = useCallback(
-    (e: React.FocusEvent | MouseEvent) => {
-      if (isStageTitleEditing && !stageTitleRef.current?.contains(e.target as Node)) {
-        setIsStageTitleEditing(false);
-        if (onStageTitleChange) {
-          if (label.trim() === '') setLabel('Untitled Stage');
-          onStageTitleChange(label);
-        }
-      }
-    },
-    [isStageTitleEditing, onStageTitleChange, label]
-  );
-
-  const handleStageTitleBlurToSave = useCallback(() => {
-    if (isStageTitleEditing) {
-      setIsStageTitleEditing(false);
-      if (onStageTitleChange) {
-        if (label.trim() === '') setLabel('Untitled Stage');
-        onStageTitleChange(label);
-      }
-    }
-  }, [isStageTitleEditing, onStageTitleChange, label]);
-
-  const handleStageTitleKeyDown = useCallback(
-    (e: React.KeyboardEvent<HTMLInputElement>) => {
-      if (e.key === 'Enter') {
-        setIsStageTitleEditing(false);
-        if (onStageTitleChange) {
-          onStageTitleChange(label);
-        }
-      }
-      // Prevent keyboard events from the title input from bubbling to xyflow
-      // and triggering canvas-level actions like node deletion or copy/paste.
-      if (e.key !== 'Escape') {
-        e.stopPropagation();
-      }
-    },
-    [onStageTitleChange, label]
-  );
-
-  useEffect(() => {
-    if (isStageTitleEditing) {
-      document.addEventListener('click', handleStageTitleClickToSave);
-    }
-    return () => {
-      document.removeEventListener('click', handleStageTitleClickToSave);
-    };
-  }, [handleStageTitleClickToSave, isStageTitleEditing]);
-
-  const hasContextMenu = !!(onReplaceTaskFromToolbox || onTaskGroupModification);
-
-  const handleTaskRegroup = useCallback(
-    (groupModificationType: GroupModificationType, groupIndex: number, taskIndex: number) => {
-      if (
-        onTaskReorder &&
-        (groupModificationType === GroupModificationType.TASK_GROUP_UP ||
-          groupModificationType === GroupModificationType.TASK_GROUP_DOWN)
-      ) {
-        const mover =
-          groupModificationType === GroupModificationType.TASK_GROUP_UP
-            ? moveGroupUp
-            : moveGroupDown;
-        const reordered = mover(tasks, groupIndex, taskIndex);
-        onTaskReorder([...reordered, ...adhocGroups]);
-        return;
-      }
-
-      onTaskGroupModification?.(groupModificationType, groupIndex, taskIndex);
-    },
-    [onTaskReorder, onTaskGroupModification, tasks, adhocGroups]
-  );
-
-  /** Lazily builds context menu items for a task. Called only when the menu opens,
-   * avoiding object allocation on every render for every task. */
-  const buildContextMenuItems = useCallback(
-    (groupIndex: number, taskIndex: number) => {
-      const taskGroup = tasks[groupIndex] ?? [];
-      const isParallel = taskGroup.length > 1;
-      const items: NodeMenuItem[] = [];
-
-      if (onReplaceTaskFromToolbox) {
-        items.push(
-          getMenuItem('replace-task', 'Replace task', () => {
-            taskStateReference.current = {
-              isParallel,
-              groupIndex,
-              taskIndex,
-            };
-            const taskId = taskGroup[taskIndex]?.id;
-            if (taskId) onTaskClick?.(taskId);
-            setIsReplacingTask(true);
-          })
-        );
-        items.push(getDivider());
-      }
-
-      if (onTaskGroupModification) {
-        const reGroupOptions = getContextMenuItems(
-          isParallel,
-          groupIndex,
-          tasks.length,
-          taskIndex,
-          taskGroup.length,
-          (tasks[groupIndex - 1]?.length ?? 0) > 1,
-          (tasks[groupIndex + 1]?.length ?? 0) > 1,
-          handleTaskRegroup,
-          hideParallelOptions
-        );
-        return [...items, ...reGroupOptions];
-      }
-
-      return items;
-    },
-    [
-      onReplaceTaskFromToolbox,
-      onTaskClick,
-      onTaskGroupModification,
-      tasks,
-      hideParallelOptions,
-      handleTaskRegroup,
-    ]
-  );
-
-  const getAdhocContextMenuItems = useCallback(
-    (groupIndex: number, taskIndex: number, taskId: string): NodeMenuItem[] => {
-      const items: NodeMenuItem[] = [];
-
-      if (onReplaceTaskFromToolbox) {
-        items.push(
-          getMenuItem('replace-task', 'Replace task', () => {
-            taskStateReference.current = {
-              isParallel: false,
-              groupIndex,
-              taskIndex,
-            };
-            onTaskClick?.(taskId);
-            setIsReplacingTask(true);
-          })
-        );
-      }
-
-      if (onTaskGroupModification) {
-        if (items.length > 0) items.push(getDivider());
-        items.push(
-          getMenuItem('remove-task', 'Delete task', () =>
-            onTaskGroupModification(GroupModificationType.REMOVE_TASK, groupIndex, taskIndex)
-          )
-        );
-      }
-
-      return items;
-    },
-    [onReplaceTaskFromToolbox, onTaskClick, onTaskGroupModification]
-  );
 
   const { setSelectedNodeId } = useSetNodeSelection();
   const handleStageClick = useCallback(() => {
     onStageClick?.();
   }, [onStageClick]);
-
-  const handleTaskClick = useCallback(
-    (e: React.MouseEvent, taskElementId: string) => {
-      e.stopPropagation();
-      onTaskClick?.(taskElementId);
-      setSelectedNodeId(id);
-    },
-    [onTaskClick, setSelectedNodeId, id]
-  );
 
   const handleTaskAddClick = useCallback(
     (event: React.MouseEvent) => {
@@ -427,148 +118,6 @@ const StageNodeInner = (props: StageNodeProps) => {
     [onReplaceTaskFromToolbox]
   );
 
-  const handleConfigurations: HandleGroupManifest[] = useMemo(
-    () =>
-      isException
-        ? []
-        : [
-            {
-              position: Position.Left,
-              handles: [
-                {
-                  id: `${id}____target____left`,
-                  type: 'target',
-                  handleType: 'input',
-                },
-              ],
-              visible: selected || isHovered || isConnecting,
-              customPositionAndOffsets: {
-                top: 0,
-                height: 64,
-              },
-            },
-            {
-              position: Position.Right,
-              handles: [
-                {
-                  id: `${id}____source____right`,
-                  type: 'source',
-                  handleType: 'output',
-                },
-              ],
-              visible: selected || isHovered || isConnecting,
-              customPositionAndOffsets: {
-                top: 0,
-                height: 64,
-              },
-            },
-            {
-              position: Position.Bottom,
-              handles: [
-                {
-                  id: `${id}____target____bottom`,
-                  type: 'target',
-                  handleType: 'input',
-                },
-              ],
-              visible: selected || isHovered || isConnecting,
-            },
-            {
-              position: Position.Bottom,
-              handles: [
-                {
-                  id: `${id}____source____bottom`,
-                  type: 'source',
-                  handleType: 'output',
-                },
-              ],
-              visible: selected || isHovered || isConnecting,
-            },
-          ],
-    [isException, id, selected, isHovered, isConnecting]
-  );
-  const handleElements = useButtonHandles({
-    handleConfigurations,
-    shouldShowHandles,
-    nodeId: id,
-    selected,
-  });
-  const sensors = useSensors(
-    useSensor(PointerSensor, {
-      activationConstraint: {
-        distance: 3,
-      },
-    }),
-    useSensor(KeyboardSensor, {
-      coordinateGetter: sortableKeyboardCoordinates,
-    })
-  );
-
-  const resetState = useCallback(() => {
-    setActiveDragId(null);
-    setOffsetLeft(0);
-    setOverId(null);
-  }, []);
-
-  const handleDragStart = useCallback((event: DragStartEvent) => {
-    setActiveDragId(event.active.id as string);
-  }, []);
-
-  const handleDragMove = useCallback(
-    (event: DragMoveEvent) => {
-      setOffsetLeft(event.delta.x / storeApi.getState().transform[2]);
-    },
-    [storeApi]
-  );
-
-  const handleDragOver = useCallback((event: DragOverEvent) => {
-    setOverId((event.over?.id as string) ?? null);
-  }, []);
-
-  const handleDragEnd = useCallback(
-    (event: DragEndEvent) => {
-      const { active, over } = event;
-      const currentOffsetLeft = offsetLeft;
-      resetState();
-
-      if (!over || !onTaskReorder) {
-        return;
-      }
-
-      const projection = getProjection(
-        tasks,
-        active.id as string,
-        over.id as string,
-        currentOffsetLeft
-      );
-      if (!projection) {
-        return;
-      }
-
-      // For in-place movement, skip if depth hasn't changed
-      if (active.id === over.id) {
-        const flattened = flattenTasks(tasks);
-        const activeTask = flattened.find((t) => t.id === active.id);
-        if (activeTask && activeTask.depth === projection.depth) {
-          return;
-        }
-      }
-
-      const newTasks = reorderTasks(
-        tasks,
-        active.id as string,
-        over.id as string,
-        projection.depth
-      );
-      onTaskReorder([...newTasks, ...adhocGroups]);
-    },
-    [tasks, onTaskReorder, offsetLeft, resetState, adhocGroups]
-  );
-
-  const handleDragCancel = useCallback(() => {
-    resetState();
-  }, [resetState]);
-
   const taskWidthStyle = useMemo(
     () =>
       taskWidth
@@ -589,200 +138,23 @@ const StageNodeInner = (props: StageNodeProps) => {
       onMouseLeave={handleMouseLeave}
     >
       <StageContainer selected={selected} status={status} width={width} style={taskWidthStyle}>
-        <StageHeader isException={isException} data-testid={`stage-header-${id}`}>
-          <Row gap={Spacing.SpacingMicro} align="center" flex={1} minW={0}>
-            {icon}
-            <Column py={2} flex={1} minW={0}>
-              <span className={cn('text-sm', !isStageTitleEditing && 'font-bold')}>
-                <CanvasTooltip content={label} placement="top" delay>
-                  <StageTitleContainer isEditing={isStageTitleEditing}>
-                    <StageTitleInput
-                      name="Stage Title"
-                      isStageTitleEditable={isStageTitleEditable}
-                      value={label}
-                      ref={stageTitleRef}
-                      isEditing={isStageTitleEditing}
-                      {...(onStageTitleChange && {
-                        onFocus: () => setIsStageTitleEditing(true),
-                        onInput: handleStageTitleChange,
-                        onKeyDown: handleStageTitleKeyDown,
-                        onBlur: handleStageTitleBlurToSave,
-                      })}
-                      readOnly={!isStageTitleEditable}
-                    />
-                  </StageTitleContainer>
-                </CanvasTooltip>
-              </span>
-              {stageDuration && (
-                <span className="text-xs text-foreground-muted">{stageDuration}</span>
-              )}
-              {stageDetails.headerChips && stageDetails.headerChips.length > 0 && (
-                <StageHeaderChipsRow>
-                  {stageDetails.headerChips.map((chip) => {
-                    const button = (
-                      <StageChip
-                        key={chip.type}
-                        type="button"
-                        aria-label={typeof chip.tooltip === 'string' ? chip.tooltip : chip.type}
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          chip.onClick?.();
-                        }}
-                      >
-                        {CHIP_ICONS[chip.type]}
-                        {chip.count !== undefined && <span className="text-xs">{chip.count}</span>}
-                      </StageChip>
-                    );
-                    if (chip.tooltip) {
-                      return (
-                        <CanvasTooltip key={chip.type} placement="bottom" content={chip.tooltip}>
-                          {button}
-                        </CanvasTooltip>
-                      );
-                    }
-                    return button;
-                  })}
-                </StageHeaderChipsRow>
-              )}
-            </Column>
-          </Row>
-          <Row gap={Spacing.SpacingMicro} align="start" py={Padding.PadS}>
-            {status && (
-              <CanvasTooltip content={statusLabel} placement="top">
-                <Button variant="ghost" size="icon" className="h-6 w-6" aria-label={statusLabel}>
-                  <ExecutionStatusIcon status={status} size={20} />
-                </Button>
-              </CanvasTooltip>
-            )}
-            {(onTaskAdd || onAddTaskFromToolbox) && !isReadOnly && (
-              <CanvasTooltip content={addTaskLabel} placement="top">
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  className="h-6 w-6"
-                  onClick={handleTaskAddClick}
-                  aria-label={addTaskLabel}
-                >
-                  <CanvasIcon icon="plus" size={20} />
-                </Button>
-              </CanvasTooltip>
-            )}
-          </Row>
-        </StageHeader>
+        <StageNodeHeader
+          props={props}
+          isReadOnly={isReadOnly}
+          isException={isException}
+          status={status}
+          handleTaskAddClick={handleTaskAddClick}
+        />
 
-        <StageContent>
-          {tasks.length === 0 && adhocTasks.length === 0 ? (
-            <Column py={2}>
-              {(onTaskAdd || onAddTaskFromToolbox) && !isReadOnly ? (
-                <Button
-                  variant="link"
-                  onClick={handleTaskAddClick}
-                  style={{ maxWidth: 'fit-content' }}
-                >
-                  {defaultContent}
-                </Button>
-              ) : (
-                <span className="text-xs text-foreground-muted">{defaultContent}</span>
-              )}
-            </Column>
-          ) : (
-            <>
-              {tasks.length > 0 && (
-                <DndContext
-                  collisionDetection={closestCenter}
-                  sensors={sensors}
-                  onDragStart={handleDragStart}
-                  onDragMove={handleDragMove}
-                  onDragOver={handleDragOver}
-                  onDragEnd={handleDragEnd}
-                  onDragCancel={handleDragCancel}
-                >
-                  <SortableContext items={taskIds} strategy={verticalListSortingStrategy}>
-                    {/* Disable dragging and panning the canvas when dragging a task */}
-                    <StageTaskList className="nodrag nopan">
-                      {tasks.map((taskGroup, groupIndex) => {
-                        const isParallel = taskGroup.length > 1;
-                        return (
-                          <Row key={`group-${groupIndex}`} gap={Spacing.SpacingS}>
-                            {isParallel && <StageParallelBracket />}
-                            <StageTaskGroup isParallel={isParallel}>
-                              {isParallel && (
-                                <StageParallelLabel>
-                                  <span className="text-xs">Parallel</span>
-                                </StageParallelLabel>
-                              )}
-                              {taskGroup.map((task, taskIndex) => {
-                                const taskExecution = execution?.taskStatus?.[task.id];
-                                return (
-                                  <DraggableTask
-                                    key={task.id}
-                                    task={task}
-                                    taskExecution={taskExecution}
-                                    isSelected={selectedTaskId === task.id}
-                                    isParallel={isParallel}
-                                    groupIndex={groupIndex}
-                                    taskIndex={taskIndex}
-                                    onTaskClick={handleTaskClick}
-                                    projectedDepth={
-                                      task.id === activeDragId && projected
-                                        ? projected.depth
-                                        : undefined
-                                    }
-                                    isDragDisabled={!onTaskReorder || isReadOnly}
-                                    isTaskLoading={loadingTaskIds?.has(task.id)}
-                                    {...(hasContextMenu &&
-                                      !isReadOnly && {
-                                        getContextMenuItems: buildContextMenuItems,
-                                      })}
-                                  />
-                                );
-                              })}
-                            </StageTaskGroup>
-                          </Row>
-                        );
-                      })}
-                    </StageTaskList>
-                  </SortableContext>
-                  <StageTaskDragOverlay
-                    activeTask={activeTask}
-                    isActiveTaskParallel={isActiveTaskParallel}
-                    taskWidthStyle={taskWidthStyle}
-                  />
-                </DndContext>
-              )}
-              {adhocTasks.length > 0 && (
-                <StageAdhocSection
-                  style={{ marginTop: tasks.length > 0 ? Spacing.SpacingS : '0px' }}
-                >
-                  <StageAdhocHeaderSection>
-                    <span className="text-xs font-bold text-foreground-muted">Ad hoc tasks</span>
-                  </StageAdhocHeaderSection>
-                  <StageTaskList>
-                    {adhocTasks.map(({ task, groupIndex, taskIndex }) => {
-                      const taskExecution = execution?.taskStatus?.[task.id];
-                      return (
-                        <AdhocTaskItem
-                          key={task.id}
-                          task={task}
-                          taskExecution={taskExecution}
-                          isSelected={selectedTaskId === task.id}
-                          onTaskClick={handleTaskClick}
-                          onTaskPlay={onTaskPlay}
-                          isTaskLoading={loadingTaskIds?.has(task.id)}
-                          {...((onTaskGroupModification || onReplaceTaskFromToolbox) &&
-                            !isReadOnly && {
-                              getContextMenuItems: () =>
-                                getAdhocContextMenuItems(groupIndex, taskIndex, task.id),
-                            })}
-                        />
-                      );
-                    })}
-                  </StageTaskList>
-                </StageAdhocSection>
-              )}
-            </>
-          )}
-        </StageContent>
+        <StageNodeAllTaskGroups
+          props={props}
+          isReadOnly={isReadOnly}
+          taskWidthStyle={taskWidthStyle}
+          taskStateReference={taskStateReference}
+          setSelectedNodeId={setSelectedNodeId}
+          handleTaskAddClick={handleTaskAddClick}
+          setIsReplacingTask={setIsReplacingTask}
+        />
       </StageContainer>
 
       {onAddTaskFromToolbox && (
@@ -813,7 +185,13 @@ const StageNodeInner = (props: StageNodeProps) => {
         <NodeContextMenu menuItems={menuItems} isVisible={shouldShowMenu} />
       )}
 
-      {handleElements}
+      <StageNodeHandles
+        id={id}
+        isReadOnly={isReadOnly}
+        selected={selected}
+        isHovered={isHovered}
+        isException={isException}
+      />
     </div>
   );
 };

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.types.ts
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.types.ts
@@ -23,6 +23,7 @@ export interface StageTaskItem {
   label: string;
   icon?: React.ReactElement;
   isAdhoc?: boolean;
+  taskGroupType?: 'sequential' | 'event-driven' | 'adhoc';
   hasEntryCondition?: boolean;
 }
 
@@ -106,4 +107,16 @@ export interface StageTaskDragOverlayProps {
   activeTask: StageTaskItem | undefined;
   isActiveTaskParallel: boolean;
   taskWidthStyle: React.CSSProperties | undefined;
+}
+
+export interface TaskStateReference {
+  isParallel: boolean;
+  groupIndex: number;
+  taskIndex: number;
+}
+
+export interface StageTaskGroup {
+  task: StageTaskItem;
+  groupIndex: number;
+  taskIndex: number;
 }

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNodeAdhocTaskGroups.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNodeAdhocTaskGroups.tsx
@@ -1,0 +1,114 @@
+import { memo, RefObject, useCallback } from 'react';
+import { GroupModificationType } from '../../utils/GroupModificationUtils';
+import type { NodeMenuItem } from '../NodeContextMenu';
+import { AdhocTaskItem } from './AdhocTask';
+import {
+  StageAdditionalTasksHeaderSection,
+  StageAdditionalTasksSection,
+  StageTaskList,
+} from './StageNode.styles';
+import type { StageNodeProps, StageTaskGroup, TaskStateReference } from './StageNode.types';
+import { getDivider, getMenuItem } from './StageNodeTaskUtilities';
+
+const StageNodeAdhocTaskGroupsInner = ({
+  props,
+  adhocTasks,
+  isReadOnly,
+  selectedTaskId,
+  taskStateReference,
+  marginTop,
+  handleTaskClick,
+  setIsReplacingTask,
+}: {
+  props: StageNodeProps;
+  adhocTasks: StageTaskGroup[];
+  isReadOnly: boolean;
+  selectedTaskId?: string;
+  taskStateReference: RefObject<TaskStateReference>;
+  marginTop: string;
+  handleTaskClick: (e: React.MouseEvent, taskElementId: string) => void;
+  setIsReplacingTask: (isReplacingTask: boolean) => void;
+}) => {
+  const {
+    execution,
+    onTaskClick,
+    onTaskGroupModification,
+    onReplaceTaskFromToolbox,
+    onTaskPlay,
+    loadingTaskIds,
+  } = props;
+
+  /** Lazily builds context menu items for a task. Called only when the menu opens,
+   * avoiding object allocation on every render for every task. */
+  const getAdhocContextMenuItems = useCallback(
+    (groupIndex: number, taskIndex: number, taskId: string): NodeMenuItem[] => {
+      const items: NodeMenuItem[] = [];
+
+      if (onReplaceTaskFromToolbox) {
+        items.push(
+          getMenuItem('replace-task', 'Replace task', () => {
+            taskStateReference.current = {
+              isParallel: false,
+              groupIndex,
+              taskIndex,
+            };
+            onTaskClick?.(taskId);
+            setIsReplacingTask(true);
+          })
+        );
+      }
+
+      if (onTaskGroupModification) {
+        if (items.length > 0) items.push(getDivider());
+        items.push(
+          getMenuItem('remove-task', 'Delete task', () =>
+            onTaskGroupModification(GroupModificationType.REMOVE_TASK, groupIndex, taskIndex)
+          )
+        );
+      }
+
+      return items;
+    },
+    [
+      onReplaceTaskFromToolbox,
+      onTaskClick,
+      onTaskGroupModification,
+      setIsReplacingTask,
+      taskStateReference,
+    ]
+  );
+
+  if (adhocTasks.length === 0) {
+    return null;
+  }
+  return (
+    <StageAdditionalTasksSection style={{ marginTop }}>
+      <StageAdditionalTasksHeaderSection>
+        <span className="text-xs font-bold text-foreground-muted">Ad hoc tasks</span>
+      </StageAdditionalTasksHeaderSection>
+      <StageTaskList>
+        {adhocTasks.map(({ task, groupIndex, taskIndex }) => {
+          const taskExecution = execution?.taskStatus?.[task.id];
+          return (
+            <AdhocTaskItem
+              key={task.id}
+              task={task}
+              taskExecution={taskExecution}
+              isSelected={selectedTaskId === task.id}
+              onTaskClick={handleTaskClick}
+              onTaskPlay={onTaskPlay}
+              isTaskLoading={loadingTaskIds?.has(task.id)}
+              {...((onTaskGroupModification || onReplaceTaskFromToolbox) &&
+                !isReadOnly && {
+                  getContextMenuItems: () =>
+                    getAdhocContextMenuItems(groupIndex, taskIndex, task.id),
+                })}
+            />
+          );
+        })}
+      </StageTaskList>
+    </StageAdditionalTasksSection>
+  );
+};
+
+export const StageNodeAdhocTaskGroups = memo(StageNodeAdhocTaskGroupsInner);

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNodeAllTaskGroups.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNodeAllTaskGroups.tsx
@@ -1,0 +1,136 @@
+import { Spacing } from '@uipath/apollo-core';
+import { Column } from '@uipath/apollo-react/canvas/layouts';
+import { Button } from '@uipath/apollo-wind';
+import { CSSProperties, memo, RefObject, useCallback, useMemo } from 'react';
+import { useStageTasksByGroups } from './hooks/useStageTasksByGroups';
+import { StageContent } from './StageNode.styles';
+import type { StageNodeProps, StageTaskItem, TaskStateReference } from './StageNode.types';
+import { StageNodeAdhocTaskGroups } from './StageNodeAdhocTaskGroups';
+import { StageNodeEventDrivenTaskGroups } from './StageNodeEventDrivenTaskGroups';
+import { StageNodeSequentialTaskGroups } from './StageNodeSequentialTaskGroups';
+
+const StageNodeAllTaskGroupsInner = ({
+  props,
+  isReadOnly,
+  taskWidthStyle,
+  taskStateReference,
+  setSelectedNodeId,
+  handleTaskAddClick,
+  setIsReplacingTask,
+}: {
+  props: StageNodeProps;
+  isReadOnly: boolean;
+  taskWidthStyle?: CSSProperties;
+  taskStateReference: RefObject<TaskStateReference>;
+  setSelectedNodeId: (nodeId: string) => void;
+  handleTaskAddClick: (event: React.MouseEvent) => void;
+  setIsReplacingTask: (isReplacingTask: boolean) => void;
+}) => {
+  const {
+    id,
+    stageDetails,
+    onTaskAdd,
+    onAddTaskFromToolbox,
+    onTaskClick,
+    onTaskGroupModification,
+    onTaskReorder,
+    onReplaceTaskFromToolbox,
+  } = props;
+
+  const allTasks = useMemo(() => stageDetails?.tasks || [], [stageDetails?.tasks]);
+
+  // Split tasks into separate sections
+  const {
+    sequentialTaskGroups,
+    sequentialTasks,
+    adhocTaskGroups,
+    adhocTasks,
+    eventDrivenTaskGroups,
+    eventDrivenTasks,
+  } = useStageTasksByGroups(allTasks);
+
+  const selectedTaskId = stageDetails?.selectedTaskId;
+  const defaultContent =
+    stageDetails?.defaultContent || (isReadOnly ? 'No tasks' : 'Add first task');
+
+  const handleReorderSequentialTasks = useCallback(
+    (newTasks: StageTaskItem[][]) => {
+      if (!onTaskReorder) {
+        return;
+      }
+      onTaskReorder([...newTasks, ...eventDrivenTaskGroups, ...adhocTaskGroups]);
+    },
+    [onTaskReorder, eventDrivenTaskGroups, adhocTaskGroups]
+  );
+
+  const hasContextMenu = !!(onReplaceTaskFromToolbox || onTaskGroupModification);
+
+  const handleTaskClick = useCallback(
+    (e: React.MouseEvent, taskElementId: string) => {
+      e.stopPropagation();
+      onTaskClick?.(taskElementId);
+      setSelectedNodeId(id);
+    },
+    [onTaskClick, setSelectedNodeId, id]
+  );
+
+  return (
+    <StageContent>
+      {sequentialTaskGroups.length === 0 &&
+      adhocTaskGroups.length === 0 &&
+      eventDrivenTaskGroups.length === 0 ? (
+        <Column py={2}>
+          {(onTaskAdd || onAddTaskFromToolbox) && !isReadOnly ? (
+            <Button variant="link" onClick={handleTaskAddClick} style={{ maxWidth: 'fit-content' }}>
+              {defaultContent}
+            </Button>
+          ) : (
+            <span className="text-xs text-foreground-muted">{defaultContent}</span>
+          )}
+        </Column>
+      ) : (
+        <Column>
+          <StageNodeSequentialTaskGroups
+            props={props}
+            sequentialTaskGroups={sequentialTaskGroups}
+            sequentialTasks={sequentialTasks}
+            isReadOnly={isReadOnly}
+            selectedTaskId={selectedTaskId}
+            taskWidthStyle={taskWidthStyle}
+            taskStateReference={taskStateReference}
+            hasContextMenu={hasContextMenu}
+            handleTaskClick={handleTaskClick}
+            setIsReplacingTask={setIsReplacingTask}
+            handleReorderSequentialTasks={handleReorderSequentialTasks}
+          />
+          <StageNodeEventDrivenTaskGroups
+            props={props}
+            eventDrivenTasks={eventDrivenTasks}
+            isReadOnly={isReadOnly}
+            selectedTaskId={selectedTaskId}
+            taskStateReference={taskStateReference}
+            marginTop={sequentialTaskGroups.length > 0 ? Spacing.SpacingS : '0px'}
+            handleTaskClick={handleTaskClick}
+            setIsReplacingTask={setIsReplacingTask}
+          />
+          <StageNodeAdhocTaskGroups
+            props={props}
+            adhocTasks={adhocTasks}
+            isReadOnly={isReadOnly}
+            selectedTaskId={selectedTaskId}
+            taskStateReference={taskStateReference}
+            marginTop={
+              sequentialTaskGroups.length > 0 || eventDrivenTaskGroups.length > 0
+                ? Spacing.SpacingS
+                : '0px'
+            }
+            handleTaskClick={handleTaskClick}
+            setIsReplacingTask={setIsReplacingTask}
+          />
+        </Column>
+      )}
+    </StageContent>
+  );
+};
+
+export const StageNodeAllTaskGroups = memo(StageNodeAllTaskGroupsInner);

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNodeEventDrivenTaskGroups.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNodeEventDrivenTaskGroups.tsx
@@ -1,0 +1,112 @@
+import { memo, RefObject, useCallback } from 'react';
+import { GroupModificationType } from '../../utils/GroupModificationUtils';
+import type { NodeMenuItem } from '../NodeContextMenu';
+import { EventDrivenTaskItem } from './EventDrivenTask';
+import {
+  StageAdditionalTasksHeaderSection,
+  StageAdditionalTasksSection,
+  StageTaskList,
+} from './StageNode.styles';
+import type { StageNodeProps, StageTaskGroup, TaskStateReference } from './StageNode.types';
+import { getDivider, getMenuItem } from './StageNodeTaskUtilities';
+
+const StageNodeEventDrivenTaskGroupsInner = ({
+  props,
+  eventDrivenTasks,
+  isReadOnly,
+  selectedTaskId,
+  taskStateReference,
+  marginTop,
+  handleTaskClick,
+  setIsReplacingTask,
+}: {
+  props: StageNodeProps;
+  eventDrivenTasks: StageTaskGroup[];
+  isReadOnly: boolean;
+  selectedTaskId?: string;
+  taskStateReference: RefObject<TaskStateReference>;
+  marginTop: string;
+  handleTaskClick: (e: React.MouseEvent, taskElementId: string) => void;
+  setIsReplacingTask: (isReplacingTask: boolean) => void;
+}) => {
+  const {
+    execution,
+    onTaskClick,
+    onTaskGroupModification,
+    onReplaceTaskFromToolbox,
+    loadingTaskIds,
+  } = props;
+
+  /** Lazily builds context menu items for a task. Called only when the menu opens,
+   * avoiding object allocation on every render for every task. */
+  const getEventDrivenContextMenuItems = useCallback(
+    (groupIndex: number, taskIndex: number, taskId: string): NodeMenuItem[] => {
+      const items: NodeMenuItem[] = [];
+
+      if (onReplaceTaskFromToolbox) {
+        items.push(
+          getMenuItem('replace-task', 'Replace task', () => {
+            taskStateReference.current = {
+              isParallel: false,
+              groupIndex,
+              taskIndex,
+            };
+            onTaskClick?.(taskId);
+            setIsReplacingTask(true);
+          })
+        );
+      }
+
+      if (onTaskGroupModification) {
+        if (items.length > 0) items.push(getDivider());
+        items.push(
+          getMenuItem('remove-task', 'Delete task', () =>
+            onTaskGroupModification(GroupModificationType.REMOVE_TASK, groupIndex, taskIndex)
+          )
+        );
+      }
+
+      return items;
+    },
+    [
+      onReplaceTaskFromToolbox,
+      onTaskClick,
+      onTaskGroupModification,
+      setIsReplacingTask,
+      taskStateReference,
+    ]
+  );
+
+  if (eventDrivenTasks.length === 0) {
+    return null;
+  }
+  return (
+    <StageAdditionalTasksSection style={{ marginTop }}>
+      <StageAdditionalTasksHeaderSection>
+        <span className="text-xs font-bold text-foreground-muted">Event-driven tasks</span>
+      </StageAdditionalTasksHeaderSection>
+      <StageTaskList>
+        {eventDrivenTasks.map(({ task, groupIndex, taskIndex }) => {
+          const taskExecution = execution?.taskStatus?.[task.id];
+          return (
+            <EventDrivenTaskItem
+              key={task.id}
+              task={task}
+              taskExecution={taskExecution}
+              isSelected={selectedTaskId === task.id}
+              onTaskClick={handleTaskClick}
+              isTaskLoading={loadingTaskIds?.has(task.id)}
+              {...((onTaskGroupModification || onReplaceTaskFromToolbox) &&
+                !isReadOnly && {
+                  getContextMenuItems: () =>
+                    getEventDrivenContextMenuItems(groupIndex, taskIndex, task.id),
+                })}
+            />
+          );
+        })}
+      </StageTaskList>
+    </StageAdditionalTasksSection>
+  );
+};
+
+export const StageNodeEventDrivenTaskGroups = memo(StageNodeEventDrivenTaskGroupsInner);

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNodeHandles.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNodeHandles.tsx
@@ -1,0 +1,98 @@
+import { Position, useStore } from '@uipath/apollo-react/canvas/xyflow/react';
+import { memo, useMemo } from 'react';
+import type { HandleGroupManifest } from '../../schema/node-definition';
+import { useConnectedHandles } from '../BaseCanvas/ConnectedHandlesContext';
+import { useButtonHandles } from '../ButtonHandle/useButtonHandles';
+
+const StageNodeHandlesInner = ({
+  id,
+  isReadOnly,
+  selected,
+  isHovered,
+  isException,
+}: {
+  id: string;
+  isReadOnly: boolean;
+  selected: boolean;
+  isHovered: boolean;
+  isException?: boolean;
+}) => {
+  const isConnecting = useStore((state) => !!state.connectionClickStartHandle);
+  const connectedHandleIds = useConnectedHandles(id);
+  const hasConnections = connectedHandleIds.size > 0;
+  const shouldShowHandles = useMemo(() => {
+    return !isReadOnly && (selected || isHovered || isConnecting || hasConnections);
+  }, [hasConnections, isConnecting, selected, isHovered, isReadOnly]);
+
+  const handleConfigurations: HandleGroupManifest[] = useMemo(
+    () =>
+      isException
+        ? []
+        : [
+            {
+              position: Position.Left,
+              handles: [
+                {
+                  id: `${id}____target____left`,
+                  type: 'target',
+                  handleType: 'input',
+                },
+              ],
+              visible: selected || isHovered || isConnecting,
+              customPositionAndOffsets: {
+                top: 0,
+                height: 64,
+              },
+            },
+            {
+              position: Position.Right,
+              handles: [
+                {
+                  id: `${id}____source____right`,
+                  type: 'source',
+                  handleType: 'output',
+                },
+              ],
+              visible: selected || isHovered || isConnecting,
+              customPositionAndOffsets: {
+                top: 0,
+                height: 64,
+              },
+            },
+            {
+              position: Position.Bottom,
+              handles: [
+                {
+                  id: `${id}____target____bottom`,
+                  type: 'target',
+                  handleType: 'input',
+                },
+              ],
+              visible: selected || isHovered || isConnecting,
+            },
+            {
+              position: Position.Bottom,
+              handles: [
+                {
+                  id: `${id}____source____bottom`,
+                  type: 'source',
+                  handleType: 'output',
+                },
+              ],
+              visible: selected || isHovered || isConnecting,
+            },
+          ],
+    [isException, id, selected, isHovered, isConnecting]
+  );
+
+  const handleElements = useButtonHandles({
+    handleConfigurations,
+    shouldShowHandles,
+    nodeId: id,
+    selected,
+  });
+
+  return handleElements;
+};
+
+export const StageNodeHandles = memo(StageNodeHandlesInner);

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNodeHeader.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNodeHeader.tsx
@@ -1,0 +1,200 @@
+import { Icon, Padding, Spacing } from '@uipath/apollo-core';
+import { Column, Row } from '@uipath/apollo-react/canvas/layouts';
+import { Button, cn } from '@uipath/apollo-wind';
+import { memo, useCallback, useEffect, useRef, useState } from 'react';
+import { EntryConditionIcon, ExitConditionIcon, ReturnToOriginIcon } from '../../icons';
+import { CanvasIcon } from '../../utils/icon-registry';
+import { CanvasTooltip } from '../CanvasTooltip';
+import { ExecutionStatusIcon } from '../ExecutionStatusIcon';
+import {
+  StageChip,
+  StageHeader,
+  StageHeaderChipsRow,
+  StageTitleContainer,
+  StageTitleInput,
+} from './StageNode.styles';
+import type { StageNodeProps, StageStatus } from './StageNode.types';
+import { StageHeaderChipType } from './StageNode.types';
+
+const CHIP_ICONS: Record<StageHeaderChipType, React.ReactElement> = {
+  [StageHeaderChipType.Entry]: <EntryConditionIcon w={Icon.IconXs} h={Icon.IconXs} />,
+  [StageHeaderChipType.Exit]: <ExitConditionIcon w={Icon.IconXs} h={Icon.IconXs} />,
+  [StageHeaderChipType.ReturnToOrigin]: <ReturnToOriginIcon w={Icon.IconXs} h={Icon.IconXs} />,
+  [StageHeaderChipType.CaseExit]: <CanvasIcon icon="x" size={16} />,
+  [StageHeaderChipType.CaseCompletion]: <CanvasIcon icon="check" size={16} />,
+};
+
+const StageNodeHeaderInner = ({
+  props,
+  isReadOnly,
+  isException,
+  status,
+  handleTaskAddClick,
+}: {
+  props: StageNodeProps;
+  isReadOnly: boolean;
+  isException?: boolean;
+  status?: StageStatus;
+  handleTaskAddClick: (event: React.MouseEvent) => void;
+}) => {
+  const {
+    id,
+    stageDetails,
+    execution,
+    addTaskLabel = 'Add task',
+    onTaskAdd,
+    onAddTaskFromToolbox,
+    onStageTitleChange,
+  } = props;
+
+  const icon = stageDetails?.icon;
+  const statusLabel = execution?.stageStatus?.label;
+  const stageDuration = execution?.stageStatus?.duration;
+
+  const isStageTitleEditable = !!onStageTitleChange && !isReadOnly;
+
+  const [isStageTitleEditing, setIsStageTitleEditing] = useState(false);
+  const stageTitleRef = useRef<HTMLInputElement>(null);
+
+  const [label, setLabel] = useState(props.stageDetails.label);
+  useEffect(() => {
+    setLabel(props.stageDetails.label);
+  }, [props.stageDetails.label]);
+
+  const handleStageTitleChange = useCallback((e: React.FormEvent<HTMLInputElement>) => {
+    setIsStageTitleEditing(true);
+    setLabel((e.target as HTMLInputElement).value);
+  }, []);
+
+  const handleStageTitleClickToSave = useCallback(
+    (e: React.FocusEvent | MouseEvent) => {
+      if (isStageTitleEditing && !stageTitleRef.current?.contains(e.target as Node)) {
+        setIsStageTitleEditing(false);
+        if (onStageTitleChange) {
+          if (label.trim() === '') setLabel('Untitled Stage');
+          onStageTitleChange(label);
+        }
+      }
+    },
+    [isStageTitleEditing, onStageTitleChange, label]
+  );
+
+  useEffect(() => {
+    if (isStageTitleEditing) {
+      document.addEventListener('click', handleStageTitleClickToSave);
+    }
+    return () => {
+      document.removeEventListener('click', handleStageTitleClickToSave);
+    };
+  }, [handleStageTitleClickToSave, isStageTitleEditing]);
+
+  const handleStageTitleBlurToSave = useCallback(() => {
+    if (isStageTitleEditing) {
+      setIsStageTitleEditing(false);
+      if (onStageTitleChange) {
+        if (label.trim() === '') setLabel('Untitled Stage');
+        onStageTitleChange(label);
+      }
+    }
+  }, [isStageTitleEditing, onStageTitleChange, label]);
+
+  const handleStageTitleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === 'Enter') {
+        setIsStageTitleEditing(false);
+        if (onStageTitleChange) {
+          onStageTitleChange(label);
+        }
+      }
+      // Prevent keyboard events from the title input from bubbling to xyflow
+      // and triggering canvas-level actions like node deletion or copy/paste.
+      if (e.key !== 'Escape') {
+        e.stopPropagation();
+      }
+    },
+    [onStageTitleChange, label]
+  );
+
+  return (
+    <StageHeader isException={isException} data-testid={`stage-header-${id}`}>
+      <Row gap={Spacing.SpacingMicro} align="center" flex={1} minW={0}>
+        {icon}
+        <Column py={2} flex={1} minW={0}>
+          <span className={cn('text-sm', !isStageTitleEditing && 'font-bold')}>
+            <CanvasTooltip content={label} placement="top" delay>
+              <StageTitleContainer isEditing={isStageTitleEditing}>
+                <StageTitleInput
+                  name="Stage Title"
+                  isStageTitleEditable={isStageTitleEditable}
+                  value={label}
+                  ref={stageTitleRef}
+                  isEditing={isStageTitleEditing}
+                  {...(onStageTitleChange && {
+                    onFocus: () => setIsStageTitleEditing(true),
+                    onInput: handleStageTitleChange,
+                    onKeyDown: handleStageTitleKeyDown,
+                    onBlur: handleStageTitleBlurToSave,
+                  })}
+                  readOnly={!isStageTitleEditable}
+                />
+              </StageTitleContainer>
+            </CanvasTooltip>
+          </span>
+          {stageDuration && <span className="text-xs text-foreground-muted">{stageDuration}</span>}
+          {stageDetails.headerChips && stageDetails.headerChips.length > 0 && (
+            <StageHeaderChipsRow>
+              {stageDetails.headerChips.map((chip) => {
+                const button = (
+                  <StageChip
+                    key={chip.type}
+                    type="button"
+                    aria-label={typeof chip.tooltip === 'string' ? chip.tooltip : chip.type}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      chip.onClick?.();
+                    }}
+                  >
+                    {CHIP_ICONS[chip.type]}
+                    {chip.count !== undefined && <span className="text-xs">{chip.count}</span>}
+                  </StageChip>
+                );
+                if (chip.tooltip) {
+                  return (
+                    <CanvasTooltip key={chip.type} placement="bottom" content={chip.tooltip}>
+                      {button}
+                    </CanvasTooltip>
+                  );
+                }
+                return button;
+              })}
+            </StageHeaderChipsRow>
+          )}
+        </Column>
+      </Row>
+      <Row gap={Spacing.SpacingMicro} align="start" py={Padding.PadS}>
+        {status && (
+          <CanvasTooltip content={statusLabel} placement="top">
+            <Button variant="ghost" size="icon" className="h-6 w-6" aria-label={statusLabel}>
+              <ExecutionStatusIcon status={status} size={20} />
+            </Button>
+          </CanvasTooltip>
+        )}
+        {(onTaskAdd || onAddTaskFromToolbox) && !isReadOnly && (
+          <CanvasTooltip content={addTaskLabel} placement="top">
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-6 w-6"
+              onClick={handleTaskAddClick}
+              aria-label={addTaskLabel}
+            >
+              <CanvasIcon icon="plus" size={20} />
+            </Button>
+          </CanvasTooltip>
+        )}
+      </Row>
+    </StageHeader>
+  );
+};
+
+export const StageNodeHeader = memo(StageNodeHeaderInner);

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNodeSequentialTaskGroups.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNodeSequentialTaskGroups.tsx
@@ -1,0 +1,245 @@
+import {
+  closestCenter,
+  DndContext,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+} from '@dnd-kit/core';
+import {
+  SortableContext,
+  sortableKeyboardCoordinates,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable';
+import { Spacing } from '@uipath/apollo-core';
+import { Row } from '@uipath/apollo-react/canvas/layouts';
+import { CSSProperties, RefObject, useCallback, useMemo } from 'react';
+import {
+  GroupModificationType,
+  moveGroupDown,
+  moveGroupUp,
+} from '../../utils/GroupModificationUtils';
+import type { NodeMenuItem } from '../NodeContextMenu';
+import { DraggableTask } from './DraggableTask';
+import { useStageTaskDragHandler } from './hooks/useStageTaskDragHandler';
+import {
+  StageParallelBracket,
+  StageParallelLabel,
+  StageTaskGroupContainer,
+  StageTaskList,
+} from './StageNode.styles';
+import type {
+  StageNodeProps,
+  StageTaskGroup,
+  StageTaskItem,
+  TaskStateReference,
+} from './StageNode.types';
+import { getContextMenuItems, getDivider, getMenuItem } from './StageNodeTaskUtilities';
+import { StageTaskDragOverlay } from './StageTaskDragOverlay';
+
+export const StageNodeSequentialTaskGroups = ({
+  props,
+  sequentialTaskGroups,
+  sequentialTasks,
+  isReadOnly,
+  selectedTaskId,
+  taskWidthStyle,
+  taskStateReference,
+  hasContextMenu,
+  handleTaskClick,
+  setIsReplacingTask,
+  handleReorderSequentialTasks,
+}: {
+  props: StageNodeProps;
+  sequentialTaskGroups: StageTaskItem[][];
+  sequentialTasks: StageTaskGroup[];
+  isReadOnly: boolean;
+  selectedTaskId?: string;
+  taskWidthStyle?: CSSProperties;
+  taskStateReference: RefObject<TaskStateReference>;
+  hasContextMenu: boolean;
+  handleTaskClick: (e: React.MouseEvent, taskElementId: string) => void;
+  setIsReplacingTask: (isReplacingTask: boolean) => void;
+  handleReorderSequentialTasks: (newTasks: StageTaskItem[][]) => void;
+}) => {
+  const {
+    execution,
+    onTaskClick,
+    onTaskGroupModification,
+    onTaskReorder,
+    onReplaceTaskFromToolbox,
+    hideParallelOptions,
+    loadingTaskIds,
+  } = props;
+
+  const sequentialTaskIds = useMemo(
+    () => sequentialTasks.map(({ task }) => task.id),
+    [sequentialTasks]
+  );
+
+  const {
+    activeDragId,
+    activeSequentialTask,
+    isActiveTaskParallel,
+    projected,
+    handleDragStart,
+    handleDragMove,
+    handleDragOver,
+    handleDragEnd,
+    handleDragCancel,
+  } = useStageTaskDragHandler({
+    sequentialTaskGroups,
+    sequentialTasks,
+    onTaskReorder: handleReorderSequentialTasks,
+  });
+
+  const handleTaskRegroup = useCallback(
+    (groupModificationType: GroupModificationType, groupIndex: number, taskIndex: number) => {
+      if (
+        onTaskReorder &&
+        (groupModificationType === GroupModificationType.TASK_GROUP_UP ||
+          groupModificationType === GroupModificationType.TASK_GROUP_DOWN)
+      ) {
+        const mover =
+          groupModificationType === GroupModificationType.TASK_GROUP_UP
+            ? moveGroupUp
+            : moveGroupDown;
+        const reordered = mover(sequentialTaskGroups, groupIndex, taskIndex);
+        handleReorderSequentialTasks(reordered);
+        return;
+      }
+
+      onTaskGroupModification?.(groupModificationType, groupIndex, taskIndex);
+    },
+    [onTaskReorder, handleReorderSequentialTasks, onTaskGroupModification, sequentialTaskGroups]
+  );
+
+  /** Lazily builds context menu items for a task. Called only when the menu opens,
+   * avoiding object allocation on every render for every task. */
+  const buildContextMenuItems = useCallback(
+    (groupIndex: number, taskIndex: number) => {
+      const taskGroup = sequentialTaskGroups[groupIndex] ?? [];
+      const isParallel = taskGroup.length > 1;
+      const items: NodeMenuItem[] = [];
+
+      if (onReplaceTaskFromToolbox) {
+        items.push(
+          getMenuItem('replace-task', 'Replace task', () => {
+            taskStateReference.current = {
+              isParallel,
+              groupIndex,
+              taskIndex,
+            };
+            const taskId = taskGroup[taskIndex]?.id;
+            if (taskId) onTaskClick?.(taskId);
+            setIsReplacingTask(true);
+          })
+        );
+        items.push(getDivider());
+      }
+
+      if (onTaskGroupModification) {
+        const reGroupOptions = getContextMenuItems(
+          isParallel,
+          groupIndex,
+          sequentialTaskGroups.length,
+          taskIndex,
+          taskGroup.length,
+          (sequentialTaskGroups[groupIndex - 1]?.length ?? 0) > 1,
+          (sequentialTaskGroups[groupIndex + 1]?.length ?? 0) > 1,
+          handleTaskRegroup,
+          hideParallelOptions
+        );
+        return [...items, ...reGroupOptions];
+      }
+
+      return items;
+    },
+    [
+      onReplaceTaskFromToolbox,
+      onTaskClick,
+      onTaskGroupModification,
+      sequentialTaskGroups,
+      hideParallelOptions,
+      handleTaskRegroup,
+      setIsReplacingTask,
+      taskStateReference,
+    ]
+  );
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, {
+      activationConstraint: {
+        distance: 3,
+      },
+    }),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    })
+  );
+
+  if (sequentialTaskGroups.length === 0) {
+    return null;
+  }
+  return (
+    <DndContext
+      collisionDetection={closestCenter}
+      sensors={sensors}
+      onDragStart={handleDragStart}
+      onDragMove={handleDragMove}
+      onDragOver={handleDragOver}
+      onDragEnd={handleDragEnd}
+      onDragCancel={handleDragCancel}
+    >
+      <SortableContext items={sequentialTaskIds} strategy={verticalListSortingStrategy}>
+        {/* Disable dragging and panning the canvas when dragging a task */}
+        <StageTaskList className="nodrag nopan">
+          {sequentialTaskGroups.map((taskGroup, groupIndex) => {
+            const isParallel = taskGroup.length > 1;
+            return (
+              <Row key={`group-${groupIndex}`} gap={Spacing.SpacingS}>
+                {isParallel && <StageParallelBracket />}
+                <StageTaskGroupContainer isParallel={isParallel}>
+                  {isParallel && (
+                    <StageParallelLabel>
+                      <span className="text-xs">Parallel</span>
+                    </StageParallelLabel>
+                  )}
+                  {taskGroup.map((task, taskIndex) => {
+                    const taskExecution = execution?.taskStatus?.[task.id];
+                    return (
+                      <DraggableTask
+                        key={task.id}
+                        task={task}
+                        taskExecution={taskExecution}
+                        isSelected={selectedTaskId === task.id}
+                        isParallel={isParallel}
+                        groupIndex={groupIndex}
+                        taskIndex={taskIndex}
+                        onTaskClick={handleTaskClick}
+                        projectedDepth={
+                          task.id === activeDragId && projected ? projected.depth : undefined
+                        }
+                        isDragDisabled={!onTaskReorder || isReadOnly}
+                        isTaskLoading={loadingTaskIds?.has(task.id)}
+                        {...(hasContextMenu &&
+                          !isReadOnly && {
+                            getContextMenuItems: buildContextMenuItems,
+                          })}
+                      />
+                    );
+                  })}
+                </StageTaskGroupContainer>
+              </Row>
+            );
+          })}
+        </StageTaskList>
+      </SortableContext>
+      <StageTaskDragOverlay
+        activeTask={activeSequentialTask?.task}
+        isActiveTaskParallel={isActiveTaskParallel}
+        taskWidthStyle={taskWidthStyle}
+      />
+    </DndContext>
+  );
+};

--- a/packages/apollo-react/src/canvas/components/StageNode/StageTaskEntryConditionIcon.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageTaskEntryConditionIcon.tsx
@@ -1,0 +1,23 @@
+import { EntryConditionIcon } from '../../icons';
+import { CanvasTooltip } from '../CanvasTooltip';
+import { StageTaskItem } from './StageNode.types';
+
+export const StageTaskEntryConditionIcon = ({ task }: { task: StageTaskItem }) => {
+  if (!task.hasEntryCondition) {
+    return null;
+  }
+  return (
+    <CanvasTooltip content="Entry condition" placement="top">
+      <span
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          color: 'var(--color-icon-default)',
+          flexShrink: 0,
+        }}
+      >
+        <EntryConditionIcon w={20} h={20} />
+      </span>
+    </CanvasTooltip>
+  );
+};

--- a/packages/apollo-react/src/canvas/components/StageNode/hooks/useStageTaskDragHandler.ts
+++ b/packages/apollo-react/src/canvas/components/StageNode/hooks/useStageTaskDragHandler.ts
@@ -1,0 +1,114 @@
+import { DragEndEvent, DragMoveEvent, DragOverEvent, DragStartEvent } from '@dnd-kit/core';
+import { useStoreApi } from '@xyflow/react';
+import { useCallback, useMemo, useState } from 'react';
+import { StageTaskGroup, StageTaskItem } from '../StageNode.types';
+import { flattenTasks, getProjection, reorderTasks } from '../StageNode.utils';
+
+export const useStageTaskDragHandler = ({
+  sequentialTaskGroups,
+  sequentialTasks,
+  onTaskReorder,
+}: {
+  sequentialTaskGroups: StageTaskItem[][];
+  sequentialTasks: StageTaskGroup[];
+  onTaskReorder: (newTasks: StageTaskItem[][]) => void;
+}) => {
+  const storeApi = useStoreApi();
+
+  const [activeDragId, setActiveDragId] = useState<string | null>(null);
+  const [offsetLeft, setOffsetLeft] = useState(0);
+  const [overId, setOverId] = useState<string | null>(null);
+  const activeSequentialTask = useMemo(
+    () => sequentialTasks.find(({ task }) => task.id === activeDragId),
+    [sequentialTasks, activeDragId]
+  );
+  const isActiveTaskParallel = useMemo(() => {
+    if (!activeDragId) {
+      return false;
+    }
+    const group = sequentialTaskGroups.find((g) => g.some((t) => t.id === activeDragId));
+    return group ? group.length > 1 : false;
+  }, [sequentialTaskGroups, activeDragId]);
+
+  const projected = useMemo(() => {
+    if (!activeDragId || !overId) return null;
+    return getProjection(sequentialTaskGroups, activeDragId, overId, offsetLeft);
+  }, [sequentialTaskGroups, activeDragId, overId, offsetLeft]);
+
+  const resetState = useCallback(() => {
+    setActiveDragId(null);
+    setOffsetLeft(0);
+    setOverId(null);
+  }, []);
+
+  const handleDragStart = useCallback((event: DragStartEvent) => {
+    setActiveDragId(event.active.id as string);
+  }, []);
+
+  const handleDragMove = useCallback(
+    (event: DragMoveEvent) => {
+      setOffsetLeft(event.delta.x / storeApi.getState().transform[2]);
+    },
+    [storeApi]
+  );
+
+  const handleDragOver = useCallback((event: DragOverEvent) => {
+    setOverId((event.over?.id as string) ?? null);
+  }, []);
+
+  const handleDragEnd = useCallback(
+    (event: DragEndEvent) => {
+      const { active, over } = event;
+      const currentOffsetLeft = offsetLeft;
+      resetState();
+
+      if (!over) {
+        return;
+      }
+
+      const projection = getProjection(
+        sequentialTaskGroups,
+        active.id as string,
+        over.id as string,
+        currentOffsetLeft
+      );
+      if (!projection) {
+        return;
+      }
+
+      // For in-place movement, skip if depth hasn't changed
+      if (active.id === over.id) {
+        const flattened = flattenTasks(sequentialTaskGroups);
+        const activeTask = flattened.find((t) => t.id === active.id);
+        if (activeTask && activeTask.depth === projection.depth) {
+          return;
+        }
+      }
+
+      const newTasks = reorderTasks(
+        sequentialTaskGroups,
+        active.id as string,
+        over.id as string,
+        projection.depth
+      );
+      onTaskReorder(newTasks);
+    },
+    [sequentialTaskGroups, onTaskReorder, offsetLeft, resetState]
+  );
+
+  const handleDragCancel = useCallback(() => {
+    resetState();
+  }, [resetState]);
+
+  return {
+    activeDragId,
+    activeSequentialTask,
+    isActiveTaskParallel,
+    projected,
+    handleDragMove,
+    handleDragOver,
+    handleDragStart,
+    handleDragEnd,
+    handleDragCancel,
+  };
+};

--- a/packages/apollo-react/src/canvas/components/StageNode/hooks/useStageTasksByGroups.ts
+++ b/packages/apollo-react/src/canvas/components/StageNode/hooks/useStageTasksByGroups.ts
@@ -1,0 +1,79 @@
+import { useMemo } from 'react';
+import { StageTaskItem } from '../StageNode.types';
+
+export const useStageTasksByGroups = (allTasks: StageTaskItem[][]) => {
+  const sequentialTaskGroups = useMemo(
+    () =>
+      allTasks.filter((group) =>
+        group.some((t) => {
+          if (t.taskGroupType != null) {
+            return t.taskGroupType === 'sequential';
+          }
+          if (t.isAdhoc != null) {
+            return !t.isAdhoc;
+          }
+          return true;
+        })
+      ),
+    [allTasks]
+  );
+  const sequentialTasks = useMemo(
+    () =>
+      sequentialTaskGroups.flatMap((group, groupIndex) =>
+        group.map((task, taskIndex) => ({ task, groupIndex, taskIndex }))
+      ),
+    [sequentialTaskGroups]
+  );
+
+  const adhocTaskGroups = useMemo(
+    () =>
+      allTasks.filter((group) =>
+        group.every((t) => {
+          if (t.taskGroupType != null) {
+            return t.taskGroupType === 'adhoc';
+          }
+          if (t.isAdhoc != null) {
+            return t.isAdhoc;
+          }
+          return false;
+        })
+      ),
+    [allTasks]
+  );
+  const adhocTasks = useMemo(
+    () =>
+      adhocTaskGroups.flatMap((group, groupIndex) =>
+        group.map((task, taskIndex) => ({ task, groupIndex, taskIndex }))
+      ),
+    [adhocTaskGroups]
+  );
+
+  const eventDrivenTaskGroups = useMemo(
+    () =>
+      allTasks.filter((group) =>
+        group.every((t) => {
+          if (t.taskGroupType != null) {
+            return t.taskGroupType === 'event-driven';
+          }
+          return false;
+        })
+      ),
+    [allTasks]
+  );
+  const eventDrivenTasks = useMemo(
+    () =>
+      eventDrivenTaskGroups.flatMap((group, groupIndex) =>
+        group.map((task, taskIndex) => ({ task, groupIndex, taskIndex }))
+      ),
+    [eventDrivenTaskGroups]
+  );
+
+  return {
+    sequentialTaskGroups,
+    sequentialTasks,
+    adhocTaskGroups,
+    adhocTasks,
+    eventDrivenTaskGroups,
+    eventDrivenTasks,
+  };
+};


### PR DESCRIPTION
This PR does two things:
1. It adds the new event-driven section to a Stage node for tasks that are specifically event-driven instead of adhoc or sequential. We are going to be updating stages to no longer have just "tasks" and "adhoc tasks", there are now "sequential tasks", "event-driven tasks", and "adhoc tasks"
2. I noticed just how big the Stage file was getting, and this was about to make it even bigger. I refactored everything in StageNode so it's now split across multiple files with some more hooks and shared code so that the files are smaller and cleaner, and it's cleared which sections of the StageNode have which functionality and use which hooks

<img width="1588" height="759" alt="Screenshot 2026-04-21 at 4 03 10 PM" src="https://github.com/user-attachments/assets/0b1f935a-6a17-46c6-94cb-f2cf9cf30f4e" />
