### PR TITLE
feat(apollo-react): support auto expansion of loop container [MST-9193]

### DIFF
--- a/packages/apollo-react/src/canvas/components/AddNodePanel/AddNodeManager.helpers.ts
+++ b/packages/apollo-react/src/canvas/components/AddNodePanel/AddNodeManager.helpers.ts
@@ -173,7 +173,15 @@ export function placeAddedNode({
   const placement = getContainerPlacement({ previewNode });
 
   if (placement) {
-    const containerNode = nodes.find((node) => node.id === placement.containerId)!;
+    const containerNode = nodes.find((node) => node.id === placement.containerId);
+
+    if (!containerNode) {
+      return resolveScopedCollisions(nodes, insertedNode, {
+        ignoredNodeTypes,
+        getNodeSize: getDimensions,
+      });
+    }
+
     const containerManifest = getManifestForNode(registry, containerNode);
 
     if (!isContainerNodeManifest(containerManifest)) {

--- a/packages/apollo-react/src/canvas/components/AddNodePanel/AddNodeManager.helpers.ts
+++ b/packages/apollo-react/src/canvas/components/AddNodePanel/AddNodeManager.helpers.ts
@@ -1,0 +1,209 @@
+import type { Edge, Node } from '@uipath/apollo-react/canvas/xyflow/react';
+import { Position } from '@uipath/apollo-react/canvas/xyflow/react';
+import type { NodeTypeRegistry } from '../../core';
+import type { PreviewNodeConnectionInfo } from '../../hooks/usePreviewNode';
+import type { NodeManifest } from '../../schema';
+import { resolveCollisions } from '../../utils';
+import { getExpandedSize } from '../../utils/collapse';
+import {
+  getContainerFitGeometry,
+  getContainerPlacement,
+  getContainerSafeArea,
+  getNodeDimensions,
+  isContainerNodeManifest,
+  type NodeDimensions,
+  placeContainerNode,
+} from '../../utils/container';
+
+interface AddNodePlacementResult {
+  nodes: Node[];
+  insertedNode: Node;
+}
+
+/**
+ * Returns the edge hidden by a preview node, if the preview replaced an
+ * existing edge during Add Node insertion.
+ */
+export function getOriginalEdge(previewNode: Node | null | undefined): Edge | null {
+  return (previewNode?.data?.originalEdge as Edge | undefined) ?? null;
+}
+
+function getManifestForNode(
+  registry: NodeTypeRegistry | null,
+  node: Node
+): NodeManifest | undefined {
+  return node.type ? registry?.getManifest(node.type) : undefined;
+}
+
+function getManifestAwareNodeDimensions(registry: NodeTypeRegistry | null, node: Node) {
+  const manifest = getManifestForNode(registry, node);
+
+  return getNodeDimensions(node, getExpandedSize(manifest?.display.shape));
+}
+
+function getPrimaryPreviewHandlePosition(
+  previewNode: Node,
+  previewConnections: PreviewNodeConnectionInfo[]
+): Position | undefined {
+  // Incoming placement is the most stable anchor for aligning the real node.
+  // Source-only previews fall back to the first connection.
+  const primaryConnection =
+    previewConnections.find((connection) => !connection.addNewNodeAsSource) ??
+    previewConnections[0];
+  const handlePosition = primaryConnection?.addNewNodeAsSource
+    ? previewNode.data?.outputHandlePosition
+    : previewNode.data?.inputHandlePosition;
+
+  return handlePosition as Position | undefined;
+}
+
+/**
+ * Repositions the real node so the handle-facing side matches the preview even
+ * when the real node's manifest size differs from the square preview.
+ */
+export function alignNodeToPreview(
+  node: Node,
+  previewNode: Node,
+  previewConnections: PreviewNodeConnectionInfo[],
+  nodeManifest: NodeManifest | undefined
+): Node {
+  const previewSize = getNodeDimensions(previewNode);
+  const nodeSize = getNodeDimensions(node, getExpandedSize(nodeManifest?.display.shape));
+
+  if (previewSize.width === nodeSize.width && previewSize.height === nodeSize.height) {
+    return node;
+  }
+
+  const previewHandlePosition = getPrimaryPreviewHandlePosition(previewNode, previewConnections);
+  const previewCenterX = previewNode.position.x + previewSize.width / 2;
+  const previewCenterY = previewNode.position.y + previewSize.height / 2;
+
+  if (previewHandlePosition === Position.Left) {
+    return {
+      ...node,
+      position: {
+        x: previewNode.position.x,
+        y: previewCenterY - nodeSize.height / 2,
+      },
+    };
+  }
+
+  if (previewHandlePosition === Position.Right) {
+    return {
+      ...node,
+      position: {
+        x: previewNode.position.x + previewSize.width - nodeSize.width,
+        y: previewCenterY - nodeSize.height / 2,
+      },
+    };
+  }
+
+  if (previewHandlePosition === Position.Top) {
+    return {
+      ...node,
+      position: {
+        x: previewCenterX - nodeSize.width / 2,
+        y: previewNode.position.y,
+      },
+    };
+  }
+
+  if (previewHandlePosition === Position.Bottom) {
+    return {
+      ...node,
+      position: {
+        x: previewCenterX - nodeSize.width / 2,
+        y: previewNode.position.y + previewSize.height - nodeSize.height,
+      },
+    };
+  }
+
+  return {
+    ...node,
+    position: {
+      x: previewCenterX - nodeSize.width / 2,
+      y: previewCenterY - nodeSize.height / 2,
+    },
+  };
+}
+
+function resolveScopedCollisions(
+  nodes: Node[],
+  insertedNode: Node,
+  options: {
+    ignoredNodeTypes?: string[];
+    getNodeSize: (node: Node) => NodeDimensions;
+  }
+): AddNodePlacementResult {
+  const siblingNodes = nodes.filter((node) => node.parentId === insertedNode.parentId);
+  const resolvedSiblings = resolveCollisions(siblingNodes, {
+    ignoredNodeTypes: options.ignoredNodeTypes,
+    getNodeSize: options.getNodeSize,
+  });
+  const resolvedSiblingById = new Map(resolvedSiblings.map((node) => [node.id, node]));
+  const resolvedNodes = nodes.map((node) => resolvedSiblingById.get(node.id) ?? node);
+
+  return {
+    nodes: resolvedNodes,
+    insertedNode: resolvedSiblingById.get(insertedNode.id)!,
+  };
+}
+
+/**
+ * Applies the final Add Node placement after a preview is accepted. Container
+ * previews use their saved placement metadata; all other previews use scoped
+ * collision resolution.
+ */
+export function placeAddedNode({
+  nodes,
+  edges,
+  previewNode,
+  insertedNode,
+  registry,
+  ignoredNodeTypes,
+}: {
+  nodes: Node[];
+  edges: Edge[];
+  previewNode: Node;
+  insertedNode: Node;
+  registry: NodeTypeRegistry | null;
+  ignoredNodeTypes?: string[];
+}): AddNodePlacementResult {
+  const getDimensions = (node: Node) => getManifestAwareNodeDimensions(registry, node);
+  const placement = getContainerPlacement({ previewNode });
+
+  if (placement) {
+    const containerNode = nodes.find((node) => node.id === placement.containerId)!;
+    const containerManifest = getManifestForNode(registry, containerNode);
+
+    if (!isContainerNodeManifest(containerManifest)) {
+      return resolveScopedCollisions(nodes, insertedNode, {
+        ignoredNodeTypes,
+        getNodeSize: getDimensions,
+      });
+    }
+
+    const resolvedNodes = placeContainerNode({
+      nodes,
+      insertedNode,
+      placement,
+      edges,
+      getNodeDimensions: getDimensions,
+      safeArea: getContainerSafeArea(containerNode),
+      getContainerFitGeometry: (node) =>
+        isContainerNodeManifest(getManifestForNode(registry, node))
+          ? getContainerFitGeometry()
+          : null,
+    });
+
+    return {
+      nodes: resolvedNodes,
+      insertedNode: resolvedNodes.find((node) => node.id === insertedNode.id)!,
+    };
+  }
+
+  return resolveScopedCollisions(nodes, insertedNode, {
+    ignoredNodeTypes,
+    getNodeSize: getDimensions,
+  });
+}

--- a/packages/apollo-react/src/canvas/components/AddNodePanel/AddNodeManager.test.tsx
+++ b/packages/apollo-react/src/canvas/components/AddNodePanel/AddNodeManager.test.tsx
@@ -1,6 +1,8 @@
 import type { Edge, Node } from '@uipath/apollo-react/canvas/xyflow/react';
+import { Position } from '@uipath/apollo-react/canvas/xyflow/react';
+import type React from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { PREVIEW_NODE_ID } from '../../constants';
+import { PREVIEW_EDGE_ID, PREVIEW_NODE_ID } from '../../constants';
 import type { PreviewNodeConnectionInfo } from '../../hooks/usePreviewNode';
 import { render, screen } from '../../utils/testing';
 import type { ListItem } from '../Toolbox';
@@ -10,8 +12,15 @@ import { AddNodeManager } from './AddNodeManager';
 
 let mockNodes: Node[] = [];
 let mockEdges: Edge[] = [];
+let mockRegistry: unknown = null;
 
 vi.mock('@uipath/apollo-react/canvas/xyflow/react', () => ({
+  Position: {
+    Top: 'top',
+    Bottom: 'bottom',
+    Left: 'left',
+    Right: 'right',
+  },
   useReactFlow: () => ({
     getNode: (id: string) => mockNodes.find((n) => n.id === id),
     getNodes: () => mockNodes,
@@ -31,7 +40,7 @@ vi.mock('../../hooks/usePreviewNode', () => ({
 }));
 
 vi.mock('../../core', () => ({
-  useOptionalNodeTypeRegistry: () => null,
+  useOptionalNodeTypeRegistry: () => mockRegistry,
 }));
 
 vi.mock('../../utils', () => ({
@@ -108,12 +117,41 @@ describe('AddNodeManager', () => {
     </button>
   );
 
+  const ClosePanel = ({ onClose }: { onClose: () => void }) => (
+    <button type="button" data-testid="close-panel" onClick={onClose}>
+      Close
+    </button>
+  );
+
+  const LoopNodePanel = ({
+    onNodeSelect,
+  }: {
+    onNodeSelect: (item: ListItem) => void;
+    onClose: () => void;
+  }) => (
+    <button
+      type="button"
+      data-testid="select-loop"
+      onClick={() =>
+        onNodeSelect({
+          id: 'loop-item',
+          name: 'For Each',
+          description: 'Loop over items',
+          data: { type: 'loop' },
+        })
+      }
+    >
+      Select loop
+    </button>
+  );
+
   beforeEach(() => {
     vi.clearAllMocks();
     vi.spyOn(Date, 'now').mockReturnValue(1234567890);
 
     mockNodes = [existingNode, previewNode];
     mockEdges = [previewEdge];
+    mockRegistry = null;
 
     mockPreviewNodeReturn.mockReturnValue({
       previewNode,
@@ -316,5 +354,572 @@ describe('AddNodeManager', () => {
         position: { x: 500, y: 600 },
       })
     );
+  });
+
+  it('restores an edge replaced by preview when the add node panel is closed', () => {
+    const replacedEdge: Edge = {
+      id: 'loop-child-1',
+      source: 'loop-1',
+      sourceHandle: 'start',
+      target: 'child-1',
+      targetHandle: 'input',
+      type: 'smoothstep',
+      data: { preserved: true },
+      style: { stroke: 'var(--canvas-foreground)' },
+      label: 'Loop child',
+      markerEnd: 'url(#loop-arrow)',
+    };
+    const previewNodeWithOriginalEdge: Node = {
+      ...previewNode,
+      data: { originalEdge: replacedEdge },
+    };
+    mockNodes = [existingNode, previewNodeWithOriginalEdge];
+    mockEdges = [
+      {
+        id: PREVIEW_EDGE_ID,
+        source: 'loop-1',
+        sourceHandle: 'start',
+        target: PREVIEW_NODE_ID,
+        targetHandle: 'input',
+      },
+      {
+        id: 'loop-child-1',
+        source: PREVIEW_NODE_ID,
+        sourceHandle: 'output',
+        target: 'child-1',
+        targetHandle: 'input',
+      },
+    ];
+    mockPreviewNodeReturn.mockReturnValue({
+      previewNode: previewNodeWithOriginalEdge,
+      previewNodeConnectionInfo: connectionInfo,
+    });
+
+    const { rerender } = render(<AddNodeManager customPanel={ClosePanel} />);
+
+    screen.getByTestId('close-panel').click();
+    mockPreviewNodeReturn.mockReturnValue({
+      previewNode: null,
+      previewNodeConnectionInfo: null,
+    });
+    rerender(<AddNodeManager customPanel={ClosePanel} />);
+
+    expect(mockNodes.find((node) => node.id === PREVIEW_NODE_ID)).toBeUndefined();
+    expect(mockEdges).toEqual([replacedEdge]);
+  });
+
+  it('does not restore a replaced edge after materializing the preview', () => {
+    const replacedEdge: Edge = {
+      id: 'edge-to-replace',
+      source: 'existing-node-1',
+      sourceHandle: 'output-1',
+      target: 'target-node',
+      targetHandle: 'input-1',
+      type: 'smoothstep',
+      data: { preserved: true },
+      style: { stroke: 'var(--canvas-foreground)' },
+      markerEnd: 'url(#edge-arrow)',
+    };
+    const targetNode: Node = {
+      id: 'target-node',
+      type: 'target',
+      position: { x: 300, y: 0 },
+      data: {},
+    };
+    const previewNodeWithOriginalEdge: Node = {
+      ...previewNode,
+      data: { originalEdge: replacedEdge },
+    };
+    const trailingPreviewEdgeId = `${PREVIEW_NODE_ID}-${targetNode.id}`;
+    mockNodes = [existingNode, targetNode, previewNodeWithOriginalEdge];
+    mockEdges = [
+      {
+        id: PREVIEW_EDGE_ID,
+        source: replacedEdge.source,
+        sourceHandle: replacedEdge.sourceHandle,
+        target: PREVIEW_NODE_ID,
+        targetHandle: 'input',
+      },
+      {
+        id: trailingPreviewEdgeId,
+        source: PREVIEW_NODE_ID,
+        sourceHandle: 'output',
+        target: replacedEdge.target,
+        targetHandle: replacedEdge.targetHandle,
+      },
+    ];
+    mockPreviewNodeReturn.mockReturnValue({
+      previewNode: previewNodeWithOriginalEdge,
+      previewNodeConnectionInfo: [
+        {
+          existingNodeId: replacedEdge.source,
+          existingHandleId: replacedEdge.sourceHandle!,
+          existingNodeManifest: undefined,
+          existingHandleManifest: undefined,
+          addNewNodeAsSource: false,
+          previewEdgeId: PREVIEW_EDGE_ID,
+        },
+        {
+          existingNodeId: replacedEdge.target,
+          existingHandleId: replacedEdge.targetHandle!,
+          existingNodeManifest: undefined,
+          existingHandleManifest: undefined,
+          addNewNodeAsSource: true,
+          previewEdgeId: trailingPreviewEdgeId,
+        },
+      ],
+    });
+
+    render(<AddNodeManager customPanel={TestPanel} />);
+
+    screen.getByTestId('select-node').click();
+
+    expect(mockEdges.find((edge) => edge.id === replacedEdge.id)).toBeUndefined();
+    expect(mockEdges.find((edge) => edge.source === 'existing-node-1')).toMatchObject({
+      target: 'test-node-1234567890',
+    });
+    expect(mockEdges.find((edge) => edge.target === 'target-node')).toMatchObject({
+      source: 'test-node-1234567890',
+    });
+  });
+
+  it('resolves root insertions without moving parented container children', () => {
+    const rootNode: Node = {
+      id: 'root-node',
+      type: 'task',
+      position: { x: 0, y: 0 },
+      measured: { width: 96, height: 96 },
+      data: {},
+    };
+    const containerNode: Node = {
+      id: 'loop-1',
+      type: 'loop',
+      position: { x: 300, y: 0 },
+      style: { width: 400, height: 240 },
+      data: {},
+    };
+    const loopChildNode: Node = {
+      id: 'loop-child',
+      type: 'task',
+      parentId: 'loop-1',
+      position: { x: 100, y: 100 },
+      measured: { width: 96, height: 96 },
+      data: {},
+    };
+    const rootPreviewNode: Node = {
+      ...previewNode,
+      position: { x: 100, y: 100 },
+    };
+
+    mockNodes = [rootNode, containerNode, loopChildNode, existingNode, rootPreviewNode];
+    mockPreviewNodeReturn.mockReturnValue({
+      previewNode: rootPreviewNode,
+      previewNodeConnectionInfo: connectionInfo,
+    });
+
+    render(<AddNodeManager customPanel={TestPanel} />);
+
+    screen.getByTestId('select-node').click();
+
+    expect(mockNodes.find((node) => node.id === 'loop-child')).toMatchObject({
+      position: { x: 100, y: 100 },
+    });
+  });
+
+  it('uses container sequence materialization for parented previews', () => {
+    mockRegistry = {
+      getManifest: vi.fn((nodeType: string) =>
+        nodeType === 'loop'
+          ? {
+              nodeType: 'loop',
+              display: { label: 'Loop', shape: 'container' },
+              handleConfiguration: [],
+            }
+          : undefined
+      ),
+      getDefaultHandle: vi.fn(),
+    };
+    const containerNode: Node = {
+      id: 'loop-1',
+      type: 'loop',
+      position: { x: 500, y: 100 },
+      style: { width: 320, height: 220 },
+      data: {},
+    };
+    const outerNode: Node = {
+      id: 'outer-node',
+      type: 'task',
+      position: { x: 100, y: 120 },
+      data: {},
+    };
+    const parentedPreviewNode: Node = {
+      ...previewNode,
+      position: { x: 112, y: 128 },
+      parentId: 'loop-1',
+      extent: 'parent',
+      data: {
+        placement: {
+          containerId: 'loop-1',
+          sourceNodeId: 'loop-1',
+          targetNodeId: 'loop-1',
+          mode: 'first-child',
+        },
+      },
+    };
+    mockNodes = [containerNode, outerNode, parentedPreviewNode];
+    mockPreviewNodeReturn.mockReturnValue({
+      previewNode: parentedPreviewNode,
+      previewNodeConnectionInfo: connectionInfo,
+    });
+
+    render(<AddNodeManager customPanel={TestPanel} />);
+
+    screen.getByTestId('select-node').click();
+
+    expect(mockNodes.find((node) => node.id === 'outer-node')).toMatchObject({
+      position: { x: 100, y: 120 },
+    });
+    expect(mockNodes.find((node) => node.id === 'test-node-1234567890')).toMatchObject({
+      parentId: 'loop-1',
+      extent: 'parent',
+      position: { x: 144, y: 96 },
+    });
+  });
+
+  it('uses standard container-safe geometry and shifts the deterministic downstream chain', () => {
+    mockRegistry = {
+      getManifest: vi.fn((nodeType: string) =>
+        nodeType === 'loop'
+          ? {
+              nodeType: 'loop',
+              display: { label: 'Loop', shape: 'container' },
+              handleConfiguration: [],
+            }
+          : {
+              nodeType,
+              display: { label: 'Task', shape: 'square' },
+              handleConfiguration: [],
+            }
+      ),
+      getDefaultHandle: vi.fn(),
+    };
+    const containerNode: Node = {
+      id: 'loop-1',
+      type: 'loop',
+      position: { x: 500, y: 100 },
+      style: { width: 704, height: 368 },
+      data: {},
+    };
+    const firstChildNode: Node = {
+      id: 'first-child',
+      type: 'task',
+      parentId: 'loop-1',
+      position: { x: 160, y: 96 },
+      measured: { width: 96, height: 96 },
+      data: {},
+    };
+    const secondChildNode: Node = {
+      id: 'second-child',
+      type: 'task',
+      parentId: 'loop-1',
+      position: { x: 432, y: 96 },
+      measured: { width: 96, height: 96 },
+      data: {},
+    };
+    const parentedPreviewNode: Node = {
+      ...previewNode,
+      position: { x: 64, y: 96 },
+      parentId: 'loop-1',
+      extent: 'parent',
+      data: {
+        placement: {
+          containerId: 'loop-1',
+          sourceNodeId: 'loop-1',
+          targetNodeId: 'first-child',
+          mode: 'sequence',
+        },
+      },
+    };
+    const parentedConnections: PreviewNodeConnectionInfo[] = [
+      {
+        existingNodeId: 'loop-1',
+        existingHandleId: 'start',
+        existingNodeManifest: undefined,
+        existingHandleManifest: undefined,
+        addNewNodeAsSource: false,
+        previewEdgeId: PREVIEW_EDGE_ID,
+      },
+      {
+        existingNodeId: 'first-child',
+        existingHandleId: 'input',
+        existingNodeManifest: undefined,
+        existingHandleManifest: undefined,
+        addNewNodeAsSource: true,
+        previewEdgeId: 'loop-child-1',
+      },
+    ];
+
+    mockNodes = [containerNode, firstChildNode, secondChildNode, parentedPreviewNode];
+    mockEdges = [
+      {
+        id: PREVIEW_EDGE_ID,
+        source: 'loop-1',
+        sourceHandle: 'start',
+        target: PREVIEW_NODE_ID,
+        targetHandle: 'input',
+      },
+      {
+        id: 'loop-child-1',
+        source: PREVIEW_NODE_ID,
+        sourceHandle: 'output',
+        target: 'first-child',
+        targetHandle: 'input',
+      },
+      { id: 'first-second', source: 'first-child', target: 'second-child' },
+      { id: 'second-loop', source: 'second-child', target: 'loop-1' },
+    ];
+    mockPreviewNodeReturn.mockReturnValue({
+      previewNode: parentedPreviewNode,
+      previewNodeConnectionInfo: parentedConnections,
+    });
+
+    render(<AddNodeManager customPanel={TestPanel} />);
+
+    screen.getByTestId('select-node').click();
+
+    expect(mockNodes.find((node) => node.id === 'test-node-1234567890')).toMatchObject({
+      parentId: 'loop-1',
+      extent: 'parent',
+      position: { x: 144, y: 96 },
+    });
+    expect(mockNodes.find((node) => node.id === 'first-child')).toMatchObject({
+      position: { x: 288, y: 96 },
+    });
+    expect(mockNodes.find((node) => node.id === 'second-child')).toMatchObject({
+      position: { x: 560, y: 96 },
+    });
+  });
+
+  it('keeps the preview center stable when adding a larger container node', () => {
+    mockRegistry = {
+      getManifest: vi.fn((nodeType: string) =>
+        nodeType === 'loop'
+          ? {
+              nodeType: 'loop',
+              display: { label: 'Loop', shape: 'container' },
+              handleConfiguration: [],
+            }
+          : undefined
+      ),
+      getDefaultHandle: vi.fn(),
+    };
+    const rootPreviewNode: Node = {
+      ...previewNode,
+      position: { x: 400, y: 200 },
+      width: 96,
+      height: 96,
+    };
+    mockNodes = [existingNode, rootPreviewNode];
+    mockPreviewNodeReturn.mockReturnValue({
+      previewNode: rootPreviewNode,
+      previewNodeConnectionInfo: [
+        {
+          existingNodeId: 'existing-node-1',
+          existingHandleId: 'output',
+          existingNodeManifest: undefined,
+          existingHandleManifest: undefined,
+          addNewNodeAsSource: false,
+          previewEdgeId: 'preview-edge-1',
+        },
+      ],
+    });
+
+    render(<AddNodeManager customPanel={LoopNodePanel} />);
+
+    screen.getByTestId('select-loop').click();
+
+    expect(mockNodes.find((node) => node.id === 'loop-1234567890')).toMatchObject({
+      type: 'loop',
+      position: { x: 168, y: 88 },
+    });
+  });
+
+  it('aligns a larger node to the selected preview handle side when replacing a handle preview', () => {
+    mockRegistry = {
+      getManifest: vi.fn((nodeType: string) =>
+        nodeType === 'loop'
+          ? {
+              nodeType: 'loop',
+              display: { label: 'Loop', shape: 'container' },
+              handleConfiguration: [],
+            }
+          : undefined
+      ),
+      getDefaultHandle: vi.fn(),
+    };
+    const rootPreviewNode: Node = {
+      ...previewNode,
+      position: { x: 400, y: 200 },
+      width: 96,
+      height: 96,
+      data: {
+        inputHandlePosition: Position.Left,
+        outputHandlePosition: Position.Right,
+      },
+    };
+    mockNodes = [existingNode, rootPreviewNode];
+    mockPreviewNodeReturn.mockReturnValue({
+      previewNode: rootPreviewNode,
+      previewNodeConnectionInfo: [
+        {
+          existingNodeId: 'existing-node-1',
+          existingHandleId: 'output',
+          existingNodeManifest: undefined,
+          existingHandleManifest: undefined,
+          addNewNodeAsSource: false,
+          previewEdgeId: 'preview-edge-1',
+        },
+      ],
+    });
+
+    render(<AddNodeManager customPanel={LoopNodePanel} />);
+
+    screen.getByTestId('select-loop').click();
+
+    expect(mockNodes.find((node) => node.id === 'existing-node-1')).toMatchObject({
+      position: { x: 0, y: 0 },
+    });
+    expect(mockNodes.find((node) => node.id === 'loop-1234567890')).toMatchObject({
+      type: 'loop',
+      position: { x: 400, y: 88 },
+    });
+  });
+
+  it('shifts downstream loop children when materializing an edge-toolbar insertion', () => {
+    mockRegistry = {
+      getManifest: vi.fn((nodeType: string) =>
+        nodeType === 'loop'
+          ? {
+              nodeType: 'loop',
+              display: { label: 'Loop', shape: 'container' },
+              handleConfiguration: [],
+            }
+          : {
+              nodeType,
+              display: { label: 'Task', shape: 'square' },
+              handleConfiguration: [],
+            }
+      ),
+      getDefaultHandle: vi.fn(),
+    };
+    const containerNode: Node = {
+      id: 'loop-1',
+      type: 'loop',
+      position: { x: 500, y: 100 },
+      style: { width: 704, height: 368 },
+      data: {},
+    };
+    const firstChildNode: Node = {
+      id: 'first-child',
+      type: 'task',
+      parentId: 'loop-1',
+      position: { x: 160, y: 96 },
+      measured: { width: 96, height: 96 },
+      data: {},
+    };
+    const secondChildNode: Node = {
+      id: 'second-child',
+      type: 'task',
+      parentId: 'loop-1',
+      position: { x: 432, y: 96 },
+      measured: { width: 96, height: 96 },
+      data: {},
+    };
+    const thirdChildNode: Node = {
+      id: 'third-child',
+      type: 'task',
+      parentId: 'loop-1',
+      position: { x: 528, y: 96 },
+      measured: { width: 96, height: 96 },
+      data: {},
+    };
+    const parentedPreviewNode: Node = {
+      ...previewNode,
+      position: { x: 296, y: 96 },
+      parentId: 'loop-1',
+      extent: 'parent',
+      data: {
+        placement: {
+          containerId: 'loop-1',
+          sourceNodeId: 'first-child',
+          targetNodeId: 'second-child',
+          mode: 'sequence',
+        },
+      },
+    };
+    const parentedConnections: PreviewNodeConnectionInfo[] = [
+      {
+        existingNodeId: 'first-child',
+        existingHandleId: 'output',
+        existingNodeManifest: undefined,
+        existingHandleManifest: undefined,
+        addNewNodeAsSource: false,
+        previewEdgeId: PREVIEW_EDGE_ID,
+      },
+      {
+        existingNodeId: 'second-child',
+        existingHandleId: 'input',
+        existingNodeManifest: undefined,
+        existingHandleManifest: undefined,
+        addNewNodeAsSource: true,
+        previewEdgeId: 'first-second',
+      },
+    ];
+
+    mockNodes = [
+      containerNode,
+      firstChildNode,
+      secondChildNode,
+      thirdChildNode,
+      parentedPreviewNode,
+    ];
+    mockEdges = [
+      {
+        id: PREVIEW_EDGE_ID,
+        source: 'first-child',
+        sourceHandle: 'output',
+        target: PREVIEW_NODE_ID,
+        targetHandle: 'input',
+      },
+      {
+        id: 'first-second',
+        source: PREVIEW_NODE_ID,
+        sourceHandle: 'output',
+        target: 'second-child',
+        targetHandle: 'input',
+      },
+      { id: 'second-third', source: 'second-child', target: 'third-child' },
+      { id: 'third-loop', source: 'third-child', target: 'loop-1' },
+    ];
+    mockPreviewNodeReturn.mockReturnValue({
+      previewNode: parentedPreviewNode,
+      previewNodeConnectionInfo: parentedConnections,
+    });
+
+    render(<AddNodeManager customPanel={TestPanel} />);
+
+    screen.getByTestId('select-node').click();
+
+    expect(mockNodes.find((node) => node.id === 'test-node-1234567890')).toMatchObject({
+      parentId: 'loop-1',
+      extent: 'parent',
+      position: { x: 304, y: 96 },
+    });
+    expect(mockNodes.find((node) => node.id === 'second-child')).toMatchObject({
+      position: { x: 448, y: 96 },
+    });
+    expect(mockNodes.find((node) => node.id === 'third-child')).toMatchObject({
+      position: { x: 544, y: 96 },
+    });
   });
 });

--- a/packages/apollo-react/src/canvas/components/AddNodePanel/AddNodeManager.tsx
+++ b/packages/apollo-react/src/canvas/components/AddNodePanel/AddNodeManager.tsx
@@ -5,10 +5,11 @@ import { useCallback, useEffect, useRef } from 'react';
 import { FLOATING_CANVAS_PANEL_OFFSET, PREVIEW_NODE_ID } from '../../constants';
 import { useOptionalNodeTypeRegistry } from '../../core';
 import { usePreviewNode } from '../../hooks/usePreviewNode';
-import { resolveCollisions } from '../../utils';
+import { isPreviewEdge } from '../../utils/createPreviewNode';
 import type { BaseNodeData } from '../BaseNode';
 import { FloatingCanvasPanel } from '../FloatingCanvasPanel';
 import type { ListItem } from '../Toolbox';
+import { alignNodeToPreview, getOriginalEdge, placeAddedNode } from './AddNodeManager.helpers';
 import { AddNodePanel } from './AddNodePanel';
 import type { NodeItemData } from './AddNodePanel.types';
 
@@ -81,20 +82,19 @@ export const AddNodeManager: React.FC<AddNodeManagerProps> = ({
       // Clean up preview node and all preview edges if they still exist
       reactFlowInstance.setNodes((nodes) => nodes.filter((n) => n.id !== PREVIEW_NODE_ID));
       reactFlowInstance.setEdges((edges) => {
-        const filteredEdges = edges.filter(
-          (e) => e.source !== PREVIEW_NODE_ID && e.target !== PREVIEW_NODE_ID
-        );
+        const filteredEdges = edges.filter((edge) => !isPreviewEdge(edge));
         // Restore original edge if it exists
-        return restoreEdgesRef.current
+        const restoredEdges = restoreEdgesRef.current
           ? [...filteredEdges, ...restoreEdgesRef.current]
           : filteredEdges;
+        restoreEdgesRef.current = null;
+        return restoredEdges;
       });
     } else if (previewNode && !restoreEdgesRef.current) {
       // Preview node just got selected
       // Store original edge(s) to restore later
-      restoreEdgesRef.current = previewNode.data.originalEdge
-        ? [previewNode.data.originalEdge as Edge]
-        : null;
+      const originalEdge = getOriginalEdge(previewNode);
+      restoreEdgesRef.current = originalEdge ? [originalEdge] : null;
     }
     lastPreviewNodeRef.current = previewNode || null;
   }, [previewNode, reactFlowInstance]);
@@ -136,22 +136,27 @@ export const AddNodeManager: React.FC<AddNodeManagerProps> = ({
       const previewNodeScope = currentPreviewNode.parentId
         ? { parentId: currentPreviewNode.parentId, extent: currentPreviewNode.extent }
         : {};
-
-      // Create new node at preview position
-      const newNode: Node = {
-        id: newNodeId,
-        type: nodeItem.data.type,
-        position: currentPreviewNode.position,
-        selected: true,
-        data: nodeData,
-        ...previewNodeScope,
-      };
       // Get the manifest for the new node type to find its default handles
       const newNodeManifest = registry?.getManifest(nodeItem.data.type);
 
+      // Create new node at preview position
+      const newNode = alignNodeToPreview(
+        {
+          id: newNodeId,
+          type: nodeItem.data.type,
+          position: currentPreviewNode.position,
+          selected: true,
+          data: nodeData,
+          ...previewNodeScope,
+        },
+        currentPreviewNode,
+        previewNodeConnectionInfo,
+        newNodeManifest
+      );
+
       // Create edges for all connections
       const newEdges: Edge[] = [];
-      const previewEdgeIds: string[] = [];
+      const previewEdgeIds = new Set<string>();
 
       for (const connectionInfoItem of previewNodeConnectionInfo) {
         // Get the default handle for the new node based on connection direction
@@ -181,7 +186,7 @@ export const AddNodeManager: React.FC<AddNodeManagerProps> = ({
           ...edgeSourceTargetData,
           type: 'default',
         });
-        previewEdgeIds.push(connectionInfoItem.previewEdgeId);
+        previewEdgeIds.add(connectionInfoItem.previewEdgeId);
       }
 
       const { newNode: finalNode, newEdges: finalEdges } = onBeforeNodeAdded?.(
@@ -191,39 +196,52 @@ export const AddNodeManager: React.FC<AddNodeManagerProps> = ({
         newNode,
         newEdges,
       };
+      const placementEdges = reactFlowInstance.getEdges();
 
       // Replace preview node with actual node and resolve collisions
+      let placedNode = finalNode;
       reactFlowInstance.setNodes((nodes) => {
         const newNodes = [
           ...nodes.filter((n) => n.id !== PREVIEW_NODE_ID).map((n) => ({ ...n, selected: false })),
           finalNode,
         ];
-        return resolveCollisions(newNodes, { ignoredNodeTypes });
+        const placement = placeAddedNode({
+          nodes: newNodes,
+          edges: placementEdges,
+          previewNode: currentPreviewNode,
+          insertedNode: finalNode,
+          registry,
+          ignoredNodeTypes,
+        });
+        placedNode = placement.insertedNode;
+        return placement.nodes;
       });
 
       // Replace all preview edges with actual edges
       reactFlowInstance.setEdges((edges) => [
-        ...edges.filter((e) => !previewEdgeIds.includes(e.id)),
+        ...edges.filter((edge) => !previewEdgeIds.has(edge.id) && !isPreviewEdge(edge)),
         ...finalEdges,
       ]);
+      restoreEdgesRef.current = null;
 
       // Call onNodeAdded for the first connection (for backwards compatibility)
       const [firstConnection] = previewNodeConnectionInfo;
       if (firstConnection) {
-        const firstEdgeSourceHandle = firstConnection.addNewNodeAsSource
-          ? newNodeManifest && registry?.getDefaultHandle(newNodeManifest.nodeType, 'source')?.id
-          : firstConnection.existingHandleId;
+        const firstMaterializedEdge = finalEdges.find(
+          (edge) => edge.source === placedNode.id || edge.target === placedNode.id
+        );
         const firstEdgeData = firstConnection.addNewNodeAsSource
-          ? { source: finalNode.id, sourceHandle: firstEdgeSourceHandle ?? 'output' }
+          ? {
+              source: placedNode.id,
+              sourceHandle: firstMaterializedEdge?.sourceHandle ?? 'output',
+            }
           : {
               source: firstConnection.existingNodeId,
               sourceHandle: firstConnection.existingHandleId,
             };
-        onNodeAdded?.(firstEdgeData.source, firstEdgeData.sourceHandle, finalNode);
+        onNodeAdded?.(firstEdgeData.source, firstEdgeData.sourceHandle, placedNode);
       }
-      // No need to restore edges once we have added the new node.
-      restoreEdgesRef.current = null;
-      handleClose();
+      lastPreviewNodeRef.current = null;
     },
     [
       previewNodeConnectionInfo,
@@ -233,7 +251,6 @@ export const AddNodeManager: React.FC<AddNodeManagerProps> = ({
       onBeforeNodeAdded,
       onNodeAdded,
       ignoredNodeTypes,
-      handleClose,
     ]
   );
 

--- a/packages/apollo-react/src/canvas/components/AddNodePanel/AddNodePanel.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/AddNodePanel/AddNodePanel.stories.tsx
@@ -231,7 +231,7 @@ function StandalonePanelWrapper({ children }: { children: React.ReactNode }) {
  */
 function PreviewSelectionStory() {
   const initialNodes = useMemo(() => createInitialNodes(), []);
-  const { canvasProps } = useCanvasStory({
+  const { canvasProps, nodeTypeRegistry } = useCanvasStory({
     initialNodes,
     initialEdges: [
       {
@@ -256,7 +256,12 @@ function PreviewSelectionStory() {
         handleId,
         reactFlowInstance,
         position as Position,
-        sourceHandleType
+        sourceHandleType,
+        [],
+        {
+          getManifestForNode: (node) =>
+            node.type ? nodeTypeRegistry.getManifest(node.type) : undefined,
+        }
       );
     }
   });
@@ -316,7 +321,7 @@ function AllSidesStory() {
     ],
     []
   );
-  const { canvasProps } = useCanvasStory({ initialNodes });
+  const { canvasProps, nodeTypeRegistry } = useCanvasStory({ initialNodes });
 
   const reactFlowInstance = useReactFlow();
   useCanvasEvent('handle:action', (event: CanvasHandleActionEvent) => {
@@ -330,7 +335,12 @@ function AllSidesStory() {
         handleId,
         reactFlowInstance,
         position as Position,
-        sourceHandleType
+        sourceHandleType,
+        [],
+        {
+          getManifestForNode: (node) =>
+            node.type ? nodeTypeRegistry.getManifest(node.type) : undefined,
+        }
       );
     }
   });

--- a/packages/apollo-react/src/canvas/components/AddNodePanel/createAddNodePreview.ts
+++ b/packages/apollo-react/src/canvas/components/AddNodePanel/createAddNodePreview.ts
@@ -1,5 +1,13 @@
 import { Position, type ReactFlowInstance } from '@uipath/apollo-react/canvas/xyflow/react';
 import { showPreviewGraph } from '../../utils/createPreviewGraph';
+import {
+  type ContainerPreviewManifestResolver,
+  resolveContainerAddNodePreview,
+} from '../LoopNode/LoopNode.helpers';
+
+export interface AddNodePreviewOptions {
+  getManifestForNode?: ContainerPreviewManifestResolver;
+}
 
 /**
  * Creates a preview node and edge when a button handle is clicked.
@@ -10,6 +18,8 @@ import { showPreviewGraph } from '../../utils/createPreviewGraph';
  * @param reactFlowInstance - The React Flow instance
  * @param handlePosition - The position/side of the handle (defaults to Right)
  * @param sourceHandleType - Whether the source handle is a "source" or "target" (defaults to "source")
+ * @param ignoredNodeTypes - Node types to ignore when calculating overlap
+ * @param options - Optional add-node preview behavior
  */
 export function createAddNodePreview(
   sourceNodeId: string,
@@ -17,14 +27,28 @@ export function createAddNodePreview(
   reactFlowInstance: ReactFlowInstance,
   handlePosition: Position = Position.Right,
   sourceHandleType: 'source' | 'target' = 'source',
-  ignoredNodeTypes: string[] = []
+  ignoredNodeTypes: string[] = [],
+  options: AddNodePreviewOptions = {}
 ): void {
+  const source = {
+    nodeId: sourceNodeId,
+    handleId: sourceHandleId,
+  };
+  const overrides = options.getManifestForNode
+    ? resolveContainerAddNodePreview({
+        source,
+        sourceHandleType,
+        reactFlowInstance,
+        getManifestForNode: options.getManifestForNode,
+      })
+    : null;
+
   showPreviewGraph({
-    sourceNodeId,
-    sourceHandleId,
+    source,
     reactFlowInstance,
     sourceHandleType,
     handlePosition,
     ignoredNodeTypes,
+    ...(overrides ?? {}),
   });
 }

--- a/packages/apollo-react/src/canvas/components/AddNodePanel/index.ts
+++ b/packages/apollo-react/src/canvas/components/AddNodePanel/index.ts
@@ -3,4 +3,4 @@ export { AddNodeManager } from './AddNodeManager';
 export { AddNodePanel } from './AddNodePanel';
 export type { AddNodePanelProps, NodeItemData } from './AddNodePanel.types';
 export { AddNodePreview, type AddNodePreviewData } from './AddNodePreview';
-export { createAddNodePreview } from './createAddNodePreview';
+export { type AddNodePreviewOptions, createAddNodePreview } from './createAddNodePreview';

--- a/packages/apollo-react/src/canvas/components/Flow.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/Flow.stories.tsx
@@ -320,8 +320,10 @@ function DefaultStory({ useSmartHandles }: FlowStoryArgs) {
       const customData = sourceNode?.data?.useSmartHandles ? { useSmartHandles: true } : undefined;
 
       showPreviewGraph({
-        sourceNodeId: nodeId,
-        sourceHandleId: handleId,
+        source: {
+          nodeId,
+          handleId,
+        },
         reactFlowInstance,
         data: customData,
         sourceHandleType,

--- a/packages/apollo-react/src/canvas/components/HierarchicalCanvas/HierarchicalCanvas.tsx
+++ b/packages/apollo-react/src/canvas/components/HierarchicalCanvas/HierarchicalCanvas.tsx
@@ -14,6 +14,7 @@ import {
   type OnSelectionChangeFunc,
   type OnSelectionChangeParams,
   Panel,
+  type Position,
   type ReactFlowInstance,
   type Viewport,
 } from '@uipath/apollo-react/canvas/xyflow/react';
@@ -24,6 +25,7 @@ import { PREVIEW_NODE_ID } from '../../constants';
 import { Breadcrumb } from '../../controls';
 import { useNodeManifests } from '../../core';
 import { useAddNodeOnConnectEnd } from '../../hooks/useAddNodeOnConnectEnd';
+import { useCanvasEvent } from '../../hooks/useCanvasEvents';
 import type { ToolbarActionEvent } from '../../schema/toolbar';
 import { animatedViewportManager } from '../../stores/animatedViewportManager';
 import {
@@ -47,16 +49,18 @@ import {
 import { viewportManager } from '../../stores/viewportManager';
 import { DefaultCanvasTranslations } from '../../types';
 import type { CanvasLevel } from '../../types/canvas.types';
+import { type CanvasHandleActionEvent, isContainerNodeManifest } from '../../utils';
 import { isPreviewEdge } from '../../utils/createPreviewNode';
 import { CanvasIcon } from '../../utils/icon-registry';
 import { prefersReducedMotion } from '../../utils/transitions';
 import { AddNodeManager } from '../AddNodePanel/AddNodeManager';
 import { AddNodePreview } from '../AddNodePanel/AddNodePreview';
+import { createAddNodePreview } from '../AddNodePanel/createAddNodePreview';
 import { BaseCanvas, type BaseCanvasRef } from '../BaseCanvas';
 import { BaseNode } from '../BaseNode';
 import { BlankCanvasNode } from '../BlankCanvasNode';
 import { CanvasPositionControls } from '../CanvasPositionControls';
-import { isContainerNodeManifest, LoopCanvasNode } from '../LoopNode';
+import { LoopCanvasNode } from '../LoopNode';
 import { MiniCanvasNavigator } from '../MiniCanvasNavigator';
 
 interface HierarchicalCanvasProps {
@@ -122,6 +126,10 @@ export const HierarchicalCanvas: React.FC<HierarchicalCanvasProps> = ({
 
   // Build node types mapping from manifests and defaults.
   const nodeManifests = useNodeManifests();
+  const nodeManifestByType = useMemo(
+    () => new Map(nodeManifests.map((manifest) => [manifest.nodeType, manifest])),
+    [nodeManifests]
+  );
   const nodeTypes = useMemo(() => {
     return nodeManifests.reduce(
       (acc, manifest) => {
@@ -131,6 +139,10 @@ export const HierarchicalCanvas: React.FC<HierarchicalCanvasProps> = ({
       { ...DEFAULT_NODE_TYPES } as NodeTypes
     );
   }, [nodeManifests]);
+  const getManifestForNode = useCallback(
+    (node: Node) => (node.type ? nodeManifestByType.get(node.type) : undefined),
+    [nodeManifestByType]
+  );
 
   // Optimized selectors to prevent unnecessary re-renders
   const currentCanvas = useCanvasStore(selectCurrentCanvas);
@@ -158,6 +170,25 @@ export const HierarchicalCanvas: React.FC<HierarchicalCanvasProps> = ({
   }, [currentPath]);
 
   const addNodeOnConnectEnd = useAddNodeOnConnectEnd();
+
+  // Keep handle-button add-node behavior in the canvas so it works without the controls wrapper.
+  const handleAddNodePreviewAction = useCallback(
+    (event: CanvasHandleActionEvent) => {
+      if (!reactFlowInstance) return;
+
+      createAddNodePreview(
+        event.nodeId,
+        event.handleId,
+        reactFlowInstance,
+        event.position as Position,
+        event.handleType === 'input' ? 'target' : 'source',
+        [],
+        { getManifestForNode }
+      );
+    },
+    [reactFlowInstance, getManifestForNode]
+  );
+  useCanvasEvent('handle:action', handleAddNodePreviewAction);
 
   // Track if we've initialized to prevent re-initialization
   const hasInitialized = useRef(false);

--- a/packages/apollo-react/src/canvas/components/HierarchicalCanvas/HierarchicalCanvasWithControls.tsx
+++ b/packages/apollo-react/src/canvas/components/HierarchicalCanvas/HierarchicalCanvasWithControls.tsx
@@ -1,12 +1,7 @@
-import {
-  type Node,
-  Panel,
-  ReactFlowProvider,
-  useReactFlow,
-} from '@uipath/apollo-react/canvas/xyflow/react';
+import { type Node, Panel, ReactFlowProvider } from '@uipath/apollo-react/canvas/xyflow/react';
 import { Button } from '@uipath/apollo-wind';
 import type React from 'react';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useState } from 'react';
 import { NodeRegistryProvider } from '../../core';
 import type { CategoryManifest } from '../../schema/node-definition';
 import type { NodeManifest } from '../../schema/node-definition/node-manifest';
@@ -20,9 +15,7 @@ import {
   useCanvasStore,
 } from '../../stores/canvasStore';
 import type { CanvasLevel } from '../../types/canvas.types';
-import { canvasEventBus } from '../../utils/CanvasEventBus';
 import { CanvasIcon } from '../../utils/icon-registry';
-import { createAddNodePreview } from '../AddNodePanel/createAddNodePreview';
 import { HierarchicalCanvas } from './HierarchicalCanvas';
 
 // Demo canvas data for Storybook testing
@@ -301,8 +294,6 @@ const CanvasWithControlsContent: React.FC<CanvasWithControlsContentProps> = ({
   onCanvasesChange,
   onPathChange,
 }) => {
-  const reactFlowInstance = useReactFlow();
-
   // Use stable selectors to avoid "getSnapshot should be cached" errors
   const currentCanvas = useCanvasStore(selectCurrentCanvas);
   const currentPathLength = useCanvasStore(selectCurrentPathLength);
@@ -310,20 +301,6 @@ const CanvasWithControlsContent: React.FC<CanvasWithControlsContentProps> = ({
   const removeNode = useCanvasStore(selectRemoveNode);
   const removeEdge = useCanvasStore(selectRemoveEdge);
   const updateNodes = useCanvasStore(selectUpdateNodes);
-
-  // Listen for handle action events and create preview
-  useEffect(() => {
-    const handleAction = (event: { nodeId: string; handleId: string }) => {
-      if (reactFlowInstance) {
-        createAddNodePreview(event.nodeId, event.handleId, reactFlowInstance);
-      }
-    };
-
-    canvasEventBus.on('handle:action', handleAction);
-    return () => {
-      canvasEventBus.off('handle:action', handleAction);
-    };
-  }, [reactFlowInstance]);
 
   const handleAddNode = useCallback(
     (nodeType: string) => {

--- a/packages/apollo-react/src/canvas/components/LoopNode/LoopNode.constants.ts
+++ b/packages/apollo-react/src/canvas/components/LoopNode/LoopNode.constants.ts
@@ -1,7 +1,0 @@
-export const DEFAULT_LOOP_ICON = 'repeat';
-export const DEFAULT_LOOP_TITLE = 'Loop';
-export const DEFAULT_CONTAINER_HEADER_HEIGHT_PX = 40;
-
-export const DEFAULT_CONTAINER_MIN_WIDTH = 400;
-export const DEFAULT_CONTAINER_MIN_HEIGHT = 220;
-export const CONTAINER_FRAME_INSET_PX = 10;

--- a/packages/apollo-react/src/canvas/components/LoopNode/LoopNode.helpers.ts
+++ b/packages/apollo-react/src/canvas/components/LoopNode/LoopNode.helpers.ts
@@ -1,11 +1,20 @@
-import { type Node, Position } from '@uipath/apollo-react/canvas/xyflow/react';
-import { DEFAULT_CONTAINER_HEIGHT, DEFAULT_CONTAINER_WIDTH } from '../../constants';
+import {
+  type Node,
+  Position,
+  type ReactFlowInstance,
+} from '@uipath/apollo-react/canvas/xyflow/react';
 import type { NodeManifest } from '../../schema/node-definition';
+import {
+  CONTAINER_FRAME_INSET_PX,
+  getContainerSafeArea,
+  isContainerNodeManifest,
+  resolveContainerPreview,
+} from '../../utils/container';
+import type { PreviewEndpoint, PreviewGraphOverrides } from '../../utils/createPreviewGraph';
 import { getOppositePosition } from '../../utils/createPreviewNode';
 import type { ResolutionContext, ResolvedHandleGroup } from '../../utils/manifest-resolver';
 import { resolveHandles } from '../../utils/manifest-resolver';
 import { snapToGrid } from '../../utils/NodeUtils';
-import { CONTAINER_FRAME_INSET_PX, DEFAULT_CONTAINER_HEADER_HEIGHT_PX } from './LoopNode.constants';
 
 export type ContainerHandleBoundary = 'outer' | 'inner';
 export type ContainerHandleGroup = ResolvedHandleGroup & {
@@ -19,16 +28,15 @@ export interface ContainerPreviewConnectionHandles {
   targetHandleId: string;
 }
 
-function clamp(value: number, min: number, max: number): number {
-  return Math.min(Math.max(value, min), max);
-}
+export type ContainerPreviewManifestResolver = (
+  node: Node
+) => Pick<NodeManifest, 'display' | 'handleConfiguration'> | undefined;
 
-export function isContainerNodeManifest(
-  manifest: Pick<NodeManifest, 'display'> | undefined
-): boolean {
-  return manifest?.display.shape === 'container';
-}
-
+/**
+ * Normalizes manifest handle groups for container rendering. Inner handles are
+ * inset from the frame and expose their connection position on the opposite side
+ * because edges visually connect from inside the container body.
+ */
 export function resolveContainerHandleGroups(
   groups: ResolvedHandleGroup[]
 ): ContainerHandleGroup[] {
@@ -46,42 +54,19 @@ export function resolveContainerHandleGroups(
   });
 }
 
-export function getContainerBodyCenter({
-  width,
-  height,
-  headerHeight,
-}: {
-  width: number;
-  height: number;
-  headerHeight: number;
-}) {
-  const clampedHeaderHeight = clamp(headerHeight, 0, height);
-
-  return {
-    x: clamp(snapToGrid(width / 2), 0, width),
-    y: clamp(snapToGrid(clampedHeaderHeight + (height - clampedHeaderHeight) / 2), 0, height),
-  };
-}
-
+/**
+ * Returns the center of the container's child-safe body area in local
+ * coordinates. Used to place empty-state affordances and first children.
+ */
 export function getContainerRelativeBodyCenter(
   containerNode: Pick<Node, 'width' | 'height' | 'measured' | 'style'>
 ) {
-  const width = readNumericDimension(
-    containerNode.width,
-    containerNode.measured?.width,
-    containerNode.style?.width
-  );
-  const height = readNumericDimension(
-    containerNode.height,
-    containerNode.measured?.height,
-    containerNode.style?.height
-  );
+  const safeArea = getContainerSafeArea(containerNode);
 
-  return getContainerBodyCenter({
-    width: width ?? DEFAULT_CONTAINER_WIDTH,
-    height: height ?? DEFAULT_CONTAINER_HEIGHT,
-    headerHeight: DEFAULT_CONTAINER_HEADER_HEIGHT_PX,
-  });
+  return {
+    x: snapToGrid(safeArea.x + safeArea.width / 2),
+    y: snapToGrid(safeArea.y + safeArea.height / 2),
+  };
 }
 
 function insetInnerGroup(group: ResolvedHandleGroup) {
@@ -101,18 +86,11 @@ function insetInnerGroup(group: ResolvedHandleGroup) {
   }
 }
 
-function readNumericDimension(...values: Array<number | string | undefined>): number | undefined {
-  for (const value of values) {
-    if (typeof value === 'number') return value;
-    if (typeof value === 'string') {
-      const parsedValue = Number.parseFloat(value);
-      if (Number.isFinite(parsedValue)) return parsedValue;
-    }
-  }
-
-  return undefined;
-}
-
+/**
+ * Finds the visible inner source/target handle pair used by container preview
+ * edges. Returns null when the manifest cannot support a child continuation
+ * preview.
+ */
 export function resolveContainerPreviewConnectionHandles(
   manifest: Pick<NodeManifest, 'handleConfiguration'> | undefined,
   context: ResolutionContext
@@ -146,4 +124,46 @@ function pickPreferredInnerHandle(
   }
 
   return null;
+}
+
+/**
+ * Produces preview-graph overrides for Add Node operations that interact with a
+ * loop/container node.
+ */
+export function resolveContainerAddNodePreview({
+  source,
+  sourceHandleType,
+  reactFlowInstance,
+  getManifestForNode,
+}: {
+  source: PreviewEndpoint;
+  sourceHandleType: 'source' | 'target';
+  reactFlowInstance: ReactFlowInstance;
+  getManifestForNode: ContainerPreviewManifestResolver;
+}): PreviewGraphOverrides | null {
+  return resolveContainerPreview({
+    source,
+    sourceHandleType,
+    reactFlowInstance,
+    isContainerNode: (node) => isContainerNodeManifest(getManifestForNode(node)),
+    getContainerSafeArea,
+    getContainerContinuationTarget: ({ containerNode }) => {
+      // Appending from a child reconnects to the container's inner target handle
+      // so the preview edge shows the continuation back into the container.
+      const previewHandles = resolveContainerPreviewConnectionHandles(
+        getManifestForNode(containerNode),
+        {
+          ...containerNode.data,
+          nodeId: containerNode.id,
+        }
+      );
+
+      return previewHandles
+        ? {
+            nodeId: containerNode.id,
+            handleId: previewHandles.targetHandleId,
+          }
+        : null;
+    },
+  });
 }

--- a/packages/apollo-react/src/canvas/components/LoopNode/LoopNode.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/LoopNode/LoopNode.stories.tsx
@@ -156,10 +156,18 @@ function DefaultStory() {
     []
   );
 
-  const { canvasProps } = useCanvasStory({
+  const { canvasProps, nodeTypeRegistry } = useCanvasStory({
     initialNodes,
     initialEdges,
   });
+
+  const loopPreviewOptions = useMemo(
+    () => ({
+      getManifestForNode: (node: Node) =>
+        node.type ? nodeTypeRegistry.getManifest(node.type) : undefined,
+    }),
+    [nodeTypeRegistry]
+  );
 
   const handleHandleAction = useCallback(
     (event: CanvasHandleActionEvent) => {
@@ -171,10 +179,12 @@ function DefaultStory() {
         handleId,
         reactFlow,
         position as Position,
-        handleType === 'input' ? 'target' : 'source'
+        handleType === 'input' ? 'target' : 'source',
+        [],
+        loopPreviewOptions
       );
     },
-    [reactFlow]
+    [loopPreviewOptions, reactFlow]
   );
 
   useCanvasEvent('handle:action', handleHandleAction);

--- a/packages/apollo-react/src/canvas/components/LoopNode/LoopNode.tsx
+++ b/packages/apollo-react/src/canvas/components/LoopNode/LoopNode.tsx
@@ -7,11 +7,16 @@ import {
 } from '@uipath/apollo-react/canvas/xyflow/react';
 import { cn } from '@uipath/apollo-wind';
 import { memo, useCallback, useEffect, useMemo, useState } from 'react';
-import { DEFAULT_CONTAINER_HEIGHT, DEFAULT_CONTAINER_WIDTH } from '../../constants';
 import { useOptionalNodeTypeRegistry } from '../../core';
 import { useElementValidationStatus, useNodeExecutionState } from '../../hooks';
 import type { SuggestionType } from '../../types';
 import { resolveAdornments } from '../../utils/adornment-resolver';
+import {
+  DEFAULT_CONTAINER_HEIGHT,
+  DEFAULT_CONTAINER_MIN_HEIGHT,
+  DEFAULT_CONTAINER_MIN_WIDTH,
+  DEFAULT_CONTAINER_WIDTH,
+} from '../../utils/container';
 import { CanvasIcon } from '../../utils/icon-registry';
 import { resolveDisplay, resolveHandles } from '../../utils/manifest-resolver';
 import { selectIsConnecting, snapToGrid } from '../../utils/NodeUtils';
@@ -26,15 +31,11 @@ import { MissingManifestNode } from '../BaseNode/BaseNodeMissingManifest';
 import type { HandleActionEvent } from '../ButtonHandle';
 import { ButtonHandles } from '../ButtonHandle';
 import { NodeToolbar } from '../Toolbar';
-import {
-  DEFAULT_CONTAINER_MIN_HEIGHT,
-  DEFAULT_CONTAINER_MIN_WIDTH,
-  DEFAULT_LOOP_ICON,
-  DEFAULT_LOOP_TITLE,
-} from './LoopNode.constants';
 import { type ContainerHandleGroup, resolveContainerHandleGroups } from './LoopNode.helpers';
 import type { LoopNodeProps } from './LoopNode.types';
 
+const DEFAULT_LOOP_ICON = 'repeat';
+const DEFAULT_LOOP_TITLE = 'Loop';
 const EMPTY_DATA: Record<string, unknown> = {};
 
 const RESIZE_CONTROLS = [
@@ -225,7 +226,7 @@ function LoopNodeComponent(props: LoopNodeProps) {
 
   const handleMouseEnter = useCallback(() => setIsHovered(true), []);
   const handleMouseLeave = useCallback(() => setIsHovered(false), []);
-  const handleOuterHandleAction = useCallback((_event: HandleActionEvent) => {
+  const handleHandleAction = useCallback((_event: HandleActionEvent) => {
     setIsHovered(false);
   }, []);
 
@@ -318,7 +319,7 @@ function LoopNodeComponent(props: LoopNodeProps) {
         nodeWidth={containerWidth}
         nodeHeight={containerHeight}
         connectedHandleIds={connectedHandleIds}
-        onOuterHandleAction={handleOuterHandleAction}
+        onHandleAction={handleHandleAction}
       />
     </div>
   );
@@ -471,7 +472,7 @@ type SharedHandleGroupProps = {
   nodeWidth: number;
   nodeHeight: number;
   connectedHandleIds: ReadonlySet<string>;
-  onOuterHandleAction: (event: HandleActionEvent) => void;
+  onHandleAction: (event: HandleActionEvent) => void;
 };
 
 type HandleGroupsProps = SharedHandleGroupProps & {
@@ -509,25 +510,32 @@ function HandleGroup({
   nodeWidth,
   nodeHeight,
   connectedHandleIds,
-  onOuterHandleAction,
+  onHandleAction,
 }: HandleGroupProps) {
   const groupVisible = shouldShowHandles && (group.visible ?? true);
   const position = group.position as Position;
   const enhancedHandles = useMemo(
     () =>
       group.handles.map((handle) => {
-        const isInnerSourceHandle = group.boundary === 'inner' && handle.type === 'source';
-        const shouldResetHoverOnAction =
-          group.boundary === 'outer' && handle.type === 'source' && handle.showButton;
+        const showHandle = connectedHandleIds.has(handle.id) || groupVisible;
+
+        if (group.boundary === 'inner') {
+          return {
+            ...handle,
+            showHandle,
+            showButton: false,
+            onAction: undefined,
+          };
+        }
 
         return {
           ...handle,
-          showHandle: connectedHandleIds.has(handle.id) || groupVisible,
-          showButton: isInnerSourceHandle ? false : handle.showButton,
-          onAction: handle.onAction ?? (shouldResetHoverOnAction ? onOuterHandleAction : undefined),
+          showHandle,
+          showButton: handle.showButton,
+          onAction: handle.onAction ?? onHandleAction,
         };
       }),
-    [group.boundary, group.handles, connectedHandleIds, groupVisible, onOuterHandleAction]
+    [group.boundary, group.handles, connectedHandleIds, groupVisible, onHandleAction]
   );
 
   return (

--- a/packages/apollo-react/src/canvas/components/LoopNode/LoopNodePreview.ts
+++ b/packages/apollo-react/src/canvas/components/LoopNode/LoopNodePreview.ts
@@ -1,4 +1,5 @@
 import type { ReactFlowInstance } from '@uipath/apollo-react/canvas/xyflow/react';
+import type { ContainerPlacement } from '../../utils/container';
 import { showPreviewGraph } from '../../utils/createPreviewGraph';
 import { getAbsolutePosition, snapToGrid } from '../../utils/NodeUtils';
 import {
@@ -27,16 +28,27 @@ export function showCenteredContainerPreview({
     x: snapToGrid(containerAbsolutePosition.x + relativeCenter.x),
     y: snapToGrid(containerAbsolutePosition.y + relativeCenter.y),
   };
+  const placement: ContainerPlacement = {
+    containerId,
+    sourceNodeId: containerId,
+    targetNodeId: containerId,
+    mode: 'first-child',
+  };
 
   showPreviewGraph({
-    sourceNodeId: containerId,
-    sourceHandleId: previewHandles.sourceHandleId,
+    source: {
+      nodeId: containerId,
+      handleId: previewHandles.sourceHandleId,
+    },
     reactFlowInstance,
     position: previewCenter,
     positionMode: 'center',
     handlePosition: previewHandles.sourceHandlePosition,
-    targetNodeId: containerId,
-    targetHandleId: previewHandles.targetHandleId,
+    target: {
+      nodeId: containerId,
+      handleId: previewHandles.targetHandleId,
+    },
+    data: { placement },
     containerId,
     trailingEdgeId,
   });

--- a/packages/apollo-react/src/canvas/components/Toolbar/EdgeToolbar/useEdgeToolbarState.test.ts
+++ b/packages/apollo-react/src/canvas/components/Toolbar/EdgeToolbar/useEdgeToolbarState.test.ts
@@ -302,6 +302,23 @@ describe('useEdgeToolbarState', () => {
       });
     });
 
+    it('should not create a preview when the edge is no longer in the store', () => {
+      mockReactFlowInstance.getEdges.mockReturnValue([]);
+
+      const { result } = renderHook(() =>
+        useEdgeToolbarState({
+          ...defaultProps,
+          isHovered: true,
+        })
+      );
+
+      act(() => {
+        result.current.config.actions[0]?.onAction('edge-1', { x: 150, y: 100 });
+      });
+
+      expect(showPreviewGraph).not.toHaveBeenCalled();
+    });
+
     it('should keep non-container edge insertion on the original drop placement path', () => {
       const sourceNode = {
         id: 'node-1',

--- a/packages/apollo-react/src/canvas/components/Toolbar/EdgeToolbar/useEdgeToolbarState.test.ts
+++ b/packages/apollo-react/src/canvas/components/Toolbar/EdgeToolbar/useEdgeToolbarState.test.ts
@@ -1,7 +1,14 @@
 import { act, renderHook } from '@testing-library/react';
-import { Position } from '@uipath/apollo-react/canvas/xyflow/react';
+import {
+  type Edge,
+  MarkerType,
+  type Node,
+  Position,
+} from '@uipath/apollo-react/canvas/xyflow/react';
+import { createElement, type ReactNode } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { PREVIEW_NODE_ID } from '../../../constants';
+import { NodeRegistryContext, type NodeTypeRegistry } from '../../../core';
 import type { EdgeToolbarPositionData } from './EdgeToolbar.types';
 import { useEdgeToolbarState } from './useEdgeToolbarState';
 
@@ -10,6 +17,7 @@ const mockReactFlowInstance = {
   setEdges: vi.fn(),
   getNode: vi.fn(),
   getNodes: vi.fn(),
+  getEdges: vi.fn(),
   setNodes: vi.fn(),
 };
 
@@ -55,6 +63,30 @@ vi.mock('../../../utils/createPreviewGraph', () => ({
 const { useEdgeToolbarPositioning } = await import('./useEdgeToolbarPositioning');
 const { showPreviewGraph } = await import('../../../utils/createPreviewGraph');
 
+function createContainerRegistry(): NodeTypeRegistry {
+  return {
+    getManifest: vi.fn((nodeType: string) =>
+      nodeType === 'loop'
+        ? {
+            nodeType,
+            display: { label: 'Loop', shape: 'container' },
+            handleConfiguration: [],
+          }
+        : {
+            nodeType,
+            display: { label: 'Task', shape: 'square' },
+            handleConfiguration: [],
+          }
+    ),
+  } as unknown as NodeTypeRegistry;
+}
+
+function createRegistryWrapper(registry: NodeTypeRegistry) {
+  return function RegistryWrapper({ children }: { children: ReactNode }) {
+    return createElement(NodeRegistryContext.Provider, { value: { registry } }, children);
+  };
+}
+
 describe('useEdgeToolbarState', () => {
   const defaultProps = {
     edgeId: 'edge-1',
@@ -67,9 +99,24 @@ describe('useEdgeToolbarState', () => {
     sourcePosition: Position.Right,
     targetPosition: Position.Left,
   };
+  const originalEdge: Edge = {
+    id: 'edge-1',
+    source: 'node-1',
+    sourceHandle: 'output',
+    target: 'node-2',
+    targetHandle: 'input',
+    type: 'smoothstep',
+    data: { replaced: true },
+    style: { stroke: 'var(--canvas-foreground)' },
+    label: 'Original edge',
+    markerEnd: { type: MarkerType.ArrowClosed, color: '#0f172a' },
+  };
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mockReactFlowInstance.getNode.mockReturnValue(undefined);
+    mockReactFlowInstance.getNodes.mockReturnValue([]);
+    mockReactFlowInstance.getEdges.mockReturnValue([originalEdge]);
     mockBaseCanvasMode.mode = 'design';
     vi.mocked(useEdgeToolbarPositioning).mockReturnValue({
       positionData: mockPositionData,
@@ -235,24 +282,150 @@ describe('useEdgeToolbarState', () => {
       });
 
       expect(showPreviewGraph).toHaveBeenCalledWith({
-        sourceNodeId: 'node-1',
-        sourceHandleId: 'output',
+        source: {
+          nodeId: 'node-1',
+          handleId: 'output',
+        },
         reactFlowInstance: mockReactFlowInstance,
         position,
-        data: expect.objectContaining({
-          originalEdge: expect.objectContaining({
-            id: 'edge-1',
-            source: 'node-1',
-            target: 'node-2',
-          }),
-        }),
+        positionMode: 'drop',
+        data: {
+          originalEdge,
+        },
         sourceHandleType: 'source',
         handlePosition: Position.Right,
         ignoredNodeTypes: [],
-        targetNodeId: 'node-2',
-        targetHandleId: 'input',
-        removedEdgeIds: ['edge-1'],
+        target: {
+          nodeId: 'node-2',
+          handleId: 'input',
+        },
       });
+    });
+
+    it('should keep non-container edge insertion on the original drop placement path', () => {
+      const sourceNode = {
+        id: 'node-1',
+        type: 'task',
+        position: { x: 100, y: 100 },
+        measured: { width: 120, height: 80 },
+        data: {},
+      };
+      const targetNode = {
+        id: 'node-2',
+        type: 'task',
+        position: { x: 320, y: 100 },
+        measured: { width: 120, height: 80 },
+        data: {},
+      };
+      const nodes = [sourceNode, targetNode];
+      mockReactFlowInstance.getNode.mockImplementation((id: string) =>
+        nodes.find((node) => node.id === id)
+      );
+      mockReactFlowInstance.getNodes.mockReturnValue(nodes);
+
+      const { result } = renderHook(() =>
+        useEdgeToolbarState({
+          ...defaultProps,
+          isHovered: true,
+        })
+      );
+
+      const position = { x: 240, y: 140 };
+
+      act(() => {
+        result.current.config.actions[0]?.onAction('edge-1', position);
+      });
+
+      expect(showPreviewGraph).toHaveBeenCalledWith(
+        expect.objectContaining({
+          position,
+          positionMode: 'drop',
+          source: {
+            nodeId: 'node-1',
+            handleId: 'output',
+          },
+          target: {
+            nodeId: 'node-2',
+            handleId: 'input',
+          },
+        })
+      );
+      expect(vi.mocked(showPreviewGraph).mock.calls[0]?.[0]).not.toHaveProperty('containerId');
+    });
+
+    it('should use container sequence placement for edge insertion between container children', () => {
+      const containerNode: Node = {
+        id: 'loop-1',
+        type: 'loop',
+        position: { x: 500, y: 100 },
+        style: { width: 704, height: 368 },
+        data: {},
+      };
+      const sourceNode: Node = {
+        id: 'node-1',
+        type: 'task',
+        position: { x: 160, y: 96 },
+        parentId: containerNode.id,
+        measured: { width: 96, height: 96 },
+        data: {},
+      };
+      const targetNode: Node = {
+        id: 'node-2',
+        type: 'task',
+        position: { x: 480, y: 96 },
+        parentId: containerNode.id,
+        measured: { width: 96, height: 96 },
+        data: {},
+      };
+      const nodes = [containerNode, sourceNode, targetNode];
+      mockReactFlowInstance.getNode.mockImplementation((id: string) =>
+        nodes.find((node) => node.id === id)
+      );
+      mockReactFlowInstance.getNodes.mockReturnValue(nodes);
+
+      const { result } = renderHook(
+        () =>
+          useEdgeToolbarState({
+            ...defaultProps,
+            isHovered: true,
+          }),
+        { wrapper: createRegistryWrapper(createContainerRegistry()) }
+      );
+
+      const rawPosition = { x: 620, y: 260 };
+
+      act(() => {
+        result.current.config.actions[0]?.onAction('edge-1', rawPosition);
+      });
+
+      const previewOptions = vi.mocked(showPreviewGraph).mock.calls[0]?.[0];
+
+      expect(previewOptions).toEqual(
+        expect.objectContaining({
+          containerId: containerNode.id,
+          positionMode: 'center',
+          source: {
+            nodeId: sourceNode.id,
+            handleId: 'output',
+          },
+          target: {
+            nodeId: targetNode.id,
+            handleId: 'input',
+          },
+        })
+      );
+      expect(previewOptions?.position).not.toEqual(rawPosition);
+      expect(previewOptions?.data).toEqual(
+        expect.objectContaining({
+          originalEdge,
+          placement: {
+            containerId: containerNode.id,
+            sourceNodeId: sourceNode.id,
+            targetNodeId: targetNode.id,
+            mode: 'sequence',
+          },
+        })
+      );
     });
 
     it('should not mutate edges directly if preview graph creation returns null', () => {
@@ -271,6 +444,59 @@ describe('useEdgeToolbarState', () => {
 
       expect(showPreviewGraph).toHaveBeenCalledOnce();
       expect(mockReactFlowInstance.setEdges).not.toHaveBeenCalled();
+    });
+
+    it('should keep structural container edges on the explicit edge-anchor path', () => {
+      const containerNode = {
+        id: 'loop-1',
+        type: 'loop',
+        position: { x: 200, y: 100 },
+        style: { width: 400, height: 300 },
+        data: {},
+      };
+      const childNode = {
+        id: 'child-1',
+        type: 'task',
+        position: { x: 220, y: 160 },
+        parentId: 'loop-1',
+        measured: { width: 80, height: 40 },
+        data: {},
+      };
+      const nodes = [containerNode, childNode];
+      mockReactFlowInstance.getNode.mockImplementation((id: string) =>
+        nodes.find((node) => node.id === id)
+      );
+      mockReactFlowInstance.getNodes.mockReturnValue(nodes);
+
+      const { result } = renderHook(() =>
+        useEdgeToolbarState({
+          ...defaultProps,
+          isHovered: true,
+          source: 'child-1',
+          target: 'loop-1',
+          targetHandleId: 'continue',
+        })
+      );
+
+      act(() => {
+        result.current.config.actions[0]?.onAction('edge-1', { x: 580, y: 260 });
+      });
+
+      expect(showPreviewGraph).toHaveBeenCalledWith(
+        expect.objectContaining({
+          position: { x: 580, y: 260 },
+          positionMode: 'drop',
+          source: {
+            nodeId: 'child-1',
+            handleId: 'output',
+          },
+          target: {
+            nodeId: 'loop-1',
+            handleId: 'continue',
+          },
+        })
+      );
+      expect(vi.mocked(showPreviewGraph).mock.calls[0]?.[0]).not.toHaveProperty('containerId');
     });
   });
 });

--- a/packages/apollo-react/src/canvas/components/Toolbar/EdgeToolbar/useEdgeToolbarState.ts
+++ b/packages/apollo-react/src/canvas/components/Toolbar/EdgeToolbar/useEdgeToolbarState.ts
@@ -1,9 +1,11 @@
-import { type Edge, type Position, useReactFlow } from '@uipath/apollo-react/canvas/xyflow/react';
+import { type Node, type Position, useReactFlow } from '@uipath/apollo-react/canvas/xyflow/react';
 import { useCallback, useMemo } from 'react';
 import { DEFAULT_SOURCE_HANDLE_ID } from '../../../constants';
+import { useOptionalNodeTypeRegistry } from '../../../core';
 import { showPreviewGraph } from '../../../utils/createPreviewGraph';
 import { isPreviewEdge } from '../../../utils/createPreviewNode';
 import { useBaseCanvasMode } from '../../BaseCanvas/BaseCanvasModeProvider';
+import { resolveContainerAddNodePreview } from '../../LoopNode/LoopNode.helpers';
 import type { EdgeToolbarConfig, EdgeToolbarPositionData } from './EdgeToolbar.types';
 import { useEdgeToolbarPositioning } from './useEdgeToolbarPositioning';
 
@@ -40,8 +42,13 @@ export function useEdgeToolbarState({
   ignoredNodeTypes,
 }: UseEdgeToolbarStateProps): EdgeToolbarState {
   const reactFlow = useReactFlow();
+  const registry = useOptionalNodeTypeRegistry();
   const { mode } = useBaseCanvasMode();
   const isDesignMode = mode === 'design';
+  const getManifestForNode = useCallback(
+    (node: Node) => (node.type ? registry?.getManifest(node.type) : undefined),
+    [registry]
+  );
 
   const previewEdge = isPreviewEdge({ id: edgeId, source, target });
 
@@ -55,28 +62,34 @@ export function useEdgeToolbarState({
   // Handle adding a node at the current mouse position along the edge
   const handleAddNodeOnEdge = useCallback(
     (position: { x: number; y: number }) => {
-      // Store original edge to restore if preview is cancelled
-      const originalEdge: Edge = {
-        id: edgeId,
-        source,
-        sourceHandle: sourceHandleId,
-        target,
-        targetHandle: targetHandleId,
-        type: 'default',
+      const originalEdge = reactFlow.getEdges().find((edge) => edge.id === edgeId)!;
+      const sourceEndpoint = {
+        nodeId: source,
+        handleId: sourceHandleId ?? DEFAULT_SOURCE_HANDLE_ID,
       };
+      const containerOverrides = registry
+        ? resolveContainerAddNodePreview({
+            source: sourceEndpoint,
+            sourceHandleType: 'source',
+            reactFlowInstance: reactFlow,
+            getManifestForNode,
+          })
+        : null;
 
       showPreviewGraph({
-        sourceNodeId: source,
-        sourceHandleId: sourceHandleId ?? DEFAULT_SOURCE_HANDLE_ID,
+        source: sourceEndpoint,
         reactFlowInstance: reactFlow,
-        position, // Drop position at mouse cursor
-        data: { originalEdge }, // Pass original edge to restore if cancelled
+        position,
+        positionMode: 'drop',
+        data: { originalEdge },
         sourceHandleType: 'source', // Source handle type
         handlePosition: sourcePosition,
         ignoredNodeTypes: ignoredNodeTypes ?? [],
-        targetNodeId: target,
-        targetHandleId,
-        removedEdgeIds: [edgeId],
+        target: {
+          nodeId: target,
+          handleId: targetHandleId,
+        },
+        ...(containerOverrides ?? {}),
       });
     },
     [
@@ -84,6 +97,8 @@ export function useEdgeToolbarState({
       source,
       sourceHandleId,
       reactFlow,
+      registry,
+      getManifestForNode,
       target,
       targetHandleId,
       edgeId,

--- a/packages/apollo-react/src/canvas/components/Toolbar/EdgeToolbar/useEdgeToolbarState.ts
+++ b/packages/apollo-react/src/canvas/components/Toolbar/EdgeToolbar/useEdgeToolbarState.ts
@@ -62,7 +62,9 @@ export function useEdgeToolbarState({
   // Handle adding a node at the current mouse position along the edge
   const handleAddNodeOnEdge = useCallback(
     (position: { x: number; y: number }) => {
-      const originalEdge = reactFlow.getEdges().find((edge) => edge.id === edgeId)!;
+      const originalEdge = reactFlow.getEdges().find((edge) => edge.id === edgeId);
+      if (!originalEdge) return;
+
       const sourceEndpoint = {
         nodeId: source,
         handleId: sourceHandleId ?? DEFAULT_SOURCE_HANDLE_ID,

--- a/packages/apollo-react/src/canvas/constants.ts
+++ b/packages/apollo-react/src/canvas/constants.ts
@@ -5,10 +5,6 @@ export const DEFAULT_NODE_SIZE = 96; // px
 
 export const GRID_SPACING = 16;
 
-/** Default intrinsic size for container nodes (grid-aligned). */
-export const DEFAULT_CONTAINER_WIDTH = GRID_SPACING * 35; // 560px
-export const DEFAULT_CONTAINER_HEIGHT = GRID_SPACING * 20; // 320px
-
 /** Canvas viewport width below which compact layout is used. */
 export const CANVAS_COMPACT_BREAKPOINT = 600;
 

--- a/packages/apollo-react/src/canvas/hooks/useAddNodeOnConnectEnd.test.ts
+++ b/packages/apollo-react/src/canvas/hooks/useAddNodeOnConnectEnd.test.ts
@@ -96,8 +96,10 @@ describe('useAddNodeOnConnectEnd', () => {
 
     expect(mockReactFlowInstance.screenToFlowPosition).toHaveBeenCalledWith({ x: 200, y: 200 });
     expect(mockShowPreviewGraph).toHaveBeenCalledWith({
-      sourceNodeId: 'node-1',
-      sourceHandleId: 'mock-output',
+      source: {
+        nodeId: 'node-1',
+        handleId: 'mock-output',
+      },
       reactFlowInstance: mockReactFlowInstance,
       position: mockFlowPosition,
       sourceHandleType: 'source',
@@ -129,8 +131,10 @@ describe('useAddNodeOnConnectEnd', () => {
 
     expect(mockShowPreviewGraph).toHaveBeenCalledWith(
       expect.objectContaining({
-        sourceNodeId: 'node-1',
-        sourceHandleId: 'output',
+        source: {
+          nodeId: 'node-1',
+          handleId: 'output',
+        },
         reactFlowInstance: mockReactFlowInstance,
         position: expect.any(Object),
         sourceHandleType: 'source',

--- a/packages/apollo-react/src/canvas/hooks/useAddNodeOnConnectEnd.ts
+++ b/packages/apollo-react/src/canvas/hooks/useAddNodeOnConnectEnd.ts
@@ -38,8 +38,10 @@ export function useAddNodeOnConnectEnd(ignoredNodeTypes: string[] = EMPTY_IGNORE
       const flowDropPosition = reactFlowInstance.screenToFlowPosition(clientPosition);
 
       showPreviewGraph({
-        sourceNodeId: connectionState.fromNode.id,
-        sourceHandleId: connectionState.fromHandle.id ?? 'output',
+        source: {
+          nodeId: connectionState.fromNode.id,
+          handleId: connectionState.fromHandle.id ?? 'output',
+        },
         reactFlowInstance,
         position: flowDropPosition,
         sourceHandleType: connectionState.fromHandle.type,

--- a/packages/apollo-react/src/canvas/storybook-utils/hooks/useCanvasStory.ts
+++ b/packages/apollo-react/src/canvas/storybook-utils/hooks/useCanvasStory.ts
@@ -10,8 +10,9 @@ import { useCallback, useMemo } from 'react';
 import { AddNodePreview } from '../../components';
 import { BaseNode } from '../../components/BaseNode/BaseNode';
 import { SequenceEdge } from '../../components/Edges';
-import { isContainerNodeManifest, LoopCanvasNode } from '../../components/LoopNode';
+import { LoopCanvasNode } from '../../components/LoopNode';
 import { useNodeTypeRegistry } from '../../core';
+import { isContainerNodeManifest } from '../../utils';
 
 /**
  * Options for the useCanvasStory hook.

--- a/packages/apollo-react/src/canvas/utils/NodeUtils.test.ts
+++ b/packages/apollo-react/src/canvas/utils/NodeUtils.test.ts
@@ -678,5 +678,41 @@ describe('NodeUtils', () => {
       expect(node1!.position).not.toEqual({ x: 100, y: 100 });
       expect(node2!.position).not.toEqual({ x: 100, y: 100 });
     });
+
+    it('should use caller-provided node sizes during collision resolution', () => {
+      const nodes: Node[] = [
+        {
+          id: 'wide-node',
+          position: { x: 100, y: 100 },
+          data: {},
+        },
+        {
+          id: 'second-node',
+          position: { x: 220, y: 100 },
+          width: 40,
+          height: 40,
+          data: {},
+        },
+      ];
+
+      const result = resolveCollisions(nodes, {
+        getNodeSize: (node) =>
+          node.id === 'wide-node'
+            ? { width: 160, height: 40 }
+            : {
+                width: node.width ?? 40,
+                height: node.height ?? 40,
+              },
+      });
+
+      expect(result.find((node) => node.id === 'wide-node')?.position).not.toEqual({
+        x: 100,
+        y: 100,
+      });
+      expect(result.find((node) => node.id === 'second-node')?.position).not.toEqual({
+        x: 220,
+        y: 100,
+      });
+    });
   });
 });

--- a/packages/apollo-react/src/canvas/utils/NodeUtils.ts
+++ b/packages/apollo-react/src/canvas/utils/NodeUtils.ts
@@ -94,11 +94,25 @@ export const snapToGrid = (value: number): number => {
   return Math.round(value / GRID_SPACING) * GRID_SPACING;
 };
 
+export const snapUpToGrid = (value: number): number => {
+  return Math.ceil(value / GRID_SPACING) * GRID_SPACING;
+};
+
+export const snapDownToGrid = (value: number): number => {
+  return Math.floor(value / GRID_SPACING) * GRID_SPACING;
+};
+
+export const clamp = (value: number, min: number, max: number): number => {
+  return Math.min(Math.max(value, min), max);
+};
+
 export type CollisionAlgorithmOptions = {
   maxIterations?: number;
   overlapThreshold?: number;
   margin?: number;
   ignoredNodeTypes?: string[];
+  /** Allows callers to resolve manifest-aware sizes before collision math runs. */
+  getNodeSize?: (node: Node) => { width: number; height: number };
 };
 
 export type CollisionAlgorithm = (nodes: Node[], options?: CollisionAlgorithmOptions) => Node[];
@@ -112,16 +126,24 @@ type Box = {
   node: Node;
 };
 
-function getBoxesFromNodes(nodes: Node[], margin: number = 0): Box[] {
+function getBoxesFromNodes(
+  nodes: Node[],
+  margin: number = 0,
+  getNodeSize?: (node: Node) => { width: number; height: number }
+): Box[] {
   const boxes: Box[] = new Array(nodes.length);
 
   for (let i = 0; i < nodes.length; i++) {
     const node = nodes[i]!;
+    const nodeSize = getNodeSize?.(node) ?? {
+      width: node.width ?? node.measured?.width ?? DEFAULT_NODE_SIZE,
+      height: node.height ?? node.measured?.height ?? DEFAULT_NODE_SIZE,
+    };
     boxes[i] = {
       x: node.position.x - margin,
       y: node.position.y - margin,
-      width: (node.width ?? node.measured?.width ?? DEFAULT_NODE_SIZE) + margin * 2,
-      height: (node.height ?? node.measured?.height ?? DEFAULT_NODE_SIZE) + margin * 2,
+      width: nodeSize.width + margin * 2,
+      height: nodeSize.height + margin * 2,
       node,
       moved: false,
     };
@@ -130,15 +152,25 @@ function getBoxesFromNodes(nodes: Node[], margin: number = 0): Box[] {
   return boxes;
 }
 
+/**
+ * Moves overlapping nodes apart on the smallest overlap axis while
+ * preserving original order and leaving ignored node types untouched.
+ */
 export const resolveCollisions: CollisionAlgorithm = (
   nodes,
-  { maxIterations = 50, overlapThreshold = 0, margin = GRID_SPACING * 2, ignoredNodeTypes } = {}
+  {
+    maxIterations = 50,
+    overlapThreshold = 0,
+    margin = GRID_SPACING * 2,
+    ignoredNodeTypes,
+    getNodeSize,
+  } = {}
 ) => {
   const ignoredSet = new Set(ignoredNodeTypes);
   const collisionNodes =
     ignoredSet.size > 0 ? nodes.filter((n) => !ignoredSet.has(n.type ?? '')) : nodes;
 
-  const boxes = getBoxesFromNodes(collisionNodes, margin);
+  const boxes = getBoxesFromNodes(collisionNodes, margin, getNodeSize);
   for (let iter = 0; iter < maxIterations; iter++) {
     let moved = false;
 

--- a/packages/apollo-react/src/canvas/utils/collapse.ts
+++ b/packages/apollo-react/src/canvas/utils/collapse.ts
@@ -5,8 +5,8 @@
  * These helpers ensure consistent behavior across the codebase.
  */
 
-import { DEFAULT_CONTAINER_HEIGHT, DEFAULT_CONTAINER_WIDTH } from '../constants';
 import type { NodeShape } from '../schema/node-definition';
+import { DEFAULT_CONTAINER_HEIGHT, DEFAULT_CONTAINER_WIDTH } from './container';
 
 /**
  * Default dimension for collapsed nodes when no measured dimensions are available.

--- a/packages/apollo-react/src/canvas/utils/container.test.ts
+++ b/packages/apollo-react/src/canvas/utils/container.test.ts
@@ -1,0 +1,66 @@
+import type { Node } from '@uipath/apollo-react/canvas/xyflow/react';
+import { describe, expect, it } from 'vitest';
+import {
+  DEFAULT_CONTAINER_MIN_HEIGHT,
+  DEFAULT_CONTAINER_MIN_WIDTH,
+  ensureContainersFitChildren,
+  getContainerFitGeometry,
+  getContainerSafeArea,
+} from './container';
+
+describe('container sizing', () => {
+  it('uses the shared default container geometry', () => {
+    const containerNode: Node = {
+      id: 'loop-1',
+      type: 'loop',
+      position: { x: 0, y: 0 },
+      style: { width: 704, height: 368 },
+      data: {},
+    };
+
+    expect(getContainerSafeArea(containerNode)).toMatchObject({
+      x: 144,
+      y: 96,
+      width: 416,
+      height: 224,
+    });
+    expect(getContainerFitGeometry()).toMatchObject({
+      minWidth: DEFAULT_CONTAINER_MIN_WIDTH,
+      minHeight: DEFAULT_CONTAINER_MIN_HEIGHT,
+      padding: { right: 144, bottom: 48 },
+    });
+  });
+
+  it('grows containers to fit direct children without shrinking them', () => {
+    const containerNode: Node = {
+      id: 'loop-1',
+      type: 'loop',
+      position: { x: 0, y: 0 },
+      style: { width: DEFAULT_CONTAINER_MIN_WIDTH, height: DEFAULT_CONTAINER_MIN_HEIGHT },
+      data: {},
+    };
+    const childNode: Node = {
+      id: 'child-1',
+      type: 'task',
+      parentId: containerNode.id,
+      position: { x: 480, y: 240 },
+      measured: { width: 96, height: 96 },
+      data: {},
+    };
+
+    const result = ensureContainersFitChildren([containerNode, childNode], {
+      getContainerFitGeometry: () => getContainerFitGeometry(),
+    });
+
+    expect(result.changes).toEqual([
+      expect.objectContaining({
+        containerId: containerNode.id,
+        previousSize: { width: DEFAULT_CONTAINER_MIN_WIDTH, height: DEFAULT_CONTAINER_MIN_HEIGHT },
+        nextSize: { width: 720, height: 384 },
+      }),
+    ]);
+    expect(result.nodes.find((node) => node.id === containerNode.id)).toMatchObject({
+      style: { width: 720, height: 384 },
+    });
+  });
+});

--- a/packages/apollo-react/src/canvas/utils/container.ts
+++ b/packages/apollo-react/src/canvas/utils/container.ts
@@ -320,7 +320,9 @@ export function ensureContainersFitChildren(
   );
 
   for (const containerId of orderedContainerIds) {
-    const containerNode = nextNodes.find((node) => node.id === containerId)!;
+    const containerNode = nextNodes.find((node) => node.id === containerId);
+    if (!containerNode) continue;
+
     const geometry = resolveContainerFitGeometry?.(containerNode);
     if (!geometry) continue;
 
@@ -539,7 +541,7 @@ export function getContainerNodeForEdge(
   }
 
   if (sourceNode.parentId && sourceNode.parentId === targetNode.parentId) {
-    return nodes.find((node) => node.id === sourceNode.parentId)!;
+    return nodes.find((node) => node.id === sourceNode.parentId) ?? null;
   }
 
   return null;
@@ -621,11 +623,11 @@ function collectDownstreamNodes({
   const nodesById = new Map(nodes.map((node) => [node.id, node]));
   const collectedIds: string[] = [];
   const visitedIds = new Set<string>();
-  let currentNodeId: string | undefined = targetNodeId;
+  let currentNodeId = targetNodeId;
 
   // Follow one local sequence chain and stop on cycles or exits from the
   // container. This keeps downstream shifts scoped to the edited sequence.
-  while (currentNodeId && !visitedIds.has(currentNodeId)) {
+  while (!visitedIds.has(currentNodeId)) {
     const currentNode = nodesById.get(currentNodeId);
     if (!currentNode || currentNode.parentId !== containerId) {
       break;

--- a/packages/apollo-react/src/canvas/utils/container.ts
+++ b/packages/apollo-react/src/canvas/utils/container.ts
@@ -1,0 +1,1239 @@
+import type {
+  Edge,
+  Node,
+  ReactFlowInstance,
+  XYPosition,
+} from '@uipath/apollo-react/canvas/xyflow/react';
+import {
+  DEFAULT_NODE_SIZE,
+  DEFAULT_SOURCE_HANDLE_ID,
+  GRID_SPACING,
+  PREVIEW_NODE_ID,
+} from '../constants';
+import type { NodeManifest } from '../schema/node-definition';
+import type { PreviewEndpoint, PreviewGraphOverrides } from './createPreviewGraph';
+import {
+  clamp,
+  getAbsolutePosition,
+  getNonOverlappingPositionForDirection,
+  snapToGrid,
+  snapUpToGrid,
+} from './NodeUtils';
+
+// -----------------------------------------------------------------------------
+// Types
+// -----------------------------------------------------------------------------
+
+export interface NodeDimensions {
+  width: number;
+  height: number;
+}
+
+/**
+ * Sizing rules used when a container needs to grow around its children.
+ * Padding is trailing-only because child positions are already relative to the
+ * container's top-left corner.
+ */
+export interface ContainerFitGeometry {
+  minWidth: number;
+  minHeight: number;
+  padding?: {
+    right?: number;
+    bottom?: number;
+  };
+}
+
+/**
+ * Local container rectangle where child nodes may be placed without covering
+ * the frame, header, or inner handle rails.
+ */
+export interface ContainerSafeArea {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  padding?: {
+    left?: number;
+    right?: number;
+    top?: number;
+    bottom?: number;
+  };
+}
+
+/** Records a single container resize caused by fitting children. */
+export interface ContainerSizeChange {
+  containerId: string;
+  previousSize: NodeDimensions;
+  nextSize: NodeDimensions;
+}
+
+/** Result of fitting one or more containers to their visible children. */
+export interface EnsureContainersFitChildrenResult {
+  nodes: Node[];
+  changes: ContainerSizeChange[];
+}
+
+/**
+ * Placement metadata carried by preview nodes so the final Add Node action can
+ * materialize the node in the same container sequence.
+ */
+export interface ContainerPlacement {
+  containerId: string;
+  sourceNodeId?: string;
+  targetNodeId?: string;
+  mode: 'first-child' | 'sequence';
+}
+
+interface PreviewPlacement {
+  containerId: string;
+  centerPosition: XYPosition;
+}
+
+interface ContainerPreviewContext {
+  source: PreviewEndpoint;
+  sourceHandleType: 'source' | 'target';
+  reactFlowInstance: ReactFlowInstance;
+}
+
+interface ContainerPreviewOptions {
+  isContainerNode?: (node: Node) => boolean;
+  getContainerSafeArea?: (containerNode: Node) => ContainerSafeArea | undefined;
+  getContainerContinuationTarget?: (context: {
+    containerNode: Node;
+    sourceNode: Node;
+    source: PreviewEndpoint;
+    reactFlowInstance: ReactFlowInstance;
+  }) => PreviewEndpoint | null | undefined;
+  previewNodeSize?: NodeDimensions;
+  gap?: number;
+  avoidSiblings?: boolean;
+  getNodeDimensions?: (node: Node) => NodeDimensions;
+}
+
+type SequenceEdgePredicate = (edge: Edge) => boolean;
+
+interface NextNodeContext {
+  nodeId: string;
+  edges: Edge[];
+  nodesById: Map<string, Node>;
+  containerId: string;
+}
+
+type NextNodeResolver = (context: NextNodeContext) => string | null | undefined;
+
+/** Default intrinsic size for container nodes (grid-aligned). */
+export const DEFAULT_CONTAINER_WIDTH = GRID_SPACING * 35; // 560px
+export const DEFAULT_CONTAINER_HEIGHT = GRID_SPACING * 20; // 320px
+
+/** Default min size for container nodes. */
+export const DEFAULT_CONTAINER_MIN_WIDTH = GRID_SPACING * 25; // 400px
+export const DEFAULT_CONTAINER_MIN_HEIGHT = GRID_SPACING * 14; // 224px
+
+/** Visual frame inset used by container handles and placement safe areas. */
+export const CONTAINER_FRAME_INSET_PX = 10;
+
+const CONTAINER_BODY_PADDING_PX = GRID_SPACING * 2;
+const CONTAINER_INNER_HANDLE_RAIL_WIDTH_PX = GRID_SPACING * 5;
+const CONTAINER_CHILD_SAFE_GAP_PX = GRID_SPACING;
+const DEFAULT_CONTAINER_HEADER_HEIGHT_PX = 40;
+
+/** Horizontal gap maintained between nodes in a container sequence. */
+export const CONTAINER_SEQUENCE_GAP_PX = GRID_SPACING * 3;
+
+const PLACEMENT_DATA_KEY = 'placement';
+
+// -----------------------------------------------------------------------------
+// Geometry
+// -----------------------------------------------------------------------------
+
+function readNumericDimension(...values: Array<number | string | undefined>): number | undefined {
+  for (const value of values) {
+    if (typeof value === 'number' && Number.isFinite(value)) return value;
+    if (typeof value === 'string') {
+      const parsedValue = Number.parseFloat(value);
+      if (Number.isFinite(parsedValue)) return parsedValue;
+    }
+  }
+
+  return undefined;
+}
+
+/**
+ * Resolves the best available node size, preferring measured/runtime values and
+ * falling back to style or a caller-provided default.
+ */
+export function getNodeDimensions(
+  node: Pick<Node, 'width' | 'height' | 'measured' | 'style'>,
+  fallback: NodeDimensions = { width: DEFAULT_NODE_SIZE, height: DEFAULT_NODE_SIZE }
+): NodeDimensions {
+  return {
+    width:
+      readNumericDimension(node.width, node.measured?.width, node.style?.width) ?? fallback.width,
+    height:
+      readNumericDimension(node.height, node.measured?.height, node.style?.height) ??
+      fallback.height,
+  };
+}
+
+/**
+ * Returns the child-placement area inside a container in local coordinates.
+ * The safe area accounts for header height, frame inset, body padding, and
+ * inner handle rails so auto-placed children stay clear of container chrome.
+ */
+export function getContainerSafeArea(
+  containerNode: Pick<Node, 'width' | 'height' | 'measured' | 'style'>,
+  fallback: NodeDimensions = { width: DEFAULT_CONTAINER_WIDTH, height: DEFAULT_CONTAINER_HEIGHT }
+): ContainerSafeArea {
+  const size = getNodeDimensions(containerNode, fallback);
+  const horizontalPadding = snapUpToGrid(
+    CONTAINER_FRAME_INSET_PX +
+      CONTAINER_BODY_PADDING_PX +
+      CONTAINER_INNER_HANDLE_RAIL_WIDTH_PX +
+      CONTAINER_CHILD_SAFE_GAP_PX
+  );
+  const verticalPadding = snapUpToGrid(CONTAINER_FRAME_INSET_PX + CONTAINER_BODY_PADDING_PX);
+  const padding = {
+    left: horizontalPadding,
+    right: horizontalPadding,
+    top: snapUpToGrid(DEFAULT_CONTAINER_HEADER_HEIGHT_PX + verticalPadding),
+    bottom: verticalPadding,
+  };
+
+  return {
+    x: padding.left,
+    y: padding.top,
+    width: Math.max(0, size.width - padding.left - padding.right),
+    height: Math.max(0, size.height - padding.top - padding.bottom),
+    padding,
+  };
+}
+
+/** Returns the default fit rules for loop/container nodes. */
+export function getContainerFitGeometry(): ContainerFitGeometry {
+  const padding = getContainerSafeArea({
+    width: DEFAULT_CONTAINER_WIDTH,
+    height: DEFAULT_CONTAINER_HEIGHT,
+  }).padding!;
+
+  return {
+    minWidth: DEFAULT_CONTAINER_MIN_WIDTH,
+    minHeight: DEFAULT_CONTAINER_MIN_HEIGHT,
+    padding: {
+      right: padding.right,
+      bottom: padding.bottom,
+    },
+  };
+}
+
+/** Returns whether a node manifest describes a structural container node. */
+export function isContainerNodeManifest(
+  manifest: Pick<NodeManifest, 'display'> | undefined
+): boolean {
+  return manifest?.display.shape === 'container';
+}
+
+function getAncestorContainerIds(containerId: string, nodesById: Map<string, Node>): string[] {
+  const ancestors: string[] = [];
+  let parentId = nodesById.get(containerId)?.parentId;
+
+  while (parentId) {
+    ancestors.push(parentId);
+    parentId = nodesById.get(parentId)?.parentId;
+  }
+
+  return ancestors;
+}
+
+function getContainerDepth(containerId: string, nodesById: Map<string, Node>): number {
+  let depth = 0;
+  let parentId = nodesById.get(containerId)?.parentId;
+
+  while (parentId) {
+    depth += 1;
+    parentId = nodesById.get(parentId)?.parentId;
+  }
+
+  return depth;
+}
+
+function withNodeDimensions(node: Node, size: NodeDimensions): Node {
+  return {
+    ...node,
+    width: size.width,
+    height: size.height,
+    style: {
+      ...node.style,
+      width: size.width,
+      height: size.height,
+    },
+  };
+}
+
+/**
+ * Expands containers to include their visible children and returns the resize
+ * changes that were applied. Containers never shrink here; this keeps automatic
+ * layout from stealing space the user may have intentionally created.
+ */
+export function ensureContainersFitChildren(
+  nodes: Node[],
+  {
+    containerIds,
+    getContainerFitGeometry: resolveContainerFitGeometry,
+    getNodeDimensions: resolveNodeDimensions = getNodeDimensions,
+    ignoredNodeTypes = [],
+    includeAncestors = true,
+  }: {
+    containerIds?: Iterable<string>;
+    getContainerFitGeometry?: (containerNode: Node) => ContainerFitGeometry | null | undefined;
+    getNodeDimensions?: (node: Node) => NodeDimensions;
+    ignoredNodeTypes?: string[];
+    includeAncestors?: boolean;
+  } = {}
+): EnsureContainersFitChildrenResult {
+  let nextNodes = nodes;
+  const changes: ContainerSizeChange[] = [];
+  const ignoredTypes = new Set(ignoredNodeTypes);
+  const nodesById = new Map(nextNodes.map((node) => [node.id, node]));
+  const idsToFit = new Set<string>();
+
+  if (containerIds) {
+    for (const id of containerIds) {
+      idsToFit.add(id);
+    }
+  } else {
+    for (const node of nextNodes) {
+      if (node.parentId) idsToFit.add(node.parentId);
+    }
+  }
+
+  if (includeAncestors) {
+    for (const id of Array.from(idsToFit)) {
+      for (const ancestorId of getAncestorContainerIds(id, nodesById)) {
+        idsToFit.add(ancestorId);
+      }
+    }
+  }
+
+  // Fit deepest containers first so ancestors see any child-container growth.
+  const orderedContainerIds = Array.from(idsToFit).sort(
+    (left, right) => getContainerDepth(right, nodesById) - getContainerDepth(left, nodesById)
+  );
+
+  for (const containerId of orderedContainerIds) {
+    const containerNode = nextNodes.find((node) => node.id === containerId)!;
+    const geometry = resolveContainerFitGeometry?.(containerNode);
+    if (!geometry) continue;
+
+    const currentSize = resolveNodeDimensions(containerNode);
+    const padding = geometry.padding ?? {};
+    let requiredWidth = geometry.minWidth;
+    let requiredHeight = geometry.minHeight;
+
+    for (const childNode of nextNodes) {
+      // Transient, hidden, and ignored children should not force a persisted
+      // container size.
+      if (
+        childNode.id === PREVIEW_NODE_ID ||
+        childNode.hidden ||
+        childNode.parentId !== containerId ||
+        ignoredTypes.has(childNode.type ?? '')
+      ) {
+        continue;
+      }
+
+      const childSize = resolveNodeDimensions(childNode);
+      requiredWidth = Math.max(
+        requiredWidth,
+        childNode.position.x + childSize.width + (padding.right ?? 0)
+      );
+      requiredHeight = Math.max(
+        requiredHeight,
+        childNode.position.y + childSize.height + (padding.bottom ?? 0)
+      );
+    }
+
+    const nextSize = {
+      width: Math.max(currentSize.width, snapUpToGrid(requiredWidth)),
+      height: Math.max(currentSize.height, snapUpToGrid(requiredHeight)),
+    };
+
+    if (nextSize.width === currentSize.width && nextSize.height === currentSize.height) {
+      continue;
+    }
+
+    nextNodes = nextNodes.map((node) =>
+      node.id === containerId ? withNodeDimensions(node, nextSize) : node
+    );
+    nodesById.set(containerId, nextNodes.find((node) => node.id === containerId)!);
+    changes.push({
+      containerId,
+      previousSize: currentSize,
+      nextSize,
+    });
+  }
+
+  return { nodes: nextNodes, changes };
+}
+
+function getSafeArea(containerNode: Node, safeArea?: ContainerSafeArea): ContainerSafeArea {
+  return safeArea ?? getContainerSafeArea(containerNode);
+}
+
+function clampTopLeftToSafeArea(
+  position: XYPosition,
+  safeArea: ContainerSafeArea,
+  nodeSize: NodeDimensions
+): XYPosition {
+  const maxX = safeArea.x + Math.max(0, safeArea.width - nodeSize.width);
+  const maxY = safeArea.y + Math.max(0, safeArea.height - nodeSize.height);
+
+  return {
+    x: clamp(position.x, safeArea.x, maxX),
+    y: clamp(position.y, safeArea.y, maxY),
+  };
+}
+
+function clampTopToSafeArea(
+  top: number,
+  safeArea: ContainerSafeArea,
+  nodeSize: NodeDimensions
+): number {
+  const maxY = safeArea.y + Math.max(0, safeArea.height - nodeSize.height);
+
+  return clamp(top, safeArea.y, maxY);
+}
+
+function rangesOverlap(startA: number, endA: number, startB: number, endB: number): boolean {
+  return startA < endB && endA > startB;
+}
+
+function centerInSafeArea(safeArea: ContainerSafeArea, nodeSize: NodeDimensions): XYPosition {
+  return {
+    x: Math.max(safeArea.x, snapToGrid(safeArea.x + (safeArea.width - nodeSize.width) / 2)),
+    y: Math.max(safeArea.y, snapToGrid(safeArea.y + (safeArea.height - nodeSize.height) / 2)),
+  };
+}
+
+function getLocalNodePosition(
+  node: Node | undefined,
+  containerNode: Node,
+  nodes: Node[]
+): XYPosition | null {
+  if (!node || node.id === containerNode.id) {
+    return null;
+  }
+
+  if (node.parentId === containerNode.id) {
+    return node.position;
+  }
+
+  const containerPosition = getAbsolutePosition(containerNode, nodes);
+  const nodePosition = node.parentId ? getAbsolutePosition(node, nodes) : node.position;
+
+  return {
+    x: nodePosition.x - containerPosition.x,
+    y: nodePosition.y - containerPosition.y,
+  };
+}
+
+function getPlacementDirection(
+  sourcePosition: XYPosition | null,
+  targetPosition: XYPosition | null
+): 'left' | 'right' | 'top' | 'bottom' {
+  if (!sourcePosition || !targetPosition) {
+    return sourcePosition ? 'right' : 'left';
+  }
+
+  return targetPosition.x >= sourcePosition.x ? 'right' : 'left';
+}
+
+function getSiblingNodes(containerId: string, nodes: Node[], insertedNodeId?: string): Node[] {
+  return nodes.filter(
+    (node) =>
+      node.id !== PREVIEW_NODE_ID && node.id !== insertedNodeId && node.parentId === containerId
+  );
+}
+
+function resolveSequenceTopLeft({
+  sourceNode,
+  targetNode,
+  containerNode,
+  nodes,
+  safeArea,
+  previewNodeSize,
+  gap,
+  getNodeDimensions,
+}: {
+  sourceNode?: Node;
+  targetNode?: Node;
+  containerNode: Node;
+  nodes: Node[];
+  safeArea: ContainerSafeArea;
+  previewNodeSize: NodeDimensions;
+  gap: number;
+  getNodeDimensions: (node: Node) => NodeDimensions;
+}): XYPosition {
+  const sourcePosition = getLocalNodePosition(sourceNode, containerNode, nodes);
+  const targetPosition = getLocalNodePosition(targetNode, containerNode, nodes);
+  const sourceSize = sourceNode ? getNodeDimensions(sourceNode) : undefined;
+  const targetSize = targetNode ? getNodeDimensions(targetNode) : undefined;
+
+  if (sourcePosition && sourceSize && targetPosition) {
+    const sourceRight = sourcePosition.x + sourceSize.width;
+    const targetLeft = targetPosition.x;
+    // Use the visual midpoint when there is enough room between the two nodes.
+    // If the gap is too small, place after the source and let materialization
+    // shift downstream nodes to create the final space.
+    const centerX =
+      targetLeft - sourceRight >= previewNodeSize.width + gap * 2
+        ? sourceRight + (targetLeft - sourceRight) / 2
+        : sourceRight + gap + previewNodeSize.width / 2;
+
+    return {
+      x: centerX - previewNodeSize.width / 2,
+      y: sourcePosition.y + sourceSize.height / 2 - previewNodeSize.height / 2,
+    };
+  }
+
+  if (sourcePosition && sourceSize) {
+    return {
+      x: sourcePosition.x + sourceSize.width + gap,
+      y: sourcePosition.y + sourceSize.height / 2 - previewNodeSize.height / 2,
+    };
+  }
+
+  if (targetPosition && targetSize) {
+    return {
+      x: targetPosition.x - previewNodeSize.width - gap,
+      y: targetPosition.y + targetSize.height / 2 - previewNodeSize.height / 2,
+    };
+  }
+
+  return {
+    x: safeArea.x + safeArea.width / 2 - previewNodeSize.width / 2,
+    y: safeArea.y + safeArea.height / 2 - previewNodeSize.height / 2,
+  };
+}
+
+// -----------------------------------------------------------------------------
+// Detection
+// -----------------------------------------------------------------------------
+
+/**
+ * Detects the structural container involved in an edge.
+ *
+ * This intentionally only uses React Flow parent relationships. Workflow edge
+ * kinds and handle names remain consumer-owned.
+ */
+export function getContainerNodeForEdge(
+  sourceNode: Node,
+  targetNode: Node,
+  nodes: Node[]
+): Node | null {
+  if (sourceNode.parentId === targetNode.id) {
+    return targetNode;
+  }
+
+  if (targetNode.parentId === sourceNode.id) {
+    return sourceNode;
+  }
+
+  if (sourceNode.parentId && sourceNode.parentId === targetNode.parentId) {
+    return nodes.find((node) => node.id === sourceNode.parentId)!;
+  }
+
+  return null;
+}
+
+function handleMatches(edgeHandleId: string | null | undefined, handleId: string): boolean {
+  return (edgeHandleId ?? DEFAULT_SOURCE_HANDLE_ID) === handleId;
+}
+
+function getOutgoingEdges(sourceNodeId: string, sourceHandleId: string, edges: Edge[]) {
+  return edges.filter(
+    (edge) =>
+      edge.source !== PREVIEW_NODE_ID &&
+      edge.target !== PREVIEW_NODE_ID &&
+      edge.source === sourceNodeId &&
+      handleMatches(edge.sourceHandle, sourceHandleId)
+  );
+}
+
+function getSingleOutgoingEdge(sourceNodeId: string, sourceHandleId: string, edges: Edge[]) {
+  const outgoingEdges = getOutgoingEdges(sourceNodeId, sourceHandleId, edges);
+  return outgoingEdges.length === 1 ? outgoingEdges[0] : null;
+}
+
+function isPreviewGraphEdge(edge: Edge): boolean {
+  return edge.source === PREVIEW_NODE_ID || edge.target === PREVIEW_NODE_ID;
+}
+
+function getDefaultNextContainerSequenceNodeId({
+  nodeId,
+  edges,
+  nodesById,
+  containerId,
+  isSequenceEdge,
+}: NextNodeContext & {
+  isSequenceEdge?: SequenceEdgePredicate;
+}): string | null {
+  const localOutgoingEdges = edges.filter((edge) => {
+    if (isPreviewGraphEdge(edge) || edge.source !== nodeId) {
+      return false;
+    }
+
+    if (isSequenceEdge && !isSequenceEdge(edge)) {
+      return false;
+    }
+
+    const targetNode = nodesById.get(edge.target);
+    return edge.target === containerId || targetNode?.parentId === containerId;
+  });
+
+  // Ambiguous branches are left untouched because there is no safe linear
+  // sequence to shift.
+  return localOutgoingEdges.length === 1 ? localOutgoingEdges[0]!.target : null;
+}
+
+// -----------------------------------------------------------------------------
+// Sequence traversal
+// -----------------------------------------------------------------------------
+
+function collectDownstreamNodes({
+  targetNodeId,
+  containerId,
+  nodes,
+  edges,
+  isSequenceEdge,
+  getNextNodeId,
+}: {
+  targetNodeId: string | undefined;
+  containerId: string;
+  nodes: Node[];
+  edges: Edge[];
+  isSequenceEdge?: SequenceEdgePredicate;
+  getNextNodeId?: NextNodeResolver;
+}): string[] {
+  if (!targetNodeId || targetNodeId === containerId) {
+    return [];
+  }
+
+  const nodesById = new Map(nodes.map((node) => [node.id, node]));
+  const collectedIds: string[] = [];
+  const visitedIds = new Set<string>();
+  let currentNodeId: string | undefined = targetNodeId;
+
+  // Follow one local sequence chain and stop on cycles or exits from the
+  // container. This keeps downstream shifts scoped to the edited sequence.
+  while (currentNodeId && !visitedIds.has(currentNodeId)) {
+    const currentNode = nodesById.get(currentNodeId);
+    if (!currentNode || currentNode.parentId !== containerId) {
+      break;
+    }
+
+    collectedIds.push(currentNodeId);
+    visitedIds.add(currentNodeId);
+
+    const nextNodeId: string | null | undefined =
+      getNextNodeId?.({
+        nodeId: currentNodeId,
+        edges,
+        nodesById,
+        containerId,
+      }) ??
+      getDefaultNextContainerSequenceNodeId({
+        nodeId: currentNodeId,
+        edges,
+        nodesById,
+        containerId,
+        isSequenceEdge,
+      });
+
+    if (!nextNodeId || nextNodeId === containerId) {
+      break;
+    }
+
+    currentNodeId = nextNodeId;
+  }
+
+  return collectedIds;
+}
+
+// -----------------------------------------------------------------------------
+// Preview
+// -----------------------------------------------------------------------------
+
+function resolveInsertPreview({
+  source,
+  sourceHandleType,
+  reactFlowInstance,
+  isContainerNode,
+  getContainerSafeArea,
+  previewNodeSize,
+  gap,
+  getNodeDimensions,
+}: ContainerPreviewContext &
+  Pick<
+    ContainerPreviewOptions,
+    'isContainerNode' | 'getContainerSafeArea' | 'previewNodeSize' | 'gap' | 'getNodeDimensions'
+  >): PreviewGraphOverrides | null {
+  if (sourceHandleType !== 'source' || !source.handleId) {
+    return null;
+  }
+
+  const replacedEdge = getSingleOutgoingEdge(
+    source.nodeId,
+    source.handleId,
+    reactFlowInstance.getEdges()
+  );
+
+  if (!replacedEdge) {
+    return null;
+  }
+
+  const sourceNode = reactFlowInstance.getNode(replacedEdge.source)!;
+  const targetNode = reactFlowInstance.getNode(replacedEdge.target)!;
+  const nodes = reactFlowInstance.getNodes();
+
+  const containerNode = getContainerNodeForEdge(sourceNode, targetNode, nodes);
+  if (!containerNode) {
+    return null;
+  }
+  if (isContainerNode && !isContainerNode(containerNode)) {
+    return null;
+  }
+
+  const containerPlacement = getPreviewPlacement({
+    sourceNode,
+    targetNode,
+    containerNode,
+    nodes,
+    safeArea: getContainerSafeArea?.(containerNode),
+    previewNodeSize,
+    gap,
+    getNodeDimensions,
+  });
+  const placement: ContainerPlacement = {
+    containerId: containerPlacement.containerId,
+    sourceNodeId: sourceNode.id,
+    targetNodeId: targetNode.id,
+    mode: 'sequence',
+  };
+
+  return {
+    position: containerPlacement.centerPosition,
+    positionMode: 'center',
+    // Store the replaced edge so the preview graph can hide exactly that edge
+    // while preserving enough data for Add Node to reconnect through the node.
+    data: { originalEdge: replacedEdge, [PLACEMENT_DATA_KEY]: placement },
+    target: {
+      nodeId: replacedEdge.target,
+      handleId: replacedEdge.targetHandle,
+    },
+    containerId: containerPlacement.containerId,
+  };
+}
+
+function resolveAppendPreview({
+  source,
+  sourceHandleType,
+  reactFlowInstance,
+  ...options
+}: ContainerPreviewContext & ContainerPreviewOptions): PreviewGraphOverrides | null {
+  if (sourceHandleType !== 'source' || !source.handleId) {
+    return null;
+  }
+
+  const sourceNode = reactFlowInstance.getNode(source.nodeId);
+  if (!sourceNode?.parentId) {
+    return null;
+  }
+
+  const outgoingEdges = getOutgoingEdges(
+    source.nodeId,
+    source.handleId,
+    reactFlowInstance.getEdges()
+  );
+  if (outgoingEdges.length > 0) {
+    return null;
+  }
+
+  const nodes = reactFlowInstance.getNodes();
+  const containerNode = nodes.find((node) => node.id === sourceNode.parentId)!;
+  if (options.isContainerNode && !options.isContainerNode(containerNode)) {
+    return null;
+  }
+
+  const continuationTarget = options.getContainerContinuationTarget?.({
+    containerNode,
+    sourceNode,
+    source,
+    reactFlowInstance,
+  });
+  if (!continuationTarget) {
+    return null;
+  }
+
+  const targetNode =
+    continuationTarget.nodeId === containerNode.id
+      ? containerNode
+      : reactFlowInstance.getNode(continuationTarget.nodeId);
+  const containerPlacement = getPreviewPlacement({
+    sourceNode,
+    targetNode,
+    containerNode,
+    nodes,
+    safeArea: options.getContainerSafeArea?.(containerNode),
+    previewNodeSize: options.previewNodeSize,
+    gap: options.gap,
+    avoidSiblings: options.avoidSiblings ?? true,
+    getNodeDimensions: options.getNodeDimensions,
+  });
+  const placement: ContainerPlacement = {
+    containerId: containerPlacement.containerId,
+    sourceNodeId: sourceNode.id,
+    targetNodeId: continuationTarget.nodeId,
+    mode: 'sequence',
+  };
+
+  return {
+    position: containerPlacement.centerPosition,
+    positionMode: 'center',
+    data: { [PLACEMENT_DATA_KEY]: placement },
+    target: continuationTarget,
+    containerId: containerPlacement.containerId,
+  };
+}
+
+/**
+ * Builds preview-graph overrides when adding a node inside or through a
+ * container sequence. The caller owns manifest-specific checks and continuation
+ * handle selection through the options callbacks.
+ */
+export function resolveContainerPreview({
+  source,
+  sourceHandleType,
+  reactFlowInstance,
+  ...options
+}: ContainerPreviewContext & ContainerPreviewOptions): PreviewGraphOverrides | null {
+  // Container previews handle two cases:
+  // 1. insert: replace an existing edge inside/through a container
+  // 2. append: continue from a child node to the container's inner target handle
+  return (
+    resolveInsertPreview({
+      source,
+      sourceHandleType,
+      reactFlowInstance,
+      ...options,
+    }) ??
+    resolveAppendPreview({
+      source,
+      sourceHandleType,
+      reactFlowInstance,
+      ...options,
+    })
+  );
+}
+
+// -----------------------------------------------------------------------------
+// Preview placement
+// -----------------------------------------------------------------------------
+
+/**
+ * Computes an absolute center point for previewing a node in a container
+ * sequence. The returned center can be passed to `showPreviewGraph` with
+ * `positionMode: 'center'` and `containerId`.
+ */
+function getPreviewPlacement({
+  sourceNode,
+  targetNode,
+  containerNode,
+  nodes,
+  containerAbsolutePosition = getAbsolutePosition(containerNode, nodes),
+  safeArea,
+  previewNodeSize = { width: DEFAULT_NODE_SIZE, height: DEFAULT_NODE_SIZE },
+  gap = CONTAINER_SEQUENCE_GAP_PX,
+  avoidSiblings = false,
+  getNodeDimensions: resolveNodeDimensions = getNodeDimensions,
+}: {
+  sourceNode?: Node;
+  targetNode?: Node;
+  containerNode: Node;
+  nodes: Node[];
+  containerAbsolutePosition?: XYPosition;
+  safeArea?: ContainerSafeArea;
+  previewNodeSize?: NodeDimensions;
+  gap?: number;
+  avoidSiblings?: boolean;
+  getNodeDimensions?: (node: Node) => NodeDimensions;
+}): PreviewPlacement {
+  const resolvedSafeArea = getSafeArea(containerNode, safeArea);
+  const sourcePosition = getLocalNodePosition(sourceNode, containerNode, nodes);
+  const targetPosition = getLocalNodePosition(targetNode, containerNode, nodes);
+  const direction = getPlacementDirection(sourcePosition, targetPosition);
+  const initialPosition = resolveSequenceTopLeft({
+    sourceNode,
+    targetNode,
+    containerNode,
+    nodes,
+    safeArea: resolvedSafeArea,
+    previewNodeSize,
+    gap,
+    getNodeDimensions: resolveNodeDimensions,
+  });
+  const collisionPosition = avoidSiblings
+    ? getNonOverlappingPositionForDirection(
+        getSiblingNodes(containerNode.id, nodes),
+        initialPosition,
+        previewNodeSize,
+        direction,
+        gap
+      )
+    : initialPosition;
+  const position = clampTopLeftToSafeArea(collisionPosition, resolvedSafeArea, previewNodeSize);
+
+  return {
+    containerId: containerNode.id,
+    centerPosition: {
+      x: containerAbsolutePosition.x + position.x + previewNodeSize.width / 2,
+      y: containerAbsolutePosition.y + position.y + previewNodeSize.height / 2,
+    },
+  };
+}
+
+// -----------------------------------------------------------------------------
+// Materialized placement
+// -----------------------------------------------------------------------------
+
+function getNodeCenterY(position: XYPosition, nodeSize: NodeDimensions): number {
+  return position.y + nodeSize.height / 2;
+}
+
+function getInsertedPosition({
+  sourceNode,
+  targetNode,
+  insertedNode,
+  containerNode,
+  nodes,
+  safeArea,
+  insertedNodeSize,
+  gap,
+  getNodeDimensions,
+}: {
+  sourceNode?: Node;
+  targetNode?: Node;
+  insertedNode: Node;
+  containerNode: Node;
+  nodes: Node[];
+  safeArea: ContainerSafeArea;
+  insertedNodeSize: NodeDimensions;
+  gap: number;
+  getNodeDimensions: (node: Node) => NodeDimensions;
+}): XYPosition {
+  const sourcePosition = getLocalNodePosition(sourceNode, containerNode, nodes);
+  const targetPosition = getLocalNodePosition(targetNode, containerNode, nodes);
+  const sourceSize = sourceNode ? getNodeDimensions(sourceNode) : undefined;
+  const targetSize = targetNode ? getNodeDimensions(targetNode) : undefined;
+  const sourceIsContainer = sourceNode?.id === containerNode.id;
+  const targetIsContainer = targetNode?.id === containerNode.id;
+
+  if (sourcePosition && sourceSize && !sourceIsContainer) {
+    return {
+      x: Math.max(safeArea.x, snapToGrid(sourcePosition.x + sourceSize.width + gap)),
+      y: clampTopToSafeArea(
+        snapToGrid(getNodeCenterY(sourcePosition, sourceSize) - insertedNodeSize.height / 2),
+        safeArea,
+        insertedNodeSize
+      ),
+    };
+  }
+
+  if (targetPosition && targetSize && !targetIsContainer) {
+    return {
+      x: Math.max(safeArea.x, snapToGrid(targetPosition.x - insertedNodeSize.width - gap)),
+      y: clampTopToSafeArea(
+        snapToGrid(getNodeCenterY(targetPosition, targetSize) - insertedNodeSize.height / 2),
+        safeArea,
+        insertedNodeSize
+      ),
+    };
+  }
+
+  return {
+    x: Math.max(safeArea.x, snapToGrid(insertedNode.position.x)),
+    y: clampTopToSafeArea(snapToGrid(insertedNode.position.y), safeArea, insertedNodeSize),
+  };
+}
+
+function getNodeDepth(node: Node | undefined, nodesById: Map<string, Node>): number {
+  let depth = 0;
+  let parentId = node?.parentId;
+
+  while (parentId) {
+    depth += 1;
+    parentId = nodesById.get(parentId)?.parentId;
+  }
+
+  return depth;
+}
+
+function sortContainerSizeChanges(
+  changes: ContainerSizeChange[],
+  nodes: Node[]
+): ContainerSizeChange[] {
+  const nodesById = new Map(nodes.map((node) => [node.id, node]));
+
+  // Inner containers move first so ancestor and sibling pushes see their final
+  // width before deciding how much room is required.
+  return [...changes].sort((left, right) => {
+    const leftNode = nodesById.get(left.containerId)!;
+    const rightNode = nodesById.get(right.containerId)!;
+    const depthDifference = getNodeDepth(rightNode, nodesById) - getNodeDepth(leftNode, nodesById);
+
+    if (depthDifference !== 0) {
+      return depthDifference;
+    }
+
+    if (leftNode.parentId === rightNode.parentId) {
+      return leftNode.position.x - rightNode.position.x;
+    }
+
+    return 0;
+  });
+}
+
+function pushSiblingsAfterContainerGrowth({
+  nodes,
+  changes,
+  getNodeDimensions,
+  gap,
+}: {
+  nodes: Node[];
+  changes: ContainerSizeChange[];
+  getNodeDimensions: (node: Node) => NodeDimensions;
+  gap: number;
+}): { nodes: Node[]; shifted: boolean } {
+  let shifted = false;
+  let nextNodes = nodes;
+
+  for (const change of sortContainerSizeChanges(changes, nextNodes)) {
+    const widthDelta = change.nextSize.width - change.previousSize.width;
+    if (widthDelta <= 0) {
+      continue;
+    }
+
+    const containerNode = nextNodes.find((node) => node.id === change.containerId)!;
+
+    const oldRight = containerNode.position.x + change.previousSize.width;
+    const newRight = containerNode.position.x + change.nextSize.width;
+    const containerTop = containerNode.position.y;
+    const containerBottom =
+      containerNode.position.y + Math.max(change.previousSize.height, change.nextSize.height);
+
+    nextNodes = nextNodes.map((node) => {
+      if (node.id === containerNode.id || node.parentId !== containerNode.parentId) {
+        return node;
+      }
+
+      const nodeSize = getNodeDimensions(node);
+      const isRightSibling = node.position.x >= oldRight;
+      // Only siblings that sit to the right and overlap the container's vertical
+      // band can be visually covered by the new width.
+      const verticallyOverlaps = rangesOverlap(
+        node.position.y,
+        node.position.y + nodeSize.height,
+        containerTop,
+        containerBottom
+      );
+
+      if (!isRightSibling || !verticallyOverlaps) {
+        return node;
+      }
+
+      const nextX = Math.max(node.position.x + widthDelta, snapUpToGrid(newRight + gap));
+      if (nextX === node.position.x) {
+        return node;
+      }
+
+      shifted = true;
+      return {
+        ...node,
+        position: {
+          ...node.position,
+          x: nextX,
+        },
+      };
+    });
+  }
+
+  return { nodes: nextNodes, shifted };
+}
+
+function fitContainersAndPushSiblings({
+  nodes,
+  containerIds,
+  getContainerFitGeometry,
+  getNodeDimensions,
+  gap,
+}: {
+  nodes: Node[];
+  containerIds: Iterable<string>;
+  getContainerFitGeometry: (containerNode: Node) => ContainerFitGeometry | null | undefined;
+  getNodeDimensions: (node: Node) => NodeDimensions;
+  gap: number;
+}): Node[] {
+  let nextNodes = nodes;
+
+  // Growth can push a sibling container, which may force an ancestor to grow as
+  // well. Iterate until the graph stabilizes, with a small cap for malformed
+  // layouts.
+  for (let iteration = 0; iteration < 10; iteration += 1) {
+    const fitResult = ensureContainersFitChildren(nextNodes, {
+      containerIds,
+      getContainerFitGeometry,
+      getNodeDimensions,
+      includeAncestors: true,
+    });
+
+    nextNodes = fitResult.nodes;
+    if (fitResult.changes.length === 0) {
+      return nextNodes;
+    }
+
+    const pushResult = pushSiblingsAfterContainerGrowth({
+      nodes: nextNodes,
+      changes: fitResult.changes,
+      getNodeDimensions,
+      gap,
+    });
+
+    nextNodes = pushResult.nodes;
+    if (!pushResult.shifted) {
+      return nextNodes;
+    }
+  }
+
+  return nextNodes;
+}
+
+/**
+ * Reads and validates container placement metadata from a preview node.
+ * Returns null when the preview is not scoped to the recorded container.
+ */
+export function getContainerPlacement({
+  previewNode,
+  isContainerId,
+}: {
+  previewNode: Pick<Node, 'data' | 'parentId'>;
+  isContainerId?: (containerId: string) => boolean;
+}): ContainerPlacement | null {
+  const placement = previewNode.data?.[PLACEMENT_DATA_KEY] as ContainerPlacement | undefined;
+  if (!placement) {
+    return null;
+  }
+
+  if (previewNode.parentId && placement.containerId !== previewNode.parentId) {
+    return null;
+  }
+
+  return isContainerId && !isContainerId(placement.containerId) ? null : placement;
+}
+
+/**
+ * Materializes an inserted node from container placement metadata, shifts the
+ * downstream sequence when necessary, then expands affected containers and
+ * pushes overlapping siblings out of the way.
+ */
+export function placeContainerNode({
+  nodes,
+  insertedNode,
+  placement,
+  safeArea,
+  getContainerFitGeometry: resolveContainerFitGeometry = getContainerFitGeometry,
+  getNodeDimensions: resolveNodeDimensions = getNodeDimensions,
+  gap = CONTAINER_SEQUENCE_GAP_PX,
+  downstreamNodeIds,
+  edges,
+}: {
+  nodes: Node[];
+  insertedNode: Node;
+  placement: ContainerPlacement;
+  safeArea?: ContainerSafeArea;
+  getContainerFitGeometry?: (containerNode: Node) => ContainerFitGeometry | null | undefined;
+  getNodeDimensions?: (node: Node) => NodeDimensions;
+  gap?: number;
+  downstreamNodeIds?: Iterable<string>;
+  edges?: Edge[];
+}): Node[] {
+  const containerNode = nodes.find((node) => node.id === placement.containerId)!;
+
+  const nodesById = new Map(nodes.map((node) => [node.id, node]));
+  const insertedSize = resolveNodeDimensions(insertedNode);
+  const resolvedSafeArea = getSafeArea(containerNode, safeArea);
+  const positionedNode =
+    placement.mode === 'first-child'
+      ? {
+          ...insertedNode,
+          position: centerInSafeArea(resolvedSafeArea, insertedSize),
+        }
+      : {
+          ...insertedNode,
+          position: getInsertedPosition({
+            sourceNode: placement.sourceNodeId ? nodesById.get(placement.sourceNodeId) : undefined,
+            targetNode: placement.targetNodeId ? nodesById.get(placement.targetNodeId) : undefined,
+            insertedNode,
+            containerNode,
+            nodes,
+            safeArea: resolvedSafeArea,
+            insertedNodeSize: insertedSize,
+            gap,
+            getNodeDimensions: resolveNodeDimensions,
+          }),
+        };
+  const targetNode =
+    placement.targetNodeId && placement.targetNodeId !== placement.containerId
+      ? nodesById.get(placement.targetNodeId)
+      : undefined;
+  const fallbackTargetIds =
+    placement.targetNodeId && placement.targetNodeId !== placement.containerId
+      ? [placement.targetNodeId]
+      : [];
+  const idsToShift = new Set(
+    downstreamNodeIds ??
+      (edges
+        ? collectDownstreamNodes({
+            targetNodeId: placement.targetNodeId,
+            containerId: placement.containerId,
+            nodes,
+            edges,
+          })
+        : fallbackTargetIds)
+  );
+  const requiredTargetLeft = positionedNode.position.x + insertedSize.width + gap;
+  const downstreamShift =
+    targetNode && targetNode.position.x < requiredTargetLeft
+      ? snapUpToGrid(requiredTargetLeft - targetNode.position.x)
+      : 0;
+  const positionedNodes = nodes.map((node) => {
+    if (node.id === insertedNode.id) return positionedNode;
+    if (downstreamShift > 0 && idsToShift.has(node.id)) {
+      return {
+        ...node,
+        position: {
+          ...node.position,
+          x: node.position.x + downstreamShift,
+        },
+      };
+    }
+
+    return node;
+  });
+
+  return fitContainersAndPushSiblings({
+    nodes: positionedNodes,
+    containerIds: [placement.containerId],
+    getContainerFitGeometry: resolveContainerFitGeometry,
+    getNodeDimensions: resolveNodeDimensions,
+    gap,
+  });
+}

--- a/packages/apollo-react/src/canvas/utils/createPreviewGraph.test.ts
+++ b/packages/apollo-react/src/canvas/utils/createPreviewGraph.test.ts
@@ -52,13 +52,17 @@ describe('createPreviewGraph', () => {
     });
 
     const preview = createPreviewGraph({
-      sourceNodeId: sourceNode.id,
-      sourceHandleId: 'source-output',
+      source: {
+        nodeId: sourceNode.id,
+        handleId: 'source-output',
+      },
       reactFlowInstance,
       position: { x: 200, y: 100 },
       handlePosition: Position.Right,
-      targetNodeId: targetNode.id,
-      targetHandleId: 'target-input',
+      target: {
+        nodeId: targetNode.id,
+        handleId: 'target-input',
+      },
       trailingEdgeId: 'preview-to-target',
     });
 
@@ -92,8 +96,10 @@ describe('createPreviewGraph', () => {
     });
 
     const preview = createPreviewGraph({
-      sourceNodeId: sourceNode.id,
-      sourceHandleId: 'source-output',
+      source: {
+        nodeId: sourceNode.id,
+        handleId: 'source-output',
+      },
       reactFlowInstance,
       position: { x: 240, y: 170 },
       positionMode: 'center',
@@ -130,8 +136,10 @@ describe('createPreviewGraph', () => {
     });
 
     const preview = createPreviewGraph({
-      sourceNodeId: childNode.id,
-      sourceHandleId: 'output',
+      source: {
+        nodeId: childNode.id,
+        handleId: 'output',
+      },
       reactFlowInstance,
       handlePosition: Position.Right,
     });
@@ -144,7 +152,7 @@ describe('createPreviewGraph', () => {
     expect(preview?.node.position.x).toBeGreaterThan(childNode.position.x);
   });
 
-  it('filters removed edges only when the preview graph is applied', () => {
+  it('filters original edges only when the preview graph is applied', () => {
     vi.useFakeTimers();
 
     const replacedEdge: Edge = {
@@ -165,16 +173,21 @@ describe('createPreviewGraph', () => {
     });
 
     const preview = createPreviewGraph({
-      sourceNodeId: sourceNode.id,
-      sourceHandleId: 'source-output',
+      source: {
+        nodeId: sourceNode.id,
+        handleId: 'source-output',
+      },
       reactFlowInstance,
       position: { x: 200, y: 100 },
       handlePosition: Position.Right,
-      targetNodeId: targetNode.id,
-      targetHandleId: 'target-input',
-      removedEdgeIds: [replacedEdge.id],
+      data: { originalEdge: replacedEdge },
+      target: {
+        nodeId: targetNode.id,
+        handleId: 'target-input',
+      },
     });
 
+    expect(preview?.node.data?.originalEdge).toEqual(replacedEdge);
     expect(reactFlowInstance.getEdges()).toEqual([replacedEdge, retainedEdge]);
 
     applyPreviewGraphToReactFlow(preview!, reactFlowInstance);

--- a/packages/apollo-react/src/canvas/utils/createPreviewGraph.ts
+++ b/packages/apollo-react/src/canvas/utils/createPreviewGraph.ts
@@ -4,6 +4,7 @@ import type {
   Position,
   ReactFlowInstance,
 } from '@uipath/apollo-react/canvas/xyflow/react';
+import type { CSSProperties } from 'react';
 import { DEFAULT_SOURCE_HANDLE_ID, PREVIEW_NODE_ID } from '../constants';
 import {
   createPreviewNode,
@@ -13,16 +14,26 @@ import {
 } from './createPreviewNode';
 import { getAbsolutePosition } from './NodeUtils';
 
+/** Preview node plus the temporary edges that should be rendered with it. */
 export interface PreviewGraph {
   node: Node;
   edges: Edge[];
-  removedEdgeIds?: string[];
 }
 
+/** Node/handle pair used for preview graph endpoints. */
+export interface PreviewEndpoint {
+  nodeId: string;
+  handleId?: string | null;
+}
+
+/**
+ * Options for building a preview graph. The primary edge is always created; the
+ * optional target creates a trailing preview edge from the preview node onward.
+ */
 export interface CreatePreviewGraphOptions {
-  sourceNodeId: string;
-  sourceHandleId: string;
   reactFlowInstance: ReactFlowInstance;
+  source: PreviewEndpoint;
+  target?: PreviewEndpoint;
   position?: { x: number; y: number };
   data?: Record<string, unknown>;
   sourceHandleType?: 'source' | 'target';
@@ -30,13 +41,23 @@ export interface CreatePreviewGraphOptions {
   handlePosition?: Position;
   ignoredNodeTypes?: string[];
   positionMode?: PreviewNodePositionMode;
-  targetNodeId?: string;
-  targetHandleId?: string | null;
   containerId?: string;
-  removedEdgeIds?: string[];
   trailingEdgeId?: string;
-  trailingEdgeStyle?: Edge['style'];
+  trailingEdgeStyle?: CSSProperties;
 }
+
+export type PreviewGraphOverrides = Partial<
+  Pick<
+    CreatePreviewGraphOptions,
+    | 'containerId'
+    | 'data'
+    | 'position'
+    | 'positionMode'
+    | 'target'
+    | 'trailingEdgeId'
+    | 'trailingEdgeStyle'
+  >
+>;
 
 function inferPreviewContainerId(sourceNode: Node, targetNode?: Node): string | undefined {
   if (!targetNode) {
@@ -58,16 +79,16 @@ function inferPreviewContainerId(sourceNode: Node, targetNode?: Node): string | 
   return undefined;
 }
 
+/**
+ * Converts an absolute preview position into container-local coordinates and
+ * constrains the preview to the container parent.
+ */
 export function reparentPreviewNodeToContainer(
   previewNode: Node,
   containerId: string,
   reactFlowInstance: ReactFlowInstance
-): Node | null {
-  const containerNode = reactFlowInstance.getNode(containerId);
-  if (!containerNode) {
-    return null;
-  }
-
+): Node {
+  const containerNode = reactFlowInstance.getNode(containerId)!;
   const containerAbsolutePosition = getAbsolutePosition(
     containerNode,
     reactFlowInstance.getNodes()
@@ -85,8 +106,7 @@ export function reparentPreviewNodeToContainer(
 }
 
 function createPreviewNodeForGraph({
-  sourceNodeId,
-  sourceHandleId,
+  source,
   reactFlowInstance,
   position,
   data,
@@ -97,8 +117,8 @@ function createPreviewNodeForGraph({
   positionMode,
 }: CreatePreviewGraphOptions) {
   return createPreviewNode(
-    sourceNodeId,
-    sourceHandleId,
+    source.nodeId,
+    source.handleId ?? DEFAULT_SOURCE_HANDLE_ID,
     reactFlowInstance,
     position,
     data,
@@ -111,43 +131,44 @@ function createPreviewNodeForGraph({
 }
 
 function createTrailingPreviewEdge({
-  targetNodeId,
-  targetHandleId,
+  target,
   trailingEdgeId,
   trailingEdgeStyle = PREVIEW_EDGE_STYLE,
-}: Pick<
-  CreatePreviewGraphOptions,
-  'targetNodeId' | 'targetHandleId' | 'trailingEdgeId' | 'trailingEdgeStyle'
->): Edge | null {
-  if (!targetNodeId) return null;
+}: {
+  target?: PreviewEndpoint;
+  trailingEdgeId?: string;
+  trailingEdgeStyle?: CSSProperties;
+}): Edge | null {
+  if (!target) return null;
 
   return {
-    id: trailingEdgeId ?? `${PREVIEW_NODE_ID}-${targetNodeId}`,
+    id: trailingEdgeId ?? `${PREVIEW_NODE_ID}-${target.nodeId}`,
     source: PREVIEW_NODE_ID,
     sourceHandle: DEFAULT_SOURCE_HANDLE_ID,
-    target: targetNodeId,
-    targetHandle: targetHandleId,
+    target: target.nodeId,
+    targetHandle: target.handleId,
     type: 'default',
     style: trailingEdgeStyle,
   };
 }
 
+/**
+ * Creates a preview node and its temporary edge(s), optionally scoped to a
+ * container. Container previews use this to show both the incoming and outgoing
+ * side of an insertion before the node is materialized.
+ */
 export function createPreviewGraph(options: CreatePreviewGraphOptions): PreviewGraph | null {
-  const { reactFlowInstance, targetNodeId, containerId, removedEdgeIds, sourceNodeId } = options;
+  const { reactFlowInstance, target, containerId, source } = options;
 
   const preview = createPreviewNodeForGraph(options);
   if (!preview) return null;
 
-  const sourceNode = reactFlowInstance.getNode(sourceNodeId);
-  if (!sourceNode) return null;
-
-  const targetNode = targetNodeId ? reactFlowInstance.getNode(targetNodeId) : undefined;
+  const sourceNode = reactFlowInstance.getNode(source.nodeId)!;
+  const targetNode = target ? reactFlowInstance.getNode(target.nodeId) : undefined;
   const resolvedContainerId = containerId ?? inferPreviewContainerId(sourceNode, targetNode);
   const finalPreviewNode = resolvedContainerId
     ? reparentPreviewNodeToContainer(preview.node, resolvedContainerId, reactFlowInstance)
     : preview.node;
-
-  if (!finalPreviewNode) return null;
 
   const trailingEdge = createTrailingPreviewEdge(options);
   const edges = trailingEdge ? [preview.edge, trailingEdge] : [preview.edge];
@@ -155,7 +176,6 @@ export function createPreviewGraph(options: CreatePreviewGraphOptions): PreviewG
   return {
     node: finalPreviewNode,
     edges,
-    removedEdgeIds,
   };
 }
 
@@ -181,7 +201,7 @@ export function applyPreviewGraphToReactFlow(
   preview: PreviewGraph,
   reactFlowInstance: ReactFlowInstance
 ): void {
-  const removedEdgeIds = new Set(preview.removedEdgeIds ?? []);
+  const originalEdge = preview.node.data?.originalEdge as Edge | undefined;
 
   setTimeout(() => {
     reactFlowInstance.setNodes((nodes) => [
@@ -192,7 +212,7 @@ export function applyPreviewGraphToReactFlow(
     ]);
 
     reactFlowInstance.setEdges((edges) => [
-      ...edges.filter((edge) => !isPreviewEdge(edge) && !removedEdgeIds.has(edge.id)),
+      ...edges.filter((edge) => !isPreviewEdge(edge) && edge.id !== originalEdge?.id),
       ...preview.edges,
     ]);
   }, 0);

--- a/packages/apollo-react/src/canvas/utils/createPreviewGraph.ts
+++ b/packages/apollo-react/src/canvas/utils/createPreviewGraph.ts
@@ -87,8 +87,10 @@ export function reparentPreviewNodeToContainer(
   previewNode: Node,
   containerId: string,
   reactFlowInstance: ReactFlowInstance
-): Node {
-  const containerNode = reactFlowInstance.getNode(containerId)!;
+): Node | null {
+  const containerNode = reactFlowInstance.getNode(containerId);
+  if (!containerNode) return null;
+
   const containerAbsolutePosition = getAbsolutePosition(
     containerNode,
     reactFlowInstance.getNodes()
@@ -169,6 +171,7 @@ export function createPreviewGraph(options: CreatePreviewGraphOptions): PreviewG
   const finalPreviewNode = resolvedContainerId
     ? reparentPreviewNodeToContainer(preview.node, resolvedContainerId, reactFlowInstance)
     : preview.node;
+  if (!finalPreviewNode) return null;
 
   const trailingEdge = createTrailingPreviewEdge(options);
   const edges = trailingEdge ? [preview.edge, trailingEdge] : [preview.edge];

--- a/packages/apollo-react/src/canvas/utils/createPreviewNode.ts
+++ b/packages/apollo-react/src/canvas/utils/createPreviewNode.ts
@@ -5,6 +5,7 @@ import {
   type ReactFlowInstance,
 } from '@uipath/apollo-react/canvas/xyflow/react';
 import { DEFAULT_NODE_SIZE, GRID_SPACING, PREVIEW_EDGE_ID, PREVIEW_NODE_ID } from '../constants';
+import { getNodeDimensions } from './container';
 import {
   getAbsolutePosition,
   getNonOverlappingPositionForDirection,
@@ -131,17 +132,27 @@ function calculateAutoPosition(
   const sourceAbsolutePosition = sourceNode.parentId
     ? getAbsolutePosition(sourceNode, existingNodes)
     : sourceNode.position;
-  const sourceWidth = sourceNode.measured?.width ?? 0;
-  const sourceHeight = sourceNode.measured?.height ?? 0;
+  const sourceSize = getNodeDimensions(sourceNode);
   // Use exact handle position when available, fall back to node center
-  const anchorX = handle?.anchor.x ?? sourceAbsolutePosition.x + sourceWidth / 2;
-  const anchorY = handle?.anchor.y ?? sourceAbsolutePosition.y + sourceHeight / 2;
+  const anchorX = handle?.anchor.x ?? sourceAbsolutePosition.x + sourceSize.width / 2;
+  const anchorY = handle?.anchor.y ?? sourceAbsolutePosition.y + sourceSize.height / 2;
+  const ignoredNodeIds = new Set<string>();
+  let parentId = sourceNode.parentId;
 
-  // Prepare nodes with absolute positions for overlap detection
-  const nodesWithAbsolutePositions = existingNodes.map((node) => ({
-    ...node,
-    position: node.parentId ? getAbsolutePosition(node, existingNodes) : node.position,
-  }));
+  while (parentId) {
+    ignoredNodeIds.add(parentId);
+    parentId = existingNodes.find((node) => node.id === parentId)?.parentId;
+  }
+
+  // Prepare nodes with absolute positions for overlap detection.
+  // Parent containers are ignored for child previews so they do not push the
+  // preview away from the scoped canvas it belongs to.
+  const nodesWithAbsolutePositions = existingNodes
+    .filter((node) => node.id !== PREVIEW_NODE_ID && !ignoredNodeIds.has(node.id))
+    .map((node) => ({
+      ...node,
+      position: node.parentId ? getAbsolutePosition(node, existingNodes) : node.position,
+    }));
 
   let initialPosition: { x: number; y: number };
   let direction: 'left' | 'right' | 'top' | 'bottom';
@@ -158,7 +169,7 @@ function calculateAutoPosition(
     case Position.Right:
       // Spread vertically when multiple handles share the right side.
       initialPosition = {
-        x: sourceAbsolutePosition.x + sourceWidth + offset,
+        x: sourceAbsolutePosition.x + sourceSize.width + offset,
         y:
           anchorY -
           previewNodeSize.height / 2 +
@@ -184,25 +195,25 @@ function calculateAutoPosition(
           anchorX -
           previewNodeSize.width / 2 +
           computeSpreadOffset(handle, previewNodeSize.width / 2),
-        y: sourceAbsolutePosition.y + sourceHeight + offset,
+        y: sourceAbsolutePosition.y + sourceSize.height + offset,
       };
       direction = 'bottom';
       break;
     default:
       // Fallback to right-side behavior
       initialPosition = {
-        x: sourceAbsolutePosition.x + sourceWidth + offset,
+        x: sourceAbsolutePosition.x + sourceSize.width + offset,
         y: anchorY - previewNodeSize.height / 2,
       };
       direction = 'right';
   }
 
   // Overflow toward the closest perpendicular edge of the source node:
-  // for top/bottom handles, left of center → shift left, right of center → shift right;
-  // for left/right handles, above center → shift up, below center → shift down.
+  // for top/bottom handles, left of center -> shift left, right of center -> shift right;
+  // for left/right handles, above center -> shift up, below center -> shift down.
   const overflowDirection = {
-    x: anchorX >= sourceAbsolutePosition.x + sourceWidth / 2 ? 'right' : 'left',
-    y: anchorY >= sourceAbsolutePosition.y + sourceHeight / 2 ? 'down' : 'up',
+    x: anchorX >= sourceAbsolutePosition.x + sourceSize.width / 2 ? 'right' : 'left',
+    y: anchorY >= sourceAbsolutePosition.y + sourceSize.height / 2 ? 'down' : 'up',
   } as { x: 'left' | 'right'; y: 'up' | 'down' };
 
   // Find non-overlapping position
@@ -218,8 +229,9 @@ function calculateAutoPosition(
 }
 
 /**
- * Creates a preview node and edge at a specific position or calculated position
- * This is the single source of truth for preview node creation
+ * Creates the preview node and primary preview edge for Add Node flows. The
+ * preview can be placed from a drop coordinate, centered at an absolute point,
+ * or auto-positioned from the clicked handle when no position is provided.
  *
  * @param ignoredNodeTypes Optional array of node types to ignore when calculating overlap (e.g., ["stickyNote"])
  */

--- a/packages/apollo-react/src/canvas/utils/index.ts
+++ b/packages/apollo-react/src/canvas/utils/index.ts
@@ -6,6 +6,7 @@ export * from './coded-agents/d3-layout';
 export * from './coded-agents/mermaid-parser';
 export * from './collapse';
 export * from './constraint-validator';
+export * from './container';
 export * from './createPreviewGraph';
 export * from './createPreviewNode';
 export * from './export-canvas';


### PR DESCRIPTION
## Description

Adds loop-container auto expansion for the canvas so nodes inserted into a loop can be previewed, placed, and materialized inside the loop safe area while the container grows to fit the resulting sequence. The change makes the Add Node panel, handle-button preview, empty-loop add, and edge-toolbar insertion paths container-aware.

## User scenarios/stories unlocked

- Add the first node inside an empty loop from the loop body plus button and get a centered preview that materializes as a loop child.
- Insert a node between existing loop children from a handle or edge toolbar while preserving the loop's sequence wiring.
- Append a node from a loop child toward the loop continuation handle without manually resizing or repositioning the loop.
- Add larger node types into a loop while keeping the selected preview handle aligned.
- Grow loop containers automatically as child nodes or downstream chains need more space, while shifting affected siblings to avoid overlap.
- Cancel an add-node preview and restore the original edge that was temporarily replaced.

## Core changes

- Added shared container utilities in `packages/apollo-react/src/canvas/utils/container.ts` for container safe areas, fit geometry, preview placement, sequence insertion, downstream shifting, auto growth, and sibling push-out.
- Routed Add Node materialization through `placeAddedNode` so preview replacements preserve parent scope, use manifest-aware dimensions, scope collision resolution to siblings, and apply container sequence placement when a preview carries container metadata.
- Extended preview graph creation to support endpoint-based source/target data, center positioning, parented previews, trailing preview edges, original edge replacement, and container inference.
- Made `LoopNode` use the shared container sizing constants, inner/outer handle grouping, resize internals refresh, and centered first-child previews.
- Updated edge-toolbar and handle-click add-node flows to resolve container-aware previews for loop insert/append cases.
- Moved `HierarchicalCanvas` handle-action preview ownership into the canvas component and removed duplicate preview wiring from the controls wrapper.
- Exported container utilities and updated stories to exercise manifest-aware loop previews.

## Mermaid chart for key flows

```mermaid
flowchart TD
  A[User starts add-node action] --> B{Entry point}
  B --> C[Empty loop plus button]
  B --> D[Loop/child handle button]
  B --> E[Edge toolbar add action]

  C --> F[showCenteredContainerPreview]
  D --> G[createAddNodePreview]
  E --> H[useEdgeToolbarState]

  F --> I[showPreviewGraph]
  G --> J[resolveContainerAddNodePreview]
  H --> J
  J --> K{Container context found?}
  K -- No --> I
  K -- Yes --> L[resolveContainerPreview]
  L --> M{Insert or append?}
  M --> N[Build parented preview]
  N --> O[Preview edge plus optional trailing edge]
  I --> P[AddNodeManager materializes selected node]
  O --> P

  P --> Q[placeAddedNode]
  Q --> R{Container placement metadata?}
  R -- No --> S[Resolve sibling collisions]
  R -- Yes --> T[placeContainerNode]
  T --> U[Shift downstream loop children]
  U --> V[ensureContainersFitChildren]
  V --> W[Push affected siblings after growth]
  S --> X[Replace preview edges with real edges]
  W --> X
```

## Testing

- Ran:
  - `pnpm --dir packages/apollo-react exec vitest --run src/canvas/components/AddNodePanel/AddNodeManager.test.tsx src/canvas/components/Toolbar/EdgeToolbar/useEdgeToolbarState.test.ts src/canvas/utils/container.test.ts src/canvas/utils/createPreviewGraph.test.ts src/canvas/utils/NodeUtils.test.ts src/canvas/hooks/useAddNodeOnConnectEnd.test.ts`
- Result: 6 test files passed, 70 tests passed.
- Added/updated coverage for parented preview replacement, edge restore/cancel behavior, container sequence materialization, downstream loop child shifting, safe container geometry growth, preview graph container reparenting, and edge-toolbar insertion behavior.
