### PR TITLE
fix(apollo-react): preserve scroll position per Toolbox navigation branch

### DIFF
--- a/packages/apollo-react/src/canvas/components/AddNodePanel/AddNodePanel.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/AddNodePanel/AddNodePanel.stories.tsx
@@ -118,6 +118,64 @@ const CATEGORY_ITEMS: ListItem<NodeItemData>[] = Object.entries(
   children: nodes,
 }));
 
+// Tall categories that overflow the panel height so scroll position is
+// actually meaningful. Used by the scroll-preservation story.
+const makeLeafChildren = (
+  prefix: string,
+  count: number,
+  iconName: string
+): ListItem<NodeItemData>[] =>
+  Array.from({ length: count }, (_, i) => ({
+    id: `${prefix}-${i}`,
+    name: `${prefix} item ${String(i).padStart(2, '0')}`,
+    icon: { name: iconName },
+    data: { type: prefix, category: prefix },
+  }));
+
+// Insert a drillable subcategory partway down so exercising scroll-restore
+// requires the user to scroll first.
+const makeCategoryWithNestedSubcategory = (
+  prefix: string,
+  leafCount: number,
+  subcategoryAtIndex: number,
+  iconName: string,
+  subIconName: string
+): ListItem<NodeItemData>[] => {
+  const leaves = makeLeafChildren(prefix, leafCount, iconName);
+  const subcategory: ListItem<NodeItemData> = {
+    id: `${prefix}-sub`,
+    name: `${prefix} ▸ Subcategory (drill in, then Back)`,
+    icon: { name: 'folder_open' },
+    data: { type: 'subcategory', category: `${prefix}/Sub` },
+    children: makeLeafChildren(`${prefix}-sub`, 30, subIconName),
+  };
+  return [...leaves.slice(0, subcategoryAtIndex), subcategory, ...leaves.slice(subcategoryAtIndex)];
+};
+
+const SCROLLABLE_CATEGORY_ITEMS: ListItem<NodeItemData>[] = [
+  {
+    id: 'scroll-category-a',
+    name: 'Category A — scroll down to find the subcategory',
+    icon: { name: 'folder' },
+    data: { type: 'category', category: 'A' },
+    children: makeCategoryWithNestedSubcategory('A', 40, 15, 'bolt', 'database'),
+  },
+  {
+    id: 'scroll-category-b',
+    name: 'Category B — subcategory near the bottom',
+    icon: { name: 'folder' },
+    data: { type: 'category', category: 'B' },
+    children: makeCategoryWithNestedSubcategory('B', 40, 30, 'code', 'bug_report'),
+  },
+  {
+    id: 'scroll-category-c',
+    name: 'Category C — never visited, opens at top',
+    icon: { name: 'folder' },
+    data: { type: 'category', category: 'C' },
+    children: makeCategoryWithNestedSubcategory('C', 40, 5, 'cpu', 'shield'),
+  },
+];
+
 function createInitialNodes(): Node<BaseNodeData>[] {
   return [
     createNode({
@@ -349,6 +407,46 @@ export const NodePanelRegistryItems: Story = {
     },
     onClose: () => console.log('Closed selector'),
     onSearch: undefined,
+  },
+  render: (args) => (
+    <StandalonePanelWrapper>
+      <AddNodePanel {...args} />
+    </StandalonePanelWrapper>
+  ),
+};
+
+export const NodePanelScrollPreservation: Story = {
+  name: 'Scroll position preservation per navigation branch',
+  parameters: {
+    docs: {
+      description: {
+        story: [
+          'Each category contains a drillable subcategory placed partway through',
+          'the list, so exercising scroll-restore requires the user to scroll',
+          'first. Plain items without a chevron are leaves — clicking them just',
+          'selects and does not navigate.',
+          '',
+          'To verify the three behaviors:',
+          '',
+          '1. Restore on back: open Category A, scroll down until the',
+          '   "Subcategory" row is visible, click it, then click Back. The list',
+          '   should return to the exact scroll position you left (not snap back',
+          '   to the top or to the subcategory row).',
+          '2. First entry resets to top: directly after clicking a subcategory,',
+          '   the inner list is at the top regardless of where the parent was',
+          '   scrolled.',
+          '3. Independent per branch: scroll Category A, go back to root, enter',
+          '   Category B and scroll it, then back to root and re-enter A — each',
+          '   branch owns its own scroll memory for as long as it is on the nav',
+          '   stack.',
+        ].join('\n'),
+      },
+    },
+  },
+  args: {
+    items: SCROLLABLE_CATEGORY_ITEMS,
+    onNodeSelect: (node) => console.log('Selected node:', node),
+    onClose: () => console.log('Closed selector'),
   },
   render: (args) => (
     <StandalonePanelWrapper>

--- a/packages/apollo-react/src/canvas/components/Toolbox/ListView.tsx
+++ b/packages/apollo-react/src/canvas/components/Toolbox/ListView.tsx
@@ -191,6 +191,7 @@ interface ListViewProps<T extends ListItem> {
   listRef?: React.RefObject<ListImperativeAPI | null>;
   onItemClick: (item: T, index: number) => void;
   onItemHover?: (item: T) => void;
+  onScroll?: React.UIEventHandler<HTMLDivElement>;
   emptyStateMessage?: string;
   emptyStateIcon?: string;
   isLoading?: boolean;
@@ -204,6 +205,7 @@ const ListViewInner = forwardRef(function ListView<T extends ListItem>(
     listRef,
     onItemClick,
     onItemHover,
+    onScroll,
     emptyStateMessage = 'No items found',
     emptyStateIcon = 'search-x',
     isLoading = false,
@@ -256,6 +258,7 @@ const ListViewInner = forwardRef(function ListView<T extends ListItem>(
       rowCount={renderedItems.length}
       rowHeight={40}
       overscanCount={20}
+      onScroll={onScroll}
     />
   );
 });

--- a/packages/apollo-react/src/canvas/components/Toolbox/Toolbox.test.tsx
+++ b/packages/apollo-react/src/canvas/components/Toolbox/Toolbox.test.tsx
@@ -1237,4 +1237,173 @@ describe('Toolbox', () => {
       expect(screen.getByText('Child 3')).toBeInTheDocument();
     });
   });
+
+  describe('Scroll position preservation', () => {
+    const scrollableItems: ListItem[] = [
+      {
+        id: 'category-a',
+        name: 'Category A',
+        data: {},
+        icon: { name: 'folder' },
+        children: Array.from({ length: 20 }, (_, i) => ({
+          id: `a-child-${i}`,
+          name: `A Child ${i}`,
+          data: {},
+          icon: { name: 'file' },
+        })),
+      },
+      {
+        id: 'category-b',
+        name: 'Category B',
+        data: {},
+        icon: { name: 'folder' },
+        children: [
+          {
+            id: 'b-sub',
+            name: 'B Subcategory',
+            data: {},
+            icon: { name: 'folder' },
+            children: [
+              { id: 'b-grandchild', name: 'B Grandchild', data: {}, icon: { name: 'file' } },
+            ],
+          },
+        ],
+      },
+    ];
+
+    const getListContainer = () => screen.getByRole('listbox') as HTMLDivElement;
+
+    const scrollList = (top: number) => {
+      const el = getListContainer();
+      el.scrollTop = top;
+      el.dispatchEvent(new Event('scroll'));
+    };
+
+    it('restores the exact scrollTop on back navigation', async () => {
+      vi.useFakeTimers({ shouldAdvanceTime: true });
+      const timedUser = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+
+      render(<Toolbox {...defaultProps} initialItems={scrollableItems} />);
+
+      // Scroll the root list to 240.
+      act(() => scrollList(240));
+
+      // Enter Category A.
+      await timedUser.click(screen.getByText('Category A'));
+      await act(() => vi.advanceTimersByTimeAsync(200));
+
+      // Fresh entry: child list is at top.
+      expect(getListContainer().scrollTop).toBe(0);
+
+      // Scroll the child list so we can tell whether we restore the parent's position.
+      act(() => scrollList(80));
+
+      // Back out.
+      await timedUser.click(screen.getByRole('button', { name: /back/i }));
+      await act(() => vi.advanceTimersByTimeAsync(200));
+
+      expect(getListContainer().scrollTop).toBe(240);
+
+      vi.useRealTimers();
+    });
+
+    it('scrolls to top when entering a branch for the first time', async () => {
+      vi.useFakeTimers({ shouldAdvanceTime: true });
+      const timedUser = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+
+      render(<Toolbox {...defaultProps} initialItems={scrollableItems} />);
+
+      act(() => scrollList(320));
+
+      await timedUser.click(screen.getByText('Category B'));
+      await act(() => vi.advanceTimersByTimeAsync(200));
+
+      expect(getListContainer().scrollTop).toBe(0);
+
+      vi.useRealTimers();
+    });
+
+    it('restores independent scroll positions through multiple levels', async () => {
+      vi.useFakeTimers({ shouldAdvanceTime: true });
+      const timedUser = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+
+      render(<Toolbox {...defaultProps} initialItems={scrollableItems} />);
+
+      // Root scrolled to 150.
+      act(() => scrollList(150));
+
+      // Push into Category B.
+      await timedUser.click(screen.getByText('Category B'));
+      await act(() => vi.advanceTimersByTimeAsync(200));
+      expect(getListContainer().scrollTop).toBe(0);
+      act(() => scrollList(60));
+
+      // Push into B Subcategory.
+      await timedUser.click(screen.getByText('B Subcategory'));
+      await act(() => vi.advanceTimersByTimeAsync(200));
+      expect(getListContainer().scrollTop).toBe(0);
+
+      // Back to B — restores 60.
+      await timedUser.click(screen.getByRole('button', { name: /back/i }));
+      await act(() => vi.advanceTimersByTimeAsync(200));
+      expect(getListContainer().scrollTop).toBe(60);
+
+      // Back to root — restores 150.
+      await timedUser.click(screen.getByRole('button', { name: /back/i }));
+      await act(() => vi.advanceTimersByTimeAsync(200));
+      expect(getListContainer().scrollTop).toBe(150);
+
+      vi.useRealTimers();
+    });
+
+    it('does not record scrollTop captured during an active search', async () => {
+      vi.useFakeTimers({ shouldAdvanceTime: true });
+      const timedUser = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+
+      const categoryA = scrollableItems[0]!;
+      const onSearch = vi.fn().mockResolvedValue([categoryA]);
+
+      render(<Toolbox {...defaultProps} initialItems={scrollableItems} onSearch={onSearch} />);
+
+      // Open search and let search-result scroll happen.
+      const searchInput = screen.getByPlaceholderText('Search');
+      await timedUser.type(searchInput, 'cat');
+      await act(() => vi.advanceTimersByTimeAsync(200));
+      act(() => scrollList(500));
+
+      // Push into Category A from search results.
+      await timedUser.click(screen.getByText('Category A'));
+      await act(() => vi.advanceTimersByTimeAsync(200));
+
+      // Back out — should restore to 0 (search-time scroll is not stored).
+      await timedUser.click(screen.getByRole('button', { name: /back/i }));
+      await act(() => vi.advanceTimersByTimeAsync(200));
+      expect(getListContainer().scrollTop).toBe(0);
+
+      vi.useRealTimers();
+    });
+
+    it('clears the navigation stack on close', async () => {
+      const onClose = vi.fn();
+      const { unmount } = render(
+        <Toolbox {...defaultProps} initialItems={scrollableItems} onClose={onClose} />
+      );
+
+      await userEvent.setup().click(screen.getByText('Category A'));
+      expect(screen.getByRole('button', { name: /back/i })).toBeInTheDocument();
+
+      // Escape at the root would close — but we're nested, so Escape goes back.
+      // Trigger close via click-outside instead.
+      await userEvent.setup().click(document.body);
+      expect(onClose).toHaveBeenCalled();
+
+      unmount();
+
+      // Re-mount: stack state is a brand-new instance; no back button is shown
+      // and the root list renders from scratch.
+      render(<Toolbox {...defaultProps} initialItems={scrollableItems} onClose={onClose} />);
+      expect(screen.queryByRole('button', { name: /back/i })).not.toBeInTheDocument();
+      expect(screen.getByText('Category A')).toBeInTheDocument();
+    });
+  });
 });

--- a/packages/apollo-react/src/canvas/components/Toolbox/Toolbox.tsx
+++ b/packages/apollo-react/src/canvas/components/Toolbox/Toolbox.tsx
@@ -141,6 +141,7 @@ export function Toolbox<T>({
     items: ListItem<T>[];
     parentItem: ListItem<T> | null;
     activeIndex: number;
+    scrollTop: number;
   }>();
 
   const [activeIndex, setActiveIndex] = useState(SEARCH_BAR_INDEX);
@@ -153,6 +154,11 @@ export function Toolbox<T>({
   const listViewRef = useRef<ListViewHandle<ListItem<T>>>(null);
   const searchInputRef = useRef<HTMLInputElement>(null);
   const clearButtonRef = useRef<HTMLButtonElement>(null);
+  const lastScrollTopRef = useRef(0);
+
+  const handleListScroll = useCallback((e: React.UIEvent<HTMLDivElement>) => {
+    lastScrollTopRef.current = e.currentTarget.scrollTop;
+  }, []);
 
   const isSearching = useMemo(() => search.length > 0, [search]);
 
@@ -252,10 +258,24 @@ export function Toolbox<T>({
     setIsSearchingInitialItems(true);
 
     const restoredIndex = previousState?.data.activeIndex ?? SEARCH_BAR_INDEX;
-    navigateToIndex(restoredIndex);
+    const restoredScrollTop = previousState?.data.scrollTop ?? 0;
+
+    setActiveIndex(restoredIndex);
+    searchInputRef.current?.focus();
+
+    // Restore exact scroll offset after the new items have mounted.
+    // element.scrollTop works against react-window@2's imperative handle, which
+    // exposes the outer scroll container but no scrollToOffset method.
+    requestAnimationFrame(() => {
+      const element = listRef.current?.element;
+      if (element) {
+        element.scrollTop = restoredScrollTop;
+      }
+      lastScrollTopRef.current = restoredScrollTop;
+    });
 
     onBack?.();
-  }, [navigationStack, onBack, startTransition, navigateToIndex]);
+  }, [navigationStack, onBack, startTransition, listRef]);
 
   const handleItemSelect = useCallback(
     async (item: ListItem<T>, index?: number) => {
@@ -269,18 +289,31 @@ export function Toolbox<T>({
           ? await item.children(item.id, item.name)
           : item.children;
       const savedIndex = isSearching ? SEARCH_BAR_INDEX : (index ?? activeIndex);
+      // Do not leak search-time scroll into the branch memory; mirrors the
+      // activeIndex guard above.
+      const savedScrollTop = isSearching ? 0 : lastScrollTopRef.current;
       navigationStack.push({
         title: currentParentItem?.name || title,
         data: {
           items,
           parentItem: currentParentItem,
           activeIndex: savedIndex,
+          scrollTop: savedScrollTop,
         },
       });
       setItems(nestedItems);
       setCurrentParentItem(item);
       clearSearch();
       setActiveIndex(SEARCH_BAR_INDEX);
+      // First entry into a branch: explicitly start at the top rather than
+      // relying on the virtualizer remount implicitly landing at 0.
+      requestAnimationFrame(() => {
+        const element = listRef.current?.element;
+        if (element) {
+          element.scrollTop = 0;
+        }
+        lastScrollTopRef.current = 0;
+      });
       startTransition('forward');
       setChildrenLoading(false);
     },
@@ -294,6 +327,7 @@ export function Toolbox<T>({
       clearSearch,
       startTransition,
       onItemSelect,
+      listRef,
     ]
   );
 
@@ -342,6 +376,7 @@ export function Toolbox<T>({
             items: newInitialItems,
             parentItem: null,
             activeIndex: stackItem.data.activeIndex,
+            scrollTop: stackItem.data.scrollTop,
           },
         };
       }
@@ -360,6 +395,7 @@ export function Toolbox<T>({
           items: updatedItems,
           parentItem: updatedParentItem,
           activeIndex: stackItem.data.activeIndex,
+          scrollTop: stackItem.data.scrollTop,
         },
       };
     });
@@ -503,6 +539,15 @@ export function Toolbox<T>({
     ]
   );
 
+  // Discard the navigation stack before handing control back to the caller so
+  // re-opening the panel starts fresh. Unmount already clears state, but an
+  // explicit clear guards against future consumers keeping the panel mounted
+  // and toggling visibility via onClose.
+  const handleClose = useCallback(() => {
+    navigationStack.clear();
+    onClose();
+  }, [navigationStack, onClose]);
+
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
       if (e.key === 'Escape') {
@@ -513,14 +558,14 @@ export function Toolbox<T>({
         } else if (navigationStack.canGoBack) {
           handleBackTransition();
         } else {
-          onClose();
+          handleClose();
         }
       }
     };
 
     const handleClickOutside = (e: MouseEvent) => {
       if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
-        onClose();
+        handleClose();
       }
     };
 
@@ -533,7 +578,7 @@ export function Toolbox<T>({
   }, [
     isSearching,
     navigationStack.canGoBack,
-    onClose,
+    handleClose,
     clearSearch,
     startTransition,
     handleBackTransition,
@@ -577,6 +622,7 @@ export function Toolbox<T>({
               emptyStateMessage={isSearching ? 'No matching nodes found' : 'No nodes found'}
               onItemClick={handleItemSelect}
               onItemHover={onItemHover}
+              onScroll={handleListScroll}
               enableSections={!isSearching}
             />
           </AnimatedContent>

--- a/packages/apollo-react/src/test/canvas-mocks.ts
+++ b/packages/apollo-react/src/test/canvas-mocks.ts
@@ -315,19 +315,41 @@ vi.mock('sanitize-html', () => ({
 }));
 
 // Mock react-window
-vi.mock('react-window', () => ({
-  List: ({
+vi.mock('react-window', () => {
+  const List = ({
     rowCount,
     rowProps,
     rowComponent: RowComponent,
+    listRef,
+    ...rest
   }: {
     rowCount: number;
     rowProps: object;
     rowComponent: (props: { index: number }) => ReactElement;
-  }) =>
-    React.createElement(
+    listRef?: React.RefObject<unknown> | ((api: unknown) => void) | null;
+    [key: string]: unknown;
+  }) => {
+    const innerRef = React.useRef<HTMLDivElement | null>(null);
+    const setRef = React.useCallback(
+      (node: HTMLDivElement | null) => {
+        innerRef.current = node;
+        const api = {
+          get element() {
+            return node;
+          },
+          scrollToRow: () => {},
+        };
+        if (typeof listRef === 'function') {
+          listRef(api);
+        } else if (listRef && typeof listRef === 'object') {
+          (listRef as { current: unknown }).current = api;
+        }
+      },
+      [listRef]
+    );
+    return React.createElement(
       'div',
-      { 'data-testid': 'virtualized-list' },
+      { 'data-testid': 'virtualized-list', ref: setRef, ...rest },
       Array.from({ length: rowCount }).map((_, index) =>
         React.createElement(
           'div',
@@ -339,9 +361,13 @@ vi.mock('react-window', () => ({
           })
         )
       )
-    ),
-  useListRef: () => React.useRef(null),
-}));
+    );
+  };
+  return {
+    List,
+    useListRef: () => React.useRef(null),
+  };
+});
 
 // Mock @mui/x-tree-view to avoid ESM directory import issues
 vi.mock('@mui/x-tree-view', () => ({


### PR DESCRIPTION
## Summary

Fixes a UX regression in `Toolbox` (used by `AddNodePanel` in both Studio Web and Flow Workbench): when the user drills into a category, backs out, then re-enters, their prior scroll position is lost. The existing restore path used `scrollToRow({ align: 'auto' })`, which only scrolls the active row into view if it's offscreen — it does **not** restore the exact `scrollTop` the user had when they left the branch.


https://github.com/user-attachments/assets/50de0d7a-c3fa-437d-a575-3e1e988915e3


Three tightly-scoped behaviors in `Toolbox`:

1. **Preserve scroll position per branch** — on pop, the list restores to the exact `scrollTop` captured on push.
2. **Scroll to top on first-time traversal** — on push, explicitly reset to `scrollTop = 0` rather than relying on the virtualizer's remount.
3. **Clear the nav stack on close** — already de-facto true via unmount; made explicit so consumers keeping the panel mounted behave correctly.

## Changes

- `Toolbox.tsx` — nav stack `data` generic now carries `scrollTop: number`. An `onScroll` handler updates a `lastScrollTopRef` from the live scroll container. On **push** (`handleItemSelect`): captures `lastScrollTopRef.current` into the stack entry (falls back to `0` while searching, mirroring the existing `activeIndex` guard), then explicitly resets the child list to `0` in an `rAF`. On **pop** (`handleBackTransition`): replaces `scrollToRow('auto')` with a direct `listRef.current.element.scrollTop = restoredScrollTop` — `react-window@2`'s `ListImperativeAPI` exposes the outer scroll container but has no `scrollToOffset`, so we set the DOM property. A `handleClose` wrapper calls `navigationStack.clear()` before `onClose()`, and routes both the Escape-at-root branch and the click-outside handler through it. The `initialItems` stack-rewrite effect preserves `scrollTop` symmetrically with `activeIndex`.
- `ListView.tsx` — optional `onScroll?: React.UIEventHandler<HTMLDivElement>` forwarded to the inner `StyledList`. `List` from `react-window@2` spreads rest props onto its outer scroll container, so no wrapping needed.
- `test/canvas-mocks.ts` — extended the `react-window` mock to forward rest props and expose a realistic `listRef.current.element` getter on the rendered div. Required so the new scroll tests exercise the actual ref-based restore path rather than a no-op mock.
- `AddNodePanel.stories.tsx` — new `NodePanelScrollPreservation` story with three categories, each containing a drillable subcategory placed partway through the list (so exercising the feature requires scrolling first). Docs tab walks through the three verification paths.

## Tests

Unit tests added in `Toolbox.test.tsx` (`Scroll position preservation` describe):

- Restore on back: scroll to 240, push, pop → assert list restored to 240.
- First entry resets to top: push from a scrolled parent → assert child list at 0.
- Independent per level: root → push → scroll child → push → pop → pop; each level's scroll is restored on the way back out.
- Search does not poison scroll memory: scrolling search results before pushing into a result does not record into the branch's stack entry.
- Clear on close: push two levels, trigger close, remount → no back button, root renders fresh.

Manual verification via Storybook (`Canvas/AddNodePanel/Scroll position preservation per navigation branch`) confirmed end-to-end: scroll Category A to 200 → enter Subcategory (lands at 0) → scroll Sub to 120 → Back (A restored to 200) → Back to root (0) → scroll Category B to 700 → enter Sub (0) → Back (B restored to 700) → enter Category C (first visit, 0). All eight expected values matched observed.

## API compatibility

Non-breaking. `NavigationStackItem<T>` accepts arbitrary `data` shapes so adding a `scrollTop` field is internal to `Toolbox`. `useNavigationStack` signature is unchanged. `ListView` gains one optional prop.

## Test plan

- [x] `pnpm test` — 1386/1386 apollo-react tests pass, including the 5 new scroll-preservation cases.
- [x] `tsc --noEmit` clean.
- [x] `biome check` clean on changed files.
- [x] Storybook: `Canvas/AddNodePanel/Scroll position preservation per navigation branch` story exercises all three behaviors.