### PR TITLE
fix(apollo-react): handle and toolbar consistency [MST-8974]

### DIFF
--- a/packages/apollo-react/src/canvas/components/BaseNode/BaseNode.test.tsx
+++ b/packages/apollo-react/src/canvas/components/BaseNode/BaseNode.test.tsx
@@ -172,19 +172,19 @@ describe('BaseNode', () => {
     });
 
     it('shrinks back to user-provided height after handle removal', () => {
-      // User height=200, 8 handles need 320px
+      // User height=200, 8 handles need 288px
       mockHandleConfigs.current = makeHandles(Position.Left, 8);
       const { rerender } = render(<BaseNode {...defaultProps} height={200} />);
-      expect(mockUpdateNode).toHaveBeenCalledWith('test-node', { height: 320 });
+      expect(mockUpdateNode).toHaveBeenCalledWith('test-node', { height: 288 });
 
       // Simulate React Flow updating height
       mockUpdateNode.mockClear();
-      rerender(<BaseNode {...defaultProps} height={320} data={{}} />);
+      rerender(<BaseNode {...defaultProps} height={288} data={{}} />);
 
       // Remove handles — should return to 200, not DEFAULT_NODE_SIZE (96)
       mockHandleConfigs.current = [];
       mockUpdateNode.mockClear();
-      rerender(<BaseNode {...defaultProps} height={320} data={{}} />);
+      rerender(<BaseNode {...defaultProps} height={288} data={{}} />);
       expect(mockUpdateNode).toHaveBeenCalledWith('test-node', { height: 200 });
     });
 

--- a/packages/apollo-react/src/canvas/components/BaseNode/BaseNode.tsx
+++ b/packages/apollo-react/src/canvas/components/BaseNode/BaseNode.tsx
@@ -257,9 +257,6 @@ const BaseNodeComponent = (props: NodeProps<Node<BaseNodeData>>) => {
   // baseHeightRef is updated above from external height changes; handle inflation
   // is computed from the current handleConfigurations.
   const computedHeight = useMemo(() => {
-    // 2.5 grid units between handles to allow space for button handles and notches
-    const handleSpacing = 2.5 * GRID_SPACING;
-
     const leftHandles = handleConfigurations
       .filter((config) => config.position === Position.Left && config.visible !== false)
       .reduce(
@@ -276,7 +273,9 @@ const BaseNodeComponent = (props: NodeProps<Node<BaseNodeData>>) => {
 
     const leftRightHandles = Math.max(leftHandles, rightHandles);
 
-    return Math.max(baseHeightRef.current, leftRightHandles * handleSpacing);
+    // Each handle gets a 2-grid-space lane (32px), plus 2-grid-space padding at top + bottom of node.
+    const minNodeHeight = (leftRightHandles * 2 + 2) * GRID_SPACING;
+    return Math.max(baseHeightRef.current, minNodeHeight);
     // eslint-disable-next-line react-hooks/exhaustive-deps -- height is not read directly but triggers recalculation after baseHeightRef is updated above
   }, [handleConfigurations, height]);
 
@@ -393,9 +392,22 @@ const BaseNodeComponent = (props: NodeProps<Node<BaseNodeData>>) => {
   }, [disabled, dragging, selected, isHovered, isFocused]);
 
   const shouldShowHandles = useMemo(
-    () => isConnecting || selected || isHovered,
-    [isConnecting, selected, isHovered]
+    () => (isConnecting || selected || isHovered) && !dragging,
+    [isConnecting, selected, isHovered, dragging]
   );
+
+  const toolbarPosition = toolbarConfig?.position ?? (toolbarConfig ? Position.Top : undefined);
+
+  // True when handle buttons at the toolbar's position would collide with it.
+  const hasHandleButtonsAtToolbar = useMemo(() => {
+    if (!toolbarPosition || !handleConfigurations?.length) return false;
+    return handleConfigurations.some(
+      (config) =>
+        config.position === toolbarPosition &&
+        config.visible !== false &&
+        config.handles.some((h) => h.type === 'source' && h.showButton !== false)
+    );
+  }, [toolbarPosition, handleConfigurations]);
 
   const hasVisibleBottomHandles = useMemo(() => {
     if (
@@ -472,7 +484,7 @@ const BaseNodeComponent = (props: NodeProps<Node<BaseNodeData>>) => {
     nodeId: id,
     selected: selected ?? false,
     hovered: isHovered,
-    showAddButton: mode === 'design' && !multipleNodesSelected && !isConnecting,
+    showAddButton: mode === 'design' && !multipleNodesSelected && !isConnecting && !dragging,
     showNotches,
     nodeWidth: width,
     nodeHeight: height,
@@ -641,8 +653,9 @@ const BaseNodeComponent = (props: NodeProps<Node<BaseNodeData>>) => {
           <NodeToolbar
             nodeId={id}
             config={toolbarConfig}
-            expanded={selected}
+            expanded={selected || isHovered}
             hidden={dragging || multipleNodesSelected}
+            offsetToolbar={hasHandleButtonsAtToolbar}
           />
         )}
       </BaseContainer>

--- a/packages/apollo-react/src/canvas/components/ButtonHandle/ButtonHandle.test.tsx
+++ b/packages/apollo-react/src/canvas/components/ButtonHandle/ButtonHandle.test.tsx
@@ -276,22 +276,22 @@ describe('ButtonHandles', () => {
         { id: 'handle2', type: 'source', handleType: 'output' },
       ];
 
-      // With nodeWidth=100, gridSize=8: ideal=33.33, rounded=32, span=32, start=34
-      // Positions: [34, 66] → 34%, 66% (differs from percentage-based 33.33%, 66.66%)
+      // With nodeWidth=96, gridSize=16: ideal=32, rounded=32, span=32, start=32.
+      // Positions: [32, 64] → 33.333...%, 66.666...%
       render(
         <ButtonHandles
           handles={handles}
           nodeId="test-node"
           position={Position.Top}
-          nodeWidth={100}
+          nodeWidth={96}
         />
       );
 
       const handleElements = screen.getAllByTestId('handle');
       expect(handleElements).toHaveLength(2);
 
-      expect(handleElements[0]).toHaveStyle({ left: '34%' });
-      expect(handleElements[1]).toHaveStyle({ left: '66%' });
+      expect(handleElements[0]).toHaveStyle({ left: '33.33333333333333%' });
+      expect(handleElements[1]).toHaveStyle({ left: '66.66666666666666%' });
     });
 
     it('uses grid-aligned positioning for Left handles when nodeHeight is provided', () => {
@@ -306,15 +306,15 @@ describe('ButtonHandles', () => {
           handles={handles}
           nodeId="test-node"
           position={Position.Left}
-          nodeHeight={100}
+          nodeHeight={96}
         />
       );
 
       const handleElements = screen.getAllByTestId('handle');
       expect(handleElements).toHaveLength(2);
 
-      expect(handleElements[0]).toHaveStyle({ top: '34%' });
-      expect(handleElements[1]).toHaveStyle({ top: '66%' });
+      expect(handleElements[0]).toHaveStyle({ top: '33.33333333333333%' });
+      expect(handleElements[1]).toHaveStyle({ top: '66.66666666666666%' });
     });
 
     it('falls back to percentage-based positioning when node dimensions are not provided', () => {

--- a/packages/apollo-react/src/canvas/components/ButtonHandle/ButtonHandle.tsx
+++ b/packages/apollo-react/src/canvas/components/ButtonHandle/ButtonHandle.tsx
@@ -46,7 +46,7 @@ const ButtonHandleBase = ({
   handleType,
   label,
   labelIcon,
-  labelBackgroundColor = 'var(--canvas-background-secondary)',
+  labelBackgroundColor,
   visible = true,
   showButton = true,
   selected = false,

--- a/packages/apollo-react/src/canvas/components/ButtonHandle/ButtonHandleStyleUtils.test.ts
+++ b/packages/apollo-react/src/canvas/components/ButtonHandle/ButtonHandleStyleUtils.test.ts
@@ -885,27 +885,37 @@ describe('ButtonHandleStyleUtils', () => {
     });
 
     it('should calculate equidistant positions for 3 handles', () => {
-      // 3 handles, gridSize=8: ideal=96/4=24, rounded=24, span=48, start=(96-48)/2=24
-      // Positions: 24, 48, 72
-      expect(calculateGridAlignedHandlePositions(96, 3)).toEqual([24, 48, 72]);
+      // 3 handles, gridSize=16: ideal=96/4=24, rounded=32, span=64, start=(96-64)/2=16
+      // Positions: 16, 48, 80
+      expect(calculateGridAlignedHandlePositions(96, 3)).toEqual([16, 48, 80]);
     });
 
     it('should calculate equidistant positions for 4 handles', () => {
-      // 4 handles, gridSize=8: ideal=96/5=19.2, rounded=16, span=48, start=(96-48)/2=24
-      // Positions: 24, 40, 56, 72 (symmetric around 48)
+      // 4 handles, gridSize=16: ideal=96/5=19.2, rounded=16, start=24.
+      // Spacing is already at gridSize so parity fix cannot bump down further.
+      // In practice BaseNode auto-grows so 4 handles never fit in 96px.
       expect(calculateGridAlignedHandlePositions(96, 4)).toEqual([24, 40, 56, 72]);
     });
 
     it('should work with larger node sizes', () => {
-      // 160px, 3 handles, gridSize=8: ideal=40, rounded=40, span=80, start=40
-      // Positions: 40, 80, 120
-      expect(calculateGridAlignedHandlePositions(160, 3)).toEqual([40, 80, 120]);
+      // 160px, 3 handles, gridSize=16: ideal=40, rounded=48, span=96, start=32
+      // Positions: 32, 80, 128
+      expect(calculateGridAlignedHandlePositions(160, 3)).toEqual([32, 80, 128]);
+    });
+
+    it('should fix parity when fewer handles share a taller node', () => {
+      // 160px node (driven by 3 handles on the other side), 2 handles on this side.
+      // ideal=53.33, rounded=48, start=56 (off-grid).
+      // Parity fix bumps spacing down to 32: span=32, start=64.
+      // Positions: 64, 96 — both on 16px grid, handles stay inward
+      expect(calculateGridAlignedHandlePositions(160, 2)).toEqual([64, 96]);
     });
 
     it('should use custom grid size', () => {
-      // 100px, 2 handles, gridSize=10: ideal=100/3≈33.33, rounded=30, span=30, start=35
-      // Positions: 35, 65 (symmetric around 50)
-      expect(calculateGridAlignedHandlePositions(100, 2, 10)).toEqual([35, 65]);
+      // 100px, 2 handles, gridSize=10: ideal=33.33, rounded=30, start=35 (off-grid).
+      // Parity fix bumps spacing down to 20: span=20, start=40.
+      // Positions: 40, 60 (symmetric around 50)
+      expect(calculateGridAlignedHandlePositions(100, 2, 10)).toEqual([40, 60]);
     });
 
     it('should calculate equidistant positions for 5 handles', () => {
@@ -914,13 +924,11 @@ describe('ButtonHandleStyleUtils', () => {
       expect(calculateGridAlignedHandlePositions(96, 5)).toEqual([16, 32, 48, 64, 80]);
     });
 
-    it('should distribute even handle counts symmetrically when spacing is an odd multiple of gridSize', () => {
-      // 80px, 6 handles, gridSize=8: ideal=80/7≈11.43, rounded=8, span=40, start=20.
-      // Positions: 20, 28, 36, 44, 52, 60. Midpoint = (20+60)/2 = 40 = nodeSize/2 ✓
-      // Regression: per-position snapping (Math.round, half-up) used to shift the
-      // entire row to [24, 32, 40, 48, 56, 64] (midpoint 44, drift +4).
+    it('should distribute even handle counts symmetrically', () => {
+      // 80px, 6 handles, gridSize=16: ideal=80/7≈11.43, rounded=16, span=80, start=0.
+      // Positions: 0, 16, 32, 48, 64, 80. Midpoint = (0+80)/2 = 40 = nodeSize/2 ✓
       const positions = calculateGridAlignedHandlePositions(80, 6);
-      expect(positions).toEqual([20, 28, 36, 44, 52, 60]);
+      expect(positions).toEqual([0, 16, 32, 48, 64, 80]);
       expect((positions[0] + positions[positions.length - 1]) / 2).toBe(40);
     });
 

--- a/packages/apollo-react/src/canvas/components/ButtonHandle/ButtonHandleStyleUtils.ts
+++ b/packages/apollo-react/src/canvas/components/ButtonHandle/ButtonHandleStyleUtils.ts
@@ -44,28 +44,41 @@ export const snapToGrid = (value: number, gridSize: number = GRID_SPACING): numb
 export const calculateGridAlignedHandlePositions = (
   nodeSize: number,
   numHandles: number,
-  gridSize: number = GRID_SPACING / 2
+  gridSize: number = GRID_SPACING
 ): number[] => {
   if (numHandles === 0) return [];
   if (nodeSize <= 0) return [];
+  if (numHandles === 1) return [nodeSize / 2];
 
-  // Ideal equidistant spacing (with padding on either side equal to the spacing).
   const idealSpacing = nodeSize / (numHandles + 1);
 
+  // Grid alignment is only meaningful when the node itself sits on the grid.
+  // When nodeSize isn't a grid multiple, snapping spacing can't produce
+  // grid-aligned positions, so just return ideal equidistant positions.
+  if (nodeSize % gridSize !== 0) {
+    const positions: number[] = [];
+    for (let i = 0; i < numHandles; i++) {
+      positions.push(idealSpacing * (i + 1));
+    }
+    return positions;
+  }
+
   // Round to the nearest grid multiple, with a lower bound of one grid step so
-  // handles don't all stack at the center when `idealSpacing < gridSize / 2`
-  // (e.g. very small node, many handles).
-  //
-  // We deliberately do NOT cap spacing to fit the node: when the natural
-  // spacing would push handles outside the node bounds, we prefer overflow
-  // over visually crowding/overlapping handles inside the node.
-  // This scenario should not happen in typical usage since base node is expected to grow to fit handles.
+  // handles don't all stack at the center when `idealSpacing < gridSize / 2`.
   const roundedSpacing = Math.round(idealSpacing / gridSize) * gridSize;
-  const gridAlignedSpacing = Math.max(gridSize, roundedSpacing);
+  let gridAlignedSpacing = Math.max(gridSize, roundedSpacing);
 
   // Distribute symmetrically around the node center.
-  const totalSpan = (numHandles - 1) * gridAlignedSpacing;
-  const startPosition = (nodeSize - totalSpan) / 2;
+  let totalSpan = (numHandles - 1) * gridAlignedSpacing;
+  let startPosition = (nodeSize - totalSpan) / 2;
+
+  // Since nodeSize is a grid multiple, startPosition is either on-grid or
+  // exactly half a grid step off. Bump spacing down one grid step to fix parity.
+  if (startPosition % gridSize !== 0 && gridAlignedSpacing > gridSize) {
+    gridAlignedSpacing -= gridSize;
+    totalSpan = (numHandles - 1) * gridAlignedSpacing;
+    startPosition = (nodeSize - totalSpan) / 2;
+  }
 
   const positions: number[] = [];
   for (let i = 0; i < numHandles; i++) {

--- a/packages/apollo-react/src/canvas/components/ButtonHandle/HandleButton.tsx
+++ b/packages/apollo-react/src/canvas/components/ButtonHandle/HandleButton.tsx
@@ -3,6 +3,7 @@ import { Position } from '@uipath/apollo-react/canvas/xyflow/react';
 import { memo, useCallback, useEffect, useRef } from 'react';
 import { cx } from '../../utils/CssUtil';
 import { CanvasInlineButton } from './CanvasInlineButton';
+import { LABEL_SHADOW_STYLE } from './HandleLabel';
 
 const BUTTON_POSITION: Record<Position, string> = {
   [Position.Top]: 'flex-col-reverse bottom-full left-1/2 -translate-x-1/2',
@@ -86,6 +87,16 @@ export const HandleButton = memo(
               clientY: rect.top + rect.height / 2,
             })
           );
+          // Clear the source node's hover state so handles hide after the
+          // connection drag ends.  Dragging from the notch fires mouseleave
+          // naturally; here it doesn't because the pointer originated on the
+          // button.  A synthetic mouseout bubbles up to BaseNode's onMouseLeave.
+          handleEl.dispatchEvent(
+            new MouseEvent('mouseout', {
+              bubbles: true,
+              relatedTarget: document.body,
+            })
+          );
         }
       };
 
@@ -104,10 +115,7 @@ export const HandleButton = memo(
 
     return (
       <div
-        className={cx(
-          'absolute flex items-center gap-1 pointer-events-none',
-          BUTTON_POSITION[position]
-        )}
+        className={cx('absolute flex items-center pointer-events-none', BUTTON_POSITION[position])}
       >
         {visible && (
           <CanvasInlineButton
@@ -143,14 +151,19 @@ const InlineLabel = ({
 }) => (
   <div
     className={cx(
-      'px-1.5 py-0.5 rounded-sm whitespace-nowrap select-none transition-opacity duration-250',
+      'px-1.5 py-0.5 rounded-sm whitespace-nowrap select-none transition-opacity duration-250 z-10',
       visible ? 'opacity-100' : 'opacity-0'
     )}
     style={backgroundColor ? { backgroundColor } : undefined}
   >
     <Row align="center" gap={4}>
       {labelIcon}
-      <span className="text-xs font-bold text-foreground-muted">{label}</span>
+      <span
+        className="text-xs font-bold text-foreground-muted"
+        style={backgroundColor ? undefined : LABEL_SHADOW_STYLE}
+      >
+        {label}
+      </span>
     </Row>
   </div>
 );
@@ -170,7 +183,7 @@ export const HandleHoverBridge = memo(
     if (!visible) return null;
     const isVertical = position === Position.Top || position === Position.Bottom;
     return (
-      <div className={cx(BRIDGE_BASE, BRIDGE_POSITION[position], isVertical ? 'h-14' : 'w-14')} />
+      <div className={cx(BRIDGE_BASE, BRIDGE_POSITION[position], isVertical ? 'h-15' : 'w-15')} />
     );
   }
 );

--- a/packages/apollo-react/src/canvas/components/ButtonHandle/HandleLabel.tsx
+++ b/packages/apollo-react/src/canvas/components/ButtonHandle/HandleLabel.tsx
@@ -2,6 +2,10 @@ import { Row } from '@uipath/apollo-react/canvas/layouts';
 import { Position } from '@uipath/apollo-react/canvas/xyflow/react';
 import { cx } from '../../utils/CssUtil';
 
+export const LABEL_SHADOW_STYLE = {
+  textShadow: '0 0 4px var(--canvas-background), 0 0 4px var(--canvas-background)',
+} as const;
+
 const LABEL_POSITION: Record<Position, string> = {
   [Position.Top]: 'bottom-[calc(100%+4px)] left-1/2 -translate-x-1/2',
   [Position.Bottom]: 'top-[calc(100%+4px)] left-1/2 -translate-x-1/2',
@@ -17,7 +21,7 @@ export const HandleLabel = ({
   shouldTruncate,
 }: {
   position: Position;
-  backgroundColor: string;
+  backgroundColor?: string;
   label: string;
   labelIcon?: React.ReactNode;
   shouldTruncate?: boolean;
@@ -28,7 +32,7 @@ export const HandleLabel = ({
       LABEL_POSITION[position],
       shouldTruncate && 'max-w-[50px] overflow-hidden'
     )}
-    style={{ backgroundColor }}
+    style={backgroundColor ? { backgroundColor } : undefined}
   >
     <Row align="center" gap={4}>
       {labelIcon}
@@ -37,6 +41,7 @@ export const HandleLabel = ({
           'text-xs font-bold text-foreground-muted',
           shouldTruncate && 'overflow-hidden text-ellipsis whitespace-nowrap'
         )}
+        style={backgroundColor ? undefined : LABEL_SHADOW_STYLE}
       >
         {label}
       </span>

--- a/packages/apollo-react/src/canvas/components/ButtonHandle/SmartHandle.tsx
+++ b/packages/apollo-react/src/canvas/components/ButtonHandle/SmartHandle.tsx
@@ -553,7 +553,7 @@ export function SmartHandle({
   nodeHeight,
   label,
   labelIcon,
-  labelBackgroundColor = 'var(--canvas-background-secondary)',
+  labelBackgroundColor,
   showButton = false,
   selected = false,
   showNotches = true,

--- a/packages/apollo-react/src/canvas/components/Toolbar/NodeToolbar/NodeToolbar.tsx
+++ b/packages/apollo-react/src/canvas/components/Toolbar/NodeToolbar/NodeToolbar.tsx
@@ -13,12 +13,16 @@ const POSITIONER_BASE_CLASS = 'absolute flex pointer-events-none z-10';
 // Container enforces a 40px cross-axis (`min-h-10 min-w-10`) in every
 // orientation, so the same offset produces a consistent ~12px gap on every
 // side: 40 (toolbar) + 12 (gap) = 52.
+// `--toolbar-offset` (default 0) adds extra displacement to clear handle buttons.
 const POSITIONER_POSITION_CLASS: Record<'top' | 'bottom' | 'left' | 'right', string> = {
-  top: 'top-[-52px] left-0 right-0 flex-row',
-  bottom: 'bottom-[-52px] left-0 right-0 flex-row',
-  left: 'left-[-52px] top-0 bottom-0 flex-col',
-  right: 'right-[-52px] top-0 bottom-0 flex-col',
+  top: 'top-[calc(-52px-var(--toolbar-offset,0px))] left-0 right-0 flex-row',
+  bottom: 'bottom-[calc(-52px-var(--toolbar-offset,0px))] left-0 right-0 flex-row',
+  left: 'left-[calc(-52px-var(--toolbar-offset,0px))] top-0 bottom-0 flex-col',
+  right: 'right-[calc(-52px-var(--toolbar-offset,0px))] top-0 bottom-0 flex-col',
 };
+
+/** Extra displacement (px) applied when `offsetToolbar` is true. */
+const TOOLBAR_OFFSET = 48; // Clears the button handle + label + gaps
 
 const POSITIONER_ALIGN_CLASS: Record<'start' | 'center' | 'end', string> = {
   start: 'justify-start',
@@ -56,7 +60,13 @@ const DROPDOWN_ITEM_BASE_CLASS =
 const DROPDOWN_ITEM_DISABLED_CLASS = 'cursor-not-allowed opacity-40 pointer-events-none';
 const DROPDOWN_ITEM_ENABLED_CLASS = 'cursor-pointer opacity-100';
 
-const NodeToolbarComponent = ({ nodeId, config, expanded, hidden }: NodeToolbarProps) => {
+const NodeToolbarComponent = ({
+  nodeId,
+  config,
+  expanded,
+  hidden,
+  offsetToolbar,
+}: NodeToolbarProps) => {
   const {
     isDropdownOpen,
     setIsDropdownOpen,
@@ -95,6 +105,11 @@ const NodeToolbarComponent = ({ nodeId, config, expanded, hidden }: NodeToolbarP
     [separatorOrientation]
   );
 
+  const offsetStyle = useMemo(() => {
+    if (!offsetToolbar) return undefined;
+    return { '--toolbar-offset': `${TOOLBAR_OFFSET}px` } as React.CSSProperties;
+  }, [offsetToolbar]);
+
   const toolbarAnimationVariants = useMemo(() => {
     const offsetAxis = position === 'top' || position === 'bottom' ? 'y' : 'x';
     const offsetAmount = position === 'top' || position === 'left' ? -10 : 10;
@@ -119,7 +134,7 @@ const NodeToolbarComponent = ({ nodeId, config, expanded, hidden }: NodeToolbarP
   return (
     <AnimatePresence>
       {displayState !== 'hidden' && (
-        <div className={positionerClassName}>
+        <div className={positionerClassName} style={offsetStyle}>
           <motion.div
             layout="position"
             className={containerClassName}

--- a/packages/apollo-react/src/canvas/components/Toolbar/NodeToolbar/NodeToolbar.types.ts
+++ b/packages/apollo-react/src/canvas/components/Toolbar/NodeToolbar/NodeToolbar.types.ts
@@ -14,4 +14,6 @@ export interface NodeToolbarProps {
   expanded: boolean;
   /** When true, forcefully hides all toolbar actions including pinned items */
   hidden?: boolean;
+  /** When true, push the toolbar further from the node to clear handle buttons. */
+  offsetToolbar?: boolean;
 }

--- a/packages/apollo-react/src/canvas/styles/reactflow-reset.css
+++ b/packages/apollo-react/src/canvas/styles/reactflow-reset.css
@@ -34,6 +34,15 @@
 }
 
 /**
+ * Elevate hovered nodes so toolbars and handle buttons aren't clipped by
+ * neighboring node wrappers. React Flow sets z-index inline, so `!important`
+ * is required to override it.
+ */
+.react-flow__node:hover {
+  z-index: 1000 !important;
+}
+
+/**
  * Canvas pane gradient for future themes.
  *
  * <Background /> passes bgColor as `background-color`, which only accepts


### PR DESCRIPTION
- Node toolbar floats above handles when they are on the same side.
- Node toolbar shows on hover.
- Handles hide while dragging (and hover is cleared when dragging from handle button).
- Handle labels use text-shadow instead of background.
- Handles align better with grid.


https://github.com/user-attachments/assets/cbfdcdb4-0932-484d-879e-f841ab9daaa9

