### PR TITLE
feat(apollo-vertex): modular dashboard — interactive surfaces [3/5]

### DIFF
--- a/apps/apollo-vertex/app/preview/dashboard-minimal/page.tsx
+++ b/apps/apollo-vertex/app/preview/dashboard-minimal/page.tsx
@@ -3,7 +3,10 @@
 import dynamic from "next/dynamic";
 
 const DashboardTemplate = dynamic(
-  () => import("@/templates/dashboard/DashboardTemplate").then((mod) => mod.DashboardTemplate),
+  () =>
+    import("@/templates/dashboard/DashboardTemplate").then(
+      (mod) => mod.DashboardTemplate,
+    ),
   { ssr: false },
 );
 

--- a/apps/apollo-vertex/app/preview/dashboard/page.tsx
+++ b/apps/apollo-vertex/app/preview/dashboard/page.tsx
@@ -3,7 +3,10 @@
 import dynamic from "next/dynamic";
 
 const DashboardTemplate = dynamic(
-  () => import("@/templates/dashboard/DashboardTemplate").then((mod) => mod.DashboardTemplate),
+  () =>
+    import("@/templates/dashboard/DashboardTemplate").then(
+      (mod) => mod.DashboardTemplate,
+    ),
   { ssr: false },
 );
 

--- a/apps/apollo-vertex/templates/dashboard/AutopilotInsight.tsx
+++ b/apps/apollo-vertex/templates/dashboard/AutopilotInsight.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+interface AutopilotInsightProps {
+  onClose: () => void;
+  sourceCardTitle: string;
+}
+
+export function AutopilotInsight({
+  onClose,
+  sourceCardTitle,
+}: AutopilotInsightProps) {
+  return (
+    <Card
+      variant="glass"
+      className="!bg-white/90 dark:!bg-card h-full overflow-hidden relative"
+    >
+      {/* Close button */}
+      <button
+        type="button"
+        onClick={onClose}
+        className="absolute top-5 right-5 z-20 size-7 rounded-md flex items-center justify-center text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-all"
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          className="size-4"
+        >
+          <path d="M18 6 6 18" />
+          <path d="m6 6 12 12" />
+        </svg>
+      </button>
+
+      <CardHeader className="!gap-2">
+        <div className="flex items-center gap-2">
+          <img
+            src="/Autopilot_dark.svg"
+            alt="Autopilot"
+            className="size-5 block dark:hidden"
+          />
+          <img
+            src="/Autopilot_light.svg"
+            alt="Autopilot"
+            className="size-5 hidden dark:block"
+          />
+          <CardTitle className="text-sm font-bold tracking-tight">
+            Autopilot Insight
+          </CardTitle>
+        </div>
+        <p className="text-xs text-muted-foreground">
+          Analyzing {sourceCardTitle}
+        </p>
+      </CardHeader>
+
+      <CardContent className="flex-1 flex flex-col">
+        {/* Placeholder for future chat UX responses */}
+        <div className="flex-1 border border-dashed border-muted-foreground/15 bg-muted/30 rounded-lg flex items-center justify-center">
+          <div className="text-center">
+            <p className="text-sm text-muted-foreground/60">
+              Autopilot response area
+            </p>
+            <p className="text-xs text-muted-foreground/40 mt-1">
+              Chat UX content will appear here
+            </p>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/apollo-vertex/templates/dashboard/DashboardCards.tsx
+++ b/apps/apollo-vertex/templates/dashboard/DashboardCards.tsx
@@ -1,0 +1,288 @@
+import { AlertTriangle, CheckCircle, Clock, XCircle } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Progress } from "@/components/ui/progress";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+
+// --- Types ---
+
+export interface KpiItem {
+  label: string;
+  value: string;
+  icon: LucideIcon;
+  change: string;
+}
+
+// --- Sample data ---
+
+const invoices = [
+  {
+    id: "INV-4021",
+    vendor: "Acme Corp",
+    amount: "$12,450.00",
+    status: "Processed" as const,
+    date: "Mar 18, 2026",
+  },
+  {
+    id: "INV-4020",
+    vendor: "Global Supplies Ltd",
+    amount: "$3,280.50",
+    status: "Pending" as const,
+    date: "Mar 18, 2026",
+  },
+  {
+    id: "INV-4019",
+    vendor: "TechParts Inc",
+    amount: "$8,920.00",
+    status: "In Review" as const,
+    date: "Mar 17, 2026",
+  },
+  {
+    id: "INV-4018",
+    vendor: "Office Depot",
+    amount: "$1,150.75",
+    status: "Processed" as const,
+    date: "Mar 17, 2026",
+  },
+  {
+    id: "INV-4017",
+    vendor: "CloudServ Solutions",
+    amount: "$24,000.00",
+    status: "Failed" as const,
+    date: "Mar 16, 2026",
+  },
+  {
+    id: "INV-4016",
+    vendor: "Metro Logistics",
+    amount: "$6,780.00",
+    status: "Processed" as const,
+    date: "Mar 16, 2026",
+  },
+];
+
+const statusVariant: Record<
+  string,
+  "default" | "secondary" | "destructive" | "outline"
+> = {
+  Processed: "default",
+  Pending: "secondary",
+  Failed: "destructive",
+  "In Review": "outline",
+};
+
+const statusIcon: Record<string, typeof CheckCircle> = {
+  Processed: CheckCircle,
+  Pending: Clock,
+  Failed: XCircle,
+  "In Review": AlertTriangle,
+};
+
+const activityBars = [
+  { label: "Mon", height: 60 },
+  { label: "Tue", height: 85 },
+  { label: "Wed", height: 45 },
+  { label: "Thu", height: 92 },
+  { label: "Fri", height: 78 },
+  { label: "Sat", height: 30 },
+  { label: "Sun", height: 15 },
+];
+
+const recentActivity = [
+  { text: "INV-4021 processed successfully", time: "2 min ago" },
+  { text: "INV-4020 submitted for review", time: "15 min ago" },
+  { text: "Batch processing completed (42 invoices)", time: "1 hr ago" },
+  { text: "INV-4017 failed — missing PO number", time: "3 hrs ago" },
+];
+
+const pipelineStages = [
+  { label: "OCR Extraction", value: 96 },
+  { label: "Field Validation", value: 88 },
+  { label: "Approval Routing", value: 72 },
+  { label: "Final Review", value: 64 },
+];
+
+const complianceChecks = [
+  { label: "Income Verification", pass: 98 },
+  { label: "Credit Score Threshold", pass: 96 },
+  { label: "Debt-to-Income Ratio", pass: 91 },
+  { label: "Collateral Appraisal", pass: 87 },
+  { label: "Document Completeness", pass: 94 },
+];
+
+// --- Card components ---
+
+export function KpiCards({ kpis }: { kpis: KpiItem[] }) {
+  return (
+    <>
+      {kpis.map((kpi) => (
+        <Card key={kpi.label} variant="glass">
+          <CardHeader className="pb-2">
+            <div className="flex items-center justify-between">
+              <CardTitle className="text-sm font-medium text-muted-foreground">
+                {kpi.label}
+              </CardTitle>
+              <kpi.icon className="w-4 h-4 text-muted-foreground" />
+            </div>
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">{kpi.value}</div>
+            <p className="text-xs text-muted-foreground mt-1">
+              <span className="text-emerald-500">{kpi.change}</span> from last
+              week
+            </p>
+          </CardContent>
+        </Card>
+      ))}
+    </>
+  );
+}
+
+export function InvoiceTable() {
+  return (
+    <Card variant="glass">
+      <CardHeader>
+        <CardTitle>Recent Invoices</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Invoice</TableHead>
+              <TableHead>Vendor</TableHead>
+              <TableHead>Amount</TableHead>
+              <TableHead>Status</TableHead>
+              <TableHead>Date</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {invoices.map((inv) => {
+              const StatusIcon = statusIcon[inv.status];
+              return (
+                <TableRow key={inv.id}>
+                  <TableCell className="font-medium">{inv.id}</TableCell>
+                  <TableCell>{inv.vendor}</TableCell>
+                  <TableCell>{inv.amount}</TableCell>
+                  <TableCell>
+                    <Badge
+                      variant={statusVariant[inv.status]}
+                      className="gap-1"
+                    >
+                      <StatusIcon className="w-3 h-3" />
+                      {inv.status}
+                    </Badge>
+                  </TableCell>
+                  <TableCell className="text-muted-foreground">
+                    {inv.date}
+                  </TableCell>
+                </TableRow>
+              );
+            })}
+          </TableBody>
+        </Table>
+      </CardContent>
+    </Card>
+  );
+}
+
+export function ActivityBarChart() {
+  return (
+    <Card variant="glass">
+      <CardHeader>
+        <CardTitle>Processing Activity</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="flex items-end gap-3 h-32">
+          {activityBars.map((bar) => (
+            <div
+              key={bar.label}
+              className="flex-1 flex flex-col items-center gap-1"
+            >
+              <div
+                className="w-full bg-primary/80 rounded-t-sm"
+                style={{ height: `${bar.height}%` }}
+              />
+              <span className="text-xs text-muted-foreground">{bar.label}</span>
+            </div>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+export function ActivityFeed() {
+  return (
+    <Card variant="glass">
+      <CardHeader>
+        <CardTitle>Recent Activity</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="space-y-4">
+          {recentActivity.map((event) => (
+            <div key={event.text} className="flex items-start gap-3">
+              <div className="mt-1.5 w-2 h-2 rounded-full bg-primary shrink-0" />
+              <div className="flex-1 min-w-0">
+                <p className="text-sm">{event.text}</p>
+                <p className="text-xs text-muted-foreground">{event.time}</p>
+              </div>
+            </div>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+export function PipelineProgress() {
+  return (
+    <Card variant="glass">
+      <CardHeader>
+        <CardTitle>Processing Pipeline</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="space-y-4">
+          {pipelineStages.map((stage) => (
+            <div key={stage.label}>
+              <div className="flex items-center justify-between text-sm mb-1.5">
+                <span>{stage.label}</span>
+                <span className="text-muted-foreground">{stage.value}%</span>
+              </div>
+              <Progress value={stage.value} />
+            </div>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+export function ComplianceProgress() {
+  return (
+    <Card variant="glass">
+      <CardHeader>
+        <CardTitle>Compliance Pass Rates</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="space-y-4">
+          {complianceChecks.map((check) => (
+            <div key={check.label}>
+              <div className="flex items-center justify-between text-sm mb-1.5">
+                <span>{check.label}</span>
+                <span className="text-muted-foreground">{check.pass}%</span>
+              </div>
+              <Progress value={check.pass} />
+            </div>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/apollo-vertex/templates/dashboard/ExpandedInsightContent.tsx
+++ b/apps/apollo-vertex/templates/dashboard/ExpandedInsightContent.tsx
@@ -1,0 +1,326 @@
+"use client";
+
+import { useState } from "react";
+import { Badge } from "@/components/ui/badge";
+import type { DrilldownTab } from "./drilldown-tabs";
+
+// --- Sample data ---
+
+const trendData = {
+  weeks: ["W1", "W2", "W3", "W4", "W5", "W6", "W7", "W8"],
+  series: [
+    {
+      label: "Wrong size/fit",
+      color: "bg-chart-1",
+      stroke: "stroke-chart-1",
+      values: [31, 33, 34, 35, 36, 37, 39, 41],
+    },
+    {
+      label: "Damaged in transit",
+      color: "bg-chart-2",
+      stroke: "stroke-chart-2",
+      values: [25, 24, 26, 23, 22, 24, 23, 21],
+    },
+    {
+      label: "Not as described",
+      color: "bg-chart-3",
+      stroke: "stroke-chart-3",
+      values: [20, 19, 18, 19, 18, 17, 18, 17],
+    },
+  ],
+  takeaway:
+    "Fit-related returns have grown steadily over 8 weeks (+32%), while damage and description issues remain flat.",
+};
+
+const categoryBreakdown = [
+  { category: "Women's Apparel", pct: 48, highlight: true },
+  { category: "Footwear", pct: 27 },
+  { category: "Men's Apparel", pct: 16 },
+  { category: "Accessories", pct: 9 },
+];
+const categoryInsight =
+  "Women's apparel and footwear account for 75% of all fit-related returns. Sizing inconsistency across brands is the primary driver.";
+
+const topProducts = [
+  {
+    name: "Slim Fit Chinos — Navy",
+    returnRate: 18.4,
+    issue: "Wrong size",
+    impact: "$12,400",
+  },
+  {
+    name: "Running Shoe Pro V2",
+    returnRate: 15.2,
+    issue: "Wrong fit",
+    impact: "$9,800",
+  },
+  {
+    name: "Wrap Dress — Floral",
+    returnRate: 14.7,
+    issue: "Wrong size",
+    impact: "$8,200",
+  },
+  {
+    name: "Oversized Hoodie — Black",
+    returnRate: 12.1,
+    issue: "Too large",
+    impact: "$6,900",
+  },
+  {
+    name: "Ankle Boot — Tan",
+    returnRate: 11.8,
+    issue: "Wrong fit",
+    impact: "$5,400",
+  },
+];
+
+const recommendations = [
+  {
+    action: "Deploy dynamic size recommendation for top 3 SKUs",
+    impact: "Est. 22% reduction in fit returns",
+    priority: "High",
+  },
+  {
+    action: "Add fit-specific review prompts to product pages",
+    impact: "Improve size confidence pre-purchase",
+    priority: "Medium",
+  },
+  {
+    action: "Flag brands with >15% size variance for supplier review",
+    impact: "Address root cause across catalog",
+    priority: "Medium",
+  },
+];
+
+const suggestedPrompts = [
+  "Why are fit-related returns increasing?",
+  "Which products are driving return volume?",
+  "What orders are at risk of return?",
+];
+
+// --- Components ---
+
+function TrendChart({ data }: { data: typeof trendData }) {
+  const allValues = data.series.flatMap((s) => s.values);
+  const max = Math.max(...allValues);
+  const h = 60;
+  const w = 180;
+  const step = w / (data.weeks.length - 1);
+
+  return (
+    <div className="space-y-5">
+      <div>
+        <div className="text-sm font-bold tracking-tight mb-1">
+          Trend over time
+        </div>
+        <p className="text-xs text-muted-foreground mb-4">
+          8-week view of the top 3 return reasons
+        </p>
+      </div>
+      <svg viewBox={`0 0 ${w} ${h}`} className="w-full h-36" fill="none">
+        {data.series.map((series) => {
+          const points = series.values
+            .map((v, i) => `${i * step},${h - (v / max) * h * 0.85}`)
+            .join(" ");
+          return (
+            <polyline
+              key={series.label}
+              points={points}
+              className={series.stroke}
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              fill="none"
+            />
+          );
+        })}
+      </svg>
+      <div className="flex gap-5 mt-3">
+        {data.series.map((s) => (
+          <div key={s.label} className="flex items-center gap-1.5">
+            <div className={`size-2.5 rounded-full ${s.color}`} />
+            <span className="text-xs text-muted-foreground">{s.label}</span>
+          </div>
+        ))}
+      </div>
+      <div className="rounded-lg bg-muted/40 p-3 mt-4">
+        <p className="text-xs leading-relaxed">{data.takeaway}</p>
+      </div>
+    </div>
+  );
+}
+
+function CategoryBreakdown() {
+  return (
+    <div className="space-y-5">
+      <div>
+        <div className="text-sm font-bold tracking-tight mb-1">
+          Category breakdown
+        </div>
+        <p className="text-xs text-muted-foreground">
+          {`Where "Wrong size/fit" returns are concentrated`}
+        </p>
+      </div>
+      <div className="space-y-4">
+        {categoryBreakdown.map((cat) => (
+          <div key={cat.category}>
+            <div className="flex items-center justify-between mb-1.5">
+              <span className="text-xs font-medium">{cat.category}</span>
+              <span className="text-xs font-bold">{cat.pct}%</span>
+            </div>
+            <div className="h-2 w-full rounded-full bg-muted relative">
+              <div
+                className={`h-full rounded-full ${cat.highlight ? "bg-chart-1" : "bg-chart-1/40"} relative`}
+                style={{ width: `${cat.pct}%` }}
+              >
+                <div
+                  className={`absolute inset-0 ${cat.highlight ? "bg-chart-1" : "bg-chart-1/40"} rounded-full opacity-35 dark:opacity-55 blur-[4px]`}
+                />
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+      <div className="rounded-lg bg-muted/40 p-3">
+        <p className="text-xs leading-relaxed">{categoryInsight}</p>
+      </div>
+    </div>
+  );
+}
+
+function TopProducts() {
+  return (
+    <div className="space-y-5">
+      <div>
+        <div className="text-sm font-bold tracking-tight mb-1">
+          Top products driving issues
+        </div>
+        <p className="text-xs text-muted-foreground">
+          Ranked by return rate with revenue impact
+        </p>
+      </div>
+      <div className="space-y-0">
+        <div className="grid grid-cols-[1fr_auto_auto_auto] gap-x-6 text-[10px] text-muted-foreground pb-2 border-b border-muted-foreground/10">
+          <span>Product</span>
+          <span>Return %</span>
+          <span>Issue</span>
+          <span>Impact</span>
+        </div>
+        {topProducts.map((p) => (
+          <div
+            key={p.name}
+            className="grid grid-cols-[1fr_auto_auto_auto] gap-x-6 text-xs items-center py-3 border-b border-muted-foreground/5 last:border-0"
+          >
+            <span className="truncate font-medium">{p.name}</span>
+            <span className="text-right tabular-nums font-bold">
+              {p.returnRate}%
+            </span>
+            <Badge variant="secondary" className="text-[10px] h-5">
+              {p.issue}
+            </Badge>
+            <span className="text-right text-muted-foreground tabular-nums">
+              {p.impact}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function Recommendations() {
+  return (
+    <div className="space-y-5">
+      <div>
+        <div className="text-sm font-bold tracking-tight mb-1">
+          Recommended actions
+        </div>
+        <p className="text-xs text-muted-foreground">
+          AI-assisted next steps based on current data
+        </p>
+      </div>
+      <div className="space-y-4">
+        {recommendations.map((rec, i) => (
+          <div
+            key={rec.action}
+            className="rounded-lg border border-muted-foreground/10 p-4 space-y-2"
+          >
+            <div className="flex items-center gap-2">
+              <span className="text-xs font-bold text-muted-foreground">
+                {i + 1}
+              </span>
+              <Badge
+                variant="secondary"
+                status={rec.priority === "High" ? "warning" : "info"}
+                className="text-[10px] h-5"
+              >
+                {rec.priority}
+              </Badge>
+            </div>
+            <p className="text-sm font-medium leading-snug">{rec.action}</p>
+            <p className="text-xs text-muted-foreground leading-relaxed">
+              {rec.impact}
+            </p>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// --- Exports ---
+
+export function DrilldownTabContent({ tab }: { tab: DrilldownTab }) {
+  if (tab === "trend") return <TrendChart data={trendData} />;
+  if (tab === "categories") return <CategoryBreakdown />;
+  if (tab === "products") return <TopProducts />;
+  if (tab === "actions") return <Recommendations />;
+  // "overview" is handled by the original card content
+  return null;
+}
+
+export function AutopilotPrompts({
+  onPromptSelect,
+}: {
+  onPromptSelect?: (prompt: string) => void;
+}) {
+  const [pressedPrompt, setPressedPrompt] = useState<string | null>(null);
+
+  return (
+    <div className="pt-3 border-t border-muted-foreground/10 shrink-0">
+      <div className="flex items-center gap-1.5 mb-2">
+        <img
+          src="/Autopilot_dark.svg"
+          alt="Autopilot"
+          className="size-3.5 block dark:hidden"
+        />
+        <img
+          src="/Autopilot_light.svg"
+          alt="Autopilot"
+          className="size-3.5 hidden dark:block"
+        />
+        <span className="text-[10px] text-muted-foreground">Ask Autopilot</span>
+      </div>
+      <div className="flex flex-wrap gap-1.5">
+        {suggestedPrompts.map((prompt) => (
+          <button
+            key={prompt}
+            type="button"
+            onClick={() => {
+              setPressedPrompt(prompt);
+              onPromptSelect?.(prompt);
+              setTimeout(() => setPressedPrompt(null), 600);
+            }}
+            className={`text-[11px] px-2.5 py-1 rounded-full transition-colors duration-200 ${
+              pressedPrompt === prompt
+                ? "bg-gradient-to-r from-insight-500 to-primary-400 text-white"
+                : "bg-secondary text-secondary-foreground hover:bg-secondary/80"
+            }`}
+          >
+            {prompt}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/apollo-vertex/templates/dashboard/InsightGrid.tsx
+++ b/apps/apollo-vertex/templates/dashboard/InsightGrid.tsx
@@ -1,0 +1,514 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { ArrowUpRight, Maximize2, Minimize2 } from "lucide-react";
+import {
+  Card,
+  CardAction,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  cardBgStyle,
+  getInsightCardClasses,
+  type CardConfig,
+  type InsightCardConfig,
+  type LayoutConfig,
+} from "./glow-config";
+import { InsightCardBody } from "./insight-card-renderers";
+import { useDashboardData } from "./DashboardDataProvider";
+import {
+  type DrilldownTab,
+  drilldownTabs,
+  DrilldownTabContent,
+  AutopilotPrompts,
+} from "./ExpandedInsightContent";
+
+const sizeToFr: Record<string, string> = { sm: "1fr", md: "2fr", lg: "1fr" };
+
+// --- Shared card inner content ---
+
+interface InsightCardInnerProps {
+  cfg: InsightCardConfig;
+  cardIndex: number;
+  shared: string;
+  cards: CardConfig;
+  isExpanding: boolean;
+  isThis: boolean;
+  phase: ExpandPhase;
+  viewMode: "desktop" | "compact" | "stacked";
+  drilldownTab: DrilldownTab;
+  onDrilldownTabChange: (tab: DrilldownTab) => void;
+  onExpandClick: () => void;
+  onAutopilotOpen?: () => void;
+  isAutopilotActive?: boolean;
+  className?: string;
+  style?: React.CSSProperties;
+}
+
+function InsightCardInner({
+  cfg,
+  cardIndex,
+  shared,
+  cards,
+  isExpanding,
+  isThis,
+  phase,
+  viewMode,
+  onExpandClick,
+  onAutopilotOpen,
+  drilldownTab,
+  onDrilldownTabChange,
+  isAutopilotActive = false,
+  className = "",
+  style,
+}: InsightCardInnerProps) {
+  const { data } = useDashboardData();
+  const cardTitle = data.insightCards[cardIndex]?.title ?? cfg.content.title;
+  const hasDrilldown = cfg.content.chartType === "horizontal-bars";
+  const isExpandedWithDrilldown =
+    isThis && isExpanding && hasDrilldown && phase === "full";
+  const classes = getInsightCardClasses(cfg.content, viewMode);
+  const isInteractive = cfg.interaction !== "static";
+
+  return (
+    <Card
+      variant="glass"
+      className={`${(isThis && isExpanding) || isAutopilotActive ? "!bg-white dark:!bg-card !shadow-[0_2px_24px_2px_rgba(0,0,0,0.08)] dark:!shadow-[0_2px_24px_2px_rgba(0,0,0,0.2)]" : "!bg-white/70"} ${shared} ${classes.cardClassName} group/card relative transition-all duration-300 ease-in-out overflow-hidden ${className}`}
+      style={{
+        ...cardBgStyle(
+          cards.insightBg,
+          cards.insightOpacity,
+          cards.insightGradient,
+        ),
+        ...style,
+      }}
+    >
+      <CardHeader className="shrink-0">
+        <CardTitle className="text-sm font-bold tracking-tight">
+          {cardTitle}
+        </CardTitle>
+        {isInteractive && cfg.interaction === "expand" && (
+          <CardAction>
+            <div
+              className={`flex items-center gap-1 transition-all duration-75 ${
+                isThis || isAutopilotActive
+                  ? "opacity-100 translate-x-0"
+                  : "opacity-0 translate-x-2 group-hover/card:opacity-100 group-hover/card:translate-x-0"
+              }`}
+            >
+              {onAutopilotOpen && (
+                <button
+                  type="button"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onAutopilotOpen();
+                  }}
+                  className={`size-7 rounded-md flex items-center justify-center transition-all ${
+                    isAutopilotActive
+                      ? "bg-gradient-to-br from-insight-500 to-primary-400 text-white"
+                      : "text-muted-foreground hover:text-foreground hover:bg-muted/50"
+                  }`}
+                >
+                  {isAutopilotActive ? (
+                    <img
+                      src="/Autopilot_light.svg"
+                      alt="Autopilot"
+                      className="size-4"
+                    />
+                  ) : (
+                    <>
+                      <img
+                        src="/Autopilot_dark.svg"
+                        alt="Autopilot"
+                        className="size-4 block dark:hidden"
+                      />
+                      <img
+                        src="/Autopilot_light.svg"
+                        alt="Autopilot"
+                        className="size-4 hidden dark:block"
+                      />
+                    </>
+                  )}
+                </button>
+              )}
+              <button
+                type="button"
+                onClick={onExpandClick}
+                className="size-7 rounded-md flex items-center justify-center text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-all"
+              >
+                {isThis && isExpanding ? (
+                  <Minimize2 className="size-4" />
+                ) : (
+                  <Maximize2 className="size-4" />
+                )}
+              </button>
+            </div>
+          </CardAction>
+        )}
+        {isInteractive && cfg.interaction === "navigate" && !isThis && (
+          <CardAction>
+            <button
+              type="button"
+              className="size-7 rounded-md flex items-center justify-center opacity-0 translate-x-2 group-hover/card:opacity-100 group-hover/card:translate-x-0 transition-all duration-75 text-muted-foreground hover:text-foreground hover:bg-muted/50"
+            >
+              <ArrowUpRight className="size-4" />
+            </button>
+          </CardAction>
+        )}
+        {/* Drilldown tabs — below title when expanded */}
+        {isThis &&
+          isExpanding &&
+          hasDrilldown &&
+          (phase === "height" || phase === "full") &&
+          (() => {
+            const visibleTabs = drilldownTabs.slice(0, 4);
+            const overflowTabs = drilldownTabs.slice(4);
+            const isOverflowActive = overflowTabs.some(
+              (t) => t.key === drilldownTab,
+            );
+            return (
+              <div
+                className={`flex gap-0.5 items-center transition-opacity duration-300 mt-3 mb-1 -ml-2 ${phase === "full" ? "opacity-100" : "opacity-0"}`}
+              >
+                {visibleTabs.map((tab) => (
+                  <button
+                    key={tab.key}
+                    type="button"
+                    onClick={() => onDrilldownTabChange(tab.key)}
+                    className={`px-2 py-1 text-xs rounded transition-colors font-medium ${
+                      drilldownTab === tab.key
+                        ? "bg-muted dark:bg-foreground/15"
+                        : "text-muted-foreground hover:text-foreground hover:bg-muted dark:hover:bg-foreground/15"
+                    }`}
+                  >
+                    {tab.label}
+                  </button>
+                ))}
+                {overflowTabs.length > 0 && (
+                  <div className="relative">
+                    <select
+                      value={isOverflowActive ? drilldownTab : ""}
+                      onChange={(e) => {
+                        if (e.target.value)
+                          onDrilldownTabChange(e.target.value as DrilldownTab);
+                      }}
+                      className={`appearance-none px-2 py-1 text-xs rounded transition-colors cursor-pointer bg-transparent pr-5 ${
+                        isOverflowActive
+                          ? "bg-muted font-medium"
+                          : "font-medium text-muted-foreground hover:text-foreground hover:bg-muted/50"
+                      }`}
+                    >
+                      {!isOverflowActive && <option value="">More…</option>}
+                      {overflowTabs.map((tab) => (
+                        <option key={tab.key} value={tab.key}>
+                          {tab.label}
+                        </option>
+                      ))}
+                    </select>
+                    <svg
+                      className="absolute right-1 top-1/2 -translate-y-1/2 size-3 text-muted-foreground pointer-events-none"
+                      viewBox="0 0 12 12"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="2"
+                    >
+                      <path d="M3 5l3 3 3-3" />
+                    </svg>
+                  </div>
+                )}
+              </div>
+            );
+          })()}
+      </CardHeader>
+      {isExpandedWithDrilldown ? (
+        /* Expanded with drilldown — unified layout for all tabs */
+        <div className="flex-1 min-h-0 flex flex-col px-6 !-mt-2">
+          <div className="flex-1 min-h-0 relative">
+            <div
+              className="absolute inset-0 overflow-y-auto pb-8"
+              style={{
+                maskImage:
+                  "linear-gradient(to bottom, black 85%, transparent 100%)",
+              }}
+            >
+              {drilldownTab === "overview" ? (
+                <InsightCardBody
+                  content={cfg.content}
+                  cardIndex={cardIndex}
+                  viewMode={viewMode}
+                  isExpanded={isThis && isExpanding}
+                />
+              ) : (
+                <DrilldownTabContent tab={drilldownTab} />
+              )}
+            </div>
+          </div>
+          <div className="shrink-0 pb-2">
+            <AutopilotPrompts onPromptSelect={() => onAutopilotOpen?.()} />
+          </div>
+        </div>
+      ) : (
+        /* Default card content — not expanded or no drilldown */
+        <CardContent className={`${classes.contentClassName} !flex-1 min-h-0`}>
+          <InsightCardBody
+            content={cfg.content}
+            cardIndex={cardIndex}
+            viewMode={viewMode}
+            isExpanded={isThis && isExpanding}
+          />
+        </CardContent>
+      )}
+      {/* Non-drilldown expanded content (other card types) */}
+      {isThis &&
+        isExpanding &&
+        !hasDrilldown &&
+        (phase === "height" || phase === "full") && (
+          <div
+            className={`flex-1 mx-6 mb-6 rounded-lg overflow-hidden transition-all duration-300 ${
+              phase === "full"
+                ? "opacity-100 translate-y-0"
+                : "opacity-0 translate-y-2"
+            }`}
+          >
+            {phase === "full" ? (
+              <div className="h-full border border-dashed border-muted-foreground/15 bg-muted/30 rounded-lg flex items-center justify-center">
+                <span className="text-xs text-muted-foreground/40">
+                  Additional content
+                </span>
+              </div>
+            ) : (
+              <div className="h-full space-y-3 p-4">
+                <div className="h-3 w-2/3 rounded-full bg-muted/50 animate-pulse" />
+                <div className="h-3 w-1/2 rounded-full bg-muted/50 animate-pulse" />
+                <div className="h-3 w-3/4 rounded-full bg-muted/50 animate-pulse" />
+              </div>
+            )}
+          </div>
+        )}
+    </Card>
+  );
+}
+
+// --- Main grid ---
+
+type ExpandPhase = "idle" | "width" | "height" | "full";
+
+export function InsightGrid({
+  layout,
+  shared,
+  cards,
+  viewMode = "desktop",
+  onAutopilotOpen,
+  autopilotActiveIdx,
+}: {
+  layout: LayoutConfig;
+  shared: string;
+  cards: CardConfig;
+  viewMode?: "desktop" | "compact" | "stacked";
+  onAutopilotOpen?: (sourceTitle: string, idx: number) => void;
+  autopilotActiveIdx?: number | null;
+}) {
+  const { data } = useDashboardData();
+  const [expandedIdx, setExpandedIdx] = useState<number | null>(null);
+  const [phase, setPhase] = useState<ExpandPhase>("idle");
+  const [drilldownTab, setDrilldownTab] = useState<DrilldownTab>("overview");
+
+  useEffect(() => {
+    if (expandedIdx === null) {
+      setPhase("idle");
+      setDrilldownTab("overview");
+      return;
+    }
+    requestAnimationFrame(() => setPhase("width"));
+    const t1 = setTimeout(() => setPhase("height"), 300);
+    const t2 = setTimeout(() => setPhase("full"), 600);
+    return () => {
+      clearTimeout(t1);
+      clearTimeout(t2);
+    };
+  }, [expandedIdx]);
+
+  const visibleCards = layout.insightCards
+    .map((cfg, i) => {
+      const dataCard = data.insightCards[i];
+      const merged = dataCard
+        ? {
+            ...cfg,
+            size: dataCard.size ?? cfg.size,
+            interaction: dataCard.interaction ?? cfg.interaction,
+            content: {
+              ...cfg.content,
+              title: dataCard.title ?? cfg.content.title,
+            },
+          }
+        : cfg;
+      return { cfg: merged, idx: i };
+    })
+    .filter(({ cfg }) => cfg.visible);
+  const rows: (typeof visibleCards)[] = [];
+  for (let i = 0; i < visibleCards.length; i += 2) {
+    rows.push(visibleCards.slice(i, i + 2));
+  }
+
+  const isExpanding = expandedIdx !== null;
+  const expandedRow = isExpanding
+    ? rows.findIndex((row) => row.some(({ idx }) => idx === expandedIdx))
+    : -1;
+
+  const handleClick = (cfg: InsightCardConfig, idx: number) => {
+    if (cfg.interaction === "expand") {
+      setExpandedIdx(expandedIdx === idx ? null : idx);
+    }
+  };
+
+  // Build grid-template-rows
+  let rowTemplates: string[];
+  if (viewMode === "compact") {
+    rowTemplates = visibleCards.map(({ idx }) => {
+      if (!isExpanding) return "1fr";
+      if (idx === expandedIdx) return "1fr";
+      if (phase !== "idle") return "0fr";
+      return "1fr";
+    });
+  } else {
+    rowTemplates = rows.map((_, rowIndex) => {
+      const isOtherRow = isExpanding && rowIndex !== expandedRow;
+      if (isOtherRow && (phase === "height" || phase === "full")) return "0fr";
+      return "1fr";
+    });
+  }
+
+  const sharedProps = {
+    shared,
+    cards,
+    isExpanding,
+    phase,
+    viewMode,
+    drilldownTab,
+    onDrilldownTabChange: setDrilldownTab,
+  };
+
+  return (
+    <div
+      className={`relative grid transition-all duration-300 ease-in-out ${
+        viewMode === "desktop"
+          ? "h-full overflow-hidden"
+          : viewMode === "compact"
+            ? isExpanding
+              ? "h-full overflow-hidden"
+              : "h-full overflow-y-auto"
+            : ""
+      }`}
+      style={{
+        gap: phase === "height" || phase === "full" ? 0 : layout.gap,
+        gridTemplateRows: rowTemplates.join(" "),
+      }}
+    >
+      {viewMode === "compact"
+        ? visibleCards.map(({ cfg, idx }) => {
+            const isThis = idx === expandedIdx;
+            const isOther = isExpanding && !isThis;
+            return (
+              <div
+                key={idx}
+                className="overflow-hidden min-h-0 transition-all duration-300 ease-in-out"
+                style={{ opacity: isOther && phase !== "idle" ? 0 : 1 }}
+              >
+                <InsightCardInner
+                  cfg={cfg}
+                  cardIndex={idx}
+                  {...sharedProps}
+                  isThis={isThis}
+                  onExpandClick={() => handleClick(cfg, idx)}
+                  onAutopilotOpen={
+                    onAutopilotOpen
+                      ? () =>
+                          onAutopilotOpen(
+                            data.insightCards[idx]?.title ?? cfg.content.title,
+                            idx,
+                          )
+                      : undefined
+                  }
+                  isAutopilotActive={autopilotActiveIdx === idx}
+                  className="h-full"
+                />
+              </div>
+            );
+          })
+        : rows.map((row, rowIndex) => {
+            const isRowWithExpanded = rowIndex === expandedRow;
+            const isOtherRow = isExpanding && !isRowWithExpanded;
+            const cols = row
+              .map(({ cfg, idx }) => {
+                if (!isExpanding)
+                  return cfg.size === "lg" ? "1fr" : sizeToFr[cfg.size];
+                if (idx === expandedIdx)
+                  return phase === "idle"
+                    ? cfg.size === "lg"
+                      ? "1fr"
+                      : sizeToFr[cfg.size]
+                    : "1fr";
+                if (isRowWithExpanded)
+                  return phase === "idle"
+                    ? cfg.size === "lg"
+                      ? "1fr"
+                      : sizeToFr[cfg.size]
+                    : "0fr";
+                return cfg.size === "lg" ? "1fr" : sizeToFr[cfg.size];
+              })
+              .join(" ");
+            return (
+              <div
+                key={row.map(({ idx }) => idx).join("-")}
+                className="grid transition-all duration-300 ease-in-out overflow-hidden min-h-0"
+                style={
+                  {
+                    gridTemplateColumns: cols,
+                    gap: isRowWithExpanded && phase !== "idle" ? 0 : layout.gap,
+                    opacity:
+                      isOtherRow && (phase === "height" || phase === "full")
+                        ? 0
+                        : 1,
+                  } as React.CSSProperties
+                }
+              >
+                {row.map(({ cfg, idx }) => {
+                  const isThis = idx === expandedIdx;
+                  const isSibling = isExpanding && !isThis && isRowWithExpanded;
+                  return (
+                    <InsightCardInner
+                      key={idx}
+                      cfg={cfg}
+                      cardIndex={idx}
+                      {...sharedProps}
+                      isThis={isThis}
+                      onExpandClick={() => handleClick(cfg, idx)}
+                      onAutopilotOpen={
+                        onAutopilotOpen
+                          ? () =>
+                              onAutopilotOpen(
+                                data.insightCards[idx]?.title ??
+                                  cfg.content.title,
+                                idx,
+                              )
+                          : undefined
+                      }
+                      isAutopilotActive={autopilotActiveIdx === idx}
+                      style={{
+                        opacity: isSibling && phase !== "idle" ? 0 : 1,
+                        transform:
+                          isSibling && phase !== "idle"
+                            ? "scale(0.95)"
+                            : "scale(1)",
+                      }}
+                    />
+                  );
+                })}
+              </div>
+            );
+          })}
+    </div>
+  );
+}

--- a/apps/apollo-vertex/templates/dashboard/PromptBar.tsx
+++ b/apps/apollo-vertex/templates/dashboard/PromptBar.tsx
@@ -1,0 +1,192 @@
+"use client";
+
+import { useState } from "react";
+import { MessagesSquare, Minimize2 } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import type { CardConfig, CardGradient } from "./glow-config";
+import { useDashboardData } from "./DashboardDataProvider";
+
+function cardBgStyle(
+  bg: string,
+  opacity: number,
+  gradient: CardGradient,
+): React.CSSProperties {
+  if (gradient.enabled) {
+    const alpha = gradient.opacity / 100;
+    return {
+      "--card-bg-override": `linear-gradient(${gradient.angle}deg, color-mix(in srgb, ${gradient.start} ${alpha * 100}%, transparent), color-mix(in srgb, ${gradient.end} ${alpha * 100}%, transparent))`,
+      borderColor: "transparent",
+    } as React.CSSProperties;
+  }
+  const value =
+    bg === "white"
+      ? `rgba(255,255,255,${opacity / 100})`
+      : `color-mix(in srgb, var(--${bg}) ${opacity}%, transparent)`;
+  return { "--card-bg-override": value } as React.CSSProperties;
+}
+
+export function PromptBar({
+  shared,
+  cards,
+  isExpanded = false,
+  onSubmit,
+  onExpand,
+  onCollapse,
+}: {
+  shared: string;
+  cards: CardConfig;
+  isExpanded?: boolean;
+  onSubmit?: (query: string) => void;
+  onExpand?: () => void;
+  onCollapse?: () => void;
+}) {
+  const { data } = useDashboardData();
+  const [value, setValue] = useState("");
+  const hasInput = value.trim().length > 0;
+
+  const handleSubmit = () => {
+    if (hasInput && onSubmit) {
+      onSubmit(value);
+    }
+  };
+
+  const handleChipClick = (suggestion: string) => {
+    setValue(suggestion);
+    onSubmit?.(suggestion);
+  };
+
+  return (
+    <div
+      className={`group flex flex-col rounded-2xl p-[2px] transition-all duration-300 ${
+        isExpanded
+          ? "flex-1 bg-gradient-to-r from-insight-500/75 to-primary-400/75"
+          : "focus-within:bg-gradient-to-r focus-within:from-insight-500/75 focus-within:to-primary-400/75"
+      }`}
+    >
+      {/* Expanded response area */}
+      {isExpanded && (
+        <div className="flex-1 flex flex-col rounded-t-[14px] !bg-white/90 dark:!bg-card/90 backdrop-blur-sm overflow-hidden">
+          <div className="flex items-center justify-between px-6 pt-5 pb-3">
+            <div className="flex items-center gap-2">
+              <img
+                src="/Autopilot_dark.svg"
+                alt="Autopilot"
+                className="size-4 block dark:hidden"
+              />
+              <img
+                src="/Autopilot_light.svg"
+                alt="Autopilot"
+                className="size-4 hidden dark:block"
+              />
+              <span className="text-sm font-bold tracking-tight">
+                Autopilot
+              </span>
+            </div>
+            {onCollapse && (
+              <button
+                type="button"
+                onClick={onCollapse}
+                className="size-7 rounded-md flex items-center justify-center text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-all"
+              >
+                <Minimize2 className="size-4" />
+              </button>
+            )}
+          </div>
+          <div className="flex-1 flex items-center justify-center px-6 pb-4">
+            <p className="text-sm text-muted-foreground/50">
+              Responses will appear here
+            </p>
+          </div>
+          <div className="border-t border-border" />
+        </div>
+      )}
+      {/* Suggestion badges — hidden when expanded */}
+      {!isExpanded && (
+        <div className="grid grid-rows-[0fr] focus-within:grid-rows-[1fr] group-focus-within:grid-rows-[1fr] transition-[grid-template-rows] duration-300">
+          <div className="overflow-hidden">
+            <div className="px-3 pt-2 pb-2 flex gap-2">
+              <Badge
+                variant="secondary"
+                status="info"
+                className="!bg-white/35 !text-foreground opacity-0 translate-y-2 group-focus-within:opacity-100 group-focus-within:translate-y-0 transition-all duration-300 cursor-pointer"
+                onClick={() =>
+                  handleChipClick(
+                    data.promptSuggestions[0] ?? "Show me top risk factors",
+                  )
+                }
+              >
+                {data.promptSuggestions[0] ?? "Show me top risk factors"}
+              </Badge>
+              <Badge
+                variant="secondary"
+                status="info"
+                className="!bg-white/35 !text-foreground opacity-0 translate-y-2 group-focus-within:opacity-100 group-focus-within:translate-y-0 transition-all duration-300 delay-75 cursor-pointer"
+                onClick={() =>
+                  handleChipClick(
+                    data.promptSuggestions[1] ?? "Compare Q1 vs Q2 performance",
+                  )
+                }
+              >
+                {data.promptSuggestions[1] ?? "Compare Q1 vs Q2 performance"}
+              </Badge>
+            </div>
+          </div>
+        </div>
+      )}
+      {/* Input bar */}
+      <div
+        className={`flex items-center px-4 py-3 !bg-white/80 backdrop-blur-sm transition-colors ${shared} ${
+          isExpanded ? "rounded-b-[14px]" : "rounded-[14px]"
+        }`}
+        style={cardBgStyle(
+          cards.promptBg,
+          cards.promptOpacity,
+          cards.promptGradient,
+        )}
+      >
+        <input
+          type="text"
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") handleSubmit();
+          }}
+          placeholder={data.promptPlaceholder}
+          className="flex-1 bg-transparent text-sm outline-none placeholder:text-muted-foreground"
+        />
+        <div className="flex items-center gap-2 ml-3">
+          <button
+            type="button"
+            onMouseDown={(e) => e.preventDefault()}
+            onClick={onExpand}
+            className="size-8 rounded-md flex items-center justify-center text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-all"
+            aria-label="Open chat"
+          >
+            <MessagesSquare className="size-4" />
+          </button>
+          <button
+            type="button"
+            disabled={!hasInput}
+            onClick={handleSubmit}
+            className="size-8 rounded-full bg-gradient-to-br from-insight-500 to-primary-400 flex items-center justify-center text-white transition-opacity disabled:opacity-30"
+            aria-label="Submit"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              className="size-4"
+            >
+              <path d="m5 12 7-7 7 7" />
+              <path d="M12 19V5" />
+            </svg>
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/apollo-vertex/templates/dashboard/glow-config.ts
+++ b/apps/apollo-vertex/templates/dashboard/glow-config.ts
@@ -1,0 +1,294 @@
+export interface GlowConfig {
+  start: string;
+  end: string;
+  containerOpacity: number;
+  fillOpacity: number;
+  startStopOpacity: number;
+  endStopOpacity: number;
+  endOffset: number;
+}
+
+export interface CardGradient {
+  enabled: boolean;
+  start: string;
+  end: string;
+  angle: number;
+  opacity: number;
+}
+
+export interface CardConfig {
+  overviewBg: string;
+  overviewOpacity: number;
+  overviewGradient: CardGradient;
+  insightBg: string;
+  insightOpacity: number;
+  insightGradient: CardGradient;
+  promptBg: string;
+  promptOpacity: number;
+  promptGradient: CardGradient;
+  borderVisible: boolean;
+  backdropBlur: boolean;
+}
+
+export const defaultLightGlow: GlowConfig = {
+  start: "var(--insight-500)",
+  end: "var(--primary-400)",
+  containerOpacity: 70,
+  fillOpacity: 0.3,
+  startStopOpacity: 1,
+  endStopOpacity: 1,
+  endOffset: 0.35,
+};
+
+export const defaultDarkGlow: GlowConfig = {
+  start: "var(--insight-700)",
+  end: "var(--primary-600)",
+  containerOpacity: 45,
+  fillOpacity: 1,
+  startStopOpacity: 1,
+  endStopOpacity: 0.4,
+  endOffset: 0.5,
+};
+
+export type CardSize = "sm" | "md" | "lg";
+
+export type InsightCardType = "kpi" | "chart";
+export type ChartType =
+  | "donut"
+  | "horizontal-bars"
+  | "sparkline"
+  | "area"
+  | "stacked-bar";
+
+export interface InsightCardContent {
+  type: InsightCardType;
+  chartType: ChartType;
+  title: string;
+}
+
+export type CardInteraction = "static" | "expand" | "navigate";
+
+export interface InsightCardConfig {
+  size: CardSize;
+  visible: boolean;
+  content: InsightCardContent;
+  interaction: CardInteraction;
+  navigateTo?: string;
+}
+
+export interface LayoutConfig {
+  gap: number;
+  overviewRatio: number;
+  promptRatio: number;
+  insightCards: [
+    InsightCardConfig,
+    InsightCardConfig,
+    InsightCardConfig,
+    InsightCardConfig,
+  ];
+  padding: number;
+  containerBg: string;
+}
+
+export const defaultLayout: LayoutConfig = {
+  gap: 4,
+  overviewRatio: 4,
+  promptRatio: 1,
+  insightCards: [
+    {
+      size: "sm",
+      visible: true,
+      interaction: "static",
+      content: {
+        type: "kpi",
+        chartType: "donut",
+        title: "Upfront decision efficiency",
+      },
+    },
+    {
+      size: "md",
+      visible: true,
+      interaction: "expand",
+      content: {
+        type: "chart",
+        chartType: "horizontal-bars",
+        title: "Top issues",
+      },
+    },
+    {
+      size: "md",
+      visible: true,
+      interaction: "expand",
+      content: {
+        type: "chart",
+        chartType: "stacked-bar",
+        title: "Pipeline",
+      },
+    },
+    {
+      size: "sm",
+      visible: true,
+      interaction: "static",
+      content: {
+        type: "kpi",
+        chartType: "donut",
+        title: "SLA compliance",
+      },
+    },
+  ],
+  padding: 24,
+  containerBg: "none",
+};
+
+const defaultGradient: CardGradient = {
+  enabled: false,
+  start: "var(--insight-500)",
+  end: "var(--primary-400)",
+  angle: 135,
+  opacity: 100,
+};
+
+export const insightOptions = [
+  { label: "300", value: "var(--insight-300)" },
+  { label: "400", value: "var(--insight-400)" },
+  { label: "500", value: "var(--insight-500)" },
+  { label: "600", value: "var(--insight-600)" },
+  { label: "700", value: "var(--insight-700)" },
+  { label: "800", value: "var(--insight-800)" },
+  { label: "900", value: "var(--insight-900)" },
+];
+
+export const primaryOptions = [
+  { label: "300", value: "var(--primary-300)" },
+  { label: "400", value: "var(--primary-400)" },
+  { label: "500", value: "var(--primary-500)" },
+  { label: "600", value: "var(--primary-600)" },
+  { label: "700", value: "var(--primary-700)" },
+  { label: "800", value: "var(--primary-800)" },
+  { label: "900", value: "var(--primary-900)" },
+];
+
+export const cardTypeOptions = [
+  { label: "KPI", value: "kpi" },
+  { label: "Chart", value: "chart" },
+];
+
+export const interactionOptions = [
+  { label: "Static", value: "static" },
+  { label: "Expand", value: "expand" },
+  { label: "Navigate", value: "navigate" },
+];
+
+export const chartTypeOptions = [
+  { label: "Donut", value: "donut" },
+  { label: "Horizontal Bars", value: "horizontal-bars" },
+  { label: "Sparkline", value: "sparkline" },
+  { label: "Area", value: "area" },
+  { label: "Stacked Bar", value: "stacked-bar" },
+];
+
+export const sizeOptions = [
+  { label: "Small (1 col)", value: "sm" },
+  { label: "Medium (1 col)", value: "md" },
+  { label: "Large (full)", value: "lg" },
+];
+
+export const containerBgOptions = [
+  { label: "None", value: "none" },
+  { label: "white", value: "white" },
+  { label: "sidebar", value: "sidebar" },
+  { label: "card", value: "card" },
+  { label: "background", value: "background" },
+  { label: "muted", value: "muted" },
+];
+
+export const bgColorOptions = [
+  { label: "white", value: "white" },
+  { label: "sidebar", value: "sidebar" },
+  { label: "card", value: "card" },
+  { label: "background", value: "background" },
+  { label: "muted", value: "muted" },
+];
+
+export function cardBgStyle(
+  bg: string,
+  opacity: number,
+  gradient: CardGradient,
+): React.CSSProperties {
+  if (gradient.enabled) {
+    const alpha = gradient.opacity / 100;
+    const style = {
+      "--card-bg-override": `linear-gradient(${gradient.angle}deg, color-mix(in srgb, ${gradient.start} ${alpha * 100}%, transparent), color-mix(in srgb, ${gradient.end} ${alpha * 100}%, transparent))`,
+      borderColor: "transparent",
+    };
+    // oxlint-disable-next-line typescript-eslint(no-unsafe-type-assertion) -- CSS custom properties require assertion
+    return style as unknown as React.CSSProperties;
+  }
+  const value =
+    bg === "white"
+      ? `rgba(255,255,255,${opacity / 100})`
+      : `color-mix(in srgb, var(--${bg}) ${opacity}%, transparent)`;
+  // oxlint-disable-next-line typescript-eslint(no-unsafe-type-assertion) -- CSS custom properties require assertion
+  return { "--card-bg-override": value } as unknown as React.CSSProperties;
+}
+
+export function getInsightCardClasses(
+  content: InsightCardContent,
+  viewMode: "desktop" | "compact" | "stacked" = "desktop",
+): {
+  cardClassName: string;
+  contentClassName: string;
+} {
+  if (content.type === "kpi") {
+    const isCompact = viewMode === "compact";
+    return {
+      cardClassName: isCompact ? "!gap-0" : "!gap-4",
+      contentClassName: isCompact
+        ? "flex-1 flex flex-col overflow-hidden"
+        : "flex-1 flex flex-col",
+    };
+  }
+  const isBarChart = content.chartType === "horizontal-bars";
+  return {
+    cardClassName: content.chartType === "donut" ? "!gap-0" : "",
+    contentClassName: isBarChart ? "flex-1" : "flex-1 flex flex-col",
+  };
+}
+
+export const defaultDarkCards: CardConfig = {
+  overviewBg: "sidebar",
+  overviewOpacity: 69,
+  overviewGradient: { ...defaultGradient, opacity: 30 },
+  insightBg: "sidebar",
+  insightOpacity: 60,
+  insightGradient: { ...defaultGradient },
+  promptBg: "sidebar",
+  promptOpacity: 80,
+  promptGradient: { ...defaultGradient },
+  borderVisible: false,
+  backdropBlur: true,
+};
+
+const CARD_SIZES = new Set<string>(["sm", "md", "lg"]);
+const INSIGHT_CARD_TYPES = new Set<string>(["kpi", "chart"]);
+const CHART_TYPES = new Set<string>([
+  "donut",
+  "horizontal-bars",
+  "sparkline",
+  "area",
+  "stacked-bar",
+]);
+const CARD_INTERACTIONS = new Set<string>(["static", "expand", "navigate"]);
+
+export function isCardSize(v: string): v is CardSize {
+  return CARD_SIZES.has(v);
+}
+export function isInsightCardType(v: string): v is InsightCardType {
+  return INSIGHT_CARD_TYPES.has(v);
+}
+export function isChartType(v: string): v is ChartType {
+  return CHART_TYPES.has(v);
+}
+export function isCardInteraction(v: string): v is CardInteraction {
+  return CARD_INTERACTIONS.has(v);
+}

--- a/apps/apollo-vertex/templates/dashboard/insight-card-renderers.tsx
+++ b/apps/apollo-vertex/templates/dashboard/insight-card-renderers.tsx
@@ -1,0 +1,349 @@
+"use client";
+
+import { useRef, useState, useEffect } from "react";
+import { Badge } from "@/components/ui/badge";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/registry/tooltip/tooltip";
+import type { InsightCardContent } from "./glow-config";
+import { useDashboardData } from "./dashboard-data-context";
+import type { InsightCardData } from "./dashboard-data";
+import { DonutContent, SparklineContent, AreaContent } from "./chart-stubs";
+
+type ViewMode = "desktop" | "compact" | "stacked";
+
+// --- Truncated text with conditional tooltip ---
+
+function TruncatedText({
+  children,
+  className,
+}: {
+  children: string | undefined;
+  className?: string;
+}) {
+  const textRef = useRef<HTMLParagraphElement>(null);
+  const [isTruncated, setIsTruncated] = useState(false);
+
+  useEffect(() => {
+    const el = textRef.current;
+    if (!el) return;
+    const check = () => setIsTruncated(el.scrollHeight > el.clientHeight);
+    check();
+    const observer = new ResizeObserver(check);
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [children]);
+
+  const textEl = (
+    <p ref={textRef} className={`line-clamp-2 ${className ?? ""}`}>
+      {children}
+    </p>
+  );
+
+  if (!isTruncated) return textEl;
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>{textEl}</TooltipTrigger>
+      <TooltipContent side="bottom" className="max-w-64">
+        {children}
+      </TooltipContent>
+    </Tooltip>
+  );
+}
+
+function KpiContent({
+  cardData,
+  viewMode,
+}: {
+  cardData: InsightCardData;
+  viewMode: ViewMode;
+}) {
+  if (viewMode === "compact") {
+    return (
+      <>
+        <div className="flex items-end gap-3">
+          <div className="text-5xl font-normal tracking-tight leading-none bg-gradient-to-r from-insight-800 to-primary-600 dark:from-insight-500 dark:to-primary-400 bg-clip-text text-transparent">
+            {cardData.kpiNumber}
+          </div>
+          <Badge variant="secondary" status="info" className="mb-1">
+            {cardData.kpiBadge}
+          </Badge>
+        </div>
+        <TruncatedText className="text-xs font-normal text-muted-foreground mt-auto">
+          {cardData.kpiDescription}
+        </TruncatedText>
+      </>
+    );
+  }
+
+  return (
+    <>
+      <div className="text-5xl font-normal tracking-tight leading-none bg-gradient-to-r from-insight-800 to-primary-600 dark:from-insight-500 dark:to-primary-400 bg-clip-text text-transparent">
+        {cardData.kpiNumber}
+      </div>
+      <div className="mt-auto">
+        <Badge variant="secondary" status="info" className="mb-2">
+          {cardData.kpiBadge}
+        </Badge>
+        <p className="text-xs font-normal text-muted-foreground">
+          {cardData.kpiDescription}
+        </p>
+      </div>
+    </>
+  );
+}
+
+function HorizontalBarsContent({
+  cardData,
+  viewMode,
+  isExpanded = false,
+}: {
+  cardData: InsightCardData;
+  viewMode: ViewMode;
+  isExpanded?: boolean;
+}) {
+  const bars = cardData.bars ?? [];
+  const chartColors = [
+    "bg-chart-1",
+    "bg-chart-2",
+    "bg-chart-3",
+    "bg-chart-4",
+    "bg-chart-5",
+  ];
+  const barsWithColor = bars.map((b, i) => ({
+    ...b,
+    color: chartColors[i % chartColors.length],
+  }));
+
+  if (viewMode === "compact" && !isExpanded) {
+    const total = barsWithColor.reduce((sum, s) => sum + s.value, 0);
+    return (
+      <div className="flex flex-col gap-3">
+        <div className="h-3 w-full rounded-full overflow-hidden flex">
+          {barsWithColor.map((issue) => (
+            <div
+              key={issue.label}
+              className={`${issue.color} relative`}
+              style={{ flex: issue.value }}
+            >
+              <div
+                className={`absolute inset-0 ${issue.color} opacity-35 dark:opacity-55 blur-[4px]`}
+              />
+            </div>
+          ))}
+        </div>
+        <div className="flex flex-wrap items-center gap-x-4 gap-y-1">
+          {barsWithColor.map((issue) => {
+            const pct = Math.round((issue.value / total) * 100);
+            return (
+              <div key={issue.label} className="flex items-center gap-1.5">
+                <div className={`size-2 rounded-full ${issue.color}`} />
+                <span className="text-[10px] text-muted-foreground">
+                  {issue.label} {pct}%
+                </span>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-5">
+      {barsWithColor.map((issue) => (
+        <div key={issue.label}>
+          <div className="flex items-center justify-between text-xs mb-1.5">
+            <span className="font-medium">{issue.label}</span>
+            <span className="font-bold">{issue.value}%</span>
+          </div>
+          <div className="h-1 w-full rounded-full bg-muted dark:bg-foreground/10 relative">
+            <div
+              className={`h-full rounded-full ${issue.color} relative`}
+              style={{ width: `${issue.value}%` }}
+            >
+              <div
+                className={`absolute inset-0 ${issue.color} rounded-full opacity-35 dark:opacity-55 blur-[4px]`}
+              />
+            </div>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function StackedBarContent({
+  cardData,
+  viewMode,
+  isExpanded = false,
+}: {
+  cardData: InsightCardData;
+  viewMode: ViewMode;
+  isExpanded?: boolean;
+}) {
+  const chartColors = [
+    "bg-chart-1",
+    "bg-chart-2",
+    "bg-chart-3",
+    "bg-chart-4",
+    "bg-chart-5",
+  ];
+  const rawBars = cardData.stackedBars ?? [];
+  const legend = (cardData.stackedLegend ?? []).map((label, i) => ({
+    label,
+    color: chartColors[i % chartColors.length],
+  }));
+  const barData = rawBars.map((bar) => ({
+    label: bar.label,
+    segments: bar.segments.map((value, i) => ({
+      value,
+      color: chartColors[i % chartColors.length],
+    })),
+  }));
+  const maxTotal = Math.max(
+    ...barData.map((d) => d.segments.reduce((sum, s) => sum + s.value, 0)),
+  );
+
+  if (viewMode === "compact" && !isExpanded) {
+    // Summary: aggregate all days into one horizontal stacked bar
+    const totals = barData.reduce(
+      (acc, day) => {
+        for (const seg of day.segments) {
+          const key = seg.color;
+          acc[key] = (acc[key] ?? 0) + seg.value;
+        }
+        return acc;
+      },
+      {} as Record<string, number>,
+    );
+    const grandTotal = Object.values(totals).reduce((a, b) => a + b, 0);
+
+    return (
+      <div className="flex flex-col gap-3">
+        <div className="h-3 w-full rounded-full overflow-hidden flex">
+          {legend.map((item) => (
+            <div
+              key={item.color}
+              className={`${item.color} relative`}
+              style={{ flex: totals[item.color] ?? 0 }}
+            >
+              <div
+                className={`absolute inset-0 ${item.color} opacity-35 dark:opacity-55 blur-[4px]`}
+              />
+            </div>
+          ))}
+        </div>
+        <div className="flex items-center justify-between">
+          {legend.map((item) => {
+            const val = totals[item.color] ?? 0;
+            const pct = Math.round((val / grandTotal) * 100);
+            return (
+              <div key={item.label} className="flex items-center gap-1.5">
+                <div className={`size-2 rounded-full ${item.color}`} />
+                <span className="text-[10px] text-muted-foreground">
+                  {item.label} {pct}%
+                </span>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col h-full">
+      <div className="flex items-end justify-between flex-1 min-h-0">
+        {barData.map((bar) => {
+          const total = bar.segments.reduce((sum, s) => sum + s.value, 0);
+          const pct = (total / maxTotal) * 100;
+          return (
+            <div
+              key={bar.label}
+              className="w-4 flex flex-col items-center gap-1 h-full"
+            >
+              <div
+                className="w-full flex flex-col-reverse rounded-t-sm overflow-visible relative mt-auto"
+                style={{ height: `${pct}%` }}
+              >
+                <div className="absolute inset-0 flex flex-col-reverse rounded-t-sm overflow-hidden">
+                  {bar.segments.map((seg) => (
+                    <div
+                      key={seg.color}
+                      className={`${seg.color} relative`}
+                      style={{ flex: seg.value }}
+                    />
+                  ))}
+                </div>
+                <div className="absolute inset-0 flex flex-col-reverse rounded-t-sm opacity-35 dark:opacity-55 blur-[4px]">
+                  {bar.segments.map((seg) => (
+                    <div
+                      key={`glow-${seg.color}`}
+                      className={seg.color}
+                      style={{ flex: seg.value }}
+                    />
+                  ))}
+                </div>
+              </div>
+              <span className="text-[10px] text-muted-foreground">
+                {bar.label}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+      <div className="flex items-center gap-4 mt-auto pt-4">
+        {legend.map((item) => (
+          <div key={item.label} className="flex items-center gap-1.5">
+            <div className={`size-2 rounded-full ${item.color}`} />
+            <span className="text-[10px] text-muted-foreground">
+              {item.label}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export function InsightCardBody({
+  content,
+  cardIndex,
+  viewMode = "desktop",
+  isExpanded = false,
+}: {
+  content: InsightCardContent;
+  cardIndex: number;
+  viewMode?: ViewMode;
+  isExpanded?: boolean;
+}) {
+  const { data } = useDashboardData();
+  const cardData = data.insightCards[cardIndex] ?? data.insightCards[0];
+
+  if (content.type === "kpi") {
+    return <KpiContent cardData={cardData} viewMode={viewMode} />;
+  }
+  if (content.chartType === "horizontal-bars")
+    return (
+      <HorizontalBarsContent
+        cardData={cardData}
+        viewMode={viewMode}
+        isExpanded={isExpanded}
+      />
+    );
+  if (content.chartType === "donut") return <DonutContent />;
+  if (content.chartType === "sparkline") return <SparklineContent />;
+  if (content.chartType === "stacked-bar")
+    return (
+      <StackedBarContent
+        cardData={cardData}
+        viewMode={viewMode}
+        isExpanded={isExpanded}
+      />
+    );
+  return <AreaContent />;
+}


### PR DESCRIPTION
Stacked on #613. This is where the dashboard becomes interactive — the grid that arranges cards and the two AI entry points.

## What's here

- `InsightGrid` — right-panel grid arranging insight cards in S/M/L layouts; handles expand/collapse animation and tracks the active card
- `PromptBar` — left-panel input that expands into a half-page AI chat surface; typing reveals suggestion chips
- `AutopilotInsight` (AI Assistant panel) — slides in from the right when triggered from an insight card, showing contextual analysis for that card

🤖 Generated with [Claude Code](https://claude.com/claude-code)