### PR TITLE
fix(apollo-vertex): responsive shell header padding and fix profile menu positioning

### DIFF
--- a/apps/apollo-vertex/registry/shell/shell-sidebar.tsx
+++ b/apps/apollo-vertex/registry/shell/shell-sidebar.tsx
@@ -55,7 +55,11 @@ export const Sidebar = ({
         )}
 
         <div className="flex items-center gap-2">
-          <UserProfile isCollapsed />
+          <UserProfile
+            isCollapsed
+            collapsedMenuSide="bottom"
+            collapsedMenuAlign="end"
+          />
         </div>
       </header>
     );

--- a/apps/apollo-vertex/registry/shell/shell-sidebar.tsx
+++ b/apps/apollo-vertex/registry/shell/shell-sidebar.tsx
@@ -35,7 +35,7 @@ export const Sidebar = ({
 
   if (variant === "minimal") {
     return (
-      <header className="relative flex items-center justify-between px-8 py-6">
+      <header className="relative flex items-center justify-between px-4 sm:px-6 lg:px-8 py-6 transition-[padding] duration-300 ease-in-out">
         <MinimalCompany
           companyName={companyName}
           productName={productName}

--- a/apps/apollo-vertex/registry/shell/shell-user-profile.tsx
+++ b/apps/apollo-vertex/registry/shell/shell-user-profile.tsx
@@ -13,9 +13,15 @@ import { useUser } from "./shell-user-provider";
 
 interface UserProfileProps {
   isCollapsed: boolean;
+  collapsedMenuSide?: "top" | "right" | "bottom" | "left";
+  collapsedMenuAlign?: "start" | "center" | "end";
 }
 
-export const UserProfile = ({ isCollapsed }: UserProfileProps) => {
+export const UserProfile = ({
+  isCollapsed,
+  collapsedMenuSide = "top",
+  collapsedMenuAlign = "start",
+}: UserProfileProps) => {
   const { t } = useTranslation();
   const { user } = useUser();
   const userInitials = user
@@ -52,8 +58,8 @@ export const UserProfile = ({ isCollapsed }: UserProfileProps) => {
           </DropdownMenuTrigger>
           <DropdownMenuContent
             className="w-56"
-            align="center"
-            side="right"
+            align={collapsedMenuAlign}
+            side={collapsedMenuSide}
             sideOffset={8}
           >
             <div className="flex flex-col gap-2 p-2">


### PR DESCRIPTION
## Summary
The minimal shell header needed to be updated to follow the grid breakpoints so that the px value always matches the grid's margins. In addition, the profile menu was opening in an unexpected position for the collapsed state of the sidebar and the minimal version, so this PR sets the position of the menu for those states/version.

- Updated the minimal shell header horizontal padding to follow the grid's breakpoint margins: `px-4` (mobile), `px-6` (tablet/sm), `px-8` (desktop/lg) with a smooth `transition-[padding]` on resize
- Added `collapsedMenuSide` and `collapsedMenuAlign` props to `UserProfile` to allow per-context dropdown positioning — minimal header opens below the avatar (`side="bottom" align="end"`), collapsed sidebar matches the expanded sidebar behaviour (`side="top" align="start"`)

## Test plan

- [ ] Resize the browser across `sm` (640px) and `lg` (1024px) breakpoints in the minimal shell and verify header padding steps match the grid spec
- [ ] Confirm padding animates smoothly on resize
- [ ] Open the profile menu in the minimal header — verify it opens below the avatar, aligned to the right edge
- [ ] Collapse the sidebar and open the profile menu — verify it opens above, aligned to the start (same as expanded)
