### PR TITLE
fix(repo): drop @uipath scope registry override from .npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,4 +1,3 @@
-@uipath:registry=https://npm.pkg.github.com
 //npm.pkg.github.com/:_authToken=${GH_NPM_REGISTRY_TOKEN}
 //registry.npmjs.org/:_authToken=${NPM_AUTH_TOKEN}
 auto-install-peers=true


### PR DESCRIPTION
## Summary

CI is failing across multiple unrelated open PRs (#604, #603, #602) because `pnpm install` 404s on `@uipath/uipath-typescript@1.3.1`:

```
ERR_PNPM_FETCH_404
GET https://npm.pkg.github.com/@uipath/uipath-typescript/-/uipath-typescript-1.3.1.tgz
Not Found - 404
```

The package is **not published to GitHub Packages** but **is published to npmjs.org** (latest is `1.3.2`, `1.3.1` returns HTTP 200). The `.npmrc` line `@uipath:registry=https://npm.pkg.github.com` forces pnpm to look in the wrong place.

This PR removes that single line so `@uipath/*` falls back to the default registry, which is where the package actually lives.

## Why this regressed

- `0b804bae chore(repo): remove gh registry for @uipath` (2026-04-15) correctly removed the scope override.
- `cfc68376 chore(ci): add GH_NPM_REGISTRY_TOKEN back to checks` (2026-04-27) re-added it, presumably as a side effect while restoring the auth token in CI workflows. The token line on its own is fine; the scope override is what breaks installs.

The other line (`//npm.pkg.github.com/:_authToken=${GH_NPM_REGISTRY_TOKEN}`) is left in place since it's still needed for publishing.

## Verification

- `curl -s -o /dev/null -w "%{http_code}" https://registry.npmjs.org/@uipath/uipath-typescript/1.3.1` → `200`
- `npm view @uipath/uipath-typescript versions` confirms `1.3.1` and `1.3.2` are both published on npmjs.org

## Impact

Unblocks any open PR that hits a fresh `pnpm install` (currently #602, #603, #604, and any future PR until this lands).