### PR TITLE
feat(apollo-vertex): add list page template

### DIFF
--- a/apps/apollo-vertex/app/templates/_meta.ts
+++ b/apps/apollo-vertex/app/templates/_meta.ts
@@ -1,3 +1,4 @@
 export default {
   dashboards: "Dashboards",
+  "list-page": "List page",
 };

--- a/apps/apollo-vertex/app/templates/list-page/page.mdx
+++ b/apps/apollo-vertex/app/templates/list-page/page.mdx
@@ -1,0 +1,63 @@
+import { ListPageTemplate } from '@/templates/list-page/ListPageTemplate';
+import { PreviewFullScreen } from '@/app/_components/preview-full-screen';
+
+# List page
+
+A full-page composition for listing records with summary metrics and a
+filterable data table. Built from the `PageHeader`, `MetricCard`,
+and `DataTable` primitives, laid out on the 12-column foundations grid,
+and intended to render inside an [`ApolloShell`](/patterns/shell).
+
+<PreviewFullScreen title="List page preview">
+    <ListPageTemplate />
+</PreviewFullScreen>
+
+## Composition
+
+From top to bottom the template stacks:
+
+- **[`Shell`](/patterns/shell)** (outer) — provides the chrome (sidebar,
+  header, auth, theme). Wrap the rest of the page inside `ApolloShell`.
+- **`PageHeader`** — title and contextual actions (refresh, time range).
+- **Metric cards row** — four `MetricCard`s summarizing pipeline counts.
+- **`DataTable`** — the record list with search, column filters, and
+  pagination. Toolbar filters target columns directly via `column={...}`.
+
+The content region uses the [layout grid](/foundation/grid): `4` columns on
+mobile, `8` on tablet, `12` on desktop, with matching `px-4 / sm:px-6 /
+lg:px-8` margins so it aligns with the default `PageHeader` padding.
+
+Source: [`templates/list-page/ClinicalReviewList.tsx`](https://github.com/UiPath/apollo-ui/blob/main/apps/apollo-vertex/templates/list-page/ClinicalReviewList.tsx)
+
+## Installation
+
+The composition itself is a pattern — copy the source from
+`templates/list-page/ClinicalReviewList.tsx` into your app, wrap it in
+`ApolloShell`, and swap in your own data. The underlying components install
+from the registry:
+
+```bash
+npx shadcn@latest add @uipath/shell
+npx shadcn@latest add @uipath/page-header
+npx shadcn@latest add @uipath/metric-card
+npx shadcn@latest add @uipath/data-table
+npx shadcn@latest add @uipath/filter-dropdown
+```
+
+## Customizing
+
+- **Metric count** — the grid is 12 columns on desktop, so two cards use
+  `lg:col-span-6`, three use `lg:col-span-4`, four use `lg:col-span-3`, six
+  use `lg:col-span-2`.
+- **Row clickability** — pass `onRowClick={(row) => navigate(...)}` to
+  `DataTable` to enable the hover state and open a detail view.
+- **Table density** — `DataTable` accepts `isLoading`,
+  `skeletonColumnWidths`, `enableSearch`, `enableViewOptions`, and a
+  `toolbarContent` render prop for filters.
+- **Status colors** — `Badge`'s `status` prop (`success | info | warning |
+  error`) maps directly to semantic tokens, so status colors follow the
+  theme.
+- **i18n** — `DataTable` uses `react-i18next`; wrap your app in
+  `ApolloShell` (which initializes i18n via `LocaleProvider`) or provide
+  your own `I18nextProvider` so strings like the pagination count render
+  correctly.

--- a/apps/apollo-vertex/templates/list-page/ClinicalReviewList.tsx
+++ b/apps/apollo-vertex/templates/list-page/ClinicalReviewList.tsx
@@ -1,0 +1,316 @@
+"use client";
+
+import type { ColumnDef } from "@tanstack/react-table";
+import { RefreshCw } from "lucide-react";
+import { useState } from "react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  DataTable,
+  DataTableColumnHeader,
+  dataTableFacetedFilterFn,
+  dataTableGlobalFilterFn,
+} from "@/components/ui/data-table";
+import {
+  FilterDropdown,
+  type FilterDropdownOption,
+} from "@/components/ui/filter-dropdown";
+import { MetricCard } from "@/components/ui/metric-card";
+import {
+  PageHeader,
+  PageHeaderActions,
+  PageHeaderNav,
+  PageHeaderTitle,
+} from "@/components/ui/page-header";
+import { useDataTable } from "@/registry/use-data-table/useDataTable";
+
+type ReviewStatus = "ready" | "in_progress" | "approved" | "rejected";
+
+const UNASSIGNED = "Unassigned";
+
+interface ClinicalReviewRecord {
+  id: string;
+  patient: string;
+  status: ReviewStatus;
+  /** Reviewer display name, or the literal "Unassigned" if none. */
+  reviewer: string;
+  template: string;
+  createdAt: string;
+}
+
+const STATUSES: {
+  value: ReviewStatus;
+  label: string;
+  badgeStatus: "success" | "info" | "warning" | "error";
+}[] = [
+  { value: "ready", label: "Ready for review", badgeStatus: "info" },
+  { value: "in_progress", label: "Review started", badgeStatus: "warning" },
+  { value: "approved", label: "Approved", badgeStatus: "success" },
+  { value: "rejected", label: "Rejected", badgeStatus: "error" },
+];
+
+const statusByValue = new Map(STATUSES.map((s) => [s.value, s]));
+
+const statusFilterOptions: FilterDropdownOption[] = STATUSES.map(
+  ({ value, label }) => ({ value, label }),
+);
+
+const timeFilterOptions: FilterDropdownOption[] = [
+  { value: "all", label: "All time" },
+  { value: "7d", label: "Last 7 days" },
+  { value: "30d", label: "Last 30 days" },
+  { value: "90d", label: "Last 90 days" },
+];
+
+const REVIEWERS = ["Dr. Mei Chen", "Dr. Anika Patel", "Dr. Julian Rivera"];
+
+const reviewerFilterOptions: FilterDropdownOption[] = [
+  { value: "Unassigned", label: "Unassigned" },
+  ...REVIEWERS.map((r) => ({ value: r, label: r })),
+];
+
+const records: ClinicalReviewRecord[] = [
+  {
+    id: "rec-4821",
+    patient: "Harrison, Oliver",
+    status: "ready",
+    reviewer: UNASSIGNED,
+    template: "Discharge Summary v2",
+    createdAt: "2026-04-22T09:14:00Z",
+  },
+  {
+    id: "rec-4820",
+    patient: "Nakamura, Yui",
+    status: "in_progress",
+    reviewer: "Dr. Mei Chen",
+    template: "Oncology Consult",
+    createdAt: "2026-04-22T08:02:00Z",
+  },
+  {
+    id: "rec-4819",
+    patient: "Vasquez, Elena",
+    status: "in_progress",
+    reviewer: "Dr. Anika Patel",
+    template: "ED Encounter",
+    createdAt: "2026-04-21T17:45:00Z",
+  },
+  {
+    id: "rec-4818",
+    patient: "Okafor, Chinedu",
+    status: "approved",
+    reviewer: "Dr. Julian Rivera",
+    template: "Discharge Summary v2",
+    createdAt: "2026-04-21T14:18:00Z",
+  },
+  {
+    id: "rec-4817",
+    patient: "Bauer, Lena",
+    status: "rejected",
+    reviewer: "Dr. Anika Patel",
+    template: "Radiology Report",
+    createdAt: "2026-04-21T11:02:00Z",
+  },
+  {
+    id: "rec-4816",
+    patient: "Morales, Santiago",
+    status: "ready",
+    reviewer: UNASSIGNED,
+    template: "ED Encounter",
+    createdAt: "2026-04-20T19:33:00Z",
+  },
+  {
+    id: "rec-4815",
+    patient: "Petrov, Anastasia",
+    status: "approved",
+    reviewer: "Dr. Mei Chen",
+    template: "Oncology Consult",
+    createdAt: "2026-04-20T15:21:00Z",
+  },
+  {
+    id: "rec-4814",
+    patient: "Thompson, Alice",
+    status: "ready",
+    reviewer: UNASSIGNED,
+    template: "Discharge Summary v2",
+    createdAt: "2026-04-19T16:12:00Z",
+  },
+];
+
+const dateFormatter = new Intl.DateTimeFormat("en-US", {
+  month: "short",
+  day: "numeric",
+  year: "numeric",
+});
+
+const columns: ColumnDef<ClinicalReviewRecord>[] = [
+  {
+    accessorKey: "patient",
+    minSize: 220,
+    header: ({ column }) => (
+      <DataTableColumnHeader column={column} title="Summary" />
+    ),
+    cell: ({ row }) => (
+      <span className="truncate font-medium">{row.original.patient}</span>
+    ),
+  },
+  {
+    accessorKey: "status",
+    minSize: 140,
+    header: ({ column }) => (
+      <DataTableColumnHeader column={column} title="Review status" />
+    ),
+    cell: ({ row }) => {
+      const meta = statusByValue.get(row.original.status);
+      if (!meta) return null;
+      return (
+        <Badge variant="secondary" status={meta.badgeStatus}>
+          {meta.label}
+        </Badge>
+      );
+    },
+    filterFn: dataTableFacetedFilterFn,
+  },
+  {
+    accessorKey: "reviewer",
+    minSize: 180,
+    header: ({ column }) => (
+      <DataTableColumnHeader column={column} title="Reviewer" />
+    ),
+    cell: ({ row }) => {
+      const reviewer = row.original.reviewer;
+      if (reviewer === UNASSIGNED) {
+        return (
+          <span className="text-muted-foreground italic">{UNASSIGNED}</span>
+        );
+      }
+      return <span className="truncate">{reviewer}</span>;
+    },
+    filterFn: dataTableFacetedFilterFn,
+  },
+  {
+    accessorKey: "template",
+    minSize: 180,
+    header: ({ column }) => (
+      <DataTableColumnHeader column={column} title="Template" />
+    ),
+    cell: ({ row }) => <div className="truncate">{row.original.template}</div>,
+  },
+  {
+    accessorKey: "createdAt",
+    minSize: 140,
+    header: ({ column }) => (
+      <DataTableColumnHeader column={column} title="Date created" />
+    ),
+    cell: ({ row }) => (
+      <span className="text-muted-foreground whitespace-nowrap">
+        {dateFormatter.format(new Date(row.original.createdAt))}
+      </span>
+    ),
+  },
+];
+
+export function ClinicalReviewList() {
+  const [timeRange, setTimeRange] = useState<string>("all");
+  const tableState = useDataTable({
+    data: records,
+    columns,
+    storageKey: "clinical-review-list",
+  });
+
+  const counts = {
+    ready: records.filter((r) => r.status === "ready").length,
+    approved: records.filter((r) => r.status === "approved").length,
+    rejected: records.filter((r) => r.status === "rejected").length,
+    total: records.length,
+  };
+
+  return (
+    <div className="relative z-10">
+      <PageHeader>
+        <PageHeaderNav>
+          <PageHeaderTitle>Clinical review</PageHeaderTitle>
+        </PageHeaderNav>
+        <PageHeaderActions>
+          <Button
+            variant="ghost"
+            size="icon"
+            aria-label="Refresh list"
+            className="size-9"
+          >
+            <RefreshCw className="size-4" />
+          </Button>
+          <FilterDropdown
+            title="Time"
+            options={timeFilterOptions}
+            multiSelect={false}
+            value={timeRange}
+            onChange={(v) => {
+              if (typeof v === "string") setTimeRange(v);
+            }}
+          />
+          <Button>Add summary</Button>
+        </PageHeaderActions>
+      </PageHeader>
+
+      <div className="px-4 sm:px-6 lg:px-8 pb-8">
+        <div className="grid grid-cols-4 sm:grid-cols-8 lg:grid-cols-12 gap-4 mb-8">
+          <div className="col-span-2 sm:col-span-4 lg:col-span-3">
+            <MetricCard
+              label="Ready for review"
+              value={counts.ready}
+              trend="up"
+              percentage={18}
+            />
+          </div>
+          <div className="col-span-2 sm:col-span-4 lg:col-span-3">
+            <MetricCard
+              label="Approved"
+              value={counts.approved}
+              trend="up"
+              percentage={9}
+            />
+          </div>
+          <div className="col-span-2 sm:col-span-4 lg:col-span-3">
+            <MetricCard
+              label="Rejected"
+              value={counts.rejected}
+              trend="down"
+              percentage={12}
+              isLowerBetter
+            />
+          </div>
+          <div className="col-span-2 sm:col-span-4 lg:col-span-3">
+            <MetricCard
+              label="Total summaries"
+              value={counts.total}
+              trend="up"
+              percentage={6}
+            />
+          </div>
+        </div>
+
+        <DataTable
+          {...tableState}
+          enableViewOptions={false}
+          globalFilterFn={dataTableGlobalFilterFn}
+          toolbarContent={(table) => (
+            <>
+              <FilterDropdown
+                column={table.getColumn("status")}
+                title="Status"
+                options={statusFilterOptions}
+              />
+              <FilterDropdown
+                column={table.getColumn("reviewer")}
+                title="Reviewer"
+                options={reviewerFilterOptions}
+                searchPlaceholder="Search people..."
+                popoverWidth="w-56"
+              />
+            </>
+          )}
+        />
+      </div>
+    </div>
+  );
+}

--- a/apps/apollo-vertex/templates/list-page/ListPageTemplate.tsx
+++ b/apps/apollo-vertex/templates/list-page/ListPageTemplate.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import dynamic from "next/dynamic";
+import { ClinicalReviewList } from "./ClinicalReviewList";
+
+function ListPageTemplateContent() {
+  // Preview-only: hide the unresolved "{{selected}} of {{total}}" i18n
+  // placeholder (real apps provide an i18n instance via ApolloShell's
+  // LocaleProvider), and pull pagination nav to the right.
+  const previewOnlyClasses =
+    "[&_[data-slot=data-table-pagination]>div:first-child]:hidden" +
+    " [&_[data-slot=data-table-pagination]>div:last-child]:flex-1" +
+    " [&_[data-slot=data-table-pagination]>div:last-child>div:first-child]:mr-auto";
+  return (
+    <div
+      className={`h-full bg-background dark:bg-sidebar overflow-y-auto custom-scrollbar ${previewOnlyClasses}`}
+    >
+      <ClinicalReviewList />
+    </div>
+  );
+}
+
+export const ListPageTemplate = dynamic(
+  () => Promise.resolve(ListPageTemplateContent),
+  { ssr: false },
+);


### PR DESCRIPTION
We want to provide a list page template composed of the page header, metrics cards, and data table components to allow teams to easily pull full page layouts to use in their apps.