### PR TITLE
docs(apollo-vertex): prefer existing hook packages in AGENTS.md

### DIFF
--- a/apps/apollo-vertex/AGENTS.md
+++ b/apps/apollo-vertex/AGENTS.md
@@ -145,6 +145,14 @@ export type { ButtonProps };
 - **Utilities**: camelCase (`cn`, `formatDate`)
 - **CSS variables**: kebab-case (`--color-primary`, `--spacing-md`)
 
+### Hooks
+
+Before implementing a custom hook, check whether a well-maintained, widely-used
+package already provides it. Prefer adopting a battle-tested implementation
+over writing one from scratch — it saves maintenance, edge-case handling, and
+test surface. Only implement a hook locally when no suitable package exists,
+the package is unmaintained, or the dependency cost outweighs the benefit.
+
 ### Tailwind CSS
 - Use Tailwind utility classes directly in JSX
 - Use `cn()` to merge conditional classes


### PR DESCRIPTION
## Summary
- Add a **Hooks** subsection to `apps/apollo-vertex/AGENTS.md` instructing agents to check for a well-maintained, widely-used package before implementing a custom hook from scratch.

## Test plan
- [x] Documentation-only change; no build/test impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)