### PR TITLE
feat(apollo-wind): controllable DataTable state + multi-field search

### DIFF
--- a/packages/apollo-wind/src/components/ui/data-table.stories.tsx
+++ b/packages/apollo-wind/src/components/ui/data-table.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta } from '@storybook/react-vite';
-import { ColumnDef } from '@tanstack/react-table';
+import { ColumnDef, ColumnSizingState, SortingState, VisibilityState } from '@tanstack/react-table';
 import {
   Archive,
   ChevronDown,
@@ -24,6 +24,7 @@ import {
 } from './alert-dialog';
 import { Badge } from './badge';
 import { Button } from './button';
+import { Checkbox } from './checkbox';
 import { DataTable, DataTableColumnHeader, DataTableSelectColumn } from './data-table';
 import {
   DropdownMenu,
@@ -69,7 +70,7 @@ const sampleUsers: User[] = [
   {
     id: '1',
     name: 'John Doe',
-    email: 'john@example.com',
+    email: 'john.doe@uipath.com',
     role: 'Admin',
     status: 'active',
     department: 'Engineering',
@@ -78,7 +79,7 @@ const sampleUsers: User[] = [
   {
     id: '2',
     name: 'Jane Smith',
-    email: 'jane@example.com',
+    email: 'jane.smith@gmail.com',
     role: 'User',
     status: 'active',
     department: 'Design',
@@ -87,7 +88,7 @@ const sampleUsers: User[] = [
   {
     id: '3',
     name: 'Bob Johnson',
-    email: 'bob@example.com',
+    email: 'bob.j@outlook.com',
     role: 'User',
     status: 'inactive',
     department: 'Marketing',
@@ -96,7 +97,7 @@ const sampleUsers: User[] = [
   {
     id: '4',
     name: 'Alice Williams',
-    email: 'alice@example.com',
+    email: 'alice@uipath.com',
     role: 'Manager',
     status: 'active',
     department: 'Engineering',
@@ -105,7 +106,7 @@ const sampleUsers: User[] = [
   {
     id: '5',
     name: 'Charlie Brown',
-    email: 'charlie@example.com',
+    email: 'charlie.brown@yahoo.com',
     role: 'User',
     status: 'pending',
     department: 'Sales',
@@ -114,7 +115,7 @@ const sampleUsers: User[] = [
   {
     id: '6',
     name: 'Diana Prince',
-    email: 'diana@example.com',
+    email: 'diana.prince@proton.me',
     role: 'Admin',
     status: 'active',
     department: 'Engineering',
@@ -123,7 +124,7 @@ const sampleUsers: User[] = [
   {
     id: '7',
     name: 'Eve Anderson',
-    email: 'eve@example.com',
+    email: 'eve@hey.com',
     role: 'User',
     status: 'inactive',
     department: 'Design',
@@ -132,7 +133,7 @@ const sampleUsers: User[] = [
   {
     id: '8',
     name: 'Frank Miller',
-    email: 'frank@example.com',
+    email: 'frank.miller@fastmail.com',
     role: 'Manager',
     status: 'active',
     department: 'Product',
@@ -141,7 +142,7 @@ const sampleUsers: User[] = [
   {
     id: '9',
     name: 'Grace Lee',
-    email: 'grace@example.com',
+    email: 'grace.lee@uipath.com',
     role: 'User',
     status: 'active',
     department: 'Engineering',
@@ -150,7 +151,7 @@ const sampleUsers: User[] = [
   {
     id: '10',
     name: 'Henry Davis',
-    email: 'henry@example.com',
+    email: 'henry@icloud.com',
     role: 'User',
     status: 'pending',
     department: 'Marketing',
@@ -159,7 +160,7 @@ const sampleUsers: User[] = [
   {
     id: '11',
     name: 'Ivy Wilson',
-    email: 'ivy@example.com',
+    email: 'ivy.w@hotmail.com',
     role: 'Admin',
     status: 'active',
     department: 'Product',
@@ -168,7 +169,7 @@ const sampleUsers: User[] = [
   {
     id: '12',
     name: 'Jack Taylor',
-    email: 'jack@example.com',
+    email: 'jack.taylor@gmail.com',
     role: 'User',
     status: 'inactive',
     department: 'Sales',
@@ -648,7 +649,7 @@ function FilteringAndSearchExample() {
   const filterDropdowns = (
     <>
       <Select value={statusFilter} onValueChange={setStatusFilter}>
-        <SelectTrigger className="h-8 w-[140px]">
+        <SelectTrigger aria-label="Filter by status" className="h-8 w-[140px]">
           <SelectValue />
         </SelectTrigger>
         <SelectContent>
@@ -659,7 +660,7 @@ function FilteringAndSearchExample() {
         </SelectContent>
       </Select>
       <Select value={roleFilter} onValueChange={setRoleFilter}>
-        <SelectTrigger className="h-8 w-[140px]">
+        <SelectTrigger aria-label="Filter by role" className="h-8 w-[140px]">
           <SelectValue />
         </SelectTrigger>
         <SelectContent>
@@ -670,7 +671,7 @@ function FilteringAndSearchExample() {
         </SelectContent>
       </Select>
       <Select value={departmentFilter} onValueChange={setDepartmentFilter}>
-        <SelectTrigger className="h-8 w-[160px]">
+        <SelectTrigger aria-label="Filter by department" className="h-8 w-[160px]">
           <SelectValue />
         </SelectTrigger>
         <SelectContent>
@@ -699,9 +700,10 @@ function FilteringAndSearchExample() {
               <button
                 type="button"
                 onClick={f.clear}
+                aria-label={`Remove filter: ${f.label}`}
                 className="ml-0.5 rounded-sm hover:bg-muted-foreground/20"
               >
-                <X className="h-3 w-3" />
+                <X className="h-3 w-3" aria-hidden="true" />
               </button>
             </Badge>
           ))}
@@ -713,8 +715,16 @@ function FilteringAndSearchExample() {
       <DataTable
         columns={sortableColumns}
         data={filtered}
-        searchKey="name"
-        searchPlaceholder="Search by name..."
+        globalFilterFn={(row, query) => {
+          const q = query.toLowerCase();
+          return (
+            row.name.toLowerCase().includes(q) ||
+            row.email.toLowerCase().includes(q) ||
+            row.role.toLowerCase().includes(q) ||
+            row.department.toLowerCase().includes(q)
+          );
+        }}
+        searchPlaceholder="Search name, email, role, or department..."
         showColumnToggle={false}
         toolbarContent={filterDropdowns}
       />
@@ -1403,6 +1413,220 @@ function FullFeaturedExample() {
     </>
   );
 }
+
+// ============================================================================
+// Persistent View (controlled state + localStorage)
+// ============================================================================
+
+function useLocalStorageState<T>(
+  key: string,
+  initial: T
+): [T, (next: T | ((prev: T) => T)) => void] {
+  const [value, setValue] = React.useState<T>(() => {
+    if (typeof window === 'undefined') return initial;
+    try {
+      const raw = window.localStorage.getItem(key);
+      return raw ? (JSON.parse(raw) as T) : initial;
+    } catch {
+      return initial;
+    }
+  });
+
+  const setAndStore = React.useCallback(
+    (next: T | ((prev: T) => T)) => {
+      setValue((prev) => {
+        const resolved = typeof next === 'function' ? (next as (p: T) => T)(prev) : next;
+        try {
+          window.localStorage.setItem(key, JSON.stringify(resolved));
+        } catch {
+          /* ignore storage failures */
+        }
+        return resolved;
+      });
+    },
+    [key]
+  );
+
+  return [value, setAndStore];
+}
+
+function PersistentViewExample() {
+  const [sorting, setSorting] = useLocalStorageState<SortingState>(
+    'apollo.datatable.demo.sorting',
+    []
+  );
+  const [columnSizing, setColumnSizing] = useLocalStorageState<ColumnSizingState>(
+    'apollo.datatable.demo.columnSizing',
+    {}
+  );
+  const [columnVisibility, setColumnVisibility] = useLocalStorageState<VisibilityState>(
+    'apollo.datatable.demo.columnVisibility',
+    {}
+  );
+
+  // Last column gets `enableResizing: false` so its resize handle (which sits at -right-1
+  // and extends 4px past the column edge) doesn't push the table into horizontal overflow.
+  const persistentColumns: ColumnDef<User>[] = React.useMemo(
+    () =>
+      sortableColumns.map((col, i) =>
+        i === sortableColumns.length - 1 ? { ...col, enableResizing: false } : col
+      ),
+    []
+  );
+
+  const reset = () => {
+    setSorting([]);
+    setColumnSizing({});
+    setColumnVisibility({});
+  };
+
+  return (
+    <div className="space-y-2 [&_table]:!w-full">
+      <div className="flex items-start justify-between gap-4">
+        <p className="text-sm text-muted-foreground">
+          Sort by clicking column headers, drag column edges to resize, or hide columns from the
+          toggle. Refresh the page — your view is still there. Click <strong>Reset view</strong> to
+          clear saved state.
+        </p>
+        <Button variant="outline" size="sm" onClick={reset}>
+          Reset view
+        </Button>
+      </div>
+      <DataTable
+        columns={persistentColumns}
+        data={sampleUsers}
+        resizable
+        sorting={sorting}
+        onSortingChange={setSorting}
+        columnSizing={columnSizing}
+        onColumnSizingChange={setColumnSizing}
+        columnVisibility={columnVisibility}
+        onColumnVisibilityChange={setColumnVisibility}
+      />
+    </div>
+  );
+}
+
+export const PersistentView = {
+  name: 'Persistent view',
+  render: () => <PersistentViewExample />,
+};
+
+// ============================================================================
+// Wrapped Content (allowWrap)
+// ============================================================================
+
+type UserWithJson = User & {
+  input: string;
+  output: string;
+  evaluator: string;
+  duration: string;
+};
+
+const usersWithJson: UserWithJson[] = sampleUsers.slice(0, 4).map((u, i) => ({
+  ...u,
+  input: JSON.stringify(
+    {
+      user_id: u.id,
+      role: u.role,
+      department: u.department,
+      status: u.status,
+      preferences: { theme: 'dark', notifications: true },
+    },
+    null,
+    2
+  ),
+  output: JSON.stringify(
+    {
+      result: i % 2 === 0 ? 'success' : 'partial',
+      score: 0.87 - i * 0.05,
+      categories: ['quality', 'relevance'],
+      metadata: { latency_ms: 120 + i * 30, model: 'gpt-4o' },
+    },
+    null,
+    2
+  ),
+  evaluator: ['exact-match', 'semantic', 'rubric', 'human-review'][i],
+  duration: `${1.2 + i * 0.4}s`,
+}));
+
+function WrappedContentExample() {
+  const [allowWrap, setAllowWrap] = React.useState(false);
+
+  const columns: ColumnDef<UserWithJson>[] = React.useMemo(() => {
+    const renderJson = (value: string) =>
+      allowWrap ? (
+        <pre className="text-xs font-mono whitespace-pre-wrap">{value}</pre>
+      ) : (
+        <span className="text-xs font-mono">{value}</span>
+      );
+
+    return [
+      {
+        accessorKey: 'name',
+        header: 'Name',
+        size: 130,
+        enableResizing: false,
+      },
+      {
+        accessorKey: 'evaluator',
+        header: 'Evaluator',
+        size: 130,
+        enableResizing: false,
+      },
+      {
+        accessorKey: 'input',
+        header: 'Input',
+        size: 270,
+        minSize: 100,
+        cell: ({ row }) => renderJson(row.original.input),
+      },
+      {
+        accessorKey: 'output',
+        header: 'Output',
+        size: 270,
+        minSize: 100,
+        cell: ({ row }) => renderJson(row.original.output),
+      },
+      {
+        accessorKey: 'status',
+        header: 'Status',
+        size: 110,
+        enableResizing: false,
+        cell: ({ row }) => statusBadge(row.getValue('status')),
+      },
+    ];
+  }, [allowWrap]);
+
+  return (
+    <div className="space-y-4 [&_table]:!w-full">
+      <div className="flex items-center gap-2">
+        <Checkbox
+          id="allow-wrap-toggle"
+          checked={allowWrap}
+          onCheckedChange={(value) => setAllowWrap(!!value)}
+        />
+        <Label htmlFor="allow-wrap-toggle" className="text-sm">
+          Enable <code>allowWrap</code> — let cells render multi-line content instead of truncating.
+          Drag the edges of <strong>Input</strong> and <strong>Output</strong> to resize.
+        </Label>
+      </div>
+      <DataTable
+        columns={columns}
+        data={usersWithJson}
+        allowWrap={allowWrap}
+        resizable
+        showColumnToggle={false}
+        showPagination={false}
+      />
+    </div>
+  );
+}
+
+export const WrappedContent = {
+  name: 'Multi-line cell content',
+  render: () => <WrappedContentExample />,
+};
 
 export const Examples = {
   name: 'Examples',

--- a/packages/apollo-wind/src/components/ui/data-table.test.tsx
+++ b/packages/apollo-wind/src/components/ui/data-table.test.tsx
@@ -28,6 +28,17 @@ const columns: ColumnDef<TestData>[] = [
   },
 ];
 
+const sortableColumns: ColumnDef<TestData>[] = [
+  {
+    accessorKey: 'name',
+    header: ({ column }) => <DataTableColumnHeader column={column} title="Name" />,
+  },
+  {
+    accessorKey: 'email',
+    header: ({ column }) => <DataTableColumnHeader column={column} title="Email" />,
+  },
+];
+
 describe('DataTable', () => {
   describe('rendering', () => {
     it('renders table with data', () => {
@@ -211,5 +222,178 @@ describe('DataTableSelectColumn', () => {
     const columnsWithSelect = [DataTableSelectColumn<TestData>(), ...columns];
     render(<DataTable columns={columnsWithSelect} data={mockData} />);
     expect(screen.getAllByLabelText('Select row')).toHaveLength(3);
+  });
+});
+
+describe('DataTable globalFilterFn', () => {
+  it('renders search input and filters across multiple fields', async () => {
+    const user = userEvent.setup();
+    render(
+      <DataTable
+        columns={columns}
+        data={mockData}
+        globalFilterFn={(row, q) =>
+          row.name.toLowerCase().includes(q.toLowerCase()) ||
+          row.email.toLowerCase().includes(q.toLowerCase())
+        }
+        searchPlaceholder="Search all..."
+      />
+    );
+
+    const input = screen.getByPlaceholderText('Search all...');
+    // Match by name only
+    await user.type(input, 'jane');
+    await waitFor(() => {
+      expect(screen.queryByText('John Doe')).not.toBeInTheDocument();
+      expect(screen.getByText('Jane Smith')).toBeInTheDocument();
+    });
+
+    // Clear and match by email substring
+    await user.clear(input);
+    await user.type(input, 'bob@');
+    await waitFor(() => {
+      expect(screen.getByText('Bob Wilson')).toBeInTheDocument();
+      expect(screen.queryByText('John Doe')).not.toBeInTheDocument();
+    });
+  });
+
+  it('takes precedence over searchKey when both are provided', () => {
+    render(
+      <DataTable
+        columns={columns}
+        data={mockData}
+        searchKey="name"
+        globalFilterFn={() => true}
+        searchPlaceholder="Global search"
+      />
+    );
+    expect(screen.getByPlaceholderText('Global search')).toBeInTheDocument();
+  });
+
+  it('has no accessibility violations with globalFilterFn', async () => {
+    const { container } = render(
+      <DataTable
+        columns={columns}
+        data={mockData}
+        globalFilterFn={(row, q) => row.name.toLowerCase().includes(q.toLowerCase())}
+      />
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});
+
+describe('DataTable allowWrap', () => {
+  it('drops the truncate class from body cells when enabled', () => {
+    render(<DataTable columns={columns} data={mockData} allowWrap />);
+    const cell = screen.getByText('John Doe').closest('td');
+    expect(cell).not.toBeNull();
+    expect(cell).not.toHaveClass('truncate');
+  });
+
+  it('keeps truncate on body cells by default', () => {
+    render(<DataTable columns={columns} data={mockData} />);
+    const cell = screen.getByText('John Doe').closest('td');
+    expect(cell).toHaveClass('truncate');
+  });
+
+  it('has no accessibility violations with allowWrap enabled', async () => {
+    const { container } = render(<DataTable columns={columns} data={mockData} allowWrap />);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});
+
+describe('DataTable controlled state', () => {
+  it('invokes onSortingChange when a sortable header is clicked', async () => {
+    const user = userEvent.setup();
+    const onSortingChange = vi.fn();
+    render(
+      <DataTable
+        columns={sortableColumns}
+        data={mockData}
+        sorting={[]}
+        onSortingChange={onSortingChange}
+      />
+    );
+
+    await user.click(screen.getByRole('button', { name: /name/i }));
+    expect(onSortingChange).toHaveBeenCalled();
+  });
+
+  it('forwards a TanStack updater function to onSortingChange (OnChangeFn contract)', async () => {
+    const user = userEvent.setup();
+    const onSortingChange = vi.fn();
+    render(
+      <DataTable
+        columns={sortableColumns}
+        data={mockData}
+        sorting={[]}
+        onSortingChange={onSortingChange}
+      />
+    );
+
+    await user.click(screen.getByRole('button', { name: /name/i }));
+
+    // Cursor's refactor forwards the updater verbatim instead of resolving to a value.
+    // Asserting we received a function (not an array) locks in that contract.
+    expect(onSortingChange).toHaveBeenCalledWith(expect.any(Function));
+
+    const updater = onSortingChange.mock.calls[0][0] as (prev: unknown) => unknown;
+    expect(updater([])).toEqual([{ id: 'name', desc: false }]);
+  });
+
+  it('applies initialSorting when sorting is uncontrolled', () => {
+    render(
+      <DataTable
+        columns={columns}
+        data={mockData}
+        initialSorting={[{ id: 'name', desc: false }]}
+        showPagination={false}
+      />
+    );
+
+    // Alphabetical: Bob Wilson, Jane Smith, John Doe
+    const [, firstRow, secondRow, thirdRow] = screen.getAllByRole('row');
+    expect(firstRow).toHaveTextContent('Bob Wilson');
+    expect(secondRow).toHaveTextContent('Jane Smith');
+    expect(thirdRow).toHaveTextContent('John Doe');
+  });
+
+  it('runs in controlled mode for columnVisibility', () => {
+    const onColumnVisibilityChange = vi.fn();
+    render(
+      <DataTable
+        columns={columns}
+        data={mockData}
+        columnVisibility={{ email: false }}
+        onColumnVisibilityChange={onColumnVisibilityChange}
+      />
+    );
+    // With email hidden, the column header should not render
+    expect(screen.queryByText('Email')).not.toBeInTheDocument();
+    expect(screen.getByText('Name')).toBeInTheDocument();
+  });
+
+  it('applies controlled columnSizing to the matching column header', () => {
+    render(<DataTable columns={columns} data={mockData} resizable columnSizing={{ name: 200 }} />);
+
+    const nameHeader = screen.getByText('Name').closest('th');
+    expect(nameHeader).toHaveStyle({ width: '200px' });
+  });
+
+  it('has no accessibility violations with controlled state', async () => {
+    const { container } = render(
+      <DataTable
+        columns={columns}
+        data={mockData}
+        sorting={[{ id: 'name', desc: false }]}
+        onSortingChange={vi.fn()}
+        columnVisibility={{}}
+        onColumnVisibilityChange={vi.fn()}
+      />
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
   });
 });

--- a/packages/apollo-wind/src/components/ui/data-table.tsx
+++ b/packages/apollo-wind/src/components/ui/data-table.tsx
@@ -27,11 +27,14 @@ import {
   ColumnDef,
   ColumnFiltersState,
   ColumnResizeMode,
+  ColumnSizingState,
   flexRender,
   getCoreRowModel,
   getFilteredRowModel,
   getPaginationRowModel,
   getSortedRowModel,
+  OnChangeFn,
+  Row,
   RowSelectionState,
   SortingState,
   useReactTable,
@@ -53,6 +56,28 @@ export interface DataTableProps<TData, TValue> {
   columnToggleText?: string;
   rowSelection?: RowSelectionState;
   onRowSelectionChange?: (selection: RowSelectionState) => void;
+  /** Controlled sort state. When provided, the table runs in controlled mode for sorting. */
+  sorting?: SortingState;
+  onSortingChange?: OnChangeFn<SortingState>;
+  /** Initial sort applied when `sorting` is uncontrolled. */
+  initialSorting?: SortingState;
+  /** Controlled column-sizing state. Pairs with `resizable`. */
+  columnSizing?: ColumnSizingState;
+  onColumnSizingChange?: OnChangeFn<ColumnSizingState>;
+  /** Controlled column-visibility state. */
+  columnVisibility?: VisibilityState;
+  onColumnVisibilityChange?: OnChangeFn<VisibilityState>;
+  /**
+   * When set, the search input filters whole rows via this predicate.
+   * Takes precedence over `searchKey`.
+   */
+  globalFilterFn?: (row: TData, query: string) => boolean;
+  /**
+   * When true, body cells render multi-line content (drops the default `truncate` class).
+   * Useful for tables that show JSON, long text, or preformatted content.
+   * Default: false (single-line + ellipsis).
+   */
+  allowWrap?: boolean;
   toolbarContent?: React.ReactNode;
   /**
    * When set, the table body scrolls independently with this max height (any CSS length).
@@ -77,25 +102,96 @@ export function DataTable<TData, TValue>({
   columnToggleText = 'Columns',
   rowSelection: controlledRowSelection,
   onRowSelectionChange: controlledOnRowSelectionChange,
+  sorting: controlledSorting,
+  onSortingChange: controlledOnSortingChange,
+  initialSorting,
+  columnSizing: controlledColumnSizing,
+  onColumnSizingChange: controlledOnColumnSizingChange,
+  columnVisibility: controlledColumnVisibility,
+  onColumnVisibilityChange: controlledOnColumnVisibilityChange,
+  globalFilterFn,
+  allowWrap = false,
   toolbarContent,
   maxBodyHeight,
 }: DataTableProps<TData, TValue>) {
   const useBlockLayout = maxBodyHeight !== undefined;
   const blockRowClasses = '[&>tr]:table [&>tr]:w-full [&>tr]:table-fixed';
-  const [sorting, setSorting] = React.useState<SortingState>([]);
+  const [internalSorting, setInternalSorting] = React.useState<SortingState>(initialSorting ?? []);
   const [columnFilters, setColumnFilters] = React.useState<ColumnFiltersState>([]);
-  const [columnVisibility, setColumnVisibility] = React.useState<VisibilityState>({});
+  const [internalColumnVisibility, setInternalColumnVisibility] = React.useState<VisibilityState>(
+    {}
+  );
+  const [internalColumnSizing, setInternalColumnSizing] = React.useState<ColumnSizingState>({});
   const [internalRowSelection, setInternalRowSelection] = React.useState<RowSelectionState>({});
+  const [globalFilter, setGlobalFilter] = React.useState('');
 
-  const isControlled = controlledRowSelection !== undefined;
-  const rowSelection = isControlled ? controlledRowSelection : internalRowSelection;
-  const setRowSelection = React.useCallback(
-    (updater: React.SetStateAction<RowSelectionState>) => {
-      const next = typeof updater === 'function' ? updater(rowSelection) : updater;
-      if (!isControlled) setInternalRowSelection(next);
+  // Sorting/sizing/visibility wrappers forward the TanStack updater (value or
+  // function) verbatim to the consumer's callback so `setState`-shaped handlers
+  // can be passed directly and their functional-updater contract is preserved.
+  // `onRowSelectionChange` predates this contract and accepts a resolved value,
+  // so its wrapper resolves the updater before invoking the consumer callback.
+  const isRowSelectionControlled = controlledRowSelection !== undefined;
+  const rowSelection = isRowSelectionControlled ? controlledRowSelection : internalRowSelection;
+  const rowSelectionRef = React.useRef(rowSelection);
+  rowSelectionRef.current = rowSelection;
+  const setRowSelection: OnChangeFn<RowSelectionState> = React.useCallback(
+    (updater) => {
+      const next = typeof updater === 'function' ? updater(rowSelectionRef.current) : updater;
+      if (!isRowSelectionControlled) setInternalRowSelection(next);
       controlledOnRowSelectionChange?.(next);
     },
-    [isControlled, rowSelection, controlledOnRowSelectionChange]
+    [isRowSelectionControlled, controlledOnRowSelectionChange]
+  );
+
+  const isSortingControlled = controlledSorting !== undefined;
+  const sorting = isSortingControlled ? controlledSorting : internalSorting;
+  const onSortingChange: OnChangeFn<SortingState> = React.useCallback(
+    (updater) => {
+      if (!isSortingControlled) {
+        setInternalSorting((prev) => (typeof updater === 'function' ? updater(prev) : updater));
+      }
+      controlledOnSortingChange?.(updater);
+    },
+    [isSortingControlled, controlledOnSortingChange]
+  );
+
+  const isColumnSizingControlled = controlledColumnSizing !== undefined;
+  const columnSizing = isColumnSizingControlled ? controlledColumnSizing : internalColumnSizing;
+  const onColumnSizingChange: OnChangeFn<ColumnSizingState> = React.useCallback(
+    (updater) => {
+      if (!isColumnSizingControlled) {
+        setInternalColumnSizing((prev) =>
+          typeof updater === 'function' ? updater(prev) : updater
+        );
+      }
+      controlledOnColumnSizingChange?.(updater);
+    },
+    [isColumnSizingControlled, controlledOnColumnSizingChange]
+  );
+
+  const isColumnVisibilityControlled = controlledColumnVisibility !== undefined;
+  const columnVisibility = isColumnVisibilityControlled
+    ? controlledColumnVisibility
+    : internalColumnVisibility;
+  const onColumnVisibilityChange: OnChangeFn<VisibilityState> = React.useCallback(
+    (updater) => {
+      if (!isColumnVisibilityControlled) {
+        setInternalColumnVisibility((prev) =>
+          typeof updater === 'function' ? updater(prev) : updater
+        );
+      }
+      controlledOnColumnVisibilityChange?.(updater);
+    },
+    [isColumnVisibilityControlled, controlledOnColumnVisibilityChange]
+  );
+
+  const tanstackGlobalFilterFn = React.useMemo(
+    () =>
+      globalFilterFn
+        ? (row: Row<TData>, _columnId: string, filterValue: string) =>
+            globalFilterFn(row.original, filterValue)
+        : undefined,
+    [globalFilterFn]
   );
 
   // Wrap columns with editable cell renderer if editable mode is enabled
@@ -124,21 +220,26 @@ export function DataTable<TData, TValue>({
   const table = useReactTable({
     data,
     columns: processedColumns,
-    onSortingChange: setSorting,
+    onSortingChange,
     onColumnFiltersChange: setColumnFilters,
     getCoreRowModel: getCoreRowModel(),
     getPaginationRowModel: getPaginationRowModel(),
     getSortedRowModel: getSortedRowModel(),
     getFilteredRowModel: getFilteredRowModel(),
-    onColumnVisibilityChange: setColumnVisibility,
+    onColumnVisibilityChange,
+    onColumnSizingChange,
     onRowSelectionChange: setRowSelection,
+    onGlobalFilterChange: setGlobalFilter,
+    globalFilterFn: tanstackGlobalFilterFn,
     enableColumnResizing: resizable,
     columnResizeMode: 'onChange' as ColumnResizeMode,
     state: {
       sorting,
       columnFilters,
       columnVisibility,
+      columnSizing,
       rowSelection,
+      globalFilter,
     },
     initialState: {
       pagination: {
@@ -150,13 +251,22 @@ export function DataTable<TData, TValue>({
   return (
     <div className="w-full">
       <div className="flex items-center gap-4 py-4">
-        {searchKey && (
+        {globalFilterFn ? (
           <Input
             placeholder={searchPlaceholder}
-            value={(table.getColumn(searchKey)?.getFilterValue() as string) ?? ''}
-            onChange={(event) => table.getColumn(searchKey)?.setFilterValue(event.target.value)}
+            value={globalFilter}
+            onChange={(event) => setGlobalFilter(event.target.value)}
             className="max-w-sm"
           />
+        ) : (
+          searchKey && (
+            <Input
+              placeholder={searchPlaceholder}
+              value={(table.getColumn(searchKey)?.getFilterValue() as string) ?? ''}
+              onChange={(event) => table.getColumn(searchKey)?.setFilterValue(event.target.value)}
+              className="max-w-sm"
+            />
+          )
         )}
         {toolbarContent}
         {showColumnToggle && (
@@ -265,8 +375,17 @@ export function DataTable<TData, TValue>({
                     return (
                       <TableCell
                         key={cell.id}
-                        className={compact ? 'h-8 truncate px-2 py-0' : 'h-12 truncate px-4 py-0'}
+                        className={cn(
+                          allowWrap
+                            ? compact
+                              ? 'min-h-8 px-2 py-1'
+                              : 'min-h-12 px-4 py-2'
+                            : compact
+                              ? 'h-8 truncate px-2 py-0'
+                              : 'h-12 truncate px-4 py-0'
+                        )}
                         onMouseEnter={(e) => {
+                          if (allowWrap) return;
                           const el = e.currentTarget;
                           const value = cell.getValue();
                           el.title =


### PR DESCRIPTION
## Summary

Three changes that fix moments where Apollo's `DataTable` breaks down for end users:

- **The table remembers their view.** They sort by status, drag the Name column wider, hide the column they don't care about — come back tomorrow or share the URL with a teammate, and the table looks the way they left it. Today every reload resets everything.
- **Search finds the row they have in their head.** They remember a fragment of an email or the role of the person they're looking for. Today the search box is wired to a single column, so they get nothing back. Now one input matches across whatever fields the product chooses — name, email, role, department, JSON content, anything.
- **They can read what's in the row.** A long JSON input no longer collapses to `{"user_id": "abc-…` on line one. Cells can now show their full content across multiple lines, with rows growing to fit. This is the original evals pain.

All three are opt-in. Tables that don't want them keep behaving exactly as they do today.

## What changed in Storybook

- **Filtering & Search** — typing `uipath` now matches three users by email domain; `engineering` matches everyone in that department. One search box does the work the dropdowns used to share.
- **Persistent view** (new) — sort, resize, hide a column, refresh the iframe; your view is still there. *Reset view* clears it.
- **Multi-line cell content** (new) — one checkbox toggles between truncated single-line and wrapped multi-line for the same JSON column. The before/after of the original pain on one screen.
- Sample emails diversified across nine domains (uipath, gmail, proton, hey, fastmail, …) so the search demos surface real variety instead of twelve rows of `@example.com`.
- Accessibility polish on the existing Filtering & Search story: the Status / Role / Department dropdowns and the active-filter chip close buttons now announce themselves to screen readers.
