### PR TITLE
feat(apollo-vertex): dashboard polish — glow system, dev controls, and layout docs

### DIFF
--- a/apps/apollo-vertex/app/experiment/_meta.ts
+++ b/apps/apollo-vertex/app/experiment/_meta.ts
@@ -1,0 +1,3 @@
+export default {
+  "modular-dashboard": "Modular Dashboard",
+};

--- a/apps/apollo-vertex/app/experiment/modular-dashboard/page.mdx
+++ b/apps/apollo-vertex/app/experiment/modular-dashboard/page.mdx
@@ -1,0 +1,149 @@
+import { DashboardTemplate } from '@/templates/dashboard/DashboardTemplateDynamic';
+import { PreviewFullScreen } from '@/app/_components/preview-full-screen';
+
+# Dashboard
+
+A configurable dashboard template for building AI-assisted operational views. The dashboard is composed of named card regions with defined interaction patterns, designed to be data-driven and adaptable across verticals.
+
+## Previews
+
+### Sidebar Shell
+
+<PreviewFullScreen title="Dashboard layout - sidebar shell">
+    <DashboardTemplate />
+</PreviewFullScreen>
+
+<a href="/preview/dashboard" target="_blank" className="text-sm text-primary hover:underline">Open standalone preview →</a>
+
+### Minimal Header Shell
+
+<PreviewFullScreen title="Dashboard layout - minimal shell">
+    <DashboardTemplate shellVariant="minimal" />
+</PreviewFullScreen>
+
+<a href="/preview/dashboard-minimal" target="_blank" className="text-sm text-primary hover:underline">Open standalone preview →</a>
+
+---
+
+## Anatomy
+
+The dashboard is built from four semantic regions, each with a distinct role:
+
+| Region | Description |
+|---|---|
+| **Overview Card** | The primary narrative area. Displays a greeting, headline, and subhead that summarize the current state. Occupies the top-left of the layout. |
+| **Prompt Bar** | The AI input surface. Supports text entry, recommendation chips, and an expand interaction that opens an inline chat view. Anchored below the overview card. |
+| **Insight Cards** | A grid of data cards on the right side. Each card has a type, a chart visualization, and an interaction pattern. Cards are arranged in rows of two. |
+| **Autopilot Panel** | A slide-in panel that provides AI-generated analysis for a specific insight card. Triggered from the card's autopilot icon. |
+
+## Card Types
+
+Every insight card has a `type` that determines what it displays:
+
+| Type | Renders | Example |
+|---|---|---|
+| `kpi` | A large number, badge, and description | "97.1%" with "+2.4%" badge |
+| `chart` | A data visualization determined by `chartType` | Horizontal bars, stacked bars |
+
+## Chart Types
+
+Cards with `type: "chart"` use a `chartType` to select the visualization:
+
+| Chart Type | Description |
+|---|---|
+| `horizontal-bars` | Ranked list of items with proportional bars and percentages |
+| `stacked-bar` | Grouped bars with color-coded segments and a legend |
+| `donut` | Circular progress indicator with a center label |
+| `sparkline` | Compact line chart for trend indication |
+| `area` | Filled area chart for volume over time |
+
+## Card Sizes
+
+Each card has a `size` that controls its column weight in the grid:
+
+| Size | Grid Weight | Use Case |
+|---|---|---|
+| `sm` | `1fr` | KPI cards, compact metrics |
+| `md` | `2fr` | Chart cards, detailed visualizations |
+| `lg` | `1fr` | Full-width cards |
+
+## Interaction Patterns
+
+Cards support three interaction modes:
+
+### Static
+
+No interactive behavior. The card displays its content without any hover or click affordance. Used for simple KPIs that don't need drill-down.
+
+### Navigate
+
+On hover, an **arrow-up-right** icon appears in the card header. Clicking the card navigates to a detail page. Used for KPIs or summaries that link to a deeper view.
+
+### Expand
+
+On hover, a **maximize** icon appears in the card header. Clicking expands the card to fill the grid with a multi-phase animation:
+
+1. **Width phase** — Card expands horizontally, sibling card collapses
+2. **Height phase** — Card expands vertically, other rows collapse
+3. **Full phase** — Expanded content fades in (drilldown tabs, autopilot prompts)
+
+Clicking the **minimize** icon or another card collapses back to the grid.
+
+For `horizontal-bars` cards, the expanded state includes **drilldown tabs** below the title for switching between data views.
+
+## Prompt Bar
+
+The prompt bar supports three ways to expand into the inline chat view:
+
+| Trigger | Behavior |
+|---|---|
+| **Type + Enter / Submit** | Expands and passes the user's typed query |
+| **Click a recommendation chip** | Expands and passes the chip text as the query |
+| **Click the chat icon** | Expands and shows the current session conversation |
+
+When expanded, the overview card collapses and the prompt bar grows to fill the left column. A **minimize** icon in the header collapses back to the default layout.
+
+## Autopilot Panel
+
+Each expandable card includes an **autopilot** icon alongside the expand icon. Clicking it slides in a panel from the right that provides AI-generated context for that card. The dashboard content shifts left to make room. Clicking the autopilot icon again or the close button dismisses the panel.
+
+## Data Configuration
+
+The dashboard is driven by a `DashboardDataset` object that defines all text and card content:
+
+```ts
+interface DashboardDataset {
+  name: string;              // Dataset identifier
+  brandName: string;         // Company name in header
+  brandLine: string;         // Tagline in header
+  dashboardTitle: string;    // Page title
+  badgeText: string;         // Badge next to title
+  greeting: string;          // Overview card greeting
+  headline: string;          // Overview card headline
+  subhead: string;           // Overview card description
+  promptPlaceholder: string; // Prompt bar placeholder text
+  promptSuggestions: string[]; // Recommendation chips
+  insightCards: [             // Exactly 4 insight cards
+    InsightCardData,
+    InsightCardData,
+    InsightCardData,
+    InsightCardData,
+  ];
+}
+```
+
+Each `InsightCardData` specifies its title, type, chart type, size, interaction, and the data for its visualization (KPI values, bar data, stacked segments, etc.).
+
+## Layout Modes
+
+The dashboard responds to container width:
+
+| Mode | Breakpoint | Behavior |
+|---|---|---|
+| **Desktop** | ≥ 1100px | Two-column layout, full card grid |
+| **Compact** | 800–1099px | Two-column layout, condensed card content |
+| **Stacked** | < 800px | Single-column, vertically stacked |
+
+## Theming
+
+Card backgrounds, glow effects, and gradients are configurable through `CardConfig` and `GlowConfig` objects. The dashboard supports light and dark modes with independent styling for each. Color tokens and theme values should be updated in `registry.json`, not directly in CSS files.

--- a/apps/apollo-vertex/app/layout.tsx
+++ b/apps/apollo-vertex/app/layout.tsx
@@ -1,5 +1,6 @@
 import { Inter } from "next/font/google";
 import Image from "next/image";
+import { headers } from "next/headers";
 import { Head } from "nextra/components";
 import { getPageMap } from "nextra/page-map";
 import { Footer, Layout, Navbar } from "nextra-theme-docs";
@@ -76,6 +77,10 @@ export default async function RootLayout({
 }: {
   children: ReactNode;
 }) {
+  const h = await headers();
+  const pathname = h.get("x-pathname") ?? "";
+  const isPreview = pathname.startsWith("/preview/");
+
   return (
     <html
       lang="en"
@@ -90,18 +95,22 @@ export default async function RootLayout({
       <body>
         <Analytics />
         <ThemeWrapper>
-          <Layout
-            sidebar={{
-              autoCollapse: false,
-              defaultMenuCollapseLevel: 1,
-            }}
-            navbar={navbar}
-            pageMap={await getPageMap()}
-            docsRepositoryBase="https://github.com/UiPath/apollo-ui/tree/main/apps/apollo-vertex"
-            footer={footer}
-          >
-            {children}
-          </Layout>
+          {isPreview ? (
+            children
+          ) : (
+            <Layout
+              sidebar={{
+                autoCollapse: false,
+                defaultMenuCollapseLevel: 1,
+              }}
+              navbar={navbar}
+              pageMap={await getPageMap()}
+              docsRepositoryBase="https://github.com/UiPath/apollo-ui/tree/main/apps/apollo-vertex"
+              footer={footer}
+            >
+              {children}
+            </Layout>
+          )}
         </ThemeWrapper>
       </body>
     </html>

--- a/apps/apollo-vertex/app/preview/dashboard-minimal/page.tsx
+++ b/apps/apollo-vertex/app/preview/dashboard-minimal/page.tsx
@@ -3,7 +3,10 @@
 import dynamic from "next/dynamic";
 
 const DashboardTemplate = dynamic(
-  () => import("@/templates/dashboard/DashboardTemplate").then((mod) => mod.DashboardTemplate),
+  () =>
+    import("@/templates/dashboard/DashboardTemplate").then(
+      (mod) => mod.DashboardTemplate,
+    ),
   { ssr: false },
 );
 

--- a/apps/apollo-vertex/app/preview/dashboard/page.tsx
+++ b/apps/apollo-vertex/app/preview/dashboard/page.tsx
@@ -3,7 +3,10 @@
 import dynamic from "next/dynamic";
 
 const DashboardTemplate = dynamic(
-  () => import("@/templates/dashboard/DashboardTemplate").then((mod) => mod.DashboardTemplate),
+  () =>
+    import("@/templates/dashboard/DashboardTemplate").then(
+      (mod) => mod.DashboardTemplate,
+    ),
   { ssr: false },
 );
 

--- a/apps/apollo-vertex/middleware.ts
+++ b/apps/apollo-vertex/middleware.ts
@@ -1,0 +1,12 @@
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+
+export function middleware(request: NextRequest) {
+  const headers = new Headers(request.headers);
+  headers.set("x-pathname", request.nextUrl.pathname);
+  return NextResponse.next({ request: { headers } });
+}
+
+export const config = {
+  matcher: ["/((?!_next|api|.*\\..*).*)"],
+};

--- a/apps/apollo-vertex/next-env.d.ts
+++ b/apps/apollo-vertex/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/apollo-vertex/templates/dashboard/DashboardContent.tsx
+++ b/apps/apollo-vertex/templates/dashboard/DashboardContent.tsx
@@ -25,10 +25,8 @@ import { InsightGrid } from "./InsightGrid";
 import { DashboardLoading } from "./DashboardLoading";
 import { PromptBar } from "./PromptBar";
 import { AutopilotInsight } from "./AutopilotInsight";
-import {
-  useDashboardData,
-  DashboardDataProvider,
-} from "./DashboardDataProvider";
+import { useDashboardData } from "./dashboard-data-context";
+import { DashboardDataProvider } from "./DashboardDataProvider";
 
 type LayoutType = "executive" | "operational" | "analytics";
 
@@ -57,12 +55,13 @@ function ExecutiveLayout({
       className="grid grid-cols-1 @[800px]:grid-cols-2 @[800px]:h-full"
       style={gapStyle}
     >
-      <div className="flex flex-col h-full" style={{ gap: promptExpanded ? 0 : layout.gap }}>
+      <div
+        className="flex flex-col h-full"
+        style={{ gap: promptExpanded ? 0 : layout.gap }}
+      >
         <div
           className={`overflow-hidden transition-all duration-300 ease-in-out ${
-            promptExpanded
-              ? "flex-[0_0_0%] opacity-0"
-              : "flex-1 opacity-100"
+            promptExpanded ? "flex-[0_0_0%] opacity-0" : "flex-1 opacity-100"
           }`}
         >
           <Card
@@ -199,9 +198,9 @@ function DashboardContentInner() {
       <div
         className={`relative h-full ${viewMode === "stacked" ? "overflow-x-hidden" : "overflow-hidden"}`}
         style={
-          layoutCfg.containerBg !== "none"
-            ? { backgroundColor: `var(--${layoutCfg.containerBg})` }
-            : {}
+          layoutCfg.containerBg === "none"
+            ? {}
+            : { backgroundColor: `var(--${layoutCfg.containerBg})` }
         }
       >
         <DashboardGlow darkConfig={darkGlow} />

--- a/apps/apollo-vertex/templates/dashboard/DashboardDataProvider.tsx
+++ b/apps/apollo-vertex/templates/dashboard/DashboardDataProvider.tsx
@@ -1,21 +1,8 @@
 "use client";
 
-import { createContext, useContext, useState, type ReactNode } from "react";
+import { useState, type ReactNode } from "react";
 import { ecommerceDataset, type DashboardDataset } from "./dashboard-data";
-
-interface DashboardDataContextValue {
-  data: DashboardDataset;
-  setDataset: (data: DashboardDataset) => void;
-}
-
-const DashboardDataContext = createContext<DashboardDataContextValue>({
-  data: ecommerceDataset,
-  setDataset: () => {},
-});
-
-export function useDashboardData() {
-  return useContext(DashboardDataContext);
-}
+import { DashboardDataContext } from "./dashboard-data-context";
 
 export function DashboardDataProvider({ children }: { children: ReactNode }) {
   const [data, setData] = useState<DashboardDataset>(ecommerceDataset);

--- a/apps/apollo-vertex/templates/dashboard/DashboardGlow.tsx
+++ b/apps/apollo-vertex/templates/dashboard/DashboardGlow.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import {
+  defaultDarkGlow,
+  defaultLightGlow,
+  type GlowConfig,
+} from "./glow-config";
+
+interface DashboardGlowProps {
+  className?: string;
+  darkConfig?: GlowConfig;
+}
+
+function GlowSvg({ id, config }: { id: string; config: GlowConfig }) {
+  return (
+    <svg
+      className="absolute inset-0 w-full h-full"
+      viewBox="0 0 1576 818"
+      fill="none"
+      preserveAspectRatio="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <g filter={`url(#blur-${id})`}>
+        <path
+          d="M541.705 724.362L75 257.99L87.1579 127.101L482.877 75L916.638 102.957L1501 84.319L1388.44 421.919L1314.32 743L847.613 651.928L541.705 724.362Z"
+          fill={`url(#grad-${id})`}
+          fillOpacity={config.fillOpacity}
+        />
+      </g>
+      <defs>
+        <filter
+          id={`blur-${id}`}
+          x="0"
+          y="0"
+          width="1576"
+          height="818"
+          filterUnits="userSpaceOnUse"
+          colorInterpolationFilters="sRGB"
+        >
+          <feFlood floodOpacity="0" result="BackgroundImageFix" />
+          <feBlend
+            mode="normal"
+            in="SourceGraphic"
+            in2="BackgroundImageFix"
+            result="shape"
+          />
+          <feGaussianBlur stdDeviation="37.5" result="effect1_foregroundBlur" />
+        </filter>
+        <linearGradient
+          id={`grad-${id}`}
+          x1="607.918"
+          y1="95.3798"
+          x2="1538.15"
+          y2="838.957"
+          gradientUnits="userSpaceOnUse"
+        >
+          <stop
+            offset="0"
+            stopColor={config.start}
+            stopOpacity={config.startStopOpacity}
+          />
+          <stop
+            offset={config.endOffset}
+            stopColor={config.end}
+            stopOpacity={config.endStopOpacity}
+          />
+        </linearGradient>
+      </defs>
+    </svg>
+  );
+}
+
+export function DashboardGlow({ className, darkConfig }: DashboardGlowProps) {
+  const light = defaultLightGlow;
+  const dark = darkConfig ?? defaultDarkGlow;
+
+  return (
+    <div
+      className={`pointer-events-none absolute top-10 -left-16 -right-32 -bottom-16 overflow-visible ${className ?? ""}`}
+    >
+      <div
+        className="absolute inset-0 dark:hidden"
+        style={{ opacity: light.containerOpacity / 100 }}
+      >
+        <GlowSvg id="light" config={light} />
+      </div>
+      <div
+        className="absolute inset-0 hidden dark:block"
+        style={{ opacity: dark.containerOpacity / 100 }}
+      >
+        <GlowSvg id="dark" config={dark} />
+      </div>
+    </div>
+  );
+}

--- a/apps/apollo-vertex/templates/dashboard/DashboardLoading.tsx
+++ b/apps/apollo-vertex/templates/dashboard/DashboardLoading.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 
 type Phase = "logo" | "skeleton" | "done";
 
@@ -87,15 +87,13 @@ export function DashboardLoading({
   const [phase, setPhase] = useState<Phase>("done");
   const [exiting, setExiting] = useState(false);
 
-  const startSequence = useCallback(() => {
-    setExiting(false);
-    setPhase("logo");
-  }, []);
-
   useEffect(() => {
     if (triggerReplay === 0) return;
-    if (triggerReplay) startSequence();
-  }, [triggerReplay, startSequence]);
+    if (triggerReplay) {
+      setExiting(false);
+      setPhase("logo");
+    }
+  }, [triggerReplay]);
 
   useEffect(() => {
     if (phase === "done") return;

--- a/apps/apollo-vertex/templates/dashboard/DashboardTemplate.tsx
+++ b/apps/apollo-vertex/templates/dashboard/DashboardTemplate.tsx
@@ -43,15 +43,24 @@ const routeTree = dashboardRootRoute.addChildren([
   ]),
 ]);
 
+const BASE_PATHS = {
+  default: "/preview/dashboard/",
+  minimal: "/preview/dashboard-minimal/",
+} as const;
+
+function normalizeEntry(path: string): string {
+  if (path === "/preview/dashboard") return BASE_PATHS.default;
+  if (path === "/preview/dashboard-minimal") return BASE_PATHS.minimal;
+  return path;
+}
+
 function getInitialEntry(
   storageKey: DashboardPreviewPathKey,
   variant?: "minimal",
 ) {
   const stored = localStorage.getItem(storageKey);
-  if (stored) return stored;
-  return variant === "minimal"
-    ? "/preview/dashboard-minimal"
-    : "/preview/dashboard";
+  if (stored) return normalizeEntry(stored);
+  return variant === "minimal" ? BASE_PATHS.minimal : BASE_PATHS.default;
 }
 
 function createDashboardRouter(
@@ -75,7 +84,7 @@ export function DashboardTemplate({ shellVariant }: DashboardTemplateProps) {
 
   useEffect(() => {
     const unsubscribe = router.subscribe("onResolved", ({ toLocation }) => {
-      localStorage.setItem(storageKey, toLocation.pathname);
+      localStorage.setItem(storageKey, normalizeEntry(toLocation.pathname));
     });
     return unsubscribe;
   }, [router, storageKey]);

--- a/apps/apollo-vertex/templates/dashboard/ExpandedInsightContent.tsx
+++ b/apps/apollo-vertex/templates/dashboard/ExpandedInsightContent.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { Badge } from "@/components/ui/badge";
+import type { DrilldownTab } from "./drilldown-tabs";
 
 // --- Sample data ---
 
@@ -157,7 +158,7 @@ function CategoryBreakdown() {
           Category breakdown
         </div>
         <p className="text-xs text-muted-foreground">
-          Where "Wrong size/fit" returns are concentrated
+          {`Where "Wrong size/fit" returns are concentrated`}
         </p>
       </div>
       <div className="space-y-4">
@@ -269,26 +270,13 @@ function Recommendations() {
 
 // --- Exports ---
 
-export type DrilldownTab =
-  | "overview"
-  | "trend"
-  | "categories"
-  | "products"
-  | "actions";
-
-export const drilldownTabs: { key: DrilldownTab; label: string }[] = [
-  { key: "overview", label: "Overview" },
-  { key: "categories", label: "Categories" },
-  { key: "products", label: "Products" },
-  { key: "actions", label: "Actions" },
-];
-
 export function DrilldownTabContent({ tab }: { tab: DrilldownTab }) {
   if (tab === "trend") return <TrendChart data={trendData} />;
   if (tab === "categories") return <CategoryBreakdown />;
   if (tab === "products") return <TopProducts />;
   if (tab === "actions") return <Recommendations />;
-  return null; // "overview" is handled by the original card content
+  // "overview" is handled by the original card content
+  return null;
 }
 
 export function AutopilotPrompts({

--- a/apps/apollo-vertex/templates/dashboard/GlowDevControls.tsx
+++ b/apps/apollo-vertex/templates/dashboard/GlowDevControls.tsx
@@ -1,0 +1,221 @@
+"use client";
+
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import { useRef, useState } from "react";
+import { useDashboardData } from "./dashboard-data-context";
+import { datasetPresets, type DashboardDataset } from "./dashboard-data";
+import { CardsTab, GlowTab, LayoutTab } from "./dev-controls-tabs";
+import type { CardConfig, GlowConfig, LayoutConfig } from "./glow-config";
+
+interface DevControlsProps {
+  glowConfig: GlowConfig;
+  onGlowChange: (config: GlowConfig) => void;
+  cardConfig: CardConfig;
+  onCardChange: (config: CardConfig) => void;
+  layoutConfig: LayoutConfig;
+  onLayoutChange: (config: LayoutConfig) => void;
+}
+
+type Tab = "glow" | "cards" | "layout" | "data";
+
+export function GlowDevControls({
+  glowConfig,
+  onGlowChange,
+  cardConfig,
+  onCardChange,
+  layoutConfig,
+  onLayoutChange,
+}: DevControlsProps) {
+  const [open, setOpen] = useState(false);
+  const [tab, setTab] = useState<Tab>("glow");
+  const { data, setDataset } = useDashboardData();
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [uploadError, setUploadError] = useState("");
+  const [uploadedDatasets, setUploadedDatasets] = useState<DashboardDataset[]>(
+    [],
+  );
+
+  const configMap: Record<Tab, unknown> = {
+    glow: glowConfig,
+    cards: cardConfig,
+    layout: layoutConfig,
+    data: data,
+  };
+  const currentConfig = configMap[tab];
+
+  return (
+    <>
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept=".json"
+        className="hidden"
+        onChange={(e) => {
+          const file = e.target.files?.[0];
+          if (!file) return;
+          setUploadError("");
+          void file.text().then((text) => {
+            try {
+              // oxlint-disable-next-line typescript-eslint(no-unsafe-type-assertion) -- JSON.parse returns untyped data
+              const parsed = JSON.parse(text) as unknown as DashboardDataset;
+              if (!parsed.brandName || !parsed.insightCards) {
+                setUploadError("Invalid format");
+                return;
+              }
+              setUploadedDatasets((prev) => {
+                const exists = prev.some((d) => d.name === parsed.name);
+                return exists
+                  ? prev.map((d) => (d.name === parsed.name ? parsed : d))
+                  : [...prev, parsed];
+              });
+              setDataset(parsed);
+            } catch {
+              setUploadError("Invalid JSON");
+            }
+          });
+          e.target.value = "";
+        }}
+      />
+      <div className="fixed left-0 top-1/2 -translate-y-1/2 z-50 flex">
+        {open && (
+          <div className="w-56 bg-popover border rounded-r-lg shadow-lg max-h-[80vh] overflow-hidden flex flex-col">
+            <div className="flex border-b">
+              <button
+                type="button"
+                onClick={() => setTab("glow")}
+                className={`flex-1 px-2 py-2 text-xs font-medium ${tab === "glow" ? "bg-muted" : ""}`}
+              >
+                Glow
+              </button>
+              <button
+                type="button"
+                onClick={() => setTab("cards")}
+                className={`flex-1 px-2 py-2 text-xs font-medium ${tab === "cards" ? "bg-muted" : ""}`}
+              >
+                Cards
+              </button>
+              <button
+                type="button"
+                onClick={() => setTab("layout")}
+                className={`flex-1 px-2 py-2 text-xs font-medium ${tab === "layout" ? "bg-muted" : ""}`}
+              >
+                Layout
+              </button>
+              <button
+                type="button"
+                onClick={() => setTab("data")}
+                className={`flex-1 px-2 py-2 text-xs font-medium ${tab === "data" ? "bg-muted" : ""}`}
+              >
+                Data
+              </button>
+            </div>
+            <div className="p-3 overflow-y-auto flex-1">
+              {tab === "glow" && (
+                <GlowTab config={glowConfig} onChange={onGlowChange} />
+              )}
+              {tab === "cards" && (
+                <CardsTab config={cardConfig} onChange={onCardChange} />
+              )}
+              {tab === "layout" && (
+                <LayoutTab config={layoutConfig} onChange={onLayoutChange} />
+              )}
+              {tab === "data" && (
+                <div className="space-y-3">
+                  <div className="text-xs font-bold tracking-tight border-b pb-2">
+                    Dataset: {data.name}
+                  </div>
+                  <div>
+                    <div className="text-xs mb-1">Preset</div>
+                    <select
+                      value={
+                        Object.entries(datasetPresets).find(
+                          ([, v]) => v.name === data.name,
+                        )?.[0] ?? `uploaded:${data.name}`
+                      }
+                      onChange={(e) => {
+                        const val = e.target.value;
+                        if (val.startsWith("uploaded:")) {
+                          const name = val.slice("uploaded:".length);
+                          const uploaded = uploadedDatasets.find(
+                            (d) => d.name === name,
+                          );
+                          if (uploaded) setDataset(uploaded);
+                        } else {
+                          const preset = datasetPresets[val];
+                          if (preset) setDataset(preset);
+                        }
+                      }}
+                      className="w-full h-7 rounded border bg-background px-1 text-xs"
+                    >
+                      {Object.entries(datasetPresets).map(([key, val]) => (
+                        <option key={key} value={key}>
+                          {val.name}
+                        </option>
+                      ))}
+                      {uploadedDatasets.map((d) => (
+                        <option
+                          key={`uploaded:${d.name}`}
+                          value={`uploaded:${d.name}`}
+                        >
+                          {d.name} (uploaded)
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+                  <div className="flex gap-2">
+                    <button
+                      type="button"
+                      onClick={() => {
+                        const blob = new Blob([JSON.stringify(data, null, 2)], {
+                          type: "application/json",
+                        });
+                        const url = URL.createObjectURL(blob);
+                        const a = document.createElement("a");
+                        a.href = url;
+                        a.download = `dashboard-${data.name.toLowerCase().replaceAll(/\s+/g, "-")}.json`;
+                        a.click();
+                        URL.revokeObjectURL(url);
+                      }}
+                      className="flex-1 h-7 rounded border bg-background text-xs hover:bg-muted transition-colors"
+                    >
+                      Download
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => fileInputRef.current?.click()}
+                      className="flex-1 h-7 rounded border bg-background text-xs hover:bg-muted transition-colors"
+                    >
+                      Upload
+                    </button>
+                  </div>
+                  {uploadError && (
+                    <div className="text-[10px] text-destructive">
+                      {uploadError}
+                    </div>
+                  )}
+                </div>
+              )}
+              <div className="border-t pt-2 mt-3">
+                <div className="text-xs text-muted-foreground">Config:</div>
+                <pre className="text-[10px] mt-1 bg-muted rounded p-1.5 overflow-x-auto whitespace-pre-wrap break-all">
+                  {JSON.stringify(currentConfig, null, 2)}
+                </pre>
+              </div>
+            </div>
+          </div>
+        )}
+        <button
+          type="button"
+          onClick={() => setOpen(!open)}
+          className="self-center h-8 w-5 bg-popover border rounded-r flex items-center justify-center shadow-md"
+        >
+          {open ? (
+            <ChevronLeft className="size-3" />
+          ) : (
+            <ChevronRight className="size-3" />
+          )}
+        </button>
+      </div>
+    </>
+  );
+}

--- a/apps/apollo-vertex/templates/dashboard/InsightCardInner.tsx
+++ b/apps/apollo-vertex/templates/dashboard/InsightCardInner.tsx
@@ -1,0 +1,290 @@
+"use client";
+
+import { ArrowUpRight, Maximize2, Minimize2 } from "lucide-react";
+import {
+  Card,
+  CardAction,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  cardBgStyle,
+  getInsightCardClasses,
+  type CardConfig,
+  type InsightCardConfig,
+} from "./glow-config";
+import { InsightCardBody } from "./insight-card-renderers";
+import { useDashboardData } from "./dashboard-data-context";
+import { type DrilldownTab, drilldownTabs } from "./drilldown-tabs";
+import {
+  DrilldownTabContent,
+  AutopilotPrompts,
+} from "./ExpandedInsightContent";
+import type { ExpandPhase } from "./InsightGrid";
+
+interface InsightCardInnerProps {
+  cfg: InsightCardConfig;
+  cardIndex: number;
+  shared: string;
+  cards: CardConfig;
+  isExpanding: boolean;
+  isThis: boolean;
+  phase: ExpandPhase;
+  viewMode: "desktop" | "compact" | "stacked";
+  drilldownTab: DrilldownTab;
+  onDrilldownTabChange: (tab: DrilldownTab) => void;
+  onExpandClick: () => void;
+  onAutopilotOpen?: (() => void) | null;
+  isAutopilotActive?: boolean;
+  className?: string;
+  style?: React.CSSProperties;
+}
+
+export function InsightCardInner({
+  cfg,
+  cardIndex,
+  shared,
+  cards,
+  isExpanding,
+  isThis,
+  phase,
+  viewMode,
+  onExpandClick,
+  onAutopilotOpen,
+  drilldownTab,
+  onDrilldownTabChange,
+  isAutopilotActive = false,
+  className = "",
+  style,
+}: InsightCardInnerProps) {
+  const { data } = useDashboardData();
+  const cardTitle = data.insightCards[cardIndex]?.title ?? cfg.content.title;
+  const hasDrilldown = cfg.content.chartType === "horizontal-bars";
+  const isExpandedWithDrilldown =
+    isThis && isExpanding && hasDrilldown && phase === "full";
+  const classes = getInsightCardClasses(cfg.content, viewMode);
+  const isInteractive = cfg.interaction !== "static";
+
+  return (
+    <Card
+      variant="glass"
+      className={`${(isThis && isExpanding) || isAutopilotActive ? "!bg-white dark:!bg-card !shadow-[0_2px_24px_2px_rgba(0,0,0,0.08)] dark:!shadow-[0_2px_24px_2px_rgba(0,0,0,0.2)]" : "!bg-white/70"} ${shared} ${classes.cardClassName} group/card relative transition-all duration-300 ease-in-out overflow-hidden ${className}`}
+      style={{
+        ...cardBgStyle(
+          cards.insightBg,
+          cards.insightOpacity,
+          cards.insightGradient,
+        ),
+        ...style,
+      }}
+    >
+      <CardHeader className="shrink-0">
+        <CardTitle className="text-sm font-bold tracking-tight">
+          {cardTitle}
+        </CardTitle>
+        {isInteractive && cfg.interaction === "expand" && (
+          <CardAction>
+            <div
+              className={`flex items-center gap-1 transition-all duration-75 ${
+                isThis || isAutopilotActive
+                  ? "opacity-100 translate-x-0"
+                  : "opacity-0 translate-x-2 group-hover/card:opacity-100 group-hover/card:translate-x-0"
+              }`}
+            >
+              {onAutopilotOpen && (
+                <button
+                  type="button"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onAutopilotOpen();
+                  }}
+                  className={`size-7 rounded-md flex items-center justify-center transition-all ${
+                    isAutopilotActive
+                      ? "bg-gradient-to-br from-insight-500 to-primary-400 text-white"
+                      : "text-muted-foreground hover:text-foreground hover:bg-muted/50"
+                  }`}
+                >
+                  {isAutopilotActive ? (
+                    <img
+                      src="/Autopilot_light.svg"
+                      alt="Autopilot"
+                      className="size-4"
+                    />
+                  ) : (
+                    <>
+                      <img
+                        src="/Autopilot_dark.svg"
+                        alt="Autopilot"
+                        className="size-4 block dark:hidden"
+                      />
+                      <img
+                        src="/Autopilot_light.svg"
+                        alt="Autopilot"
+                        className="size-4 hidden dark:block"
+                      />
+                    </>
+                  )}
+                </button>
+              )}
+              <button
+                type="button"
+                onClick={onExpandClick}
+                className="size-7 rounded-md flex items-center justify-center text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-all"
+              >
+                {isThis && isExpanding ? (
+                  <Minimize2 className="size-4" />
+                ) : (
+                  <Maximize2 className="size-4" />
+                )}
+              </button>
+            </div>
+          </CardAction>
+        )}
+        {isInteractive && cfg.interaction === "navigate" && !isThis && (
+          <CardAction>
+            <button
+              type="button"
+              className="size-7 rounded-md flex items-center justify-center opacity-0 translate-x-2 group-hover/card:opacity-100 group-hover/card:translate-x-0 transition-all duration-75 text-muted-foreground hover:text-foreground hover:bg-muted/50"
+            >
+              <ArrowUpRight className="size-4" />
+            </button>
+          </CardAction>
+        )}
+        {/* Drilldown tabs — below title when expanded */}
+        {isThis &&
+          isExpanding &&
+          hasDrilldown &&
+          (phase === "height" || phase === "full") &&
+          (() => {
+            const visibleTabs = drilldownTabs.slice(0, 4);
+            const overflowTabs = drilldownTabs.slice(4);
+            const isOverflowActive = overflowTabs.some(
+              (t) => t.key === drilldownTab,
+            );
+            return (
+              <div
+                className={`flex gap-0.5 items-center transition-opacity duration-300 mt-3 mb-1 -ml-2 ${phase === "full" ? "opacity-100" : "opacity-0"}`}
+              >
+                {visibleTabs.map((tab) => (
+                  <button
+                    key={tab.key}
+                    type="button"
+                    onClick={() => onDrilldownTabChange(tab.key)}
+                    className={`px-2 py-1 text-xs rounded transition-colors font-medium ${
+                      drilldownTab === tab.key
+                        ? "bg-muted dark:bg-foreground/15"
+                        : "text-muted-foreground hover:text-foreground hover:bg-muted dark:hover:bg-foreground/15"
+                    }`}
+                  >
+                    {tab.label}
+                  </button>
+                ))}
+                {overflowTabs.length > 0 && (
+                  <div className="relative">
+                    <select
+                      value={isOverflowActive ? drilldownTab : ""}
+                      onChange={(e) => {
+                        const tab = drilldownTabs.find(
+                          (t) => t.key === e.target.value,
+                        );
+                        if (tab) onDrilldownTabChange(tab.key);
+                      }}
+                      className={`appearance-none px-2 py-1 text-xs rounded transition-colors cursor-pointer bg-transparent pr-5 ${
+                        isOverflowActive
+                          ? "bg-muted font-medium"
+                          : "font-medium text-muted-foreground hover:text-foreground hover:bg-muted/50"
+                      }`}
+                    >
+                      {!isOverflowActive && <option value="">More…</option>}
+                      {overflowTabs.map((tab) => (
+                        <option key={tab.key} value={tab.key}>
+                          {tab.label}
+                        </option>
+                      ))}
+                    </select>
+                    <svg
+                      className="absolute right-1 top-1/2 -translate-y-1/2 size-3 text-muted-foreground pointer-events-none"
+                      viewBox="0 0 12 12"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="2"
+                    >
+                      <path d="M3 5l3 3 3-3" />
+                    </svg>
+                  </div>
+                )}
+              </div>
+            );
+          })()}
+      </CardHeader>
+      {isExpandedWithDrilldown ? (
+        /* Expanded with drilldown — unified layout for all tabs */
+        <div className="flex-1 min-h-0 flex flex-col px-6 !-mt-2">
+          <div className="flex-1 min-h-0 relative">
+            <div
+              className="absolute inset-0 overflow-y-auto pb-8"
+              style={{
+                maskImage:
+                  "linear-gradient(to bottom, black 85%, transparent 100%)",
+              }}
+            >
+              {drilldownTab === "overview" ? (
+                <InsightCardBody
+                  content={cfg.content}
+                  cardIndex={cardIndex}
+                  viewMode={viewMode}
+                  isExpanded={isThis && isExpanding}
+                />
+              ) : (
+                <DrilldownTabContent tab={drilldownTab} />
+              )}
+            </div>
+          </div>
+          <div className="shrink-0 pb-2">
+            <AutopilotPrompts onPromptSelect={() => onAutopilotOpen?.()} />
+          </div>
+        </div>
+      ) : (
+        /* Default card content — not expanded or no drilldown */
+        <CardContent className={`${classes.contentClassName} !flex-1 min-h-0`}>
+          <InsightCardBody
+            content={cfg.content}
+            cardIndex={cardIndex}
+            viewMode={viewMode}
+            isExpanded={isThis && isExpanding}
+          />
+        </CardContent>
+      )}
+      {/* Non-drilldown expanded content (other card types) */}
+      {isThis &&
+        isExpanding &&
+        !hasDrilldown &&
+        (phase === "height" || phase === "full") && (
+          <div
+            className={`flex-1 mx-6 mb-6 rounded-lg overflow-hidden transition-all duration-300 ${
+              phase === "full"
+                ? "opacity-100 translate-y-0"
+                : "opacity-0 translate-y-2"
+            }`}
+          >
+            {phase === "full" ? (
+              <div className="h-full border border-dashed border-muted-foreground/15 bg-muted/30 rounded-lg flex items-center justify-center">
+                <span className="text-xs text-muted-foreground/40">
+                  Additional content
+                </span>
+              </div>
+            ) : (
+              <div className="h-full space-y-3 p-4">
+                <div className="h-3 w-2/3 rounded-full bg-muted/50 animate-pulse" />
+                <div className="h-3 w-1/2 rounded-full bg-muted/50 animate-pulse" />
+                <div className="h-3 w-3/4 rounded-full bg-muted/50 animate-pulse" />
+              </div>
+            )}
+          </div>
+        )}
+    </Card>
+  );
+}
+
+export type { InsightCardInnerProps };

--- a/apps/apollo-vertex/templates/dashboard/InsightGrid.tsx
+++ b/apps/apollo-vertex/templates/dashboard/InsightGrid.tsx
@@ -1,293 +1,18 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { ArrowUpRight, Maximize2, Minimize2 } from "lucide-react";
-import { Card, CardAction, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { useDashboardData } from "./dashboard-data-context";
+import type { DrilldownTab } from "./drilldown-tabs";
 import {
-  cardBgStyle,
-  getInsightCardClasses,
-  type CardConfig,
-  type InsightCardConfig,
-  type LayoutConfig,
-} from "./glow-config";
-import { InsightCardBody } from "./insight-card-renderers";
-import { useDashboardData } from "./DashboardDataProvider";
-import {
-  type DrilldownTab,
-  drilldownTabs,
-  DrilldownTabContent,
   AutopilotPrompts,
+  DrilldownTabContent,
 } from "./ExpandedInsightContent";
+import type { CardConfig, LayoutConfig } from "./glow-config";
+import { InsightCardInner } from "./InsightCardInner";
+
+export type ExpandPhase = "idle" | "width" | "height" | "full";
 
 const sizeToFr: Record<string, string> = { sm: "1fr", md: "2fr", lg: "1fr" };
-
-// --- Shared card inner content ---
-
-interface InsightCardInnerProps {
-  cfg: InsightCardConfig;
-  cardIndex: number;
-  shared: string;
-  cards: CardConfig;
-  isExpanding: boolean;
-  isThis: boolean;
-  phase: ExpandPhase;
-  viewMode: "desktop" | "compact" | "stacked";
-  drilldownTab: DrilldownTab;
-  onDrilldownTabChange: (tab: DrilldownTab) => void;
-  onExpandClick: () => void;
-  onAutopilotOpen?: () => void;
-  isAutopilotActive?: boolean;
-  className?: string;
-  style?: React.CSSProperties;
-}
-
-function InsightCardInner({
-  cfg,
-  cardIndex,
-  shared,
-  cards,
-  isExpanding,
-  isThis,
-  phase,
-  viewMode,
-  onExpandClick,
-  onAutopilotOpen,
-  drilldownTab,
-  onDrilldownTabChange,
-  isAutopilotActive = false,
-  className = "",
-  style,
-}: InsightCardInnerProps) {
-  const { data } = useDashboardData();
-  const cardTitle = data.insightCards[cardIndex]?.title ?? cfg.content.title;
-  const hasDrilldown = cfg.content.chartType === "horizontal-bars";
-  const isExpandedWithDrilldown =
-    isThis && isExpanding && hasDrilldown && phase === "full";
-  const classes = getInsightCardClasses(cfg.content, viewMode);
-  const isInteractive = cfg.interaction !== "static";
-
-  return (
-    <Card
-      variant="glass"
-      className={`${(isThis && isExpanding) || isAutopilotActive ? "!bg-white dark:!bg-card !shadow-[0_2px_24px_2px_rgba(0,0,0,0.08)] dark:!shadow-[0_2px_24px_2px_rgba(0,0,0,0.2)]" : "!bg-white/70"} ${shared} ${classes.cardClassName} group/card relative transition-all duration-300 ease-in-out overflow-hidden ${className}`}
-      style={{
-        ...cardBgStyle(
-          cards.insightBg,
-          cards.insightOpacity,
-          cards.insightGradient,
-        ),
-        ...style,
-      }}
-    >
-      <CardHeader className="shrink-0">
-        <CardTitle className="text-sm font-bold tracking-tight">
-          {cardTitle}
-        </CardTitle>
-        {isInteractive && cfg.interaction === "expand" && (
-          <CardAction>
-            <div
-              className={`flex items-center gap-1 transition-all duration-75 ${
-                isThis || isAutopilotActive
-                  ? "opacity-100 translate-x-0"
-                  : "opacity-0 translate-x-2 group-hover/card:opacity-100 group-hover/card:translate-x-0"
-              }`}
-            >
-              {onAutopilotOpen && (
-                <button
-                  type="button"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    onAutopilotOpen();
-                  }}
-                  className={`size-7 rounded-md flex items-center justify-center transition-all ${
-                    isAutopilotActive
-                      ? "bg-gradient-to-br from-insight-500 to-primary-400 text-white"
-                      : "text-muted-foreground hover:text-foreground hover:bg-muted/50"
-                  }`}
-                >
-                  {isAutopilotActive ? (
-                    <img
-                      src="/Autopilot_light.svg"
-                      alt="Autopilot"
-                      className="size-4"
-                    />
-                  ) : (
-                    <>
-                      <img
-                        src="/Autopilot_dark.svg"
-                        alt="Autopilot"
-                        className="size-4 block dark:hidden"
-                      />
-                      <img
-                        src="/Autopilot_light.svg"
-                        alt="Autopilot"
-                        className="size-4 hidden dark:block"
-                      />
-                    </>
-                  )}
-                </button>
-              )}
-              <button
-                type="button"
-                onClick={onExpandClick}
-                className="size-7 rounded-md flex items-center justify-center text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-all"
-              >
-                {isThis && isExpanding ? (
-                  <Minimize2 className="size-4" />
-                ) : (
-                  <Maximize2 className="size-4" />
-                )}
-              </button>
-            </div>
-          </CardAction>
-        )}
-        {isInteractive && cfg.interaction === "navigate" && !isThis && (
-          <CardAction>
-            <button
-              type="button"
-              className="size-7 rounded-md flex items-center justify-center opacity-0 translate-x-2 group-hover/card:opacity-100 group-hover/card:translate-x-0 transition-all duration-75 text-muted-foreground hover:text-foreground hover:bg-muted/50"
-            >
-              <ArrowUpRight className="size-4" />
-            </button>
-          </CardAction>
-        )}
-        {/* Drilldown tabs — below title when expanded */}
-        {isThis &&
-          isExpanding &&
-          hasDrilldown &&
-          (phase === "height" || phase === "full") &&
-          (() => {
-            const visibleTabs = drilldownTabs.slice(0, 4);
-            const overflowTabs = drilldownTabs.slice(4);
-            const isOverflowActive = overflowTabs.some(
-              (t) => t.key === drilldownTab,
-            );
-            return (
-              <div
-                className={`flex gap-0.5 items-center transition-opacity duration-300 mt-3 mb-1 -ml-2 ${phase === "full" ? "opacity-100" : "opacity-0"}`}
-              >
-                {visibleTabs.map((tab) => (
-                  <button
-                    key={tab.key}
-                    type="button"
-                    onClick={() => onDrilldownTabChange(tab.key)}
-                    className={`px-2 py-1 text-xs rounded transition-colors font-medium ${
-                      drilldownTab === tab.key
-                        ? "bg-muted dark:bg-foreground/15"
-                        : "text-muted-foreground hover:text-foreground hover:bg-muted dark:hover:bg-foreground/15"
-                    }`}
-                  >
-                    {tab.label}
-                  </button>
-                ))}
-                {overflowTabs.length > 0 && (
-                  <div className="relative">
-                    <select
-                      value={isOverflowActive ? drilldownTab : ""}
-                      onChange={(e) => {
-                        if (e.target.value)
-                          onDrilldownTabChange(e.target.value as DrilldownTab);
-                      }}
-                      className={`appearance-none px-2 py-1 text-xs rounded transition-colors cursor-pointer bg-transparent pr-5 ${
-                        isOverflowActive
-                          ? "bg-muted font-medium"
-                          : "font-medium text-muted-foreground hover:text-foreground hover:bg-muted/50"
-                      }`}
-                    >
-                      {!isOverflowActive && <option value="">More…</option>}
-                      {overflowTabs.map((tab) => (
-                        <option key={tab.key} value={tab.key}>
-                          {tab.label}
-                        </option>
-                      ))}
-                    </select>
-                    <svg
-                      className="absolute right-1 top-1/2 -translate-y-1/2 size-3 text-muted-foreground pointer-events-none"
-                      viewBox="0 0 12 12"
-                      fill="none"
-                      stroke="currentColor"
-                      strokeWidth="2"
-                    >
-                      <path d="M3 5l3 3 3-3" />
-                    </svg>
-                  </div>
-                )}
-              </div>
-            );
-          })()}
-      </CardHeader>
-      {isExpandedWithDrilldown ? (
-        /* Expanded with drilldown — unified layout for all tabs */
-        <div className="flex-1 min-h-0 flex flex-col px-6 !-mt-2">
-          <div className="flex-1 min-h-0 relative">
-            <div
-              className="absolute inset-0 overflow-y-auto pb-8"
-              style={{
-                maskImage:
-                  "linear-gradient(to bottom, black 85%, transparent 100%)",
-              }}
-            >
-              {drilldownTab === "overview" ? (
-                <InsightCardBody
-                  content={cfg.content}
-                  cardIndex={cardIndex}
-                  viewMode={viewMode}
-                  isExpanded={isThis && isExpanding}
-                />
-              ) : (
-                <DrilldownTabContent tab={drilldownTab} />
-              )}
-            </div>
-          </div>
-          <div className="shrink-0 pb-2">
-            <AutopilotPrompts onPromptSelect={() => onAutopilotOpen?.()} />
-          </div>
-        </div>
-      ) : (
-        /* Default card content — not expanded or no drilldown */
-        <CardContent className={`${classes.contentClassName} !flex-1 min-h-0`}>
-          <InsightCardBody
-            content={cfg.content}
-            cardIndex={cardIndex}
-            viewMode={viewMode}
-            isExpanded={isThis && isExpanding}
-          />
-        </CardContent>
-      )}
-      {/* Non-drilldown expanded content (other card types) */}
-      {isThis &&
-        isExpanding &&
-        !hasDrilldown &&
-        (phase === "height" || phase === "full") && (
-          <div
-            className={`flex-1 mx-6 mb-6 rounded-lg overflow-hidden transition-all duration-300 ${
-              phase === "full"
-                ? "opacity-100 translate-y-0"
-                : "opacity-0 translate-y-2"
-            }`}
-          >
-            {phase === "full" ? (
-              <div className="h-full border border-dashed border-muted-foreground/15 bg-muted/30 rounded-lg flex items-center justify-center">
-                <span className="text-xs text-muted-foreground/40">
-                  Additional content
-                </span>
-              </div>
-            ) : (
-              <div className="h-full space-y-3 p-4">
-                <div className="h-3 w-2/3 rounded-full bg-muted/50 animate-pulse" />
-                <div className="h-3 w-1/2 rounded-full bg-muted/50 animate-pulse" />
-                <div className="h-3 w-3/4 rounded-full bg-muted/50 animate-pulse" />
-              </div>
-            )}
-          </div>
-        )}
-    </Card>
-  );
-}
-
-// --- Main grid ---
-
-type ExpandPhase = "idle" | "width" | "height" | "full";
 
 export function InsightGrid({
   layout,
@@ -351,7 +76,10 @@ export function InsightGrid({
     ? rows.findIndex((row) => row.some(({ idx }) => idx === expandedIdx))
     : -1;
 
-  const handleClick = (cfg: InsightCardConfig, idx: number) => {
+  const handleClick = (
+    cfg: (typeof visibleCards)[number]["cfg"],
+    idx: number,
+  ) => {
     if (cfg.interaction === "expand") {
       setExpandedIdx(expandedIdx === idx ? null : idx);
     }
@@ -423,7 +151,7 @@ export function InsightGrid({
                             data.insightCards[idx]?.title ?? cfg.content.title,
                             idx,
                           )
-                      : undefined
+                      : null
                   }
                   isAutopilotActive={autopilotActiveIdx === idx}
                   className="h-full"
@@ -487,7 +215,7 @@ export function InsightGrid({
                                   cfg.content.title,
                                 idx,
                               )
-                          : undefined
+                          : null
                       }
                       isAutopilotActive={autopilotActiveIdx === idx}
                       style={{
@@ -506,3 +234,7 @@ export function InsightGrid({
     </div>
   );
 }
+
+// Re-export for consumers that import these from InsightGrid
+export { DrilldownTabContent, AutopilotPrompts };
+export type { DrilldownTab };

--- a/apps/apollo-vertex/templates/dashboard/PromptBar.tsx
+++ b/apps/apollo-vertex/templates/dashboard/PromptBar.tsx
@@ -3,27 +3,8 @@
 import { useState } from "react";
 import { MessagesSquare, Minimize2 } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
-import type { CardConfig, CardGradient } from "./glow-config";
-import { useDashboardData } from "./DashboardDataProvider";
-
-function cardBgStyle(
-  bg: string,
-  opacity: number,
-  gradient: CardGradient,
-): React.CSSProperties {
-  if (gradient.enabled) {
-    const alpha = gradient.opacity / 100;
-    return {
-      "--card-bg-override": `linear-gradient(${gradient.angle}deg, color-mix(in srgb, ${gradient.start} ${alpha * 100}%, transparent), color-mix(in srgb, ${gradient.end} ${alpha * 100}%, transparent))`,
-      borderColor: "transparent",
-    } as React.CSSProperties;
-  }
-  const value =
-    bg === "white"
-      ? `rgba(255,255,255,${opacity / 100})`
-      : `color-mix(in srgb, var(--${bg}) ${opacity}%, transparent)`;
-  return { "--card-bg-override": value } as React.CSSProperties;
-}
+import { cardBgStyle, type CardConfig } from "./glow-config";
+import { useDashboardData } from "./dashboard-data-context";
 
 export function PromptBar({
   shared,
@@ -123,8 +104,7 @@ export function PromptBar({
                 className="!bg-white/35 !text-foreground opacity-0 translate-y-2 group-focus-within:opacity-100 group-focus-within:translate-y-0 transition-all duration-300 delay-75 cursor-pointer"
                 onClick={() =>
                   handleChipClick(
-                    data.promptSuggestions[1] ??
-                      "Compare Q1 vs Q2 performance",
+                    data.promptSuggestions[1] ?? "Compare Q1 vs Q2 performance",
                   )
                 }
               >

--- a/apps/apollo-vertex/templates/dashboard/chart-stubs.tsx
+++ b/apps/apollo-vertex/templates/dashboard/chart-stubs.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+const sparklinePoints = [4, 7, 5, 9, 6, 8, 12, 10, 14, 11, 15, 13];
+const areaPoints = [3, 5, 4, 8, 6, 9, 7, 11, 10, 14, 12, 16];
+
+export function DonutContent() {
+  return (
+    <div className="flex items-center justify-center flex-1">
+      <div className="relative size-3/4 aspect-square">
+        <svg viewBox="0 0 36 36" className="size-full -rotate-90">
+          <circle
+            cx="18"
+            cy="18"
+            r="15.5"
+            fill="none"
+            className="stroke-muted"
+            strokeWidth="2"
+          />
+          <circle
+            cx="18"
+            cy="18"
+            r="15.5"
+            fill="none"
+            className="stroke-chart-1"
+            strokeWidth="2"
+            strokeDasharray="97.39"
+            strokeDashoffset={97.39 * (1 - 0.47)}
+            strokeLinecap="round"
+          />
+        </svg>
+        <div className="absolute inset-0 flex flex-col items-center justify-center">
+          <span className="text-2xl font-normal tracking-tight leading-none">
+            47%
+          </span>
+          <span className="text-[10px] text-muted-foreground mt-0.5">
+            funded
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function SparklineContent() {
+  const max = Math.max(...sparklinePoints);
+  const h = 40;
+  const w = 120;
+  const step = w / (sparklinePoints.length - 1);
+  const points = sparklinePoints
+    .map((v, i) => `${i * step},${h - (v / max) * h}`)
+    .join(" ");
+
+  return (
+    <div className="flex items-center justify-center flex-1">
+      <svg viewBox={`0 0 ${w} ${h}`} className="w-full h-16" fill="none">
+        <polyline
+          points={points}
+          className="stroke-chart-1"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          fill="none"
+        />
+      </svg>
+    </div>
+  );
+}
+
+export function AreaContent() {
+  const max = Math.max(...areaPoints);
+  const h = 40;
+  const w = 120;
+  const step = w / (areaPoints.length - 1);
+  const linePoints = areaPoints
+    .map((v, i) => `${i * step},${h - (v / max) * h}`)
+    .join(" ");
+  const areaPath = `0,${h} ${linePoints} ${w},${h}`;
+
+  return (
+    <div className="flex items-center justify-center flex-1">
+      <svg viewBox={`0 0 ${w} ${h}`} className="w-full h-16" fill="none">
+        <polygon points={areaPath} className="fill-chart-1/20" />
+        <polyline
+          points={linePoints}
+          className="stroke-chart-1"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          fill="none"
+        />
+      </svg>
+    </div>
+  );
+}

--- a/apps/apollo-vertex/templates/dashboard/dashboard-data-context.ts
+++ b/apps/apollo-vertex/templates/dashboard/dashboard-data-context.ts
@@ -1,0 +1,22 @@
+"use client";
+
+import { createContext, useContext } from "react";
+import { ecommerceDataset, type DashboardDataset } from "./dashboard-data";
+
+export interface DashboardDataContextValue {
+  data: DashboardDataset;
+  setDataset: (data: DashboardDataset) => void;
+}
+
+export const DashboardDataContext = createContext<DashboardDataContextValue>({
+  data: ecommerceDataset,
+  setDataset: () => {
+    throw new Error(
+      "useDashboardData must be used within DashboardDataProvider",
+    );
+  },
+});
+
+export function useDashboardData() {
+  return useContext(DashboardDataContext);
+}

--- a/apps/apollo-vertex/templates/dashboard/dev-controls-primitives.tsx
+++ b/apps/apollo-vertex/templates/dashboard/dev-controls-primitives.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+export function Slider({
+  label,
+  value,
+  min,
+  max,
+  step,
+  onChange,
+  displayValue,
+}: {
+  label: string;
+  value: number;
+  min: number;
+  max: number;
+  step: number;
+  onChange: (v: number) => void;
+  displayValue?: string;
+}) {
+  return (
+    <div>
+      <div className="flex justify-between text-xs mb-1">
+        <span>{label}</span>
+        <span className="text-muted-foreground">{displayValue ?? value}</span>
+      </div>
+      <input
+        type="range"
+        min={min}
+        max={max}
+        step={step}
+        value={value}
+        onChange={(e) => onChange(Number(e.target.value))}
+        className="w-full h-1 accent-primary"
+      />
+    </div>
+  );
+}
+
+export function SelectControl({
+  label,
+  value,
+  options,
+  onChange,
+}: {
+  label: string;
+  value: string;
+  options: { label: string; value: string }[];
+  onChange: (v: string) => void;
+}) {
+  return (
+    <div>
+      <div className="text-xs mb-1">{label}</div>
+      <select
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        className="w-full h-7 rounded border bg-background px-1 text-xs"
+      >
+        {options.map((opt) => (
+          <option key={opt.value} value={opt.value}>
+            {opt.label}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+}
+
+export function Toggle({
+  label,
+  checked,
+  onChange,
+}: {
+  label: string;
+  checked: boolean;
+  onChange: (v: boolean) => void;
+}) {
+  return (
+    <label className="flex items-center justify-between text-xs">
+      <span>{label}</span>
+      <input
+        type="checkbox"
+        checked={checked}
+        onChange={(e) => onChange(e.target.checked)}
+        className="accent-primary"
+      />
+    </label>
+  );
+}
+
+export function TextInput({
+  label,
+  value,
+  onChange,
+  placeholder,
+}: {
+  label: string;
+  value: string;
+  onChange: (v: string) => void;
+  placeholder?: string;
+}) {
+  return (
+    <div>
+      <div className="text-xs mb-1">{label}</div>
+      <input
+        type="text"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        className="w-full h-7 rounded border bg-background px-1 text-xs"
+        placeholder={placeholder}
+      />
+    </div>
+  );
+}

--- a/apps/apollo-vertex/templates/dashboard/dev-controls-tabs.tsx
+++ b/apps/apollo-vertex/templates/dashboard/dev-controls-tabs.tsx
@@ -1,0 +1,396 @@
+"use client";
+
+import {
+  SelectControl,
+  Slider,
+  TextInput,
+  Toggle,
+} from "./dev-controls-primitives";
+import {
+  bgColorOptions,
+  cardTypeOptions,
+  chartTypeOptions,
+  containerBgOptions,
+  insightOptions,
+  interactionOptions,
+  isCardInteraction,
+  isCardSize,
+  isChartType,
+  isInsightCardType,
+  primaryOptions,
+  sizeOptions,
+  type CardConfig,
+  type CardGradient,
+  type GlowConfig,
+  type InsightCardConfig,
+  type LayoutConfig,
+} from "./glow-config";
+
+function GradientSection({
+  gradient,
+  onChange,
+}: {
+  gradient: CardGradient;
+  onChange: (g: CardGradient) => void;
+}) {
+  const update = (partial: Partial<CardGradient>) =>
+    onChange({ ...gradient, ...partial });
+
+  return (
+    <div className="space-y-2 pl-2 border-l border-muted">
+      <Toggle
+        label="Gradient"
+        checked={gradient.enabled}
+        onChange={(v) => update({ enabled: v })}
+      />
+      {gradient.enabled && (
+        <>
+          <SelectControl
+            label="Start (Insight)"
+            value={gradient.start}
+            options={insightOptions}
+            onChange={(v) => update({ start: v })}
+          />
+          <SelectControl
+            label="End (Primary)"
+            value={gradient.end}
+            options={primaryOptions}
+            onChange={(v) => update({ end: v })}
+          />
+          <Slider
+            label="Angle"
+            value={gradient.angle}
+            min={0}
+            max={360}
+            step={15}
+            onChange={(v) => update({ angle: v })}
+            displayValue={`${gradient.angle}°`}
+          />
+          <Slider
+            label="Opacity"
+            value={gradient.opacity}
+            min={0}
+            max={100}
+            step={5}
+            onChange={(v) => update({ opacity: v })}
+            displayValue={`${gradient.opacity}%`}
+          />
+        </>
+      )}
+    </div>
+  );
+}
+
+export function GlowTab({
+  config,
+  onChange,
+}: {
+  config: GlowConfig;
+  onChange: (c: GlowConfig) => void;
+}) {
+  const update = (partial: Partial<GlowConfig>) =>
+    onChange({ ...config, ...partial });
+
+  return (
+    <div className="space-y-3">
+      <SelectControl
+        label="Start (Insight)"
+        value={config.start}
+        options={insightOptions}
+        onChange={(v) => update({ start: v })}
+      />
+      <SelectControl
+        label="End (Primary)"
+        value={config.end}
+        options={primaryOptions}
+        onChange={(v) => update({ end: v })}
+      />
+      <Slider
+        label="Container Opacity"
+        value={config.containerOpacity}
+        min={0}
+        max={100}
+        step={5}
+        onChange={(v) => update({ containerOpacity: v })}
+        displayValue={`${config.containerOpacity}%`}
+      />
+      <Slider
+        label="Fill Opacity"
+        value={config.fillOpacity}
+        min={0}
+        max={1}
+        step={0.05}
+        onChange={(v) => update({ fillOpacity: v })}
+      />
+      <Slider
+        label="Start Stop Opacity"
+        value={config.startStopOpacity}
+        min={0}
+        max={1}
+        step={0.05}
+        onChange={(v) => update({ startStopOpacity: v })}
+      />
+      <Slider
+        label="End Stop Opacity"
+        value={config.endStopOpacity}
+        min={0}
+        max={1}
+        step={0.05}
+        onChange={(v) => update({ endStopOpacity: v })}
+      />
+      <Slider
+        label="End Offset"
+        value={config.endOffset}
+        min={0}
+        max={1}
+        step={0.05}
+        onChange={(v) => update({ endOffset: v })}
+      />
+    </div>
+  );
+}
+
+export function CardsTab({
+  config,
+  onChange,
+}: {
+  config: CardConfig;
+  onChange: (c: CardConfig) => void;
+}) {
+  const update = (partial: Partial<CardConfig>) =>
+    onChange({ ...config, ...partial });
+
+  return (
+    <div className="space-y-3">
+      <div className="text-xs font-medium border-b pb-1">Overview Card</div>
+      <SelectControl
+        label="Background"
+        value={config.overviewBg}
+        options={bgColorOptions}
+        onChange={(v) => update({ overviewBg: v })}
+      />
+      <Slider
+        label="Opacity"
+        value={config.overviewOpacity}
+        min={0}
+        max={100}
+        step={1}
+        onChange={(v) => update({ overviewOpacity: v })}
+        displayValue={`${config.overviewOpacity}%`}
+      />
+      <GradientSection
+        gradient={config.overviewGradient}
+        onChange={(g) => update({ overviewGradient: g })}
+      />
+
+      <div className="text-xs font-medium border-b pb-1 pt-1">
+        Insight Cards
+      </div>
+      <SelectControl
+        label="Background"
+        value={config.insightBg}
+        options={bgColorOptions}
+        onChange={(v) => update({ insightBg: v })}
+      />
+      <Slider
+        label="Opacity"
+        value={config.insightOpacity}
+        min={0}
+        max={100}
+        step={1}
+        onChange={(v) => update({ insightOpacity: v })}
+        displayValue={`${config.insightOpacity}%`}
+      />
+      <GradientSection
+        gradient={config.insightGradient}
+        onChange={(g) => update({ insightGradient: g })}
+      />
+
+      <div className="text-xs font-medium border-b pb-1 pt-1">Prompt Bar</div>
+      <SelectControl
+        label="Background"
+        value={config.promptBg}
+        options={bgColorOptions}
+        onChange={(v) => update({ promptBg: v })}
+      />
+      <Slider
+        label="Opacity"
+        value={config.promptOpacity}
+        min={0}
+        max={100}
+        step={1}
+        onChange={(v) => update({ promptOpacity: v })}
+        displayValue={`${config.promptOpacity}%`}
+      />
+      <GradientSection
+        gradient={config.promptGradient}
+        onChange={(g) => update({ promptGradient: g })}
+      />
+
+      <div className="text-xs font-medium border-b pb-1 pt-1">Shared</div>
+      <Toggle
+        label="Borders"
+        checked={config.borderVisible}
+        onChange={(v) => update({ borderVisible: v })}
+      />
+      <Toggle
+        label="Backdrop Blur"
+        checked={config.backdropBlur}
+        onChange={(v) => update({ backdropBlur: v })}
+      />
+    </div>
+  );
+}
+
+export function LayoutTab({
+  config,
+  onChange,
+}: {
+  config: LayoutConfig;
+  onChange: (c: LayoutConfig) => void;
+}) {
+  const update = (partial: Partial<LayoutConfig>) =>
+    onChange({ ...config, ...partial });
+
+  const updateInsightCard = (
+    index: number,
+    partial: Partial<InsightCardConfig>,
+  ) => {
+    const cards = [...config.insightCards] as [
+      InsightCardConfig,
+      InsightCardConfig,
+      InsightCardConfig,
+      InsightCardConfig,
+    ];
+    cards[index] = { ...cards[index], ...partial };
+    update({ insightCards: cards });
+  };
+
+  return (
+    <div className="space-y-3">
+      <SelectControl
+        label="Container Background"
+        value={config.containerBg}
+        options={containerBgOptions}
+        onChange={(v) => update({ containerBg: v })}
+      />
+      <Slider
+        label="Gap (px)"
+        value={config.gap}
+        min={0}
+        max={24}
+        step={1}
+        onChange={(v) => update({ gap: v })}
+        displayValue={`${config.gap}px`}
+      />
+      <Slider
+        label="Padding (px)"
+        value={config.padding}
+        min={0}
+        max={48}
+        step={4}
+        onChange={(v) => update({ padding: v })}
+        displayValue={`${config.padding}px`}
+      />
+      <div className="text-xs font-medium border-b pb-1 pt-1">Left Column</div>
+      <Slider
+        label="Overview Ratio"
+        value={config.overviewRatio}
+        min={1}
+        max={8}
+        step={1}
+        onChange={(v) => update({ overviewRatio: v })}
+      />
+      <Slider
+        label="Prompt Ratio"
+        value={config.promptRatio}
+        min={1}
+        max={4}
+        step={1}
+        onChange={(v) => update({ promptRatio: v })}
+      />
+      <div className="text-xs font-medium border-b pb-1 pt-1">
+        Insight Cards
+      </div>
+      {["Top Left", "Top Right", "Bottom Left", "Bottom Right"].map(
+        (label, i) => (
+          <div key={label} className="space-y-1 pb-2 border-b border-muted">
+            <div className="flex items-center justify-between">
+              <span className="text-xs font-medium">{label}</span>
+              <Toggle
+                label=""
+                checked={config.insightCards[i].visible}
+                onChange={(v) => updateInsightCard(i, { visible: v })}
+              />
+            </div>
+            {config.insightCards[i].visible && (
+              <>
+                <SelectControl
+                  label="Size"
+                  value={config.insightCards[i].size}
+                  options={sizeOptions}
+                  onChange={(v) => {
+                    if (isCardSize(v)) updateInsightCard(i, { size: v });
+                  }}
+                />
+                <SelectControl
+                  label="Type"
+                  value={config.insightCards[i].content.type}
+                  options={cardTypeOptions}
+                  onChange={(v) => {
+                    if (isInsightCardType(v))
+                      updateInsightCard(i, {
+                        content: { ...config.insightCards[i].content, type: v },
+                      });
+                  }}
+                />
+                {config.insightCards[i].content.type === "chart" && (
+                  <SelectControl
+                    label="Chart"
+                    value={config.insightCards[i].content.chartType}
+                    options={chartTypeOptions}
+                    onChange={(v) => {
+                      if (isChartType(v))
+                        updateInsightCard(i, {
+                          content: {
+                            ...config.insightCards[i].content,
+                            chartType: v,
+                          },
+                        });
+                    }}
+                  />
+                )}
+                <TextInput
+                  label="Title"
+                  value={config.insightCards[i].content.title}
+                  onChange={(v) =>
+                    updateInsightCard(i, {
+                      content: { ...config.insightCards[i].content, title: v },
+                    })
+                  }
+                />
+                <SelectControl
+                  label="Interaction"
+                  value={config.insightCards[i].interaction}
+                  options={interactionOptions}
+                  onChange={(v) => {
+                    if (isCardInteraction(v))
+                      updateInsightCard(i, { interaction: v });
+                  }}
+                />
+                {config.insightCards[i].interaction === "navigate" && (
+                  <TextInput
+                    label="Navigate to"
+                    value={config.insightCards[i].navigateTo ?? ""}
+                    onChange={(v) => updateInsightCard(i, { navigateTo: v })}
+                    placeholder="/preview/dashboard/..."
+                  />
+                )}
+              </>
+            )}
+          </div>
+        ),
+      )}
+    </div>
+  );
+}

--- a/apps/apollo-vertex/templates/dashboard/drilldown-tabs.ts
+++ b/apps/apollo-vertex/templates/dashboard/drilldown-tabs.ts
@@ -1,0 +1,13 @@
+export type DrilldownTab =
+  | "overview"
+  | "trend"
+  | "categories"
+  | "products"
+  | "actions";
+
+export const drilldownTabs: { key: DrilldownTab; label: string }[] = [
+  { key: "overview", label: "Overview" },
+  { key: "categories", label: "Categories" },
+  { key: "products", label: "Products" },
+  { key: "actions", label: "Actions" },
+];

--- a/apps/apollo-vertex/templates/dashboard/glow-config.ts
+++ b/apps/apollo-vertex/templates/dashboard/glow-config.ts
@@ -1,0 +1,294 @@
+export interface GlowConfig {
+  start: string;
+  end: string;
+  containerOpacity: number;
+  fillOpacity: number;
+  startStopOpacity: number;
+  endStopOpacity: number;
+  endOffset: number;
+}
+
+export interface CardGradient {
+  enabled: boolean;
+  start: string;
+  end: string;
+  angle: number;
+  opacity: number;
+}
+
+export interface CardConfig {
+  overviewBg: string;
+  overviewOpacity: number;
+  overviewGradient: CardGradient;
+  insightBg: string;
+  insightOpacity: number;
+  insightGradient: CardGradient;
+  promptBg: string;
+  promptOpacity: number;
+  promptGradient: CardGradient;
+  borderVisible: boolean;
+  backdropBlur: boolean;
+}
+
+export const defaultLightGlow: GlowConfig = {
+  start: "var(--insight-500)",
+  end: "var(--primary-400)",
+  containerOpacity: 70,
+  fillOpacity: 0.3,
+  startStopOpacity: 1,
+  endStopOpacity: 1,
+  endOffset: 0.35,
+};
+
+export const defaultDarkGlow: GlowConfig = {
+  start: "var(--insight-700)",
+  end: "var(--primary-600)",
+  containerOpacity: 45,
+  fillOpacity: 1,
+  startStopOpacity: 1,
+  endStopOpacity: 0.4,
+  endOffset: 0.5,
+};
+
+export type CardSize = "sm" | "md" | "lg";
+
+export type InsightCardType = "kpi" | "chart";
+export type ChartType =
+  | "donut"
+  | "horizontal-bars"
+  | "sparkline"
+  | "area"
+  | "stacked-bar";
+
+export interface InsightCardContent {
+  type: InsightCardType;
+  chartType: ChartType;
+  title: string;
+}
+
+export type CardInteraction = "static" | "expand" | "navigate";
+
+export interface InsightCardConfig {
+  size: CardSize;
+  visible: boolean;
+  content: InsightCardContent;
+  interaction: CardInteraction;
+  navigateTo?: string;
+}
+
+export interface LayoutConfig {
+  gap: number;
+  overviewRatio: number;
+  promptRatio: number;
+  insightCards: [
+    InsightCardConfig,
+    InsightCardConfig,
+    InsightCardConfig,
+    InsightCardConfig,
+  ];
+  padding: number;
+  containerBg: string;
+}
+
+export const defaultLayout: LayoutConfig = {
+  gap: 4,
+  overviewRatio: 4,
+  promptRatio: 1,
+  insightCards: [
+    {
+      size: "sm",
+      visible: true,
+      interaction: "static",
+      content: {
+        type: "kpi",
+        chartType: "donut",
+        title: "Upfront decision efficiency",
+      },
+    },
+    {
+      size: "md",
+      visible: true,
+      interaction: "expand",
+      content: {
+        type: "chart",
+        chartType: "horizontal-bars",
+        title: "Top issues",
+      },
+    },
+    {
+      size: "md",
+      visible: true,
+      interaction: "expand",
+      content: {
+        type: "chart",
+        chartType: "stacked-bar",
+        title: "Pipeline",
+      },
+    },
+    {
+      size: "sm",
+      visible: true,
+      interaction: "static",
+      content: {
+        type: "kpi",
+        chartType: "donut",
+        title: "SLA compliance",
+      },
+    },
+  ],
+  padding: 24,
+  containerBg: "none",
+};
+
+const defaultGradient: CardGradient = {
+  enabled: false,
+  start: "var(--insight-500)",
+  end: "var(--primary-400)",
+  angle: 135,
+  opacity: 100,
+};
+
+export const insightOptions = [
+  { label: "300", value: "var(--insight-300)" },
+  { label: "400", value: "var(--insight-400)" },
+  { label: "500", value: "var(--insight-500)" },
+  { label: "600", value: "var(--insight-600)" },
+  { label: "700", value: "var(--insight-700)" },
+  { label: "800", value: "var(--insight-800)" },
+  { label: "900", value: "var(--insight-900)" },
+];
+
+export const primaryOptions = [
+  { label: "300", value: "var(--primary-300)" },
+  { label: "400", value: "var(--primary-400)" },
+  { label: "500", value: "var(--primary-500)" },
+  { label: "600", value: "var(--primary-600)" },
+  { label: "700", value: "var(--primary-700)" },
+  { label: "800", value: "var(--primary-800)" },
+  { label: "900", value: "var(--primary-900)" },
+];
+
+export const cardTypeOptions = [
+  { label: "KPI", value: "kpi" },
+  { label: "Chart", value: "chart" },
+];
+
+export const interactionOptions = [
+  { label: "Static", value: "static" },
+  { label: "Expand", value: "expand" },
+  { label: "Navigate", value: "navigate" },
+];
+
+export const chartTypeOptions = [
+  { label: "Donut", value: "donut" },
+  { label: "Horizontal Bars", value: "horizontal-bars" },
+  { label: "Sparkline", value: "sparkline" },
+  { label: "Area", value: "area" },
+  { label: "Stacked Bar", value: "stacked-bar" },
+];
+
+export const sizeOptions = [
+  { label: "Small (1 col)", value: "sm" },
+  { label: "Medium (1 col)", value: "md" },
+  { label: "Large (full)", value: "lg" },
+];
+
+export const containerBgOptions = [
+  { label: "None", value: "none" },
+  { label: "white", value: "white" },
+  { label: "sidebar", value: "sidebar" },
+  { label: "card", value: "card" },
+  { label: "background", value: "background" },
+  { label: "muted", value: "muted" },
+];
+
+export const bgColorOptions = [
+  { label: "white", value: "white" },
+  { label: "sidebar", value: "sidebar" },
+  { label: "card", value: "card" },
+  { label: "background", value: "background" },
+  { label: "muted", value: "muted" },
+];
+
+export function cardBgStyle(
+  bg: string,
+  opacity: number,
+  gradient: CardGradient,
+): React.CSSProperties {
+  if (gradient.enabled) {
+    const alpha = gradient.opacity / 100;
+    const style = {
+      "--card-bg-override": `linear-gradient(${gradient.angle}deg, color-mix(in srgb, ${gradient.start} ${alpha * 100}%, transparent), color-mix(in srgb, ${gradient.end} ${alpha * 100}%, transparent))`,
+      borderColor: "transparent",
+    };
+    // oxlint-disable-next-line typescript-eslint(no-unsafe-type-assertion) -- CSS custom properties require assertion
+    return style as unknown as React.CSSProperties;
+  }
+  const value =
+    bg === "white"
+      ? `rgba(255,255,255,${opacity / 100})`
+      : `color-mix(in srgb, var(--${bg}) ${opacity}%, transparent)`;
+  // oxlint-disable-next-line typescript-eslint(no-unsafe-type-assertion) -- CSS custom properties require assertion
+  return { "--card-bg-override": value } as unknown as React.CSSProperties;
+}
+
+export function getInsightCardClasses(
+  content: InsightCardContent,
+  viewMode: "desktop" | "compact" | "stacked" = "desktop",
+): {
+  cardClassName: string;
+  contentClassName: string;
+} {
+  if (content.type === "kpi") {
+    const isCompact = viewMode === "compact";
+    return {
+      cardClassName: isCompact ? "!gap-0" : "!gap-4",
+      contentClassName: isCompact
+        ? "flex-1 flex flex-col overflow-hidden"
+        : "flex-1 flex flex-col",
+    };
+  }
+  const isBarChart = content.chartType === "horizontal-bars";
+  return {
+    cardClassName: content.chartType === "donut" ? "!gap-0" : "",
+    contentClassName: isBarChart ? "flex-1" : "flex-1 flex flex-col",
+  };
+}
+
+export const defaultDarkCards: CardConfig = {
+  overviewBg: "sidebar",
+  overviewOpacity: 69,
+  overviewGradient: { ...defaultGradient, opacity: 30 },
+  insightBg: "sidebar",
+  insightOpacity: 60,
+  insightGradient: { ...defaultGradient },
+  promptBg: "sidebar",
+  promptOpacity: 80,
+  promptGradient: { ...defaultGradient },
+  borderVisible: false,
+  backdropBlur: true,
+};
+
+const CARD_SIZES = new Set<string>(["sm", "md", "lg"]);
+const INSIGHT_CARD_TYPES = new Set<string>(["kpi", "chart"]);
+const CHART_TYPES = new Set<string>([
+  "donut",
+  "horizontal-bars",
+  "sparkline",
+  "area",
+  "stacked-bar",
+]);
+const CARD_INTERACTIONS = new Set<string>(["static", "expand", "navigate"]);
+
+export function isCardSize(v: string): v is CardSize {
+  return CARD_SIZES.has(v);
+}
+export function isInsightCardType(v: string): v is InsightCardType {
+  return INSIGHT_CARD_TYPES.has(v);
+}
+export function isChartType(v: string): v is ChartType {
+  return CHART_TYPES.has(v);
+}
+export function isCardInteraction(v: string): v is CardInteraction {
+  return CARD_INTERACTIONS.has(v);
+}

--- a/apps/apollo-vertex/templates/dashboard/insight-card-renderers.tsx
+++ b/apps/apollo-vertex/templates/dashboard/insight-card-renderers.tsx
@@ -8,8 +8,9 @@ import {
   TooltipTrigger,
 } from "@/registry/tooltip/tooltip";
 import type { InsightCardContent } from "./glow-config";
-import { useDashboardData } from "./DashboardDataProvider";
+import { useDashboardData } from "./dashboard-data-context";
 import type { InsightCardData } from "./dashboard-data";
+import { DonutContent, SparklineContent, AreaContent } from "./chart-stubs";
 
 type ViewMode = "desktop" | "compact" | "stacked";
 
@@ -53,13 +54,6 @@ function TruncatedText({
   );
 }
 
-// --- Sample data per card type ---
-
-const sparklinePoints = [4, 7, 5, 9, 6, 8, 12, 10, 14, 11, 15, 13];
-const areaPoints = [3, 5, 4, 8, 6, 9, 7, 11, 10, 14, 12, 16];
-
-// --- Renderers ---
-
 function KpiContent({
   cardData,
   viewMode,
@@ -99,44 +93,6 @@ function KpiContent({
         </p>
       </div>
     </>
-  );
-}
-
-function DonutContent() {
-  return (
-    <div className="flex items-center justify-center flex-1">
-      <div className="relative size-3/4 aspect-square">
-        <svg viewBox="0 0 36 36" className="size-full -rotate-90">
-          <circle
-            cx="18"
-            cy="18"
-            r="15.5"
-            fill="none"
-            className="stroke-muted"
-            strokeWidth="2"
-          />
-          <circle
-            cx="18"
-            cy="18"
-            r="15.5"
-            fill="none"
-            className="stroke-chart-1"
-            strokeWidth="2"
-            strokeDasharray="97.39"
-            strokeDashoffset={97.39 * (1 - 0.47)}
-            strokeLinecap="round"
-          />
-        </svg>
-        <div className="absolute inset-0 flex flex-col items-center justify-center">
-          <span className="text-2xl font-normal tracking-tight leading-none">
-            47%
-          </span>
-          <span className="text-[10px] text-muted-foreground mt-0.5">
-            funded
-          </span>
-        </div>
-      </div>
-    </div>
   );
 }
 
@@ -216,58 +172,6 @@ function HorizontalBarsContent({
           </div>
         </div>
       ))}
-    </div>
-  );
-}
-
-function SparklineContent() {
-  const max = Math.max(...sparklinePoints);
-  const h = 40;
-  const w = 120;
-  const step = w / (sparklinePoints.length - 1);
-  const points = sparklinePoints
-    .map((v, i) => `${i * step},${h - (v / max) * h}`)
-    .join(" ");
-
-  return (
-    <div className="flex items-center justify-center flex-1">
-      <svg viewBox={`0 0 ${w} ${h}`} className="w-full h-16" fill="none">
-        <polyline
-          points={points}
-          className="stroke-chart-1"
-          strokeWidth="2"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          fill="none"
-        />
-      </svg>
-    </div>
-  );
-}
-
-function AreaContent() {
-  const max = Math.max(...areaPoints);
-  const h = 40;
-  const w = 120;
-  const step = w / (areaPoints.length - 1);
-  const linePoints = areaPoints
-    .map((v, i) => `${i * step},${h - (v / max) * h}`)
-    .join(" ");
-  const areaPath = `0,${h} ${linePoints} ${w},${h}`;
-
-  return (
-    <div className="flex items-center justify-center flex-1">
-      <svg viewBox={`0 0 ${w} ${h}`} className="w-full h-16" fill="none">
-        <polygon points={areaPath} className="fill-chart-1/20" />
-        <polyline
-          points={linePoints}
-          className="stroke-chart-1"
-          strokeWidth="2"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          fill="none"
-        />
-      </svg>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- Adds `DashboardGlow` — a CSS-variable-driven ambient glow system that responds to the active dataset and layout config
- Introduces `GlowDevControls` — a dev-only panel for tuning glow intensity, color, layout, and dataset in real time
- Adds `dev-controls-tabs` and `dev-controls-primitives` for the tabbed control surface
- Registers the dashboard template in `registry.json` and adds the `modular-dashboard` documentation page under `/experiment`
- Includes the `glow-config.ts` type system that maps layout configs to visual glow parameters

**Stacked on:** #610

## Test plan

- [ ] Glow renders correctly in light and dark mode across all three datasets
- [ ] Dev controls panel opens, all sliders/toggles affect the live dashboard
- [ ] Documentation page renders at `/experiment/modular-dashboard`
- [ ] Registry build passes (`pnpm registry:build`)
- [ ] No TypeScript errors (`pnpm typecheck`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)