### PR TITLE
fix(apollo-react): stage node task menu options not respecting index properly

### DIFF
--- a/packages/apollo-react/src/canvas/components/StageNode/DraggableTask.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/DraggableTask.tsx
@@ -46,8 +46,8 @@ const DraggableTaskComponent = ({
     if (!getContextMenuItems) {
       return [];
     }
-    return getContextMenuItems(groupIndex, taskIndex);
-  }, [getContextMenuItems, groupIndex, taskIndex]);
+    return getContextMenuItems(groupIndex, taskIndex, task.id);
+  }, [getContextMenuItems, groupIndex, taskIndex, task.id]);
 
   const { attributes, listeners, setNodeRef, transition, transform, isDragging } = useSortable({
     id: task.id,

--- a/packages/apollo-react/src/canvas/components/StageNode/DraggableTask.types.ts
+++ b/packages/apollo-react/src/canvas/components/StageNode/DraggableTask.types.ts
@@ -8,7 +8,7 @@ export interface DraggableTaskProps {
   isParallel: boolean;
   groupIndex: number;
   taskIndex: number;
-  getContextMenuItems?: (groupIndex: number, taskIndex: number) => NodeMenuItem[];
+  getContextMenuItems?: (groupIndex: number, taskIndex: number, taskId: string) => NodeMenuItem[];
   onTaskClick: (e: React.MouseEvent, taskId: string) => void;
   onTaskPlay?: (taskId: string) => Promise<void>;
   isDragDisabled?: boolean;

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.test.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.test.tsx
@@ -120,7 +120,8 @@ vi.mock('./DraggableTask', () => ({
     isDragDisabled?: boolean;
     getContextMenuItems?: (
       groupIndex: number,
-      taskIndex: number
+      taskIndex: number,
+      taskId: string
     ) => Array<{ id?: string; label?: string; onClick?: () => void }>;
   }) => {
     const [menuItems, setMenuItems] = React.useState<
@@ -138,7 +139,7 @@ vi.mock('./DraggableTask', () => ({
             data-testid={`task-menu-button-${task.id}`}
             onClick={() => {
               if (groupIndex !== undefined && taskIndex !== undefined) {
-                setMenuItems(getContextMenuItems(groupIndex, taskIndex));
+                setMenuItems(getContextMenuItems(groupIndex, taskIndex, task.id));
               }
             }}
           >

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNodeAdhocTaskGroups.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNodeAdhocTaskGroups.tsx
@@ -1,5 +1,4 @@
-import { memo, RefObject, useCallback } from 'react';
-import { GroupModificationType } from '../../utils/GroupModificationUtils';
+import { memo, useCallback } from 'react';
 import type { NodeMenuItem } from '../NodeContextMenu';
 import { AdhocTaskItem } from './AdhocTask';
 import {
@@ -7,31 +6,32 @@ import {
   StageAdditionalTasksSection,
   StageTaskList,
 } from './StageNode.styles';
-import type { StageNodeProps, StageTaskGroup, TaskStateReference } from './StageNode.types';
-import { getDivider, getMenuItem } from './StageNodeTaskUtilities';
+import type { StageNodeProps, StageTaskGroup } from './StageNode.types';
 
 const StageNodeAdhocTaskGroupsInner = ({
   props,
   adhocTasks,
   isReadOnly,
   selectedTaskId,
-  taskStateReference,
   marginTop,
   handleTaskClick,
-  setIsReplacingTask,
+  generateReplaceTaskMenuItemForTask,
+  generateDeleteTaskMenuItemForTask,
 }: {
   props: StageNodeProps;
   adhocTasks: StageTaskGroup[];
   isReadOnly: boolean;
   selectedTaskId?: string;
-  taskStateReference: RefObject<TaskStateReference>;
   marginTop: string;
   handleTaskClick: (e: React.MouseEvent, taskElementId: string) => void;
-  setIsReplacingTask: (isReplacingTask: boolean) => void;
+  generateReplaceTaskMenuItemForTask: (
+    taskId: string,
+    isParallel: boolean
+  ) => NodeMenuItem | undefined;
+  generateDeleteTaskMenuItemForTask: (taskId: string) => NodeMenuItem | undefined;
 }) => {
   const {
     execution,
-    onTaskClick,
     onTaskGroupModification,
     onReplaceTaskFromToolbox,
     onTaskPlay,
@@ -41,41 +41,22 @@ const StageNodeAdhocTaskGroupsInner = ({
   /** Lazily builds context menu items for a task. Called only when the menu opens,
    * avoiding object allocation on every render for every task. */
   const getAdhocContextMenuItems = useCallback(
-    (groupIndex: number, taskIndex: number, taskId: string): NodeMenuItem[] => {
+    (taskId: string): NodeMenuItem[] => {
       const items: NodeMenuItem[] = [];
 
-      if (onReplaceTaskFromToolbox) {
-        items.push(
-          getMenuItem('replace-task', 'Replace task', () => {
-            taskStateReference.current = {
-              isParallel: false,
-              groupIndex,
-              taskIndex,
-            };
-            onTaskClick?.(taskId);
-            setIsReplacingTask(true);
-          })
-        );
+      const replaceTaskMenuItem = generateReplaceTaskMenuItemForTask(taskId, false);
+      if (replaceTaskMenuItem) {
+        items.push(replaceTaskMenuItem);
       }
 
-      if (onTaskGroupModification) {
-        if (items.length > 0) items.push(getDivider());
-        items.push(
-          getMenuItem('remove-task', 'Delete task', () =>
-            onTaskGroupModification(GroupModificationType.REMOVE_TASK, groupIndex, taskIndex)
-          )
-        );
+      const deleteTaskMenuItem = generateDeleteTaskMenuItemForTask(taskId);
+      if (deleteTaskMenuItem) {
+        items.push(deleteTaskMenuItem);
       }
 
       return items;
     },
-    [
-      onReplaceTaskFromToolbox,
-      onTaskClick,
-      onTaskGroupModification,
-      setIsReplacingTask,
-      taskStateReference,
-    ]
+    [generateReplaceTaskMenuItemForTask, generateDeleteTaskMenuItemForTask]
   );
 
   if (adhocTasks.length === 0) {
@@ -87,7 +68,7 @@ const StageNodeAdhocTaskGroupsInner = ({
         <span className="text-xs font-bold text-foreground-muted">Ad hoc tasks</span>
       </StageAdditionalTasksHeaderSection>
       <StageTaskList>
-        {adhocTasks.map(({ task, groupIndex, taskIndex }) => {
+        {adhocTasks.map(({ task }) => {
           const taskExecution = execution?.taskStatus?.[task.id];
           return (
             <AdhocTaskItem
@@ -100,8 +81,7 @@ const StageNodeAdhocTaskGroupsInner = ({
               isTaskLoading={loadingTaskIds?.has(task.id)}
               {...((onTaskGroupModification || onReplaceTaskFromToolbox) &&
                 !isReadOnly && {
-                  getContextMenuItems: () =>
-                    getAdhocContextMenuItems(groupIndex, taskIndex, task.id),
+                  getContextMenuItems: () => getAdhocContextMenuItems(task.id),
                 })}
             />
           );

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNodeAllTaskGroups.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNodeAllTaskGroups.tsx
@@ -2,12 +2,14 @@ import { Spacing } from '@uipath/apollo-core';
 import { Column } from '@uipath/apollo-react/canvas/layouts';
 import { Button } from '@uipath/apollo-wind';
 import { CSSProperties, memo, RefObject, useCallback, useMemo } from 'react';
+import { GroupModificationType } from '../../utils';
 import { useStageTasksByGroups } from './hooks/useStageTasksByGroups';
 import { StageContent } from './StageNode.styles';
 import type { StageNodeProps, StageTaskItem, TaskStateReference } from './StageNode.types';
 import { StageNodeAdhocTaskGroups } from './StageNodeAdhocTaskGroups';
 import { StageNodeEventDrivenTaskGroups } from './StageNodeEventDrivenTaskGroups';
 import { StageNodeSequentialTaskGroups } from './StageNodeSequentialTaskGroups';
+import { getMenuItem } from './StageNodeTaskUtilities';
 
 const StageNodeAllTaskGroupsInner = ({
   props,
@@ -74,6 +76,68 @@ const StageNodeAllTaskGroupsInner = ({
     [onTaskClick, setSelectedNodeId, id]
   );
 
+  const generateReplaceTaskMenuItemForTask = useCallback(
+    (taskId: string, isParallel: boolean) => {
+      if (!onReplaceTaskFromToolbox) {
+        return undefined;
+      }
+
+      let groupIndex: number | undefined;
+      let taskIndex: number | undefined;
+      for (const [allTasksGroupIndex, group] of allTasks.entries()) {
+        for (const [allTasksTaskIndex, task] of group.entries()) {
+          if (task.id === taskId) {
+            groupIndex = allTasksGroupIndex;
+            taskIndex = allTasksTaskIndex;
+            break;
+          }
+        }
+      }
+      if (groupIndex === undefined || taskIndex === undefined) {
+        return undefined;
+      }
+
+      return getMenuItem('replace-task', 'Replace task', () => {
+        taskStateReference.current = {
+          isParallel,
+          groupIndex,
+          taskIndex,
+        };
+        onTaskClick?.(taskId);
+        setIsReplacingTask(true);
+      });
+    },
+    [onReplaceTaskFromToolbox, allTasks, onTaskClick, setIsReplacingTask, taskStateReference]
+  );
+
+  const generateDeleteTaskMenuItemForTask = useCallback(
+    (taskId: string) => {
+      if (!onTaskGroupModification) {
+        return undefined;
+      }
+
+      let groupIndex: number | undefined;
+      let taskIndex: number | undefined;
+      for (const [allTasksGroupIndex, group] of allTasks.entries()) {
+        for (const [allTasksTaskIndex, task] of group.entries()) {
+          if (task.id === taskId) {
+            groupIndex = allTasksGroupIndex;
+            taskIndex = allTasksTaskIndex;
+            break;
+          }
+        }
+      }
+      if (groupIndex === undefined || taskIndex === undefined) {
+        return undefined;
+      }
+
+      return getMenuItem('remove-task', 'Delete task', () =>
+        onTaskGroupModification(GroupModificationType.REMOVE_TASK, groupIndex, taskIndex)
+      );
+    },
+    [allTasks, onTaskGroupModification]
+  );
+
   return (
     <StageContent>
       {sequentialTaskGroups.length === 0 &&
@@ -97,35 +161,35 @@ const StageNodeAllTaskGroupsInner = ({
             isReadOnly={isReadOnly}
             selectedTaskId={selectedTaskId}
             taskWidthStyle={taskWidthStyle}
-            taskStateReference={taskStateReference}
             hasContextMenu={hasContextMenu}
             handleTaskClick={handleTaskClick}
-            setIsReplacingTask={setIsReplacingTask}
             handleReorderSequentialTasks={handleReorderSequentialTasks}
+            allTasks={allTasks}
+            generateReplaceTaskMenuItemForTask={generateReplaceTaskMenuItemForTask}
           />
           <StageNodeEventDrivenTaskGroups
             props={props}
             eventDrivenTasks={eventDrivenTasks}
             isReadOnly={isReadOnly}
             selectedTaskId={selectedTaskId}
-            taskStateReference={taskStateReference}
             marginTop={sequentialTaskGroups.length > 0 ? Spacing.SpacingS : '0px'}
             handleTaskClick={handleTaskClick}
-            setIsReplacingTask={setIsReplacingTask}
+            generateReplaceTaskMenuItemForTask={generateReplaceTaskMenuItemForTask}
+            generateDeleteTaskMenuItemForTask={generateDeleteTaskMenuItemForTask}
           />
           <StageNodeAdhocTaskGroups
             props={props}
             adhocTasks={adhocTasks}
             isReadOnly={isReadOnly}
             selectedTaskId={selectedTaskId}
-            taskStateReference={taskStateReference}
             marginTop={
               sequentialTaskGroups.length > 0 || eventDrivenTaskGroups.length > 0
                 ? Spacing.SpacingS
                 : '0px'
             }
             handleTaskClick={handleTaskClick}
-            setIsReplacingTask={setIsReplacingTask}
+            generateReplaceTaskMenuItemForTask={generateReplaceTaskMenuItemForTask}
+            generateDeleteTaskMenuItemForTask={generateDeleteTaskMenuItemForTask}
           />
         </Column>
       )}

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNodeEventDrivenTaskGroups.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNodeEventDrivenTaskGroups.tsx
@@ -1,5 +1,4 @@
-import { memo, RefObject, useCallback } from 'react';
-import { GroupModificationType } from '../../utils/GroupModificationUtils';
+import { memo, useCallback } from 'react';
 import type { NodeMenuItem } from '../NodeContextMenu';
 import { EventDrivenTaskItem } from './EventDrivenTask';
 import {
@@ -7,74 +6,51 @@ import {
   StageAdditionalTasksSection,
   StageTaskList,
 } from './StageNode.styles';
-import type { StageNodeProps, StageTaskGroup, TaskStateReference } from './StageNode.types';
-import { getDivider, getMenuItem } from './StageNodeTaskUtilities';
+import type { StageNodeProps, StageTaskGroup } from './StageNode.types';
 
 const StageNodeEventDrivenTaskGroupsInner = ({
   props,
   eventDrivenTasks,
   isReadOnly,
   selectedTaskId,
-  taskStateReference,
   marginTop,
   handleTaskClick,
-  setIsReplacingTask,
+  generateReplaceTaskMenuItemForTask,
+  generateDeleteTaskMenuItemForTask,
 }: {
   props: StageNodeProps;
   eventDrivenTasks: StageTaskGroup[];
   isReadOnly: boolean;
   selectedTaskId?: string;
-  taskStateReference: RefObject<TaskStateReference>;
   marginTop: string;
   handleTaskClick: (e: React.MouseEvent, taskElementId: string) => void;
-  setIsReplacingTask: (isReplacingTask: boolean) => void;
+  generateReplaceTaskMenuItemForTask: (
+    taskId: string,
+    isParallel: boolean
+  ) => NodeMenuItem | undefined;
+  generateDeleteTaskMenuItemForTask: (taskId: string) => NodeMenuItem | undefined;
 }) => {
-  const {
-    execution,
-    onTaskClick,
-    onTaskGroupModification,
-    onReplaceTaskFromToolbox,
-    loadingTaskIds,
-  } = props;
+  const { execution, onTaskGroupModification, onReplaceTaskFromToolbox, loadingTaskIds } = props;
 
   /** Lazily builds context menu items for a task. Called only when the menu opens,
    * avoiding object allocation on every render for every task. */
   const getEventDrivenContextMenuItems = useCallback(
-    (groupIndex: number, taskIndex: number, taskId: string): NodeMenuItem[] => {
+    (taskId: string): NodeMenuItem[] => {
       const items: NodeMenuItem[] = [];
 
-      if (onReplaceTaskFromToolbox) {
-        items.push(
-          getMenuItem('replace-task', 'Replace task', () => {
-            taskStateReference.current = {
-              isParallel: false,
-              groupIndex,
-              taskIndex,
-            };
-            onTaskClick?.(taskId);
-            setIsReplacingTask(true);
-          })
-        );
+      const replaceTaskMenuItem = generateReplaceTaskMenuItemForTask(taskId, false);
+      if (replaceTaskMenuItem) {
+        items.push(replaceTaskMenuItem);
       }
 
-      if (onTaskGroupModification) {
-        if (items.length > 0) items.push(getDivider());
-        items.push(
-          getMenuItem('remove-task', 'Delete task', () =>
-            onTaskGroupModification(GroupModificationType.REMOVE_TASK, groupIndex, taskIndex)
-          )
-        );
+      const deleteTaskMenuItem = generateDeleteTaskMenuItemForTask(taskId);
+      if (deleteTaskMenuItem) {
+        items.push(deleteTaskMenuItem);
       }
 
       return items;
     },
-    [
-      onReplaceTaskFromToolbox,
-      onTaskClick,
-      onTaskGroupModification,
-      setIsReplacingTask,
-      taskStateReference,
-    ]
+    [generateReplaceTaskMenuItemForTask, generateDeleteTaskMenuItemForTask]
   );
 
   if (eventDrivenTasks.length === 0) {
@@ -86,7 +62,7 @@ const StageNodeEventDrivenTaskGroupsInner = ({
         <span className="text-xs font-bold text-foreground-muted">Event-driven tasks</span>
       </StageAdditionalTasksHeaderSection>
       <StageTaskList>
-        {eventDrivenTasks.map(({ task, groupIndex, taskIndex }) => {
+        {eventDrivenTasks.map(({ task }) => {
           const taskExecution = execution?.taskStatus?.[task.id];
           return (
             <EventDrivenTaskItem
@@ -98,8 +74,7 @@ const StageNodeEventDrivenTaskGroupsInner = ({
               isTaskLoading={loadingTaskIds?.has(task.id)}
               {...((onTaskGroupModification || onReplaceTaskFromToolbox) &&
                 !isReadOnly && {
-                  getContextMenuItems: () =>
-                    getEventDrivenContextMenuItems(groupIndex, taskIndex, task.id),
+                  getContextMenuItems: () => getEventDrivenContextMenuItems(task.id),
                 })}
             />
           );

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNodeSequentialTaskGroups.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNodeSequentialTaskGroups.tsx
@@ -13,7 +13,7 @@ import {
 } from '@dnd-kit/sortable';
 import { Spacing } from '@uipath/apollo-core';
 import { Row } from '@uipath/apollo-react/canvas/layouts';
-import { CSSProperties, RefObject, useCallback, useMemo } from 'react';
+import { CSSProperties, useCallback, useMemo } from 'react';
 import {
   GroupModificationType,
   moveGroupDown,
@@ -28,49 +28,40 @@ import {
   StageTaskGroupContainer,
   StageTaskList,
 } from './StageNode.styles';
-import type {
-  StageNodeProps,
-  StageTaskGroup,
-  StageTaskItem,
-  TaskStateReference,
-} from './StageNode.types';
-import { getContextMenuItems, getDivider, getMenuItem } from './StageNodeTaskUtilities';
+import type { StageNodeProps, StageTaskGroup, StageTaskItem } from './StageNode.types';
+import { getContextMenuItems, getDivider } from './StageNodeTaskUtilities';
 import { StageTaskDragOverlay } from './StageTaskDragOverlay';
 
 export const StageNodeSequentialTaskGroups = ({
   props,
   sequentialTaskGroups,
   sequentialTasks,
+  allTasks,
   isReadOnly,
   selectedTaskId,
   taskWidthStyle,
-  taskStateReference,
   hasContextMenu,
   handleTaskClick,
-  setIsReplacingTask,
   handleReorderSequentialTasks,
+  generateReplaceTaskMenuItemForTask,
 }: {
   props: StageNodeProps;
   sequentialTaskGroups: StageTaskItem[][];
   sequentialTasks: StageTaskGroup[];
+  allTasks: StageTaskItem[][];
   isReadOnly: boolean;
   selectedTaskId?: string;
   taskWidthStyle?: CSSProperties;
-  taskStateReference: RefObject<TaskStateReference>;
   hasContextMenu: boolean;
   handleTaskClick: (e: React.MouseEvent, taskElementId: string) => void;
-  setIsReplacingTask: (isReplacingTask: boolean) => void;
   handleReorderSequentialTasks: (newTasks: StageTaskItem[][]) => void;
+  generateReplaceTaskMenuItemForTask: (
+    taskId: string,
+    isParallel: boolean
+  ) => NodeMenuItem | undefined;
 }) => {
-  const {
-    execution,
-    onTaskClick,
-    onTaskGroupModification,
-    onTaskReorder,
-    onReplaceTaskFromToolbox,
-    hideParallelOptions,
-    loadingTaskIds,
-  } = props;
+  const { execution, onTaskGroupModification, onTaskReorder, hideParallelOptions, loadingTaskIds } =
+    props;
 
   const sequentialTaskIds = useMemo(
     () => sequentialTasks.map(({ task }) => task.id),
@@ -117,53 +108,56 @@ export const StageNodeSequentialTaskGroups = ({
   /** Lazily builds context menu items for a task. Called only when the menu opens,
    * avoiding object allocation on every render for every task. */
   const buildContextMenuItems = useCallback(
-    (groupIndex: number, taskIndex: number) => {
+    (groupIndex: number, _: number, taskId: string) => {
       const taskGroup = sequentialTaskGroups[groupIndex] ?? [];
       const isParallel = taskGroup.length > 1;
       const items: NodeMenuItem[] = [];
 
-      if (onReplaceTaskFromToolbox) {
-        items.push(
-          getMenuItem('replace-task', 'Replace task', () => {
-            taskStateReference.current = {
-              isParallel,
-              groupIndex,
-              taskIndex,
-            };
-            const taskId = taskGroup[taskIndex]?.id;
-            if (taskId) onTaskClick?.(taskId);
-            setIsReplacingTask(true);
-          })
-        );
+      const replaceTaskMenuItem = generateReplaceTaskMenuItemForTask(taskId, isParallel);
+      if (replaceTaskMenuItem) {
+        items.push(replaceTaskMenuItem);
         items.push(getDivider());
       }
+      let groupIndexInAllTasks: number | undefined;
+      let taskIndexInAllTasks: number | undefined;
+      for (const [allTasksGroupIndex, group] of allTasks.entries()) {
+        for (const [allTasksTaskIndex, task] of group.entries()) {
+          if (task.id === taskId) {
+            groupIndexInAllTasks = allTasksGroupIndex;
+            taskIndexInAllTasks = allTasksTaskIndex;
+            break;
+          }
+        }
+      }
 
-      if (onTaskGroupModification) {
-        const reGroupOptions = getContextMenuItems(
-          isParallel,
+      if (
+        onTaskGroupModification &&
+        groupIndexInAllTasks !== undefined &&
+        taskIndexInAllTasks !== undefined
+      ) {
+        const reGroupOptions = getContextMenuItems({
+          isParallelGroup: isParallel,
           groupIndex,
-          sequentialTaskGroups.length,
-          taskIndex,
-          taskGroup.length,
-          (sequentialTaskGroups[groupIndex - 1]?.length ?? 0) > 1,
-          (sequentialTaskGroups[groupIndex + 1]?.length ?? 0) > 1,
-          handleTaskRegroup,
-          hideParallelOptions
-        );
+          tasksLength: sequentialTaskGroups.length,
+          groupIndexInAllTasks,
+          taskIndexInAllTasks,
+          isAboveParallel: (sequentialTaskGroups[groupIndex - 1]?.length ?? 0) > 1,
+          isBelowParallel: (sequentialTaskGroups[groupIndex + 1]?.length ?? 0) > 1,
+          reGroupTaskFunction: handleTaskRegroup,
+          hideParallelOptions,
+        });
         return [...items, ...reGroupOptions];
       }
 
       return items;
     },
     [
-      onReplaceTaskFromToolbox,
-      onTaskClick,
       onTaskGroupModification,
       sequentialTaskGroups,
       hideParallelOptions,
       handleTaskRegroup,
-      setIsReplacingTask,
-      taskStateReference,
+      generateReplaceTaskMenuItemForTask,
+      allTasks,
     ]
   );
 

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNodeTaskUtilities.ts
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNodeTaskUtilities.ts
@@ -4,59 +4,113 @@ import type { NodeMenuAction, NodeMenuItem } from '../NodeContextMenu';
 
 // TODO: Add translation for the menu items
 
-export const getContextMenuItems = (
-  isParallelGroup: boolean,
-  groupIndex: number,
-  tasksLength: number,
-  taskIndex: number,
-  _taskGroupLength: number,
-  isAboveParallel: boolean,
-  isBelowParallel: boolean,
+export const getContextMenuItems = ({
+  isParallelGroup,
+  groupIndex,
+  tasksLength,
+  groupIndexInAllTasks,
+  taskIndexInAllTasks,
+  isAboveParallel,
+  isBelowParallel,
+  reGroupTaskFunction,
+  hideParallelOptions = false,
+}: {
+  isParallelGroup: boolean;
+  groupIndex: number;
+  tasksLength: number;
+  groupIndexInAllTasks: number;
+  taskIndexInAllTasks: number;
+  isAboveParallel: boolean;
+  isBelowParallel: boolean;
   reGroupTaskFunction: (
     groupModificationType: GroupModificationType,
     groupIndex: number,
     taskIndex: number
-  ) => void,
-  hideParallelOptions = false
-): NodeMenuItem[] => {
+  ) => void;
+  hideParallelOptions?: boolean;
+}): NodeMenuItem[] => {
   const CONTEXT_MENU_ITEMS = {
     MOVE_UP: getMenuItem('move-up', 'Move up', () =>
-      reGroupTaskFunction(GroupModificationType.TASK_GROUP_UP, groupIndex, taskIndex)
+      reGroupTaskFunction(
+        GroupModificationType.TASK_GROUP_UP,
+        groupIndexInAllTasks,
+        taskIndexInAllTasks
+      )
     ),
     MOVE_DOWN: getMenuItem('move-down', 'Move down', () =>
-      reGroupTaskFunction(GroupModificationType.TASK_GROUP_DOWN, groupIndex, taskIndex)
+      reGroupTaskFunction(
+        GroupModificationType.TASK_GROUP_DOWN,
+        groupIndexInAllTasks,
+        taskIndexInAllTasks
+      )
     ),
     UNGROUP_ALL: getMenuItem('ungroup', 'Ungroup parallel tasks', () =>
-      reGroupTaskFunction(GroupModificationType.UNGROUP_ALL_TASKS, groupIndex, taskIndex)
+      reGroupTaskFunction(
+        GroupModificationType.UNGROUP_ALL_TASKS,
+        groupIndexInAllTasks,
+        taskIndexInAllTasks
+      )
     ),
     SPLIT_TASK: getMenuItem('split', 'Remove from parallel group', () =>
-      reGroupTaskFunction(GroupModificationType.SPLIT_GROUP, groupIndex, taskIndex)
+      reGroupTaskFunction(
+        GroupModificationType.SPLIT_GROUP,
+        groupIndexInAllTasks,
+        taskIndexInAllTasks
+      )
     ),
     REMOVE_GROUP: getMenuItem('remove-group', 'Remove group from stage', () =>
-      reGroupTaskFunction(GroupModificationType.REMOVE_GROUP, groupIndex, taskIndex)
+      reGroupTaskFunction(
+        GroupModificationType.REMOVE_GROUP,
+        groupIndexInAllTasks,
+        taskIndexInAllTasks
+      )
     ),
     REMOVE_TASK: getMenuItem('remove-task', 'Delete task', () =>
-      reGroupTaskFunction(GroupModificationType.REMOVE_TASK, groupIndex, taskIndex)
+      reGroupTaskFunction(
+        GroupModificationType.REMOVE_TASK,
+        groupIndexInAllTasks,
+        taskIndexInAllTasks
+      )
     ),
     CREATE_PARALLEL_GROUP_ABOVE: getMenuItem(
       'group-with-up',
       'Create parallel group with task above',
-      () => reGroupTaskFunction(GroupModificationType.MERGE_GROUP_UP, groupIndex, taskIndex)
+      () =>
+        reGroupTaskFunction(
+          GroupModificationType.MERGE_GROUP_UP,
+          groupIndexInAllTasks,
+          taskIndexInAllTasks
+        )
     ),
     CREATE_PARALLEL_GROUP_BELOW: getMenuItem(
       'group-with-down',
       'Create parallel group with task below',
-      () => reGroupTaskFunction(GroupModificationType.MERGE_GROUP_DOWN, groupIndex, taskIndex)
+      () =>
+        reGroupTaskFunction(
+          GroupModificationType.MERGE_GROUP_DOWN,
+          groupIndexInAllTasks,
+          taskIndexInAllTasks
+        )
     ),
     ADD_TO_PARALLEL_GROUP_ABOVE: getMenuItem(
       'add-to-group-with-up',
       'Add task to parallel group above',
-      () => reGroupTaskFunction(GroupModificationType.MERGE_GROUP_UP, groupIndex, taskIndex)
+      () =>
+        reGroupTaskFunction(
+          GroupModificationType.MERGE_GROUP_UP,
+          groupIndexInAllTasks,
+          taskIndexInAllTasks
+        )
     ),
     ADD_TO_PARALLEL_GROUP_BELOW: getMenuItem(
       'add-to-group-with-down',
       'Add task to parallel group below',
-      () => reGroupTaskFunction(GroupModificationType.MERGE_GROUP_DOWN, groupIndex, taskIndex)
+      () =>
+        reGroupTaskFunction(
+          GroupModificationType.MERGE_GROUP_DOWN,
+          groupIndexInAllTasks,
+          taskIndexInAllTasks
+        )
     ),
     DIVIDER: getDivider(),
   };


### PR DESCRIPTION
Noticed that our menu options were not respecting the task index properly now they're split into multiple sections. I assume this also isn't working for the adhoc section we have right now 😬 

Now we properly pass the actually task index and it's group index into the modification function, so we can better handle it on the PO.Frontend