### PR TITLE
fix(apollo-react): change case NotExecuted to be hourglass

### DIFF
--- a/packages/apollo-react/src/canvas/components/StageNode/StageNodeHeader.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNodeHeader.tsx
@@ -6,6 +6,7 @@ import { EntryConditionIcon, ExitConditionIcon, ReturnToOriginIcon } from '../..
 import { CanvasIcon } from '../../utils/icon-registry';
 import { CanvasTooltip } from '../CanvasTooltip';
 import { ExecutionStatusIcon } from '../ExecutionStatusIcon';
+import { getExecutionStatusColor } from '../ExecutionStatusIcon/ExecutionStatusIcon';
 import {
   StageChip,
   StageHeader,
@@ -175,7 +176,15 @@ const StageNodeHeaderInner = ({
         {status && (
           <CanvasTooltip content={statusLabel} placement="top">
             <Button variant="ghost" size="icon" className="h-6 w-6" aria-label={statusLabel}>
-              <ExecutionStatusIcon status={status} size={20} />
+              {status === 'NotExecuted' ? (
+                <CanvasIcon
+                  icon="hourglass"
+                  size={20}
+                  color={getExecutionStatusColor('NotExecuted')}
+                />
+              ) : (
+                <ExecutionStatusIcon status={status} size={20} />
+              )}
             </Button>
           </CanvasTooltip>
         )}


### PR DESCRIPTION
## Description

Force the case NotExecuted icon to the hourglass
<img width="412" height="248" alt="image" src="https://github.com/user-attachments/assets/5794823e-70f2-4dcd-81ba-8b7041bd0dc0" />
