### PR TITLE
fix(apollo-react): do not render tooltip with empty content [MST-9144]

### DIFF
--- a/packages/apollo-react/src/canvas/components/CanvasTooltip.test.tsx
+++ b/packages/apollo-react/src/canvas/components/CanvasTooltip.test.tsx
@@ -1,0 +1,81 @@
+import type { PropsWithChildren } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '../utils/testing';
+import { CanvasTooltip, CanvasTooltipProviderMarker } from './CanvasTooltip';
+
+vi.mock('@uipath/apollo-wind/components/ui/tooltip', () => ({
+  Tooltip: ({ children }: PropsWithChildren) => <div data-testid="tooltip">{children}</div>,
+  TooltipContent: ({ children }: PropsWithChildren) => (
+    <div data-testid="tooltip-content">{children}</div>
+  ),
+  TooltipPortal: ({ children }: PropsWithChildren) => <>{children}</>,
+  TooltipProvider: ({ children }: PropsWithChildren) => (
+    <div data-testid="tooltip-provider">{children}</div>
+  ),
+  TooltipTrigger: ({ children }: PropsWithChildren) => (
+    <div data-testid="tooltip-trigger">{children}</div>
+  ),
+}));
+
+describe('CanvasTooltip', () => {
+  it('returns children directly when content is empty', () => {
+    render(
+      <CanvasTooltip content=" ">
+        <button type="button">Click me</button>
+      </CanvasTooltip>
+    );
+
+    expect(screen.getByRole('button', { name: 'Click me' })).toBeInTheDocument();
+    expect(screen.queryByTestId('tooltip')).not.toBeInTheDocument();
+  });
+
+  it('returns children directly when content is false', () => {
+    render(
+      <CanvasTooltip content={false}>
+        <button type="button">Click me</button>
+      </CanvasTooltip>
+    );
+
+    expect(screen.getByRole('button', { name: 'Click me' })).toBeInTheDocument();
+    expect(screen.queryByTestId('tooltip')).not.toBeInTheDocument();
+  });
+
+  it('returns children directly when content is null', () => {
+    render(
+      <CanvasTooltip content={null}>
+        <button type="button">Click me</button>
+      </CanvasTooltip>
+    );
+
+    expect(screen.getByRole('button', { name: 'Click me' })).toBeInTheDocument();
+    expect(screen.queryByTestId('tooltip')).not.toBeInTheDocument();
+  });
+
+  it('renders tooltip without its own TooltipProvider when inside CanvasTooltipProviderMarker', () => {
+    render(
+      <CanvasTooltipProviderMarker>
+        <CanvasTooltip content="Tooltip text">
+          <button type="button">Hover me</button>
+        </CanvasTooltip>
+      </CanvasTooltipProviderMarker>
+    );
+
+    expect(screen.getByRole('button', { name: 'Hover me' })).toBeInTheDocument();
+    expect(screen.getByTestId('tooltip')).toBeInTheDocument();
+    expect(screen.getByTestId('tooltip-content')).toHaveTextContent('Tooltip text');
+    expect(screen.queryByTestId('tooltip-provider')).not.toBeInTheDocument();
+  });
+
+  it('renders tooltip with its own TooltipProvider when no provider marker exists', () => {
+    render(
+      <CanvasTooltip content="Tooltip text">
+        <button type="button">Hover me</button>
+      </CanvasTooltip>
+    );
+
+    expect(screen.getByRole('button', { name: 'Hover me' })).toBeInTheDocument();
+    expect(screen.getByTestId('tooltip')).toBeInTheDocument();
+    expect(screen.getByTestId('tooltip-content')).toHaveTextContent('Tooltip text');
+    expect(screen.getByTestId('tooltip-provider')).toBeInTheDocument();
+  });
+});

--- a/packages/apollo-react/src/canvas/components/CanvasTooltip.tsx
+++ b/packages/apollo-react/src/canvas/components/CanvasTooltip.tsx
@@ -132,6 +132,13 @@ export function CanvasTooltip({
 
   const hasProvider = useContext(HasTooltipProviderContext);
 
+  const isEmptyContent =
+    content == null || content === false || (typeof content === 'string' && content.trim() === '');
+
+  if (isEmptyContent) {
+    return children;
+  }
+
   const tooltip = (
     <Tooltip open={effectiveOpen} onOpenChange={handleOpenChange} delayDuration={delay ? 700 : 200}>
       <TooltipTrigger asChild>{triggerWithHandlers}</TooltipTrigger>


### PR DESCRIPTION
Before: <img width="153" height="112" alt="Screenshot 2026-04-28 at 10 32 42 PM" src="https://github.com/user-attachments/assets/d4ebcd16-2405-45c8-a046-786de2d92bb8" />

After: 
<img width="195" height="93" alt="Screenshot 2026-04-28 at 10 41 23 PM" src="https://github.com/user-attachments/assets/2a6d6698-d2f4-4940-a06e-3961679cf100" />
