### PR TITLE
feat(apollo-vertex): modular dashboard — component architecture [4/5]

### DIFF
--- a/apps/apollo-vertex/app/preview/dashboard-minimal/page.tsx
+++ b/apps/apollo-vertex/app/preview/dashboard-minimal/page.tsx
@@ -3,7 +3,10 @@
 import dynamic from "next/dynamic";
 
 const DashboardTemplate = dynamic(
-  () => import("@/templates/dashboard/DashboardTemplate").then((mod) => mod.DashboardTemplate),
+  () =>
+    import("@/templates/dashboard/DashboardTemplate").then(
+      (mod) => mod.DashboardTemplate,
+    ),
   { ssr: false },
 );
 

--- a/apps/apollo-vertex/app/preview/dashboard/page.tsx
+++ b/apps/apollo-vertex/app/preview/dashboard/page.tsx
@@ -3,7 +3,10 @@
 import dynamic from "next/dynamic";
 
 const DashboardTemplate = dynamic(
-  () => import("@/templates/dashboard/DashboardTemplate").then((mod) => mod.DashboardTemplate),
+  () =>
+    import("@/templates/dashboard/DashboardTemplate").then(
+      (mod) => mod.DashboardTemplate,
+    ),
   { ssr: false },
 );
 

--- a/apps/apollo-vertex/templates/dashboard/AutopilotInsight.tsx
+++ b/apps/apollo-vertex/templates/dashboard/AutopilotInsight.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+interface AutopilotInsightProps {
+  onClose: () => void;
+  sourceCardTitle: string;
+}
+
+export function AutopilotInsight({
+  onClose,
+  sourceCardTitle,
+}: AutopilotInsightProps) {
+  return (
+    <Card
+      variant="glass"
+      className="!bg-white/90 dark:!bg-card h-full overflow-hidden relative"
+    >
+      {/* Close button */}
+      <button
+        type="button"
+        onClick={onClose}
+        className="absolute top-5 right-5 z-20 size-7 rounded-md flex items-center justify-center text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-all"
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          className="size-4"
+        >
+          <path d="M18 6 6 18" />
+          <path d="m6 6 12 12" />
+        </svg>
+      </button>
+
+      <CardHeader className="!gap-2">
+        <div className="flex items-center gap-2">
+          <img
+            src="/Autopilot_dark.svg"
+            alt="Autopilot"
+            className="size-5 block dark:hidden"
+          />
+          <img
+            src="/Autopilot_light.svg"
+            alt="Autopilot"
+            className="size-5 hidden dark:block"
+          />
+          <CardTitle className="text-sm font-bold tracking-tight">
+            Autopilot Insight
+          </CardTitle>
+        </div>
+        <p className="text-xs text-muted-foreground">
+          Analyzing {sourceCardTitle}
+        </p>
+      </CardHeader>
+
+      <CardContent className="flex-1 flex flex-col">
+        {/* Placeholder for future chat UX responses */}
+        <div className="flex-1 border border-dashed border-muted-foreground/15 bg-muted/30 rounded-lg flex items-center justify-center">
+          <div className="text-center">
+            <p className="text-sm text-muted-foreground/60">
+              Autopilot response area
+            </p>
+            <p className="text-xs text-muted-foreground/40 mt-1">
+              Chat UX content will appear here
+            </p>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/apollo-vertex/templates/dashboard/DashboardCards.tsx
+++ b/apps/apollo-vertex/templates/dashboard/DashboardCards.tsx
@@ -1,0 +1,288 @@
+import { AlertTriangle, CheckCircle, Clock, XCircle } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Progress } from "@/components/ui/progress";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+
+// --- Types ---
+
+export interface KpiItem {
+  label: string;
+  value: string;
+  icon: LucideIcon;
+  change: string;
+}
+
+// --- Sample data ---
+
+const invoices = [
+  {
+    id: "INV-4021",
+    vendor: "Acme Corp",
+    amount: "$12,450.00",
+    status: "Processed" as const,
+    date: "Mar 18, 2026",
+  },
+  {
+    id: "INV-4020",
+    vendor: "Global Supplies Ltd",
+    amount: "$3,280.50",
+    status: "Pending" as const,
+    date: "Mar 18, 2026",
+  },
+  {
+    id: "INV-4019",
+    vendor: "TechParts Inc",
+    amount: "$8,920.00",
+    status: "In Review" as const,
+    date: "Mar 17, 2026",
+  },
+  {
+    id: "INV-4018",
+    vendor: "Office Depot",
+    amount: "$1,150.75",
+    status: "Processed" as const,
+    date: "Mar 17, 2026",
+  },
+  {
+    id: "INV-4017",
+    vendor: "CloudServ Solutions",
+    amount: "$24,000.00",
+    status: "Failed" as const,
+    date: "Mar 16, 2026",
+  },
+  {
+    id: "INV-4016",
+    vendor: "Metro Logistics",
+    amount: "$6,780.00",
+    status: "Processed" as const,
+    date: "Mar 16, 2026",
+  },
+];
+
+const statusVariant: Record<
+  string,
+  "default" | "secondary" | "destructive" | "outline"
+> = {
+  Processed: "default",
+  Pending: "secondary",
+  Failed: "destructive",
+  "In Review": "outline",
+};
+
+const statusIcon: Record<string, typeof CheckCircle> = {
+  Processed: CheckCircle,
+  Pending: Clock,
+  Failed: XCircle,
+  "In Review": AlertTriangle,
+};
+
+const activityBars = [
+  { label: "Mon", height: 60 },
+  { label: "Tue", height: 85 },
+  { label: "Wed", height: 45 },
+  { label: "Thu", height: 92 },
+  { label: "Fri", height: 78 },
+  { label: "Sat", height: 30 },
+  { label: "Sun", height: 15 },
+];
+
+const recentActivity = [
+  { text: "INV-4021 processed successfully", time: "2 min ago" },
+  { text: "INV-4020 submitted for review", time: "15 min ago" },
+  { text: "Batch processing completed (42 invoices)", time: "1 hr ago" },
+  { text: "INV-4017 failed — missing PO number", time: "3 hrs ago" },
+];
+
+const pipelineStages = [
+  { label: "OCR Extraction", value: 96 },
+  { label: "Field Validation", value: 88 },
+  { label: "Approval Routing", value: 72 },
+  { label: "Final Review", value: 64 },
+];
+
+const complianceChecks = [
+  { label: "Income Verification", pass: 98 },
+  { label: "Credit Score Threshold", pass: 96 },
+  { label: "Debt-to-Income Ratio", pass: 91 },
+  { label: "Collateral Appraisal", pass: 87 },
+  { label: "Document Completeness", pass: 94 },
+];
+
+// --- Card components ---
+
+export function KpiCards({ kpis }: { kpis: KpiItem[] }) {
+  return (
+    <>
+      {kpis.map((kpi) => (
+        <Card key={kpi.label} variant="glass">
+          <CardHeader className="pb-2">
+            <div className="flex items-center justify-between">
+              <CardTitle className="text-sm font-medium text-muted-foreground">
+                {kpi.label}
+              </CardTitle>
+              <kpi.icon className="w-4 h-4 text-muted-foreground" />
+            </div>
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">{kpi.value}</div>
+            <p className="text-xs text-muted-foreground mt-1">
+              <span className="text-emerald-500">{kpi.change}</span> from last
+              week
+            </p>
+          </CardContent>
+        </Card>
+      ))}
+    </>
+  );
+}
+
+export function InvoiceTable() {
+  return (
+    <Card variant="glass">
+      <CardHeader>
+        <CardTitle>Recent Invoices</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Invoice</TableHead>
+              <TableHead>Vendor</TableHead>
+              <TableHead>Amount</TableHead>
+              <TableHead>Status</TableHead>
+              <TableHead>Date</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {invoices.map((inv) => {
+              const StatusIcon = statusIcon[inv.status];
+              return (
+                <TableRow key={inv.id}>
+                  <TableCell className="font-medium">{inv.id}</TableCell>
+                  <TableCell>{inv.vendor}</TableCell>
+                  <TableCell>{inv.amount}</TableCell>
+                  <TableCell>
+                    <Badge
+                      variant={statusVariant[inv.status]}
+                      className="gap-1"
+                    >
+                      <StatusIcon className="w-3 h-3" />
+                      {inv.status}
+                    </Badge>
+                  </TableCell>
+                  <TableCell className="text-muted-foreground">
+                    {inv.date}
+                  </TableCell>
+                </TableRow>
+              );
+            })}
+          </TableBody>
+        </Table>
+      </CardContent>
+    </Card>
+  );
+}
+
+export function ActivityBarChart() {
+  return (
+    <Card variant="glass">
+      <CardHeader>
+        <CardTitle>Processing Activity</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="flex items-end gap-3 h-32">
+          {activityBars.map((bar) => (
+            <div
+              key={bar.label}
+              className="flex-1 flex flex-col items-center gap-1"
+            >
+              <div
+                className="w-full bg-primary/80 rounded-t-sm"
+                style={{ height: `${bar.height}%` }}
+              />
+              <span className="text-xs text-muted-foreground">{bar.label}</span>
+            </div>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+export function ActivityFeed() {
+  return (
+    <Card variant="glass">
+      <CardHeader>
+        <CardTitle>Recent Activity</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="space-y-4">
+          {recentActivity.map((event) => (
+            <div key={event.text} className="flex items-start gap-3">
+              <div className="mt-1.5 w-2 h-2 rounded-full bg-primary shrink-0" />
+              <div className="flex-1 min-w-0">
+                <p className="text-sm">{event.text}</p>
+                <p className="text-xs text-muted-foreground">{event.time}</p>
+              </div>
+            </div>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+export function PipelineProgress() {
+  return (
+    <Card variant="glass">
+      <CardHeader>
+        <CardTitle>Processing Pipeline</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="space-y-4">
+          {pipelineStages.map((stage) => (
+            <div key={stage.label}>
+              <div className="flex items-center justify-between text-sm mb-1.5">
+                <span>{stage.label}</span>
+                <span className="text-muted-foreground">{stage.value}%</span>
+              </div>
+              <Progress value={stage.value} />
+            </div>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+export function ComplianceProgress() {
+  return (
+    <Card variant="glass">
+      <CardHeader>
+        <CardTitle>Compliance Pass Rates</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="space-y-4">
+          {complianceChecks.map((check) => (
+            <div key={check.label}>
+              <div className="flex items-center justify-between text-sm mb-1.5">
+                <span>{check.label}</span>
+                <span className="text-muted-foreground">{check.pass}%</span>
+              </div>
+              <Progress value={check.pass} />
+            </div>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/apollo-vertex/templates/dashboard/DashboardTemplate.tsx
+++ b/apps/apollo-vertex/templates/dashboard/DashboardTemplate.tsx
@@ -43,15 +43,24 @@ const routeTree = dashboardRootRoute.addChildren([
   ]),
 ]);
 
+const BASE_PATHS = {
+  default: "/preview/dashboard/",
+  minimal: "/preview/dashboard-minimal/",
+} as const;
+
+function normalizeEntry(path: string): string {
+  if (path === "/preview/dashboard") return BASE_PATHS.default;
+  if (path === "/preview/dashboard-minimal") return BASE_PATHS.minimal;
+  return path;
+}
+
 function getInitialEntry(
   storageKey: DashboardPreviewPathKey,
   variant?: "minimal",
 ) {
   const stored = localStorage.getItem(storageKey);
-  if (stored) return stored;
-  return variant === "minimal"
-    ? "/preview/dashboard-minimal"
-    : "/preview/dashboard";
+  if (stored) return normalizeEntry(stored);
+  return variant === "minimal" ? BASE_PATHS.minimal : BASE_PATHS.default;
 }
 
 function createDashboardRouter(
@@ -75,7 +84,7 @@ export function DashboardTemplate({ shellVariant }: DashboardTemplateProps) {
 
   useEffect(() => {
     const unsubscribe = router.subscribe("onResolved", ({ toLocation }) => {
-      localStorage.setItem(storageKey, toLocation.pathname);
+      localStorage.setItem(storageKey, normalizeEntry(toLocation.pathname));
     });
     return unsubscribe;
   }, [router, storageKey]);

--- a/apps/apollo-vertex/templates/dashboard/InsightCardInner.tsx
+++ b/apps/apollo-vertex/templates/dashboard/InsightCardInner.tsx
@@ -1,0 +1,290 @@
+"use client";
+
+import { ArrowUpRight, Maximize2, Minimize2 } from "lucide-react";
+import {
+  Card,
+  CardAction,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  cardBgStyle,
+  getInsightCardClasses,
+  type CardConfig,
+  type InsightCardConfig,
+} from "./glow-config";
+import { InsightCardBody } from "./insight-card-renderers";
+import { useDashboardData } from "./dashboard-data-context";
+import { type DrilldownTab, drilldownTabs } from "./drilldown-tabs";
+import {
+  DrilldownTabContent,
+  AutopilotPrompts,
+} from "./ExpandedInsightContent";
+import type { ExpandPhase } from "./InsightGrid";
+
+interface InsightCardInnerProps {
+  cfg: InsightCardConfig;
+  cardIndex: number;
+  shared: string;
+  cards: CardConfig;
+  isExpanding: boolean;
+  isThis: boolean;
+  phase: ExpandPhase;
+  viewMode: "desktop" | "compact" | "stacked";
+  drilldownTab: DrilldownTab;
+  onDrilldownTabChange: (tab: DrilldownTab) => void;
+  onExpandClick: () => void;
+  onAutopilotOpen?: (() => void) | null;
+  isAutopilotActive?: boolean;
+  className?: string;
+  style?: React.CSSProperties;
+}
+
+export function InsightCardInner({
+  cfg,
+  cardIndex,
+  shared,
+  cards,
+  isExpanding,
+  isThis,
+  phase,
+  viewMode,
+  onExpandClick,
+  onAutopilotOpen,
+  drilldownTab,
+  onDrilldownTabChange,
+  isAutopilotActive = false,
+  className = "",
+  style,
+}: InsightCardInnerProps) {
+  const { data } = useDashboardData();
+  const cardTitle = data.insightCards[cardIndex]?.title ?? cfg.content.title;
+  const hasDrilldown = cfg.content.chartType === "horizontal-bars";
+  const isExpandedWithDrilldown =
+    isThis && isExpanding && hasDrilldown && phase === "full";
+  const classes = getInsightCardClasses(cfg.content, viewMode);
+  const isInteractive = cfg.interaction !== "static";
+
+  return (
+    <Card
+      variant="glass"
+      className={`${(isThis && isExpanding) || isAutopilotActive ? "!bg-white dark:!bg-card !shadow-[0_2px_24px_2px_rgba(0,0,0,0.08)] dark:!shadow-[0_2px_24px_2px_rgba(0,0,0,0.2)]" : "!bg-white/70"} ${shared} ${classes.cardClassName} group/card relative transition-all duration-300 ease-in-out overflow-hidden ${className}`}
+      style={{
+        ...cardBgStyle(
+          cards.insightBg,
+          cards.insightOpacity,
+          cards.insightGradient,
+        ),
+        ...style,
+      }}
+    >
+      <CardHeader className="shrink-0">
+        <CardTitle className="text-sm font-bold tracking-tight">
+          {cardTitle}
+        </CardTitle>
+        {isInteractive && cfg.interaction === "expand" && (
+          <CardAction>
+            <div
+              className={`flex items-center gap-1 transition-all duration-75 ${
+                isThis || isAutopilotActive
+                  ? "opacity-100 translate-x-0"
+                  : "opacity-0 translate-x-2 group-hover/card:opacity-100 group-hover/card:translate-x-0"
+              }`}
+            >
+              {onAutopilotOpen && (
+                <button
+                  type="button"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onAutopilotOpen();
+                  }}
+                  className={`size-7 rounded-md flex items-center justify-center transition-all ${
+                    isAutopilotActive
+                      ? "bg-gradient-to-br from-insight-500 to-primary-400 text-white"
+                      : "text-muted-foreground hover:text-foreground hover:bg-muted/50"
+                  }`}
+                >
+                  {isAutopilotActive ? (
+                    <img
+                      src="/Autopilot_light.svg"
+                      alt="Autopilot"
+                      className="size-4"
+                    />
+                  ) : (
+                    <>
+                      <img
+                        src="/Autopilot_dark.svg"
+                        alt="Autopilot"
+                        className="size-4 block dark:hidden"
+                      />
+                      <img
+                        src="/Autopilot_light.svg"
+                        alt="Autopilot"
+                        className="size-4 hidden dark:block"
+                      />
+                    </>
+                  )}
+                </button>
+              )}
+              <button
+                type="button"
+                onClick={onExpandClick}
+                className="size-7 rounded-md flex items-center justify-center text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-all"
+              >
+                {isThis && isExpanding ? (
+                  <Minimize2 className="size-4" />
+                ) : (
+                  <Maximize2 className="size-4" />
+                )}
+              </button>
+            </div>
+          </CardAction>
+        )}
+        {isInteractive && cfg.interaction === "navigate" && !isThis && (
+          <CardAction>
+            <button
+              type="button"
+              className="size-7 rounded-md flex items-center justify-center opacity-0 translate-x-2 group-hover/card:opacity-100 group-hover/card:translate-x-0 transition-all duration-75 text-muted-foreground hover:text-foreground hover:bg-muted/50"
+            >
+              <ArrowUpRight className="size-4" />
+            </button>
+          </CardAction>
+        )}
+        {/* Drilldown tabs — below title when expanded */}
+        {isThis &&
+          isExpanding &&
+          hasDrilldown &&
+          (phase === "height" || phase === "full") &&
+          (() => {
+            const visibleTabs = drilldownTabs.slice(0, 4);
+            const overflowTabs = drilldownTabs.slice(4);
+            const isOverflowActive = overflowTabs.some(
+              (t) => t.key === drilldownTab,
+            );
+            return (
+              <div
+                className={`flex gap-0.5 items-center transition-opacity duration-300 mt-3 mb-1 -ml-2 ${phase === "full" ? "opacity-100" : "opacity-0"}`}
+              >
+                {visibleTabs.map((tab) => (
+                  <button
+                    key={tab.key}
+                    type="button"
+                    onClick={() => onDrilldownTabChange(tab.key)}
+                    className={`px-2 py-1 text-xs rounded transition-colors font-medium ${
+                      drilldownTab === tab.key
+                        ? "bg-muted dark:bg-foreground/15"
+                        : "text-muted-foreground hover:text-foreground hover:bg-muted dark:hover:bg-foreground/15"
+                    }`}
+                  >
+                    {tab.label}
+                  </button>
+                ))}
+                {overflowTabs.length > 0 && (
+                  <div className="relative">
+                    <select
+                      value={isOverflowActive ? drilldownTab : ""}
+                      onChange={(e) => {
+                        const tab = drilldownTabs.find(
+                          (t) => t.key === e.target.value,
+                        );
+                        if (tab) onDrilldownTabChange(tab.key);
+                      }}
+                      className={`appearance-none px-2 py-1 text-xs rounded transition-colors cursor-pointer bg-transparent pr-5 ${
+                        isOverflowActive
+                          ? "bg-muted font-medium"
+                          : "font-medium text-muted-foreground hover:text-foreground hover:bg-muted/50"
+                      }`}
+                    >
+                      {!isOverflowActive && <option value="">More…</option>}
+                      {overflowTabs.map((tab) => (
+                        <option key={tab.key} value={tab.key}>
+                          {tab.label}
+                        </option>
+                      ))}
+                    </select>
+                    <svg
+                      className="absolute right-1 top-1/2 -translate-y-1/2 size-3 text-muted-foreground pointer-events-none"
+                      viewBox="0 0 12 12"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="2"
+                    >
+                      <path d="M3 5l3 3 3-3" />
+                    </svg>
+                  </div>
+                )}
+              </div>
+            );
+          })()}
+      </CardHeader>
+      {isExpandedWithDrilldown ? (
+        /* Expanded with drilldown — unified layout for all tabs */
+        <div className="flex-1 min-h-0 flex flex-col px-6 !-mt-2">
+          <div className="flex-1 min-h-0 relative">
+            <div
+              className="absolute inset-0 overflow-y-auto pb-8"
+              style={{
+                maskImage:
+                  "linear-gradient(to bottom, black 85%, transparent 100%)",
+              }}
+            >
+              {drilldownTab === "overview" ? (
+                <InsightCardBody
+                  content={cfg.content}
+                  cardIndex={cardIndex}
+                  viewMode={viewMode}
+                  isExpanded={isThis && isExpanding}
+                />
+              ) : (
+                <DrilldownTabContent tab={drilldownTab} />
+              )}
+            </div>
+          </div>
+          <div className="shrink-0 pb-2">
+            <AutopilotPrompts onPromptSelect={() => onAutopilotOpen?.()} />
+          </div>
+        </div>
+      ) : (
+        /* Default card content — not expanded or no drilldown */
+        <CardContent className={`${classes.contentClassName} !flex-1 min-h-0`}>
+          <InsightCardBody
+            content={cfg.content}
+            cardIndex={cardIndex}
+            viewMode={viewMode}
+            isExpanded={isThis && isExpanding}
+          />
+        </CardContent>
+      )}
+      {/* Non-drilldown expanded content (other card types) */}
+      {isThis &&
+        isExpanding &&
+        !hasDrilldown &&
+        (phase === "height" || phase === "full") && (
+          <div
+            className={`flex-1 mx-6 mb-6 rounded-lg overflow-hidden transition-all duration-300 ${
+              phase === "full"
+                ? "opacity-100 translate-y-0"
+                : "opacity-0 translate-y-2"
+            }`}
+          >
+            {phase === "full" ? (
+              <div className="h-full border border-dashed border-muted-foreground/15 bg-muted/30 rounded-lg flex items-center justify-center">
+                <span className="text-xs text-muted-foreground/40">
+                  Additional content
+                </span>
+              </div>
+            ) : (
+              <div className="h-full space-y-3 p-4">
+                <div className="h-3 w-2/3 rounded-full bg-muted/50 animate-pulse" />
+                <div className="h-3 w-1/2 rounded-full bg-muted/50 animate-pulse" />
+                <div className="h-3 w-3/4 rounded-full bg-muted/50 animate-pulse" />
+              </div>
+            )}
+          </div>
+        )}
+    </Card>
+  );
+}
+
+export type { InsightCardInnerProps };

--- a/apps/apollo-vertex/templates/dashboard/InsightGrid.tsx
+++ b/apps/apollo-vertex/templates/dashboard/InsightGrid.tsx
@@ -1,293 +1,18 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { ArrowUpRight, Maximize2, Minimize2 } from "lucide-react";
-import { Card, CardAction, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { useDashboardData } from "./dashboard-data-context";
+import type { DrilldownTab } from "./drilldown-tabs";
 import {
-  cardBgStyle,
-  getInsightCardClasses,
-  type CardConfig,
-  type InsightCardConfig,
-  type LayoutConfig,
-} from "./glow-config";
-import { InsightCardBody } from "./insight-card-renderers";
-import { useDashboardData } from "./DashboardDataProvider";
-import {
-  type DrilldownTab,
-  drilldownTabs,
-  DrilldownTabContent,
   AutopilotPrompts,
+  DrilldownTabContent,
 } from "./ExpandedInsightContent";
+import type { CardConfig, LayoutConfig } from "./glow-config";
+import { InsightCardInner } from "./InsightCardInner";
+
+export type ExpandPhase = "idle" | "width" | "height" | "full";
 
 const sizeToFr: Record<string, string> = { sm: "1fr", md: "2fr", lg: "1fr" };
-
-// --- Shared card inner content ---
-
-interface InsightCardInnerProps {
-  cfg: InsightCardConfig;
-  cardIndex: number;
-  shared: string;
-  cards: CardConfig;
-  isExpanding: boolean;
-  isThis: boolean;
-  phase: ExpandPhase;
-  viewMode: "desktop" | "compact" | "stacked";
-  drilldownTab: DrilldownTab;
-  onDrilldownTabChange: (tab: DrilldownTab) => void;
-  onExpandClick: () => void;
-  onAutopilotOpen?: () => void;
-  isAutopilotActive?: boolean;
-  className?: string;
-  style?: React.CSSProperties;
-}
-
-function InsightCardInner({
-  cfg,
-  cardIndex,
-  shared,
-  cards,
-  isExpanding,
-  isThis,
-  phase,
-  viewMode,
-  onExpandClick,
-  onAutopilotOpen,
-  drilldownTab,
-  onDrilldownTabChange,
-  isAutopilotActive = false,
-  className = "",
-  style,
-}: InsightCardInnerProps) {
-  const { data } = useDashboardData();
-  const cardTitle = data.insightCards[cardIndex]?.title ?? cfg.content.title;
-  const hasDrilldown = cfg.content.chartType === "horizontal-bars";
-  const isExpandedWithDrilldown =
-    isThis && isExpanding && hasDrilldown && phase === "full";
-  const classes = getInsightCardClasses(cfg.content, viewMode);
-  const isInteractive = cfg.interaction !== "static";
-
-  return (
-    <Card
-      variant="glass"
-      className={`${(isThis && isExpanding) || isAutopilotActive ? "!bg-white dark:!bg-card !shadow-[0_2px_24px_2px_rgba(0,0,0,0.08)] dark:!shadow-[0_2px_24px_2px_rgba(0,0,0,0.2)]" : "!bg-white/70"} ${shared} ${classes.cardClassName} group/card relative transition-all duration-300 ease-in-out overflow-hidden ${className}`}
-      style={{
-        ...cardBgStyle(
-          cards.insightBg,
-          cards.insightOpacity,
-          cards.insightGradient,
-        ),
-        ...style,
-      }}
-    >
-      <CardHeader className="shrink-0">
-        <CardTitle className="text-sm font-bold tracking-tight">
-          {cardTitle}
-        </CardTitle>
-        {isInteractive && cfg.interaction === "expand" && (
-          <CardAction>
-            <div
-              className={`flex items-center gap-1 transition-all duration-75 ${
-                isThis || isAutopilotActive
-                  ? "opacity-100 translate-x-0"
-                  : "opacity-0 translate-x-2 group-hover/card:opacity-100 group-hover/card:translate-x-0"
-              }`}
-            >
-              {onAutopilotOpen && (
-                <button
-                  type="button"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    onAutopilotOpen();
-                  }}
-                  className={`size-7 rounded-md flex items-center justify-center transition-all ${
-                    isAutopilotActive
-                      ? "bg-gradient-to-br from-insight-500 to-primary-400 text-white"
-                      : "text-muted-foreground hover:text-foreground hover:bg-muted/50"
-                  }`}
-                >
-                  {isAutopilotActive ? (
-                    <img
-                      src="/Autopilot_light.svg"
-                      alt="Autopilot"
-                      className="size-4"
-                    />
-                  ) : (
-                    <>
-                      <img
-                        src="/Autopilot_dark.svg"
-                        alt="Autopilot"
-                        className="size-4 block dark:hidden"
-                      />
-                      <img
-                        src="/Autopilot_light.svg"
-                        alt="Autopilot"
-                        className="size-4 hidden dark:block"
-                      />
-                    </>
-                  )}
-                </button>
-              )}
-              <button
-                type="button"
-                onClick={onExpandClick}
-                className="size-7 rounded-md flex items-center justify-center text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-all"
-              >
-                {isThis && isExpanding ? (
-                  <Minimize2 className="size-4" />
-                ) : (
-                  <Maximize2 className="size-4" />
-                )}
-              </button>
-            </div>
-          </CardAction>
-        )}
-        {isInteractive && cfg.interaction === "navigate" && !isThis && (
-          <CardAction>
-            <button
-              type="button"
-              className="size-7 rounded-md flex items-center justify-center opacity-0 translate-x-2 group-hover/card:opacity-100 group-hover/card:translate-x-0 transition-all duration-75 text-muted-foreground hover:text-foreground hover:bg-muted/50"
-            >
-              <ArrowUpRight className="size-4" />
-            </button>
-          </CardAction>
-        )}
-        {/* Drilldown tabs — below title when expanded */}
-        {isThis &&
-          isExpanding &&
-          hasDrilldown &&
-          (phase === "height" || phase === "full") &&
-          (() => {
-            const visibleTabs = drilldownTabs.slice(0, 4);
-            const overflowTabs = drilldownTabs.slice(4);
-            const isOverflowActive = overflowTabs.some(
-              (t) => t.key === drilldownTab,
-            );
-            return (
-              <div
-                className={`flex gap-0.5 items-center transition-opacity duration-300 mt-3 mb-1 -ml-2 ${phase === "full" ? "opacity-100" : "opacity-0"}`}
-              >
-                {visibleTabs.map((tab) => (
-                  <button
-                    key={tab.key}
-                    type="button"
-                    onClick={() => onDrilldownTabChange(tab.key)}
-                    className={`px-2 py-1 text-xs rounded transition-colors font-medium ${
-                      drilldownTab === tab.key
-                        ? "bg-muted dark:bg-foreground/15"
-                        : "text-muted-foreground hover:text-foreground hover:bg-muted dark:hover:bg-foreground/15"
-                    }`}
-                  >
-                    {tab.label}
-                  </button>
-                ))}
-                {overflowTabs.length > 0 && (
-                  <div className="relative">
-                    <select
-                      value={isOverflowActive ? drilldownTab : ""}
-                      onChange={(e) => {
-                        if (e.target.value)
-                          onDrilldownTabChange(e.target.value as DrilldownTab);
-                      }}
-                      className={`appearance-none px-2 py-1 text-xs rounded transition-colors cursor-pointer bg-transparent pr-5 ${
-                        isOverflowActive
-                          ? "bg-muted font-medium"
-                          : "font-medium text-muted-foreground hover:text-foreground hover:bg-muted/50"
-                      }`}
-                    >
-                      {!isOverflowActive && <option value="">More…</option>}
-                      {overflowTabs.map((tab) => (
-                        <option key={tab.key} value={tab.key}>
-                          {tab.label}
-                        </option>
-                      ))}
-                    </select>
-                    <svg
-                      className="absolute right-1 top-1/2 -translate-y-1/2 size-3 text-muted-foreground pointer-events-none"
-                      viewBox="0 0 12 12"
-                      fill="none"
-                      stroke="currentColor"
-                      strokeWidth="2"
-                    >
-                      <path d="M3 5l3 3 3-3" />
-                    </svg>
-                  </div>
-                )}
-              </div>
-            );
-          })()}
-      </CardHeader>
-      {isExpandedWithDrilldown ? (
-        /* Expanded with drilldown — unified layout for all tabs */
-        <div className="flex-1 min-h-0 flex flex-col px-6 !-mt-2">
-          <div className="flex-1 min-h-0 relative">
-            <div
-              className="absolute inset-0 overflow-y-auto pb-8"
-              style={{
-                maskImage:
-                  "linear-gradient(to bottom, black 85%, transparent 100%)",
-              }}
-            >
-              {drilldownTab === "overview" ? (
-                <InsightCardBody
-                  content={cfg.content}
-                  cardIndex={cardIndex}
-                  viewMode={viewMode}
-                  isExpanded={isThis && isExpanding}
-                />
-              ) : (
-                <DrilldownTabContent tab={drilldownTab} />
-              )}
-            </div>
-          </div>
-          <div className="shrink-0 pb-2">
-            <AutopilotPrompts onPromptSelect={() => onAutopilotOpen?.()} />
-          </div>
-        </div>
-      ) : (
-        /* Default card content — not expanded or no drilldown */
-        <CardContent className={`${classes.contentClassName} !flex-1 min-h-0`}>
-          <InsightCardBody
-            content={cfg.content}
-            cardIndex={cardIndex}
-            viewMode={viewMode}
-            isExpanded={isThis && isExpanding}
-          />
-        </CardContent>
-      )}
-      {/* Non-drilldown expanded content (other card types) */}
-      {isThis &&
-        isExpanding &&
-        !hasDrilldown &&
-        (phase === "height" || phase === "full") && (
-          <div
-            className={`flex-1 mx-6 mb-6 rounded-lg overflow-hidden transition-all duration-300 ${
-              phase === "full"
-                ? "opacity-100 translate-y-0"
-                : "opacity-0 translate-y-2"
-            }`}
-          >
-            {phase === "full" ? (
-              <div className="h-full border border-dashed border-muted-foreground/15 bg-muted/30 rounded-lg flex items-center justify-center">
-                <span className="text-xs text-muted-foreground/40">
-                  Additional content
-                </span>
-              </div>
-            ) : (
-              <div className="h-full space-y-3 p-4">
-                <div className="h-3 w-2/3 rounded-full bg-muted/50 animate-pulse" />
-                <div className="h-3 w-1/2 rounded-full bg-muted/50 animate-pulse" />
-                <div className="h-3 w-3/4 rounded-full bg-muted/50 animate-pulse" />
-              </div>
-            )}
-          </div>
-        )}
-    </Card>
-  );
-}
-
-// --- Main grid ---
-
-type ExpandPhase = "idle" | "width" | "height" | "full";
 
 export function InsightGrid({
   layout,
@@ -351,7 +76,10 @@ export function InsightGrid({
     ? rows.findIndex((row) => row.some(({ idx }) => idx === expandedIdx))
     : -1;
 
-  const handleClick = (cfg: InsightCardConfig, idx: number) => {
+  const handleClick = (
+    cfg: (typeof visibleCards)[number]["cfg"],
+    idx: number,
+  ) => {
     if (cfg.interaction === "expand") {
       setExpandedIdx(expandedIdx === idx ? null : idx);
     }
@@ -423,7 +151,7 @@ export function InsightGrid({
                             data.insightCards[idx]?.title ?? cfg.content.title,
                             idx,
                           )
-                      : undefined
+                      : null
                   }
                   isAutopilotActive={autopilotActiveIdx === idx}
                   className="h-full"
@@ -487,7 +215,7 @@ export function InsightGrid({
                                   cfg.content.title,
                                 idx,
                               )
-                          : undefined
+                          : null
                       }
                       isAutopilotActive={autopilotActiveIdx === idx}
                       style={{
@@ -506,3 +234,7 @@ export function InsightGrid({
     </div>
   );
 }
+
+// Re-export for consumers that import these from InsightGrid
+export { DrilldownTabContent, AutopilotPrompts };
+export type { DrilldownTab };

--- a/apps/apollo-vertex/templates/dashboard/InsightGrid.tsx
+++ b/apps/apollo-vertex/templates/dashboard/InsightGrid.tsx
@@ -1,0 +1,508 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { ArrowUpRight, Maximize2, Minimize2 } from "lucide-react";
+import { Card, CardAction, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  cardBgStyle,
+  getInsightCardClasses,
+  type CardConfig,
+  type InsightCardConfig,
+  type LayoutConfig,
+} from "./glow-config";
+import { InsightCardBody } from "./insight-card-renderers";
+import { useDashboardData } from "./DashboardDataProvider";
+import {
+  type DrilldownTab,
+  drilldownTabs,
+  DrilldownTabContent,
+  AutopilotPrompts,
+} from "./ExpandedInsightContent";
+
+const sizeToFr: Record<string, string> = { sm: "1fr", md: "2fr", lg: "1fr" };
+
+// --- Shared card inner content ---
+
+interface InsightCardInnerProps {
+  cfg: InsightCardConfig;
+  cardIndex: number;
+  shared: string;
+  cards: CardConfig;
+  isExpanding: boolean;
+  isThis: boolean;
+  phase: ExpandPhase;
+  viewMode: "desktop" | "compact" | "stacked";
+  drilldownTab: DrilldownTab;
+  onDrilldownTabChange: (tab: DrilldownTab) => void;
+  onExpandClick: () => void;
+  onAutopilotOpen?: () => void;
+  isAutopilotActive?: boolean;
+  className?: string;
+  style?: React.CSSProperties;
+}
+
+function InsightCardInner({
+  cfg,
+  cardIndex,
+  shared,
+  cards,
+  isExpanding,
+  isThis,
+  phase,
+  viewMode,
+  onExpandClick,
+  onAutopilotOpen,
+  drilldownTab,
+  onDrilldownTabChange,
+  isAutopilotActive = false,
+  className = "",
+  style,
+}: InsightCardInnerProps) {
+  const { data } = useDashboardData();
+  const cardTitle = data.insightCards[cardIndex]?.title ?? cfg.content.title;
+  const hasDrilldown = cfg.content.chartType === "horizontal-bars";
+  const isExpandedWithDrilldown =
+    isThis && isExpanding && hasDrilldown && phase === "full";
+  const classes = getInsightCardClasses(cfg.content, viewMode);
+  const isInteractive = cfg.interaction !== "static";
+
+  return (
+    <Card
+      variant="glass"
+      className={`${(isThis && isExpanding) || isAutopilotActive ? "!bg-white dark:!bg-card !shadow-[0_2px_24px_2px_rgba(0,0,0,0.08)] dark:!shadow-[0_2px_24px_2px_rgba(0,0,0,0.2)]" : "!bg-white/70"} ${shared} ${classes.cardClassName} group/card relative transition-all duration-300 ease-in-out overflow-hidden ${className}`}
+      style={{
+        ...cardBgStyle(
+          cards.insightBg,
+          cards.insightOpacity,
+          cards.insightGradient,
+        ),
+        ...style,
+      }}
+    >
+      <CardHeader className="shrink-0">
+        <CardTitle className="text-sm font-bold tracking-tight">
+          {cardTitle}
+        </CardTitle>
+        {isInteractive && cfg.interaction === "expand" && (
+          <CardAction>
+            <div
+              className={`flex items-center gap-1 transition-all duration-75 ${
+                isThis || isAutopilotActive
+                  ? "opacity-100 translate-x-0"
+                  : "opacity-0 translate-x-2 group-hover/card:opacity-100 group-hover/card:translate-x-0"
+              }`}
+            >
+              {onAutopilotOpen && (
+                <button
+                  type="button"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onAutopilotOpen();
+                  }}
+                  className={`size-7 rounded-md flex items-center justify-center transition-all ${
+                    isAutopilotActive
+                      ? "bg-gradient-to-br from-insight-500 to-primary-400 text-white"
+                      : "text-muted-foreground hover:text-foreground hover:bg-muted/50"
+                  }`}
+                >
+                  {isAutopilotActive ? (
+                    <img
+                      src="/Autopilot_light.svg"
+                      alt="Autopilot"
+                      className="size-4"
+                    />
+                  ) : (
+                    <>
+                      <img
+                        src="/Autopilot_dark.svg"
+                        alt="Autopilot"
+                        className="size-4 block dark:hidden"
+                      />
+                      <img
+                        src="/Autopilot_light.svg"
+                        alt="Autopilot"
+                        className="size-4 hidden dark:block"
+                      />
+                    </>
+                  )}
+                </button>
+              )}
+              <button
+                type="button"
+                onClick={onExpandClick}
+                className="size-7 rounded-md flex items-center justify-center text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-all"
+              >
+                {isThis && isExpanding ? (
+                  <Minimize2 className="size-4" />
+                ) : (
+                  <Maximize2 className="size-4" />
+                )}
+              </button>
+            </div>
+          </CardAction>
+        )}
+        {isInteractive && cfg.interaction === "navigate" && !isThis && (
+          <CardAction>
+            <button
+              type="button"
+              className="size-7 rounded-md flex items-center justify-center opacity-0 translate-x-2 group-hover/card:opacity-100 group-hover/card:translate-x-0 transition-all duration-75 text-muted-foreground hover:text-foreground hover:bg-muted/50"
+            >
+              <ArrowUpRight className="size-4" />
+            </button>
+          </CardAction>
+        )}
+        {/* Drilldown tabs — below title when expanded */}
+        {isThis &&
+          isExpanding &&
+          hasDrilldown &&
+          (phase === "height" || phase === "full") &&
+          (() => {
+            const visibleTabs = drilldownTabs.slice(0, 4);
+            const overflowTabs = drilldownTabs.slice(4);
+            const isOverflowActive = overflowTabs.some(
+              (t) => t.key === drilldownTab,
+            );
+            return (
+              <div
+                className={`flex gap-0.5 items-center transition-opacity duration-300 mt-3 mb-1 -ml-2 ${phase === "full" ? "opacity-100" : "opacity-0"}`}
+              >
+                {visibleTabs.map((tab) => (
+                  <button
+                    key={tab.key}
+                    type="button"
+                    onClick={() => onDrilldownTabChange(tab.key)}
+                    className={`px-2 py-1 text-xs rounded transition-colors font-medium ${
+                      drilldownTab === tab.key
+                        ? "bg-muted dark:bg-foreground/15"
+                        : "text-muted-foreground hover:text-foreground hover:bg-muted dark:hover:bg-foreground/15"
+                    }`}
+                  >
+                    {tab.label}
+                  </button>
+                ))}
+                {overflowTabs.length > 0 && (
+                  <div className="relative">
+                    <select
+                      value={isOverflowActive ? drilldownTab : ""}
+                      onChange={(e) => {
+                        if (e.target.value)
+                          onDrilldownTabChange(e.target.value as DrilldownTab);
+                      }}
+                      className={`appearance-none px-2 py-1 text-xs rounded transition-colors cursor-pointer bg-transparent pr-5 ${
+                        isOverflowActive
+                          ? "bg-muted font-medium"
+                          : "font-medium text-muted-foreground hover:text-foreground hover:bg-muted/50"
+                      }`}
+                    >
+                      {!isOverflowActive && <option value="">More…</option>}
+                      {overflowTabs.map((tab) => (
+                        <option key={tab.key} value={tab.key}>
+                          {tab.label}
+                        </option>
+                      ))}
+                    </select>
+                    <svg
+                      className="absolute right-1 top-1/2 -translate-y-1/2 size-3 text-muted-foreground pointer-events-none"
+                      viewBox="0 0 12 12"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="2"
+                    >
+                      <path d="M3 5l3 3 3-3" />
+                    </svg>
+                  </div>
+                )}
+              </div>
+            );
+          })()}
+      </CardHeader>
+      {isExpandedWithDrilldown ? (
+        /* Expanded with drilldown — unified layout for all tabs */
+        <div className="flex-1 min-h-0 flex flex-col px-6 !-mt-2">
+          <div className="flex-1 min-h-0 relative">
+            <div
+              className="absolute inset-0 overflow-y-auto pb-8"
+              style={{
+                maskImage:
+                  "linear-gradient(to bottom, black 85%, transparent 100%)",
+              }}
+            >
+              {drilldownTab === "overview" ? (
+                <InsightCardBody
+                  content={cfg.content}
+                  cardIndex={cardIndex}
+                  viewMode={viewMode}
+                  isExpanded={isThis && isExpanding}
+                />
+              ) : (
+                <DrilldownTabContent tab={drilldownTab} />
+              )}
+            </div>
+          </div>
+          <div className="shrink-0 pb-2">
+            <AutopilotPrompts onPromptSelect={() => onAutopilotOpen?.()} />
+          </div>
+        </div>
+      ) : (
+        /* Default card content — not expanded or no drilldown */
+        <CardContent className={`${classes.contentClassName} !flex-1 min-h-0`}>
+          <InsightCardBody
+            content={cfg.content}
+            cardIndex={cardIndex}
+            viewMode={viewMode}
+            isExpanded={isThis && isExpanding}
+          />
+        </CardContent>
+      )}
+      {/* Non-drilldown expanded content (other card types) */}
+      {isThis &&
+        isExpanding &&
+        !hasDrilldown &&
+        (phase === "height" || phase === "full") && (
+          <div
+            className={`flex-1 mx-6 mb-6 rounded-lg overflow-hidden transition-all duration-300 ${
+              phase === "full"
+                ? "opacity-100 translate-y-0"
+                : "opacity-0 translate-y-2"
+            }`}
+          >
+            {phase === "full" ? (
+              <div className="h-full border border-dashed border-muted-foreground/15 bg-muted/30 rounded-lg flex items-center justify-center">
+                <span className="text-xs text-muted-foreground/40">
+                  Additional content
+                </span>
+              </div>
+            ) : (
+              <div className="h-full space-y-3 p-4">
+                <div className="h-3 w-2/3 rounded-full bg-muted/50 animate-pulse" />
+                <div className="h-3 w-1/2 rounded-full bg-muted/50 animate-pulse" />
+                <div className="h-3 w-3/4 rounded-full bg-muted/50 animate-pulse" />
+              </div>
+            )}
+          </div>
+        )}
+    </Card>
+  );
+}
+
+// --- Main grid ---
+
+type ExpandPhase = "idle" | "width" | "height" | "full";
+
+export function InsightGrid({
+  layout,
+  shared,
+  cards,
+  viewMode = "desktop",
+  onAutopilotOpen,
+  autopilotActiveIdx,
+}: {
+  layout: LayoutConfig;
+  shared: string;
+  cards: CardConfig;
+  viewMode?: "desktop" | "compact" | "stacked";
+  onAutopilotOpen?: (sourceTitle: string, idx: number) => void;
+  autopilotActiveIdx?: number | null;
+}) {
+  const { data } = useDashboardData();
+  const [expandedIdx, setExpandedIdx] = useState<number | null>(null);
+  const [phase, setPhase] = useState<ExpandPhase>("idle");
+  const [drilldownTab, setDrilldownTab] = useState<DrilldownTab>("overview");
+
+  useEffect(() => {
+    if (expandedIdx === null) {
+      setPhase("idle");
+      setDrilldownTab("overview");
+      return;
+    }
+    requestAnimationFrame(() => setPhase("width"));
+    const t1 = setTimeout(() => setPhase("height"), 300);
+    const t2 = setTimeout(() => setPhase("full"), 600);
+    return () => {
+      clearTimeout(t1);
+      clearTimeout(t2);
+    };
+  }, [expandedIdx]);
+
+  const visibleCards = layout.insightCards
+    .map((cfg, i) => {
+      const dataCard = data.insightCards[i];
+      const merged = dataCard
+        ? {
+            ...cfg,
+            size: dataCard.size ?? cfg.size,
+            interaction: dataCard.interaction ?? cfg.interaction,
+            content: {
+              ...cfg.content,
+              title: dataCard.title ?? cfg.content.title,
+            },
+          }
+        : cfg;
+      return { cfg: merged, idx: i };
+    })
+    .filter(({ cfg }) => cfg.visible);
+  const rows: (typeof visibleCards)[] = [];
+  for (let i = 0; i < visibleCards.length; i += 2) {
+    rows.push(visibleCards.slice(i, i + 2));
+  }
+
+  const isExpanding = expandedIdx !== null;
+  const expandedRow = isExpanding
+    ? rows.findIndex((row) => row.some(({ idx }) => idx === expandedIdx))
+    : -1;
+
+  const handleClick = (cfg: InsightCardConfig, idx: number) => {
+    if (cfg.interaction === "expand") {
+      setExpandedIdx(expandedIdx === idx ? null : idx);
+    }
+  };
+
+  // Build grid-template-rows
+  let rowTemplates: string[];
+  if (viewMode === "compact") {
+    rowTemplates = visibleCards.map(({ idx }) => {
+      if (!isExpanding) return "1fr";
+      if (idx === expandedIdx) return "1fr";
+      if (phase !== "idle") return "0fr";
+      return "1fr";
+    });
+  } else {
+    rowTemplates = rows.map((_, rowIndex) => {
+      const isOtherRow = isExpanding && rowIndex !== expandedRow;
+      if (isOtherRow && (phase === "height" || phase === "full")) return "0fr";
+      return "1fr";
+    });
+  }
+
+  const sharedProps = {
+    shared,
+    cards,
+    isExpanding,
+    phase,
+    viewMode,
+    drilldownTab,
+    onDrilldownTabChange: setDrilldownTab,
+  };
+
+  return (
+    <div
+      className={`relative grid transition-all duration-300 ease-in-out ${
+        viewMode === "desktop"
+          ? "h-full overflow-hidden"
+          : viewMode === "compact"
+            ? isExpanding
+              ? "h-full overflow-hidden"
+              : "h-full overflow-y-auto"
+            : ""
+      }`}
+      style={{
+        gap: phase === "height" || phase === "full" ? 0 : layout.gap,
+        gridTemplateRows: rowTemplates.join(" "),
+      }}
+    >
+      {viewMode === "compact"
+        ? visibleCards.map(({ cfg, idx }) => {
+            const isThis = idx === expandedIdx;
+            const isOther = isExpanding && !isThis;
+            return (
+              <div
+                key={idx}
+                className="overflow-hidden min-h-0 transition-all duration-300 ease-in-out"
+                style={{ opacity: isOther && phase !== "idle" ? 0 : 1 }}
+              >
+                <InsightCardInner
+                  cfg={cfg}
+                  cardIndex={idx}
+                  {...sharedProps}
+                  isThis={isThis}
+                  onExpandClick={() => handleClick(cfg, idx)}
+                  onAutopilotOpen={
+                    onAutopilotOpen
+                      ? () =>
+                          onAutopilotOpen(
+                            data.insightCards[idx]?.title ?? cfg.content.title,
+                            idx,
+                          )
+                      : undefined
+                  }
+                  isAutopilotActive={autopilotActiveIdx === idx}
+                  className="h-full"
+                />
+              </div>
+            );
+          })
+        : rows.map((row, rowIndex) => {
+            const isRowWithExpanded = rowIndex === expandedRow;
+            const isOtherRow = isExpanding && !isRowWithExpanded;
+            const cols = row
+              .map(({ cfg, idx }) => {
+                if (!isExpanding)
+                  return cfg.size === "lg" ? "1fr" : sizeToFr[cfg.size];
+                if (idx === expandedIdx)
+                  return phase === "idle"
+                    ? cfg.size === "lg"
+                      ? "1fr"
+                      : sizeToFr[cfg.size]
+                    : "1fr";
+                if (isRowWithExpanded)
+                  return phase === "idle"
+                    ? cfg.size === "lg"
+                      ? "1fr"
+                      : sizeToFr[cfg.size]
+                    : "0fr";
+                return cfg.size === "lg" ? "1fr" : sizeToFr[cfg.size];
+              })
+              .join(" ");
+            return (
+              <div
+                key={row.map(({ idx }) => idx).join("-")}
+                className="grid transition-all duration-300 ease-in-out overflow-hidden min-h-0"
+                style={
+                  {
+                    gridTemplateColumns: cols,
+                    gap: isRowWithExpanded && phase !== "idle" ? 0 : layout.gap,
+                    opacity:
+                      isOtherRow && (phase === "height" || phase === "full")
+                        ? 0
+                        : 1,
+                  } as React.CSSProperties
+                }
+              >
+                {row.map(({ cfg, idx }) => {
+                  const isThis = idx === expandedIdx;
+                  const isSibling = isExpanding && !isThis && isRowWithExpanded;
+                  return (
+                    <InsightCardInner
+                      key={idx}
+                      cfg={cfg}
+                      cardIndex={idx}
+                      {...sharedProps}
+                      isThis={isThis}
+                      onExpandClick={() => handleClick(cfg, idx)}
+                      onAutopilotOpen={
+                        onAutopilotOpen
+                          ? () =>
+                              onAutopilotOpen(
+                                data.insightCards[idx]?.title ??
+                                  cfg.content.title,
+                                idx,
+                              )
+                          : undefined
+                      }
+                      isAutopilotActive={autopilotActiveIdx === idx}
+                      style={{
+                        opacity: isSibling && phase !== "idle" ? 0 : 1,
+                        transform:
+                          isSibling && phase !== "idle"
+                            ? "scale(0.95)"
+                            : "scale(1)",
+                      }}
+                    />
+                  );
+                })}
+              </div>
+            );
+          })}
+    </div>
+  );
+}

--- a/apps/apollo-vertex/templates/dashboard/PromptBar.tsx
+++ b/apps/apollo-vertex/templates/dashboard/PromptBar.tsx
@@ -1,0 +1,193 @@
+"use client";
+
+import { useState } from "react";
+import { MessagesSquare, Minimize2 } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import type { CardConfig, CardGradient } from "./glow-config";
+import { useDashboardData } from "./DashboardDataProvider";
+
+function cardBgStyle(
+  bg: string,
+  opacity: number,
+  gradient: CardGradient,
+): React.CSSProperties {
+  if (gradient.enabled) {
+    const alpha = gradient.opacity / 100;
+    return {
+      "--card-bg-override": `linear-gradient(${gradient.angle}deg, color-mix(in srgb, ${gradient.start} ${alpha * 100}%, transparent), color-mix(in srgb, ${gradient.end} ${alpha * 100}%, transparent))`,
+      borderColor: "transparent",
+    } as React.CSSProperties;
+  }
+  const value =
+    bg === "white"
+      ? `rgba(255,255,255,${opacity / 100})`
+      : `color-mix(in srgb, var(--${bg}) ${opacity}%, transparent)`;
+  return { "--card-bg-override": value } as React.CSSProperties;
+}
+
+export function PromptBar({
+  shared,
+  cards,
+  isExpanded = false,
+  onSubmit,
+  onExpand,
+  onCollapse,
+}: {
+  shared: string;
+  cards: CardConfig;
+  isExpanded?: boolean;
+  onSubmit?: (query: string) => void;
+  onExpand?: () => void;
+  onCollapse?: () => void;
+}) {
+  const { data } = useDashboardData();
+  const [value, setValue] = useState("");
+  const hasInput = value.trim().length > 0;
+
+  const handleSubmit = () => {
+    if (hasInput && onSubmit) {
+      onSubmit(value);
+    }
+  };
+
+  const handleChipClick = (suggestion: string) => {
+    setValue(suggestion);
+    onSubmit?.(suggestion);
+  };
+
+  return (
+    <div
+      className={`group flex flex-col rounded-2xl p-[2px] transition-all duration-300 ${
+        isExpanded
+          ? "flex-1 bg-gradient-to-r from-insight-500/75 to-primary-400/75"
+          : "focus-within:bg-gradient-to-r focus-within:from-insight-500/75 focus-within:to-primary-400/75"
+      }`}
+    >
+      {/* Expanded response area */}
+      {isExpanded && (
+        <div className="flex-1 flex flex-col rounded-t-[14px] !bg-white/90 dark:!bg-card/90 backdrop-blur-sm overflow-hidden">
+          <div className="flex items-center justify-between px-6 pt-5 pb-3">
+            <div className="flex items-center gap-2">
+              <img
+                src="/Autopilot_dark.svg"
+                alt="Autopilot"
+                className="size-4 block dark:hidden"
+              />
+              <img
+                src="/Autopilot_light.svg"
+                alt="Autopilot"
+                className="size-4 hidden dark:block"
+              />
+              <span className="text-sm font-bold tracking-tight">
+                Autopilot
+              </span>
+            </div>
+            {onCollapse && (
+              <button
+                type="button"
+                onClick={onCollapse}
+                className="size-7 rounded-md flex items-center justify-center text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-all"
+              >
+                <Minimize2 className="size-4" />
+              </button>
+            )}
+          </div>
+          <div className="flex-1 flex items-center justify-center px-6 pb-4">
+            <p className="text-sm text-muted-foreground/50">
+              Responses will appear here
+            </p>
+          </div>
+          <div className="border-t border-border" />
+        </div>
+      )}
+      {/* Suggestion badges — hidden when expanded */}
+      {!isExpanded && (
+        <div className="grid grid-rows-[0fr] focus-within:grid-rows-[1fr] group-focus-within:grid-rows-[1fr] transition-[grid-template-rows] duration-300">
+          <div className="overflow-hidden">
+            <div className="px-3 pt-2 pb-2 flex gap-2">
+              <Badge
+                variant="secondary"
+                status="info"
+                className="!bg-white/35 !text-foreground opacity-0 translate-y-2 group-focus-within:opacity-100 group-focus-within:translate-y-0 transition-all duration-300 cursor-pointer"
+                onClick={() =>
+                  handleChipClick(
+                    data.promptSuggestions[0] ?? "Show me top risk factors",
+                  )
+                }
+              >
+                {data.promptSuggestions[0] ?? "Show me top risk factors"}
+              </Badge>
+              <Badge
+                variant="secondary"
+                status="info"
+                className="!bg-white/35 !text-foreground opacity-0 translate-y-2 group-focus-within:opacity-100 group-focus-within:translate-y-0 transition-all duration-300 delay-75 cursor-pointer"
+                onClick={() =>
+                  handleChipClick(
+                    data.promptSuggestions[1] ??
+                      "Compare Q1 vs Q2 performance",
+                  )
+                }
+              >
+                {data.promptSuggestions[1] ?? "Compare Q1 vs Q2 performance"}
+              </Badge>
+            </div>
+          </div>
+        </div>
+      )}
+      {/* Input bar */}
+      <div
+        className={`flex items-center px-4 py-3 !bg-white/80 backdrop-blur-sm transition-colors ${shared} ${
+          isExpanded ? "rounded-b-[14px]" : "rounded-[14px]"
+        }`}
+        style={cardBgStyle(
+          cards.promptBg,
+          cards.promptOpacity,
+          cards.promptGradient,
+        )}
+      >
+        <input
+          type="text"
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") handleSubmit();
+          }}
+          placeholder={data.promptPlaceholder}
+          className="flex-1 bg-transparent text-sm outline-none placeholder:text-muted-foreground"
+        />
+        <div className="flex items-center gap-2 ml-3">
+          <button
+            type="button"
+            onMouseDown={(e) => e.preventDefault()}
+            onClick={onExpand}
+            className="size-8 rounded-md flex items-center justify-center text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-all"
+            aria-label="Open chat"
+          >
+            <MessagesSquare className="size-4" />
+          </button>
+          <button
+            type="button"
+            disabled={!hasInput}
+            onClick={handleSubmit}
+            className="size-8 rounded-full bg-gradient-to-br from-insight-500 to-primary-400 flex items-center justify-center text-white transition-opacity disabled:opacity-30"
+            aria-label="Submit"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              className="size-4"
+            >
+              <path d="m5 12 7-7 7 7" />
+              <path d="M12 19V5" />
+            </svg>
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/apollo-vertex/templates/dashboard/PromptBar.tsx
+++ b/apps/apollo-vertex/templates/dashboard/PromptBar.tsx
@@ -3,27 +3,8 @@
 import { useState } from "react";
 import { MessagesSquare, Minimize2 } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
-import type { CardConfig, CardGradient } from "./glow-config";
-import { useDashboardData } from "./DashboardDataProvider";
-
-function cardBgStyle(
-  bg: string,
-  opacity: number,
-  gradient: CardGradient,
-): React.CSSProperties {
-  if (gradient.enabled) {
-    const alpha = gradient.opacity / 100;
-    return {
-      "--card-bg-override": `linear-gradient(${gradient.angle}deg, color-mix(in srgb, ${gradient.start} ${alpha * 100}%, transparent), color-mix(in srgb, ${gradient.end} ${alpha * 100}%, transparent))`,
-      borderColor: "transparent",
-    } as React.CSSProperties;
-  }
-  const value =
-    bg === "white"
-      ? `rgba(255,255,255,${opacity / 100})`
-      : `color-mix(in srgb, var(--${bg}) ${opacity}%, transparent)`;
-  return { "--card-bg-override": value } as React.CSSProperties;
-}
+import { cardBgStyle, type CardConfig } from "./glow-config";
+import { useDashboardData } from "./dashboard-data-context";
 
 export function PromptBar({
   shared,
@@ -123,8 +104,7 @@ export function PromptBar({
                 className="!bg-white/35 !text-foreground opacity-0 translate-y-2 group-focus-within:opacity-100 group-focus-within:translate-y-0 transition-all duration-300 delay-75 cursor-pointer"
                 onClick={() =>
                   handleChipClick(
-                    data.promptSuggestions[1] ??
-                      "Compare Q1 vs Q2 performance",
+                    data.promptSuggestions[1] ?? "Compare Q1 vs Q2 performance",
                   )
                 }
               >

--- a/apps/apollo-vertex/templates/dashboard/chart-stubs.tsx
+++ b/apps/apollo-vertex/templates/dashboard/chart-stubs.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+const sparklinePoints = [4, 7, 5, 9, 6, 8, 12, 10, 14, 11, 15, 13];
+const areaPoints = [3, 5, 4, 8, 6, 9, 7, 11, 10, 14, 12, 16];
+
+export function DonutContent() {
+  return (
+    <div className="flex items-center justify-center flex-1">
+      <div className="relative size-3/4 aspect-square">
+        <svg viewBox="0 0 36 36" className="size-full -rotate-90">
+          <circle
+            cx="18"
+            cy="18"
+            r="15.5"
+            fill="none"
+            className="stroke-muted"
+            strokeWidth="2"
+          />
+          <circle
+            cx="18"
+            cy="18"
+            r="15.5"
+            fill="none"
+            className="stroke-chart-1"
+            strokeWidth="2"
+            strokeDasharray="97.39"
+            strokeDashoffset={97.39 * (1 - 0.47)}
+            strokeLinecap="round"
+          />
+        </svg>
+        <div className="absolute inset-0 flex flex-col items-center justify-center">
+          <span className="text-2xl font-normal tracking-tight leading-none">
+            47%
+          </span>
+          <span className="text-[10px] text-muted-foreground mt-0.5">
+            funded
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function SparklineContent() {
+  const max = Math.max(...sparklinePoints);
+  const h = 40;
+  const w = 120;
+  const step = w / (sparklinePoints.length - 1);
+  const points = sparklinePoints
+    .map((v, i) => `${i * step},${h - (v / max) * h}`)
+    .join(" ");
+
+  return (
+    <div className="flex items-center justify-center flex-1">
+      <svg viewBox={`0 0 ${w} ${h}`} className="w-full h-16" fill="none">
+        <polyline
+          points={points}
+          className="stroke-chart-1"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          fill="none"
+        />
+      </svg>
+    </div>
+  );
+}
+
+export function AreaContent() {
+  const max = Math.max(...areaPoints);
+  const h = 40;
+  const w = 120;
+  const step = w / (areaPoints.length - 1);
+  const linePoints = areaPoints
+    .map((v, i) => `${i * step},${h - (v / max) * h}`)
+    .join(" ");
+  const areaPath = `0,${h} ${linePoints} ${w},${h}`;
+
+  return (
+    <div className="flex items-center justify-center flex-1">
+      <svg viewBox={`0 0 ${w} ${h}`} className="w-full h-16" fill="none">
+        <polygon points={areaPath} className="fill-chart-1/20" />
+        <polyline
+          points={linePoints}
+          className="stroke-chart-1"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          fill="none"
+        />
+      </svg>
+    </div>
+  );
+}

--- a/apps/apollo-vertex/templates/dashboard/drilldown-tabs.ts
+++ b/apps/apollo-vertex/templates/dashboard/drilldown-tabs.ts
@@ -1,0 +1,13 @@
+export type DrilldownTab =
+  | "overview"
+  | "trend"
+  | "categories"
+  | "products"
+  | "actions";
+
+export const drilldownTabs: { key: DrilldownTab; label: string }[] = [
+  { key: "overview", label: "Overview" },
+  { key: "categories", label: "Categories" },
+  { key: "products", label: "Products" },
+  { key: "actions", label: "Actions" },
+];


### PR DESCRIPTION
Stacked on #614. Separates card chrome from grid layout and decouples data access — keeps each component focused on one job.

## What's here

- `InsightCardInner` — extracted from InsightGrid; owns all card chrome: title, expand/collapse, AI Assistant trigger, drilldown tabs. InsightGrid is now pure layout.
- `dashboard-data-context.ts` — React context letting any component read dashboard data without direct provider coupling
- `drilldown-tabs.ts` — shared tab config for the expanded card drilldown view
- `chart-stubs.tsx` — lightweight placeholder charts for loading/empty states

🤖 Generated with [Claude Code](https://claude.com/claude-code)