### PR TITLE
fix(apollo-vertex): contain viewport-sized and fixed children in preview wrapper

### DIFF
--- a/apps/apollo-vertex/app/_components/preview-full-screen.tsx
+++ b/apps/apollo-vertex/app/_components/preview-full-screen.tsx
@@ -31,7 +31,9 @@ export function PreviewFullScreen({
         style={{ height }}
       >
         {!isOpen && (
-          <div className="[&_.h-screen]:!h-full h-full">{children}</div>
+          <div className="[&_.h-screen]:!h-full [&_.h-svh]:!h-full [&_.min-h-svh]:!min-h-full h-full [transform:translateZ(0)]">
+            {children}
+          </div>
         )}
         <DialogTrigger asChild>
           <Button
@@ -59,7 +61,9 @@ export function PreviewFullScreen({
             <Minimize2 className="size-4" />
           </Button>
         </DialogClose>
-        <div className="[&_.h-screen]:!h-full h-full">{children}</div>
+        <div className="[&_.h-screen]:!h-full [&_.h-svh]:!h-full [&_.min-h-svh]:!min-h-full h-full [transform:translateZ(0)]">
+          {children}
+        </div>
       </DialogContent>
     </Dialog>
   );


### PR DESCRIPTION
Next PR updates the shell to use SidebarProvider which will cause the sidebar to not be properly contained by the preview containers. This fix allows the sidebar to preview properly in the docs pages.