### PR TITLE
feat(apollo-react): stacked node visual treatment [MST-8373]

### DIFF
--- a/packages/apollo-react/src/canvas/components/BaseNode/BaseNode.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/BaseNode/BaseNode.stories.tsx
@@ -13,6 +13,8 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { NodeRegistryProvider } from '../../core';
 import type { CategoryManifest, NodeManifest } from '../../schema';
 import {
+  allCategoryManifests,
+  allNodeManifests,
   createNode,
   StoryInfoPanel,
   useCanvasStory,
@@ -782,6 +784,120 @@ export const Adornments: Story = {
     }),
   ],
   render: () => <AdornmentsStory />,
+};
+
+// ============================================================================
+// Stacked Treatment Story (drillable / collapsed)
+// ============================================================================
+
+/**
+ * Story-only manifest registering a drillable agent type, so we can demo the
+ * `drillable` branch of the stacked treatment without touching the shared
+ * default manifests.
+ */
+const stackedManifest: { nodes: NodeManifest[]; categories: CategoryManifest[] } = {
+  categories: [
+    ...allCategoryManifests,
+    {
+      id: 'agents',
+      name: 'Agents',
+      sortOrder: 1,
+      color: '#7c3aed',
+      colorDark: '#8b5cf6',
+      icon: 'robot',
+      tags: [],
+    },
+  ],
+  nodes: [
+    ...allNodeManifests,
+    {
+      nodeType: 'uipath.agent.drillable',
+      version: '1.0.0',
+      category: 'agents',
+      tags: ['agent'],
+      sortOrder: 1,
+      drillable: true,
+      display: {
+        label: 'Drillable Agent',
+        icon: 'agent',
+        shape: 'square',
+      },
+      handleConfiguration: [
+        {
+          position: 'left',
+          handles: [{ id: 'input', type: 'target', handleType: 'input' }],
+        },
+        {
+          position: 'right',
+          handles: [{ id: 'output', type: 'source', handleType: 'output' }],
+        },
+      ],
+    },
+  ],
+};
+
+function StackedTreatmentStory() {
+  const initialNodes = useMemo<Node<BaseNodeData>[]>(
+    () => [
+      createNode({
+        id: 'plain',
+        type: 'uipath.blank-node',
+        position: { x: 96, y: 200 },
+        data: {
+          nodeType: 'uipath.blank-node',
+          version: '1.0.0',
+          display: { label: 'Plain', subLabel: 'No treatment', shape: 'square' },
+        },
+      }),
+      createNode({
+        id: 'drillable',
+        type: 'uipath.agent.drillable',
+        position: { x: 320, y: 200 },
+        data: {
+          nodeType: 'uipath.agent.drillable',
+          version: '1.0.0',
+          display: { label: 'Drillable', subLabel: 'manifest.drillable', shape: 'square' },
+        },
+      }),
+      createNode({
+        id: 'collapsed',
+        type: 'uipath.blank-node',
+        position: { x: 544, y: 200 },
+        data: {
+          nodeType: 'uipath.blank-node',
+          version: '1.0.0',
+          display: { label: 'Collapsed', subLabel: 'data.isCollapsed', shape: 'square' },
+          isCollapsed: true,
+        },
+      }),
+    ],
+    []
+  );
+  const { canvasProps } = useCanvasStory({ initialNodes });
+
+  return (
+    <BaseCanvas {...canvasProps} mode="design">
+      <Panel position="bottom-right">
+        <CanvasPositionControls translations={DefaultCanvasTranslations} />
+      </Panel>
+      <StoryInfoPanel
+        title="Stacked Treatment"
+        description="Drillable (manifest) and collapsed (instance data) nodes render a decorative stacked layer behind the card. The effect is purely visual — node dimensions and hit area are unchanged."
+      />
+    </BaseCanvas>
+  );
+}
+
+export const StackedTreatment: Story = {
+  name: 'Stacked Treatment',
+  decorators: [
+    (Story) => (
+      <NodeRegistryProvider manifest={stackedManifest}>
+        <Story />
+      </NodeRegistryProvider>
+    ),
+  ],
+  render: () => <StackedTreatmentStory />,
 };
 
 export const ValidationStates: Story = {

--- a/packages/apollo-react/src/canvas/components/BaseNode/BaseNode.test.tsx
+++ b/packages/apollo-react/src/canvas/components/BaseNode/BaseNode.test.tsx
@@ -4,10 +4,21 @@ import { Position } from '@uipath/apollo-react/canvas/xyflow/react';
 import { describe, expect, it, vi } from 'vitest';
 import type { BaseNodeData } from './BaseNode.types';
 
+const DEFAULT_MANIFEST = {
+  display: { label: 'Test Node', shape: 'square', icon: 'test-icon' },
+  handleConfiguration: [],
+} as const;
+
 // Hoisted mocks — available inside vi.mock factories
-const { mockUpdateNode, mockHandleConfigs } = vi.hoisted(() => ({
+const { mockUpdateNode, mockHandleConfigs, mockManifest } = vi.hoisted(() => ({
   mockUpdateNode: vi.fn(),
   mockHandleConfigs: { current: undefined as HandleGroupManifest[] | undefined },
+  mockManifest: {
+    current: {
+      display: { label: 'Test Node', shape: 'square', icon: 'test-icon' },
+      handleConfiguration: [],
+    } as Record<string, unknown>,
+  },
 }));
 
 // xyflow is globally mocked in canvas-mocks.ts; extend with test-specific overrides.
@@ -25,10 +36,7 @@ vi.mock('../../hooks', () => ({
 
 vi.mock('../../core', () => ({
   useNodeTypeRegistry: () => ({
-    getManifest: () => ({
-      display: { label: 'Test Node', shape: 'square', icon: 'test-icon' },
-      handleConfiguration: [],
-    }),
+    getManifest: () => mockManifest.current,
   }),
 }));
 
@@ -115,6 +123,7 @@ describe('BaseNode', () => {
   afterEach(() => {
     mockUpdateNode.mockClear();
     mockHandleConfigs.current = undefined;
+    mockManifest.current = { ...DEFAULT_MANIFEST };
   });
 
   describe('Height computation', () => {
@@ -222,6 +231,24 @@ describe('BaseNode', () => {
 
       expect(screen.getByTestId('skeleton-icon')).toBeInTheDocument();
       expect(screen.getByText('Test Node')).toBeInTheDocument();
+    });
+  });
+
+  describe('Stacked treatment', () => {
+    it('sets data-stacked when manifest.drillable is true', () => {
+      mockManifest.current = { ...DEFAULT_MANIFEST, drillable: true };
+      render(<BaseNode {...defaultProps} />);
+      expect(screen.getByTestId('base-container')).toHaveAttribute('data-stacked', 'true');
+    });
+
+    it('sets data-stacked when data.isCollapsed is true', () => {
+      render(<BaseNode {...defaultProps} data={{ isCollapsed: true }} />);
+      expect(screen.getByTestId('base-container')).toHaveAttribute('data-stacked', 'true');
+    });
+
+    it('omits data-stacked when neither drillable nor collapsed', () => {
+      render(<BaseNode {...defaultProps} />);
+      expect(screen.getByTestId('base-container')).not.toHaveAttribute('data-stacked');
     });
   });
 });

--- a/packages/apollo-react/src/canvas/components/BaseNode/BaseNode.tsx
+++ b/packages/apollo-react/src/canvas/components/BaseNode/BaseNode.tsx
@@ -180,6 +180,10 @@ const BaseNodeComponent = (props: NodeProps<Node<BaseNodeData>>) => {
     [manifest, data, id]
   );
 
+  // Drillable (manifest) or collapsed (instance data) nodes render a decorative
+  // stacked layer to signal they stand in for more than themselves.
+  const isStacked = Boolean(manifest?.drillable || data?.isCollapsed);
+
   // Icon resolution: component prop takes precedence, then icon string from display
   const Icon = useMemo(() => {
     // Priority 1: Component prop (e.g., dynamic tool icon)
@@ -584,6 +588,7 @@ const BaseNodeComponent = (props: NodeProps<Node<BaseNodeData>>) => {
         shape={displayShape}
         isSelected={selected}
         isHovered={isHovered}
+        isStacked={isStacked}
         interactionState={interactionState}
         executionStatus={executionStatus}
         validationStatus={validationState?.validationStatus}

--- a/packages/apollo-react/src/canvas/components/BaseNode/BaseNodeContainer.tsx
+++ b/packages/apollo-react/src/canvas/components/BaseNode/BaseNodeContainer.tsx
@@ -34,6 +34,7 @@ export const getStatusBorder = (
 interface BaseContainerProps {
   isSelected?: boolean;
   isHovered?: boolean;
+  isStacked?: boolean;
   shape?: NodeShape;
   interactionState?: string;
   executionStatus?: ElementStatusValues;
@@ -48,6 +49,7 @@ interface BaseContainerProps {
 export const BaseContainer = ({
   isSelected,
   isHovered,
+  isStacked,
   shape,
   interactionState,
   executionStatus,
@@ -76,9 +78,14 @@ export const BaseContainer = ({
         isHovered && 'shadow-(--canvas-node-shadow-hover) border-border-hover',
         isSelected && 'outline outline-2 outline-foreground-accent-muted',
         interactionState === 'disabled' && 'opacity-50 cursor-not-allowed',
-        interactionState === 'drag' && 'cursor-grabbing shadow-(--canvas-node-shadow-lifted)'
+        interactionState === 'drag' && 'cursor-grabbing shadow-(--canvas-node-shadow-lifted)',
+        // Decorative stacked layer for drillable / collapsed nodes. Purely visual:
+        // a ::before pseudo inherits the container's radius/size, sits behind at
+        // -z-10, and is offset down so only a thin arc peeks out below the card.
+        isStacked &&
+          'before:content-[""] before:absolute before:inset-x-0 before:top-0 before:h-full before:rounded-[inherit] before:bg-surface-overlay before:border before:border-brand before:translate-y-[6px] before:-z-10 before:pointer-events-none'
       ),
-    [shape, hasFooter, activeStatus, isSelected, isHovered, interactionState]
+    [shape, hasFooter, activeStatus, isSelected, isHovered, isStacked, interactionState]
   );
 
   return (
@@ -88,6 +95,7 @@ export const BaseContainer = ({
       data-interaction-state={interactionState}
       data-validation-status={validationStatus}
       data-suggestion-type={suggestionType}
+      data-stacked={isStacked || undefined}
       className={className}
       style={background ? { background } : undefined}
       aria-busy={loading || undefined}


### PR DESCRIPTION
- Adds new visual treatment for "stacked" nodes, which include for now drillable or collapsed nodes.

<img width="655" height="251" alt="Screenshot 2026-04-22 at 5 59 21 PM" src="https://github.com/user-attachments/assets/01381c42-11b8-462c-add7-9e8b9c3dc840" />
<img width="650" height="239" alt="Screenshot 2026-04-22 at 5 59 26 PM" src="https://github.com/user-attachments/assets/edb8aacf-ff93-43ba-bddd-cb1020a62ba3" />

https://github.com/user-attachments/assets/4d902c22-da5b-417b-980a-4237bd9fb8c1


