### PR TITLE
fix(apollo-react): canvas insert between positioning, container positioning

### DIFF
--- a/packages/apollo-react/src/canvas/components/AddNodePanel/AddNodeManager.helpers.test.ts
+++ b/packages/apollo-react/src/canvas/components/AddNodePanel/AddNodeManager.helpers.test.ts
@@ -1,0 +1,257 @@
+import type { Edge, Node } from '@uipath/apollo-react/canvas/xyflow/react';
+import { describe, expect, it } from 'vitest';
+import { PREVIEW_NODE_ID } from '../../constants';
+import type { NodeTypeRegistry } from '../../core';
+import type { NodeManifest, NodeShape } from '../../schema/node-definition';
+import { placeAddedNode } from './AddNodeManager.helpers';
+
+function buildRegistry(manifestsByType: Record<string, { shape?: NodeShape }>): NodeTypeRegistry {
+  const get = (nodeType: string): NodeManifest | undefined => {
+    const entry = manifestsByType[nodeType];
+    if (!entry) return undefined;
+    return {
+      nodeType,
+      version: '1',
+      display: { label: nodeType, ...(entry.shape ? { shape: entry.shape } : {}) },
+      handleConfiguration: [],
+    } as NodeManifest;
+  };
+  return { getManifest: get } as unknown as NodeTypeRegistry;
+}
+
+const ORIGINAL_EDGE: Edge = {
+  id: 'e-trigger-action',
+  source: 'trigger',
+  target: 'action',
+};
+
+function makePreviewNode(position: { x: number; y: number }): Node {
+  return {
+    id: PREVIEW_NODE_ID,
+    type: 'preview',
+    position,
+    width: 96,
+    height: 96,
+    data: { originalEdge: ORIGINAL_EDGE },
+  };
+}
+
+describe('placeAddedNode', () => {
+  describe('top-level edge insertion', () => {
+    const trigger: Node = {
+      id: 'trigger',
+      type: 'square-source',
+      position: { x: 96, y: 96 },
+      measured: { width: 96, height: 96 },
+      data: {},
+    };
+    const action: Node = {
+      id: 'action',
+      type: 'square-target',
+      position: { x: 288, y: 96 },
+      measured: { width: 96, height: 96 },
+      data: {},
+    };
+
+    it('shifts the downstream chain right when inserting a wider rectangle', () => {
+      const registry = buildRegistry({
+        'square-source': { shape: 'square' },
+        'square-target': { shape: 'square' },
+        rectangle: { shape: 'rectangle' },
+      });
+      const previewNode = makePreviewNode({ x: 200, y: 96 });
+      const insertedNode: Node = {
+        id: 'inserted',
+        type: 'rectangle',
+        // Already aligned to preview by alignNodeToPreview.
+        position: { x: 200, y: 96 },
+        data: {},
+      };
+
+      const { nodes } = placeAddedNode({
+        nodes: [trigger, action, insertedNode],
+        edges: [ORIGINAL_EDGE],
+        previewNode,
+        insertedNode,
+        registry,
+      });
+
+      const placedAction = nodes.find((n) => n.id === 'action');
+      const placedInserted = nodes.find((n) => n.id === 'inserted');
+      const placedTrigger = nodes.find((n) => n.id === 'trigger');
+
+      // Trigger does not move — it is upstream of the insertion.
+      expect(placedTrigger?.position).toEqual({ x: 96, y: 96 });
+      // The rectangle is bumped right just enough to clear the upstream
+      // trigger's right edge (96 + 96 = 192) plus the insertion gap.
+      expect(placedInserted?.position.x).toBeGreaterThanOrEqual(192);
+      // Action is downstream and clears the rectangle's right edge plus gap.
+      const rectRight = (placedInserted?.position.x ?? 0) + 288;
+      expect(placedAction?.position.x).toBeGreaterThanOrEqual(rectRight);
+      // Y stays in row layout — no vertical splitting.
+      expect(placedAction?.position.y).toBe(96);
+    });
+
+    it('shifts the downstream chain right when inserting a container shape', () => {
+      const registry = buildRegistry({
+        'square-source': { shape: 'square' },
+        'square-target': { shape: 'square' },
+        loop: { shape: 'container' },
+      });
+      const previewNode = makePreviewNode({ x: 200, y: 96 });
+      const insertedNode: Node = {
+        id: 'inserted',
+        type: 'loop',
+        position: { x: 200, y: 96 },
+        data: {},
+      };
+
+      const { nodes } = placeAddedNode({
+        nodes: [trigger, action, insertedNode],
+        edges: [ORIGINAL_EDGE],
+        previewNode,
+        insertedNode,
+        registry,
+      });
+
+      const placedAction = nodes.find((n) => n.id === 'action');
+      const placedInserted = nodes.find((n) => n.id === 'inserted');
+
+      // Container default size is 560 wide; action must clear it.
+      expect(placedAction?.position.x).toBeGreaterThanOrEqual(
+        (placedInserted?.position.x ?? 0) + 560
+      );
+      // Action stays in the same row (no vertical re-shuffling).
+      expect(placedAction?.position.y).toBe(96);
+    });
+
+    it('cascades the shift through a multi-node downstream chain', () => {
+      const registry = buildRegistry({
+        'square-source': { shape: 'square' },
+        'square-target': { shape: 'square' },
+        rectangle: { shape: 'rectangle' },
+      });
+      const middle: Node = {
+        id: 'middle',
+        type: 'square-target',
+        position: { x: 480, y: 96 },
+        measured: { width: 96, height: 96 },
+        data: {},
+      };
+      const tail: Node = {
+        id: 'tail',
+        type: 'square-target',
+        position: { x: 672, y: 96 },
+        measured: { width: 96, height: 96 },
+        data: {},
+      };
+      const edges: Edge[] = [
+        ORIGINAL_EDGE,
+        { id: 'e-action-middle', source: 'action', target: 'middle' },
+        { id: 'e-middle-tail', source: 'middle', target: 'tail' },
+      ];
+      const previewNode = makePreviewNode({ x: 200, y: 96 });
+      const insertedNode: Node = {
+        id: 'inserted',
+        type: 'rectangle',
+        position: { x: 200, y: 96 },
+        data: {},
+      };
+
+      const { nodes } = placeAddedNode({
+        nodes: [trigger, action, middle, tail, insertedNode],
+        edges,
+        previewNode,
+        insertedNode,
+        registry,
+      });
+
+      const placedAction = nodes.find((n) => n.id === 'action')!;
+      const placedMiddle = nodes.find((n) => n.id === 'middle')!;
+      const placedTail = nodes.find((n) => n.id === 'tail')!;
+
+      // Order in the chain is preserved.
+      expect(placedAction.position.x).toBeLessThan(placedMiddle.position.x);
+      expect(placedMiddle.position.x).toBeLessThan(placedTail.position.x);
+      // All chain nodes shifted right by the same amount, preserving original
+      // spacing between them.
+      const actionShift = placedAction.position.x - 288;
+      const middleShift = placedMiddle.position.x - 480;
+      const tailShift = placedTail.position.x - 672;
+      expect(actionShift).toBeGreaterThan(0);
+      expect(middleShift).toBe(actionShift);
+      expect(tailShift).toBe(actionShift);
+    });
+
+    it('does not shift the chain when the inserted node already fits', () => {
+      const registry = buildRegistry({
+        'square-source': { shape: 'square' },
+        'square-target': { shape: 'square' },
+        square: { shape: 'square' },
+      });
+      // Trigger and action with enough room for a square between them.
+      const farAction: Node = {
+        ...action,
+        position: { x: 480, y: 96 },
+      };
+      const previewNode = makePreviewNode({ x: 240, y: 96 });
+      const insertedNode: Node = {
+        id: 'inserted',
+        type: 'square',
+        position: { x: 240, y: 96 },
+        data: {},
+      };
+
+      const { nodes } = placeAddedNode({
+        nodes: [trigger, farAction, insertedNode],
+        edges: [{ ...ORIGINAL_EDGE, target: 'action' }],
+        previewNode,
+        insertedNode,
+        registry,
+      });
+
+      const placedAction = nodes.find((n) => n.id === 'action');
+      // Square at 240 spans 240-336, action at 480. Already enough room → no shift.
+      expect(placedAction?.position).toEqual({ x: 480, y: 96 });
+    });
+
+    it('does not shift any chain when no originalEdge metadata is present', () => {
+      const registry = buildRegistry({
+        'square-source': { shape: 'square' },
+        'square-target': { shape: 'square' },
+        rectangle: { shape: 'rectangle' },
+      });
+      // Preview without originalEdge metadata — this is the "click + on a leaf
+      // handle" path, not the edge-toolbar insertion path.
+      const previewNode: Node = {
+        id: PREVIEW_NODE_ID,
+        type: 'preview',
+        position: { x: 200, y: 96 },
+        width: 96,
+        height: 96,
+        data: {},
+      };
+      const insertedNode: Node = {
+        id: 'inserted',
+        type: 'rectangle',
+        position: { x: 200, y: 96 },
+        data: {},
+      };
+
+      const { nodes } = placeAddedNode({
+        nodes: [trigger, action, insertedNode],
+        edges: [ORIGINAL_EDGE],
+        previewNode,
+        insertedNode,
+        registry,
+      });
+
+      const placedAction = nodes.find((n) => n.id === 'action');
+      // Without originalEdge, this branch isn't a graph-aware insertion — fall
+      // back to generic collision resolution. We only assert that the chain
+      // didn't deterministically shift; actual position is decided by the
+      // collision resolver and not part of this contract.
+      expect(placedAction?.position).toBeDefined();
+    });
+  });
+});

--- a/packages/apollo-react/src/canvas/components/AddNodePanel/AddNodeManager.helpers.ts
+++ b/packages/apollo-react/src/canvas/components/AddNodePanel/AddNodeManager.helpers.ts
@@ -1,5 +1,6 @@
 import type { Edge, Node } from '@uipath/apollo-react/canvas/xyflow/react';
 import { Position } from '@uipath/apollo-react/canvas/xyflow/react';
+import { GRID_SPACING } from '../../constants';
 import type { NodeTypeRegistry } from '../../core';
 import type { PreviewNodeConnectionInfo } from '../../hooks/usePreviewNode';
 import type { NodeManifest } from '../../schema';
@@ -14,6 +15,15 @@ import {
   type NodeDimensions,
   placeContainerNode,
 } from '../../utils/container';
+import { isPreviewEdge } from '../../utils/createPreviewNode';
+import { snapUpToGrid } from '../../utils/NodeUtils';
+
+/**
+ * Gap (px) used when shifting nodes around an Add Node insertion at the
+ * top-level scope. Must exceed `2 × resolveCollisions` margin (32 each side =
+ * 64 total) so the post-shift layout doesn't trigger another collision pass.
+ */
+const TOP_LEVEL_INSERTION_GAP_PX = GRID_SPACING * 5;
 
 interface AddNodePlacementResult {
   nodes: Node[];
@@ -150,6 +160,138 @@ function resolveScopedCollisions(
 }
 
 /**
+ * Walks one linear sibling chain downstream from `startNodeId`, following
+ * single outgoing edges that stay within the same parent scope. Stops on
+ * branches, cycles, container exits, and preview edges.
+ *
+ * Used to find the set of nodes that should rigidly shift right when a wider
+ * node is inserted upstream.
+ */
+function collectLinearDownstreamChain({
+  startNodeId,
+  parentId,
+  nodes,
+  edges,
+}: {
+  startNodeId: string;
+  parentId: string | undefined;
+  nodes: Node[];
+  edges: Edge[];
+}): string[] {
+  const nodesById = new Map(nodes.map((n) => [n.id, n]));
+  const collected: string[] = [];
+  const visited = new Set<string>();
+  let currentId: string | null = startNodeId;
+
+  while (currentId && !visited.has(currentId)) {
+    const current = nodesById.get(currentId);
+    if (!current || current.parentId !== parentId) break;
+
+    collected.push(currentId);
+    visited.add(currentId);
+
+    const outgoing = edges.filter(
+      (edge) =>
+        !isPreviewEdge(edge) &&
+        edge.source === currentId &&
+        nodesById.get(edge.target)?.parentId === parentId
+    );
+    // Branches and dead-ends both stop the linear shift; ambiguous cases get
+    // handed off to generic collision resolution.
+    currentId = outgoing.length === 1 ? outgoing[0]!.target : null;
+  }
+
+  return collected;
+}
+
+/**
+ * For top-level edge insertions (preview replaced an existing edge but is not
+ * scoped to a container), keeps the row layout intact regardless of the
+ * inserted node's shape:
+ *
+ *   1. Bumps the inserted node right if it would overlap the upstream source's
+ *      gap zone — `alignNodeToPreview` only matches the preview's anchor and
+ *      doesn't account for size differences vs the source.
+ *   2. Shifts the downstream target and its linear chain right by enough to
+ *      clear the inserted node's trailing edge plus a sequence gap.
+ *
+ * Without these adjustments, generic collision resolution picks the
+ * smallest-overlap axis and can split the row vertically for wider/larger
+ * shapes (rectangle, container) or push the upstream source backwards.
+ */
+function shiftForEdgeInsertion({
+  nodes,
+  edges,
+  previewNode,
+  insertedNode,
+  getNodeSize,
+}: {
+  nodes: Node[];
+  edges: Edge[];
+  previewNode: Node;
+  insertedNode: Node;
+  getNodeSize: (node: Node) => NodeDimensions;
+}): { nodes: Node[]; insertedNode: Node } | null {
+  const originalEdge = getOriginalEdge(previewNode);
+  if (!originalEdge) return null;
+
+  const targetNode = nodes.find((node) => node.id === originalEdge.target);
+  if (!targetNode || targetNode.parentId !== insertedNode.parentId) return null;
+
+  const insertedSize = getNodeSize(insertedNode);
+
+  // Step 1: clear the upstream source.
+  let insertedX = insertedNode.position.x;
+  const sourceNode = nodes.find((node) => node.id === originalEdge.source);
+  if (sourceNode && sourceNode.parentId === insertedNode.parentId) {
+    const sourceSize = getNodeSize(sourceNode);
+    const requiredInsertedLeft =
+      sourceNode.position.x + sourceSize.width + TOP_LEVEL_INSERTION_GAP_PX;
+    if (insertedX < requiredInsertedLeft) {
+      insertedX = snapUpToGrid(requiredInsertedLeft);
+    }
+  }
+
+  // Step 2: shift the downstream chain.
+  const requiredTargetLeft = insertedX + insertedSize.width + TOP_LEVEL_INSERTION_GAP_PX;
+  const downstreamShift =
+    targetNode.position.x < requiredTargetLeft
+      ? snapUpToGrid(requiredTargetLeft - targetNode.position.x)
+      : 0;
+  const chainIds =
+    downstreamShift > 0
+      ? new Set(
+          collectLinearDownstreamChain({
+            startNodeId: targetNode.id,
+            parentId: insertedNode.parentId,
+            nodes,
+            edges,
+          })
+        )
+      : new Set<string>();
+
+  const insertedXChanged = insertedX !== insertedNode.position.x;
+  if (!insertedXChanged && downstreamShift === 0) return null;
+
+  const updatedInsertedNode: Node = insertedXChanged
+    ? { ...insertedNode, position: { x: insertedX, y: insertedNode.position.y } }
+    : insertedNode;
+
+  const updatedNodes = nodes.map((node) => {
+    if (node.id === insertedNode.id) return updatedInsertedNode;
+    if (chainIds.has(node.id)) {
+      return {
+        ...node,
+        position: { x: node.position.x + downstreamShift, y: node.position.y },
+      };
+    }
+    return node;
+  });
+
+  return { nodes: updatedNodes, insertedNode: updatedInsertedNode };
+}
+
+/**
  * Applies the final Add Node placement after a preview is accepted. Container
  * previews use their saved placement metadata; all other previews use scoped
  * collision resolution.
@@ -210,7 +352,15 @@ export function placeAddedNode({
     };
   }
 
-  return resolveScopedCollisions(nodes, insertedNode, {
+  const shifted = shiftForEdgeInsertion({
+    nodes,
+    edges,
+    previewNode,
+    insertedNode,
+    getNodeSize: getDimensions,
+  });
+
+  return resolveScopedCollisions(shifted?.nodes ?? nodes, shifted?.insertedNode ?? insertedNode, {
     ignoredNodeTypes,
     getNodeSize: getDimensions,
   });

--- a/packages/apollo-react/src/canvas/components/AddNodePanel/AddNodeManager.helpers.ts
+++ b/packages/apollo-react/src/canvas/components/AddNodePanel/AddNodeManager.helpers.ts
@@ -7,6 +7,7 @@ import type { NodeManifest } from '../../schema';
 import { resolveCollisions } from '../../utils';
 import { getExpandedSize } from '../../utils/collapse';
 import {
+  collectLinearDownstreamSiblings,
   getContainerFitGeometry,
   getContainerPlacement,
   getContainerSafeArea,
@@ -15,7 +16,6 @@ import {
   type NodeDimensions,
   placeContainerNode,
 } from '../../utils/container';
-import { isPreviewEdge } from '../../utils/createPreviewNode';
 import { snapUpToGrid } from '../../utils/NodeUtils';
 
 /**
@@ -160,70 +160,6 @@ function resolveScopedCollisions(
 }
 
 /**
- * Walks one linear sibling chain downstream from `startNodeId`, following
- * single outgoing edges that stay within the same parent scope.
- *
- * Stop conditions:
- *   - Cycles (already-visited node).
- *   - The current node leaves the target parent scope.
- *   - The current node has 0 or >1 in-scope outgoing edges (dead-end or
- *     in-scope branch — generic collision resolution handles ambiguous cases).
- *
- * Edges whose target sits outside `parentId` (e.g., a child wiring back to its
- * container's continue handle, or any cross-scope link) are filtered out
- * before the count, since the off-scope target isn't a sibling that needs to
- * shift. They don't terminate the walk on their own — only the in-scope edge
- * count matters.
- *
- * Used to find the set of nodes that should rigidly shift right when a wider
- * node is inserted upstream.
- */
-function collectLinearDownstreamChain({
-  startNodeId,
-  parentId,
-  nodes,
-  edges,
-}: {
-  startNodeId: string;
-  parentId: string | undefined;
-  nodes: Node[];
-  edges: Edge[];
-}): string[] {
-  const nodesById = new Map(nodes.map((n) => [n.id, n]));
-  // Pre-bucket edges by source so the chain walk is O(chainLength) instead of
-  // O(chainLength × edgeCount). Filters here exclude preview edges and
-  // off-scope targets up front so the per-step check is just a length read.
-  const inScopeEdgesBySource = new Map<string, Edge[]>();
-  for (const edge of edges) {
-    if (isPreviewEdge(edge)) continue;
-    if (nodesById.get(edge.target)?.parentId !== parentId) continue;
-    const bucket = inScopeEdgesBySource.get(edge.source);
-    if (bucket) {
-      bucket.push(edge);
-    } else {
-      inScopeEdgesBySource.set(edge.source, [edge]);
-    }
-  }
-
-  const collected: string[] = [];
-  const visited = new Set<string>();
-  let currentId: string | null = startNodeId;
-
-  while (currentId && !visited.has(currentId)) {
-    const current = nodesById.get(currentId);
-    if (!current || current.parentId !== parentId) break;
-
-    collected.push(currentId);
-    visited.add(currentId);
-
-    const outgoing: Edge[] = inScopeEdgesBySource.get(currentId) ?? [];
-    currentId = outgoing.length === 1 ? outgoing[0]!.target : null;
-  }
-
-  return collected;
-}
-
-/**
  * For top-level edge insertions (preview replaced an existing edge but is not
  * scoped to a container), keeps the row layout intact regardless of the
  * inserted node's shape:
@@ -280,7 +216,7 @@ function shiftForEdgeInsertion({
   const chainIds =
     downstreamShift > 0
       ? new Set(
-          collectLinearDownstreamChain({
+          collectLinearDownstreamSiblings({
             startNodeId: targetNode.id,
             parentId: insertedNode.parentId,
             nodes,
@@ -331,7 +267,7 @@ export function placeAddedNode({
   ignoredNodeTypes?: string[];
 }): AddNodePlacementResult {
   const getDimensions = (node: Node) => getManifestAwareNodeDimensions(registry, node);
-  const placement = getContainerPlacement({ previewNode });
+  const placement = getContainerPlacement(previewNode);
 
   if (placement) {
     const containerNode = nodes.find((node) => node.id === placement.containerId);

--- a/packages/apollo-react/src/canvas/components/AddNodePanel/AddNodeManager.helpers.ts
+++ b/packages/apollo-react/src/canvas/components/AddNodePanel/AddNodeManager.helpers.ts
@@ -161,8 +161,19 @@ function resolveScopedCollisions(
 
 /**
  * Walks one linear sibling chain downstream from `startNodeId`, following
- * single outgoing edges that stay within the same parent scope. Stops on
- * branches, cycles, container exits, and preview edges.
+ * single outgoing edges that stay within the same parent scope.
+ *
+ * Stop conditions:
+ *   - Cycles (already-visited node).
+ *   - The current node leaves the target parent scope.
+ *   - The current node has 0 or >1 in-scope outgoing edges (dead-end or
+ *     in-scope branch — generic collision resolution handles ambiguous cases).
+ *
+ * Edges whose target sits outside `parentId` (e.g., a child wiring back to its
+ * container's continue handle, or any cross-scope link) are filtered out
+ * before the count, since the off-scope target isn't a sibling that needs to
+ * shift. They don't terminate the walk on their own — only the in-scope edge
+ * count matters.
  *
  * Used to find the set of nodes that should rigidly shift right when a wider
  * node is inserted upstream.
@@ -179,6 +190,21 @@ function collectLinearDownstreamChain({
   edges: Edge[];
 }): string[] {
   const nodesById = new Map(nodes.map((n) => [n.id, n]));
+  // Pre-bucket edges by source so the chain walk is O(chainLength) instead of
+  // O(chainLength × edgeCount). Filters here exclude preview edges and
+  // off-scope targets up front so the per-step check is just a length read.
+  const inScopeEdgesBySource = new Map<string, Edge[]>();
+  for (const edge of edges) {
+    if (isPreviewEdge(edge)) continue;
+    if (nodesById.get(edge.target)?.parentId !== parentId) continue;
+    const bucket = inScopeEdgesBySource.get(edge.source);
+    if (bucket) {
+      bucket.push(edge);
+    } else {
+      inScopeEdgesBySource.set(edge.source, [edge]);
+    }
+  }
+
   const collected: string[] = [];
   const visited = new Set<string>();
   let currentId: string | null = startNodeId;
@@ -190,14 +216,7 @@ function collectLinearDownstreamChain({
     collected.push(currentId);
     visited.add(currentId);
 
-    const outgoing = edges.filter(
-      (edge) =>
-        !isPreviewEdge(edge) &&
-        edge.source === currentId &&
-        nodesById.get(edge.target)?.parentId === parentId
-    );
-    // Branches and dead-ends both stop the linear shift; ambiguous cases get
-    // handed off to generic collision resolution.
+    const outgoing: Edge[] = inScopeEdgesBySource.get(currentId) ?? [];
     currentId = outgoing.length === 1 ? outgoing[0]!.target : null;
   }
 

--- a/packages/apollo-react/src/canvas/components/AddNodePanel/AddNodePanel.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/AddNodePanel/AddNodePanel.stories.tsx
@@ -18,7 +18,7 @@ import { CanvasPositionControls } from '../CanvasPositionControls';
 import type { ListItem } from '../Toolbox';
 import { AddNodePanel } from '.';
 import { AddNodeManager } from './AddNodeManager';
-import type { NodeItemData } from './AddNodePanel.types';
+import type { AddNodePanelProps, NodeItemData } from './AddNodePanel.types';
 import { createAddNodePreview } from './createAddNodePreview';
 
 // ============================================================================
@@ -359,6 +359,137 @@ function AllSidesStory() {
   );
 }
 
+/**
+ * Curated items mapping each shape (container, rectangle, square, circle) to a
+ * concrete registry node type so picking one materializes a real node with the
+ * matching geometry.
+ */
+const SHAPE_TEST_ITEMS: ListItem<NodeItemData>[] = [
+  {
+    id: 'shape-container',
+    name: 'Container — For Each',
+    icon: { name: 'repeat' },
+    data: { type: 'uipath.control-flow.foreach', category: 'Shapes' },
+    description: 'Container shape — wraps child nodes (uipath.control-flow.foreach)',
+  },
+  {
+    id: 'shape-rectangle',
+    name: 'Rectangle — Agent',
+    icon: { name: 'agent' },
+    data: { type: 'uipath.agent', category: 'Shapes' },
+    description: 'Rectangle shape — wider node body (uipath.agent)',
+  },
+  {
+    id: 'shape-square',
+    name: 'Square — API Workflow',
+    icon: { name: 'api' },
+    data: { type: 'uipath.api-workflow', category: 'Shapes' },
+    description: 'Square shape — compact node body (uipath.api-workflow)',
+  },
+  {
+    id: 'shape-circle',
+    name: 'Circle — Terminate',
+    icon: { name: 'octagon' },
+    data: { type: 'uipath.control-flow.terminate', category: 'Shapes' },
+    description: 'Circle shape — small round node (uipath.control-flow.terminate)',
+  },
+];
+
+/**
+ * Filters the static shape items by query so search inside this story only
+ * resolves to the four shape options (instead of falling back to the registry).
+ */
+async function searchShapeItems(query: string): Promise<ListItem<NodeItemData>[]> {
+  const normalized = query.trim().toLowerCase();
+  if (!normalized) return SHAPE_TEST_ITEMS;
+  return SHAPE_TEST_ITEMS.filter((item) => {
+    const haystack = [item.name, item.description ?? '', item.data.type, item.data.category ?? '']
+      .join(' ')
+      .toLowerCase();
+    return haystack.includes(normalized);
+  });
+}
+
+/**
+ * Custom panel that always presents the four shape options, regardless of
+ * connection-constraint filtering. Used to exercise shape geometry/rendering.
+ */
+function ShapeTestPanel(props: AddNodePanelProps) {
+  return (
+    <AddNodePanel
+      {...props}
+      title="Add node by shape"
+      items={SHAPE_TEST_ITEMS}
+      onSearch={searchShapeItems}
+    />
+  );
+}
+
+/**
+ * Story for testing all available node shapes (container, rectangle, square, circle).
+ *
+ * Click + on the Action node's right handle, then pick any of the four shape
+ * options to verify the materialized node renders with the correct geometry.
+ */
+function AllShapesStory() {
+  const initialNodes = useMemo(() => createInitialNodes(), []);
+  const { canvasProps, nodeTypeRegistry } = useCanvasStory({
+    initialNodes,
+    initialEdges: [
+      {
+        id: 'e-trigger-action-1',
+        source: 'trigger',
+        target: 'action-1',
+        sourceHandle: 'output',
+        targetHandle: 'input',
+      },
+    ],
+  });
+
+  const reactFlowInstance = useReactFlow();
+  useCanvasEvent('handle:action', (event: CanvasHandleActionEvent) => {
+    if (!reactFlowInstance) return;
+
+    const { handleId, nodeId, position, handleType } = event;
+    if (handleId && nodeId) {
+      const sourceHandleType = handleType === 'input' ? 'target' : 'source';
+      createAddNodePreview(
+        nodeId,
+        handleId,
+        reactFlowInstance,
+        position as Position,
+        sourceHandleType,
+        [],
+        {
+          getManifestForNode: (node) =>
+            node.type ? nodeTypeRegistry.getManifest(node.type) : undefined,
+        }
+      );
+    }
+  });
+
+  const handleAddNodeOnConnectEnd = useAddNodeOnConnectEnd();
+
+  return (
+    <BaseCanvas
+      {...canvasProps}
+      onConnectEnd={handleAddNodeOnConnectEnd}
+      deleteKeyCode={['Backspace', 'Delete']}
+      mode="design"
+      defaultViewport={{ x: 0, y: 0, zoom: 1 }}
+    >
+      <AddNodeManager customPanel={ShapeTestPanel} />
+      <Panel position="bottom-right">
+        <CanvasPositionControls translations={DefaultCanvasTranslations} />
+      </Panel>
+      <StoryInfoPanel
+        title="Add node — all shapes"
+        description="Click + on the Action node, then pick container, rectangle, square, or circle to verify shape rendering."
+      />
+    </BaseCanvas>
+  );
+}
+
 // ============================================================================
 // Exported Stories
 // ============================================================================
@@ -371,6 +502,32 @@ export const PreviewSelection: Story = {
 export const HandlesOnAllSides: Story = {
   name: 'Add node on all sides',
   render: () => <AllSidesStory />,
+};
+
+export const AllShapes: Story = {
+  name: 'Add node — all shapes',
+  parameters: {
+    docs: {
+      description: {
+        story: [
+          'Exercises every shape supported by the canvas: **container**,',
+          '**rectangle**, **square**, and **circle**.',
+          '',
+          'Click the **+** button on the Action node, and the panel will show',
+          'one item per shape, each wired to a real registry node type:',
+          '',
+          '- Container → `uipath.control-flow.foreach`',
+          '- Rectangle → `uipath.agent`',
+          '- Square → `uipath.api-workflow`',
+          '- Circle → `uipath.control-flow.terminate`',
+          '',
+          'Selecting an item materializes a node with the corresponding shape',
+          'so you can visually verify geometry, sizing, and connection layout.',
+        ].join('\n'),
+      },
+    },
+  },
+  render: () => <AllShapesStory />,
 };
 
 export const NodePanelStaticItems: Story = {

--- a/packages/apollo-react/src/canvas/components/AddNodePanel/createAddNodePreview.ts
+++ b/packages/apollo-react/src/canvas/components/AddNodePanel/createAddNodePreview.ts
@@ -1,5 +1,7 @@
 import { Position, type ReactFlowInstance } from '@uipath/apollo-react/canvas/xyflow/react';
 import { showPreviewGraph } from '../../utils/createPreviewGraph';
+import { resolveHandles } from '../../utils/manifest-resolver';
+import type { HandleBoundaryResolver } from '../../utils/NodeUtils';
 import {
   type ContainerPreviewManifestResolver,
   resolveContainerAddNodePreview,
@@ -7,6 +9,44 @@ import {
 
 export interface AddNodePreviewOptions {
   getManifestForNode?: ContainerPreviewManifestResolver;
+}
+
+/**
+ * Builds a boundary resolver for the clicked source node's handles.
+ *
+ * Container nodes flip inner handles to the opposite side via
+ * `connectionPosition`, which collapses outer + inner-flipped handles onto the
+ * same React Flow `position`. Without a boundary resolver, peer-count math
+ * (`computeSpreadOffset`) would treat them as siblings and shift the preview
+ * away from the clicked handle's anchor. Returning a (handleId → boundary) map
+ * lets `resolveHandleContext` filter peers to only those visually sharing a
+ * rail.
+ */
+function buildSourceBoundaryResolver(
+  sourceNodeId: string,
+  reactFlowInstance: ReactFlowInstance,
+  getManifestForNode: ContainerPreviewManifestResolver
+): HandleBoundaryResolver | undefined {
+  const sourceNode = reactFlowInstance.getNode(sourceNodeId);
+  if (!sourceNode) return undefined;
+
+  const manifest = getManifestForNode(sourceNode);
+  if (!manifest?.handleConfiguration) return undefined;
+
+  const resolvedGroups = resolveHandles(manifest.handleConfiguration, {
+    ...sourceNode.data,
+    nodeId: sourceNode.id,
+  });
+
+  const handleToBoundary = new Map<string, 'outer' | 'inner'>();
+  for (const group of resolvedGroups) {
+    const boundary = (group.boundary ?? 'outer') as 'outer' | 'inner';
+    for (const handle of group.handles) {
+      handleToBoundary.set(handle.id, boundary);
+    }
+  }
+
+  return (handleId) => handleToBoundary.get(handleId);
 }
 
 /**
@@ -42,6 +82,9 @@ export function createAddNodePreview(
         getManifestForNode: options.getManifestForNode,
       })
     : null;
+  const sourceBoundaryOf = options.getManifestForNode
+    ? buildSourceBoundaryResolver(sourceNodeId, reactFlowInstance, options.getManifestForNode)
+    : undefined;
 
   showPreviewGraph({
     source,
@@ -49,6 +92,7 @@ export function createAddNodePreview(
     sourceHandleType,
     handlePosition,
     ignoredNodeTypes,
+    sourceBoundaryOf,
     ...(overrides ?? {}),
   });
 }

--- a/packages/apollo-react/src/canvas/components/LoopNode/LoopNode.tsx
+++ b/packages/apollo-react/src/canvas/components/LoopNode/LoopNode.tsx
@@ -294,11 +294,17 @@ function LoopNodeComponent(props: LoopNodeProps) {
       <ResizeCornerIndicators visible={showResizeControls} />
       {showResizeControls ? <ResizeControls onResize={handleResize} /> : null}
       <Header title={displayTitle} icon={displayIcon} loading={isLoading} isParallel={isParallel} />
-      <BodyFrame
-        isEmpty={showEmptyStateButton}
-        isLoading={isLoading}
-        onAddFirstChild={handleEmptyClick}
-      />
+      <BodyFrame isEmpty={showEmptyStateButton} isLoading={isLoading} />
+      {showEmptyStateButton ? (
+        <div
+          className={cn(
+            'pointer-events-none absolute left-1/2 top-1/2',
+            '-translate-x-1/2 -translate-y-1/2'
+          )}
+        >
+          <EmptyState onAddFirstChild={handleEmptyClick} />
+        </div>
+      ) : null}
       {toolbarConfig && (
         <NodeToolbar
           nodeId={id}
@@ -391,29 +397,19 @@ function EmptyState({ onAddFirstChild }: { onAddFirstChild: () => void }) {
   );
 }
 
-function BodyFrame({
-  isEmpty,
-  isLoading,
-  onAddFirstChild,
-}: {
-  isEmpty?: boolean;
-  isLoading?: boolean;
-  onAddFirstChild: () => void;
-}) {
+function BodyFrame({ isEmpty, isLoading }: { isEmpty?: boolean; isLoading?: boolean }) {
   return (
     <div
       data-testid="loop-body-frame"
       data-empty={isEmpty ? 'true' : 'false'}
       className={cn(
         'relative m-2.5 flex flex-1 rounded-xl border-[1.5px] border-dashed border-border-subtle bg-transparent',
-        'pointer-events-none',
-        isEmpty && 'items-center justify-center'
+        'pointer-events-none'
       )}
     >
       {isLoading ? (
         <div className="m-6 h-14 w-full animate-pulse rounded-[18px] bg-(--canvas-background-overlay)" />
       ) : null}
-      {isEmpty ? <EmptyState onAddFirstChild={onAddFirstChild} /> : null}
     </div>
   );
 }

--- a/packages/apollo-react/src/canvas/components/LoopNode/LoopNodePreview.ts
+++ b/packages/apollo-react/src/canvas/components/LoopNode/LoopNodePreview.ts
@@ -1,5 +1,5 @@
 import type { ReactFlowInstance } from '@uipath/apollo-react/canvas/xyflow/react';
-import type { ContainerPlacement } from '../../utils/container';
+import { type ContainerPlacement, getNodeDimensions } from '../../utils/container';
 import { showPreviewGraph } from '../../utils/createPreviewGraph';
 import { getAbsolutePosition, snapToGrid } from '../../utils/NodeUtils';
 import {
@@ -24,9 +24,13 @@ export function showCenteredContainerPreview({
   const allNodes = reactFlowInstance.getNodes();
   const containerAbsolutePosition = getAbsolutePosition(containerNode, allNodes);
   const relativeCenter = getContainerRelativeBodyCenter(containerNode);
+  const containerSize = getNodeDimensions(containerNode);
+  // Y aligns with the inner source handle's rail (50% of container height) so
+  // the preview shows on the same row as the Start handle and the empty-state
+  // button. X stays at the body's horizontal center.
   const previewCenter = {
     x: snapToGrid(containerAbsolutePosition.x + relativeCenter.x),
-    y: snapToGrid(containerAbsolutePosition.y + relativeCenter.y),
+    y: snapToGrid(containerAbsolutePosition.y + containerSize.height / 2),
   };
   const placement: ContainerPlacement = {
     containerId,

--- a/packages/apollo-react/src/canvas/storybook-utils/manifests/node-definitions.ts
+++ b/packages/apollo-react/src/canvas/storybook-utils/manifests/node-definitions.ts
@@ -698,6 +698,10 @@ export const allNodeManifests: NodeManifest[] = [
             label: "{agentName || 'Agent'}",
             type: 'source',
             handleType: 'output',
+            // Artifact handles (memory, tools, escalation, context) appear in
+            // earlier groups, so without this flag `getDefaultHandle` would
+            // pick `memory` as the agent's outgoing handle.
+            isDefaultForType: true,
             constraints: {
               forbiddenTargetCategories: ['trigger'],
             },

--- a/packages/apollo-react/src/canvas/storybook-utils/mocks/nodes.ts
+++ b/packages/apollo-react/src/canvas/storybook-utils/mocks/nodes.ts
@@ -5,6 +5,12 @@ import type { HandleGroupManifest, NodeShape } from '../../schema/node-definitio
 
 /**
  * Common node positions for grid layouts.
+ *
+ * All values are multiples of GRID_SPACING (16) so initial layouts land on
+ * the canvas grid. Snap-aware downstream code (preview placement, edge
+ * routing via `useEdgePath`, container child centering) assumes the starting
+ * nodes are already grid-aligned — even single-pixel drift here cascades
+ * into kinked edges and off-center materialization.
  */
 export const NodePositions = {
   /** First row, first column */
@@ -14,17 +20,17 @@ export const NodePositions = {
   /** First row, third column */
   row1col3: { x: 480, y: 96 },
   /** Second row, first column */
-  row2col1: { x: 96, y: 255 },
+  row2col1: { x: 96, y: 256 },
   /** Second row, second column */
-  row2col2: { x: 288, y: 255 },
+  row2col2: { x: 288, y: 256 },
   /** Second row, third column */
-  row2col3: { x: 480, y: 255 },
+  row2col3: { x: 480, y: 256 },
   /** Third row, first column */
-  row3col1: { x: 96, y: 414 },
+  row3col1: { x: 96, y: 416 },
   /** Third row, second column */
-  row3col2: { x: 288, y: 414 },
+  row3col2: { x: 288, y: 416 },
   /** Third row, third column */
-  row3col3: { x: 480, y: 414 },
+  row3col3: { x: 480, y: 416 },
 } as const;
 
 /**

--- a/packages/apollo-react/src/canvas/utils/NodeUtils.test.ts
+++ b/packages/apollo-react/src/canvas/utils/NodeUtils.test.ts
@@ -1,10 +1,12 @@
-import type { Node } from '@uipath/apollo-react/canvas/xyflow/react';
+import type { InternalNode, Node } from '@uipath/apollo-react/canvas/xyflow/react';
+import { Position } from '@uipath/apollo-react/canvas/xyflow/react';
 import { describe, expect, it } from 'vitest';
 import { GRID_SPACING, PREVIEW_NODE_ID } from '../constants';
 import {
   getAbsolutePosition,
   getNonOverlappingPositionForDirection,
   resolveCollisions,
+  resolveHandleContext,
 } from './NodeUtils';
 
 describe('NodeUtils', () => {
@@ -713,6 +715,98 @@ describe('NodeUtils', () => {
         x: 220,
         y: 100,
       });
+    });
+  });
+
+  describe('resolveHandleContext', () => {
+    type TestHandleSpec = {
+      id: string;
+      type: 'source' | 'target';
+      position: Position;
+      x: number;
+      y: number;
+    };
+
+    function makeInternalNode(
+      handles: TestHandleSpec[],
+      positionAbsolute: { x: number; y: number } = { x: 0, y: 0 }
+    ): InternalNode {
+      const sources = handles.filter((h) => h.type === 'source');
+      const targets = handles.filter((h) => h.type === 'target');
+      const toBound = (h: TestHandleSpec) => ({
+        id: h.id,
+        nodeId: 'n',
+        x: h.x,
+        y: h.y,
+        position: h.position,
+        type: h.type,
+        width: 8,
+        height: 8,
+      });
+      return {
+        internals: {
+          positionAbsolute,
+          handleBounds: {
+            source: sources.map(toBound),
+            target: targets.map(toBound),
+          },
+        },
+      } as unknown as InternalNode;
+    }
+
+    // Container layout: success on outer-right, start inner-left flipped to right
+    // (Handle component renders at opposite side via connectionPosition).
+    // Both report `position: Right` to React Flow but live on different visual rails.
+    const containerHandles: TestHandleSpec[] = [
+      { id: 'success', type: 'source', position: Position.Right, x: 700, y: 160 },
+      { id: 'start', type: 'source', position: Position.Right, x: 80, y: 160 },
+      { id: 'continue', type: 'target', position: Position.Left, x: 624, y: 104 },
+      { id: 'break', type: 'target', position: Position.Left, x: 624, y: 216 },
+      { id: 'input', type: 'target', position: Position.Left, x: 0, y: 160 },
+    ];
+
+    it('counts every handle with the same React Flow position when no boundaryOf is provided', () => {
+      const internalNode = makeInternalNode(containerHandles);
+
+      const ctx = resolveHandleContext(internalNode, 'success', Position.Right);
+
+      // Without boundary awareness, success and the inner-flipped start both
+      // count as right-side peers — count is 2.
+      expect(ctx?.count).toBe(2);
+    });
+
+    it('filters peer count by boundary so flipped inner handles are excluded', () => {
+      const internalNode = makeInternalNode(containerHandles);
+      const boundaryOf = (handleId: string): 'outer' | 'inner' | undefined => {
+        if (handleId === 'success' || handleId === 'input') return 'outer';
+        if (handleId === 'start' || handleId === 'continue' || handleId === 'break') {
+          return 'inner';
+        }
+        return undefined;
+      };
+
+      const ctx = resolveHandleContext(internalNode, 'success', Position.Right, {
+        boundaryOf,
+      });
+
+      // success is the only handle on the outer-right rail.
+      expect(ctx).toMatchObject({ count: 1, index: 0 });
+    });
+
+    it('groups two outer-right peers as count=2 with boundary-aware filtering', () => {
+      // Branching node: two source handles share the outer-right rail.
+      const branchingHandles: TestHandleSpec[] = [
+        { id: 'output-1', type: 'source', position: Position.Right, x: 96, y: 32 },
+        { id: 'output-2', type: 'source', position: Position.Right, x: 96, y: 64 },
+      ];
+      const internalNode = makeInternalNode(branchingHandles);
+      const boundaryOf = () => 'outer' as const;
+
+      const ctx = resolveHandleContext(internalNode, 'output-1', Position.Right, {
+        boundaryOf,
+      });
+
+      expect(ctx).toMatchObject({ count: 2, index: 0 });
     });
   });
 });

--- a/packages/apollo-react/src/canvas/utils/NodeUtils.ts
+++ b/packages/apollo-react/src/canvas/utils/NodeUtils.ts
@@ -243,13 +243,27 @@ export type HandleContext = {
 };
 
 /**
+ * Resolves the manifest-level boundary ('outer' | 'inner') for a given handle
+ * id. Container nodes flip inner-handle Handle components to the opposite side
+ * via `connectionPosition`, so multiple visual rails collapse onto the same
+ * React Flow `Position`. Pass this to `resolveHandleContext` so the peer count
+ * only includes handles that visually share an edge with the queried handle.
+ */
+export type HandleBoundaryResolver = (handleId: string) => 'outer' | 'inner' | undefined;
+
+export interface ResolveHandleContextOptions {
+  boundaryOf?: HandleBoundaryResolver;
+}
+
+/**
  * Resolves handle context (anchor coordinates, peer index, peer count) for a
  * given handle on an internal node. Returns undefined if the handle isn't found.
  */
 export function resolveHandleContext(
   internalNode: InternalNode,
   handleId: string,
-  handlePosition: Position
+  handlePosition: Position,
+  options?: ResolveHandleContextOptions
 ): HandleContext | undefined {
   const allHandles = [
     ...(internalNode.internals.handleBounds?.source ?? []),
@@ -258,14 +272,41 @@ export function resolveHandleContext(
   const matchedHandle = allHandles.find((h) => h.id === handleId);
   if (!matchedHandle) return undefined;
 
+  const peers = filterRailPeers(allHandles, handleId, handlePosition, options?.boundaryOf);
+
   return {
     anchor: {
       x: internalNode.internals.positionAbsolute.x + matchedHandle.x + matchedHandle.width / 2,
       y: internalNode.internals.positionAbsolute.y + matchedHandle.y + matchedHandle.height / 2,
     },
-    index: getHandleIndex(handleId, handlePosition, allHandles),
-    count: allHandles.filter((h) => h.position === handlePosition).length,
+    index: getHandleIndex(handleId, handlePosition, peers),
+    count: peers.length,
   };
+}
+
+/**
+ * Filters handles to those sharing the same visual rail as the queried handle:
+ * matching React Flow position, and (when a boundary resolver is provided) the
+ * same manifest boundary. Without a resolver, falls back to position-only
+ * matching to preserve legacy behavior.
+ */
+function filterRailPeers(
+  allHandles: Handle[],
+  handleId: string,
+  handlePosition: Position,
+  boundaryOf: HandleBoundaryResolver | undefined
+): Handle[] {
+  const samePosition = allHandles.filter((h) => h.position === handlePosition);
+  if (!boundaryOf) return samePosition;
+
+  const targetBoundary = boundaryOf(handleId);
+  if (targetBoundary === undefined) return samePosition;
+
+  return samePosition.filter((h) => {
+    if (!h.id) return false;
+    const peerBoundary = boundaryOf(h.id);
+    return peerBoundary === undefined || peerBoundary === targetBoundary;
+  });
 }
 
 /**

--- a/packages/apollo-react/src/canvas/utils/container.test.ts
+++ b/packages/apollo-react/src/canvas/utils/container.test.ts
@@ -1,11 +1,14 @@
 import type { Node } from '@uipath/apollo-react/canvas/xyflow/react';
 import { describe, expect, it } from 'vitest';
 import {
+  type ContainerPlacement,
   DEFAULT_CONTAINER_MIN_HEIGHT,
   DEFAULT_CONTAINER_MIN_WIDTH,
   ensureContainersFitChildren,
   getContainerFitGeometry,
   getContainerSafeArea,
+  getNodeDimensions,
+  placeContainerNode,
 } from './container';
 
 describe('container sizing', () => {
@@ -62,5 +65,89 @@ describe('container sizing', () => {
     expect(result.nodes.find((node) => node.id === containerNode.id)).toMatchObject({
       style: { width: 720, height: 384 },
     });
+  });
+});
+
+describe('placeContainerNode first-child placement', () => {
+  it('positions the first child on the container vertical mid-line, not the body center', () => {
+    // 320-tall container has enough vertical room that body-center (after
+    // header padding) and container-center diverge by ~32px. The first child
+    // should land aligned with the inner source handle's rail (50% of
+    // container height) so the dashed Start → child edge stays a straight
+    // horizontal line.
+    const containerNode: Node = {
+      id: 'loop-1',
+      type: 'loop',
+      position: { x: 0, y: 0 },
+      style: { width: 560, height: 320 },
+      data: {},
+    };
+    const insertedNode: Node = {
+      id: 'inserted',
+      type: 'task',
+      parentId: 'loop-1',
+      extent: 'parent',
+      position: { x: 0, y: 0 },
+      measured: { width: 96, height: 96 },
+      data: {},
+    };
+    const placement: ContainerPlacement = {
+      containerId: 'loop-1',
+      sourceNodeId: 'loop-1',
+      targetNodeId: 'loop-1',
+      mode: 'first-child',
+    };
+
+    const placed = placeContainerNode({
+      nodes: [containerNode, insertedNode],
+      insertedNode,
+      placement,
+      edges: [],
+      getNodeDimensions: (node) => getNodeDimensions(node),
+    });
+
+    const result = placed.find((node) => node.id === 'inserted');
+    // Container is 320 tall, child is 96 tall — center on the container rail
+    // → 320/2 - 96/2 = 112.
+    expect(result?.position.y).toBe(112);
+  });
+
+  it('clamps to safeArea.y when the container is too short for container-center placement', () => {
+    // 220-tall container: container-center child y = 110 - 48 = 62, but the
+    // body's safeArea starts at y=96 (header + padding). Clamp keeps the
+    // child inside the body.
+    const containerNode: Node = {
+      id: 'loop-1',
+      type: 'loop',
+      position: { x: 0, y: 0 },
+      style: { width: 320, height: 220 },
+      data: {},
+    };
+    const insertedNode: Node = {
+      id: 'inserted',
+      type: 'task',
+      parentId: 'loop-1',
+      extent: 'parent',
+      position: { x: 0, y: 0 },
+      measured: { width: 96, height: 96 },
+      data: {},
+    };
+    const placement: ContainerPlacement = {
+      containerId: 'loop-1',
+      sourceNodeId: 'loop-1',
+      targetNodeId: 'loop-1',
+      mode: 'first-child',
+    };
+
+    const placed = placeContainerNode({
+      nodes: [containerNode, insertedNode],
+      insertedNode,
+      placement,
+      edges: [],
+      getNodeDimensions: (node) => getNodeDimensions(node),
+    });
+
+    const result = placed.find((node) => node.id === 'inserted');
+    expect(result?.position.y).toBe(96);
   });
 });

--- a/packages/apollo-react/src/canvas/utils/container.test.ts
+++ b/packages/apollo-react/src/canvas/utils/container.test.ts
@@ -112,6 +112,59 @@ describe('placeContainerNode first-child placement', () => {
     expect(result?.position.y).toBe(112);
   });
 
+  it('pushes top-level siblings below a container down when nested growth makes the container taller', () => {
+    // ContainerA sits at the top with a top-level NodeB directly beneath it.
+    // Adding a tall child inside ContainerA forces vertical growth — NodeB
+    // must shift down so it stays clear of the container's new bottom edge.
+    const containerNode: Node = {
+      id: 'container-a',
+      type: 'loop',
+      position: { x: 0, y: 0 },
+      style: { width: DEFAULT_CONTAINER_MIN_WIDTH, height: DEFAULT_CONTAINER_MIN_HEIGHT },
+      data: {},
+    };
+    const siblingBelow: Node = {
+      id: 'node-b',
+      type: 'task',
+      position: { x: 96, y: 280 },
+      measured: { width: 96, height: 96 },
+      data: {},
+    };
+    const insertedNode: Node = {
+      id: 'inner-container',
+      type: 'loop',
+      parentId: 'container-a',
+      extent: 'parent',
+      position: { x: 0, y: 0 },
+      style: { width: 320, height: 320 },
+      data: {},
+    };
+    const placement: ContainerPlacement = {
+      containerId: 'container-a',
+      sourceNodeId: 'container-a',
+      targetNodeId: 'container-a',
+      mode: 'first-child',
+    };
+
+    const placed = placeContainerNode({
+      nodes: [containerNode, siblingBelow, insertedNode],
+      insertedNode,
+      placement,
+      edges: [],
+      getNodeDimensions: (node) => getNodeDimensions(node),
+    });
+
+    const grownContainer = placed.find((node) => node.id === 'container-a');
+    const containerHeight =
+      (grownContainer?.style?.height as number | undefined) ?? DEFAULT_CONTAINER_MIN_HEIGHT;
+    const containerBottom = (grownContainer?.position.y ?? 0) + containerHeight;
+
+    const movedSibling = placed.find((node) => node.id === 'node-b');
+    expect(movedSibling?.position.y).toBeGreaterThanOrEqual(containerBottom);
+    // Original X is preserved — vertical growth shouldn't push horizontally.
+    expect(movedSibling?.position.x).toBe(96);
+  });
+
   it('clamps to safeArea.y when the container is too short for container-center placement', () => {
     // 220-tall container: container-center child y = 110 - 48 = 62, but the
     // body's safeArea starts at y=96 (header + padding). Clamp keeps the

--- a/packages/apollo-react/src/canvas/utils/container.ts
+++ b/packages/apollo-react/src/canvas/utils/container.ts
@@ -409,10 +409,23 @@ function rangesOverlap(startA: number, endA: number, startB: number, endB: numbe
   return startA < endB && endA > startB;
 }
 
-function centerInSafeArea(safeArea: ContainerSafeArea, nodeSize: NodeDimensions): XYPosition {
+/**
+ * Centers a child horizontally inside the container's body but vertically on
+ * the container's geometric mid-line, so the child sits on the same rail as
+ * the inner source handle (which renders at `top: 50%` of the container).
+ * Falls back to `safeArea.y` when the container is too short for the rail
+ * placement to fit inside the body.
+ */
+function centerOnContainerRail(
+  containerSize: NodeDimensions,
+  safeArea: ContainerSafeArea,
+  nodeSize: NodeDimensions
+): XYPosition {
+  const railY = snapToGrid(containerSize.height / 2 - nodeSize.height / 2);
+  const maxY = safeArea.y + Math.max(0, safeArea.height - nodeSize.height);
   return {
     x: Math.max(safeArea.x, snapToGrid(safeArea.x + (safeArea.width - nodeSize.width) / 2)),
-    y: Math.max(safeArea.y, snapToGrid(safeArea.y + (safeArea.height - nodeSize.height) / 2)),
+    y: clamp(railY, safeArea.y, maxY),
   };
 }
 
@@ -1176,7 +1189,11 @@ export function placeContainerNode({
     placement.mode === 'first-child'
       ? {
           ...insertedNode,
-          position: centerInSafeArea(resolvedSafeArea, insertedSize),
+          position: centerOnContainerRail(
+            resolveNodeDimensions(containerNode),
+            resolvedSafeArea,
+            insertedSize
+          ),
         }
       : {
           ...insertedNode,

--- a/packages/apollo-react/src/canvas/utils/container.ts
+++ b/packages/apollo-react/src/canvas/utils/container.ts
@@ -116,7 +116,12 @@ interface NextNodeContext {
   nodeId: string;
   edges: Edge[];
   nodesById: Map<string, Node>;
-  containerId: string;
+  /**
+   * Parent ID for the chain's scope. Sibling nodes share this parentId.
+   * Undefined for top-level (root) scope, or set to a container's id when
+   * walking children of that container.
+   */
+  parentId: string | undefined;
 }
 
 type NextNodeResolver = (context: NextNodeContext) => string | null | undefined;
@@ -583,92 +588,119 @@ function isPreviewGraphEdge(edge: Edge): boolean {
   return edge.source === PREVIEW_NODE_ID || edge.target === PREVIEW_NODE_ID;
 }
 
-function getDefaultNextContainerSequenceNodeId({
-  nodeId,
-  edges,
-  nodesById,
-  containerId,
-  isSequenceEdge,
-}: NextNodeContext & {
-  isSequenceEdge?: SequenceEdgePredicate;
-}): string | null {
-  const localOutgoingEdges = edges.filter((edge) => {
-    if (isPreviewGraphEdge(edge) || edge.source !== nodeId) {
-      return false;
-    }
-
-    if (isSequenceEdge && !isSequenceEdge(edge)) {
-      return false;
-    }
-
-    const targetNode = nodesById.get(edge.target);
-    return edge.target === containerId || targetNode?.parentId === containerId;
-  });
-
-  // Ambiguous branches are left untouched because there is no safe linear
-  // sequence to shift.
-  return localOutgoingEdges.length === 1 ? localOutgoingEdges[0]!.target : null;
-}
-
 // -----------------------------------------------------------------------------
 // Sequence traversal
 // -----------------------------------------------------------------------------
 
-function collectDownstreamNodes({
-  targetNodeId,
-  containerId,
+/**
+ * Pre-buckets non-preview edges by source for O(1) chain-step lookup.
+ *
+ * Edges are kept when their target is a sibling in the chain's scope (matching
+ * `parentId`) or, when `parentId` is a string, the parent itself — this lets
+ * container-internal chains terminate cleanly when a child wires back to its
+ * container's continue handle.
+ */
+function bucketInScopeEdgesBySource({
+  edges,
+  nodesById,
+  parentId,
+  isSequenceEdge,
+}: {
+  edges: Edge[];
+  nodesById: Map<string, Node>;
+  parentId: string | undefined;
+  isSequenceEdge?: SequenceEdgePredicate;
+}): Map<string, Edge[]> {
+  const bySource = new Map<string, Edge[]>();
+  for (const edge of edges) {
+    if (isPreviewGraphEdge(edge)) continue;
+    if (isSequenceEdge && !isSequenceEdge(edge)) continue;
+
+    const targetIsParent = parentId !== undefined && edge.target === parentId;
+    const targetIsSibling = nodesById.get(edge.target)?.parentId === parentId;
+    if (!targetIsParent && !targetIsSibling) continue;
+
+    const bucket = bySource.get(edge.source);
+    if (bucket) {
+      bucket.push(edge);
+    } else {
+      bySource.set(edge.source, [edge]);
+    }
+  }
+  return bySource;
+}
+
+/**
+ * Walks one linear sibling chain downstream from `startNodeId`, following
+ * single in-scope outgoing edges. Used to find the set of nodes that should
+ * rigidly shift right when a wider node is inserted upstream.
+ *
+ * Scope is set by `parentId`:
+ *   - `undefined` → top-level (root) chain.
+ *   - container id → walk children of that container; an edge from a child
+ *     back to the container itself counts as in-scope (so an exact-1 outgoing
+ *     match on a loop-back terminates the walk cleanly).
+ *
+ * Stop conditions: cycles, the current node leaving `parentId` scope, dead
+ * ends, in-scope branches (>1 outgoing), and (for container scope) an edge
+ * that would walk into the container itself.
+ *
+ * Edges leaving the parent scope without targeting it are ignored entirely —
+ * they are not siblings, so they do not need to shift.
+ */
+export function collectLinearDownstreamSiblings({
+  startNodeId,
+  parentId,
   nodes,
   edges,
   isSequenceEdge,
   getNextNodeId,
 }: {
-  targetNodeId: string | undefined;
-  containerId: string;
+  startNodeId: string | undefined;
+  parentId: string | undefined;
   nodes: Node[];
   edges: Edge[];
   isSequenceEdge?: SequenceEdgePredicate;
   getNextNodeId?: NextNodeResolver;
 }): string[] {
-  if (!targetNodeId || targetNodeId === containerId) {
-    return [];
-  }
+  if (!startNodeId || startNodeId === parentId) return [];
 
   const nodesById = new Map(nodes.map((node) => [node.id, node]));
+  const inScopeEdgesBySource = bucketInScopeEdgesBySource({
+    edges,
+    nodesById,
+    parentId,
+    isSequenceEdge,
+  });
+
   const collectedIds: string[] = [];
   const visitedIds = new Set<string>();
-  let currentNodeId = targetNodeId;
+  let currentNodeId: string = startNodeId;
 
-  // Follow one local sequence chain and stop on cycles or exits from the
-  // container. This keeps downstream shifts scoped to the edited sequence.
   while (!visitedIds.has(currentNodeId)) {
     const currentNode = nodesById.get(currentNodeId);
-    if (!currentNode || currentNode.parentId !== containerId) {
-      break;
-    }
+    if (!currentNode || currentNode.parentId !== parentId) break;
 
     collectedIds.push(currentNodeId);
     visitedIds.add(currentNodeId);
 
-    const nextNodeId: string | null | undefined =
-      getNextNodeId?.({
-        nodeId: currentNodeId,
-        edges,
-        nodesById,
-        containerId,
-      }) ??
-      getDefaultNextContainerSequenceNodeId({
-        nodeId: currentNodeId,
-        edges,
-        nodesById,
-        containerId,
-        isSequenceEdge,
-      });
-
-    if (!nextNodeId || nextNodeId === containerId) {
-      break;
+    let next: string | null | undefined = getNextNodeId
+      ? getNextNodeId({
+          nodeId: currentNodeId,
+          edges,
+          nodesById,
+          parentId,
+        })
+      : undefined;
+    if (next === undefined) {
+      const outgoing: Edge[] = inScopeEdgesBySource.get(currentNodeId) ?? [];
+      next = outgoing.length === 1 ? outgoing[0]!.target : null;
     }
 
-    currentNodeId = nextNodeId;
+    // Container-scope walks terminate when the next step would re-enter the
+    // parent itself (a child wiring back to the container).
+    if (!next || next === parentId) break;
+    currentNodeId = next;
   }
 
   return collectedIds;
@@ -1031,16 +1063,23 @@ function pushSiblingsAfterContainerGrowth({
   let shifted = false;
   let nextNodes = nodes;
 
+  // For each container that grew, push siblings outward — right when width
+  // grew, down when height grew. Both directions are evaluated in the same
+  // pass so a sibling that's both right-of and below-of a doubly-growing
+  // container is visited once.
   for (const change of sortContainerSizeChanges(changes, nextNodes)) {
     const widthDelta = change.nextSize.width - change.previousSize.width;
-    if (widthDelta <= 0) {
-      continue;
-    }
+    const heightDelta = change.nextSize.height - change.previousSize.height;
+    if (widthDelta <= 0 && heightDelta <= 0) continue;
 
     const containerNode = nextNodes.find((node) => node.id === change.containerId)!;
-
     const oldRight = containerNode.position.x + change.previousSize.width;
     const newRight = containerNode.position.x + change.nextSize.width;
+    const oldBottom = containerNode.position.y + change.previousSize.height;
+    const newBottom = containerNode.position.y + change.nextSize.height;
+    const containerLeft = containerNode.position.x;
+    const containerRight =
+      containerNode.position.x + Math.max(change.previousSize.width, change.nextSize.width);
     const containerTop = containerNode.position.y;
     const containerBottom =
       containerNode.position.y + Math.max(change.previousSize.height, change.nextSize.height);
@@ -1051,32 +1090,42 @@ function pushSiblingsAfterContainerGrowth({
       }
 
       const nodeSize = getNodeDimensions(node);
-      const isRightSibling = node.position.x >= oldRight;
-      // Only siblings that sit to the right and overlap the container's vertical
-      // band can be visually covered by the new width.
-      const verticallyOverlaps = rangesOverlap(
-        node.position.y,
-        node.position.y + nodeSize.height,
-        containerTop,
-        containerBottom
-      );
+      let nextX = node.position.x;
+      let nextY = node.position.y;
 
-      if (!isRightSibling || !verticallyOverlaps) {
-        return node;
+      // Width grew: only siblings that sit to the right and overlap the
+      // container's vertical band can be visually covered by the new width.
+      if (widthDelta > 0 && node.position.x >= oldRight) {
+        const verticallyOverlaps = rangesOverlap(
+          node.position.y,
+          node.position.y + nodeSize.height,
+          containerTop,
+          containerBottom
+        );
+        if (verticallyOverlaps) {
+          nextX = Math.max(node.position.x + widthDelta, snapUpToGrid(newRight + gap));
+        }
       }
 
-      const nextX = Math.max(node.position.x + widthDelta, snapUpToGrid(newRight + gap));
-      if (nextX === node.position.x) {
-        return node;
+      // Height grew: mirror logic along Y. Sibling must sit below and
+      // horizontally overlap the container's column.
+      if (heightDelta > 0 && node.position.y >= oldBottom) {
+        const horizontallyOverlaps = rangesOverlap(
+          node.position.x,
+          node.position.x + nodeSize.width,
+          containerLeft,
+          containerRight
+        );
+        if (horizontallyOverlaps) {
+          nextY = Math.max(node.position.y + heightDelta, snapUpToGrid(newBottom + gap));
+        }
       }
 
+      if (nextX === node.position.x && nextY === node.position.y) return node;
       shifted = true;
       return {
         ...node,
-        position: {
-          ...node.position,
-          x: nextX,
-        },
+        position: { x: nextX, y: nextY },
       };
     });
   }
@@ -1135,23 +1184,17 @@ function fitContainersAndPushSiblings({
  * Reads and validates container placement metadata from a preview node.
  * Returns null when the preview is not scoped to the recorded container.
  */
-export function getContainerPlacement({
-  previewNode,
-  isContainerId,
-}: {
-  previewNode: Pick<Node, 'data' | 'parentId'>;
-  isContainerId?: (containerId: string) => boolean;
-}): ContainerPlacement | null {
+export function getContainerPlacement(
+  previewNode: Pick<Node, 'data' | 'parentId'>
+): ContainerPlacement | null {
   const placement = previewNode.data?.[PLACEMENT_DATA_KEY] as ContainerPlacement | undefined;
-  if (!placement) {
-    return null;
-  }
+  if (!placement) return null;
 
   if (previewNode.parentId && placement.containerId !== previewNode.parentId) {
     return null;
   }
 
-  return isContainerId && !isContainerId(placement.containerId) ? null : placement;
+  return placement;
 }
 
 /**
@@ -1220,9 +1263,9 @@ export function placeContainerNode({
   const idsToShift = new Set(
     downstreamNodeIds ??
       (edges
-        ? collectDownstreamNodes({
-            targetNodeId: placement.targetNodeId,
-            containerId: placement.containerId,
+        ? collectLinearDownstreamSiblings({
+            startNodeId: placement.targetNodeId,
+            parentId: placement.containerId,
             nodes,
             edges,
           })

--- a/packages/apollo-react/src/canvas/utils/createPreviewGraph.ts
+++ b/packages/apollo-react/src/canvas/utils/createPreviewGraph.ts
@@ -12,7 +12,7 @@ import {
   PREVIEW_EDGE_STYLE,
   type PreviewNodePositionMode,
 } from './createPreviewNode';
-import { getAbsolutePosition } from './NodeUtils';
+import { getAbsolutePosition, type HandleBoundaryResolver } from './NodeUtils';
 
 /** Preview node plus the temporary edges that should be rendered with it. */
 export interface PreviewGraph {
@@ -44,6 +44,13 @@ export interface CreatePreviewGraphOptions {
   containerId?: string;
   trailingEdgeId?: string;
   trailingEdgeStyle?: CSSProperties;
+  /**
+   * Manifest-aware boundary resolver for the source node's handles. Used so
+   * the preview's auto-position math counts only handles that share a visual
+   * rail with the clicked one — important for container nodes where inner
+   * handles are flipped to the opposite side via `connectionPosition`.
+   */
+  sourceBoundaryOf?: HandleBoundaryResolver;
 }
 
 export type PreviewGraphOverrides = Partial<
@@ -117,10 +124,11 @@ function createPreviewNodeForGraph({
   handlePosition,
   ignoredNodeTypes,
   positionMode,
+  sourceBoundaryOf,
 }: CreatePreviewGraphOptions) {
-  return createPreviewNode(
-    source.nodeId,
-    source.handleId ?? DEFAULT_SOURCE_HANDLE_ID,
+  return createPreviewNode({
+    sourceNodeId: source.nodeId,
+    sourceHandleId: source.handleId ?? DEFAULT_SOURCE_HANDLE_ID,
     reactFlowInstance,
     position,
     data,
@@ -128,8 +136,9 @@ function createPreviewNodeForGraph({
     previewNodeSize,
     handlePosition,
     ignoredNodeTypes,
-    positionMode
-  );
+    positionMode,
+    sourceBoundaryOf,
+  });
 }
 
 function createTrailingPreviewEdge({

--- a/packages/apollo-react/src/canvas/utils/createPreviewNode.ts
+++ b/packages/apollo-react/src/canvas/utils/createPreviewNode.ts
@@ -9,6 +9,7 @@ import { getNodeDimensions } from './container';
 import {
   getAbsolutePosition,
   getNonOverlappingPositionForDirection,
+  type HandleBoundaryResolver,
   type HandleContext,
   resolveHandleContext,
 } from './NodeUtils';
@@ -228,28 +229,73 @@ function calculateAutoPosition(
   );
 }
 
+export interface CreatePreviewNodeOptions {
+  /** ID of the node the preview originates from. */
+  sourceNodeId: string;
+  /** ID of the handle the preview connects to. */
+  sourceHandleId: string;
+  /** React Flow instance for reading nodes/edges and handle bounds. */
+  reactFlowInstance: ReactFlowInstance;
+  /**
+   * Optional explicit anchor for the preview. When provided, auto-positioning
+   * is skipped and `positionMode` decides whether the value is treated as a
+   * drop point (`'drop'`) or as the preview's center (`'center'`).
+   */
+  position?: { x: number; y: number };
+  /** Extra data merged into the preview node. */
+  data?: Record<string, unknown>;
+  /**
+   * Whether the clicked handle is a `'source'` or `'target'`. Determines
+   * which side of the preview points back at the source node.
+   * @default 'source'
+   */
+  sourceHandleType?: 'source' | 'target';
+  /**
+   * Size used for the preview node. Defaults to a square node of
+   * `DEFAULT_NODE_SIZE`.
+   */
+  previewNodeSize?: { width: number; height: number };
+  /** Side of the source the preview should appear on. @default Position.Right */
+  handlePosition?: Position;
+  /** Node types to ignore during overlap detection (e.g., sticky notes). */
+  ignoredNodeTypes?: string[];
+  /**
+   * Interpretation of `position`: `'drop'` places the preview adjacent to the
+   * point; `'center'` centers the preview on the point.
+   * @default 'drop'
+   */
+  positionMode?: PreviewNodePositionMode;
+  /**
+   * Manifest-aware boundary resolver for the source node's handles. Lets the
+   * peer-count math distinguish outer handles from inner handles flipped to
+   * the opposite side via `connectionPosition`, so previews stay anchored to
+   * the clicked handle's actual rail.
+   */
+  sourceBoundaryOf?: HandleBoundaryResolver;
+}
+
 /**
  * Creates the preview node and primary preview edge for Add Node flows. The
  * preview can be placed from a drop coordinate, centered at an absolute point,
  * or auto-positioned from the clicked handle when no position is provided.
- *
- * @param ignoredNodeTypes Optional array of node types to ignore when calculating overlap (e.g., ["stickyNote"])
  */
 export function createPreviewNode(
-  sourceNodeId: string,
-  sourceHandleId: string,
-  reactFlowInstance: ReactFlowInstance,
-  position?: { x: number; y: number },
-  data?: Record<string, unknown>,
-  sourceHandleType: 'source' | 'target' = 'source',
-  previewNodeSize: { width: number; height: number } = {
-    width: DEFAULT_NODE_SIZE,
-    height: DEFAULT_NODE_SIZE,
-  },
-  handlePosition: Position = Position.Right,
-  ignoredNodeTypes: string[] = [],
-  positionMode: PreviewNodePositionMode = 'drop'
+  options: CreatePreviewNodeOptions
 ): { node: Node; edge: Edge } | null {
+  const {
+    sourceNodeId,
+    sourceHandleId,
+    reactFlowInstance,
+    position,
+    data,
+    sourceHandleType = 'source',
+    previewNodeSize = { width: DEFAULT_NODE_SIZE, height: DEFAULT_NODE_SIZE },
+    handlePosition = Position.Right,
+    ignoredNodeTypes = [],
+    positionMode = 'drop',
+    sourceBoundaryOf,
+  } = options;
+
   const sourceNode = reactFlowInstance.getNode(sourceNodeId);
   if (!sourceNode) {
     console.warn(`Source node ${sourceNodeId} not found`);
@@ -266,7 +312,9 @@ export function createPreviewNode(
   const internalNode =
     position === undefined ? reactFlowInstance.getInternalNode(sourceNodeId) : undefined;
   const handle = internalNode
-    ? resolveHandleContext(internalNode, sourceHandleId, handlePosition)
+    ? resolveHandleContext(internalNode, sourceHandleId, handlePosition, {
+        boundaryOf: sourceBoundaryOf,
+      })
     : undefined;
 
   const nodePosition = position


### PR DESCRIPTION
## Demo

### 1. Node created from container was not centered
Before:

https://github.com/user-attachments/assets/51d7fe4f-d006-4c00-ab22-d672d348aa01

After:

https://github.com/user-attachments/assets/9cf96a7c-20e6-4096-bd8d-3a58c4aa971b

### 2. Adding nodes within container was not centered
Before:

https://github.com/user-attachments/assets/5347ddc8-11e4-444c-b80a-28a1b16ef80d

After: 

https://github.com/user-attachments/assets/f67a8405-4008-44eb-9032-8e82ed407560


### 3. Placing a node in between 2 nodes was not properly resizing.
Before:

https://github.com/user-attachments/assets/623df5d5-ff72-4b29-b51c-fd040114a66c

After:

https://github.com/user-attachments/assets/185bb38a-6444-438b-8274-058bbb1a1140

## Complete example of right/down push of siblings

https://github.com/user-attachments/assets/d6d06f2b-26c2-4c06-8f7d-de4a3ea6e590

## Summary

Fixes three classes of positioning bugs in the canvas Add Node flow that were producing kinked edges, off-center nodes, and broken row layouts when inserting non-square shapes (rectangle, container) or working inside container nodes.

## What was wrong

### 1. Container outer handles placed previews off the rail

Clicking + on a container's outer handle (e.g. `For Each` → `success`) dropped the preview at the top-right of the container instead of vertically centered. The cause: container nodes flip inner handles to the opposite side via `connectionPosition`, which collapses outer + inner-flipped handles onto the same React Flow `Position`. `resolveHandleContext`'s peer count then included the flipped handle, inflating the spread offset (`computeSpreadOffset`) and shifting the preview off the clicked handle's anchor. The Left branch of `calculateAutoPosition` doesn't apply spread, which is why the bug only appeared on Right/Top/Bottom.

### 2. Wider shapes broke the row layout when inserted on an edge

Inserting a rectangle (288 wide) or container (560 wide) via the SequenceEdge `+` toolbar landed on top of the original target. Generic `resolveCollisions` then picked the smallest-overlap axis and pushed nodes vertically (or pushed the upstream trigger backwards), producing layouts like the For Each ending up below the trigger.

### 3. Container empty-state and first-child off the inner-handle rail

The `For Each` empty `+` button sat at the body's geometric center (below container center because of the header). The preview the + produced — and the materialized first child — landed at the same body-center Y, so the dashed `Start → child` line bent. On top of this, `NodePositions.row2*` / `row3*` in storybook helpers were 1–2 px off-grid (255, 414), which cascaded snap drift downstream.

The Agent node picked `memory` (artifact, top side) as its default outgoing handle instead of `success` because artifact handles were registered first in the manifest and `getDefaultHandle` falls back to "first registered" without an `isDefaultForType` marker.

## What changed

### `apollo-react`/canvas

**Boundary-aware peer counting** (`utils/NodeUtils.ts`)
- `resolveHandleContext` now takes an optional `{ boundaryOf }` resolver. When provided, peer counts only include handles sharing the same React Flow position **and** the same manifest boundary (outer/outer or inner/inner), so inner-flipped handles no longer pollute the outer-rail spread.
- New exported `HandleBoundaryResolver` type.

**Threading the resolver** (`utils/createPreviewNode.ts`, `utils/createPreviewGraph.ts`, `components/AddNodePanel/createAddNodePreview.ts`)
- `createAddNodePreview` derives a `(handleId → boundary)` map from the source manifest via `resolveHandles` and passes it through `showPreviewGraph` → `createPreviewGraph` → `createPreviewNode` → `resolveHandleContext`.
- **Breaking change** to keep the surface clean: `createPreviewNode` now takes a single `CreatePreviewNodeOptions` object instead of 11 positional parameters. Only internal caller `createPreviewGraph.ts` was updated; external consumers passing positional args will need a one-line update.

**Top-level edge-insertion chain shift** (`components/AddNodePanel/AddNodeManager.helpers.ts`)
- New `shiftForEdgeInsertion` helper invoked from `placeAddedNode` whenever the preview replaced an existing edge and is not container-scoped. It (a) bumps the inserted node right if it would overlap the upstream source's gap zone, and (b) shifts the original target plus its linear downstream chain by enough to clear the inserted node + sequence gap. Uses an 80 px gap (`GRID_SPACING * 5`) so the post-shift layout sits outside `resolveCollisions`'s 64 px margin total and won't be re-shuffled.

**Container empty-state + first-child + preview alignment** (`components/LoopNode/LoopNode.tsx`, `components/LoopNode/LoopNodePreview.ts`, `utils/container.ts`)
- Empty-state `+` button moved out of `BodyFrame`'s flex centering and rendered as an absolutely-positioned sibling at the container's geometric center.
- `showCenteredContainerPreview` places the preview at `containerHeight / 2` (matches the inner source handle's rail) instead of the body's center.
- `placeContainerNode` first-child placement uses a new `centerOnContainerRail` (clamped to safeArea on short containers); `centerInSafeArea` was removed as it had no remaining callers.

**Manifest-level handle defaults** (`storybook-utils/manifests/node-definitions.ts`)
- Marked `success` on `uipath.agent` with `isDefaultForType: true` so the Agent's outgoing edge attaches to the right-side `Success` handle instead of the top-side `Memory` artifact.

**Storybook fixtures** (`storybook-utils/mocks/nodes.ts`, `components/AddNodePanel/AddNodePanel.stories.tsx`)
- Snapped `NodePositions.row2*` (255 → 256) and `row3*` (414 → 416) to the 16 px grid; off-grid trigger positions were the root cause of cascading snap drift in every canvas storybook.
- Added the `Add node — all shapes` story exercising container / rectangle / square / circle materialization.
- Scoped the All Shapes panel's search to its 4 static items via a custom `onSearch` (instead of falling back to the registry).

## Test plan

- [ ] `pnpm --filter @uipath/apollo-react test` — 1188 canvas tests pass (8 new across `NodeUtils.test.ts`, `AddNodeManager.helpers.test.ts`, `container.test.ts`, plus the `Add node — all shapes` storybook story).
- [ ] `pnpm --filter @uipath/apollo-react tsc --noEmit` — clean.
- [ ] `pnpm --filter @uipath/apollo-react biome check` — no new warnings on changed files.
- [ ] In storybook → Canvas → AddNodePanel → \"Add node — all shapes\":
  - Click + on the trigger / Action handles, pick each of container / rectangle / square / circle. Materialized node sits on the row.
  - Click + on the For Each container's outer right \"Success\" handle. Preview is vertically centered; pick a square to confirm the materialized node centers too.
  - Click + on the empty For Each body. Preview lines up with `Start`; pick API Workflow to confirm the materialized child stays on the rail (straight Start → child line).
  - Insert a rectangle/container between two existing nodes via the SequenceEdge + toolbar. Downstream nodes shift right; row stays intact.
  - Insert an Agent rectangle. The outgoing edge attaches to `Success` (right), not `Memory` (top).
  - Type a query into the All Shapes panel search. Only the four shape items match.

## Breaking changes

- `createPreviewNode(...)` signature changed from 11 positional arguments to a single `CreatePreviewNodeOptions` object. Only consumers calling it directly need to migrate; everything that goes through `showPreviewGraph` / `createAddNodePreview` is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)