### PR TITLE
fix(apollo-vertex): responsive padding and smooth transitions on page header

### DIFF
--- a/apps/apollo-vertex/registry/page-header/page-header.tsx
+++ b/apps/apollo-vertex/registry/page-header/page-header.tsx
@@ -18,7 +18,7 @@ const pageHeaderVariants = cva("", {
   variants: {
     size: {
       default: [
-        "flex flex-wrap items-center gap-4 py-4 px-4 sm:px-6 lg:px-8 min-h-[92px]",
+        "flex flex-wrap items-center gap-4 py-4 px-4 sm:px-6 lg:px-8 min-h-[92px] transition-[padding] duration-300 ease-in-out",
         "@3xl:grid @3xl:grid-cols-[1fr_auto] @3xl:py-0",
         "@3xl:has-[[data-slot=page-header-content]]:grid-cols-[3fr_6fr_3fr]",
       ].join(" "),
@@ -110,7 +110,7 @@ function PageHeaderTitleGroup({
 }
 
 const pageHeaderTitleVariants = cva(
-  "font-bold text-foreground w-full min-w-[80px] truncate",
+  "font-bold text-foreground w-full min-w-[80px] truncate transition-[font-size,line-height,letter-spacing] duration-300 ease-in-out",
   {
     variants: {
       size: {

--- a/apps/apollo-vertex/registry/page-header/page-header.tsx
+++ b/apps/apollo-vertex/registry/page-header/page-header.tsx
@@ -18,7 +18,7 @@ const pageHeaderVariants = cva("", {
   variants: {
     size: {
       default: [
-        "flex flex-wrap items-center gap-4 py-4 px-6 min-h-[92px]",
+        "flex flex-wrap items-center gap-4 py-4 px-4 sm:px-6 lg:px-8 min-h-[92px]",
         "@3xl:grid @3xl:grid-cols-[1fr_auto] @3xl:py-0",
         "@3xl:has-[[data-slot=page-header-content]]:grid-cols-[3fr_6fr_3fr]",
       ].join(" "),


### PR DESCRIPTION
## Intent
Page header margins didn't align with the shell header nor the grid, so updating the px value and adding breakpoints. Another PR is forthcoming to add the breakpoints to the minimal shell header as well so these will always be in line.

Also saw a snap between breakpoints on the text size change, so just added tailwind transition to make the transition smooth.

## Summary

- Updated page header horizontal padding to follow the grid's breakpoint margins: `px-4` (mobile), `px-6` (tablet/sm), `px-8` (desktop/lg)
- Added smooth CSS transitions to the page header container padding (`transition-[padding]`) and title size/leading/tracking (`transition-[font-size,line-height,letter-spacing]`) using a 300ms ease-in-out curve

## Test plan

- [ ] Resize the browser across the `sm` (640px) and `lg` (1024px) breakpoints and verify padding steps match the grid spec
- [ ] Confirm padding and title size changes animate smoothly on resize
- [ ] Verify no visual regressions in page header variants (with/without back button, content slot, actions)
