### PR TITLE
Switch: proportional sizing for dense form rows (size="sm")

### DIFF
--- a/packages/apollo-wind/src/components/ui/switch.stories.tsx
+++ b/packages/apollo-wind/src/components/ui/switch.stories.tsx
@@ -26,6 +26,18 @@ export const WithLabel = {
   ),
 };
 
+export const Small = {
+  args: {},
+  render: () => (
+    <Row gap={2} align="center">
+      <Switch id="case-sensitive" size="sm" />
+      <Label htmlFor="case-sensitive" className="text-sm">
+        Case sensitive
+      </Label>
+    </Row>
+  ),
+};
+
 export const Disabled = {
   args: {},
   render: () => (

--- a/packages/apollo-wind/src/components/ui/switch.test.tsx
+++ b/packages/apollo-wind/src/components/ui/switch.test.tsx
@@ -124,4 +124,33 @@ describe('Switch', () => {
     await user.click(switchElement);
     expect(switchElement).toHaveAttribute('data-state', 'unchecked');
   });
+
+  describe('size variants', () => {
+    it('renders default size when size prop is not provided', () => {
+      render(<Switch aria-label="Toggle" />);
+      const switchElement = screen.getByRole('switch');
+      expect(switchElement).toHaveClass('h-6', 'w-11');
+    });
+
+    it('renders sm size when size="sm"', () => {
+      render(<Switch size="sm" aria-label="Toggle" />);
+      const switchElement = screen.getByRole('switch');
+      expect(switchElement).toHaveClass('h-5', 'w-9');
+      expect(switchElement).not.toHaveClass('h-6', 'w-11');
+    });
+
+    it('renders sm thumb when size="sm"', () => {
+      render(<Switch size="sm" aria-label="Toggle" />);
+      const thumb = screen.getByRole('switch').firstElementChild;
+      expect(thumb).toHaveClass('h-4', 'w-4');
+    });
+
+    it('has no accessibility violations at sm size', async () => {
+      const { container } = render(
+        <Switch size="sm" aria-label="Enable case-sensitive matching" />
+      );
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+  });
 });

--- a/packages/apollo-wind/src/components/ui/switch.tsx
+++ b/packages/apollo-wind/src/components/ui/switch.tsx
@@ -1,27 +1,47 @@
 import * as SwitchPrimitives from '@radix-ui/react-switch';
+import { cva, type VariantProps } from 'class-variance-authority';
 import * as React from 'react';
 
 import { cn } from '@/lib';
 
+const switchVariants = cva(
+  'peer inline-flex shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-border',
+  {
+    variants: {
+      size: {
+        default: 'h-6 w-11',
+        sm: 'h-5 w-9',
+      },
+    },
+    defaultVariants: {
+      size: 'default',
+    },
+  }
+);
+
+const switchThumbVariants = cva(
+  'pointer-events-none block rounded-full bg-background shadow-lg ring-0 transition-transform data-[state=unchecked]:translate-x-0',
+  {
+    variants: {
+      size: {
+        default: 'h-5 w-5 data-[state=checked]:translate-x-5',
+        sm: 'h-4 w-4 data-[state=checked]:translate-x-4',
+      },
+    },
+    defaultVariants: {
+      size: 'default',
+    },
+  }
+);
+
 const Switch = React.forwardRef<
   React.ElementRef<typeof SwitchPrimitives.Root>,
-  React.ComponentPropsWithoutRef<typeof SwitchPrimitives.Root>
->(({ className, ...props }, ref) => (
-  <SwitchPrimitives.Root
-    className={cn(
-      'peer inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-border',
-      className
-    )}
-    {...props}
-    ref={ref}
-  >
-    <SwitchPrimitives.Thumb
-      className={cn(
-        'pointer-events-none block h-5 w-5 rounded-full bg-background shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-5 data-[state=unchecked]:translate-x-0'
-      )}
-    />
+  React.ComponentPropsWithoutRef<typeof SwitchPrimitives.Root> & VariantProps<typeof switchVariants>
+>(({ className, size, ...props }, ref) => (
+  <SwitchPrimitives.Root className={cn(switchVariants({ size }), className)} {...props} ref={ref}>
+    <SwitchPrimitives.Thumb className={cn(switchThumbVariants({ size }))} />
   </SwitchPrimitives.Root>
 ));
 Switch.displayName = SwitchPrimitives.Root.displayName;
 
-export { Switch };
+export { Switch, switchVariants };


### PR DESCRIPTION
## Why

The default `Switch` (24×44) is sized for primary toggles where the switch *is* the interaction. In dense config panels (variables panel, properties panel, evaluator forms) it sits next to a `text-sm` label as one of many binary settings — and at that size, the affordance reads louder than the label. Hierarchy upside-down.

Designers/devs already work around it with `className="scale-75 origin-right"`, which shrinks pixels but not the layout box or hit target — a quiet a11y regression.

## What

New `size="sm"` variant: 20×36 root, 16px thumb. Proportional to `text-sm` labels, mirrors `Button size="sm"`, consistent with the `xs` we shipped on `ToggleGroup` for the same reason.

- Refactored to CVA (`switchVariants` + `switchThumbVariants`), matching the `Toggle` pattern.
- **Default size unchanged.** Purely additive.
- New `Small` Storybook story alongside the canonical "label + switch in a dense row" layout.
- Tests cover both sizes + jest-axe pass at sm.

## Test plan

- [ ] Storybook → `Components/Core/Switch` → **Default** unchanged, **Small** sits in proportion to `text-sm` label
- [ ] Accessibility panel: no violations at sm
- [ ] Hit target matches the rendered 20×36 region (no ghost)
- [ ] `<Switch size="sm" />` autocompletes; `<Switch size="huge" />` is a type error
- [ ] `pnpm --filter @uipath/apollo-wind test` passes

Follow-up PR in flow-workbench replaces the `scale-75` workarounds with `size="sm"` once this ships.


## screenshot with new size

<img width="262" height="149" alt="image" src="https://github.com/user-attachments/assets/4373fbdb-2bde-46fc-8033-e19c80fc3920" />

