### PR TITLE
feat(apollo-vertex): onboarding tour with driver.js — limited styling

### DIFF
--- a/apps/apollo-vertex/app/patterns/_meta.ts
+++ b/apps/apollo-vertex/app/patterns/_meta.ts
@@ -1,6 +1,7 @@
 export default {
   "ai-chat": "AI Chat",
   "metric-card": "Metric Card",
+  "onboarding-tour-basic": "Onboarding tour (basic)",
   "page-header": "Page Header",
   shell: "Shell",
 };

--- a/apps/apollo-vertex/app/patterns/onboarding-tour-basic/onboarding-tour-basic-demo.tsx
+++ b/apps/apollo-vertex/app/patterns/onboarding-tour-basic/onboarding-tour-basic-demo.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { Button } from "@/registry/button/button";
+import type { TourDefinition } from "@/registry/onboarding-tour-basic";
+import {
+  OnboardingTourProvider,
+  resetTourState,
+  useOnboardingTour,
+} from "@/registry/onboarding-tour-basic";
+
+const DEMO_TOUR: TourDefinition = {
+  id: "onboarding-tour-basic-page-demo",
+  steps: [
+    {
+      id: "welcome",
+      title: "A tour of the basic tour component",
+      description:
+        "This is the driver.js native popover with Apollo Vertex theme overrides. Click through to see how each piece looks in context.",
+    },
+    {
+      id: "step-popover-preview",
+      selector: "#tour-popover-preview",
+      title: "Step popovers",
+      description:
+        "driver.js renders the popover — we only style it. Title, description, and native next / previous / close buttons.",
+      placement: "top",
+    },
+    {
+      id: "features",
+      selector: "#tour-features",
+      title: "What's included",
+      description:
+        "Spotlight overlay, keyboard navigation, persistence, and dark mode support — everything driver.js gives you, themed to Vertex.",
+      placement: "top",
+    },
+    {
+      id: "install",
+      selector: "#tour-install",
+      title: "Drop it in",
+      description: "One command to add it to your project.",
+      placement: "top",
+    },
+  ],
+};
+
+const DEMO_TOURS = [DEMO_TOUR];
+
+function TourTrigger() {
+  const { startTour } = useOnboardingTour();
+
+  return (
+    <Button
+      onClick={() => {
+        resetTourState(DEMO_TOUR.id);
+        startTour(DEMO_TOUR.id);
+      }}
+    >
+      {"Start tour demo"}
+    </Button>
+  );
+}
+
+export function OnboardingTourBasicDemoTrigger() {
+  return (
+    <OnboardingTourProvider tours={DEMO_TOURS}>
+      <TourTrigger />
+    </OnboardingTourProvider>
+  );
+}

--- a/apps/apollo-vertex/app/patterns/onboarding-tour-basic/onboarding-tour-basic-static-preview.tsx
+++ b/apps/apollo-vertex/app/patterns/onboarding-tour-basic/onboarding-tour-basic-static-preview.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+/**
+ * Static HTML preview mirroring the driver.js native popover DOM so the
+ * theme overrides in `onboarding-tour-basic.css` style it identically.
+ * See driver.js docs for the real DOM structure.
+ */
+
+// Import the registry CSS so the preview picks up the same theme overrides
+// that the live tour uses.
+import "@/registry/onboarding-tour-basic/onboarding-tour-basic.css";
+import "driver.js/dist/driver.css";
+
+export function PopoverStepPreview() {
+  return (
+    <div className="flex items-center justify-center rounded-lg bg-muted/20 p-8">
+      <div id="tour-popover-preview" className="relative inline-block">
+        {/* Mimic driver.js popover DOM so the CSS selectors apply. */}
+        <div
+          className="driver-popover onboarding-tour-basic"
+          style={{
+            position: "static",
+            display: "block",
+            transform: "none",
+            pointerEvents: "auto",
+          }}
+        >
+          <button
+            type="button"
+            className="driver-popover-close-btn"
+            aria-label="Close"
+          >
+            &times;
+          </button>
+          <div className="driver-popover-title">Step popovers</div>
+          <div className="driver-popover-description">
+            driver.js renders the popover — we only style it. Title,
+            description, and native next / previous / close buttons.
+          </div>
+          <div className="driver-popover-footer">
+            <button type="button" className="driver-popover-prev-btn">
+              &larr; Previous
+            </button>
+            <button type="button" className="driver-popover-next-btn">
+              Next &rarr;
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/apollo-vertex/app/patterns/onboarding-tour-basic/page.mdx
+++ b/apps/apollo-vertex/app/patterns/onboarding-tour-basic/page.mdx
@@ -1,0 +1,129 @@
+import { OnboardingTourBasicDemoTrigger } from './onboarding-tour-basic-demo';
+import { PopoverStepPreview } from './onboarding-tour-basic-static-preview';
+
+# Onboarding tour (basic)
+
+A lightweight onboarding tour using driver.js's native popover with Apollo Vertex theme overrides. No custom React popover rendering, no welcome modal, no conditional steps — the smallest possible surface area while still looking like Vertex.
+
+<div className="not-prose my-6">
+  <OnboardingTourBasicDemoTrigger />
+</div>
+
+## Step popover
+
+driver.js ships the popover; we override its CSS so it uses Vertex tokens for background, border, foreground, muted foreground, and button variants. Light and dark mode both resolve from `var(--*)` tokens, so the popover follows the theme automatically.
+
+<div className="not-prose my-8">
+  <PopoverStepPreview />
+</div>
+
+## Features
+
+<div id="tour-features">
+
+- **Spotlight overlay**: driver.js highlights the target element with a cutout in a dimmed overlay
+- **Native popover**: driver.js renders the popover — we only override CSS
+- **CSS selector targeting**: Target elements by CSS selector; omit the selector for a centered popover
+- **Native navigation**: driver.js's built-in next / previous / close buttons, styled to match Vertex buttons
+- **Keyboard support**: Escape to close the tour (driver.js default)
+- **Persistence**: Tracks completed tours in `localStorage` so they don't repeat
+- **Dark mode**: Popover inherits from theme CSS variables; overlay switches based on the `.dark` class
+
+</div>
+
+## Installation
+
+<div id="tour-install">
+
+```bash
+npx shadcn@latest add @uipath/onboarding-tour-basic
+```
+
+</div>
+
+## Usage
+
+### 1. Define your tour
+
+```tsx
+import type { TourDefinition } from '@/components/ui/onboarding-tour-basic';
+
+const myTour: TourDefinition = {
+  id: 'my-onboarding-tour',
+  steps: [
+    {
+      id: 'welcome',
+      title: 'Welcome!',
+      description: 'Let us show you around your new workspace.',
+    },
+    {
+      id: 'sidebar',
+      selector: '[data-sidebar]',
+      title: 'Navigation',
+      description: 'Use the sidebar to move between sections.',
+      placement: 'right',
+    },
+    {
+      id: 'search',
+      selector: '#search-bar',
+      title: 'Quick search',
+      description: 'Find anything across your workspace. Try <strong>Cmd+K</strong> for a shortcut.',
+      placement: 'bottom',
+    },
+  ],
+};
+```
+
+### 2. Set up the provider
+
+```tsx
+import { OnboardingTourProvider } from '@/components/ui/onboarding-tour-basic';
+
+function App() {
+  return (
+    <OnboardingTourProvider tours={[myTour]}>
+      <YourApp />
+    </OnboardingTourProvider>
+  );
+}
+```
+
+### 3. Start the tour
+
+```tsx
+import {
+  isTourCompleted,
+  useOnboardingTour,
+} from '@/components/ui/onboarding-tour-basic';
+
+function WelcomeBanner() {
+  const { startTour } = useOnboardingTour();
+
+  if (isTourCompleted('my-onboarding-tour')) return null;
+
+  return (
+    <button onClick={() => startTour('my-onboarding-tour')}>Take a tour</button>
+  );
+}
+```
+
+## Step types
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `id` | `string` | Unique step identifier |
+| `selector` | `string` | CSS selector for the target element. Omit for a centered popover (e.g. welcome). |
+| `title` | `string` | Step title |
+| `description` | `string` | Step description. driver.js renders HTML strings, so `<strong>` / `<em>` work. |
+| `placement` | `'top' \| 'bottom' \| 'left' \| 'right'` | Popover position relative to the target |
+| `onEnter` | `() => void` | Callback when the step becomes active |
+
+## API
+
+| Export | Description |
+|--------|-------------|
+| `OnboardingTourProvider` | Context provider — wrap your app with this. Accepts `tours`. |
+| `useOnboardingTour()` | Access tour actions: `startTour`. Must be inside `OnboardingTourProvider`. |
+| `isTourCompleted(tourId)` | Check whether a tour has been completed. |
+| `markTourCompleted(tourId)` | Manually mark a tour as completed. |
+| `resetTourState(tourId)` | Clear completion state so the tour can be shown again. |

--- a/apps/apollo-vertex/next-env.d.ts
+++ b/apps/apollo-vertex/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/apollo-vertex/package.json
+++ b/apps/apollo-vertex/package.json
@@ -66,6 +66,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
+    "driver.js": "^1.4.0",
     "embla-carousel-react": "^8.6.0",
     "eventsource-parser": "^3.0.6",
     "framer-motion": "^12.26.2",

--- a/apps/apollo-vertex/registry.json
+++ b/apps/apollo-vertex/registry.json
@@ -840,6 +840,41 @@
       ]
     },
     {
+      "name": "onboarding-tour-basic",
+      "type": "registry:ui",
+      "title": "Onboarding Tour (Basic)",
+      "description": "A lightweight onboarding tour using driver.js's native popover with Apollo Vertex theme overrides. No custom React popover, no welcome modal, no conditional steps.",
+      "dependencies": ["driver.js"],
+      "registryDependencies": [],
+      "files": [
+        {
+          "path": "registry/onboarding-tour-basic/index.ts",
+          "type": "registry:ui",
+          "target": "components/ui/onboarding-tour-basic/index.ts"
+        },
+        {
+          "path": "registry/onboarding-tour-basic/onboarding-tour-basic-types.ts",
+          "type": "registry:ui",
+          "target": "components/ui/onboarding-tour-basic/onboarding-tour-basic-types.ts"
+        },
+        {
+          "path": "registry/onboarding-tour-basic/onboarding-tour-basic-provider.tsx",
+          "type": "registry:ui",
+          "target": "components/ui/onboarding-tour-basic/onboarding-tour-basic-provider.tsx"
+        },
+        {
+          "path": "registry/onboarding-tour-basic/onboarding-tour-basic.css",
+          "type": "registry:ui",
+          "target": "components/ui/onboarding-tour-basic/onboarding-tour-basic.css"
+        },
+        {
+          "path": "registry/onboarding-tour-basic/tour-persistence.ts",
+          "type": "registry:ui",
+          "target": "components/ui/onboarding-tour-basic/tour-persistence.ts"
+        }
+      ]
+    },
+    {
       "name": "pagination",
       "type": "registry:ui",
       "title": "Pagination",

--- a/apps/apollo-vertex/registry/onboarding-tour-basic/index.ts
+++ b/apps/apollo-vertex/registry/onboarding-tour-basic/index.ts
@@ -1,0 +1,17 @@
+// Context and hooks
+export type {
+  OnboardingTourContextValue,
+  OnboardingTourProviderProps,
+} from "./onboarding-tour-basic-provider";
+export {
+  OnboardingTourProvider,
+  useOnboardingTour,
+} from "./onboarding-tour-basic-provider";
+// Types
+export type { TourDefinition, TourStep } from "./onboarding-tour-basic-types";
+// Persistence
+export {
+  isTourCompleted,
+  markTourCompleted,
+  resetTourState,
+} from "./tour-persistence";

--- a/apps/apollo-vertex/registry/onboarding-tour-basic/onboarding-tour-basic-provider.tsx
+++ b/apps/apollo-vertex/registry/onboarding-tour-basic/onboarding-tour-basic-provider.tsx
@@ -1,0 +1,120 @@
+"use client";
+
+import { type DriveStep, driver } from "driver.js";
+import "driver.js/dist/driver.css";
+import "./onboarding-tour-basic.css";
+import {
+  createContext,
+  type ReactNode,
+  useContext,
+  useEffect,
+  useRef,
+} from "react";
+import type { TourDefinition, TourStep } from "./onboarding-tour-basic-types";
+import { isTourCompleted, markTourCompleted } from "./tour-persistence";
+
+interface OnboardingTourContextValue {
+  /** Start a tour by its ID. No-op if the tour is already completed. */
+  startTour: (tourId: string) => void;
+}
+
+const OnboardingTourContext = createContext<OnboardingTourContextValue | null>(
+  null,
+);
+
+interface OnboardingTourProviderProps {
+  children: ReactNode;
+  /** Tour definitions available to this provider */
+  tours: TourDefinition[];
+}
+
+function toDriveStep(step: TourStep): DriveStep {
+  const driveStep: DriveStep = {
+    element: step.selector,
+    popover: {
+      title: step.title,
+      description: step.description,
+      side: step.placement ?? "bottom",
+      align: "center",
+      showButtons: ["next", "previous", "close"],
+      popoverClass: "onboarding-tour-basic",
+    },
+  };
+  if (step.onEnter) {
+    const onEnter = step.onEnter;
+    driveStep.onHighlightStarted = () => onEnter();
+  }
+  return driveStep;
+}
+
+function OnboardingTourProvider({
+  children,
+  tours,
+}: OnboardingTourProviderProps) {
+  const driverRef = useRef<ReturnType<typeof driver> | null>(null);
+  const activeTourIdRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    return () => {
+      driverRef.current?.destroy();
+    };
+  }, []);
+
+  function startTour(tourId: string) {
+    if (isTourCompleted(tourId)) return;
+    const tour = tours.find((t) => t.id === tourId);
+    if (!tour) return;
+
+    driverRef.current?.destroy();
+    activeTourIdRef.current = tour.id;
+
+    const isDark =
+      typeof document !== "undefined" &&
+      document.documentElement.classList.contains("dark");
+
+    const driverInstance = driver({
+      steps: tour.steps.map(toDriveStep),
+      showProgress: false,
+      showButtons: ["next", "previous", "close"],
+      allowClose: true,
+      // driver.js does not accept CSS variables for overlayColor, so pick a
+      // solid black/white based on current theme.
+      overlayColor: isDark ? "rgb(0,0,0)" : "rgb(255,255,255)",
+      overlayOpacity: 0.7,
+      stagePadding: 8,
+      stageRadius: 12,
+      popoverOffset: 12,
+      animate: true,
+      onDestroyed: () => {
+        if (activeTourIdRef.current) {
+          markTourCompleted(activeTourIdRef.current);
+          activeTourIdRef.current = null;
+        }
+      },
+    });
+
+    driverRef.current = driverInstance;
+    driverInstance.drive();
+  }
+
+  const value: OnboardingTourContextValue = { startTour };
+
+  return (
+    <OnboardingTourContext.Provider value={value}>
+      {children}
+    </OnboardingTourContext.Provider>
+  );
+}
+
+function useOnboardingTour(): OnboardingTourContextValue {
+  const context = useContext(OnboardingTourContext);
+  if (!context) {
+    throw new Error(
+      "useOnboardingTour must be used within an OnboardingTourProvider",
+    );
+  }
+  return context;
+}
+
+export { OnboardingTourProvider, useOnboardingTour };
+export type { OnboardingTourContextValue, OnboardingTourProviderProps };

--- a/apps/apollo-vertex/registry/onboarding-tour-basic/onboarding-tour-basic-types.ts
+++ b/apps/apollo-vertex/registry/onboarding-tour-basic/onboarding-tour-basic-types.ts
@@ -1,0 +1,26 @@
+interface TourStep {
+  /** Unique step identifier */
+  id: string;
+  /** CSS selector for the target element. Omit for a centered popover (e.g. welcome). */
+  selector?: string;
+  /** Step title (plain string; rendered by driver.js native popover) */
+  title: string;
+  /**
+   * Step description. driver.js's native popover accepts HTML strings,
+   * so plain text works and basic HTML (e.g. `<strong>`, `<em>`) is supported.
+   */
+  description: string;
+  /** Popover placement relative to target */
+  placement?: "top" | "bottom" | "left" | "right";
+  /** Callback when this step becomes active */
+  onEnter?: () => void;
+}
+
+interface TourDefinition {
+  /** Unique tour identifier */
+  id: string;
+  /** Tour steps in order */
+  steps: TourStep[];
+}
+
+export type { TourDefinition, TourStep };

--- a/apps/apollo-vertex/registry/onboarding-tour-basic/onboarding-tour-basic.css
+++ b/apps/apollo-vertex/registry/onboarding-tour-basic/onboarding-tour-basic.css
@@ -1,0 +1,137 @@
+/*
+ * Apollo Vertex theme overrides for driver.js's native popover.
+ *
+ * driver.js ships its own styles for `.driver-popover` and its buttons,
+ * so `!important` is required to win specificity without increasing it artificially.
+ * Colors resolve from the Apollo Vertex theme CSS variables, so dark mode
+ * flips automatically via the `.dark` class on `documentElement`.
+ */
+
+.driver-popover.onboarding-tour-basic {
+  background-color: var(--card) !important;
+  color: var(--foreground) !important;
+  border: 1px solid var(--border) !important;
+  border-radius: 12px !important;
+  box-shadow:
+    0 10px 15px -3px rgb(0 0 0 / 0.1),
+    0 4px 6px -4px rgb(0 0 0 / 0.1) !important;
+  padding: 20px !important;
+  max-width: 360px !important;
+  font-family: var(--font-sans, inherit) !important;
+}
+
+.driver-popover.onboarding-tour-basic .driver-popover-title {
+  color: var(--foreground) !important;
+  font-size: 16px !important;
+  font-weight: 600 !important;
+  line-height: 1.4 !important;
+  margin: 0 0 8px 0 !important;
+  padding: 0 !important;
+}
+
+.driver-popover.onboarding-tour-basic .driver-popover-description {
+  color: var(--muted-foreground) !important;
+  font-size: 14px !important;
+  line-height: 1.5 !important;
+  margin: 0 0 16px 0 !important;
+  padding: 0 !important;
+}
+
+/* driver.js's close button is absolutely positioned in the top-right.
+   Style it as a subtle icon-button style. */
+.driver-popover.onboarding-tour-basic .driver-popover-close-btn {
+  color: var(--muted-foreground) !important;
+  background: transparent !important;
+  border: none !important;
+  font-size: 18px !important;
+  line-height: 1 !important;
+  padding: 4px !important;
+  top: 8px !important;
+  right: 8px !important;
+  border-radius: 6px !important;
+  transition:
+    background-color 150ms ease,
+    color 150ms ease !important;
+}
+
+.driver-popover.onboarding-tour-basic .driver-popover-close-btn:hover,
+.driver-popover.onboarding-tour-basic .driver-popover-close-btn:focus {
+  background-color: var(--accent) !important;
+  color: var(--accent-foreground) !important;
+  outline: none !important;
+}
+
+/* Footer hosts prev/next buttons. */
+.driver-popover.onboarding-tour-basic .driver-popover-footer {
+  display: flex !important;
+  align-items: center !important;
+  justify-content: flex-end !important;
+  gap: 8px !important;
+  margin-top: 0 !important;
+  padding: 0 !important;
+}
+
+.driver-popover.onboarding-tour-basic .driver-popover-progress-text {
+  color: var(--muted-foreground) !important;
+  font-size: 12px !important;
+  margin-right: auto !important;
+}
+
+/* Shared button reset for prev/next. */
+.driver-popover.onboarding-tour-basic .driver-popover-prev-btn,
+.driver-popover.onboarding-tour-basic .driver-popover-next-btn {
+  height: 32px !important;
+  padding: 0 12px !important;
+  font-size: 13px !important;
+  font-weight: 500 !important;
+  line-height: 1 !important;
+  border-radius: 8px !important;
+  text-shadow: none !important;
+  box-shadow: none !important;
+  cursor: pointer !important;
+  transition:
+    background-color 150ms ease,
+    color 150ms ease,
+    border-color 150ms ease !important;
+}
+
+/* Previous button → Vertex `outline` button variant. */
+.driver-popover.onboarding-tour-basic .driver-popover-prev-btn {
+  background-color: var(--background) !important;
+  color: var(--foreground) !important;
+  border: 1px solid var(--border) !important;
+}
+
+.driver-popover.onboarding-tour-basic .driver-popover-prev-btn:hover,
+.driver-popover.onboarding-tour-basic .driver-popover-prev-btn:focus {
+  background-color: var(--accent) !important;
+  color: var(--accent-foreground) !important;
+  outline: none !important;
+}
+
+/* Next button → Vertex `default` (primary) button variant. */
+.driver-popover.onboarding-tour-basic .driver-popover-next-btn {
+  background-color: var(--primary) !important;
+  color: var(--primary-foreground) !important;
+  border: 1px solid var(--primary) !important;
+}
+
+.driver-popover.onboarding-tour-basic .driver-popover-next-btn:hover,
+.driver-popover.onboarding-tour-basic .driver-popover-next-btn:focus {
+  background-color: var(--primary-600, var(--primary)) !important;
+  border-color: var(--primary-600, var(--primary)) !important;
+  outline: none !important;
+}
+
+/* Hide arrow — Vertex popovers don't use a stem. */
+.driver-popover.onboarding-tour-basic .driver-popover-arrow {
+  display: none !important;
+}
+
+/* driver.js adds `overflow: hidden !important` to any non-body ancestor that
+   has the active element as a direct child. If that ancestor had a visible
+   scrollbar, it's removed and the text width shifts (~15px). Undo it — the
+   page scroll container isn't our highlight target anyway. */
+:not(body):has(> .driver-active-element) {
+  overflow: visible !important;
+}

--- a/apps/apollo-vertex/registry/onboarding-tour-basic/tour-persistence.ts
+++ b/apps/apollo-vertex/registry/onboarding-tour-basic/tour-persistence.ts
@@ -1,0 +1,32 @@
+const TOUR_STORAGE_KEY = "onboarding-tour-basic-completed";
+
+function loadCompletedTours(): string[] {
+  try {
+    const data = localStorage.getItem(TOUR_STORAGE_KEY);
+    if (!data) return [];
+    const parsed: unknown = JSON.parse(data);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter((item): item is string => typeof item === "string");
+  } catch {
+    return [];
+  }
+}
+
+function isTourCompleted(tourId: string): boolean {
+  return loadCompletedTours().includes(tourId);
+}
+
+function markTourCompleted(tourId: string) {
+  const completed = loadCompletedTours();
+  if (!completed.includes(tourId)) {
+    completed.push(tourId);
+    localStorage.setItem(TOUR_STORAGE_KEY, JSON.stringify(completed));
+  }
+}
+
+function resetTourState(tourId: string) {
+  const completed = loadCompletedTours().filter((id) => id !== tourId);
+  localStorage.setItem(TOUR_STORAGE_KEY, JSON.stringify(completed));
+}
+
+export { isTourCompleted, markTourCompleted, resetTourState };

--- a/apps/apollo-vertex/tsconfig.json
+++ b/apps/apollo-vertex/tsconfig.json
@@ -62,6 +62,9 @@
       "@/components/ui/navigation-menu": [
         "./registry/navigation-menu/navigation-menu"
       ],
+      "@/components/ui/onboarding-tour-basic": [
+        "./registry/onboarding-tour-basic/index"
+      ],
       "@/components/ui/page-header": ["./registry/page-header/page-header"],
       "@/components/ui/pagination": ["./registry/pagination/pagination"],
       "@/components/ui/popover": ["./registry/popover/popover"],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -121,10 +121,10 @@ importers:
         version: 0.4.6(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       nextra:
         specifier: ^4.6.1
-        version: 4.6.1(next@16.2.3(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.94.2))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
+        version: 4.6.1(next@16.2.3(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.94.2))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
       nextra-theme-docs:
         specifier: ^4.6.1
-        version: 4.6.1(@types/react@19.2.8)(next@16.2.3(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.94.2))(nextra@4.6.1(next@16.2.3(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.94.2))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(use-sync-external-store@1.6.0(react@19.2.3))
+        version: 4.6.1(@types/react@19.2.8)(next@16.2.3(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.94.2))(nextra@4.6.1(next@16.2.3(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.94.2))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(use-sync-external-store@1.6.0(react@19.2.3))
       postcss:
         specifier: ^8.5.6
         version: 8.5.6
@@ -285,6 +285,9 @@ importers:
       cmdk:
         specifier: ^1.1.1
         version: 1.1.1(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      driver.js:
+        specifier: ^1.4.0
+        version: 1.4.0
       embla-carousel-react:
         specifier: ^8.6.0
         version: 8.6.0(react@19.2.3)
@@ -317,10 +320,10 @@ importers:
         version: 0.4.6(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       nextra:
         specifier: ^4.6.1
-        version: 4.6.1(next@16.2.3(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.94.2))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
+        version: 4.6.1(next@16.2.3(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.94.2))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
       nextra-theme-docs:
         specifier: ^4.6.1
-        version: 4.6.1(@types/react@19.2.8)(next@16.2.3(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.94.2))(nextra@4.6.1(next@16.2.3(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.94.2))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(use-sync-external-store@1.6.0(react@19.2.3))
+        version: 4.6.1(@types/react@19.2.8)(next@16.2.3(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.94.2))(nextra@4.6.1(next@16.2.3(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.94.2))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(use-sync-external-store@1.6.0(react@19.2.3))
       pkce-challenge:
         specifier: ^6.0.0
         version: 6.0.0
@@ -405,7 +408,7 @@ importers:
         version: 1.4.0
       shadcn:
         specifier: latest
-        version: 4.3.0(@types/node@24.10.1)(babel-plugin-macros@3.1.0)(typescript@5.9.3)
+        version: 4.4.0(@types/node@24.10.1)(babel-plugin-macros@3.1.0)(typescript@5.9.3)
       tw-animate-css:
         specifier: ^1.4.0
         version: 1.4.0
@@ -7657,6 +7660,9 @@ packages:
     resolution: {integrity: sha512-JVUnt+DUIzu87TABbhPmNfVdBDt18BLOWjMUFJMSi/Qqg7NTYtabbvSNJGOJ7afbRuv9D/lngizHtP7QyLQ+9w==}
     engines: {node: '>=12'}
 
+  driver.js@1.4.0:
+    resolution: {integrity: sha512-Gm64jm6PmcU+si21sQhBrTAM1JvUrR0QhNmjkprNLxohOBzul9+pNHXgQaT9lW84gwg9GMLB3NZGuGolsz5uew==}
+
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
@@ -11630,8 +11636,8 @@ packages:
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
 
-  shadcn@4.3.0:
-    resolution: {integrity: sha512-7vhnBh2LVLyxOd1ZQWwXv7OATCnQcxdqc8FbZdNigZriNOwDsHklQmPpvPt1jcrFK5mzMI+cyuAYv8WzERx2Og==}
+  shadcn@4.4.0:
+    resolution: {integrity: sha512-0V1AjVktKwhK1e0ONXb9SeBoyJePH04iTSJeMjl9eROqjjyb8OoWYtWDI39UdBU3GzpUlFBJFohhB9c6fGOkQA==}
     hasBin: true
 
   shallowequal@1.1.0:
@@ -19851,6 +19857,8 @@ snapshots:
 
   dotenv@17.2.3: {}
 
+  driver.js@1.4.0: {}
+
   dunder-proto@1.0.1:
     dependencies:
       call-bind-apply-helpers: 1.0.2
@@ -22812,13 +22820,13 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
-  nextra-theme-docs@4.6.1(@types/react@19.2.8)(next@16.2.3(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.94.2))(nextra@4.6.1(next@16.2.3(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.94.2))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(use-sync-external-store@1.6.0(react@19.2.3)):
+  nextra-theme-docs@4.6.1(@types/react@19.2.8)(next@16.2.3(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.94.2))(nextra@4.6.1(next@16.2.3(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.94.2))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(use-sync-external-store@1.6.0(react@19.2.3)):
     dependencies:
       '@headlessui/react': 2.2.9(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       clsx: 2.1.1
       next: 16.2.3(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.94.2)
       next-themes: 0.4.6(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      nextra: 4.6.1(next@16.2.3(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.94.2))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
+      nextra: 4.6.1(next@16.2.3(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.94.2))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
       react: 19.2.3
       react-compiler-runtime: 19.1.0-rc.3(react@19.2.3)
       react-dom: 19.2.3(react@19.2.3)
@@ -22830,7 +22838,7 @@ snapshots:
       - immer
       - use-sync-external-store
 
-  nextra@4.6.1(next@16.2.3(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.94.2))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3):
+  nextra@4.6.1(next@16.2.3(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.94.2))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3):
     dependencies:
       '@formatjs/intl-localematcher': 0.6.2
       '@headlessui/react': 2.2.9(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -24710,7 +24718,7 @@ snapshots:
 
   setprototypeof@1.2.0: {}
 
-  shadcn@4.3.0(@types/node@24.10.1)(babel-plugin-macros@3.1.0)(typescript@5.9.3):
+  shadcn@4.4.0(@types/node@24.10.1)(babel-plugin-macros@3.1.0)(typescript@5.9.3):
     dependencies:
       '@babel/core': 7.28.5
       '@babel/parser': 7.28.5


### PR DESCRIPTION
## Summary
Option 1 of a 3-way comparison of onboarding tour implementations.

- Uses driver.js's native popover with CSS overrides tuned to Apollo Vertex theme tokens.
- Smallest footprint: no custom React popover, no welcome modal, no conditional steps.
- Compare with:
  - #586 (Option 2: driver.js + custom React popover hack)
  - (Option 3: React Joyride — branch TBD)

## Test plan
- [ ] Visit \`/patterns/onboarding-tour-basic\` in the vertex app
- [ ] Click "Start tour demo" — walk 4 steps
- [ ] Verify dark mode
- [ ] typecheck, lint, format, registry:build pass