### PR TITLE
feat(apollo-react): add renderEmptyState prop to ListView/Toolbox/AddNodePanel

### DIFF
--- a/packages/apollo-react/src/canvas/components/AddNodePanel/AddNodePanel.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/AddNodePanel/AddNodePanel.stories.tsx
@@ -11,7 +11,7 @@ import {
   withCanvasProviders,
 } from '../../storybook-utils';
 import { DefaultCanvasTranslations } from '../../types';
-import type { CanvasHandleActionEvent } from '../../utils';
+import { CanvasIcon, type CanvasHandleActionEvent } from '../../utils';
 import { BaseCanvas } from '../BaseCanvas';
 import type { BaseNodeData } from '../BaseNode';
 import { CanvasPositionControls } from '../CanvasPositionControls';
@@ -195,15 +195,24 @@ function createInitialNodes(): Node<BaseNodeData>[] {
 
 /**
  * Standalone panel wrapper component.
+ *
+ * `paddingTop` overrides the default 40px top offset — useful in stories that
+ * also render a top-anchored `StoryInfoPanel` and need to clear it.
  */
-function StandalonePanelWrapper({ children }: { children: React.ReactNode }) {
+function StandalonePanelWrapper({
+  children,
+  paddingTop = '200px',
+}: {
+  children: React.ReactNode;
+  paddingTop?: string;
+}) {
   return (
     <div
       style={{
         height: '100vh',
         width: '100vw',
         backgroundColor: 'var(--color-background-secondary)',
-        paddingTop: '40px',
+        paddingTop,
       }}
     >
       <div
@@ -579,6 +588,167 @@ export const NodePanelRegistryItems: Story = {
     <StandalonePanelWrapper>
       <AddNodePanel {...args} />
     </StandalonePanelWrapper>
+  ),
+};
+
+// ============================================================================
+// renderEmptyState demos
+// ============================================================================
+
+/**
+ * Render-prop that branches on `currentCategory` so the same story can
+ * demonstrate both "no nodes registered" (root-level empty) and
+ * "category is empty" (after drilling into an empty category) UX paths.
+ * Search-empty cases are handled by Toolbox's built-in fallback — this
+ * renderer is *not* invoked during search.
+ */
+const renderCustomEmptyState = ({
+  currentCategory,
+}: {
+  currentCategory?: ListItem<NodeItemData>;
+}) => {
+  if (currentCategory) {
+    return (
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+          gap: 8,
+          padding: 24,
+          minHeight: 250,
+          textAlign: 'center',
+        }}
+      >
+        <CanvasIcon icon="folder-open" size={28} color="var(--canvas-foreground-de-emp)" />
+        <div style={{ fontWeight: 600, fontSize: 13 }}>{currentCategory.name} is empty</div>
+        <div style={{ fontSize: 12, color: 'var(--canvas-foreground-de-emp)' }}>
+          Add a node to this category to get started.
+        </div>
+      </div>
+    );
+  }
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        gap: 12,
+        padding: 24,
+        minHeight: 250,
+        textAlign: 'center',
+      }}
+    >
+      <CanvasIcon icon="package-open" size={28} color="var(--canvas-foreground-de-emp)" />
+      <div style={{ fontWeight: 600, fontSize: 13 }}>No nodes registered</div>
+      <div style={{ fontSize: 12, color: 'var(--canvas-foreground-de-emp)' }}>
+        Connect a node provider to start adding nodes.
+      </div>
+      <button
+        type="button"
+        style={{
+          padding: '6px 12px',
+          borderRadius: 6,
+          backgroundColor: 'var(--canvas-accent)',
+          color: 'var(--canvas-accent-foreground)',
+          border: 'none',
+          fontSize: 12,
+          cursor: 'pointer',
+        }}
+      >
+        Connect provider
+      </button>
+    </div>
+  );
+};
+
+export const NodePanelEmptyStateNoNodes: Story = {
+  name: 'renderEmptyState — no nodes registered',
+  parameters: {
+    docs: {
+      description: {
+        story: [
+          'Demonstrates the root-level branch of `renderEmptyState`. The panel is',
+          'given an empty `items` array, so the render prop is invoked with',
+          '`currentCategory: undefined`. The host app renders an onboarding CTA',
+          'in place of the built-in "No nodes found" message.',
+        ].join(' '),
+      },
+    },
+  },
+  args: {
+    items: [],
+    onNodeSelect: (node) => console.log('Selected node:', node),
+    onClose: () => console.log('Closed selector'),
+    renderEmptyState: renderCustomEmptyState,
+  },
+  render: (args) => (
+    <>
+      <StoryInfoPanel
+        title="renderEmptyState — no nodes"
+        description={
+          'AddNodePanel was given an empty `items` array, so `renderEmptyState` is ' +
+          'called with `currentCategory: undefined`. The custom render replaces the ' +
+          'built-in "No nodes found" message — useful for onboarding CTAs in apps that ' +
+          'have no nodes registered yet.'
+        }
+      />
+      <StandalonePanelWrapper>
+        <AddNodePanel {...args} />
+      </StandalonePanelWrapper>
+    </>
+  ),
+};
+
+const EMPTY_CATEGORY_ITEMS: ListItem<NodeItemData>[] = [
+  {
+    id: 'empty-category',
+    name: 'Empty category',
+    icon: { name: 'folder' },
+    data: { type: 'empty-category' },
+    children: [],
+  },
+];
+
+export const NodePanelEmptyStateInCategory: Story = {
+  name: 'renderEmptyState — drilled into empty category',
+  parameters: {
+    docs: {
+      description: {
+        story: [
+          'Demonstrates the per-category branch of `renderEmptyState`. The panel',
+          'has a single category with no children. Click the category to drill in —',
+          'the render prop is invoked with `currentCategory` set to the drilled-in',
+          'item, letting the host show category-specific empty UI.',
+        ].join(' '),
+      },
+    },
+  },
+  args: {
+    items: EMPTY_CATEGORY_ITEMS,
+    onNodeSelect: (node) => console.log('Selected node:', node),
+    onClose: () => console.log('Closed selector'),
+    renderEmptyState: renderCustomEmptyState,
+  },
+  render: (args) => (
+    <>
+      <StoryInfoPanel
+        title="renderEmptyState — drilled-in category"
+        description={
+          'Click "Empty category" to drill in. `renderEmptyState` is invoked with ' +
+          '`currentCategory` set to that item, so the renderer can show category-' +
+          'specific empty UI (e.g. a CTA tied to the category). Search-empty cases ' +
+          'still use the built-in "No nodes found" fallback — this renderer never ' +
+          'fires during search.'
+        }
+      />
+      <StandalonePanelWrapper>
+        <AddNodePanel {...args} />
+      </StandalonePanelWrapper>
+    </>
   ),
 };
 

--- a/packages/apollo-react/src/canvas/components/AddNodePanel/AddNodePanel.test.tsx
+++ b/packages/apollo-react/src/canvas/components/AddNodePanel/AddNodePanel.test.tsx
@@ -16,7 +16,13 @@ vi.mock('../../hooks', () => ({
 
 // Mock Toolbox to test only AddNodePanel's data transformation logic
 vi.mock('../Toolbox', () => ({
-  Toolbox: ({ title, initialItems, onClose, onItemSelect }: ToolboxProps<NodeItemData>) => (
+  Toolbox: ({
+    title,
+    initialItems,
+    onClose,
+    onItemSelect,
+    renderEmptyState,
+  }: ToolboxProps<NodeItemData>) => (
     <div data-testid="toolbox-mock">
       <div data-testid="toolbox-title">{title}</div>
       <div data-testid="toolbox-items">{JSON.stringify(initialItems)}</div>
@@ -30,6 +36,12 @@ vi.mock('../Toolbox', () => ({
       >
         Select First
       </button>
+      {/* Match real Toolbox: only invoke renderEmptyState when there are no items. */}
+      {renderEmptyState && initialItems.length === 0 && (
+        <div data-testid="toolbox-empty-state">
+          {renderEmptyState({ currentCategory: undefined })}
+        </div>
+      )}
     </div>
   ),
 }));
@@ -227,6 +239,32 @@ describe('AddNodePanel', () => {
     // Should only have 1 category (agents), empty category should be filtered out
     expect(items).toHaveLength(1);
     expect(items[0].id).toBe('agent-node');
+  });
+
+  it('should forward renderEmptyState through to Toolbox when items are empty', () => {
+    const renderEmptyState = vi.fn(() => <div data-testid="custom-empty">empty</div>);
+
+    // Pass items={[]} so the (gated) mock path invokes renderEmptyState — same
+    // behavior as the real Toolbox, which only calls the prop when ListView
+    // would render the empty state.
+    render(<AddNodePanel {...defaultProps} items={[]} renderEmptyState={renderEmptyState} />);
+
+    expect(screen.getByTestId('toolbox-empty-state')).toBeInTheDocument();
+    expect(screen.getByTestId('custom-empty')).toHaveTextContent('empty');
+    expect(renderEmptyState).toHaveBeenCalledWith({ currentCategory: undefined });
+  });
+
+  it('should not invoke renderEmptyState when items are present', () => {
+    const renderEmptyState = vi.fn(() => <div data-testid="custom-empty">should not render</div>);
+
+    render(
+      <NodeRegistryProvider manifest={mockManifest}>
+        <AddNodePanel {...defaultProps} renderEmptyState={renderEmptyState} />
+      </NodeRegistryProvider>
+    );
+
+    expect(screen.queryByTestId('toolbox-empty-state')).not.toBeInTheDocument();
+    expect(renderEmptyState).not.toHaveBeenCalled();
   });
 
   it('should support custom nodeOptions instead of registry', () => {

--- a/packages/apollo-react/src/canvas/components/AddNodePanel/AddNodePanel.tsx
+++ b/packages/apollo-react/src/canvas/components/AddNodePanel/AddNodePanel.tsx
@@ -20,6 +20,7 @@ export const AddNodePanel = memo(function AddNodePanel({
   items,
   title,
   loading,
+  renderEmptyState,
 }: AddNodePanelProps) {
   const registry = useOptionalNodeTypeRegistry();
   const { previewNodeConnectionInfo } = usePreviewNode();
@@ -85,6 +86,7 @@ export const AddNodePanel = memo(function AddNodePanel({
       onSearch={handleSearch}
       onClose={onClose}
       onItemHover={onNodeHover}
+      renderEmptyState={renderEmptyState}
     />
   );
 });

--- a/packages/apollo-react/src/canvas/components/AddNodePanel/AddNodePanel.types.ts
+++ b/packages/apollo-react/src/canvas/components/AddNodePanel/AddNodePanel.types.ts
@@ -1,4 +1,4 @@
-import type { ListItem } from '../Toolbox';
+import type { ListItem, ToolboxEmptyStateRenderer } from '../Toolbox';
 
 export interface NodeItemData {
   type: string;
@@ -22,4 +22,11 @@ export interface AddNodePanelProps {
    */
   items?: ListItem[];
   loading?: boolean;
+  /**
+   * Custom render for the empty-state body. Invoked only when the user has
+   * navigated into a category (or is at the root) and the list is empty —
+   * not during search. Receives the currently-selected category as context.
+   * When provided, replaces the built-in icon + message empty state.
+   */
+  renderEmptyState?: ToolboxEmptyStateRenderer<NodeItemData>;
 }

--- a/packages/apollo-react/src/canvas/components/Toolbox/ListView.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/Toolbox/ListView.stories.tsx
@@ -1,0 +1,280 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { StoryInfoPanel, withCanvasProviders } from '../../storybook-utils';
+import { CanvasIcon } from '../../utils/icon-registry';
+import { ListView } from './ListView';
+
+const meta: Meta<typeof ListView> = {
+  title: 'Canvas/Toolbox/ListView',
+  component: ListView,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component: [
+          'Stories for the empty-state path of `ListView`. When `items` is empty',
+          'and no skeleton spec is active, the component renders an icon +',
+          'message instead of the virtualized list. Both the icon and the',
+          'message can be overridden via `emptyStateIcon` and',
+          '`emptyStateMessage`.',
+        ].join(' '),
+      },
+    },
+  },
+  decorators: [withCanvasProviders({ fullscreen: false })],
+};
+
+export default meta;
+type Story = StoryObj<typeof ListView>;
+
+function PanelWrapper({
+  children,
+  paddingTop = '200px',
+}: {
+  children: React.ReactNode;
+  paddingTop?: string;
+}) {
+  return (
+    <div
+      style={{
+        minHeight: '100vh',
+        width: '100vw',
+        backgroundColor: 'var(--color-background-secondary)',
+        paddingTop,
+      }}
+    >
+      <div
+        style={{
+          width: '320px',
+          margin: '0 auto',
+          display: 'flex',
+          flexDirection: 'column',
+          backgroundColor: 'var(--canvas-background-raised)',
+          border: '1px solid var(--canvas-border-de-emp)',
+          borderRadius: '8px',
+          boxShadow: '0 4px 12px rgba(0, 0, 0, 0.1)',
+          overflow: 'hidden',
+        }}
+      >
+        {children}
+      </div>
+    </div>
+  );
+}
+
+const noop = () => {};
+
+export const EmptyStateDefault: Story = {
+  name: 'Empty state — defaults',
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'No overrides. Shows the built-in `"No items found"` message and the default `search-x` lucide icon.',
+      },
+    },
+  },
+  args: {
+    items: [],
+    onItemClick: noop,
+  },
+  render: (args) => (
+    <PanelWrapper>
+      <ListView {...args} />
+    </PanelWrapper>
+  ),
+};
+
+export const EmptyStateCustomMessage: Story = {
+  name: 'Empty state — custom message',
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Overrides only `emptyStateMessage`. Useful when the surface has a more specific empty-state copy than the generic default.',
+      },
+    },
+  },
+  args: {
+    items: [],
+    onItemClick: noop,
+    emptyStateMessage: 'No tools match your search. Try a different keyword.',
+  },
+  render: (args) => (
+    <PanelWrapper>
+      <ListView {...args} />
+    </PanelWrapper>
+  ),
+};
+
+export const EmptyStateCustomIcon: Story = {
+  name: 'Empty state — custom icon',
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Overrides only `emptyStateIcon`. Any lucide icon name (kebab-case) or registered custom icon id is accepted.',
+      },
+    },
+  },
+  args: {
+    items: [],
+    onItemClick: noop,
+    emptyStateIcon: 'inbox',
+  },
+  render: (args) => (
+    <PanelWrapper>
+      <ListView {...args} />
+    </PanelWrapper>
+  ),
+};
+
+export const EmptyStateFullyCustom: Story = {
+  name: 'Empty state — custom icon and message',
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Overrides both props together — the realistic "first-run" / onboarding scenario where the panel has nothing to show yet and wants to guide the user.',
+      },
+    },
+  },
+  args: {
+    items: [],
+    onItemClick: noop,
+    emptyStateIcon: 'package-open',
+    emptyStateMessage: 'Nothing here yet — add your first item to get started.',
+  },
+  render: (args) => (
+    <PanelWrapper>
+      <ListView {...args} />
+    </PanelWrapper>
+  ),
+};
+
+export const EmptyStateRenderProp: Story = {
+  name: 'Empty state — renderEmptyState (custom node)',
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Demonstrates `renderEmptyState`. When supplied, the prop fully replaces the built-in Column + icon + message and lets the caller control layout, illustration, copy, and actions. Useful for richer onboarding states or app-specific CTAs.',
+      },
+    },
+  },
+  args: {
+    items: [],
+    onItemClick: noop,
+    renderEmptyState: () => (
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+          gap: 12,
+          padding: 24,
+          minHeight: 250,
+        }}
+      >
+        <div
+          style={{
+            width: 64,
+            height: 64,
+            borderRadius: 12,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            backgroundColor: 'var(--canvas-background-raised)',
+            border: '1px dashed var(--canvas-border-de-emp)',
+          }}
+        >
+          <CanvasIcon icon="sparkles" size={28} color="var(--canvas-foreground-de-emp)" />
+        </div>
+        <div style={{ textAlign: 'center' }}>
+          <div style={{ fontWeight: 600, fontSize: 13 }}>No nodes available yet</div>
+          <div style={{ fontSize: 12, color: 'var(--canvas-foreground-de-emp)', marginTop: 4 }}>
+            Connect your data source to start building.
+          </div>
+        </div>
+        <button
+          type="button"
+          style={{
+            padding: '6px 12px',
+            borderRadius: 6,
+            backgroundColor: 'var(--canvas-accent)',
+            color: 'var(--canvas-accent-foreground)',
+            border: 'none',
+            fontSize: 12,
+            cursor: 'pointer',
+          }}
+        >
+          Connect data source
+        </button>
+      </div>
+    ),
+  },
+  render: (args) => (
+    <>
+      <StoryInfoPanel
+        title="renderEmptyState"
+        description={
+          'The panel is given an empty `items` array. Instead of the built-in icon + ' +
+          '"No items found" message, ListView renders the caller-supplied node. The ' +
+          'caller controls layout, illustration, copy, and any CTAs — useful for ' +
+          'onboarding flows.'
+        }
+      />
+      <PanelWrapper>
+        <ListView {...args} />
+      </PanelWrapper>
+    </>
+  ),
+};
+
+export const EmptyStateRenderPropOverridesMessage: Story = {
+  name: 'Empty state — renderEmptyState wins over emptyStateMessage',
+  parameters: {
+    docs: {
+      description: {
+        story:
+          '`renderEmptyState` takes precedence over `emptyStateMessage` / `emptyStateIcon`. Both props are passed here but only the render-prop output is shown — handy when staged rollouts gradually replace the legacy message-only API.',
+      },
+    },
+  },
+  args: {
+    items: [],
+    onItemClick: noop,
+    emptyStateIcon: 'search-x',
+    emptyStateMessage: 'This default message is intentionally suppressed by renderEmptyState.',
+    renderEmptyState: () => (
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          minHeight: 250,
+          fontSize: 12,
+          color: 'var(--canvas-foreground)',
+        }}
+      >
+        Render-prop output wins.
+      </div>
+    ),
+  },
+  render: (args) => (
+    <>
+      <StoryInfoPanel
+        title="Render-prop precedence"
+        description={
+          'Both `emptyStateMessage` and `renderEmptyState` are supplied. The render ' +
+          'prop wins — the default message is suppressed, the custom node is shown ' +
+          'instead. Useful when migrating an existing surface from the message-only ' +
+          'API to the render-prop API.'
+        }
+      />
+      <PanelWrapper>
+        <ListView {...args} />
+      </PanelWrapper>
+    </>
+  ),
+};

--- a/packages/apollo-react/src/canvas/components/Toolbox/ListView.test.tsx
+++ b/packages/apollo-react/src/canvas/components/Toolbox/ListView.test.tsx
@@ -25,6 +25,76 @@ describe('ListView', () => {
       expect(screen.getByText('Custom empty message')).toBeInTheDocument();
     });
 
+    it('should call renderEmptyState and render its result when items are empty', () => {
+      const renderEmptyState = vi.fn(() => (
+        <div data-testid="custom-empty">Bring your own empty state</div>
+      ));
+      render(<ListView {...defaultProps} items={[]} renderEmptyState={renderEmptyState} />);
+
+      expect(renderEmptyState).toHaveBeenCalledTimes(1);
+      expect(screen.getByTestId('custom-empty')).toBeInTheDocument();
+    });
+
+    it('should let renderEmptyState replace the default icon + message', () => {
+      render(
+        <ListView
+          {...defaultProps}
+          items={[]}
+          emptyStateMessage="Default message"
+          renderEmptyState={() => <div>Custom render wins</div>}
+        />
+      );
+
+      expect(screen.getByText('Custom render wins')).toBeInTheDocument();
+      expect(screen.queryByText('Default message')).not.toBeInTheDocument();
+    });
+
+    it('should not call renderEmptyState when items are present', () => {
+      const renderEmptyState = vi.fn(() => <div>Should not render</div>);
+      const items: ListItem[] = [{ id: 'a', name: 'A', data: {} }];
+
+      render(<ListView {...defaultProps} items={items} renderEmptyState={renderEmptyState} />);
+
+      expect(renderEmptyState).not.toHaveBeenCalled();
+      expect(screen.queryByText('Should not render')).not.toBeInTheDocument();
+    });
+
+    it('should not call renderEmptyState while isLoading produces skeleton rows', () => {
+      const renderEmptyState = vi.fn(() => <div>Should not render</div>);
+
+      render(
+        <ListView
+          {...defaultProps}
+          items={[]}
+          isLoading={true}
+          renderEmptyState={renderEmptyState}
+        />
+      );
+
+      // isLoading + empty items → 3 default skeletons render → renderedItems is
+      // non-empty → renderEmptyState is bypassed.
+      expect(renderEmptyState).not.toHaveBeenCalled();
+      expect(screen.queryByText('Should not render')).not.toBeInTheDocument();
+      expect(screen.getAllByTestId('list-item-skeleton')).toHaveLength(3);
+    });
+
+    it('should not call renderEmptyState while loadingSkeleton produces rows', () => {
+      const renderEmptyState = vi.fn(() => <div>Should not render</div>);
+
+      render(
+        <ListView
+          {...defaultProps}
+          items={[]}
+          loadingSkeleton={true}
+          renderEmptyState={renderEmptyState}
+        />
+      );
+
+      expect(renderEmptyState).not.toHaveBeenCalled();
+      expect(screen.queryByText('Should not render')).not.toBeInTheDocument();
+      expect(screen.getAllByTestId('list-item-skeleton')).toHaveLength(3);
+    });
+
     it('should show loading spinner when loading with no items', () => {
       render(<ListView {...defaultProps} items={[]} isLoading={true} />);
 

--- a/packages/apollo-react/src/canvas/components/Toolbox/ListView.tsx
+++ b/packages/apollo-react/src/canvas/components/Toolbox/ListView.tsx
@@ -256,6 +256,14 @@ interface ListViewProps<T extends ListItem> {
   onScroll?: React.UIEventHandler<HTMLDivElement>;
   emptyStateMessage?: string;
   emptyStateIcon?: string;
+  /**
+   * Custom render for the empty state. When provided, fully replaces the
+   * default Column + icon + message layout — `emptyStateIcon` and
+   * `emptyStateMessage` are ignored. Loading paths still take precedence:
+   * the prop is not invoked while `isLoading` or `loadingSkeleton` produce
+   * placeholder rows.
+   */
+  renderEmptyState?: () => React.ReactElement | null;
   isLoading?: boolean;
   enableSections?: boolean;
   /**
@@ -298,6 +306,7 @@ const ListViewInner = forwardRef(function ListView<T extends ListItem>(
     onScroll,
     emptyStateMessage = 'No items found',
     emptyStateIcon = 'search-x',
+    renderEmptyState,
     isLoading = false,
     enableSections = true,
     loadingSkeleton,
@@ -324,8 +333,10 @@ const ListViewInner = forwardRef(function ListView<T extends ListItem>(
   );
 
   // Show empty state when nothing would render — neither real items nor
-  // skeleton placeholders.
+  // skeleton placeholders. Loading-driven paths above keep `renderedItems`
+  // non-empty (skeleton rows), so renderEmptyState is naturally bypassed.
   if (renderedItems.length === 0) {
+    if (renderEmptyState) return renderEmptyState();
     return (
       <Column align="center" justify="center" flex={1} gap={10} style={{ minHeight: '250px' }}>
         <CanvasIcon icon={emptyStateIcon} size={48} color="var(--canvas-foreground-de-emp)" />

--- a/packages/apollo-react/src/canvas/components/Toolbox/Toolbox.test.tsx
+++ b/packages/apollo-react/src/canvas/components/Toolbox/Toolbox.test.tsx
@@ -255,6 +255,62 @@ describe('Toolbox', () => {
     });
   });
 
+  describe('renderEmptyState', () => {
+    let user: UserEvent;
+
+    beforeEach(() => {
+      user = userEvent.setup();
+    });
+
+    it('invokes renderEmptyState with currentCategory=undefined at the root level when there are no items', () => {
+      const renderEmptyState = vi.fn(() => <div data-testid="custom-empty">empty</div>);
+      render(<Toolbox {...defaultProps} initialItems={[]} renderEmptyState={renderEmptyState} />);
+
+      expect(screen.getByTestId('custom-empty')).toBeInTheDocument();
+      expect(renderEmptyState).toHaveBeenLastCalledWith({ currentCategory: undefined });
+    });
+
+    it('invokes renderEmptyState with the drilled-in category when its children list is empty', async () => {
+      const itemsWithEmptyCategory: ListItem[] = [
+        { id: 'cat-1', name: 'Empty category', data: {}, icon: { name: 'folder' }, children: [] },
+      ];
+      const renderEmptyState = vi.fn(({ currentCategory }: { currentCategory?: ListItem }) => (
+        <div data-testid="custom-empty">in: {currentCategory?.id ?? 'root'}</div>
+      ));
+      render(
+        <Toolbox
+          {...defaultProps}
+          initialItems={itemsWithEmptyCategory}
+          renderEmptyState={renderEmptyState}
+        />
+      );
+
+      // Drill into the empty category
+      await user.click(screen.getByText('Empty category'));
+
+      expect(screen.getByTestId('custom-empty')).toHaveTextContent('in: cat-1');
+      expect(renderEmptyState).toHaveBeenLastCalledWith({
+        currentCategory: expect.objectContaining({ id: 'cat-1' }),
+      });
+    });
+
+    it('falls back to the built-in empty message during search even when renderEmptyState is provided', async () => {
+      const renderEmptyState = vi.fn(() => <div data-testid="custom-empty">should not show</div>);
+      render(<Toolbox {...defaultProps} renderEmptyState={renderEmptyState} />);
+
+      await user.type(screen.getByPlaceholderText('Search'), 'NonExistent');
+
+      expect(screen.getByText('No matching nodes found')).toBeInTheDocument();
+      expect(screen.queryByTestId('custom-empty')).not.toBeInTheDocument();
+    });
+
+    it('falls back to the built-in empty message when renderEmptyState is not provided', () => {
+      render(<Toolbox {...defaultProps} initialItems={[]} />);
+
+      expect(screen.getByText('No nodes found')).toBeInTheDocument();
+    });
+  });
+
   describe('Keyboard shortcuts', () => {
     let user: UserEvent;
 

--- a/packages/apollo-react/src/canvas/components/Toolbox/Toolbox.tsx
+++ b/packages/apollo-react/src/canvas/components/Toolbox/Toolbox.tsx
@@ -51,6 +51,17 @@ function findItemById<T>(items: ListItem<T>[], id: string): ListItem<T> | null {
   return null;
 }
 
+/**
+ * Render-prop signature for `renderEmptyState`. The `ctx` bag carries
+ * caller-relevant state — currently the category the user has drilled into
+ * (or `undefined` at the root level). The renderer is only invoked when the
+ * user is *not* searching; search-empty states fall back to the built-in UI.
+ * Kept as an object so future fields can be added without breaking call sites.
+ */
+export type ToolboxEmptyStateRenderer<T = any> = (ctx: {
+  currentCategory?: ListItem<T>;
+}) => React.ReactElement | null;
+
 export type ToolboxSearchHandler<T = any> = (
   query: string,
   isTopLevelSearch: boolean,
@@ -75,6 +86,13 @@ export interface ToolboxProps<T> {
    * appear after the visual separator.
    */
   quickActions?: ToolboxQuickAction[];
+  /**
+   * Custom render for the empty-state body. Invoked only when the user has
+   * navigated into a category (or is at the root) and the list is empty —
+   * not during search. Receives the currently-selected category as context.
+   * When provided, replaces the built-in icon + message empty state.
+   */
+  renderEmptyState?: ToolboxEmptyStateRenderer<T>;
 }
 
 function getNextSelectableIndex(
@@ -135,6 +153,7 @@ export function Toolbox<T>({
   fullWidth = false,
   fullHeight = false,
   quickActions,
+  renderEmptyState,
 }: ToolboxProps<T>) {
   const [items, setItems] = useState<ListItem<T>[]>(initialItems);
   const [search, setSearch] = useState('');
@@ -173,6 +192,18 @@ export function Toolbox<T>({
   }, []);
 
   const isSearching = useMemo(() => search.length > 0, [search]);
+
+  // Adapts the Toolbox-level `(ctx) => ReactNode` signature to ListView's
+  // no-arg form. We deliberately skip the user renderer while searching so
+  // the built-in "No nodes found" empty state handles search-empty cases —
+  // category-specific renderers are meaningful only at category drill-in.
+  const wrappedRenderEmptyState = useMemo(
+    () =>
+      renderEmptyState && !isSearching
+        ? () => renderEmptyState({ currentCategory: currentParentItem ?? undefined })
+        : undefined,
+    [renderEmptyState, isSearching, currentParentItem]
+  );
 
   const displayedItems = useMemo(
     () => (isSearching && !isSearchingInitialItems ? searchedItems : items),
@@ -633,6 +664,7 @@ export function Toolbox<T>({
               activeIndex={activeIndex}
               listRef={listRef}
               emptyStateMessage={isSearching ? 'No matching nodes found' : 'No nodes found'}
+              renderEmptyState={wrappedRenderEmptyState}
               onItemClick={handleItemSelect}
               onItemHover={onItemHover}
               onScroll={handleListScroll}


### PR DESCRIPTION
## Description

The default empty state for the canvas `ListView` (and the `Toolbox` / `AddNodePanel` surfaces that compose it) is a built-in icon + message column. Host apps don't currently have a way to replace it with richer content — onboarding CTAs, app-specific illustrations, "create your first node" buttons, etc.

This PR adds an optional `renderEmptyState` prop to all three components. When provided, it fully replaces the default empty-state body. `Toolbox` and `AddNodePanel` expose a richer signature that hands callers the currently drilled-in category (or `undefined` at the root) so the same renderer can branch on context — e.g. a different illustration per category, or a "create your first X" CTA at the top level. The renderer is **only invoked when the user is not searching** — search-empty states intentionally fall back to the built-in `"No matching nodes found"` message so the search experience stays consistent across consumers.

**Default behavior is unchanged** — the prop is optional, and the existing `emptyStateIcon` / `emptyStateMessage` defaults still fire when it's omitted.

## Implementation

Three layers, each with a slightly different signature:

- **`ListView`** — `renderEmptyState?: () => ReactElement | null`. ListView doesn't track searching or category state, so it takes the no-arg form. Loading paths still take precedence: when `isLoading` or `loadingSkeleton` would render skeleton sentinels, `renderedItems.length > 0` and `renderEmptyState` is naturally bypassed.
- **`Toolbox`** — `renderEmptyState?: ToolboxEmptyStateRenderer<T>` where `ToolboxEmptyStateRenderer<T> = (ctx: { currentCategory?: ListItem<T> }) => ReactElement | null`. Toolbox owns search and navigation state, so it adapts its richer signature to ListView's no-arg form via a `useMemo`-stable wrapper. The wrapper is gated on `!isSearching` and returns `undefined` while a search query is active, which lets ListView fall through to the built-in empty message for the "no search match" case.
- **`AddNodePanel`** — same `ToolboxEmptyStateRenderer<T>` shape, forwarded straight through to Toolbox.

The `ctx` bag (rather than a positional arg) keeps the door open for future fields without breaking call sites. Tightened the renderer return type to `ReactElement | null` (instead of the broader `ReactNode`) so it lines up with `ListView`'s exported return-type cast and callers can't accidentally return strings/arrays/fragments through a signature that promises an element.

Files:
- `packages/apollo-react/src/canvas/components/Toolbox/ListView.tsx` — adds the no-arg prop and an early-return branch in the existing empty-state block.
- `packages/apollo-react/src/canvas/components/Toolbox/Toolbox.tsx` — exports the shared generic `ToolboxEmptyStateRenderer<T>` type, adds the prop on `ToolboxProps`, plumbs the search-gated `currentCategory`-capturing wrapper.
- `packages/apollo-react/src/canvas/components/AddNodePanel/AddNodePanel.tsx` + `AddNodePanel.types.ts` — re-exposes the prop on `AddNodePanelProps` (reusing the shared type) and threads it through to Toolbox.

## Description
This is how the change is wired into flow-workbench for the `Document extraction` category:
<img width="676" height="914" alt="image" src="https://github.com/user-attachments/assets/905f202b-35a9-44cf-a198-38ad8eb861d2" />


## How it's tested

**Unit tests** (`pnpm --filter @uipath/apollo-react test` — 1485 / 1485 passing):

- `ListView.test.tsx` — five new tests covering: invocation when items empty, replacement of the default icon/message, no invocation when items are present, no invocation while `isLoading` produces skeletons, no invocation while `loadingSkeleton` produces skeleton rows.
- `Toolbox.test.tsx` — four new tests covering: `currentCategory=undefined` at the root level when items are empty, `currentCategory=<drilled-in item>` when its children list is empty, fallback to the built-in message during search even when `renderEmptyState` is provided, fallback to the built-in message when the prop is omitted.
- `AddNodePanel.test.tsx` — two new tests: forwards the prop through to Toolbox when items are empty, and is not invoked when items are present.

**Storybook** (`pnpm --filter storybook-app dev`):

- `Canvas / ListView` — new stories for `renderEmptyState` (custom node) and `renderEmptyState` overriding `emptyStateMessage`, alongside the existing default / icon / message variants.
- `Canvas / AddNodePanel` — story exercising the panel's empty-state customization end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
