### PR TITLE
fix(apollo-wind): DataTable headers stay put, resize feels grabbable, body scrolls independently

### DIFF
--- a/packages/apollo-wind/src/components/ui/data-table.stories.tsx
+++ b/packages/apollo-wind/src/components/ui/data-table.stories.tsx
@@ -1061,6 +1061,180 @@ export const Density = {
 };
 
 // ============================================================================
+// Scrolling & Resizing
+// ============================================================================
+
+const manyUsers: User[] = Array.from({ length: 40 }, (_, i) => {
+  const base = sampleUsers[i % sampleUsers.length];
+  return { ...base, id: `sticky-${i + 1}`, name: `${base.name} ${i + 1}` };
+});
+
+function StickyHeaderExample() {
+  const columns: ColumnDef<User>[] = [
+    {
+      accessorKey: 'name',
+      header: ({ column }) => <DataTableColumnHeader column={column} title="Name" />,
+    },
+    {
+      accessorKey: 'email',
+      header: ({ column }) => <DataTableColumnHeader column={column} title="Email" />,
+    },
+    {
+      accessorKey: 'role',
+      header: ({ column }) => <DataTableColumnHeader column={column} title="Role" />,
+    },
+    {
+      accessorKey: 'department',
+      header: ({ column }) => <DataTableColumnHeader column={column} title="Department" />,
+    },
+    {
+      accessorKey: 'status',
+      header: ({ column }) => <DataTableColumnHeader column={column} title="Status" />,
+      cell: ({ row }) => statusBadge(row.getValue('status')),
+    },
+  ];
+
+  return (
+    <div className="space-y-2">
+      <p className="text-sm text-muted-foreground">
+        Scroll the table body — the column headers stay pinned. The scrollbar is confined to the
+        body region via <code>maxBodyHeight</code>, so it doesn't run up next to the header row.
+      </p>
+      <DataTable
+        columns={columns}
+        data={manyUsers}
+        maxBodyHeight="24rem"
+        showPagination={false}
+        showColumnToggle={false}
+      />
+    </div>
+  );
+}
+
+export const StickyHeader = {
+  name: 'Sticky Header',
+  render: () => <StickyHeaderExample />,
+};
+
+type ResizableRow = User & {
+  team: string;
+  manager: string;
+  location: string;
+  lastActive: string;
+  employeeId: string;
+};
+
+const teams = ['Platform', 'Growth', 'Data', 'Insights', 'Runtime'];
+const managers = ['Pat Jenkins', 'Sam Okonkwo', 'Riley Kim', 'Morgan Chen', 'Alex Petrov'];
+const locations = ['Bucharest', 'Seattle', 'Bengaluru', 'London', 'New York', 'Tokyo'];
+
+const resizableSampleRows: ResizableRow[] = sampleUsers.map((u, i) => ({
+  ...u,
+  team: teams[i % teams.length],
+  manager: managers[i % managers.length],
+  location: locations[i % locations.length],
+  lastActive: `2026-04-${String(10 + (i % 14)).padStart(2, '0')} 14:32`,
+  employeeId: `EMP-${String(10000 + i)}`,
+}));
+
+function ResizableNarrowColumnsExample() {
+  const columns: ColumnDef<ResizableRow>[] = [
+    {
+      accessorKey: 'name',
+      header: ({ column }) => (
+        <DataTableColumnHeader column={column} title="Full contact name" />
+      ),
+      size: 160,
+      minSize: 60,
+    },
+    {
+      accessorKey: 'email',
+      header: ({ column }) => (
+        <DataTableColumnHeader column={column} title="Primary email address" />
+      ),
+      size: 170,
+      minSize: 60,
+    },
+    {
+      accessorKey: 'role',
+      header: ({ column }) => <DataTableColumnHeader column={column} title="Role" />,
+      size: 110,
+      minSize: 60,
+    },
+    {
+      accessorKey: 'department',
+      header: ({ column }) => (
+        <DataTableColumnHeader column={column} title="Department assignment" />
+      ),
+      size: 150,
+      minSize: 60,
+    },
+    {
+      accessorKey: 'team',
+      header: ({ column }) => <DataTableColumnHeader column={column} title="Team" />,
+      size: 110,
+      minSize: 60,
+    },
+    {
+      accessorKey: 'manager',
+      header: ({ column }) => <DataTableColumnHeader column={column} title="Direct manager" />,
+      size: 140,
+      minSize: 60,
+    },
+    {
+      accessorKey: 'location',
+      header: ({ column }) => <DataTableColumnHeader column={column} title="Office location" />,
+      size: 140,
+      minSize: 60,
+    },
+    {
+      accessorKey: 'joined',
+      header: ({ column }) => <DataTableColumnHeader column={column} title="Date joined" />,
+      size: 120,
+      minSize: 60,
+    },
+    {
+      accessorKey: 'lastActive',
+      header: ({ column }) => (
+        <DataTableColumnHeader column={column} title="Last activity timestamp" />
+      ),
+      size: 170,
+      minSize: 60,
+    },
+    {
+      accessorKey: 'status',
+      header: ({ column }) => <DataTableColumnHeader column={column} title="Status" />,
+      cell: ({ row }) => statusBadge(row.getValue('status')),
+      size: 100,
+      minSize: 60,
+    },
+  ];
+
+  return (
+    <div className="space-y-2">
+      <p className="text-sm text-muted-foreground">
+        Ten columns sized to fill a typical canvas. Long titles start narrower than their text so
+        the ellipsis is visible immediately. Drag any column divider to resize — the handle
+        brightens and thickens on hover and during drag, and narrowing further keeps each label
+        cleanly truncated without bleeding into the next column.
+      </p>
+      <DataTable
+        columns={columns}
+        data={resizableSampleRows}
+        resizable
+        showPagination={false}
+        showColumnToggle={false}
+      />
+    </div>
+  );
+}
+
+export const ResizableNarrowColumns = {
+  name: 'Resizable Narrow Columns',
+  render: () => <ResizableNarrowColumnsExample />,
+};
+
+// ============================================================================
 // Examples
 // ============================================================================
 

--- a/packages/apollo-wind/src/components/ui/data-table.stories.tsx
+++ b/packages/apollo-wind/src/components/ui/data-table.stories.tsx
@@ -1141,9 +1141,7 @@ function ResizableNarrowColumnsExample() {
   const columns: ColumnDef<ResizableRow>[] = [
     {
       accessorKey: 'name',
-      header: ({ column }) => (
-        <DataTableColumnHeader column={column} title="Full contact name" />
-      ),
+      header: ({ column }) => <DataTableColumnHeader column={column} title="Full contact name" />,
       size: 160,
       minSize: 60,
     },

--- a/packages/apollo-wind/src/components/ui/data-table.tsx
+++ b/packages/apollo-wind/src/components/ui/data-table.tsx
@@ -266,6 +266,11 @@ export function DataTable<TData, TValue>({
                       <TableCell
                         key={cell.id}
                         className={compact ? 'h-8 truncate px-2 py-0' : 'h-12 truncate px-4 py-0'}
+                        title={
+                          typeof cell.getValue() === 'string' || typeof cell.getValue() === 'number'
+                            ? String(cell.getValue())
+                            : undefined
+                        }
                         style={{
                           width: resizable
                             ? cell.column.getSize()
@@ -353,6 +358,7 @@ export function DataTableColumnHeader<TData, TValue>({
       size="sm"
       className="-ml-3 h-8 max-w-full data-[state=open]:bg-accent"
       onClick={handleClick}
+      title={title}
     >
       <span className="truncate min-w-0">{title}</span>
       {children}

--- a/packages/apollo-wind/src/components/ui/data-table.tsx
+++ b/packages/apollo-wind/src/components/ui/data-table.tsx
@@ -266,11 +266,15 @@ export function DataTable<TData, TValue>({
                       <TableCell
                         key={cell.id}
                         className={compact ? 'h-8 truncate px-2 py-0' : 'h-12 truncate px-4 py-0'}
-                        title={
-                          typeof cell.getValue() === 'string' || typeof cell.getValue() === 'number'
-                            ? String(cell.getValue())
-                            : undefined
-                        }
+                        onMouseEnter={(e) => {
+                          const el = e.currentTarget;
+                          const value = cell.getValue();
+                          el.title =
+                            el.scrollWidth > el.clientWidth &&
+                            (typeof value === 'string' || typeof value === 'number')
+                              ? String(value)
+                              : '';
+                        }}
                         style={{
                           width: resizable
                             ? cell.column.getSize()
@@ -358,7 +362,10 @@ export function DataTableColumnHeader<TData, TValue>({
       size="sm"
       className="-ml-3 h-8 max-w-full data-[state=open]:bg-accent"
       onClick={handleClick}
-      title={title}
+      onMouseEnter={(e) => {
+        const span = e.currentTarget.querySelector<HTMLSpanElement>('span');
+        e.currentTarget.title = span && span.scrollWidth > span.clientWidth ? title : '';
+      }}
     >
       <span className="truncate min-w-0">{title}</span>
       {children}

--- a/packages/apollo-wind/src/components/ui/data-table.tsx
+++ b/packages/apollo-wind/src/components/ui/data-table.tsx
@@ -187,10 +187,7 @@ export function DataTable<TData, TValue>({
         )}
       </div>
       <div
-        className={cn(
-          'rounded-md border',
-          useBlockLayout ? 'overflow-x-auto' : 'overflow-auto'
-        )}
+        className={cn('rounded-md border', useBlockLayout ? 'overflow-x-auto' : 'overflow-auto')}
       >
         <Table
           className={useBlockLayout ? 'block' : undefined}
@@ -256,9 +253,7 @@ export function DataTable<TData, TValue>({
             ))}
           </TableHeader>
           <TableBody
-            className={
-              useBlockLayout ? cn('block overflow-y-auto', blockRowClasses) : undefined
-            }
+            className={useBlockLayout ? cn('block overflow-y-auto', blockRowClasses) : undefined}
             style={useBlockLayout ? { maxHeight: maxBodyHeight } : undefined}
             tabIndex={useBlockLayout ? 0 : undefined}
           >

--- a/packages/apollo-wind/src/components/ui/data-table.tsx
+++ b/packages/apollo-wind/src/components/ui/data-table.tsx
@@ -20,6 +20,7 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table';
+import { cn } from '@/lib';
 import {
   CellContext,
   Column,
@@ -53,6 +54,12 @@ export interface DataTableProps<TData, TValue> {
   rowSelection?: RowSelectionState;
   onRowSelectionChange?: (selection: RowSelectionState) => void;
   toolbarContent?: React.ReactNode;
+  /**
+   * When set, the table body scrolls independently with this max height (any CSS length).
+   * The header stays above the scroll region and the vertical scrollbar is confined to the
+   * body, leaving the header row clear of scrollbar tracks.
+   */
+  maxBodyHeight?: string;
 }
 
 export function DataTable<TData, TValue>({
@@ -71,7 +78,10 @@ export function DataTable<TData, TValue>({
   rowSelection: controlledRowSelection,
   onRowSelectionChange: controlledOnRowSelectionChange,
   toolbarContent,
+  maxBodyHeight,
 }: DataTableProps<TData, TValue>) {
+  const useBlockLayout = maxBodyHeight !== undefined;
+  const blockRowClasses = '[&>tr]:table [&>tr]:w-full [&>tr]:table-fixed';
   const [sorting, setSorting] = React.useState<SortingState>([]);
   const [columnFilters, setColumnFilters] = React.useState<ColumnFiltersState>([]);
   const [columnVisibility, setColumnVisibility] = React.useState<VisibilityState>({});
@@ -176,11 +186,22 @@ export function DataTable<TData, TValue>({
           </DropdownMenu>
         )}
       </div>
-      <div className="rounded-md border overflow-auto">
+      <div
+        className={cn(
+          'rounded-md border',
+          useBlockLayout ? 'overflow-x-auto' : 'overflow-auto'
+        )}
+      >
         <Table
+          className={useBlockLayout ? 'block' : undefined}
           style={resizable ? { width: table.getTotalSize(), tableLayout: 'fixed' } : undefined}
         >
-          <TableHeader>
+          <TableHeader
+            className={cn(
+              'sticky top-0 z-10 bg-background',
+              useBlockLayout && `block ${blockRowClasses}`
+            )}
+          >
             {table.getHeaderGroups().map((headerGroup) => (
               <TableRow key={headerGroup.id}>
                 {headerGroup.headers.map((header) => {
@@ -188,7 +209,10 @@ export function DataTable<TData, TValue>({
                   return (
                     <TableHead
                       key={header.id}
-                      className={compact ? 'relative h-8 px-2 py-0' : 'relative py-0'}
+                      className={cn(
+                        compact ? 'relative h-8 px-2 py-0' : 'relative py-0',
+                        resizable && 'overflow-visible'
+                      )}
                       style={{
                         width: resizable
                           ? header.getSize()
@@ -216,11 +240,12 @@ export function DataTable<TData, TValue>({
                           className={`absolute -right-1 top-0 z-10 h-full w-2 cursor-col-resize select-none touch-none group`}
                         >
                           <div
-                            className={`h-full w-px mx-auto ${
+                            className={cn(
+                              'h-full mx-auto transition-all duration-150',
                               header.column.getIsResizing()
-                                ? 'bg-primary'
-                                : 'group-hover:bg-primary/50'
-                            }`}
+                                ? 'w-0.5 bg-primary'
+                                : 'w-px group-hover:w-0.5 group-hover:bg-primary'
+                            )}
                           />
                         </div>
                       )}
@@ -230,7 +255,13 @@ export function DataTable<TData, TValue>({
               </TableRow>
             ))}
           </TableHeader>
-          <TableBody>
+          <TableBody
+            className={
+              useBlockLayout ? cn('block overflow-y-auto', blockRowClasses) : undefined
+            }
+            style={useBlockLayout ? { maxHeight: maxBodyHeight } : undefined}
+            tabIndex={useBlockLayout ? 0 : undefined}
+          >
             {table.getRowModel().rows?.length ? (
               table.getRowModel().rows.map((row) => (
                 <TableRow key={row.id} data-state={row.getIsSelected() && 'selected'}>
@@ -325,10 +356,10 @@ export function DataTableColumnHeader<TData, TValue>({
     <Button
       variant="ghost"
       size="sm"
-      className="-ml-3 h-8 data-[state=open]:bg-accent"
+      className="-ml-3 h-8 max-w-full data-[state=open]:bg-accent"
       onClick={handleClick}
     >
-      <span>{title}</span>
+      <span className="truncate min-w-0">{title}</span>
       {children}
       {sorted === 'asc' ? (
         <ArrowUp className="ml-2 h-4 w-4" />

--- a/packages/apollo-wind/src/components/ui/table.tsx
+++ b/packages/apollo-wind/src/components/ui/table.tsx
@@ -44,7 +44,7 @@ const TableRow = React.forwardRef<HTMLTableRowElement, React.HTMLAttributes<HTML
     <tr
       ref={ref}
       className={cn(
-        'border-b transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted',
+        'border-b transition-colors bg-background hover:bg-muted/50 data-[state=selected]:bg-muted',
         className
       )}
       {...props}
@@ -60,7 +60,7 @@ const TableHead = React.forwardRef<
   <th
     ref={ref}
     className={cn(
-      'h-12 px-4 text-left align-middle font-medium text-muted-foreground [&:has([role=checkbox])]:pr-0',
+      'h-12 px-4 text-left align-middle font-medium text-muted-foreground overflow-hidden bg-background [&:has([role=checkbox])]:pr-0',
       className
     )}
     {...props}


### PR DESCRIPTION
## Summary:

- Column headers now stay pinned as you scroll through long tables, you no longer lose track of which column is which
- Resizing a column narrow no longer causes its label to bleed into the next header
- The resize handle is easier to grab, more visible on hover, thicker while dragging
- New maxBodyHeight prop: the scrollbar sits inside the data rows only, keeping the header row visually separate.

## Also included:

- Keyboard users can scroll the table body without a mouse
- Two new Storybook stories: sticky header with 40 rows, and a resizable wide table to showcase the narrow-column fixes