### PR TITLE
feat(apollo-vertex): add customize appearance pattern

### DIFF
--- a/apps/apollo-vertex/app/patterns/_meta.ts
+++ b/apps/apollo-vertex/app/patterns/_meta.ts
@@ -1,5 +1,6 @@
 export default {
   "ai-chat": "AI Chat",
+  "customize-appearance": "Customize Appearance",
   "metric-card": "Metric Card",
   "page-header": "Page Header",
   shell: "Shell",

--- a/apps/apollo-vertex/app/patterns/customize-appearance/page.mdx
+++ b/apps/apollo-vertex/app/patterns/customize-appearance/page.mdx
@@ -1,0 +1,245 @@
+import { CustomizeAppearanceTemplate } from '@/templates/customize-appearance/CustomizeAppearanceTemplate';
+import { PreviewFullScreen } from '@/app/_components/preview-full-screen';
+
+# Customize Appearance
+
+A self-serve branding settings page that lets a tenant admin swap in their own company name, logo, and brand colors. Edits preview live across the shell — sidebar logo, product title, and primary-driven surfaces (active nav, buttons, focus rings) all update as the user types.
+
+<PreviewFullScreen title="Customize appearance preview">
+    <CustomizeAppearanceTemplate />
+</PreviewFullScreen>
+
+## Minimal header variant
+
+The same pattern works with the minimal shell variant. The customization form is identical; the shell chrome is just a horizontal header instead of a sidebar.
+
+<PreviewFullScreen title="Customize appearance minimal preview">
+    <CustomizeAppearanceTemplate variant="minimal" />
+</PreviewFullScreen>
+
+## Composition
+
+From top to bottom the pattern stacks:
+
+- **[`Shell`](/patterns/shell)** (outer) — wrap your app in `ApolloShell`. Read `companyName` and `companyLogo` from the branding store so the shell updates live.
+- **`PageHeader`** (`size="content"`) — in-page title and description for the settings form.
+- **Company logo** — file-upload tile with hover-to-remove. Accepts any image; converts to a data URL for local preview.
+- **Company name** — text `Input`, feeds `ApolloShell`'s `companyName`.
+- **Theming** — two-up `Card` selector (Default / Custom). Custom mode locks to light theme and reveals color pickers.
+- **Primary & Accent** — native `<input type="color">` overlaid on an `Input` that shows the raw `oklch()` string. Conversion is bidirectional.
+- **Actions** — `Reset to defaults` and `Save changes` `Button`s.
+
+The content region uses the [layout grid](/foundation/grid): `4` columns on mobile, `8` on tablet, `12` on desktop, with `px-4 / sm:px-6 / lg:px-8` margins. The form itself spans `col-span-7` on desktop for a readable measure.
+
+Files:
+
+- [`templates/customize-appearance/CustomizeAppearance.tsx`](https://github.com/UiPath/apollo-ui/blob/main/apps/apollo-vertex/templates/customize-appearance/CustomizeAppearance.tsx) — the form composition.
+- [`templates/customize-appearance/branding-store.ts`](https://github.com/UiPath/apollo-ui/blob/main/apps/apollo-vertex/templates/customize-appearance/branding-store.ts) — store + persistence adapter.
+- [`templates/customize-appearance/color-utils.ts`](https://github.com/UiPath/apollo-ui/blob/main/apps/apollo-vertex/templates/customize-appearance/color-utils.ts) — oklch ↔ hex conversion and primary-ramp generation.
+- [`templates/customize-appearance/use-branding-theme-enforcer.ts`](https://github.com/UiPath/apollo-ui/blob/main/apps/apollo-vertex/templates/customize-appearance/use-branding-theme-enforcer.ts) — hook that locks the app to light mode when a custom theme is active.
+
+## Installation
+
+Copy the three files above into your app and wire them into your router. The underlying components install from the registry:
+
+```bash
+npx shadcn@latest add @uipath/shell
+npx shadcn@latest add @uipath/page-header
+npx shadcn@latest add @uipath/card
+npx shadcn@latest add @uipath/collapsible
+npx shadcn@latest add @uipath/button
+npx shadcn@latest add @uipath/input
+npx shadcn@latest add @uipath/label
+npx shadcn@latest add @uipath/spinner
+npx shadcn@latest add @uipath/sonner
+```
+
+In your app root, render a `<Toaster />`, call `useBrandingThemeEnforcer()` inside the `ThemeProvider`, and pass live branding to `<ApolloShell>`:
+
+```tsx
+import { ApolloShell } from '@/components/ui/shell';
+import { ThemeProvider } from '@/components/ui/shell/shell-theme-provider';
+import { Toaster } from '@/components/ui/sonner';
+import { useEffect } from 'react';
+import { brandingStore, useBrandingStore } from './branding-store';
+import { buildBrandingStyle } from './color-utils';
+import { useBrandingThemeEnforcer } from './use-branding-theme-enforcer';
+
+function BrandedApp() {
+  useBrandingThemeEnforcer();
+  const { appTitle, logoUrl, logoAlt, themeMode, primaryColor, accentColor } =
+    useBrandingStore();
+
+  useEffect(() => {
+    brandingStore.hydrate();
+  }, []);
+
+  const style =
+    themeMode === 'custom'
+      ? buildBrandingStyle(primaryColor, accentColor)
+      : undefined;
+
+  return (
+    <div style={style}>
+      <ApolloShell
+        companyName={appTitle || 'Your Company'}
+        productName="Your Product"
+        companyLogo={
+          logoUrl
+            ? { url: logoUrl, alt: logoAlt || 'Company logo', isCustom: true }
+            : undefined
+        }
+        navItems={navItems}
+      >
+        <YourRoutes />
+      </ApolloShell>
+      <Toaster />
+    </div>
+  );
+}
+
+export function App() {
+  return (
+    <ThemeProvider>
+      <BrandedApp />
+    </ThemeProvider>
+  );
+}
+```
+
+The `style` prop on the outer `<div>` applies the custom CSS variables via inheritance, scoped to that subtree. No global `document.documentElement` mutation.
+
+### Why the theme enforcer
+
+The primary-ramp generator (`buildPrimaryVars`) is calibrated for light-palette lightness values. Applied in dark mode the ramp looks wrong against dark chrome, and many brand colors lose sufficient contrast on dark surfaces. `useBrandingThemeEnforcer` locks the app to light whenever `themeMode === 'custom'` and restores the user's previous theme (light / dark / system) when they switch back to the default themes. Call it once at app root, inside `ThemeProvider` — never inside the customization form itself.
+
+## Persisting to a backend
+
+The store ships with a `localStorage` adapter so the pattern works out of the box. For real deployments, replace the adapter with one that syncs to your backend. The recommended target for UiPath vertical solutions is **Data Fabric**, which stores the branding record on a first-class entity and uploads the logo as an attachment.
+
+### Adapter interface
+
+```ts
+export interface BrandingAdapter {
+  load(): Promise<Partial<BrandingSettings> | null>;
+  save(settings: BrandingSettings): Promise<void>;
+  uploadLogo?(file: File): Promise<string>;
+  clearLogo?(): Promise<void>;
+}
+```
+
+Logo uploads are deferred: `CustomizeAppearance` stages the `File` locally (reading it as a data URL for instant preview) and only calls `adapter.uploadLogo` when the user clicks **Save changes**. Backends that separate the settings record from file attachments (like Data Fabric) should implement both `uploadLogo` and `clearLogo` so the store can orchestrate the upload → save (or clear → save) flow atomically. `save` should only persist the non-logo fields — the store writes the resolved `logoUrl` back into the record after `uploadLogo` resolves.
+
+### Data Fabric adapter (sketch)
+
+```ts
+import dataFabricService from '@/services/dataFabricService';
+import {
+  readFileAsDataUrl,
+  type BrandingAdapter,
+  type BrandingSettings,
+} from './branding-store';
+
+const ENTITY_NAME = 'AppBranding';
+const LOGO_FIELD = 'Logo';
+
+export function createDataFabricAdapter(): BrandingAdapter {
+  let entityId: string | null = null;
+  let recordId: string | null = null;
+
+  async function ensureEntity() {
+    if (entityId) return entityId;
+    const entities = await dataFabricService.getAllEntities();
+    const entity = entities.find((e) => e.name === ENTITY_NAME);
+    if (!entity) throw new Error(`${ENTITY_NAME} entity not found`);
+    entityId = entity.id;
+    return entityId;
+  }
+
+  return {
+    async load() {
+      const id = await ensureEntity();
+      const response = await dataFabricService.queryEntityRecords(id, {
+        selectedFields: ['Id', 'HeaderTitle', 'PrimaryColor', 'AccentColor', 'Logo'],
+        limit: 1,
+      });
+      const record = response.value[0];
+      if (!record) return null;
+      recordId = record.Id;
+
+      let logoUrl = '';
+      if (record.Logo) {
+        logoUrl = await dataFabricService.getFileAsDataUrl(
+          ENTITY_NAME,
+          record.Id,
+          LOGO_FIELD,
+        );
+      }
+
+      return {
+        appTitle: record.HeaderTitle ?? '',
+        primaryColor: record.PrimaryColor ?? '',
+        accentColor: record.AccentColor ?? '',
+        themeMode: record.PrimaryColor || record.AccentColor ? 'custom' : 'default',
+        logoUrl,
+      };
+    },
+
+    async save(settings: BrandingSettings) {
+      const id = await ensureEntity();
+      const record = {
+        HeaderTitle: settings.appTitle,
+        PrimaryColor: settings.primaryColor,
+        AccentColor: settings.accentColor,
+      };
+      if (recordId) {
+        await dataFabricService.updateRecords(id, [{ Id: recordId, ...record }]);
+      } else {
+        const result = await dataFabricService.insertRecords(id, [record]);
+        recordId = result.items[0].Id;
+      }
+    },
+
+    async uploadLogo(file: File) {
+      const id = await ensureEntity();
+      if (!recordId) {
+        const result = await dataFabricService.insertRecords(id, [{ HeaderTitle: '' }]);
+        recordId = result.items[0].Id;
+      }
+      await dataFabricService.uploadFileToEntity(
+        ENTITY_NAME,
+        recordId,
+        LOGO_FIELD,
+        file,
+      );
+      // Return a data URL so the shell can render the logo without a refetch.
+      return readFileAsDataUrl(file);
+    },
+
+    async clearLogo() {
+      if (!recordId) return;
+      await dataFabricService.deleteFileFromEntity(
+        ENTITY_NAME,
+        recordId,
+        LOGO_FIELD,
+      );
+    },
+  };
+}
+```
+
+Wire it up once at app startup, before the first `brandingStore.hydrate()` call:
+
+```ts
+brandingStore.setAdapter(createDataFabricAdapter());
+```
+
+Model the entity in Data Fabric with `HeaderTitle`, `PrimaryColor`, `AccentColor` (plus any additional fields you want to expose — `BodyFont`, `LogoAlt`, etc.) and a file field `Logo` for the uploaded image.
+
+## Customizing
+
+- **Add more fields** — the pattern generalizes: add `bodyFont`, `brandVoice`, `favicon`, etc. to `BrandingSettings`, surface them in `CustomizeAppearance`, and update `BrandingAdapter` implementations to persist them. `buildBrandingStyle` is the single place where CSS variables are derived.
+- **Lock dark mode** — the example locks custom theming to light mode (the primary-ramp generator targets light-palette lightness values). To support custom dark mode, generate a second ramp in `buildPrimaryVars` and merge `dark: {...}` into the style map.
+- **Restrict access** — this is a tenant-admin surface. Gate the route behind a group check (see [`GroupMembershipGuard`](/patterns/shell#gating-access-by-group-membership)) so only admins can change the tenant's branding.
+- **Accessibility** — warn users before they save colors with insufficient contrast. Run `primaryColor` through a contrast check (WCAG 4.5:1 against `--primary-foreground`) and surface a toast if it fails. The color picker does not validate this by default.
+- **Debounce saves** — if you wire the adapter to hit the backend on every keystroke, your users will DOS themselves. The pattern defers persistence to the explicit `Save changes` button; keep that interaction model when you swap adapters.

--- a/apps/apollo-vertex/registry/card/card.tsx
+++ b/apps/apollo-vertex/registry/card/card.tsx
@@ -43,7 +43,7 @@ function Card({
 
     return (
       <div
-        className="relative group h-full"
+        className="relative group/card h-full"
         data-slot="card"
         data-variant={variant}
         data-selectable={selectable}
@@ -73,7 +73,7 @@ function Card({
           className={cn(
             "absolute inset-0 rounded-2xl pointer-events-none blur-xl bg-primary-400/15 dark:bg-primary-400/50",
             "opacity-0 transition-opacity duration-150",
-            !selected && "group-hover:opacity-100",
+            !selected && "group-hover/card:opacity-100",
           )}
         />
 

--- a/apps/apollo-vertex/templates/customize-appearance/CustomizeAppearance.tsx
+++ b/apps/apollo-vertex/templates/customize-appearance/CustomizeAppearance.tsx
@@ -1,0 +1,330 @@
+"use client";
+
+import { Upload, X } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import { Collapsible, CollapsibleContent } from "@/components/ui/collapsible";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  PageHeader,
+  PageHeaderDescription,
+  PageHeaderTitle,
+} from "@/components/ui/page-header";
+import { Spinner } from "@/components/ui/spinner";
+import {
+  brandingStore,
+  type ThemeMode,
+  useBrandingHasChanges,
+  useBrandingStore,
+} from "./branding-store";
+import { hexToOklchString, toHexForPicker } from "./color-utils";
+
+const DEFAULT_PRIMARY_COLOR = "oklch(0.64 0.115 208)";
+const DEFAULT_ACCENT_COLOR = "oklch(0.78 0.112 207.1)";
+
+const COLOR_FIELDS = [
+  {
+    key: "primaryColor" as const,
+    label: "Primary",
+    defaultValue: DEFAULT_PRIMARY_COLOR,
+  },
+  {
+    key: "accentColor" as const,
+    label: "Accent",
+    defaultValue: DEFAULT_ACCENT_COLOR,
+  },
+];
+
+export function CustomizeAppearance() {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const branding = useBrandingStore();
+  const hasChanges = useBrandingHasChanges();
+  const [isSaving, setIsSaving] = useState(false);
+
+  useEffect(() => {
+    void brandingStore.hydrate();
+  }, []);
+
+  useEffect(() => {
+    if (!hasChanges) return;
+    const handleBeforeUnload = (e: BeforeUnloadEvent) => {
+      e.preventDefault();
+    };
+    window.addEventListener("beforeunload", handleBeforeUnload);
+    return () => window.removeEventListener("beforeunload", handleBeforeUnload);
+  }, [hasChanges]);
+
+  const isCustom = branding.themeMode === "custom";
+  const hasLogo = !!branding.logoUrl;
+  const hasAnyCustomization =
+    isCustom ||
+    !!branding.primaryColor ||
+    !!branding.accentColor ||
+    hasLogo ||
+    !!branding.appTitle;
+
+  const handleFieldChange = (key: keyof typeof branding, value: string) => {
+    brandingStore.setCurrent({ [key]: value });
+  };
+
+  const handleModeChange = (mode: ThemeMode) => {
+    if (mode === branding.themeMode) return;
+
+    if (mode === "default") {
+      brandingStore.setCurrent({
+        themeMode: mode,
+        primaryColor: "",
+        accentColor: "",
+      });
+    } else {
+      brandingStore.setCurrent({
+        themeMode: mode,
+        primaryColor: branding.primaryColor || DEFAULT_PRIMARY_COLOR,
+        accentColor: branding.accentColor || DEFAULT_ACCENT_COLOR,
+      });
+    }
+  };
+
+  const handleLogoUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    if (file.size > 10 * 1024 * 1024) {
+      toast.error("Logo file is too large", {
+        description: "Maximum size is 10MB.",
+      });
+      return;
+    }
+
+    if (file.size > 500 * 1024) {
+      toast.warning("Large logo file", {
+        description:
+          "Consider using a smaller image (under 500KB) for better performance.",
+      });
+    }
+
+    try {
+      await brandingStore.stageLogo(file);
+    } catch (error) {
+      toast.error("Failed to read logo file", {
+        description:
+          error instanceof Error ? error.message : "Please try again.",
+      });
+    }
+  };
+
+  const handleRemoveLogo = () => {
+    brandingStore.removeLogo();
+  };
+
+  const handleSave = async () => {
+    setIsSaving(true);
+    try {
+      await brandingStore.save();
+      toast.success("Settings saved", {
+        description: "Your appearance changes have been applied.",
+      });
+    } catch (error) {
+      toast.error("Failed to save settings", {
+        description:
+          error instanceof Error ? error.message : "Please try again.",
+      });
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const handleReset = async () => {
+    setIsSaving(true);
+    try {
+      await brandingStore.reset();
+      toast.success("Defaults restored", {
+        description: "Appearance has been reset to defaults.",
+      });
+    } catch (error) {
+      toast.error("Failed to reset settings", {
+        description:
+          error instanceof Error ? error.message : "Please try again.",
+      });
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  return (
+    <div className="@container px-4 sm:px-6 lg:px-8 py-6">
+      <PageHeader size="content">
+        <PageHeaderTitle>Customize appearance</PageHeaderTitle>
+        <PageHeaderDescription className="text-sm">
+          Changes to the appearance apply to all users in your organization
+        </PageHeaderDescription>
+      </PageHeader>
+
+      <div className="grid grid-cols-4 @md:grid-cols-8 @3xl:grid-cols-12 gap-x-4 gap-y-8 mt-6">
+        <div className="col-span-4 @md:col-span-8 @3xl:col-span-7 space-y-2">
+          <Label>Company logo</Label>
+          <div className="relative w-16 h-16 group/logo">
+            <button
+              type="button"
+              onClick={() => fileInputRef.current?.click()}
+              className="w-full h-full border-2 border-dashed border-border rounded-lg overflow-hidden flex items-center justify-center bg-muted cursor-pointer hover:bg-muted/80 transition-colors"
+            >
+              {hasLogo ? (
+                <img
+                  src={branding.logoUrl}
+                  alt={branding.logoAlt || "Logo preview"}
+                  className="max-w-full max-h-full object-contain"
+                />
+              ) : (
+                <Upload className="h-5 w-5 text-muted-foreground" />
+              )}
+            </button>
+            {hasLogo && (
+              <button
+                type="button"
+                onClick={handleRemoveLogo}
+                className="absolute -top-2 -right-2 w-5 h-5 rounded-full bg-destructive text-destructive-foreground flex items-center justify-center opacity-0 group-hover/logo:opacity-100 transition-opacity hover:bg-destructive/90"
+                aria-label="Remove logo"
+              >
+                <X className="h-3 w-3" />
+              </button>
+            )}
+          </div>
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept="image/*"
+            onChange={(e) => {
+              void handleLogoUpload(e);
+            }}
+            className="hidden"
+          />
+          <p className="text-xs text-muted-foreground">
+            PNG or SVG, under 500KB recommended
+          </p>
+        </div>
+
+        <div className="col-span-4 @md:col-span-8 @3xl:col-span-7 space-y-2">
+          <Label htmlFor="app-title">Company name</Label>
+          <Input
+            id="app-title"
+            type="text"
+            value={branding.appTitle}
+            onChange={(e) => handleFieldChange("appTitle", e.target.value)}
+            placeholder="Enter company name..."
+            className="max-w-sm"
+          />
+        </div>
+
+        <div className="col-span-4 @md:col-span-8 @3xl:col-span-7">
+          <Label>Theming</Label>
+          <p className="text-sm text-muted-foreground mt-1">
+            Choose between built-in themes or a custom theme
+          </p>
+        </div>
+
+        <div className="col-span-4 @md:col-span-4 @3xl:col-span-3 @3xl:col-start-1">
+          <Card
+            selectable="standard"
+            selected={!isCustom}
+            onClick={() => handleModeChange("default")}
+          >
+            <span className="text-base font-semibold text-foreground mb-1">
+              Default themes
+            </span>
+            <p className="text-sm text-muted-foreground leading-relaxed">
+              Light, dark, and system preference.
+            </p>
+          </Card>
+        </div>
+
+        <div className="col-span-4 @md:col-span-4 @3xl:col-span-3">
+          <Card
+            selectable="standard"
+            selected={isCustom}
+            onClick={() => handleModeChange("custom")}
+          >
+            <span className="text-base font-semibold text-foreground mb-1">
+              Custom theme
+            </span>
+            <p className="text-sm text-muted-foreground leading-relaxed">
+              Apply your brand colors. Light theme only.
+            </p>
+          </Card>
+        </div>
+
+        <Collapsible
+          className="col-span-4 @md:col-span-8 @3xl:col-span-6 @3xl:col-start-1"
+          open={isCustom}
+        >
+          <CollapsibleContent className="transition-opacity duration-200 data-[state=closed]:opacity-0 data-[state=open]:opacity-100">
+            <div className="grid grid-cols-2 gap-4 pt-1">
+              {COLOR_FIELDS.map(({ key, label, defaultValue }) => {
+                const rawValue = branding[key];
+                const displayValue = rawValue || defaultValue;
+                const hexForPicker = toHexForPicker(displayValue);
+
+                return (
+                  <div key={key} className="space-y-1.5">
+                    <Label htmlFor={key}>{label}</Label>
+                    <div className="relative">
+                      <input
+                        type="color"
+                        value={hexForPicker}
+                        className="absolute left-1.5 top-1/2 -translate-y-1/2 w-6 h-6 rounded cursor-pointer border-0 p-0 [&::-webkit-color-swatch-wrapper]:p-0 [&::-webkit-color-swatch]:rounded [&::-webkit-color-swatch]:border-0 [&::-moz-color-swatch]:rounded [&::-moz-color-swatch]:border-0"
+                        onChange={(e) =>
+                          handleFieldChange(
+                            key,
+                            hexToOklchString(e.target.value),
+                          )
+                        }
+                        title={`Pick ${label.toLowerCase()} color`}
+                      />
+                      <Input
+                        id={key}
+                        value={displayValue}
+                        onChange={(e) => handleFieldChange(key, e.target.value)}
+                        className="text-sm pl-10"
+                        placeholder={defaultValue}
+                      />
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </CollapsibleContent>
+        </Collapsible>
+
+        <div className="col-span-4 @md:col-span-8 @3xl:col-span-6 @3xl:col-start-1 flex items-center justify-end gap-3">
+          <Button
+            variant="outline"
+            onClick={() => {
+              void handleReset();
+            }}
+            disabled={isSaving || !hasAnyCustomization}
+          >
+            Reset to defaults
+          </Button>
+          <Button
+            onClick={() => {
+              void handleSave();
+            }}
+            disabled={!hasChanges || isSaving}
+          >
+            {isSaving ? (
+              <>
+                <Spinner className="mr-2" />
+                Saving...
+              </>
+            ) : (
+              "Save changes"
+            )}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/apollo-vertex/templates/customize-appearance/CustomizeAppearancePreview.tsx
+++ b/apps/apollo-vertex/templates/customize-appearance/CustomizeAppearancePreview.tsx
@@ -1,0 +1,225 @@
+"use client";
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+  Outlet,
+  redirect,
+  RouterProvider,
+} from "@tanstack/react-router";
+import { BarChart3, FolderOpen, Home, Settings } from "lucide-react";
+import { useEffect, useState } from "react";
+import { ApolloShell, type ShellNavItem } from "@/components/ui/shell";
+import { Toaster } from "@/components/ui/sonner";
+import { brandingStore, useBrandingStore } from "./branding-store";
+import { buildBrandingStyle } from "./color-utils";
+import { CustomizeAppearance } from "./CustomizeAppearance";
+
+export interface CustomizeAppearancePreviewProps {
+  variant?: "minimal";
+}
+
+const PLACEHOLDER_KEYS = {
+  dashboard: "Dashboard",
+  projects: "Projects",
+  analytics: "Analytics",
+} as const;
+
+function PlaceholderPage({ title }: { title: string }) {
+  return (
+    <div className="flex items-center justify-center h-full">
+      <div className="text-center space-y-2">
+        <h1 className="text-2xl font-semibold text-foreground">{title}</h1>
+        <p className="text-muted-foreground">
+          Navigate to Settings to customize appearance.
+        </p>
+      </div>
+    </div>
+  );
+}
+
+function BrandedShell({ variant }: { variant?: "minimal" }) {
+  const { appTitle, logoUrl, logoAlt } = useBrandingStore();
+
+  const navItems: ShellNavItem[] =
+    variant === "minimal"
+      ? [
+          {
+            path: "/preview/customize-appearance-minimal",
+            label: "dashboard",
+            icon: Home,
+          },
+          {
+            path: "/preview/customize-appearance-minimal/projects",
+            label: "projects",
+            icon: FolderOpen,
+          },
+          {
+            path: "/preview/customize-appearance-minimal/settings",
+            label: "settings",
+            icon: Settings,
+          },
+        ]
+      : [
+          {
+            path: "/preview/customize-appearance/dashboard",
+            label: "dashboard",
+            icon: Home,
+          },
+          {
+            path: "/preview/customize-appearance/projects",
+            label: "projects",
+            icon: FolderOpen,
+          },
+          {
+            path: "/preview/customize-appearance/analytics",
+            label: "analytics",
+            icon: BarChart3,
+          },
+          {
+            path: "/preview/customize-appearance/settings",
+            label: "settings",
+            icon: Settings,
+          },
+        ];
+
+  return (
+    <ApolloShell
+      companyName={appTitle || "Your Company"}
+      productName="Apollo Vertex"
+      companyLogo={
+        logoUrl
+          ? {
+              url: logoUrl,
+              alt: logoAlt || "Company logo",
+              isCustom: true,
+            }
+          : {
+              url: "/UiPath.svg",
+              darkUrl: "/UiPath_dark.svg",
+              alt: "UiPath",
+            }
+      }
+      variant={variant}
+      navItems={navItems}
+    >
+      <Outlet />
+    </ApolloShell>
+  );
+}
+
+function buildRouter(variant?: "minimal") {
+  const rootRoute = createRootRoute();
+  const basePath =
+    variant === "minimal"
+      ? "/preview/customize-appearance-minimal"
+      : "/preview/customize-appearance";
+
+  const shellRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: basePath,
+    component: () => <BrandedShell variant={variant} />,
+  });
+
+  const routes = [
+    createRoute({
+      getParentRoute: () => shellRoute,
+      path: "/",
+      component: () => <PlaceholderPage title={PLACEHOLDER_KEYS.dashboard} />,
+    }),
+    createRoute({
+      getParentRoute: () => shellRoute,
+      path: "/dashboard",
+      component: () => <PlaceholderPage title={PLACEHOLDER_KEYS.dashboard} />,
+    }),
+    createRoute({
+      getParentRoute: () => shellRoute,
+      path: "/projects",
+      component: () => <PlaceholderPage title={PLACEHOLDER_KEYS.projects} />,
+    }),
+    createRoute({
+      getParentRoute: () => shellRoute,
+      path: "/analytics",
+      component: () => <PlaceholderPage title={PLACEHOLDER_KEYS.analytics} />,
+    }),
+    createRoute({
+      getParentRoute: () => shellRoute,
+      path: "/settings",
+      component: CustomizeAppearance,
+    }),
+  ];
+
+  // The shell's company logo links to "/" — redirect any hit outside the
+  // preview subtree (including "/") back to the dashboard so the logo click
+  // lands somewhere meaningful inside the memory router.
+  const catchAllRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: "$",
+    beforeLoad: () => {
+      // oxlint-disable-next-line typescript-eslint/only-throw-error -- TanStack Router uses thrown redirects as its redirect API
+      throw redirect({ to: `${basePath}/dashboard` });
+    },
+  });
+
+  const routeTree = rootRoute.addChildren([
+    shellRoute.addChildren(routes),
+    catchAllRoute,
+  ]);
+
+  const storageKey =
+    variant === "minimal"
+      ? "customize-appearance-minimal-preview-path"
+      : "customize-appearance-preview-path";
+
+  const initialPath =
+    typeof window === "undefined"
+      ? `${basePath}/settings`
+      : (window.localStorage.getItem(storageKey) ?? `${basePath}/settings`);
+
+  const history = createMemoryHistory({ initialEntries: [initialPath] });
+  const router = createRouter({ routeTree, history });
+
+  router.subscribe("onResolved", ({ toLocation }) => {
+    if (typeof window !== "undefined") {
+      window.localStorage.setItem(storageKey, toLocation.pathname);
+    }
+  });
+
+  return router;
+}
+
+const queryClient = new QueryClient();
+
+function BrandingScope({ children }: { children: React.ReactNode }) {
+  const { themeMode, primaryColor, accentColor } = useBrandingStore();
+  const style =
+    themeMode === "custom" ? buildBrandingStyle(primaryColor, accentColor) : {};
+
+  return (
+    <div className="h-full" style={style}>
+      {children}
+    </div>
+  );
+}
+
+export function CustomizeAppearancePreview({
+  variant,
+}: CustomizeAppearancePreviewProps) {
+  const [router] = useState(() => buildRouter(variant));
+
+  useEffect(() => {
+    void brandingStore.hydrate();
+  }, []);
+
+  return (
+    <QueryClientProvider client={queryClient}>
+      <BrandingScope>
+        <RouterProvider router={router} />
+        <Toaster />
+      </BrandingScope>
+    </QueryClientProvider>
+  );
+}

--- a/apps/apollo-vertex/templates/customize-appearance/CustomizeAppearanceTemplate.tsx
+++ b/apps/apollo-vertex/templates/customize-appearance/CustomizeAppearanceTemplate.tsx
@@ -1,0 +1,11 @@
+"use client";
+
+import dynamic from "next/dynamic";
+
+export const CustomizeAppearanceTemplate = dynamic(
+  () =>
+    import("./CustomizeAppearancePreview").then((mod) => ({
+      default: mod.CustomizeAppearancePreview,
+    })),
+  { ssr: false },
+);

--- a/apps/apollo-vertex/templates/customize-appearance/branding-store.ts
+++ b/apps/apollo-vertex/templates/customize-appearance/branding-store.ts
@@ -1,0 +1,249 @@
+"use client";
+
+import { useSyncExternalStore } from "react";
+
+export type ThemeMode = "default" | "custom";
+
+export interface BrandingSettings {
+  themeMode: ThemeMode;
+  appTitle: string;
+  logoUrl: string;
+  logoAlt: string;
+  primaryColor: string;
+  accentColor: string;
+}
+
+// Persistence adapter — swap the default localStorage implementation with a
+// Data Fabric (or other backend) adapter to sync branding across users.
+export interface BrandingAdapter {
+  load(): Promise<Partial<BrandingSettings> | null>;
+  // Persist non-logo fields. Logo upload/clear is handled via uploadLogo /
+  // clearLogo so backends that store logos as attachments (e.g. Data Fabric)
+  // can upload the File directly instead of embedding a data URL in the
+  // settings record.
+  save(settings: BrandingSettings): Promise<void>;
+  // Returns the URL (or data URL) to display for the newly uploaded logo.
+  uploadLogo?(file: File): Promise<string>;
+  // Remove the current logo from the backend (e.g. delete the attachment).
+  clearLogo?(): Promise<void>;
+}
+
+export const DEFAULT_BRANDING: BrandingSettings = {
+  themeMode: "default",
+  appTitle: "",
+  logoUrl: "",
+  logoAlt: "",
+  primaryColor: "",
+  accentColor: "",
+};
+
+const STORAGE_KEY = "vertex-branding";
+
+function parseStored(raw: string): Partial<BrandingSettings> | null {
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (parsed && typeof parsed === "object") {
+      return parsed as Partial<BrandingSettings>;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+export function readFileAsDataUrl(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.addEventListener("load", () => {
+      const result = reader.result;
+      if (typeof result === "string") {
+        resolve(result);
+      } else {
+        reject(new Error("FileReader did not return a string"));
+      }
+    });
+    reader.addEventListener("error", () => {
+      reject(reader.error ?? new Error("Failed to read file"));
+    });
+    reader.readAsDataURL(file);
+  });
+}
+
+export function createLocalStorageAdapter(
+  key: string = STORAGE_KEY,
+): BrandingAdapter {
+  return {
+    load() {
+      if (typeof window === "undefined") return Promise.resolve(null);
+      const raw = window.localStorage.getItem(key);
+      return Promise.resolve(raw ? parseStored(raw) : null);
+    },
+    save(settings) {
+      if (typeof window !== "undefined") {
+        window.localStorage.setItem(key, JSON.stringify(settings));
+      }
+      return Promise.resolve();
+    },
+    // localStorage embeds the logo as a data URL inside the settings record,
+    // so uploadLogo just returns the data URL form of the file and clearLogo
+    // is a no-op (the logoUrl is already cleared in the settings record).
+    uploadLogo(file) {
+      return readFileAsDataUrl(file);
+    },
+    clearLogo() {
+      return Promise.resolve();
+    },
+  };
+}
+
+type Listener = () => void;
+
+interface StoreState {
+  current: BrandingSettings;
+  saved: BrandingSettings;
+  pendingLogoFile: File | null;
+  shouldClearLogo: boolean;
+}
+
+let state: StoreState = {
+  current: { ...DEFAULT_BRANDING },
+  saved: { ...DEFAULT_BRANDING },
+  pendingLogoFile: null,
+  shouldClearLogo: false,
+};
+let adapter: BrandingAdapter = createLocalStorageAdapter();
+let hasLoaded = false;
+const listeners = new Set<Listener>();
+
+function emit() {
+  for (const l of listeners) l();
+}
+
+function getState(): StoreState {
+  return state;
+}
+
+function getCurrent(): BrandingSettings {
+  return state.current;
+}
+
+function subscribe(listener: Listener) {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+export const brandingStore = {
+  getState,
+  getCurrent,
+  subscribe,
+  setCurrent(partial: Partial<BrandingSettings>) {
+    state = { ...state, current: { ...state.current, ...partial } };
+    emit();
+  },
+  // Stage a new logo: read the file as a data URL for immediate preview and
+  // hold the File object until the user clicks Save, at which point the real
+  // upload runs via the adapter.
+  async stageLogo(file: File) {
+    const dataUrl = await readFileAsDataUrl(file);
+    state = {
+      ...state,
+      current: { ...state.current, logoUrl: dataUrl, logoAlt: file.name },
+      pendingLogoFile: file,
+      shouldClearLogo: false,
+    };
+    emit();
+  },
+  // Flag the logo for removal on next save. Also discards any pending upload.
+  removeLogo() {
+    const savedHasLogo = !!state.saved.logoUrl;
+    state = {
+      ...state,
+      current: { ...state.current, logoUrl: "", logoAlt: "" },
+      pendingLogoFile: null,
+      // Only ask the backend to clear if there was a saved logo to remove.
+      shouldClearLogo: savedHasLogo,
+    };
+    emit();
+  },
+  setAdapter(next: BrandingAdapter) {
+    adapter = next;
+    hasLoaded = false;
+  },
+  async hydrate() {
+    if (hasLoaded) return;
+    hasLoaded = true;
+    const loaded = await adapter.load();
+    if (loaded) {
+      const merged = { ...DEFAULT_BRANDING, ...loaded };
+      state = {
+        current: merged,
+        saved: merged,
+        pendingLogoFile: null,
+        shouldClearLogo: false,
+      };
+      emit();
+    }
+  },
+  async save() {
+    const next = { ...state.current };
+
+    if (state.pendingLogoFile && adapter.uploadLogo) {
+      next.logoUrl = await adapter.uploadLogo(state.pendingLogoFile);
+    } else if (state.shouldClearLogo && adapter.clearLogo) {
+      await adapter.clearLogo();
+    }
+
+    await adapter.save(next);
+
+    state = {
+      current: next,
+      saved: next,
+      pendingLogoFile: null,
+      shouldClearLogo: false,
+    };
+    emit();
+  },
+  async reset() {
+    const savedHasLogo = !!state.saved.logoUrl;
+    const next = { ...DEFAULT_BRANDING };
+
+    if (savedHasLogo && adapter.clearLogo) {
+      await adapter.clearLogo();
+    }
+    await adapter.save(next);
+
+    state = {
+      current: next,
+      saved: next,
+      pendingLogoFile: null,
+      shouldClearLogo: false,
+    };
+    emit();
+  },
+};
+
+export function useBrandingStore(): BrandingSettings {
+  return useSyncExternalStore(subscribe, getCurrent, getCurrent);
+}
+
+export function useBrandingHasChanges(): boolean {
+  return useSyncExternalStore(
+    subscribe,
+    () => {
+      const { current, saved, pendingLogoFile, shouldClearLogo } = getState();
+      return (
+        !!pendingLogoFile ||
+        shouldClearLogo ||
+        current.themeMode !== saved.themeMode ||
+        current.appTitle !== saved.appTitle ||
+        current.logoUrl !== saved.logoUrl ||
+        current.logoAlt !== saved.logoAlt ||
+        current.primaryColor !== saved.primaryColor ||
+        current.accentColor !== saved.accentColor
+      );
+    },
+    () => false,
+  );
+}

--- a/apps/apollo-vertex/templates/customize-appearance/color-utils.ts
+++ b/apps/apollo-vertex/templates/customize-appearance/color-utils.ts
@@ -1,0 +1,194 @@
+import type { CSSProperties } from "react";
+
+function linearToSrgb(val: number): number {
+  if (val <= 0.0031308) return 12.92 * val;
+  return 1.055 * val ** (1 / 2.4) - 0.055;
+}
+
+function srgbToLinear(val: number): number {
+  if (val <= 0.04045) return val / 12.92;
+  return ((val + 0.055) / 1.055) ** 2.4;
+}
+
+export function oklchToHex(oklchString: string): string {
+  const match = oklchString.match(
+    /oklch\s*\(\s*([0-9.]+)%?\s+([0-9.]+)\s+([0-9.]+)(?:deg)?(?:\s*\/\s*([0-9.]+)%?)?\s*\)/i,
+  );
+  if (!match) return oklchString;
+
+  let l = Number.parseFloat(match[1]);
+  const c = Number.parseFloat(match[2]);
+  const h = Number.parseFloat(match[3]);
+  let alpha = match[4] ? Number.parseFloat(match[4]) : 1;
+
+  if (oklchString.includes("%") && match[1].includes("%")) l = l / 100;
+  if (match[4] && oklchString.includes(`/ ${match[4]}%`)) alpha = alpha / 100;
+
+  const hRad = (h * Math.PI) / 180;
+  const a = c * Math.cos(hRad);
+  const b = c * Math.sin(hRad);
+
+  const l_ = l + 0.3963377774 * a + 0.2158037573 * b;
+  const m_ = l - 0.1055613458 * a - 0.0638541728 * b;
+  const s_ = l - 0.0894841775 * a - 1.291485548 * b;
+
+  let r =
+    4.0767416621 * l_ ** 3 - 3.3077115913 * m_ ** 3 + 0.2309699292 * s_ ** 3;
+  let g =
+    -1.2684380046 * l_ ** 3 + 2.6097574011 * m_ ** 3 - 0.3413193965 * s_ ** 3;
+  let b_rgb =
+    -0.0041960863 * l_ ** 3 - 0.7034186147 * m_ ** 3 + 1.707614701 * s_ ** 3;
+
+  r = linearToSrgb(r);
+  g = linearToSrgb(g);
+  b_rgb = linearToSrgb(b_rgb);
+
+  r = Math.max(0, Math.min(255, Math.round(r * 255)));
+  g = Math.max(0, Math.min(255, Math.round(g * 255)));
+  b_rgb = Math.max(0, Math.min(255, Math.round(b_rgb * 255)));
+
+  if (alpha < 1) {
+    const bgValue = 51;
+    r = Math.round(r * alpha + bgValue * (1 - alpha));
+    g = Math.round(g * alpha + bgValue * (1 - alpha));
+    b_rgb = Math.round(b_rgb * alpha + bgValue * (1 - alpha));
+  }
+
+  return `#${[r, g, b_rgb].map((x) => x.toString(16).padStart(2, "0")).join("")}`;
+}
+
+export function hexToOklchString(hex: string): string {
+  const clean = hex.replace("#", "");
+  const full =
+    clean.length === 3
+      ? clean[0] + clean[0] + clean[1] + clean[1] + clean[2] + clean[2]
+      : clean;
+
+  const r = srgbToLinear(Number.parseInt(full.slice(0, 2), 16) / 255);
+  const g = srgbToLinear(Number.parseInt(full.slice(2, 4), 16) / 255);
+  const b = srgbToLinear(Number.parseInt(full.slice(4, 6), 16) / 255);
+
+  const l_ = Math.cbrt(0.4122214708 * r + 0.5363325363 * g + 0.0514459929 * b);
+  const m_ = Math.cbrt(0.2119034982 * r + 0.6806995451 * g + 0.1073969566 * b);
+  const s_ = Math.cbrt(0.0883024619 * r + 0.2817188376 * g + 0.6299787005 * b);
+
+  const L = 0.2104542553 * l_ + 0.793617785 * m_ - 0.0040720468 * s_;
+  const a = 1.9779984951 * l_ - 2.428592205 * m_ + 0.4505937099 * s_;
+  const bLab = 0.0259040371 * l_ + 0.7827717662 * m_ - 0.808675766 * s_;
+
+  const C = Math.hypot(a, bLab);
+  let H = (Math.atan2(bLab, a) * 180) / Math.PI;
+  if (H < 0) H += 360;
+
+  return `oklch(${L.toFixed(4)} ${C.toFixed(4)} ${H.toFixed(4)})`;
+}
+
+export function toHexForPicker(value: string): string {
+  if (!value) return "#000000";
+  if (value.startsWith("#")) return value;
+  if (value.includes("oklch")) {
+    try {
+      return oklchToHex(value);
+    } catch {
+      return "#000000";
+    }
+  }
+  return value;
+}
+
+function parseToOklch(
+  value: string,
+): { L: number; C: number; H: number } | null {
+  const oklchMatch = value.match(
+    /oklch\s*\(\s*([0-9.]+)%?\s+([0-9.]+)\s+([0-9.]+)/i,
+  );
+  if (oklchMatch) {
+    let l = Number.parseFloat(oklchMatch[1]);
+    if (value.includes("%")) l = l / 100;
+    return {
+      L: l,
+      C: Number.parseFloat(oklchMatch[2]),
+      H: Number.parseFloat(oklchMatch[3]),
+    };
+  }
+
+  if (value.startsWith("#")) {
+    const clean = value.replace("#", "");
+    if (clean.length !== 6 && clean.length !== 3) return null;
+    const full =
+      clean.length === 3
+        ? clean[0] + clean[0] + clean[1] + clean[1] + clean[2] + clean[2]
+        : clean;
+
+    const r = srgbToLinear(Number.parseInt(full.slice(0, 2), 16) / 255);
+    const g = srgbToLinear(Number.parseInt(full.slice(2, 4), 16) / 255);
+    const b = srgbToLinear(Number.parseInt(full.slice(4, 6), 16) / 255);
+
+    const l_ = Math.cbrt(
+      0.4122214708 * r + 0.5363325363 * g + 0.0514459929 * b,
+    );
+    const m_ = Math.cbrt(
+      0.2119034982 * r + 0.6806995451 * g + 0.1073969566 * b,
+    );
+    const s_ = Math.cbrt(
+      0.0883024619 * r + 0.2817188376 * g + 0.6299787005 * b,
+    );
+
+    const L = 0.2104542553 * l_ + 0.793617785 * m_ - 0.0040720468 * s_;
+    const a = 1.9779984951 * l_ - 2.428592205 * m_ + 0.4505937099 * s_;
+    const bLab = 0.0259040371 * l_ + 0.7827717662 * m_ - 0.808675766 * s_;
+
+    const C = Math.hypot(a, bLab);
+    let H = (Math.atan2(bLab, a) * 180) / Math.PI;
+    if (H < 0) H += 360;
+
+    return { L, C, H };
+  }
+
+  return null;
+}
+
+// Generates a full primary shade ramp + sidebar vars from a single primary color.
+// Used so Tailwind utilities like bg-primary-700 pick up the custom brand color.
+export function buildPrimaryVars(primaryColor: string): Record<string, string> {
+  const vars: Record<string, string> = {};
+  const parsed = parseToOklch(primaryColor);
+
+  vars["--primary"] = primaryColor;
+  vars["--sidebar-primary"] = primaryColor;
+  vars["--sidebar-ring"] = primaryColor;
+
+  if (parsed) {
+    const { C, H } = parsed;
+    vars["--primary-50"] = `oklch(0.95 ${(C * 0.3).toFixed(3)} ${H})`;
+    vars["--primary-100"] = `oklch(0.92 ${(C * 0.39).toFixed(3)} ${H})`;
+    vars["--primary-200"] = `oklch(0.86 ${(C * 0.52).toFixed(3)} ${H})`;
+    vars["--primary-300"] = `oklch(0.8 ${(C * 0.7).toFixed(3)} ${H})`;
+    vars["--primary-400"] = `oklch(0.75 ${(C * 0.87).toFixed(3)} ${H})`;
+    vars["--primary-500"] = `oklch(0.69 ${(C * 0.97).toFixed(3)} ${H})`;
+    vars["--primary-600"] =
+      `oklch(${parsed.L.toFixed(2)} ${C.toFixed(3)} ${H})`;
+    vars["--primary-700"] = `oklch(0.6 ${(C * 1.09).toFixed(3)} ${H})`;
+    vars["--primary-800"] = `oklch(0.53 ${(C * 0.96).toFixed(3)} ${H})`;
+    vars["--primary-900"] = `oklch(0.46 ${(C * 0.83).toFixed(3)} ${H})`;
+  }
+
+  return vars;
+}
+
+export function buildBrandingStyle(
+  primaryColor: string,
+  accentColor: string,
+): CSSProperties {
+  const vars: Record<string, string> = {};
+
+  if (primaryColor) {
+    Object.assign(vars, buildPrimaryVars(primaryColor));
+  }
+  if (accentColor) {
+    vars["--accent"] = accentColor;
+    vars["--sidebar-accent"] = accentColor;
+  }
+
+  return vars as CSSProperties;
+}

--- a/apps/apollo-vertex/templates/customize-appearance/use-branding-theme-enforcer.ts
+++ b/apps/apollo-vertex/templates/customize-appearance/use-branding-theme-enforcer.ts
@@ -1,0 +1,43 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { useTheme } from "@/registry/shell/shell-theme-provider";
+import { useBrandingStore } from "./branding-store";
+
+const PREVIOUS_THEME_KEY = "vertex-branding-previous-theme";
+
+// Custom brand colors are calibrated for the light palette (the primary ramp
+// generator targets light-mode lightness values). In dark mode the ramp
+// renders against dark chrome and looks wrong. This hook locks the app to
+// light mode whenever the user selects a custom theme and restores their
+// previous theme when they switch back to the default themes.
+//
+// Call from your app root, inside the ThemeProvider:
+//
+//   function App() {
+//     useBrandingThemeEnforcer();
+//     return <YourRoutes />;
+//   }
+export function useBrandingThemeEnforcer() {
+  const { themeMode } = useBrandingStore();
+  const { theme, setTheme } = useTheme();
+  const prevMode = useRef(themeMode);
+
+  useEffect(() => {
+    if (themeMode === "custom") {
+      if (prevMode.current !== "custom" && typeof window !== "undefined") {
+        window.localStorage.setItem(PREVIOUS_THEME_KEY, theme);
+      }
+      if (theme !== "light") {
+        setTheme("light");
+      }
+    } else if (prevMode.current === "custom" && typeof window !== "undefined") {
+      const saved = window.localStorage.getItem(PREVIOUS_THEME_KEY);
+      if (saved === "light" || saved === "dark" || saved === "system") {
+        setTheme(saved);
+        window.localStorage.removeItem(PREVIOUS_THEME_KEY);
+      }
+    }
+    prevMode.current = themeMode;
+  }, [themeMode, theme, setTheme]);
+}


### PR DESCRIPTION
## Summary

Adds a new **Customize Appearance** pattern to Apollo Vertex — a tenant-admin settings page that lets users swap in their own company name, logo, and brand colors, with edits previewed live across the shell.

Ported from the `CustomizeAppearance` page in `vertical-medical-mrs` and generalized for reuse.

## What's included

- **Pattern page** at `/patterns/customize-appearance` with live previews for both the default (sidebar) and `minimal` shell variants, plus docs for composition, installation, Data Fabric adapter sketch, and extension points.
- **Grab-and-go composition** (`CustomizeAppearance.tsx`) using only `@uipath/*` registry primitives (Button, Card, Collapsible, Input, Label, PageHeader, Spinner, Sonner).
- **Branding store** (`branding-store.ts`) with a pluggable `BrandingAdapter`. Ships with a `localStorage` adapter; the docs include a Data Fabric adapter sketch so vertical solutions can swap it in at app startup. Logo uploads are staged locally and only pushed to the backend on Save.
- **`useBrandingThemeEnforcer` hook** that locks the app to light mode when a custom theme is active (the primary-ramp generator is light-calibrated) and restores the user's previous theme when they switch back.
- **Layout via container queries** (`@container`, `@md:`, `@3xl:`) instead of viewport breakpoints, so the form responds to its rendered container width — previews, sidebar-collapsed shells, and iframes all lay out correctly.
- **Preview infrastructure**: TanStack memory router with a catch-all redirect so clicking the shell's company logo lands on the dashboard instead of 404ing. Both the sidebar and minimal-header shell variants read branding from the same store to demonstrate live-preview.

## Incidental Card fix

The selectable `Card` variant used an unnamed `group` class with `group-hover:` for its hover glow, which matched *any* ancestor `.group` — so the glow fired whenever the card rendered inside a `.group`-classed wrapper (e.g. `PreviewFullScreen`). Scoped to `group/card` + `group-hover/card:`. Surgical registry fix, low risk.

## Test plan

- [ ] Preview (`/patterns/customize-appearance`) renders both default and minimal variants; clicking Settings shows the form
- [ ] Typing a company name updates the shell sidebar product title live
- [ ] Uploading a logo replaces the default UiPath mark in the shell; removing restores the default
- [ ] Switching to Custom theme reveals color pickers (grow-down + fade)
- [ ] Changing the primary color updates the shell's active nav item, button colors, and focus rings live
- [ ] Save persists to localStorage (verify refresh loads saved values)
- [ ] Reset to defaults clears all customization
- [ ] Clicking the shell company logo navigates to the dashboard (not 404)
- [ ] Cards lay out cleanly at multiple container widths (narrow preview, full-screen preview, real desktop shell)
- [ ] Hovering anywhere in the preview does NOT trigger the logo-remove X or the card hover glow spuriously