### PR TITLE
fix(apollo-react): disable add task button while task is loading [MST-8019][MST-8171]

### DIFF
--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.stories.tsx
@@ -1744,32 +1744,11 @@ const AddTaskLoadingStory = () => {
     [setEdges]
   );
 
-  // Mark the stage read-only while tasks are loading so DnD is disabled mid-add
-  const nodesWithReadOnly = useMemo(
-    () =>
-      nodes.map((node) => {
-        const data = node.data as Record<string, any>;
-        const isLoading = ((data.loadingTaskIds as Set<string> | undefined)?.size ?? 0) > 0;
-        const existingIsReadOnly = Boolean(data.stageDetails?.isReadOnly);
-        return {
-          ...node,
-          data: {
-            ...data,
-            stageDetails: {
-              ...data.stageDetails,
-              isReadOnly: existingIsReadOnly || isLoading,
-            },
-          },
-        };
-      }),
-    [nodes]
-  );
-
   return (
     <div style={{ width: '100vw', height: '100vh' }}>
       <ReactFlowProvider>
         <BaseCanvas
-          nodes={nodesWithReadOnly}
+          nodes={nodes}
           edges={edges}
           onNodesChange={onNodesChange}
           onEdgesChange={onEdgesChange}

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.test.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.test.tsx
@@ -944,3 +944,30 @@ describe('StageNode - Header Chips', () => {
     ).toBeInTheDocument();
   });
 });
+
+describe('StageNode - Add Task Button', () => {
+  it('disables the add task button when loadingTaskIds is non-empty', () => {
+    renderStageNode({
+      onTaskAdd: vi.fn(),
+      loadingTaskIds: new Set(['loading-task']),
+    });
+
+    expect(screen.getByRole('button', { name: 'Add task' })).toBeDisabled();
+  });
+
+  it('does not invoke onTaskAdd when the disabled add task button is clicked', async () => {
+    const user = userEvent.setup();
+    const onTaskAdd = vi.fn();
+    renderStageNode({ onTaskAdd, loadingTaskIds: new Set(['loading-task']) });
+
+    await user.click(screen.getByRole('button', { name: 'Add task' }));
+
+    expect(onTaskAdd).not.toHaveBeenCalled();
+  });
+
+  it('enables the add task button when loadingTaskIds is empty', () => {
+    renderStageNode({ onTaskAdd: vi.fn(), loadingTaskIds: new Set() });
+
+    expect(screen.getByRole('button', { name: 'Add task' })).not.toBeDisabled();
+  });
+});

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNodeHeader.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNodeHeader.tsx
@@ -46,7 +46,10 @@ const StageNodeHeaderInner = ({
     onTaskAdd,
     onAddTaskFromToolbox,
     onStageTitleChange,
+    loadingTaskIds,
   } = props;
+
+  const isAddTaskDisabled = (loadingTaskIds?.size ?? 0) > 0;
 
   const icon = stageDetails?.icon;
   const statusLabel = execution?.stageStatus?.label;
@@ -196,6 +199,7 @@ const StageNodeHeaderInner = ({
               className="h-6 w-6"
               onClick={handleTaskAddClick}
               aria-label={addTaskLabel}
+              disabled={isAddTaskDisabled}
             >
               <CanvasIcon icon="plus" size={20} />
             </Button>


### PR DESCRIPTION
## Summary

- Forwards `loadingTaskIds` into `StageNodeHeader` and disables the "+" Add Task button when its size > 0
- Removes the `nodesWithReadOnly` wrapper from the `AddTaskLoading` story so the demo reflects the real (non-`isReadOnly`) production behavior

## Demo


https://github.com/user-attachments/assets/4e818db9-0fc7-41ec-861d-8f18655941e3



## Test plan

- [x] `pnpm --filter @uipath/apollo-react test` — 1390/1390 pass
- [x] `tsc --noEmit` clean
- [ ] Storybook: `AddTaskLoading` story — "+" stays visible and disabled for 3s on the empty-stage variant; per-task 3-dot stays disabled on the loading-task variant