### PR TITLE
feat(apollo-react): parameterize sequence edge [AG-1080]

### DIFF
--- a/packages/apollo-react/src/canvas/components/Edges/SequenceEdge.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/Edges/SequenceEdge.stories.tsx
@@ -466,6 +466,98 @@ function EdgeLabelsStory() {
 }
 
 // ============================================================================
+// Plain Line Story (artifact-style: no arrow head, no edge toolbar)
+// ============================================================================
+
+function PlainLineStory() {
+  const initialNodes = useMemo(
+    () => [
+      createStickyNote(
+        'sticky-plain-line',
+        'yellow',
+        '**Plain Line**\nSet `data.hideArrowHead: true` to render a line with no arrow — the target end terminates plainly like the source end. Set `data.hideToolbar: true` to suppress the mid-edge insert toolbar. Useful for artifact / annotation edges.',
+        { x: 100, y: 70 },
+        { width: 550, height: 256 }
+      ),
+      createNode({
+        id: 'plain-source',
+        label: 'Source',
+        x: 130,
+        y: 180,
+        sourcePositions: [Position.Right],
+      }),
+      createNode({
+        id: 'plain-target',
+        label: 'Target',
+        x: 470,
+        y: 180,
+        targetPositions: [Position.Left],
+      }),
+
+      createStickyNote(
+        'sticky-plain-compare',
+        'white',
+        '**With arrow (default)**\nStandard SequenceEdge for comparison.',
+        { x: 100, y: 340 },
+        { width: 550, height: 224 }
+      ),
+      createNode({
+        id: 'compare-source',
+        label: 'Source',
+        x: 130,
+        y: 410,
+        sourcePositions: [Position.Right],
+      }),
+      createNode({
+        id: 'compare-target',
+        label: 'Target',
+        x: 470,
+        y: 410,
+        targetPositions: [Position.Left],
+      }),
+    ],
+    []
+  );
+
+  const initialEdges: Edge[] = useMemo(
+    () => [
+      {
+        id: 'e-plain',
+        source: 'plain-source',
+        target: 'plain-target',
+        sourceHandle: `out-${Position.Right}`,
+        targetHandle: `in-${Position.Left}`,
+        type: 'sequence',
+        data: { hideArrowHead: true, hideToolbar: true, label: 'artifact' },
+      },
+      {
+        id: 'e-compare',
+        source: 'compare-source',
+        target: 'compare-target',
+        sourceHandle: `out-${Position.Right}`,
+        targetHandle: `in-${Position.Left}`,
+        type: 'sequence',
+      },
+    ],
+    []
+  );
+
+  const { canvasProps } = useCanvasStory({
+    initialNodes,
+    initialEdges,
+    additionalNodeTypes: nodeTypes,
+  });
+
+  return (
+    <BaseCanvas {...canvasProps} edgeTypes={edgeTypes} mode="design">
+      <Panel position="bottom-right">
+        <CanvasPositionControls translations={DefaultCanvasTranslations} />
+      </Panel>
+    </BaseCanvas>
+  );
+}
+
+// ============================================================================
 // Readonly Mode Story (Execution States)
 // ============================================================================
 
@@ -605,6 +697,129 @@ function ReadonlyStory() {
         { x: 100, y: 80 },
         { width: 400, height: 320 }
       ),
+
+      // Plain-line (no arrow head) duplicate
+      createStickyNote(
+        'sticky-execution-plain',
+        'blue',
+        '**Execution States (Plain line)**\nReadonly mode edge statuses',
+        { x: 1150, y: 80 },
+        { width: 550, height: 825 }
+      ),
+      createNode({
+        id: 'execp-start',
+        label: 'Start',
+        x: 1180,
+        y: 160,
+        sourcePositions: [Position.Right],
+      }),
+      createNode({
+        id: 'execp-InProgress',
+        label: 'In Progress',
+        x: 1370,
+        y: 160,
+        targetPositions: [Position.Left],
+        sourcePositions: [Position.Right],
+      }),
+      createNode({
+        id: 'execp-target-1',
+        label: 'Target',
+        x: 1570,
+        y: 160,
+        targetPositions: [Position.Left],
+      }),
+
+      createNode({
+        id: 'execp-source-2',
+        label: 'Source',
+        x: 1180,
+        y: 310,
+        sourcePositions: [Position.Right],
+      }),
+      createNode({
+        id: 'execp-Completed',
+        label: 'Completed',
+        x: 1370,
+        y: 310,
+        targetPositions: [Position.Left],
+        sourcePositions: [Position.Right],
+      }),
+      createNode({
+        id: 'execp-target-2',
+        label: 'Target',
+        x: 1570,
+        y: 310,
+        targetPositions: [Position.Left],
+      }),
+
+      createNode({
+        id: 'execp-source-3',
+        label: 'Source',
+        x: 1180,
+        y: 460,
+        sourcePositions: [Position.Right],
+      }),
+      createNode({
+        id: 'execp-Failed',
+        label: 'Failed',
+        x: 1370,
+        y: 460,
+        targetPositions: [Position.Left],
+        sourcePositions: [Position.Right],
+      }),
+      createNode({
+        id: 'execp-target-3',
+        label: 'Target',
+        x: 1570,
+        y: 460,
+        targetPositions: [Position.Left],
+      }),
+
+      createNode({
+        id: 'execp-source-4',
+        label: 'Source',
+        x: 1180,
+        y: 610,
+        sourcePositions: [Position.Right],
+      }),
+      createNode({
+        id: 'execp-Paused',
+        label: 'Paused',
+        x: 1370,
+        y: 610,
+        targetPositions: [Position.Left],
+        sourcePositions: [Position.Right],
+      }),
+      createNode({
+        id: 'execp-target-4',
+        label: 'Target',
+        x: 1570,
+        y: 610,
+        targetPositions: [Position.Left],
+      }),
+
+      createNode({
+        id: 'execp-source-5',
+        label: 'Source',
+        x: 1180,
+        y: 760,
+        sourcePositions: [Position.Right],
+      }),
+      createNode({
+        id: 'execp-Cancelled',
+        label: 'Cancelled',
+        x: 1370,
+        y: 760,
+        targetPositions: [Position.Left],
+        sourcePositions: [Position.Right],
+      }),
+      createNode({
+        id: 'execp-target-5',
+        label: 'Target',
+        x: 1570,
+        y: 760,
+        targetPositions: [Position.Left],
+      }),
     ],
     []
   );
@@ -691,6 +906,98 @@ function ReadonlyStory() {
         sourceHandle: `out-${Position.Right}`,
         targetHandle: `in-${Position.Left}`,
         type: 'sequence',
+      },
+
+      // Plain-line (hideArrowHead) duplicates of the same execution states
+      {
+        id: 'ep-InProgress-1',
+        source: 'execp-start',
+        target: 'execp-InProgress',
+        sourceHandle: `out-${Position.Right}`,
+        targetHandle: `in-${Position.Left}`,
+        type: 'sequence',
+        data: { hideArrowHead: true },
+      },
+      {
+        id: 'ep-InProgress-2',
+        source: 'execp-InProgress',
+        target: 'execp-target-1',
+        sourceHandle: `out-${Position.Right}`,
+        targetHandle: `in-${Position.Left}`,
+        type: 'sequence',
+        data: { hideArrowHead: true },
+      },
+      {
+        id: 'ep-Completed-1',
+        source: 'execp-source-2',
+        target: 'execp-Completed',
+        sourceHandle: `out-${Position.Right}`,
+        targetHandle: `in-${Position.Left}`,
+        type: 'sequence',
+        data: { hideArrowHead: true },
+      },
+      {
+        id: 'ep-Completed-2',
+        source: 'execp-Completed',
+        target: 'execp-target-2',
+        sourceHandle: `out-${Position.Right}`,
+        targetHandle: `in-${Position.Left}`,
+        type: 'sequence',
+        data: { hideArrowHead: true },
+      },
+      {
+        id: 'ep-Failed-1',
+        source: 'execp-source-3',
+        target: 'execp-Failed',
+        sourceHandle: `out-${Position.Right}`,
+        targetHandle: `in-${Position.Left}`,
+        type: 'sequence',
+        data: { hideArrowHead: true },
+      },
+      {
+        id: 'ep-Failed-2',
+        source: 'execp-Failed',
+        target: 'execp-target-3',
+        sourceHandle: `out-${Position.Right}`,
+        targetHandle: `in-${Position.Left}`,
+        type: 'sequence',
+        data: { hideArrowHead: true },
+      },
+      {
+        id: 'ep-Paused-1',
+        source: 'execp-source-4',
+        target: 'execp-Paused',
+        sourceHandle: `out-${Position.Right}`,
+        targetHandle: `in-${Position.Left}`,
+        type: 'sequence',
+        data: { hideArrowHead: true },
+      },
+      {
+        id: 'ep-Paused-2',
+        source: 'execp-Paused',
+        target: 'execp-target-4',
+        sourceHandle: `out-${Position.Right}`,
+        targetHandle: `in-${Position.Left}`,
+        type: 'sequence',
+        data: { hideArrowHead: true },
+      },
+      {
+        id: 'ep-Cancelled-1',
+        source: 'execp-source-5',
+        target: 'execp-Cancelled',
+        sourceHandle: `out-${Position.Right}`,
+        targetHandle: `in-${Position.Left}`,
+        type: 'sequence',
+        data: { hideArrowHead: true },
+      },
+      {
+        id: 'ep-Cancelled-2',
+        source: 'execp-Cancelled',
+        target: 'execp-target-5',
+        sourceHandle: `out-${Position.Right}`,
+        targetHandle: `in-${Position.Left}`,
+        type: 'sequence',
+        data: { hideArrowHead: true },
       },
     ],
     []
@@ -969,6 +1276,18 @@ export const EdgeLabels: Story = {
       description: {
         story:
           'Demonstrates edge labels rendered at the midpoint via data.label. Labels work alongside all edge states including diff styling.',
+      },
+    },
+  },
+};
+
+export const PlainLine: Story = {
+  render: () => <PlainLineStory />,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Demonstrates a SequenceEdge parameterized to render as a plain line. `data.hideArrowHead: true` omits the directional arrow at the target so both ends terminate plainly (useful for artifact / annotation edges). `data.hideToolbar: true` suppresses the mid-edge insert toolbar. Everything else about SequenceEdge (path, label, status animations, diff styling) is unchanged.',
       },
     },
   },

--- a/packages/apollo-react/src/canvas/components/Edges/SequenceEdge.tsx
+++ b/packages/apollo-react/src/canvas/components/Edges/SequenceEdge.tsx
@@ -85,9 +85,15 @@ export const SequenceEdge = memo(function SequenceEdge({
   const isDiffAdded = data?.isDiffAdded === true;
   const isDiffRemoved = data?.isDiffRemoved === true;
 
+  const hideArrowHead = data?.hideArrowHead === true;
+  const hideToolbar = data?.hideToolbar === true;
+
   const angle = ANGLE_MAP[targetPosition];
   const { x: offsetX, y: offsetY } = ARROW_OFFSETS[targetPosition];
 
+  // When the arrow head is hidden, inset the target point so the line stops at
+  // the same visual distance from the target node as the source side — the
+  // arrow polygon normally fills this gap.
   const { edgePath, labelX, labelY } = useEdgePath({
     sourceNodeId: source,
     targetNodeId: target,
@@ -96,8 +102,8 @@ export const SequenceEdge = memo(function SequenceEdge({
     sourceX,
     sourceY,
     sourcePosition,
-    targetX,
-    targetY,
+    targetX: hideArrowHead ? targetX + offsetX : targetX,
+    targetY: hideArrowHead ? targetY + offsetY : targetY,
     targetPosition,
   });
 
@@ -186,20 +192,22 @@ export const SequenceEdge = memo(function SequenceEdge({
         />
 
         {/* Arrow head - filled triangle */}
-        <polygon
-          points={`
-            ${targetX},${targetY}
-            ${targetX - ARROW_SIZE * Math.cos(angle - Math.PI / 6)},${targetY - ARROW_SIZE * Math.sin(angle - Math.PI / 6)}
-            ${targetX - ARROW_SIZE * Math.cos(angle + Math.PI / 6)},${targetY - ARROW_SIZE * Math.sin(angle + Math.PI / 6)}
-          `}
-          fill={edgeColor}
-          style={{
-            pointerEvents: 'none',
-            opacity: style?.opacity !== undefined ? style.opacity : 1,
-            transition: 'fill 0.2s ease, opacity 0.2s ease',
-            transform: `translate(${offsetX}px, ${offsetY}px)`,
-          }}
-        />
+        {!hideArrowHead && (
+          <polygon
+            points={`
+              ${targetX},${targetY}
+              ${targetX - ARROW_SIZE * Math.cos(angle - Math.PI / 6)},${targetY - ARROW_SIZE * Math.sin(angle - Math.PI / 6)}
+              ${targetX - ARROW_SIZE * Math.cos(angle + Math.PI / 6)},${targetY - ARROW_SIZE * Math.sin(angle + Math.PI / 6)}
+            `}
+            fill={edgeColor}
+            style={{
+              pointerEvents: 'none',
+              opacity: style?.opacity !== undefined ? style.opacity : 1,
+              transition: 'fill 0.2s ease, opacity 0.2s ease',
+              transform: `translate(${offsetX}px, ${offsetY}px)`,
+            }}
+          />
+        )}
 
         {getStatusAnimation(status, edgePath)}
 
@@ -237,7 +245,7 @@ export const SequenceEdge = memo(function SequenceEdge({
       </g>
 
       {/* Edge toolbar for adding nodes */}
-      {showToolbar && toolbarPositioning && (
+      {!hideToolbar && showToolbar && toolbarPositioning && (
         <EdgeToolbar
           edgeId={id}
           visible={showToolbar}


### PR DESCRIPTION
## Summary

Parameterizes `SequenceEdge` so consumers can opt out of the arrow head and/or the mid-edge insert toolbar via two optional booleans on the existing `data` field:

- **`data.hideArrowHead: boolean`** — when true, the arrow polygon at the target is omitted and the target coordinate is inset with the same `ARROW_OFFSETS` value so the line terminates at the same visual distance from the target node as the source end does (symmetric plain-line look, like the tail).
- **`data.hideToolbar: boolean`** — when true, the mid-edge insert toolbar is suppressed. `useEdgeToolbarState` still runs to preserve hook order.

Everything else about SequenceEdge (path computation via `useEdgePath`, label, status animations, memoization, hover/select/diff styling) is unchanged. No new props, no new exports — both flags ride on the existing `data` field alongside `label`, `isDiffAdded`, `isDiffRemoved`.

### Why
flow-workbench ships its own `ArtifactEdge` component that duplicates ~90% of `SequenceEdge` just to draw a plain line with no arrow. With this parameterization in place, flow-workbench can delete its `ArtifactEdge` and render the `artifact` edge type as `SequenceEdge` with both flags set (see companion flow-workbench PR).

### Stories
- New **PlainLine** story compares a plain-line (`hideArrowHead + hideToolbar`) edge against a default SequenceEdge.
- **ExecutionStates** story gains a second (blue) copy of the execution-state grid with `hideArrowHead: true` edges so you can verify status color + in-progress dot animation still work when the arrow is hidden.

## Test plan

- [ ] Storybook → `Canvas/Edges/SequenceEdge` → **Default**: arrows still point into target, no visual regression.
- [ ] Storybook → **PlainLine**: plain line renders with symmetric gaps at both ends and no toolbar appears on hover.
- [ ] Storybook → **ExecutionStates**: blue (plain-line) grid mirrors the green grid's InProgress / Completed / Failed / Paused / Cancelled colors; in-progress dot still animates.
- [ ] Storybook → **EdgeLabels / ValidationStates / LoopEdges**: no regression.
- [ ] Typecheck + lint pass.

https://github.com/user-attachments/assets/c2572aba-2de8-4bca-8126-bcde59d0452a

