### PR TITLE
feat(apollo-vertex): ai chat multi line chart tool [AGVSOL-2792]

### DIFF
--- a/apps/apollo-vertex/app/patterns/ai-chat/page.mdx
+++ b/apps/apollo-vertex/app/patterns/ai-chat/page.mdx
@@ -19,6 +19,7 @@ A composable AI chat UI component for Apollo Vertex. Built with React, TypeScrip
 - **Data Fabric Table Tool** — Display entity data as filterable tables with list, search, and range filters, and multi-entity joins
 - **Data Fabric Distribution Tool** — Render histogram charts for numeric or datetime fields with optional aggregations, filters, and joins
 - **Data Fabric Line Chart Tool** — Render time-series line charts over a datetime field with optional aggregations, filters, and joins
+- **Data Fabric Multi-Line Chart Tool** — Compare two metrics on a shared datetime axis, each with its own Y axis, totals label, and join support
 - **Suggestion Buttons** — Interactive choice buttons rendered from tool results
 
 ## Installation
@@ -324,9 +325,58 @@ const lineTool = createDataFabricLineTool({
 - **Line** — trend / time-series questions: *"orders over time"*, *"revenue trend by month"*, *"growth across quarters"*. Always datetime on the X axis.
 - **Distribution** — histogram-style requests: *"distribution of order amount"*, *"histogram of X"*, numeric value-range binning. Either numeric or datetime dimension.
 
+For comparing **two or more metrics** on the same time axis, use [`data_fabric_multi_line`](#data-fabric-multi-line-chart-tool) instead.
+
 ### Metric, filters, and joins
 
 Metric, filter, and join semantics are identical to the distribution tool. Omit `metric` for `COUNT`, or pass `{ aggregation, field }` for `SUM` / `AVG` / `MIN` / `MAX` of a numeric field. When joins are present, `dimension` and `metric.field` must use qualified `EntityName.FieldName` names.
+
+---
+
+## Data Fabric Multi-Line Chart Tool
+
+The `data_fabric_multi_line` tool renders two lines on a shared datetime X axis. The first metric uses the left Y axis (and gets its own color and totals label at the top); the second uses the right Y axis. Exactly two metrics — pass three and the tool call is rejected.
+
+```tsx
+import {
+  createDataFabricMultiLineTool,
+  dataFabricMultiLineClient,
+} from '@/components/ui/ai-chat/tools/data-fabric-multi-line';
+
+const multiLineTool = createDataFabricMultiLineTool({
+  entities,           // Record<string, Entity> — entity metadata with field names and types
+  accessToken,        // Bearer token for Data Fabric API
+  dataFabricBaseUrl,  // Base URL for Data Fabric proxy
+});
+
+// Use dataFabricMultiLineClient in your tools array, multiLineTool.toolPrompt in your
+// system prompt, and multiLineTool.renderMultiLine(part.output, part.id) in your parts loop.
+```
+
+### Metrics
+
+Pass an array of exactly two metrics with distinct `(aggregation, field)` pairs. Each entry uses the same shape as the line tool — `{ aggregation: "COUNT" }` for record counts (optional `field`), or `{ aggregation, field }` for `SUM` / `AVG` / `MIN` / `MAX` of a numeric field. Schema validation rejects duplicate `(aggregation, field)` pairs before the chart is rendered. If duplicates only emerge after field resolution (e.g., a `COUNT` with an explicit `field` that resolves to the same primary key as a default `COUNT`), the chart shows its no-data state instead. Order matters: the first metric gets the left axis and primary color; put the metric you want to emphasize first.
+
+```json
+{
+  "entityName": "Order",
+  "dimension": "OrderDate",
+  "metrics": [
+    { "aggregation": "COUNT" },
+    { "aggregation": "SUM", "field": "Total" }
+  ]
+}
+```
+
+### When to use multi-line vs line
+
+- **Multi-line** — comparing two metrics on the same time axis: *"orders count and revenue over time"*, *"min vs max price by month"*.
+- **Line** — a single metric over time. Don't use multi-line for a single metric.
+- For 3+ metrics, render multiple charts (one per metric, or pair them) — the underlying chart only has two Y axes.
+
+### Filters and joins
+
+Identical to the line tool. Filter and join schemas are shared, and qualified `EntityName.FieldName` names are required for the dimension and every metric `field` when joins are present.
 
 ---
 

--- a/apps/apollo-vertex/registry.json
+++ b/apps/apollo-vertex/registry.json
@@ -384,6 +384,11 @@
           "target": "components/ui/ai-chat/charts/line-chart-card.tsx"
         },
         {
+          "path": "registry/ai-chat/charts/multi-line-chart-card.tsx",
+          "type": "registry:ui",
+          "target": "components/ui/ai-chat/charts/multi-line-chart-card.tsx"
+        },
+        {
           "path": "registry/ai-chat/tools/choices/choices-tool.tsx",
           "type": "registry:ui",
           "target": "components/ui/ai-chat/tools/choices/choices-tool.tsx"
@@ -437,6 +442,16 @@
           "path": "registry/ai-chat/tools/data-fabric-line/index.ts",
           "type": "registry:lib",
           "target": "components/ui/ai-chat/tools/data-fabric-line/index.ts"
+        },
+        {
+          "path": "registry/ai-chat/tools/data-fabric-multi-line/data-fabric-multi-line-tool.tsx",
+          "type": "registry:ui",
+          "target": "components/ui/ai-chat/tools/data-fabric-multi-line/data-fabric-multi-line-tool.tsx"
+        },
+        {
+          "path": "registry/ai-chat/tools/data-fabric-multi-line/index.ts",
+          "type": "registry:lib",
+          "target": "components/ui/ai-chat/tools/data-fabric-multi-line/index.ts"
         }
       ]
     },

--- a/apps/apollo-vertex/registry/ai-chat/charts/multi-line-chart-card.tsx
+++ b/apps/apollo-vertex/registry/ai-chat/charts/multi-line-chart-card.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { useQueryClient } from "@tanstack/react-query";
+import {
+  type ChartDataModel,
+  type DataAdapter,
+  MultiLineChart,
+  type MultiLineChartConfiguration,
+  type NumericOrDatetimeField,
+} from "@uipath/apollo-dashboarding";
+import { Card, CardContent } from "@/components/ui/card";
+
+interface MultiLineChartCardProps {
+  configuration: MultiLineChartConfiguration;
+  dataModel: ChartDataModel<NumericOrDatetimeField>;
+  dataAdapter: DataAdapter;
+}
+
+export function MultiLineChartCard({
+  configuration,
+  dataModel,
+  dataAdapter,
+}: MultiLineChartCardProps) {
+  const queryClient = useQueryClient();
+
+  return (
+    <Card className="flex flex-col w-full h-[300px] gap-2 py-4">
+      <CardContent className="flex-1 overflow-hidden p-0 px-20 [&_.recharts-surface]:overflow-visible">
+        <MultiLineChart
+          configuration={configuration}
+          dataModel={dataModel}
+          dataAdapter={dataAdapter}
+          queryClient={queryClient}
+        />
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/apollo-vertex/registry/ai-chat/tools/data-fabric-multi-line/data-fabric-multi-line-tool.tsx
+++ b/apps/apollo-vertex/registry/ai-chat/tools/data-fabric-multi-line/data-fabric-multi-line-tool.tsx
@@ -1,0 +1,226 @@
+"use client";
+
+import { toolDefinition } from "@tanstack/ai";
+import { dataFabricAdapter } from "@uipath/apollo-dashboarding";
+import { DateTime } from "luxon";
+import { z } from "zod";
+import { MultiLineChartCard } from "../../charts/multi-line-chart-card";
+import { NoDataMessage } from "../../charts/no-data-message";
+import {
+  buildMultiBinnedDataModel,
+  metricSchema,
+  type ResolvedMetric,
+  resolveMultiBinnedDimension,
+  resolveMultiBinnedMetric,
+  resolveSingleBinnedDimension,
+  resolveSingleBinnedMetric,
+} from "../data-fabric/binned";
+import {
+  collectQualifiedFields,
+  type DataFabricToolContext,
+  filterSchema,
+  generateEntityFieldsDocs,
+  joinSchema,
+  resolveFilters,
+} from "../data-fabric/shared";
+
+const MULTI_LINE_DIMENSION_TYPES = ["datetime"] as const;
+
+const dataFabricMultiLineInput = z.object({
+  entityName: z.string().describe("Data Fabric entity name to query"),
+  dimension: z
+    .string()
+    .describe(
+      "Datetime field name to bin the time axis by. When joining, use EntityName.Field format.",
+    ),
+  metrics: z
+    .array(metricSchema)
+    .min(2)
+    .max(2)
+    .refine(
+      (metrics) => {
+        const keys = new Set(
+          metrics.map((m) => `${m.aggregation}|${m.field ?? ""}`),
+        );
+        return keys.size === metrics.length;
+      },
+      {
+        message:
+          "Metrics must have distinct (aggregation, field) pairs — pick two different metrics to compare.",
+      },
+    )
+    .describe(
+      "Exactly two metrics with distinct (aggregation, field) pairs, plotted as separate lines on a shared time axis. The first metric uses the left Y axis; the second uses the right.",
+    ),
+  filters: z
+    .array(filterSchema)
+    .optional()
+    .describe("Optional filters to narrow down results."),
+  joins: z
+    .array(joinSchema)
+    .optional()
+    .describe(
+      "Join other entities. Use EntityName.Field format for the dimension and metric fields when joining.",
+    ),
+});
+
+const dataFabricMultiLineDef = toolDefinition({
+  name: "data_fabric_multi_line",
+  description:
+    "Render a multi-line chart from a Data Fabric entity, plotting exactly two metrics over a datetime dimension on a shared X axis (one per Y axis: left and right). Use when the user wants to compare two metrics over time.",
+  inputSchema: dataFabricMultiLineInput,
+  outputSchema: dataFabricMultiLineInput,
+  metadata: { skipFollowUp: true },
+});
+
+export const dataFabricMultiLineClient = dataFabricMultiLineDef.client(
+  (input) => input,
+);
+
+type MultiLineInput = z.infer<typeof dataFabricMultiLineInput>;
+
+function dedupeMetrics(metrics: ResolvedMetric[]): ResolvedMetric[] {
+  const seen = new Set<string>();
+  return metrics.filter((m) => {
+    const key = `${m.aggregation}|${m.field}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+export function createDataFabricMultiLineTool(context: DataFabricToolContext) {
+  const today = DateTime.now().toISODate();
+  const toolPrompt = `You have a "data_fabric_multi_line" tool.
+Use it to render a multi-line chart that plots EXACTLY TWO metrics over time on a shared datetime X axis.
+
+## When to use multi-line vs line
+- Use "data_fabric_multi_line" when the user asks to compare two metrics on the same time axis (e.g. "orders count and revenue over time", "min vs max price by month", "sum of A and sum of B per quarter").
+- Use "data_fabric_line" when there is only ONE metric to plot. Do NOT call multi-line with a single metric.
+- The chart only supports 2 metrics: the FIRST metric uses the LEFT Y axis (and its color/totals label), the SECOND uses the RIGHT. If the user asks to compare 3+ metrics, ask them to pick the two most important and offer to render the others in follow-up charts — do NOT pass more than 2.
+
+## Dimension
+- Pass exactly one "dimension" — a datetime field name on the chosen entity (see Entity Reference). The field MUST be a datetime field; do NOT use this tool with a numeric or string dimension.
+- When the user explicitly names a field (e.g. "<metric_a> and <metric_b> over EntityName.Field"), use EXACTLY that field as the dimension.
+- If the user-named field is not a datetime field, do NOT call this tool. Reply explaining that line charts require a datetime field, and list the candidate datetime fields on that entity.
+
+## Metrics
+- Pass an array of EXACTLY TWO metrics with distinct (aggregation, field) pairs. Each entry follows the same shape as the line tool:
+  - For COUNT, pass { aggregation: "COUNT" } — "field" is optional and defaults to the entity primary key.
+  - For SUM/AVG/MIN/MAX, pass { aggregation, field } where "field" is a numeric field on the chosen entity.
+- Pick only metrics the user asked to compare. Do not invent extra metrics.
+- Two metrics with the same (aggregation, field) pair are duplicates and the tool call will be REJECTED at validation. Make sure the two metrics differ in either aggregation, field, or both.
+- Order matters: put the metric you want emphasized (or with the larger scale) first, since it gets the left axis and the primary color.
+
+## Filters
+You can optionally pass filters to narrow results. Available filter types:
+- **list**: match specific values. Use valueType matching the field type (string/number/boolean). Set invert=true to exclude.
+- **search**: text pattern matching on string fields. searchFilterType: "default" (contains), "startsWith", "endsWith".
+- **range** (numeric): use valueType="number" with min/max numbers.
+- **range** (datetime): use valueType="datetime" with min/max as ISO 8601 strings (e.g. "2026-01-01" or "2026-01-01T00:00:00Z"). Today is ${today} — use it to resolve relative phrases like "last 30 days" or "this year" into absolute ISO dates before passing them.
+Only add filters when the user asks to filter, search, or narrow results.
+
+## Multi-Entity Joins
+To bin a datetime field that lives on a joined entity, or to aggregate a numeric field from a joined entity, add "joins" to link related entities. The entityName field is the primary entity.
+When using joins, use qualified field names everywhere: "EntityName.FieldName" (using the EXACT entity names from the Entity Reference, never abbreviations or aliases).
+Only use joins when the user explicitly asks to combine data from multiple entities.
+
+## Entity Reference
+${generateEntityFieldsDocs(context.entities)}`;
+
+  function renderMultiLine(output: MultiLineInput, id: string) {
+    const { entityName, dimension, metrics, filters, joins } = output;
+    const isMultiEntity = joins != null && joins.length > 0;
+
+    const entity = context.entities[entityName];
+    if (!entity) {
+      return <NoDataMessage />;
+    }
+
+    const qualifiedFields = isMultiEntity
+      ? collectQualifiedFields(
+          [entityName, ...joins.map((j) => j.entity)],
+          context.entities,
+        )
+      : null;
+
+    const resolvedDimension = qualifiedFields
+      ? resolveMultiBinnedDimension(
+          entityName,
+          dimension,
+          qualifiedFields,
+          MULTI_LINE_DIMENSION_TYPES,
+        )
+      : resolveSingleBinnedDimension(
+          entity,
+          dimension,
+          MULTI_LINE_DIMENSION_TYPES,
+        );
+
+    if (!resolvedDimension) {
+      return <NoDataMessage />;
+    }
+
+    const resolvedMetrics = metrics
+      .map((metric) =>
+        qualifiedFields
+          ? resolveMultiBinnedMetric(entityName, metric, qualifiedFields)
+          : resolveSingleBinnedMetric(entity, metric),
+      )
+      .filter((m): m is ResolvedMetric => m !== null);
+
+    const uniqueMetrics = dedupeMetrics(resolvedMetrics);
+
+    if (uniqueMetrics.length < 2) {
+      return <NoDataMessage />;
+    }
+
+    const dataModel = buildMultiBinnedDataModel({
+      id: entityName,
+      dimension: resolvedDimension.id,
+      dimensionType: resolvedDimension.type,
+      metrics: uniqueMetrics,
+    });
+
+    const normalizedFilters = qualifiedFields
+      ? resolveFilters(filters, {
+          mode: "multi",
+          primaryEntity: entityName,
+          qualifiedFields,
+        })
+      : resolveFilters(filters, {
+          mode: "single",
+          validFields: entity.fields.map((f) => f.name),
+        });
+
+    const configuration = {
+      id,
+      name: entityName,
+      type: "multi_line" as const,
+      dimensions: [resolvedDimension.id],
+      metrics: dataModel.metrics.map((m) => m.id),
+      filters: normalizedFilters,
+      ...(qualifiedFields &&
+        joins && {
+          from: { entity: entityName, alias: entityName },
+          joins: joins.map((j) => ({ ...j, alias: j.entity })),
+        }),
+    };
+
+    const adapter = dataFabricAdapter({
+      baseUrl: context.dataFabricBaseUrl,
+      accessToken: context.accessToken,
+      entityName,
+    });
+
+    return (
+      <MultiLineChartCard
+        configuration={configuration}
+        dataModel={dataModel}
+        dataAdapter={adapter}
+      />
+    );
+  }
+
+  return { toolPrompt, renderMultiLine };
+}

--- a/apps/apollo-vertex/registry/ai-chat/tools/data-fabric-multi-line/index.ts
+++ b/apps/apollo-vertex/registry/ai-chat/tools/data-fabric-multi-line/index.ts
@@ -1,0 +1,4 @@
+export {
+  createDataFabricMultiLineTool,
+  dataFabricMultiLineClient,
+} from "./data-fabric-multi-line-tool";

--- a/apps/apollo-vertex/registry/ai-chat/tools/data-fabric/binned.ts
+++ b/apps/apollo-vertex/registry/ai-chat/tools/data-fabric/binned.ts
@@ -26,29 +26,51 @@ interface BuildBinnedDataModelInput {
   };
 }
 
+// Data Fabric rewrites aliases that contain dots (qualified field paths)
+// into a canonical `<FUNCTION>_<field>` form when joins are used, breaking
+// the chart's `r[alias]` lookup. Sanitize the alias by replacing dots, so
+// the server respects what we send. The `field` reference still needs to
+// be qualified for the server to resolve the correct entity.
+function buildMetricEntry(metric: BuildBinnedDataModelInput["metric"]) {
+  const aliasField = metric.field.replaceAll(".", "_");
+  return {
+    id: `${metric.aggregation.toLowerCase()}_${aliasField}`,
+    display: metric.display,
+    aggregation: metric.aggregation,
+    field: metric.field,
+  };
+}
+
 export function buildBinnedDataModel({
   id,
   dimension,
   dimensionType,
   metric,
 }: BuildBinnedDataModelInput): ChartDataModel<NumericOrDatetimeField> {
-  // Data Fabric rewrites aliases that contain dots (qualified field paths)
-  // into a canonical `<FUNCTION>_<field>` form when joins are used, breaking
-  // the chart's `r[alias]` lookup. Sanitize the alias by replacing dots, so
-  // the server respects what we send. The `field` reference still needs to
-  // be qualified for the server to resolve the correct entity.
-  const aliasField = metric.field.replaceAll(".", "_");
   return {
     id,
     dimensions: [{ id: dimension, type: dimensionType }],
-    metrics: [
-      {
-        id: `${metric.aggregation.toLowerCase()}_${aliasField}`,
-        display: metric.display,
-        aggregation: metric.aggregation,
-        field: metric.field,
-      },
-    ],
+    metrics: [buildMetricEntry(metric)],
+  };
+}
+
+interface BuildMultiBinnedDataModelInput {
+  id: string;
+  dimension: string;
+  dimensionType: BinnedDimensionType;
+  metrics: ResolvedMetric[];
+}
+
+export function buildMultiBinnedDataModel({
+  id,
+  dimension,
+  dimensionType,
+  metrics,
+}: BuildMultiBinnedDataModelInput): ChartDataModel<NumericOrDatetimeField> {
+  return {
+    id,
+    dimensions: [{ id: dimension, type: dimensionType }],
+    metrics: metrics.map((m) => buildMetricEntry(m)),
   };
 }
 
@@ -139,12 +161,17 @@ export function resolveSingleBinnedMetric(
   metric: MetricInput | undefined,
 ): ResolvedMetric | null {
   if (!metric || metric.aggregation === "COUNT") {
-    const field =
+    const userField =
       metric?.field && entity.fields.some((f) => f.name === metric.field)
         ? metric.field
-        : pickCountField(entity);
+        : null;
+    const field = userField ?? pickCountField(entity);
     if (!field) return null;
-    return { field, aggregation: "COUNT", display: "Count" };
+    return {
+      field,
+      aggregation: "COUNT",
+      display: userField ? `Count of ${userField}` : "Count",
+    };
   }
 
   if (!metric.field) return null;
@@ -157,22 +184,37 @@ export function resolveSingleBinnedMetric(
   };
 }
 
+// Drop the entity prefix from a qualified `EntityName.Field` reference for use
+// in human-facing labels (chart legend, totals title, tooltip). The qualified
+// form is still required as the `field` for server-side resolution; only the
+// display string is shortened, since the entity is implicit in the chart.
+function unqualifiedDisplay(qualified: string): string {
+  return qualified.split(".").at(-1) ?? qualified;
+}
+
 export function resolveMultiBinnedMetric(
   primaryEntity: string,
   metric: MetricInput | undefined,
   qualifiedFields: Map<string, EntityField>,
 ): ResolvedMetric | null {
   if (!metric || metric.aggregation === "COUNT") {
-    let field: string | null = null;
+    let userField: string | null = null;
     if (metric?.field) {
       const qualified = metric.field.includes(".")
         ? metric.field
         : `${primaryEntity}.${metric.field}`;
-      if (qualifiedFields.has(qualified)) field = qualified;
+      if (qualifiedFields.has(qualified)) userField = qualified;
     }
-    field ??= pickCountFieldQualified(primaryEntity, qualifiedFields);
+    const field =
+      userField ?? pickCountFieldQualified(primaryEntity, qualifiedFields);
     if (!field) return null;
-    return { field, aggregation: "COUNT", display: "Count" };
+    return {
+      field,
+      aggregation: "COUNT",
+      display: userField
+        ? `Count of ${unqualifiedDisplay(userField)}`
+        : "Count",
+    };
   }
 
   if (!metric.field) return null;
@@ -184,6 +226,6 @@ export function resolveMultiBinnedMetric(
   return {
     field: qualified,
     aggregation: metric.aggregation,
-    display: `${formatAggregation(metric.aggregation)} of ${qualified}`,
+    display: `${formatAggregation(metric.aggregation)} of ${unqualifiedDisplay(qualified)}`,
   };
 }

--- a/apps/apollo-vertex/registry/ai-chat/tools/data-fabric/index.ts
+++ b/apps/apollo-vertex/registry/ai-chat/tools/data-fabric/index.ts
@@ -1,5 +1,6 @@
 export { createDataFabricDistributionTool } from "../data-fabric-distribution";
 export { createDataFabricLineTool } from "../data-fabric-line";
+export { createDataFabricMultiLineTool } from "../data-fabric-multi-line";
 export { createDataFabricTableTool } from "../data-fabric-table";
 export {
   buildTableDataModel,

--- a/apps/apollo-vertex/templates/ai-chat/AiChatAgentHubMode.tsx
+++ b/apps/apollo-vertex/templates/ai-chat/AiChatAgentHubMode.tsx
@@ -23,6 +23,10 @@ import {
   dataFabricLineClient,
 } from "@/registry/ai-chat/tools/data-fabric-line";
 import {
+  createDataFabricMultiLineTool,
+  dataFabricMultiLineClient,
+} from "@/registry/ai-chat/tools/data-fabric-multi-line";
+import {
   createDataFabricTableTool,
   dataFabricTableClient,
 } from "@/registry/ai-chat/tools/data-fabric-table";
@@ -68,19 +72,27 @@ function AgentHubChatInner({
     dataFabricBaseUrl,
   });
 
+  const multiLineTool = createDataFabricMultiLineTool({
+    entities,
+    accessToken,
+    dataFabricBaseUrl,
+  });
+
   const tools = clientTools(
     presentChoicesClient,
     dataFabricTableClient,
     dataFabricDistributionClient,
     dataFabricLineClient,
+    dataFabricMultiLineClient,
   );
 
   const chartToolSteering = [
     "When the user asks about Data Fabric data, pick the chart tool that best fits the request:",
     '- "data_fabric_table" — list/show records, view fields side by side.',
-    '- "data_fabric_line" — trend / time-series questions ("orders over time", "revenue by month", "growth across quarters").',
+    '- "data_fabric_line" — single-metric trend / time-series questions ("orders over time", "revenue by month", "growth across quarters").',
+    '- "data_fabric_multi_line" — compare EXACTLY TWO metrics on a shared time axis ("orders count and revenue over time", "min vs max price by month"). The chart only supports two Y axes; for 3+ metrics render multiple charts.',
     '- "data_fabric_distribution" — histogram-style requests ("distribution of X", "histogram of X", numeric value-range binning).',
-    "If two tools could both answer, prefer the more specific one (line beats distribution for explicit time-series phrasing).",
+    "If two tools could both answer, prefer the more specific one: multi-line beats line when the user names 2+ metrics; line beats distribution for explicit time-series phrasing.",
   ].join("\n");
 
   const systemPrompt = [
@@ -90,6 +102,7 @@ function AgentHubChatInner({
     tableTool.toolPrompt,
     distributionTool.toolPrompt,
     lineTool.toolPrompt,
+    multiLineTool.toolPrompt,
   ].join("\n\n");
 
   const connection = createAgentHubConnection({
@@ -147,6 +160,14 @@ function AgentHubChatInner({
               return (
                 <Suspense key={part.id}>
                   {lineTool.renderLine(part.output, part.id)}
+                </Suspense>
+              );
+            }
+
+            if (part.name === "data_fabric_multi_line") {
+              return (
+                <Suspense key={part.id}>
+                  {multiLineTool.renderMultiLine(part.output, part.id)}
                 </Suspense>
               );
             }


### PR DESCRIPTION
popoc -> defaulttenant

Plot order count and total Amount over OrderDate from ChartExampleSalesOrder

Compare order count and total Amount over OrderDate in 2025

Plot count and sum of Amount over OrderDate from ChartExampleSalesOrder joined to ChartExampleSalesCategory on CategoryCode, only for Region = North

note: multi line chart from Apollo dashboarding is shitty; should be addressed separately

<img width="854" height="850" alt="Apr-30-2026 11-46-30" src="https://github.com/user-attachments/assets/68610ede-06ff-43f0-a908-b365410f50f3" />
