### PR TITLE
feat(apollo-react): add canvasLabel for canvas display, distinct from palette label

### DIFF
--- a/packages/apollo-react/src/canvas/components/AddNodePanel/AddNodePanel.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/AddNodePanel/AddNodePanel.stories.tsx
@@ -2,8 +2,12 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import type { Node } from '@uipath/apollo-react/canvas/xyflow/react';
 import { Panel, Position, useReactFlow } from '@uipath/apollo-react/canvas/xyflow/react';
 import { useEffect, useMemo, useState } from 'react';
+import { NodeRegistryProvider } from '../../core';
 import { useAddNodeOnConnectEnd, useCanvasEvent } from '../../hooks';
+import type { CategoryManifest, NodeManifest } from '../../schema';
 import {
+  allCategoryManifests,
+  allNodeManifests,
   createNode,
   NodePositions,
   StoryInfoPanel,
@@ -750,6 +754,117 @@ export const NodePanelEmptyStateInCategory: Story = {
       </StandalonePanelWrapper>
     </>
   ),
+};
+
+// ============================================================================
+// Search by canvasLabel
+// ============================================================================
+
+/**
+ * Story-local manifest registering a node whose only "outlook"-related token
+ * lives on `display.canvasLabel`. Used to verify that CategoryTree.filterBySearch
+ * indexes canvasLabel — typing "outlook" in the panel search must surface the
+ * node even though `display.label` doesn't contain that token.
+ */
+const canvasLabelSearchManifest: { nodes: NodeManifest[]; categories: CategoryManifest[] } = {
+  categories: [
+    ...allCategoryManifests,
+    {
+      id: 'communications',
+      name: 'Communications',
+      sortOrder: 99,
+      color: '#3b82f6',
+      colorDark: '#60a5fa',
+      icon: 'agent',
+      tags: [],
+    },
+  ],
+  nodes: [
+    ...allNodeManifests,
+    {
+      nodeType: 'uipath.send-corporate-mail',
+      version: '1.0.0',
+      category: 'communications',
+      tags: [],
+      sortOrder: 1,
+      description: 'Dispatch an email through the corporate mail provider.',
+      display: {
+        label: 'Send Email',
+        canvasLabel: 'Outlook',
+        icon: 'agent',
+        shape: 'rectangle',
+      },
+      handleConfiguration: [
+        { position: 'left', handles: [{ id: 'input', type: 'target', handleType: 'input' }] },
+        { position: 'right', handles: [{ id: 'output', type: 'source', handleType: 'output' }] },
+      ],
+    },
+  ],
+};
+
+function CanvasLabelSearchStory() {
+  const initialNodes = useMemo(
+    () => [
+      createNode({
+        id: 'trigger',
+        type: 'uipath.manual-trigger',
+        position: NodePositions.row2col1,
+        display: { label: 'Manual trigger' },
+      }),
+    ],
+    []
+  );
+  const { canvasProps } = useCanvasStory({ initialNodes });
+
+  const reactFlowInstance = useReactFlow();
+
+  useCanvasEvent('handle:action', (event: CanvasHandleActionEvent) => {
+    if (!reactFlowInstance) return;
+
+    const { handleId, nodeId, position, handleType } = event;
+    if (handleId && nodeId) {
+      const sourceHandleType = handleType === 'input' ? 'target' : 'source';
+      createAddNodePreview(
+        nodeId,
+        handleId,
+        reactFlowInstance,
+        position as Position,
+        sourceHandleType
+      );
+    }
+  });
+
+  return (
+    <BaseCanvas {...canvasProps} mode="design" defaultViewport={{ x: 0, y: 0, zoom: 1 }}>
+      <AddNodeManager />
+      <Panel position="bottom-right">
+        <CanvasPositionControls translations={DefaultCanvasTranslations} />
+      </Panel>
+      <StoryInfoPanel
+        title="Search by 'canvasLabel'"
+        description={
+          'Click the + handle on the trigger node to open the Add node panel. ' +
+          'The story-local manifest registers a "Send Email" node whose only ' +
+          '"outlook" token lives on display.canvasLabel — its label, description, ' +
+          'tags and nodeType deliberately exclude that word. Type "outlook" into ' +
+          'the search and the node still surfaces because CategoryTree.filterBySearch ' +
+          'now indexes canvasLabel.'
+        }
+      />
+    </BaseCanvas>
+  );
+}
+
+export const NodePanelSearchByCanvasLabel: Story = {
+  name: 'Search by canvasLabel',
+  decorators: [
+    (Story) => (
+      <NodeRegistryProvider manifest={canvasLabelSearchManifest}>
+        <Story />
+      </NodeRegistryProvider>
+    ),
+  ],
+  render: () => <CanvasLabelSearchStory />,
 };
 
 // ============================================================================

--- a/packages/apollo-react/src/canvas/components/BaseNode/BaseNode.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/BaseNode/BaseNode.stories.tsx
@@ -900,6 +900,146 @@ export const StackedTreatment: Story = {
   render: () => <StackedTreatmentStory />,
 };
 
+// ============================================================================
+// canvasLabel Resolution Story
+// ============================================================================
+
+/**
+ * Story-only manifest with two node types: one declaring both `label` (palette)
+ * and `canvasLabel` (canvas), one declaring only `label`. Used to demo the
+ * precedence in `resolveDisplay`:
+ * instance.canvasLabel > instance.label > manifest.canvasLabel > manifest.label.
+ */
+const canvasLabelManifest: { nodes: NodeManifest[]; categories: CategoryManifest[] } = {
+  categories: [
+    ...allCategoryManifests,
+    {
+      id: 'communications',
+      name: 'Communications',
+      sortOrder: 99,
+      color: '#3b82f6',
+      colorDark: '#60a5fa',
+      icon: 'agent',
+      tags: [],
+    },
+  ],
+  nodes: [
+    ...allNodeManifests,
+    {
+      nodeType: 'uipath.send-outlook-email',
+      version: '1.0.0',
+      category: 'communications',
+      tags: ['email', 'outlook'],
+      sortOrder: 1,
+      display: {
+        label: 'Send Outlook 365 Email',
+        canvasLabel: 'Send Email',
+        icon: 'agent',
+        shape: 'rectangle',
+      },
+      handleConfiguration: [
+        { position: 'left', handles: [{ id: 'input', type: 'target', handleType: 'input' }] },
+        { position: 'right', handles: [{ id: 'output', type: 'source', handleType: 'output' }] },
+      ],
+    },
+    {
+      nodeType: 'uipath.long-decision',
+      version: '1.0.0',
+      category: 'communications',
+      tags: ['decision'],
+      sortOrder: 2,
+      display: {
+        label: 'Long Decision Without canvasLabel',
+        icon: 'agent',
+        shape: 'rectangle',
+      },
+      handleConfiguration: [
+        { position: 'left', handles: [{ id: 'input', type: 'target', handleType: 'input' }] },
+        { position: 'right', handles: [{ id: 'output', type: 'source', handleType: 'output' }] },
+      ],
+    },
+  ],
+};
+
+function CanvasLabelStory() {
+  const initialNodes = useMemo<Node<BaseNodeData>[]>(
+    () => [
+      createNode({
+        id: 'with-canvaslabel',
+        type: 'uipath.send-outlook-email',
+        position: { x: 96, y: 160 },
+        data: {
+          nodeType: 'uipath.send-outlook-email',
+          version: '1.0.0',
+          display: { shape: 'rectangle', subLabel: 'manifest.canvasLabel wins' },
+        },
+      }),
+      createNode({
+        id: 'without-canvaslabel',
+        type: 'uipath.long-decision',
+        position: { x: 96, y: 320 },
+        data: {
+          nodeType: 'uipath.long-decision',
+          version: '1.0.0',
+          display: {
+            shape: 'rectangle',
+            subLabel: 'falls back to manifest.label since canvasLabel is not defined',
+          },
+        },
+      }),
+      createNode({
+        id: 'instance-rename',
+        type: 'uipath.send-outlook-email',
+        position: { x: 96, y: 480 },
+        data: {
+          nodeType: 'uipath.send-outlook-email',
+          version: '1.0.0',
+          display: {
+            shape: 'rectangle',
+            canvasLabel: 'Notify Ops Team',
+            subLabel: 'instance.canvasLabel overrides manifest.canvasLabel',
+          },
+        },
+      }),
+    ],
+    []
+  );
+  const { canvasProps } = useCanvasStory({ initialNodes });
+
+  return (
+    <BaseCanvas {...canvasProps} mode="design">
+      <Panel position="bottom-right">
+        <CanvasPositionControls translations={DefaultCanvasTranslations} />
+      </Panel>
+      <StoryInfoPanel
+        title="canvasLabel resolution"
+        description={
+          'Three instances of the same canvas, exercising the precedence ' +
+          'instance.canvasLabel > instance.label > manifest.canvasLabel > ' +
+          'manifest.label resolved by resolveDisplay(). Top: manifest declares ' +
+          'both label ("Send Outlook 365 Email") and canvasLabel ("Send Email") ' +
+          '— canvas renders the short canvasLabel. Middle: manifest declares ' +
+          'only label — canvas falls back to it. Bottom: instance.canvasLabel ' +
+          'is set to "Notify Ops Team" — explicit canvas-side override beats ' +
+          'manifest.canvasLabel.'
+        }
+      />
+    </BaseCanvas>
+  );
+}
+
+export const CanvasLabel: Story = {
+  name: 'canvasLabel resolution',
+  decorators: [
+    (Story) => (
+      <NodeRegistryProvider manifest={canvasLabelManifest}>
+        <Story />
+      </NodeRegistryProvider>
+    ),
+  ],
+  render: () => <CanvasLabelStory />,
+};
+
 export const ValidationStates: Story = {
   name: 'Validation States',
   decorators: [

--- a/packages/apollo-react/src/canvas/components/BaseNode/BaseNode.types.ts
+++ b/packages/apollo-react/src/canvas/components/BaseNode/BaseNode.types.ts
@@ -7,6 +7,12 @@ export type FooterVariant = 'none' | 'button' | 'single' | 'double';
 export interface BaseNodeData extends Record<string, unknown> {
   display?: {
     label?: string;
+    /**
+     * Canvas-side label override. Independent of `label`, which serves the panel /
+     * properties view. When set, takes precedence over `manifest.canvasLabel`,
+     * `instance.label`, and `manifest.label` for the canvas chip.
+     */
+    canvasLabel?: string;
     subLabel?: string;
     shape?: NodeShape;
     color?: string;

--- a/packages/apollo-react/src/canvas/core/CategoryTree.test.ts
+++ b/packages/apollo-react/src/canvas/core/CategoryTree.test.ts
@@ -510,6 +510,63 @@ describe('CategoryTree', () => {
 
       expect(filesCategory?.nodes).toHaveLength(2);
     });
+
+    it('should filter nodes by canvasLabel when only canvasLabel matches', () => {
+      const categories = createMockCategories();
+      const nodes: NodeManifest[] = [
+        ...createMockNodes(),
+        {
+          nodeType: 'send-outlook-email',
+          category: 'automation.email',
+          version: '1.0.0',
+          display: {
+            label: 'Send Outlook 365 Message',
+            canvasLabel: 'Outlook',
+            icon: 'mail',
+          },
+          description: 'Dispatch a message via Outlook 365',
+          sortOrder: 5,
+          handleConfiguration: [],
+          tags: [],
+        },
+      ];
+      const tree = new CategoryTree(categories, nodes);
+
+      const filtered = tree.filterBySearch('outlook');
+      const emailCategory = filtered.findCategory('automation.email');
+
+      expect(emailCategory?.nodes).toHaveLength(1);
+      expect(emailCategory?.nodes[0]?.nodeType).toBe('send-outlook-email');
+    });
+
+    it('should match multi-word search across label and canvasLabel', () => {
+      const categories = createMockCategories();
+      const nodes: NodeManifest[] = [
+        ...createMockNodes(),
+        {
+          nodeType: 'send-outlook-email',
+          category: 'automation.email',
+          version: '1.0.0',
+          display: {
+            label: 'Send Outlook 365 Message',
+            canvasLabel: 'Quick Send',
+            icon: 'mail',
+          },
+          description: 'Dispatch a message via Outlook 365',
+          sortOrder: 5,
+          handleConfiguration: [],
+          tags: [],
+        },
+      ];
+      const tree = new CategoryTree(categories, nodes);
+
+      // "outlook" matches label, "quick" matches canvasLabel
+      const filtered = tree.filterBySearch('outlook quick');
+      const emailCategory = filtered.findCategory('automation.email');
+
+      expect(emailCategory?.nodes).toHaveLength(1);
+      expect(emailCategory?.nodes[0]?.nodeType).toBe('send-outlook-email');
+    });
   });
 
   describe('filterByConnections', () => {

--- a/packages/apollo-react/src/canvas/core/CategoryTree.ts
+++ b/packages/apollo-react/src/canvas/core/CategoryTree.ts
@@ -308,8 +308,8 @@ export class CategoryTree {
    * Filter the tree by search term using combination search.
    *
    * The search term is split into words. A node matches if every word matches
-   * at least one searchable attribute: node label, type, description, tags,
-   * or ancestor category names.
+   * at least one searchable attribute: node label, display.canvasLabel, type,
+   * description, tags, or ancestor category names.
    *
    * This allows queries like "Outlook Email" to match a node named "Archive Email"
    * inside a "Microsoft Outlook 365" category.
@@ -333,6 +333,7 @@ export class CategoryTree {
     const matchesAllWords = (node: NodeManifest, ancestorCategoryNames: string[]): boolean => {
       const searchableTexts = [
         node.display.label.toLowerCase(),
+        ...(node.display.canvasLabel ? [node.display.canvasLabel.toLowerCase()] : []),
         node.nodeType.toLowerCase(),
         ...(node.description ? [node.description.toLowerCase()] : []),
         ...(node.tags

--- a/packages/apollo-react/src/canvas/core/NodeTypeRegistry.test.ts
+++ b/packages/apollo-react/src/canvas/core/NodeTypeRegistry.test.ts
@@ -364,9 +364,12 @@ describe('NodeTypeRegistry', () => {
       expect(data.display!.icon).toBe('trigger');
     });
 
-    it('should use manifest label when no label provided', () => {
+    it('should not seed display.label from manifest when no label provided', () => {
+      // resolveDisplay() derives the rendered label from manifest.canvasLabel ?? manifest.label,
+      // so leaving instance.label unset lets manifest changes propagate at render time.
       const data = registry.createDefaultData('trigger');
-      expect(data.display!.label).toBe('Trigger');
+      expect(data.display!.label).toBeUndefined();
+      expect(data.display!.icon).toBe('trigger');
     });
 
     it('should handle non-existent node types gracefully', () => {

--- a/packages/apollo-react/src/canvas/core/NodeTypeRegistry.ts
+++ b/packages/apollo-react/src/canvas/core/NodeTypeRegistry.ts
@@ -204,9 +204,13 @@ export class NodeTypeRegistry {
       };
     }
 
-    // Build default display from manifest
+    // Omit `label` and `canvasLabel` unless caller supplied them — resolveDisplay()
+    // derives the canvas chip from instance.canvasLabel ?? instance.label ??
+    // manifest.canvasLabel ?? manifest.label, so leaving the instance side
+    // empty lets the manifest win on the chip while still allowing user renames
+    // (which write to instance.label) to take precedence later.
     const display: InstanceDisplayConfig = {
-      label: label || manifest.display.label,
+      ...(label ? { label } : {}),
       icon: manifest.display.icon,
       shape: manifest.display.shape,
       color: manifest.display.color,

--- a/packages/apollo-react/src/canvas/schema/node-definition/node-manifest.ts
+++ b/packages/apollo-react/src/canvas/schema/node-definition/node-manifest.ts
@@ -29,6 +29,9 @@ export const nodeDisplayManifestSchema = z.object({
   /** Human-readable display name */
   label: z.string().min(1),
 
+  /** Short label rendered on the node when it appears on the canvas. Falls back to `label` when omitted. */
+  canvasLabel: z.string().min(1).optional(),
+
   /** Description of what the node does */
   description: z.string().optional(),
 

--- a/packages/apollo-react/src/canvas/schema/node-instance/base.ts
+++ b/packages/apollo-react/src/canvas/schema/node-instance/base.ts
@@ -29,6 +29,12 @@ export const typeVersionKeySchema = z
 export const displayConfigSchema = z
   .object({
     label: z.string().optional(),
+    /**
+     * Canvas-side label override. Independent of `label`, which serves the panel /
+     * properties view. When set, takes precedence over `manifest.canvasLabel`,
+     * `instance.label`, and `manifest.label` for the canvas chip.
+     */
+    canvasLabel: z.string().optional(),
     subLabel: z.any().optional(), // Can be string or React.ReactNode
     shape: nodeShapeSchema.optional(),
     background: z.string().optional(),

--- a/packages/apollo-react/src/canvas/utils/manifest-resolver.test.ts
+++ b/packages/apollo-react/src/canvas/utils/manifest-resolver.test.ts
@@ -52,6 +52,62 @@ describe('resolveDisplay', () => {
     );
     expect(result.shape).toBe('circle');
   });
+
+  it('uses manifest canvasLabel for canvas label when no instance override', () => {
+    const result = resolveDisplay({
+      label: 'Send Outlook Email',
+      canvasLabel: 'Send Email',
+      icon: 'mail',
+    });
+    expect(result.label).toBe('Send Email');
+    expect(result.canvasLabel).toBe('Send Email');
+  });
+
+  it('falls back to manifest label when canvasLabel is not defined', () => {
+    const result = resolveDisplay({ label: 'Decision', icon: 'git-branch' });
+    expect(result.label).toBe('Decision');
+  });
+
+  it('lets instance.label override manifest.canvasLabel — user renames win', () => {
+    // The properties-panel rename surface writes to instance.display.label. It
+    // must beat manifest.canvasLabel so the rename actually shows on the chip.
+    // Consumers that auto-bake instance.label at creation must skip that bake
+    // when the manifest declares canvasLabel — otherwise the bake would always
+    // pose as a "user rename" and shadow canvasLabel.
+    const result = resolveDisplay(
+      { label: 'Send Outlook Email', canvasLabel: 'Send Email', icon: 'mail' },
+      { display: { label: 'Notify ops team' } }
+    );
+    expect(result.label).toBe('Notify ops team');
+    expect(result.canvasLabel).toBe('Send Email');
+  });
+
+  it('falls back to instance.label when no canvasLabel exists at either level', () => {
+    const result = resolveDisplay(
+      { label: 'Decision', icon: 'git-branch' },
+      { display: { label: 'Check if admin' } }
+    );
+    expect(result.label).toBe('Check if admin');
+  });
+
+  it('lets instance.canvasLabel override manifest.canvasLabel', () => {
+    // Explicit canvas-side override on the instance — used when the user
+    // renames the canvas chip and we want that rename to persist.
+    const result = resolveDisplay(
+      { label: 'Send Outlook Email', canvasLabel: 'Send Email', icon: 'mail' },
+      { display: { canvasLabel: 'Notify Ops' } }
+    );
+    expect(result.canvasLabel).toBe('Notify Ops');
+    expect(result.label).toBe('Notify Ops');
+  });
+
+  it('prefers instance.canvasLabel over instance.label and manifest values', () => {
+    const result = resolveDisplay(
+      { label: 'Send Outlook Email', canvasLabel: 'Send Email', icon: 'mail' },
+      { display: { canvasLabel: 'Notify Ops', label: 'Some panel label' } }
+    );
+    expect(result.label).toBe('Notify Ops');
+  });
 });
 
 // ============================================================================

--- a/packages/apollo-react/src/canvas/utils/manifest-resolver.ts
+++ b/packages/apollo-react/src/canvas/utils/manifest-resolver.ts
@@ -108,9 +108,29 @@ export function resolveDisplay(
   const collapsedShape = getCollapsedShape(shape);
   const expandedShape = manifestDisplay.shape;
 
+  // Resolve the canvas chip label.
+  //
+  // Order: instance.canvasLabel > instance.label > manifest.canvasLabel > manifest.label.
+  //
+  // - `instance.canvasLabel` is the explicit canvas-side override — top priority.
+  // - `instance.label` is the user-facing rename surface (properties panel /
+  //   inline edit). It must beat `manifest.canvasLabel` so a user rename
+  //   actually appears on the chip.
+  // - `manifest.canvasLabel` is the manifest's canvas-side default; consumers
+  //   relying on it must avoid auto-baking `instance.label` at creation time
+  //   (otherwise the auto-baked value would shadow this default).
+  // - `manifest.label` is the panel-side identity; final fallback.
+  const resolvedLabel =
+    context?.display?.canvasLabel ??
+    context?.display?.label ??
+    manifestDisplay.canvasLabel ??
+    manifestDisplay.label;
+
   return {
     ...manifestDisplay,
     ...context?.display,
+    label: resolvedLabel,
+    canvasLabel: context?.display?.canvasLabel ?? manifestDisplay.canvasLabel,
     shape: isCollapsed ? collapsedShape : expandedShape,
   };
 }


### PR DESCRIPTION
## Description

Today, a node manifest's `display.label` is shown both in the **palette / nodes list** and as the title rendered on each instance in the **canvas / diagram**. For nodes with long descriptive names (e.g. `"Send Outlook 365 Email"`), this works in the palette but is too long for the canvas, where a shorter variant (e.g. `"Send Email"`) reads better.

This PR introduces an optional `canvasLabel` field on **both the node manifest and the instance display config**, decoupling the canvas-chip identity from the palette / properties-panel label across all four levels of the precedence chain.

- **Palette / nodes list** — keeps using `display.label` (long-form, descriptive).
- **Canvas / diagram** — prefers `manifest.canvasLabel` when set, falling back to `manifest.label` otherwise.
- **Search** — `CategoryTree.filterBySearch` indexes `canvasLabel` too, so a query for the on-canvas name still surfaces the node.
- **Instance-level overrides** — `instance.display.canvasLabel` is a dedicated canvas-side override that beats the manifest's canvasLabel without touching `instance.label` (the panel-side rename surface).
- **User renames** — properties-panel renames (which write to `instance.label`) take precedence over `manifest.canvasLabel` so a user rename actually appears on the chip.

**Final precedence resolved by `resolveDisplay()`**:

```
instance.canvasLabel > instance.label > manifest.canvasLabel > manifest.label
```

This ordering lets consumers auto-bake `instance.label` (e.g. a dedup'd `"Document extraction 2"` for the Nth drop) without shadowing an explicit `instance.canvasLabel` override, while still letting properties-panel renames (also writing to `instance.label`) override the manifest's canvasLabel.

Existing canvas instances persisted before this change keep their saved `instance.display.label` (treated as user customization). Only newly-dropped instances pick up `manifest.canvasLabel` from the manifest.

## Implementation

The precedence rule lives in **one place** — `resolveDisplay()` — so renderers (`BaseNode`, `LoopNode`) don't need to know about `canvasLabel`.

- `packages/apollo-react/src/canvas/schema/node-definition/node-manifest.ts` — added optional `canvasLabel` field on `nodeDisplayManifestSchema`.
- `packages/apollo-react/src/canvas/schema/node-instance/base.ts` — added optional `canvasLabel` field on `displayConfigSchema` so the instance side can carry an explicit canvas-only override.
- `packages/apollo-react/src/canvas/components/BaseNode/BaseNode.types.ts` — mirrored `canvasLabel?: string` on `BaseNodeData.display`.
- `packages/apollo-react/src/canvas/utils/manifest-resolver.ts` — `resolveDisplay()` now derives the resolved `label` as `instance.canvasLabel ?? instance.label ?? manifest.canvasLabel ?? manifest.label`. Renderers continue to read `display.label` and get the right value. The returned `canvasLabel` field mirrors the same precedence (`instance.canvasLabel ?? manifest.canvasLabel`) so consumers introspecting the resolved display see consistent values.
- `packages/apollo-react/src/canvas/core/NodeTypeRegistry.ts` — `createDefaultData()` no longer pre-seeds `instance.display.label` from the manifest; only sets it when the caller explicitly supplies a custom label. This lets manifest changes propagate at render time and keeps user renames meaningful.
- `packages/apollo-react/src/canvas/core/CategoryTree.ts` — `filterBySearch()` adds `display.canvasLabel` to the searchable text array, joining the existing token-based, case-insensitive search across `label`, `nodeType`, `description`, `tags`, and ancestor category names.

No changes were needed in:
- `CategoryTreeAdapter.ts` (palette listing) — already reads `display.label`, which is still the right choice for the palette.
- `BaseNode.tsx` / `LoopNode.tsx` — keep reading `display.label`; the resolver now returns the right value.

## DEMO
Attaching a video demonstrating the `canvasLabel` usage in flow. The `Document extraction` nodes are using `canvasLabel` while the `Filter` nodes are using the default `label`

https://github.com/user-attachments/assets/a5b89f2e-6af7-4150-9c1e-142e65ef2e93

## How it's tested

**Unit tests** (`pnpm --filter @uipath/apollo-react test`):

- `manifest-resolver.test.ts` — tests for each branch of the four-level precedence chain: manifest canvasLabel default, manifest label fallback, user rename via instance.label beating manifest.canvasLabel, instance.canvasLabel beating manifest.canvasLabel, and instance.canvasLabel beating instance.label.
- `NodeTypeRegistry.test.ts` — updated assertion to reflect that `createDefaultData()` no longer seeds `display.label` when no caller-supplied label is given; the explicit-caller-label test still passes.
- `CategoryTree.test.ts` — tests covering search-by-`canvasLabel` only, and multi-word search across `label` + `canvasLabel`.

**Storybook** (`pnpm --filter storybook-app dev`, http://localhost:6007):

- `Canvas / BaseNode → canvasLabel resolution` — three real `BaseNode` instances on a canvas, demonstrating the precedence chain: manifest with both fields, manifest without `canvasLabel`, and an instance-level `canvasLabel` override.
- `Canvas / AddNodePanel → Add node panel — search by canvasLabel` — registers a story-local manifest with a node whose only `"outlook"` token lives on `display.canvasLabel`. Click the + handle on the trigger node, type `outlook` in the panel search, and confirm the node still surfaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)