### PR TITLE
fix(repo): pin @uipath/uipath-typescript tarball to GH registry

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6746,7 +6746,7 @@ packages:
       '@microsoft/applicationinsights-web': 3.1.2
 
   '@uipath/uipath-typescript@1.3.1':
-    resolution: {integrity: sha512-fahNaE63XE4yP+pIkwqThSApgU+0AeLw/UvUPDqrHp9xfVSDNCeoGcKaSeUZirNV7TXOkWiLbBRV0MJvSwQAXA==}
+    resolution: {integrity: sha512-fahNaE63XE4yP+pIkwqThSApgU+0AeLw/UvUPDqrHp9xfVSDNCeoGcKaSeUZirNV7TXOkWiLbBRV0MJvSwQAXA==, tarball: https://npm.pkg.github.com/download/@uipath/uipath-typescript/1.3.1/e2296394adccb2cb1467968eacfb501106443100}
     peerDependencies:
       zod: ^4.2.1
 


### PR DESCRIPTION
## Summary

Restores release/CI installs that broke with `ERR_PNPM_FETCH_404` for `@uipath/uipath-typescript@1.3.1`. Adds an explicit `tarball:` URL to the lockfile entry so pnpm uses the GH Packages download path instead of constructing a non-existent npm-canonical path.

## Background

- #521 removed `@uipath:registry=https://npm.pkg.github.com` from `.npmrc` and bumped `@uipath/uipath-typescript` to `^1.3.1`. The lockfile entry for 1.3.1 was therefore stored **without** an explicit tarball URL — pnpm would construct one from the configured registry at install time.
- #584 added the scope override back. With the override active, pnpm now constructs:

  ```
  https://npm.pkg.github.com/@uipath/uipath-typescript/-/uipath-typescript-1.3.1.tgz
  ```

  GH Packages does not serve that path — it serves tarballs at `https://npm.pkg.github.com/download/<package>/<version>/<sha>`. Result: 404 in `Release`, `Apollo Vertex Lint`, `PR Checks`, etc.

The package is dual-published (npmjs.org and GH Packages), but with the scope override routing `@uipath/*` through GH Packages, only the GH-style URL resolves. The existing `1.2.2` entry already carries this URL — 1.3.1 was simply locked during the window when the override was off.

## Change

Single-line edit to `pnpm-lock.yaml`:

```diff
   '@uipath/uipath-typescript@1.3.1':
-    resolution: {integrity: sha512-fahN...XA==}
+    resolution: {integrity: sha512-fahN...XA==, tarball: https://npm.pkg.github.com/download/@uipath/uipath-typescript/1.3.1/e2296394adccb2cb1467968eacfb501106443100}
```

`.npmrc` is intentionally left untouched — the `@uipath:registry` override stays.

## Why this approach (vs. dropping the override)

An alternative fix is to drop `@uipath:registry=https://npm.pkg.github.com` from `.npmrc` so `@uipath/*` resolves from npmjs.org. That works for `uipath-typescript` (dual-published) but routes other `@uipath/*` deps (e.g. `apollo-react`) away from GH Packages, which is a bigger policy change. Pinning the tarball URL is the minimal fix that preserves the registry topology #584 reinstated.

## Test plan

- [x] `pnpm install --frozen-lockfile` passes locally with `GH_NPM_REGISTRY_TOKEN` set
- [ ] CI checks pass (PR Checks, Apollo Vertex Lint, Dependency Review, Commit Lint)
- [ ] Release pipeline runs cleanly on next merge to `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)