### PR TITLE
feat(apollo-react): add ListItem.childrenLoading skeleton API [MST-9224]

### DIFF
--- a/packages/apollo-react/src/canvas/components/AddNodePanel/AddNodePanel.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/AddNodePanel/AddNodePanel.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import type { Node } from '@uipath/apollo-react/canvas/xyflow/react';
 import { Panel, Position, useReactFlow } from '@uipath/apollo-react/canvas/xyflow/react';
-import { useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useAddNodeOnConnectEnd, useCanvasEvent } from '../../hooks';
 import {
   createNode,
@@ -413,6 +413,192 @@ export const NodePanelRegistryItems: Story = {
       <AddNodePanel {...args} />
     </StandalonePanelWrapper>
   ),
+};
+
+// ============================================================================
+// childrenLoading demos
+// ============================================================================
+
+const RPA_TOOL_PUBLISHED_ITEMS: ListItem<NodeItemData>[] = [
+  {
+    id: 'rpa-1',
+    name: 'invoice-extractor',
+    icon: { name: 'rpa' },
+    data: { type: 'rpa', category: 'RPA' },
+    description: '(Shared) extracts invoice data from PDFs',
+    section: 'Published',
+  },
+  {
+    id: 'rpa-2',
+    name: 'employee-onboarding',
+    icon: { name: 'rpa' },
+    data: { type: 'rpa', category: 'RPA' },
+    description: '(Shared) onboarding workflow',
+    section: 'Published',
+  },
+  {
+    id: 'rpa-3',
+    name: 'finance-reporter',
+    icon: { name: 'rpa' },
+    data: { type: 'rpa', category: 'RPA' },
+    description: '(Shared) monthly finance report',
+    section: 'Published',
+  },
+];
+
+const RPA_TOOL_IN_SOLUTION_ITEM: ListItem<NodeItemData> = {
+  id: 'rpa-local',
+  name: 'RPA Workflow',
+  icon: { name: 'rpa' },
+  data: { type: 'rpa', category: 'RPA' },
+  section: 'In this solution',
+};
+
+const RPA_TOOL_CREATE_NEW_ITEM: ListItem<NodeItemData> = {
+  id: 'create-new-rpa',
+  name: 'Create new RPA workflow',
+  icon: { name: 'plus' },
+  data: { type: 'create-new-rpa', category: 'RPA' },
+};
+
+const CHILDREN_LOADING_DEFAULT_ITEMS: ListItem<NodeItemData>[] = [
+  {
+    id: 'rpa-tool-default',
+    name: 'RPA workflow',
+    icon: { name: 'rpa' },
+    data: { type: 'rpa-category', category: 'RPA' },
+    children: [RPA_TOOL_CREATE_NEW_ITEM],
+    childrenLoading: true,
+  },
+];
+
+const CHILDREN_LOADING_SECTIONS_ITEMS: ListItem<NodeItemData>[] = [
+  {
+    id: 'rpa-tool-sections',
+    name: 'RPA workflow',
+    icon: { name: 'rpa' },
+    data: { type: 'rpa-category', category: 'RPA' },
+    // The user already has one solution-local item; orchestrator-backed
+    // "Published" content is still streaming, so we render its header
+    // pre-emptively + 3 skeletons. Once items arrive they slot under the
+    // same header without layout shift.
+    children: [RPA_TOOL_CREATE_NEW_ITEM, RPA_TOOL_IN_SOLUTION_ITEM],
+    childrenLoading: { sections: [{ name: 'Published', count: 3 }] },
+  },
+];
+
+/**
+ * Wrapper that flips `childrenLoading` to false and adds real items after
+ * `delayMs` to simulate a streaming source resolving.
+ */
+function StreamingChildrenLoadingStory({ delayMs }: { delayMs: number }) {
+  const [resolved, setResolved] = useState(false);
+
+  useEffect(() => {
+    const timer = setTimeout(() => setResolved(true), delayMs);
+    return () => clearTimeout(timer);
+  }, [delayMs]);
+
+  const items: ListItem<NodeItemData>[] = useMemo(
+    () => [
+      {
+        id: 'rpa-tool-streaming',
+        name: 'RPA workflow',
+        icon: { name: 'rpa' },
+        data: { type: 'rpa-category', category: 'RPA' },
+        children: resolved
+          ? [RPA_TOOL_CREATE_NEW_ITEM, RPA_TOOL_IN_SOLUTION_ITEM, ...RPA_TOOL_PUBLISHED_ITEMS]
+          : [RPA_TOOL_CREATE_NEW_ITEM, RPA_TOOL_IN_SOLUTION_ITEM],
+        childrenLoading: resolved ? undefined : { sections: [{ name: 'Published', count: 3 }] },
+      },
+    ],
+    [resolved]
+  );
+
+  return (
+    <StandalonePanelWrapper>
+      <AddNodePanel
+        items={items}
+        onNodeSelect={(node) => console.log('Selected:', node)}
+        onClose={() => console.log('Closed')}
+      />
+    </StandalonePanelWrapper>
+  );
+}
+
+export const NodePanelChildrenLoadingDefault: Story = {
+  name: 'childrenLoading: default skeletons',
+  parameters: {
+    docs: {
+      description: {
+        story: [
+          'Drill into "RPA workflow" to see the default 3 skeleton rows.',
+          '',
+          "The category sets `childrenLoading: true` to opt into Apollo's built-in",
+          "skeleton placeholder. The skeleton mirrors a real row's geometry —",
+          '32×32 icon + name + description — so the layout stays stable when real',
+          'items take over. Top-level rows are not dimmed.',
+        ].join('\n'),
+      },
+    },
+  },
+  args: {
+    items: CHILDREN_LOADING_DEFAULT_ITEMS,
+    onNodeSelect: (node) => console.log('Selected node:', node),
+    onClose: () => console.log('Closed selector'),
+  },
+  render: (args) => (
+    <StandalonePanelWrapper>
+      <AddNodePanel {...args} />
+    </StandalonePanelWrapper>
+  ),
+};
+
+export const NodePanelChildrenLoadingSections: Story = {
+  name: 'childrenLoading: preemptive section headers',
+  parameters: {
+    docs: {
+      description: {
+        story: [
+          'Drill into "RPA workflow" to see the "Published" section header pre-rendered',
+          'with skeleton rows beneath it, while a separate "In this solution" item is',
+          'already loaded above.',
+          '',
+          'Use `childrenLoading: { sections: [...] }` when you already know the final',
+          'section structure. Real items with a matching `section` slot under the same',
+          'header so the layout does not shift when content arrives.',
+        ].join('\n'),
+      },
+    },
+  },
+  args: {
+    items: CHILDREN_LOADING_SECTIONS_ITEMS,
+    onNodeSelect: (node) => console.log('Selected node:', node),
+    onClose: () => console.log('Closed selector'),
+  },
+  render: (args) => (
+    <StandalonePanelWrapper>
+      <AddNodePanel {...args} />
+    </StandalonePanelWrapper>
+  ),
+};
+
+export const NodePanelChildrenLoadingStreaming: Story = {
+  name: 'childrenLoading: streaming → real content',
+  parameters: {
+    docs: {
+      description: {
+        story: [
+          'Demonstrates the layout-stability promise. Drill into "RPA workflow"',
+          'while the source is still loading — you see the "Published" section',
+          'header + 3 skeletons. After ~3 seconds, real items replace the',
+          'skeletons under the same header. The "Create new" row, "In this',
+          'solution" item, and "Published" header all stay put.',
+        ].join('\n'),
+      },
+    },
+  },
+  render: () => <StreamingChildrenLoadingStory delayMs={3000} />,
 };
 
 export const NodePanelScrollPreservation: Story = {

--- a/packages/apollo-react/src/canvas/components/Toolbox/ListView.test.tsx
+++ b/packages/apollo-react/src/canvas/components/Toolbox/ListView.test.tsx
@@ -48,6 +48,92 @@ describe('ListView', () => {
     });
   });
 
+  describe('loadingSkeleton', () => {
+    it('should render the default 3 skeleton rows when loadingSkeleton=true and items is empty', () => {
+      render(<ListView {...defaultProps} items={[]} loadingSkeleton={true} />);
+
+      expect(screen.getAllByTestId('list-item-skeleton')).toHaveLength(3);
+      expect(screen.queryByText('No items found')).not.toBeInTheDocument();
+    });
+
+    it('should respect a custom skeleton count', () => {
+      render(<ListView {...defaultProps} items={[]} loadingSkeleton={{ count: 5 }} />);
+
+      expect(screen.getAllByTestId('list-item-skeleton')).toHaveLength(5);
+    });
+
+    it('should render section headers + per-section skeletons when sections are provided', () => {
+      render(
+        <ListView
+          {...defaultProps}
+          items={[]}
+          loadingSkeleton={{
+            sections: [
+              { name: 'Published', count: 2 },
+              { name: 'In this solution', count: 1 },
+            ],
+          }}
+        />
+      );
+
+      expect(screen.getByText('Published')).toBeInTheDocument();
+      expect(screen.getByText('In this solution')).toBeInTheDocument();
+      expect(screen.getAllByTestId('list-item-skeleton')).toHaveLength(3);
+    });
+
+    it('should append skeletons after real items while loadingSkeleton is active', () => {
+      // The whole point of `loadingSkeleton` is "more on the way" — skeletons
+      // must keep rendering even after some content has loaded.
+      const items: ListItem[] = [{ id: 'item-1', name: 'Item 1', data: {} }];
+
+      render(<ListView {...defaultProps} items={items} loadingSkeleton={true} />);
+
+      expect(screen.getByText('Item 1')).toBeInTheDocument();
+      expect(screen.getAllByTestId('list-item-skeleton')).toHaveLength(3);
+    });
+
+    it('should drop skeletons once loadingSkeleton is cleared', () => {
+      const items: ListItem[] = [{ id: 'item-1', name: 'Item 1', data: {} }];
+
+      const { rerender } = render(
+        <ListView {...defaultProps} items={items} loadingSkeleton={true} />
+      );
+      expect(screen.getAllByTestId('list-item-skeleton')).toHaveLength(3);
+
+      rerender(<ListView {...defaultProps} items={items} loadingSkeleton={undefined} />);
+      expect(screen.queryByTestId('list-item-skeleton')).not.toBeInTheDocument();
+      expect(screen.getByText('Item 1')).toBeInTheDocument();
+    });
+
+    it('should not apply the .loading row class while loadingSkeleton is active with items', () => {
+      // `loadingSkeleton` is independent of `isLoading`; it only swaps the
+      // empty-state for skeletons and must not dim/disable other rows.
+      const items: ListItem[] = [{ id: 'item-1', name: 'Item 1', data: {} }];
+
+      render(<ListView {...defaultProps} items={items} loadingSkeleton={true} />);
+
+      const option = screen.getByRole('option');
+      expect(option).not.toHaveClass('loading');
+      expect(option).not.toBeDisabled();
+    });
+
+    it('should prefer loadingSkeleton over isLoading for the empty state when both are set', () => {
+      // Sections-aware skeleton wins over the legacy 3-row default so consumers
+      // can opt into preemptive headers without having to gate isLoading.
+      render(
+        <ListView
+          {...defaultProps}
+          items={[]}
+          isLoading={true}
+          loadingSkeleton={{ sections: [{ name: 'Published', count: 1 }] }}
+        />
+      );
+
+      expect(screen.getByText('Published')).toBeInTheDocument();
+      expect(screen.getAllByTestId('list-item-skeleton')).toHaveLength(1);
+    });
+  });
+
   describe('Item rendering', () => {
     it('should render basic item with name and icon', () => {
       const items: ListItem[] = [

--- a/packages/apollo-react/src/canvas/components/Toolbox/ListView.tsx
+++ b/packages/apollo-react/src/canvas/components/Toolbox/ListView.tsx
@@ -25,15 +25,22 @@ export interface ListItemIcon {
 /**
  * Configuration for the skeleton placeholder shown when an item is drilled
  * into and its children are still loading.
+ *
+ * For best perf, callers passing this as an object should memoize it —
+ * passing a fresh object each render rebuilds the skeleton items and
+ * cascades through the row virtualizer.
  */
 export type ChildrenLoadingSpec = {
-  /** Number of skeleton rows to render when no `sections` are provided. Defaults to 3. */
+  /**
+   * Number of skeleton rows. When `sections` is set, this is the per-section
+   * default for any section that omits its own `count`. Defaults to 3.
+   */
   count?: number;
   /**
    * Pre-render section headers + skeleton rows under each. Once real items
    * arrive with a matching `section`, they slot under the same header so the
-   * layout doesn't shift. Use this when you already know the final section
-   * structure (e.g. "Published", "In this solution").
+   * layout doesn't shift. Each section's `count` overrides the top-level
+   * `count` (or the built-in default of 3).
    */
   sections?: { name: string; count?: number }[];
 };
@@ -159,8 +166,8 @@ const ListViewRow = memo(
     const item = renderItem.item;
 
     // Skeleton sentinels render as the placeholder bar, never as a clickable
-    // row. They can't appear in `activeIndex` because Toolbox's keyboard
-    // navigation skips items injected by ListView itself.
+    // row. Toolbox's keyboard nav also skips them via the exported
+    // `isSkeletonItem` helper, so they never become the active descendant.
     if (isSkeletonItem(item)) {
       return (
         <div style={style}>
@@ -261,10 +268,20 @@ const ListItemSkeleton = () => (
   </div>
 );
 
-// Internal id prefix used to mark skeleton sentinel items injected by
-// `ListView`. Consumers must not produce ids with this prefix.
-const SKELETON_ID_PREFIX = '__listview_skeleton__';
-const isSkeletonItem = (item: ListItem): boolean => item.id.startsWith(SKELETON_ID_PREFIX);
+// Skeleton sentinel items are tracked by reference in this `WeakSet`, not by
+// an id prefix. This keeps the marker entirely internal — consumers can't
+// collide with it from their own `id` strings — and entries auto-expire when
+// the items become unreferenced.
+const skeletonItemRegistry = new WeakSet<ListItem>();
+
+/**
+ * True for skeleton sentinel rows produced by {@link ListView} (via the
+ * `loadingSkeleton` prop or `ListItem.childrenLoading`). Exposed so callers
+ * such as `Toolbox`'s keyboard navigation can skip these presentational rows.
+ */
+export function isSkeletonItem(item: ListItem): boolean {
+  return skeletonItemRegistry.has(item);
+}
 
 /**
  * Build the synthetic skeleton ListItem entries that get appended to the
@@ -276,19 +293,25 @@ const isSkeletonItem = (item: ListItem): boolean => item.id.startsWith(SKELETON_
 function buildSkeletonItems(spec: boolean | ChildrenLoadingSpec): ListItem[] {
   const config: ChildrenLoadingSpec = typeof spec === 'object' ? spec : {};
   const defaultCount = config.count ?? 3;
-  const make = (id: string, section?: string): ListItem => ({
-    id: `${SKELETON_ID_PREFIX}${id}`,
-    name: '',
-    data: {},
-    ...(section ? { section } : {}),
-  });
+  const make = (id: string, section?: string): ListItem => {
+    const item: ListItem = {
+      id,
+      name: '',
+      data: {},
+      ...(section ? { section } : {}),
+    };
+    skeletonItemRegistry.add(item);
+    return item;
+  };
 
   if (config.sections && config.sections.length > 0) {
     return config.sections.flatMap((s) =>
-      Array.from({ length: s.count ?? defaultCount }, (_, i) => make(`${s.name}-${i}`, s.name))
+      Array.from({ length: s.count ?? defaultCount }, (_, i) =>
+        make(`__listview_skeleton__${s.name}-${i}`, s.name)
+      )
     );
   }
-  return Array.from({ length: defaultCount }, (_, i) => make(`${i}`));
+  return Array.from({ length: defaultCount }, (_, i) => make(`__listview_skeleton__${i}`));
 }
 
 const ListViewInner = forwardRef(function ListView<T extends ListItem>(
@@ -314,11 +337,15 @@ const ListViewInner = forwardRef(function ListView<T extends ListItem>(
   // is the opt-in per-drill-in path; the legacy `isLoading && items.length
   // === 0` behaviour is preserved by falling through to a `true` spec.
   const activeSkeleton = loadingSkeleton ?? (isLoading && items.length === 0 ? true : null);
-  const skeletonItems = useMemo(
-    () => (activeSkeleton ? buildSkeletonItems(activeSkeleton) : []),
+  // Skeletons are synthesized as plain `ListItem`s with `data: {}` and an
+  // internal id prefix. Casting to `T[]` is sound because `ListViewRow`
+  // short-circuits skeleton sentinels before reading any consumer-shaped data
+  // (handled by `isSkeletonItem`).
+  const skeletonItems = useMemo<T[]>(
+    () => (activeSkeleton ? (buildSkeletonItems(activeSkeleton) as T[]) : []),
     [activeSkeleton]
   );
-  const allItems = useMemo(
+  const allItems = useMemo<T[]>(
     () => (skeletonItems.length > 0 ? [...items, ...skeletonItems] : items),
     [items, skeletonItems]
   );
@@ -349,6 +376,9 @@ const ListViewInner = forwardRef(function ListView<T extends ListItem>(
     <StyledList
       id="toolbox-listbox"
       role="listbox"
+      // Signal "list is being updated" to assistive tech while skeleton
+      // sentinels are rendered in place of real items.
+      aria-busy={skeletonItems.length > 0 || undefined}
       listRef={listRef}
       rowProps={rowProps}
       rowComponent={ListViewRow}

--- a/packages/apollo-react/src/canvas/components/Toolbox/ListView.tsx
+++ b/packages/apollo-react/src/canvas/components/Toolbox/ListView.tsx
@@ -79,11 +79,7 @@ export function buildRenderedItems<T extends ListItem>(
 ): RenderItem<T>[] {
   const result: RenderItem<T>[] = [];
   const skeletonConfig: ChildrenLoadingSpec | undefined =
-    typeof loadingSkeleton === 'object'
-      ? loadingSkeleton
-      : loadingSkeleton
-        ? {}
-        : undefined;
+    typeof loadingSkeleton === 'object' ? loadingSkeleton : loadingSkeleton ? {} : undefined;
   const baseSkeletonCount = skeletonConfig?.count ?? DEFAULT_SKELETON_COUNT;
 
   // Skeletons are emitted as `{ type: 'skeleton' }` so they're a distinct

--- a/packages/apollo-react/src/canvas/components/Toolbox/ListView.tsx
+++ b/packages/apollo-react/src/canvas/components/Toolbox/ListView.tsx
@@ -101,33 +101,29 @@ export function buildRenderedItems<T extends ListItem>(
   // Items without a section render at the top.
   for (const item of itemsWithoutSection) result.push({ type: 'item', item });
 
-  // Build the union of section names from real items + preemptive skeleton
-  // sections, preserving insertion order. Real-item sections come first to
-  // match the existing behaviour.
-  const sectionNames: string[] = [];
-  const seenSections = new Set<string>();
+  // Group items by section in one pass; insertion order is preserved by Map.
+  const itemsBySection = new Map<string, T[]>();
   for (const item of itemsWithSection) {
     const name = item.section as string;
-    if (!seenSections.has(name)) {
-      seenSections.add(name);
-      sectionNames.push(name);
-    }
+    const bucket = itemsBySection.get(name);
+    if (bucket) bucket.push(item);
+    else itemsBySection.set(name, [item]);
   }
-  if (skeletonConfig?.sections) {
-    for (const s of skeletonConfig.sections) {
-      if (!seenSections.has(s.name)) {
-        seenSections.add(s.name);
-        sectionNames.push(s.name);
-      }
-    }
+
+  // Map skeleton sections for O(1) lookup, then build the final section order
+  // — real-item sections first, then any skeleton-only sections appended.
+  const skeletonBySection = new Map(skeletonConfig?.sections?.map((s) => [s.name, s]) ?? []);
+  const sectionNames = [...itemsBySection.keys()];
+  for (const s of skeletonConfig?.sections ?? []) {
+    if (!itemsBySection.has(s.name)) sectionNames.push(s.name);
   }
 
   for (const sectionName of sectionNames) {
     result.push({ type: 'section', sectionName });
-    for (const item of itemsWithSection) {
-      if (item.section === sectionName) result.push({ type: 'item', item });
+    for (const item of itemsBySection.get(sectionName) ?? []) {
+      result.push({ type: 'item', item });
     }
-    const skeletonForSection = skeletonConfig?.sections?.find((s) => s.name === sectionName);
+    const skeletonForSection = skeletonBySection.get(sectionName);
     if (skeletonForSection) {
       pushSkeletons(skeletonForSection.count ?? baseSkeletonCount);
     }

--- a/packages/apollo-react/src/canvas/components/Toolbox/ListView.tsx
+++ b/packages/apollo-react/src/canvas/components/Toolbox/ListView.tsx
@@ -67,45 +67,80 @@ export type ListItem<T = any> = {
 
 export type RenderItem<T extends ListItem> =
   | { type: 'section'; sectionName: string }
-  | { type: 'item'; item: T };
+  | { type: 'item'; item: T }
+  | { type: 'skeleton' };
+
+const DEFAULT_SKELETON_COUNT = 3;
 
 export function buildRenderedItems<T extends ListItem>(
   items: T[],
-  enableSections: boolean
+  enableSections: boolean,
+  loadingSkeleton?: boolean | ChildrenLoadingSpec
 ): RenderItem<T>[] {
   const result: RenderItem<T>[] = [];
+  const skeletonConfig: ChildrenLoadingSpec | undefined =
+    typeof loadingSkeleton === 'object'
+      ? loadingSkeleton
+      : loadingSkeleton
+        ? {}
+        : undefined;
+  const baseSkeletonCount = skeletonConfig?.count ?? DEFAULT_SKELETON_COUNT;
 
-  if (items.length === 0) return result;
+  // Skeletons are emitted as `{ type: 'skeleton' }` so they're a distinct
+  // shape from real items. That keeps clicks / hovers / keyboard nav (which
+  // all filter on `type === 'item'`) auto-skipping them without per-row
+  // sentinel checks.
+  const pushSkeletons = (count: number) => {
+    for (let i = 0; i < count; i++) result.push({ type: 'skeleton' });
+  };
 
   if (!enableSections) {
-    // if sections are disabled, return all items as is
-    for (const item of items) {
-      result.push({ type: 'item', item });
-    }
+    for (const item of items) result.push({ type: 'item', item });
+    if (skeletonConfig && !skeletonConfig.sections) pushSkeletons(baseSkeletonCount);
     return result;
   }
 
   const [itemsWithSection, itemsWithoutSection] = partition(items, (item) => !!item.section);
 
-  // process items without sections first
-  for (const item of itemsWithoutSection) {
-    result.push({ type: 'item', item });
-  }
+  // Items without a section render at the top.
+  for (const item of itemsWithoutSection) result.push({ type: 'item', item });
 
-  // return early if no items with sections
-  if (itemsWithSection.length === 0) {
-    return result;
-  }
-
-  // process items with sections next
-  const sections = Array.from(new Set(itemsWithSection.map((item) => item.section)));
-
-  for (const section of sections) {
-    result.push({ type: 'section', sectionName: section as string });
-
-    for (const item of itemsWithSection.filter((item) => item.section === section)) {
-      result.push({ type: 'item', item });
+  // Build the union of section names from real items + preemptive skeleton
+  // sections, preserving insertion order. Real-item sections come first to
+  // match the existing behaviour.
+  const sectionNames: string[] = [];
+  const seenSections = new Set<string>();
+  for (const item of itemsWithSection) {
+    const name = item.section as string;
+    if (!seenSections.has(name)) {
+      seenSections.add(name);
+      sectionNames.push(name);
     }
+  }
+  if (skeletonConfig?.sections) {
+    for (const s of skeletonConfig.sections) {
+      if (!seenSections.has(s.name)) {
+        seenSections.add(s.name);
+        sectionNames.push(s.name);
+      }
+    }
+  }
+
+  for (const sectionName of sectionNames) {
+    result.push({ type: 'section', sectionName });
+    for (const item of itemsWithSection) {
+      if (item.section === sectionName) result.push({ type: 'item', item });
+    }
+    const skeletonForSection = skeletonConfig?.sections?.find((s) => s.name === sectionName);
+    if (skeletonForSection) {
+      pushSkeletons(skeletonForSection.count ?? baseSkeletonCount);
+    }
+  }
+
+  // Skeletons without sections trail the list. Suppressed when the spec uses
+  // `sections` (those skeletons are already emitted under their headers).
+  if (skeletonConfig && !skeletonConfig.sections) {
+    pushSkeletons(baseSkeletonCount);
   }
 
   return result;
@@ -143,16 +178,12 @@ const ListViewRow = memo(
 
     const handleButtonClick = useCallback(() => {
       const clickTarget = renderedItems[index];
-      if (clickTarget?.type === 'item' && !isSkeletonItem(clickTarget.item)) {
-        onItemClick(clickTarget.item, index);
-      }
+      if (clickTarget?.type === 'item') onItemClick(clickTarget.item, index);
     }, [onItemClick, renderedItems, index]);
 
     const handleButtonHover = useCallback(() => {
       const hoverTarget = renderedItems[index];
-      if (hoverTarget?.type === 'item' && !isSkeletonItem(hoverTarget.item)) {
-        onItemHover?.(hoverTarget.item);
-      }
+      if (hoverTarget?.type === 'item') onItemHover?.(hoverTarget.item);
     }, [onItemHover, renderedItems, index]);
 
     if (renderItem.type === 'section') {
@@ -163,18 +194,15 @@ const ListViewRow = memo(
       );
     }
 
-    const item = renderItem.item;
-
-    // Skeleton sentinels render as the placeholder bar, never as a clickable
-    // row. Toolbox's keyboard nav also skips them via the exported
-    // `isSkeletonItem` helper, so they never become the active descendant.
-    if (isSkeletonItem(item)) {
+    if (renderItem.type === 'skeleton') {
       return (
         <div style={style}>
           <ListItemSkeleton />
         </div>
       );
     }
+
+    const item = renderItem.item;
     const bgColor = isDarkMode ? (item.colorDark ?? item.color) : item.color;
 
     const isActive = index === activeIndex;
@@ -255,64 +283,18 @@ interface ListViewProps<T extends ListItem> {
  */
 const ListItemSkeleton = () => (
   <div
-    className="flex items-center gap-2.5 h-8 px-2"
+    className="flex items-center gap-2.5 h-8"
     role="presentation"
     aria-hidden="true"
     data-testid="list-item-skeleton"
   >
-    <Skeleton className="h-8 w-8 shrink-0 rounded-full" />
+    <Skeleton className="h-8 w-8 shrink-0 rounded-lg" />
     <div className="flex-1 space-y-1.5 min-w-0">
       <Skeleton className="h-3.5 w-1/3" />
       <Skeleton className="h-3 w-2/3" />
     </div>
   </div>
 );
-
-// Skeleton sentinel items are tracked by reference in this `WeakSet`, not by
-// an id prefix. This keeps the marker entirely internal — consumers can't
-// collide with it from their own `id` strings — and entries auto-expire when
-// the items become unreferenced.
-const skeletonItemRegistry = new WeakSet<ListItem>();
-
-/**
- * True for skeleton sentinel rows produced by {@link ListView} (via the
- * `loadingSkeleton` prop or `ListItem.childrenLoading`). Exposed so callers
- * such as `Toolbox`'s keyboard navigation can skip these presentational rows.
- */
-export function isSkeletonItem(item: ListItem): boolean {
-  return skeletonItemRegistry.has(item);
-}
-
-/**
- * Build the synthetic skeleton ListItem entries that get appended to the
- * caller's `items` while `loadingSkeleton` is active. These flow through the
- * normal section-grouping pipeline so real items with a matching `section`
- * end up under the same header — and inserting them as ListItems means
- * react-window virtualizes them just like any other row.
- */
-function buildSkeletonItems(spec: boolean | ChildrenLoadingSpec): ListItem[] {
-  const config: ChildrenLoadingSpec = typeof spec === 'object' ? spec : {};
-  const defaultCount = config.count ?? 3;
-  const make = (id: string, section?: string): ListItem => {
-    const item: ListItem = {
-      id,
-      name: '',
-      data: {},
-      ...(section ? { section } : {}),
-    };
-    skeletonItemRegistry.add(item);
-    return item;
-  };
-
-  if (config.sections && config.sections.length > 0) {
-    return config.sections.flatMap((s) =>
-      Array.from({ length: s.count ?? defaultCount }, (_, i) =>
-        make(`__listview_skeleton__${s.name}-${i}`, s.name)
-      )
-    );
-  }
-  return Array.from({ length: defaultCount }, (_, i) => make(`__listview_skeleton__${i}`));
-}
 
 const ListViewInner = forwardRef(function ListView<T extends ListItem>(
   {
@@ -332,27 +314,14 @@ const ListViewInner = forwardRef(function ListView<T extends ListItem>(
 ) {
   const { isDarkMode } = useCanvasTheme();
 
-  // Merge skeleton sentinel rows with the caller's items so they flow through
-  // the normal section-grouping + virtualization pipeline. `loadingSkeleton`
-  // is the opt-in per-drill-in path; the legacy `isLoading && items.length
-  // === 0` behaviour is preserved by falling through to a `true` spec.
-  const activeSkeleton = loadingSkeleton ?? (isLoading && items.length === 0 ? true : null);
-  // Skeletons are synthesized as plain `ListItem`s with `data: {}` and an
-  // internal id prefix. Casting to `T[]` is sound because `ListViewRow`
-  // short-circuits skeleton sentinels before reading any consumer-shaped data
-  // (handled by `isSkeletonItem`).
-  const skeletonItems = useMemo<T[]>(
-    () => (activeSkeleton ? (buildSkeletonItems(activeSkeleton) as T[]) : []),
-    [activeSkeleton]
-  );
-  const allItems = useMemo<T[]>(
-    () => (skeletonItems.length > 0 ? [...items, ...skeletonItems] : items),
-    [items, skeletonItems]
-  );
+  // The legacy `isLoading && items.length === 0` empty-state path is preserved
+  // by falling through to a `true` spec, which `buildRenderedItems` turns into
+  // 3 default skeleton rows.
+  const activeSkeleton = loadingSkeleton ?? (isLoading && items.length === 0 ? true : undefined);
 
   const renderedItems = useMemo(
-    () => buildRenderedItems(allItems, enableSections),
-    [allItems, enableSections]
+    () => buildRenderedItems(items, enableSections, activeSkeleton),
+    [items, enableSections, activeSkeleton]
   );
 
   useImperativeHandle(ref, () => ({ renderedItems }), [renderedItems]);
@@ -362,8 +331,9 @@ const ListViewInner = forwardRef(function ListView<T extends ListItem>(
     [renderedItems, activeIndex, isLoading, isDarkMode, onItemClick, onItemHover]
   );
 
-  // Show empty state if neither real items nor skeletons would render.
-  if (allItems.length === 0) {
+  // Show empty state when nothing would render — neither real items nor
+  // skeleton placeholders.
+  if (renderedItems.length === 0) {
     return (
       <Column align="center" justify="center" flex={1} gap={10} style={{ minHeight: '250px' }}>
         <CanvasIcon icon={emptyStateIcon} size={48} color="var(--canvas-foreground-de-emp)" />
@@ -378,7 +348,7 @@ const ListViewInner = forwardRef(function ListView<T extends ListItem>(
       role="listbox"
       // Signal "list is being updated" to assistive tech while skeleton
       // sentinels are rendered in place of real items.
-      aria-busy={skeletonItems.length > 0 || undefined}
+      aria-busy={activeSkeleton ? true : undefined}
       listRef={listRef}
       rowProps={rowProps}
       rowComponent={ListViewRow}

--- a/packages/apollo-react/src/canvas/components/Toolbox/ListView.tsx
+++ b/packages/apollo-react/src/canvas/components/Toolbox/ListView.tsx
@@ -22,6 +22,22 @@ export interface ListItemIcon {
   Component?: React.ComponentType;
 }
 
+/**
+ * Configuration for the skeleton placeholder shown when an item is drilled
+ * into and its children are still loading.
+ */
+export type ChildrenLoadingSpec = {
+  /** Number of skeleton rows to render when no `sections` are provided. Defaults to 3. */
+  count?: number;
+  /**
+   * Pre-render section headers + skeleton rows under each. Once real items
+   * arrive with a matching `section`, they slot under the same header so the
+   * layout doesn't shift. Use this when you already know the final section
+   * structure (e.g. "Published", "In this solution").
+   */
+  sections?: { name: string; count?: number }[];
+};
+
 export type ListItem<T = any> = {
   id: string;
   name: string;
@@ -32,6 +48,14 @@ export type ListItem<T = any> = {
   color?: string;
   colorDark?: string;
   children?: ListItem<T>[] | ((id: string, name: string) => Promise<ListItem<T>[]>);
+  /**
+   * When this item is drilled into and `children` resolves to an empty array,
+   * render skeleton placeholder rows instead of the empty-state message.
+   * Pass `true` for the default (3 rows) or a {@link ChildrenLoadingSpec} for
+   * customization. Skeletons disappear once `children` updates to a non-empty
+   * array.
+   */
+  childrenLoading?: boolean | ChildrenLoadingSpec;
 };
 
 export type RenderItem<T extends ListItem> =
@@ -112,14 +136,14 @@ const ListViewRow = memo(
 
     const handleButtonClick = useCallback(() => {
       const clickTarget = renderedItems[index];
-      if (clickTarget?.type === 'item') {
+      if (clickTarget?.type === 'item' && !isSkeletonItem(clickTarget.item)) {
         onItemClick(clickTarget.item, index);
       }
     }, [onItemClick, renderedItems, index]);
 
     const handleButtonHover = useCallback(() => {
       const hoverTarget = renderedItems[index];
-      if (hoverTarget?.type === 'item') {
+      if (hoverTarget?.type === 'item' && !isSkeletonItem(hoverTarget.item)) {
         onItemHover?.(hoverTarget.item);
       }
     }, [onItemHover, renderedItems, index]);
@@ -133,6 +157,17 @@ const ListViewRow = memo(
     }
 
     const item = renderItem.item;
+
+    // Skeleton sentinels render as the placeholder bar, never as a clickable
+    // row. They can't appear in `activeIndex` because Toolbox's keyboard
+    // navigation skips items injected by ListView itself.
+    if (isSkeletonItem(item)) {
+      return (
+        <div style={style}>
+          <ListItemSkeleton />
+        </div>
+      );
+    }
     const bgColor = isDarkMode ? (item.colorDark ?? item.color) : item.color;
 
     const isActive = index === activeIndex;
@@ -196,6 +231,64 @@ interface ListViewProps<T extends ListItem> {
   emptyStateIcon?: string;
   isLoading?: boolean;
   enableSections?: boolean;
+  /**
+   * Render skeleton placeholder rows when `items` is empty, independent of
+   * `isLoading`. Accepts the same shape as {@link ListItem.childrenLoading}.
+   * Use this when you want to show "more on the way" without disabling the
+   * rest of the panel (which `isLoading` does via the `.loading` row class).
+   */
+  loadingSkeleton?: boolean | ChildrenLoadingSpec;
+}
+
+/**
+ * Skeleton row used for the {@link ListItem.childrenLoading} drill-in path
+ * and the legacy `isLoading && items.length === 0` empty-state. Mirrors a
+ * real row's geometry — 32×32 icon + name + description — so the layout
+ * stays stable when real items take over.
+ */
+const ListItemSkeleton = () => (
+  <div
+    className="flex items-center gap-2.5 h-8 px-2"
+    role="presentation"
+    aria-hidden="true"
+    data-testid="list-item-skeleton"
+  >
+    <Skeleton className="h-8 w-8 shrink-0 rounded-full" />
+    <div className="flex-1 space-y-1.5 min-w-0">
+      <Skeleton className="h-3.5 w-1/3" />
+      <Skeleton className="h-3 w-2/3" />
+    </div>
+  </div>
+);
+
+// Internal id prefix used to mark skeleton sentinel items injected by
+// `ListView`. Consumers must not produce ids with this prefix.
+const SKELETON_ID_PREFIX = '__listview_skeleton__';
+const isSkeletonItem = (item: ListItem): boolean => item.id.startsWith(SKELETON_ID_PREFIX);
+
+/**
+ * Build the synthetic skeleton ListItem entries that get appended to the
+ * caller's `items` while `loadingSkeleton` is active. These flow through the
+ * normal section-grouping pipeline so real items with a matching `section`
+ * end up under the same header — and inserting them as ListItems means
+ * react-window virtualizes them just like any other row.
+ */
+function buildSkeletonItems(spec: boolean | ChildrenLoadingSpec): ListItem[] {
+  const config: ChildrenLoadingSpec = typeof spec === 'object' ? spec : {};
+  const defaultCount = config.count ?? 3;
+  const make = (id: string, section?: string): ListItem => ({
+    id: `${SKELETON_ID_PREFIX}${id}`,
+    name: '',
+    data: {},
+    ...(section ? { section } : {}),
+  });
+
+  if (config.sections && config.sections.length > 0) {
+    return config.sections.flatMap((s) =>
+      Array.from({ length: s.count ?? defaultCount }, (_, i) => make(`${s.name}-${i}`, s.name))
+    );
+  }
+  return Array.from({ length: defaultCount }, (_, i) => make(`${i}`));
 }
 
 const ListViewInner = forwardRef(function ListView<T extends ListItem>(
@@ -210,14 +303,29 @@ const ListViewInner = forwardRef(function ListView<T extends ListItem>(
     emptyStateIcon = 'search-x',
     isLoading = false,
     enableSections = true,
+    loadingSkeleton,
   }: ListViewProps<T>,
   ref: React.Ref<ListViewHandle<T>>
 ) {
   const { isDarkMode } = useCanvasTheme();
 
+  // Merge skeleton sentinel rows with the caller's items so they flow through
+  // the normal section-grouping + virtualization pipeline. `loadingSkeleton`
+  // is the opt-in per-drill-in path; the legacy `isLoading && items.length
+  // === 0` behaviour is preserved by falling through to a `true` spec.
+  const activeSkeleton = loadingSkeleton ?? (isLoading && items.length === 0 ? true : null);
+  const skeletonItems = useMemo(
+    () => (activeSkeleton ? buildSkeletonItems(activeSkeleton) : []),
+    [activeSkeleton]
+  );
+  const allItems = useMemo(
+    () => (skeletonItems.length > 0 ? [...items, ...skeletonItems] : items),
+    [items, skeletonItems]
+  );
+
   const renderedItems = useMemo(
-    () => buildRenderedItems(items, enableSections),
-    [items, enableSections]
+    () => buildRenderedItems(allItems, enableSections),
+    [allItems, enableSections]
   );
 
   useImperativeHandle(ref, () => ({ renderedItems }), [renderedItems]);
@@ -227,19 +335,8 @@ const ListViewInner = forwardRef(function ListView<T extends ListItem>(
     [renderedItems, activeIndex, isLoading, isDarkMode, onItemClick, onItemHover]
   );
 
-  // Only show skeleton loaders when loading and no items exist
-  if (isLoading && items.length === 0) {
-    return (
-      <Column gap={8}>
-        {[...Array(3)].map((_, index) => (
-          <Skeleton className="h-8 w-full" key={index} />
-        ))}
-      </Column>
-    );
-  }
-
-  // Show empty state if no items and explicitly requested
-  if (items.length === 0) {
+  // Show empty state if neither real items nor skeletons would render.
+  if (allItems.length === 0) {
     return (
       <Column align="center" justify="center" flex={1} gap={10} style={{ minHeight: '250px' }}>
         <CanvasIcon icon={emptyStateIcon} size={48} color="var(--canvas-foreground-de-emp)" />

--- a/packages/apollo-react/src/canvas/components/Toolbox/Toolbox.test.tsx
+++ b/packages/apollo-react/src/canvas/components/Toolbox/Toolbox.test.tsx
@@ -1470,5 +1470,91 @@ describe('Toolbox', () => {
       expect(screen.getByText('Real Child')).toBeInTheDocument();
       expect(screen.getAllByTestId('list-item-skeleton')).toHaveLength(3);
     });
+
+    it('skips skeleton sentinels when navigating via arrow keys', async () => {
+      // Skeletons are presentational — keyboard nav must land on the real
+      // item, not on placeholder rows. Without the fix, ArrowDown would set
+      // the active descendant to a skeleton row.
+      vi.useFakeTimers({ shouldAdvanceTime: true });
+      const timedUser = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+
+      render(
+        <Toolbox
+          {...defaultProps}
+          initialItems={[
+            {
+              id: 'parent',
+              name: 'Loading Parent',
+              data: {},
+              children: [{ id: 'real-child', name: 'Real Child', data: {} }],
+              childrenLoading: true,
+            } as ListItem,
+          ]}
+        />
+      );
+      await timedUser.click(screen.getByText('Loading Parent'));
+      // Wait past the forward-transition timeout so the new level has stably
+      // rendered and the search bar is back in focus.
+      await act(() => vi.advanceTimersByTimeAsync(200));
+
+      await timedUser.keyboard('{ArrowDown}');
+
+      const activeItem = document.querySelector('[aria-selected="true"]');
+      expect(activeItem).toHaveAttribute('id', 'toolbox-item-real-child');
+
+      vi.useRealTimers();
+    });
+
+    it('does not call onItemSelect or onItemHover for skeleton clicks/hovers', async () => {
+      const onItemSelect = vi.fn();
+      const onItemHover = vi.fn();
+      const items: ListItem[] = [
+        {
+          id: 'parent',
+          name: 'Loading Parent',
+          data: {},
+          children: [],
+          childrenLoading: true,
+        },
+      ];
+
+      render(
+        <Toolbox
+          {...defaultProps}
+          initialItems={items}
+          onItemSelect={onItemSelect}
+          onItemHover={onItemHover}
+        />
+      );
+      await user.click(screen.getByText('Loading Parent'));
+
+      const skeletonRows = screen.getAllByTestId('list-item-skeleton');
+      // Click the skeleton's parent <button> (the row), not the inner div.
+      const firstRow = skeletonRows[0]!.parentElement!;
+      await user.click(firstRow);
+      await user.hover(firstRow);
+
+      expect(onItemSelect).not.toHaveBeenCalled();
+      expect(onItemHover).not.toHaveBeenCalled();
+    });
+
+    it('suppresses skeletons during search', async () => {
+      const items: ListItem[] = [
+        {
+          id: 'parent',
+          name: 'Loading Parent',
+          data: {},
+          children: [{ id: 'child', name: 'Real Child', data: {} }],
+          childrenLoading: true,
+        },
+      ];
+
+      render(<Toolbox {...defaultProps} initialItems={items} />);
+      await user.click(screen.getByText('Loading Parent'));
+      expect(screen.getAllByTestId('list-item-skeleton').length).toBeGreaterThan(0);
+
+      await user.type(screen.getByPlaceholderText('Search'), 'Real');
+      expect(screen.queryByTestId('list-item-skeleton')).not.toBeInTheDocument();
+    });
   });
 });

--- a/packages/apollo-react/src/canvas/components/Toolbox/Toolbox.test.tsx
+++ b/packages/apollo-react/src/canvas/components/Toolbox/Toolbox.test.tsx
@@ -1406,4 +1406,69 @@ describe('Toolbox', () => {
       expect(screen.getByText('Category A')).toBeInTheDocument();
     });
   });
+
+  describe('childrenLoading', () => {
+    let user: UserEvent;
+
+    beforeEach(() => {
+      user = userEvent.setup();
+    });
+
+    it('renders skeletons when drilling into an item with childrenLoading=true and empty children', async () => {
+      const items: ListItem[] = [
+        {
+          id: 'parent',
+          name: 'Loading Parent',
+          data: {},
+          children: [],
+          childrenLoading: true,
+        },
+      ];
+
+      render(<Toolbox {...defaultProps} initialItems={items} />);
+      await user.click(screen.getByText('Loading Parent'));
+
+      expect(screen.getAllByTestId('list-item-skeleton')).toHaveLength(3);
+      expect(screen.queryByText('No nodes found')).not.toBeInTheDocument();
+    });
+
+    it('renders preemptive section headers when childrenLoading provides sections', async () => {
+      const items: ListItem[] = [
+        {
+          id: 'parent',
+          name: 'Loading Parent',
+          data: {},
+          children: [],
+          childrenLoading: { sections: [{ name: 'Published', count: 2 }] },
+        },
+      ];
+
+      render(<Toolbox {...defaultProps} initialItems={items} />);
+      await user.click(screen.getByText('Loading Parent'));
+
+      expect(screen.getByText('Published')).toBeInTheDocument();
+      expect(screen.getAllByTestId('list-item-skeleton')).toHaveLength(2);
+    });
+
+    it('appends skeletons after partially-loaded children to signal "more on the way"', async () => {
+      // Multi-source categories load progressively — Apollo keeps showing
+      // skeletons as long as the parent flags `childrenLoading`, so the user
+      // knows additional items are still arriving.
+      const items: ListItem[] = [
+        {
+          id: 'parent',
+          name: 'Loading Parent',
+          data: {},
+          children: [{ id: 'child', name: 'Real Child', data: {} }],
+          childrenLoading: true,
+        },
+      ];
+
+      render(<Toolbox {...defaultProps} initialItems={items} />);
+      await user.click(screen.getByText('Loading Parent'));
+
+      expect(screen.getByText('Real Child')).toBeInTheDocument();
+      expect(screen.getAllByTestId('list-item-skeleton')).toHaveLength(3);
+    });
+  });
 });

--- a/packages/apollo-react/src/canvas/components/Toolbox/Toolbox.tsx
+++ b/packages/apollo-react/src/canvas/components/Toolbox/Toolbox.tsx
@@ -10,13 +10,7 @@ import {
   TOOLBOX_WIDTH,
 } from '../../constants';
 import { Header } from './Header';
-import {
-  isSkeletonItem,
-  type ListItem,
-  ListView,
-  type ListViewHandle,
-  type RenderItem,
-} from './ListView';
+import { type ListItem, ListView, type ListViewHandle, type RenderItem } from './ListView';
 import { SearchBox } from './SearchBox';
 import { AnimatedContainer, AnimatedContent } from './Toolbox.styles';
 
@@ -75,10 +69,6 @@ export interface ToolboxProps<T> {
   onSearch?: ToolboxSearchHandler<T>;
 }
 
-function isSelectable(rendered: RenderItem<ListItem> | undefined): boolean {
-  return rendered?.type === 'item' && !isSkeletonItem(rendered.item);
-}
-
 function getNextSelectableIndex(
   renderedItems: RenderItem<ListItem>[],
   currentIndex: number,
@@ -87,7 +77,7 @@ function getNextSelectableIndex(
   const numericDirection = direction === 'up' ? -1 : 1;
   let next = currentIndex + numericDirection;
   while (next >= 0 && next < renderedItems.length) {
-    if (isSelectable(renderedItems[next])) return next;
+    if (renderedItems[next]?.type === 'item') return next;
     next += numericDirection;
   }
   return SEARCH_BAR_INDEX;
@@ -95,14 +85,14 @@ function getNextSelectableIndex(
 
 function getFirstSelectableIndex(renderedItems: RenderItem<ListItem>[]): number {
   for (let i = 0; i < renderedItems.length; i++) {
-    if (isSelectable(renderedItems[i])) return i;
+    if (renderedItems[i]?.type === 'item') return i;
   }
   return SEARCH_BAR_INDEX;
 }
 
 function getLastSelectableIndex(renderedItems: RenderItem<ListItem>[]): number {
   for (let i = renderedItems.length - 1; i >= 0; i--) {
-    if (isSelectable(renderedItems[i])) return i;
+    if (renderedItems[i]?.type === 'item') return i;
   }
   return SEARCH_BAR_INDEX;
 }

--- a/packages/apollo-react/src/canvas/components/Toolbox/Toolbox.tsx
+++ b/packages/apollo-react/src/canvas/components/Toolbox/Toolbox.tsx
@@ -10,7 +10,13 @@ import {
   TOOLBOX_WIDTH,
 } from '../../constants';
 import { Header } from './Header';
-import { type ListItem, ListView, type ListViewHandle, type RenderItem } from './ListView';
+import {
+  isSkeletonItem,
+  type ListItem,
+  ListView,
+  type ListViewHandle,
+  type RenderItem,
+} from './ListView';
 import { SearchBox } from './SearchBox';
 import { AnimatedContainer, AnimatedContent } from './Toolbox.styles';
 
@@ -69,6 +75,10 @@ export interface ToolboxProps<T> {
   onSearch?: ToolboxSearchHandler<T>;
 }
 
+function isSelectable(rendered: RenderItem<ListItem> | undefined): boolean {
+  return rendered?.type === 'item' && !isSkeletonItem(rendered.item);
+}
+
 function getNextSelectableIndex(
   renderedItems: RenderItem<ListItem>[],
   currentIndex: number,
@@ -77,7 +87,7 @@ function getNextSelectableIndex(
   const numericDirection = direction === 'up' ? -1 : 1;
   let next = currentIndex + numericDirection;
   while (next >= 0 && next < renderedItems.length) {
-    if (renderedItems[next]?.type === 'item') return next;
+    if (isSelectable(renderedItems[next])) return next;
     next += numericDirection;
   }
   return SEARCH_BAR_INDEX;
@@ -85,14 +95,14 @@ function getNextSelectableIndex(
 
 function getFirstSelectableIndex(renderedItems: RenderItem<ListItem>[]): number {
   for (let i = 0; i < renderedItems.length; i++) {
-    if (renderedItems[i]?.type === 'item') return i;
+    if (isSelectable(renderedItems[i])) return i;
   }
   return SEARCH_BAR_INDEX;
 }
 
 function getLastSelectableIndex(renderedItems: RenderItem<ListItem>[]): number {
   for (let i = renderedItems.length - 1; i >= 0; i--) {
-    if (renderedItems[i]?.type === 'item') return i;
+    if (isSelectable(renderedItems[i])) return i;
   }
   return SEARCH_BAR_INDEX;
 }
@@ -130,7 +140,10 @@ export function Toolbox<T>({
   const [items, setItems] = useState<ListItem<T>[]>(initialItems);
   const [search, setSearch] = useState('');
   const [searchLoading, setSearchLoading] = useState(false);
-  const [childrenLoading, setChildrenLoading] = useState(false);
+  // True only while we're awaiting an async `item.children(...)` resolver.
+  // Distinct from the public `ListItem.childrenLoading` API field, which
+  // signals to ListView that an item should render skeleton placeholders.
+  const [awaitingChildren, setAwaitingChildren] = useState(false);
   const [isSearchingInitialItems, setIsSearchingInitialItems] = useState(true);
   const [searchedItems, setSearchedItems] = useState<ListItem<T>[]>([]);
   const [currentParentItem, setCurrentParentItem] = useState<ListItem<T> | null>(null);
@@ -283,7 +296,7 @@ export function Toolbox<T>({
         onItemSelect(item);
         return;
       }
-      setChildrenLoading(true);
+      setAwaitingChildren(true);
       const nestedItems =
         typeof item.children === 'function'
           ? await item.children(item.id, item.name)
@@ -315,7 +328,7 @@ export function Toolbox<T>({
         lastScrollTopRef.current = 0;
       });
       startTransition('forward');
-      setChildrenLoading(false);
+      setAwaitingChildren(false);
     },
     [
       navigationStack,
@@ -615,7 +628,7 @@ export function Toolbox<T>({
           <AnimatedContent entering={isTransitioning} direction={animationDirection}>
             <ListView
               ref={listViewRef}
-              isLoading={childrenLoading || searchLoading || loading}
+              isLoading={awaitingChildren || searchLoading || loading}
               items={displayedItems}
               activeIndex={activeIndex}
               listRef={listRef}

--- a/packages/apollo-react/src/canvas/components/Toolbox/Toolbox.tsx
+++ b/packages/apollo-react/src/canvas/components/Toolbox/Toolbox.tsx
@@ -624,6 +624,9 @@ export function Toolbox<T>({
               onItemHover={onItemHover}
               onScroll={handleListScroll}
               enableSections={!isSearching}
+              // Suppress skeletons while searching — the user expects
+              // search results, not a "more on the way" hint.
+              loadingSkeleton={isSearching ? undefined : currentParentItem?.childrenLoading}
             />
           </AnimatedContent>
         </AnimatedContainer>


### PR DESCRIPTION
Latest:
<img width="470" height="550" alt="image" src="https://github.com/user-attachments/assets/56d85e9e-1fe2-4c67-b2d5-32282eaff0b1" />

https://github.com/user-attachments/assets/2110a2c4-6ab9-493f-bdfc-6138baf501ef

## Summary

Apollo-side support for the loading-skeleton work tracked in MST-9164. The current `loading` prop on `<AddNodePanel>` / `<Toolbox>` is panel-wide — it dims and disables every row via the `.loading` CSS, which makes it impossible to show skeletons inside a single drilled-in level without breaking interactions everywhere else. This PR adds a per-item `childrenLoading` opt-in plus a `ListItemSkeleton` component that mirrors a real row's geometry, so consumers can preview a category's loading state without affecting the surrounding panel.

## Demo

> _insert demo here_

(Storybook → `Canvas/AddNodePanel` → 3 new stories: default skeletons, preemptive section headers, streaming → real content.)

## Changes

- **`ListItem.childrenLoading?: boolean | ChildrenLoadingSpec`** — when the user drills into an item with this flag, Apollo renders skeleton placeholder rows. The optional `sections` config preempts section headers so real items slot under their final header without layout shift.
- **`ListView.loadingSkeleton`** prop forwards the spec from `Toolbox` (read off `currentParentItem.childrenLoading`).
- **`ListItemSkeleton`** — circle + 2 stacked bars, replaces the legacy `<Skeleton h-8 w-full />` × 3 used by the `isLoading && items.length === 0` empty-state path.
- Skeletons are injected as `ListItem` entries into the virtualized list and grouped through the normal section pipeline. They append after real content while `childrenLoading` is set so multi-source categories keep showing "more on the way" until the last source resolves.
- `Toolbox` suppresses skeletons during search.
- Storybook: 3 new stories under `Canvas/AddNodePanel`.

## Flow

```mermaid
flowchart TD
    A[Consumer sets ListItem.childrenLoading] --> B[Toolbox.handleItemSelect drills in]
    B --> C[Toolbox passes currentParentItem.childrenLoading<br/>to ListView as loadingSkeleton]
    C --> D[ListView.buildSkeletonItems creates sentinels<br/>with optional section markers]
    D --> E[Skeletons merged into items array]
    E --> F[buildRenderedItems groups by section]
    F --> G[ListViewRow renders ListItemSkeleton<br/>for items with __listview_skeleton__ id]
    G --> H[Real items arrive → consumer drops childrenLoading<br/>→ skeletons removed, layout stable]
```

## Backward compatibility

- `loading: boolean` prop semantics unchanged
- Existing `ListItem` shape unchanged (`childrenLoading` is opt-in)
- Only behaviour change is the visual update to the skeleton row design (bar → row-shaped placeholder)

## Testing

- [x] `pnpm --filter @uipath/apollo-react test` — 97/97 pass (added 9 new tests)
- [x] Typecheck clean
- [x] Lint clean (no new warnings)
- [x] Storybook stories cover defaults, sections, and streaming swap
- [ ] Manual verification in consumer (flow-workbench MST-9164 / PR #1280)

## Consumer

flow-workbench MST-9164 / PR [UiPath/flow-workbench#1280](https://github.com/UiPath/flow-workbench/pull/1280) — drops the sentinel-row hack in `InternalAddNodePanel.tsx` and switches to `item.childrenLoading` once Apollo publishes.
