### PR TITLE
feat(apollo-vertex): ai-chat code blocks — syntax-highlighted fenced code with copy [2/5]

### DIFF
--- a/apps/apollo-vertex/package.json
+++ b/apps/apollo-vertex/package.json
@@ -70,6 +70,7 @@
     "embla-carousel-react": "^8.6.0",
     "eventsource-parser": "^3.0.6",
     "framer-motion": "^12.26.2",
+    "highlight.js": "^11.11.1",
     "i18next": "^25.8.1",
     "input-otp": "^1.4.2",
     "jwt-decode": "^4.0.0",

--- a/apps/apollo-vertex/registry.json
+++ b/apps/apollo-vertex/registry.json
@@ -321,6 +321,7 @@
         "lucide-react",
         "luxon",
         "react-i18next",
+        "highlight.js",
         "react-markdown",
         "remark-gfm",
         "framer-motion"
@@ -396,6 +397,11 @@
           "path": "registry/ai-chat/components/ai-chat-markdown.tsx",
           "type": "registry:ui",
           "target": "components/ui/ai-chat/components/ai-chat-markdown.tsx"
+        },
+        {
+          "path": "registry/ai-chat/components/ai-chat-code-block.tsx",
+          "type": "registry:ui",
+          "target": "components/ui/ai-chat/components/ai-chat-code-block.tsx"
         },
         {
           "path": "registry/ai-chat/components/ai-chat-message.tsx",

--- a/apps/apollo-vertex/registry/ai-chat/components/ai-chat-code-block.tsx
+++ b/apps/apollo-vertex/registry/ai-chat/components/ai-chat-code-block.tsx
@@ -1,0 +1,164 @@
+"use client";
+
+import "highlight.js/styles/github.min.css";
+
+// Dark-mode override: github-dark-dimmed palette scoped to `.dark`
+const DARK_HLJS_STYLE = `
+.dark .hljs {
+  color: #adbac7;
+  background: transparent;
+}
+.dark .hljs-doctag,.dark .hljs-keyword,.dark .hljs-meta .hljs-keyword,.dark .hljs-template-tag,.dark .hljs-template-variable,.dark .hljs-type,.dark .hljs-variable.language_ {
+  color: #f47067;
+}
+.dark .hljs-title,.dark .hljs-title.class_,.dark .hljs-title.class_.inherited__,.dark .hljs-title.function_ {
+  color: #dcbdfb;
+}
+.dark .hljs-attr,.dark .hljs-attribute,.dark .hljs-literal,.dark .hljs-meta,.dark .hljs-number,.dark .hljs-operator,.dark .hljs-variable,.dark .hljs-selector-attr,.dark .hljs-selector-class,.dark .hljs-selector-id {
+  color: #6cb6ff;
+}
+.dark .hljs-regexp,.dark .hljs-string,.dark .hljs-meta .hljs-string {
+  color: #96d0ff;
+}
+.dark .hljs-built_in,.dark .hljs-symbol {
+  color: #f69d50;
+}
+.dark .hljs-comment,.dark .hljs-code,.dark .hljs-formula {
+  color: #768390;
+}
+.dark .hljs-name,.dark .hljs-quote,.dark .hljs-selector-tag,.dark .hljs-selector-pseudo {
+  color: #8ddb8c;
+}
+.dark .hljs-subst {
+  color: #adbac7;
+}
+.dark .hljs-section {
+  color: #316dca;
+  font-weight: bold;
+}
+.dark .hljs-bullet {
+  color: #eac55f;
+}
+.dark .hljs-emphasis {
+  color: #adbac7;
+  font-style: italic;
+}
+.dark .hljs-strong {
+  color: #adbac7;
+  font-weight: bold;
+}
+.dark .hljs-addition {
+  color: #b4f1b4;
+  background-color: #1b4721;
+}
+.dark .hljs-deletion {
+  color: #ffd8d3;
+  background-color: #78191b;
+}
+`;
+
+import hljs from "highlight.js/lib/core";
+import bash from "highlight.js/lib/languages/bash";
+import css from "highlight.js/lib/languages/css";
+import javascript from "highlight.js/lib/languages/javascript";
+import json from "highlight.js/lib/languages/json";
+import python from "highlight.js/lib/languages/python";
+import sql from "highlight.js/lib/languages/sql";
+import typescript from "highlight.js/lib/languages/typescript";
+import xml from "highlight.js/lib/languages/xml";
+import { Check, Copy } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+
+hljs.registerLanguage("javascript", javascript);
+hljs.registerLanguage("js", javascript);
+hljs.registerLanguage("typescript", typescript);
+hljs.registerLanguage("ts", typescript);
+hljs.registerLanguage("tsx", typescript);
+hljs.registerLanguage("jsx", javascript);
+hljs.registerLanguage("python", python);
+hljs.registerLanguage("py", python);
+hljs.registerLanguage("bash", bash);
+hljs.registerLanguage("sh", bash);
+hljs.registerLanguage("shell", bash);
+hljs.registerLanguage("json", json);
+hljs.registerLanguage("css", css);
+hljs.registerLanguage("html", xml);
+hljs.registerLanguage("xml", xml);
+hljs.registerLanguage("sql", sql);
+
+const COPY_LABEL = "Copy code";
+const COPIED_LABEL = "Copied!";
+
+interface AiChatCodeBlockProps {
+  children: string;
+  language?: string;
+}
+
+export function AiChatCodeBlock({ children, language }: AiChatCodeBlockProps) {
+  const [copied, setCopied] = useState(false);
+  const codeRef = useRef<HTMLElement>(null);
+
+  const highlightedHtml =
+    language && hljs.getLanguage(language)
+      ? hljs.highlight(children, { language }).value
+      : hljs.highlightAuto(children).value;
+
+  useEffect(() => {
+    if (codeRef.current) {
+      codeRef.current.innerHTML = highlightedHtml;
+    }
+  }, [highlightedHtml]);
+
+  const handleCopy = async () => {
+    await navigator.clipboard.writeText(children);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  const copyLabel = copied ? COPIED_LABEL : COPY_LABEL;
+
+  return (
+    <>
+      <style>{DARK_HLJS_STYLE}</style>
+      <div className="relative group/codeblock mb-2 last:mb-0 rounded-lg bg-ai-chat-muted/50 overflow-hidden">
+        <div className="flex items-center justify-between px-3 py-1.5 border-b border-ai-chat-border">
+          {language && (
+            <span className="text-[11px] font-mono text-ai-chat-muted-foreground uppercase tracking-wider">
+              {language}
+            </span>
+          )}
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                onClick={() => {
+                  void handleCopy();
+                }}
+                className="ml-auto size-6 inline-flex items-center justify-center rounded-md opacity-0 group-hover/codeblock:opacity-100 transition-opacity hover:bg-ai-chat-border"
+                aria-label={copyLabel}
+              >
+                {copied ? (
+                  <Check className="size-3 text-success" aria-hidden="true" />
+                ) : (
+                  <Copy
+                    className="size-3 text-ai-chat-muted-foreground"
+                    aria-hidden="true"
+                  />
+                )}
+              </button>
+            </TooltipTrigger>
+            <TooltipContent>{copyLabel}</TooltipContent>
+          </Tooltip>
+        </div>
+        <pre className="p-3 overflow-x-auto">
+          <code ref={codeRef} className="hljs text-xs font-mono" />
+        </pre>
+      </div>
+    </>
+  );
+}

--- a/apps/apollo-vertex/registry/ai-chat/components/ai-chat-markdown.tsx
+++ b/apps/apollo-vertex/registry/ai-chat/components/ai-chat-markdown.tsx
@@ -3,73 +3,112 @@
 import type { ComponentProps, ReactNode } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
+import { AiChatCodeBlock } from "./ai-chat-code-block";
 
 type NodeProps = { children?: ReactNode };
 type AnchorProps = { children?: ReactNode; href?: string };
+type ImageProps = { src?: string | Blob; alt?: string; title?: string };
+
+function extractCodeProps(props: NodeProps & { className?: string }) {
+  const { className, children } = props;
+  const match = /language-(\w+)/.exec(className ?? "");
+  const language = match ? match[1] : "";
+  const code = (typeof children === "string" ? children : "").replace(
+    /\n$/,
+    "",
+  );
+  return { language, code };
+}
 
 const components: ComponentProps<typeof ReactMarkdown>["components"] = {
-  p: ({ children }: NodeProps) => <p className="mb-2 last:mb-0">{children}</p>,
+  p: ({ children }: NodeProps) => (
+    <p className="mt-5 mb-5 first:mt-0 last:mb-0">{children}</p>
+  ),
   ul: ({ children }: NodeProps) => (
-    <ul className="mb-2 last:mb-0 ml-4 list-disc">{children}</ul>
+    <ul className="mt-5 mb-5 first:mt-0 last:mb-0 ml-4 list-disc">
+      {children}
+    </ul>
   ),
   ol: ({ children }: NodeProps) => (
-    <ol className="mb-2 last:mb-0 ml-4 list-decimal">{children}</ol>
-  ),
-  li: ({ children }: NodeProps) => <li className="mb-1">{children}</li>,
-  pre: ({ children }: NodeProps) => (
-    <pre className="mb-2 last:mb-0 p-3 rounded bg-muted text-foreground font-mono text-xs overflow-x-auto">
+    <ol className="mt-5 mb-5 first:mt-0 last:mb-0 ml-4 list-decimal">
       {children}
-    </pre>
+    </ol>
   ),
+  li: ({ children }: NodeProps) => <li className="mb-3">{children}</li>,
+  pre: ({ children }: NodeProps) => <div>{children}</div>,
   code: ({
     children,
     className,
     ...props
-  }: NodeProps & { className?: string }) => (
-    <code
-      className={
-        className ??
-        "px-1.5 py-0.5 rounded bg-muted text-foreground font-mono text-xs"
-      }
+  }: NodeProps & { className?: string }) => {
+    const isBlock =
+      (className?.startsWith("language-") ?? false) ||
+      (typeof children === "string" && children.includes("\n"));
+
+    if (isBlock) {
+      const { language, code } = extractCodeProps({
+        className,
+        children,
+        ...props,
+      });
+      return <AiChatCodeBlock language={language}>{code}</AiChatCodeBlock>;
+    }
+
+    return (
+      <code className="px-1.5 py-0.5 rounded bg-ai-chat-muted text-ai-chat-foreground font-mono text-xs">
+        {children}
+      </code>
+    );
+  },
+  a: ({ children, ...props }: AnchorProps) => (
+    <a
+      className="text-primary-700 dark:text-primary-400 hover:underline"
       {...props}
     >
       {children}
-    </code>
-  ),
-  a: ({ children, ...props }: AnchorProps) => (
-    <a className="text-primary hover:underline" {...props}>
-      {children}
     </a>
+  ),
+  img: ({ src, alt, title }: ImageProps) => (
+    <img
+      src={typeof src === "string" ? src : ""}
+      alt={alt ?? ""}
+      title={title}
+      loading="lazy"
+      decoding="async"
+      className="block max-w-full max-h-[400px] object-contain rounded-lg border border-ai-chat-border"
+    />
   ),
   strong: ({ children }: NodeProps) => (
     <strong className="font-semibold">{children}</strong>
   ),
   em: ({ children }: NodeProps) => <em className="italic">{children}</em>,
   blockquote: ({ children }: NodeProps) => (
-    <blockquote className="border-l-2 border-muted-foreground/30 pl-3 italic my-2">
+    <blockquote className="border-l-2 border-ai-chat-accent pl-3 bg-ai-chat-accent/5 rounded-r italic my-2 py-1">
       {children}
     </blockquote>
   ),
   h1: ({ children }: NodeProps) => (
-    <h1 className="text-lg font-bold mb-2 mt-3 first:mt-0">{children}</h1>
+    <h1 className="text-2xl font-bold mb-3 mt-6 first:mt-0">{children}</h1>
   ),
   h2: ({ children }: NodeProps) => (
-    <h2 className="text-base font-bold mb-2 mt-3 first:mt-0">{children}</h2>
+    <h2 className="text-xl font-bold mb-2 mt-5 first:mt-0">{children}</h2>
   ),
   h3: ({ children }: NodeProps) => (
-    <h3 className="text-sm font-bold mb-2 mt-2 first:mt-0">{children}</h3>
+    <h3 className="text-lg font-bold mb-2 mt-4 first:mt-0">{children}</h3>
   ),
-  hr: () => <hr className="my-3 border-border" />,
+  hr: () => <hr className="my-3 border-ai-chat-border" />,
   table: ({ children }: NodeProps) => (
     <div className="overflow-x-auto my-2">
-      <table className="min-w-full divide-y divide-border">{children}</table>
+      <table className="min-w-full divide-y divide-ai-chat-border">
+        {children}
+      </table>
     </div>
   ),
   thead: ({ children }: NodeProps) => (
-    <thead className="bg-muted">{children}</thead>
+    <thead className="bg-ai-chat-muted">{children}</thead>
   ),
   tbody: ({ children }: NodeProps) => (
-    <tbody className="divide-y divide-border">{children}</tbody>
+    <tbody className="divide-y divide-ai-chat-border">{children}</tbody>
   ),
   tr: ({ children }: NodeProps) => <tr>{children}</tr>,
   th: ({ children }: NodeProps) => (
@@ -86,7 +125,7 @@ interface AiChatMarkdownProps {
 
 export function AiChatMarkdown({ children }: AiChatMarkdownProps) {
   return (
-    <div className="px-4 py-3 text-sm rounded-lg bg-primary/10 prose prose-sm dark:prose-invert max-w-none">
+    <div className="py-1 text-base leading-relaxed bg-transparent text-foreground prose dark:prose-invert max-w-none">
       <ReactMarkdown remarkPlugins={[remarkGfm]} components={components}>
         {children}
       </ReactMarkdown>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -300,6 +300,9 @@ importers:
       framer-motion:
         specifier: ^12.26.2
         version: 12.26.2(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      highlight.js:
+        specifier: ^11.11.1
+        version: 11.11.1
       i18next:
         specifier: ^25.8.1
         version: 25.8.1(typescript@5.9.3)


### PR DESCRIPTION
## What this does

Adds proper code rendering inside AI responses — the most common place where plain text breaks down.

- **Syntax highlighting** via highlight.js for all major languages (JS, TS, Python, SQL, etc.)
- **Language label** shown in the top-right corner of each code block so users know what they're looking at
- **One-click copy** button per block — copies the raw code without the surrounding markdown
- **Dark/light theme** aware — highlight colors adapt to the active theme
- Inline `code` spans (backtick-wrapped) render as styled chips rather than plain monospace text

Without this, AI responses that include code snippets render as a wall of unstyled text.

## Test plan
- [ ] Fenced code blocks render with syntax highlighting
- [ ] Language label appears (e.g., "typescript", "python")
- [ ] Copy button copies raw code to clipboard
- [ ] Inline code renders as a styled chip
- [ ] Highlighting updates correctly in dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)