### PR TITLE
fix(apollo-react): loop back node positioning

### DIFF
--- a/packages/apollo-react/src/canvas/components/AddNodePanel/AddNodeManager.helpers.test.ts
+++ b/packages/apollo-react/src/canvas/components/AddNodePanel/AddNodeManager.helpers.test.ts
@@ -215,6 +215,129 @@ describe('placeAddedNode', () => {
       expect(placedAction?.position).toEqual({ x: 480, y: 96 });
     });
 
+    it('does not shift the source node when inserting onto a self-loop edge', () => {
+      // Reproduces the Loop V1 loopback regression: the original edge is a
+      // self-loop (source === target, e.g. Loop("output") → Loop("loopBack")),
+      // so shifting the "downstream chain" would move the source away from
+      // the inserted node and produce a backward-wrapping edge.
+      const registry = buildRegistry({
+        loop: { shape: 'square' },
+        rectangle: { shape: 'rectangle' },
+      });
+      const loop: Node = {
+        id: 'loop',
+        type: 'loop',
+        position: { x: 96, y: 96 },
+        measured: { width: 96, height: 96 },
+        data: {},
+      };
+      const selfLoopEdge: Edge = {
+        id: 'e-loop-self',
+        source: 'loop',
+        target: 'loop',
+        sourceHandle: 'output',
+        targetHandle: 'loopBack',
+      };
+      const previewNode: Node = {
+        id: PREVIEW_NODE_ID,
+        type: 'preview',
+        position: { x: 240, y: 96 },
+        width: 96,
+        height: 96,
+        data: { originalEdge: selfLoopEdge },
+      };
+      const insertedNode: Node = {
+        id: 'inserted',
+        type: 'rectangle',
+        position: { x: 240, y: 96 },
+        data: {},
+      };
+
+      const { nodes } = placeAddedNode({
+        nodes: [loop, insertedNode],
+        edges: [selfLoopEdge],
+        previewNode,
+        insertedNode,
+        registry,
+      });
+
+      const placedLoop = nodes.find((n) => n.id === 'loop');
+      // The Loop is both source and target of the original edge — it must
+      // not be treated as a downstream chain to shift.
+      expect(placedLoop?.position).toEqual({ x: 96, y: 96 });
+    });
+
+    it('does not shift the source when the chain cycles back through it', () => {
+      // Reproduces the second-insertion regression on a loopBack chain:
+      // After a node has been inserted onto the self-loop, the resulting graph
+      // is `loop body → child → loop loopBack`. Inserting again onto
+      // `loop body → child` walks from the target (child) along the cycle
+      // (child → loop), so the loop ends up in chainIds. Without this guard,
+      // the loop is shifted right alongside the child, producing the broken
+      // backward-wrapping body edge.
+      const registry = buildRegistry({
+        loop: { shape: 'square' },
+        rectangle: { shape: 'rectangle' },
+      });
+      const loop: Node = {
+        id: 'loop',
+        type: 'loop',
+        position: { x: 96, y: 96 },
+        measured: { width: 96, height: 96 },
+        data: {},
+      };
+      const child: Node = {
+        id: 'child',
+        type: 'rectangle',
+        position: { x: 672, y: 96 },
+        measured: { width: 288, height: 96 },
+        data: {},
+      };
+      const bodyEdge: Edge = {
+        id: 'e-loop-child',
+        source: 'loop',
+        target: 'child',
+        sourceHandle: 'body',
+        targetHandle: 'input',
+      };
+      const loopBackEdge: Edge = {
+        id: 'e-child-loop',
+        source: 'child',
+        target: 'loop',
+        sourceHandle: 'output',
+        targetHandle: 'loopBack',
+      };
+      const previewNode: Node = {
+        id: PREVIEW_NODE_ID,
+        type: 'preview',
+        position: { x: 288, y: 96 },
+        width: 96,
+        height: 96,
+        data: { originalEdge: bodyEdge },
+      };
+      const insertedNode: Node = {
+        id: 'inserted',
+        type: 'rectangle',
+        position: { x: 288, y: 96 },
+        data: {},
+      };
+
+      const { nodes } = placeAddedNode({
+        nodes: [loop, child, insertedNode],
+        edges: [bodyEdge, loopBackEdge],
+        previewNode,
+        insertedNode,
+        registry,
+      });
+
+      const placedLoop = nodes.find((n) => n.id === 'loop');
+      // Loop is the upstream source — it must not move even though the chain
+      // walk cycles back through it. Other position adjustments are decided
+      // by the generic collision resolver (matching pre-PR behavior for
+      // cyclic edges) and aren't part of this contract.
+      expect(placedLoop?.position).toEqual({ x: 96, y: 96 });
+    });
+
     it('does not shift any chain when no originalEdge metadata is present', () => {
       const registry = buildRegistry({
         'square-source': { shape: 'square' },

--- a/packages/apollo-react/src/canvas/components/AddNodePanel/AddNodeManager.helpers.ts
+++ b/packages/apollo-react/src/canvas/components/AddNodePanel/AddNodeManager.helpers.ts
@@ -208,9 +208,21 @@ function shiftForEdgeInsertion({
   }
 
   // Step 2: shift the downstream chain.
+  // Back-edge detection: when source is visually at or past target on the
+  // x axis, the original edge points backward in flow (a loopback). The
+  // inserted node already lives past source via Step 1; shifting target
+  // right would push the loop's start further from the cycle and produce
+  // a backward-wrapping body edge. Forward edges (source.x < target.x)
+  // continue to shift normally, including in cycles where the body chain
+  // is the part being inserted on (the source still stays via the
+  // chainIds.delete below, but the rest of the chain shifts right).
+  const isBackEdge =
+    sourceNode !== undefined &&
+    sourceNode.parentId === insertedNode.parentId &&
+    sourceNode.position.x >= targetNode.position.x;
   const requiredTargetLeft = insertedX + insertedSize.width + TOP_LEVEL_INSERTION_GAP_PX;
   const downstreamShift =
-    targetNode.position.x < requiredTargetLeft
+    !isBackEdge && targetNode.position.x < requiredTargetLeft
       ? snapUpToGrid(requiredTargetLeft - targetNode.position.x)
       : 0;
   const chainIds =
@@ -224,9 +236,14 @@ function shiftForEdgeInsertion({
           })
         )
       : new Set<string>();
+  // The upstream source must never shift, even when it appears in the
+  // chain via a cycle (Loop V1 body→…→loopBack chains). Removing it from
+  // the shift set lets the rest of the linear chain expand right while
+  // the loop's start stays anchored.
+  chainIds.delete(originalEdge.source);
 
   const insertedXChanged = insertedX !== insertedNode.position.x;
-  if (!insertedXChanged && downstreamShift === 0) return null;
+  if (!insertedXChanged && chainIds.size === 0) return null;
 
   const updatedInsertedNode: Node = insertedXChanged
     ? { ...insertedNode, position: { x: insertedX, y: insertedNode.position.y } }

--- a/packages/apollo-react/src/canvas/utils/container.test.ts
+++ b/packages/apollo-react/src/canvas/utils/container.test.ts
@@ -204,3 +204,238 @@ describe('placeContainerNode first-child placement', () => {
     expect(result?.position.y).toBe(96);
   });
 });
+
+describe('placeContainerNode cyclic edges', () => {
+  it('does not shift the source when inserting on a child self-loop', () => {
+    // Mirrors the top-level loopback regression but inside a container: a
+    // Loop V1-like child has a self-loop edge (output → loopBack). Inserting
+    // onto that edge must not shift the cyclic child away from the inserted
+    // node — the chain walk reaches back to the source, so placeContainerNode
+    // would otherwise push the loop right and produce a backward-wrapping
+    // body edge.
+    const containerNode: Node = {
+      id: 'outer',
+      type: 'loop',
+      position: { x: 0, y: 0 },
+      style: { width: 560, height: 320 },
+      data: {},
+    };
+    const innerLoop: Node = {
+      id: 'inner-loop',
+      type: 'while-like',
+      parentId: 'outer',
+      extent: 'parent',
+      position: { x: 144, y: 112 },
+      measured: { width: 96, height: 96 },
+      data: {},
+    };
+    const insertedNode: Node = {
+      id: 'inserted',
+      type: 'task',
+      parentId: 'outer',
+      extent: 'parent',
+      position: { x: 288, y: 112 },
+      measured: { width: 96, height: 96 },
+      data: {},
+    };
+    const placement: ContainerPlacement = {
+      containerId: 'outer',
+      sourceNodeId: 'inner-loop',
+      targetNodeId: 'inner-loop',
+      mode: 'sequence',
+    };
+    const selfLoopEdge = {
+      id: 'e-inner-self',
+      source: 'inner-loop',
+      target: 'inner-loop',
+      sourceHandle: 'output',
+      targetHandle: 'loopBack',
+    };
+
+    const placed = placeContainerNode({
+      nodes: [containerNode, innerLoop, insertedNode],
+      insertedNode,
+      placement,
+      edges: [selfLoopEdge],
+      getNodeDimensions: (node) => getNodeDimensions(node),
+    });
+
+    const placedInner = placed.find((node) => node.id === 'inner-loop');
+    // The cyclic child must stay put — it is both source and target of the
+    // edge being replaced.
+    expect(placedInner?.position).toEqual({ x: 144, y: 112 });
+  });
+
+  it('does not shift the loop when its body chain branches to the parent loopBack', () => {
+    // Reproduces the third-insertion regression: a Loop V1-style child inside
+    // a For Each container has both a self-loop body chain (output → … →
+    // loopBack) AND a parent-loopBack edge (success → container.loopBack)
+    // created by createLoopBackEdgesForNewLoop. The branching at the loop's
+    // outgoing handles makes the linear chain walk terminate after one node,
+    // so a chainIds-membership cycle check misses the cycle. Detection has
+    // to be reachability-based: target=loop reaches source=n2 via
+    // loop.output → n2, making this a back-edge insertion.
+    const containerNode: Node = {
+      id: 'outer',
+      type: 'foreach',
+      position: { x: 0, y: 0 },
+      style: { width: 800, height: 320 },
+      data: {},
+    };
+    const innerLoop: Node = {
+      id: 'inner-loop',
+      type: 'while-like',
+      parentId: 'outer',
+      extent: 'parent',
+      position: { x: 144, y: 112 },
+      measured: { width: 96, height: 96 },
+      data: {},
+    };
+    const n2: Node = {
+      id: 'n2',
+      type: 'task',
+      parentId: 'outer',
+      extent: 'parent',
+      position: { x: 288, y: 112 },
+      measured: { width: 96, height: 96 },
+      data: {},
+    };
+    const insertedNode: Node = {
+      id: 'inserted',
+      type: 'task',
+      parentId: 'outer',
+      extent: 'parent',
+      position: { x: 432, y: 112 },
+      measured: { width: 96, height: 96 },
+      data: {},
+    };
+    // body: inner-loop.output → n2
+    // back: n2.output → inner-loop.loopBack    ← about to be replaced
+    // parent: inner-loop.success → outer.loopBack
+    const edges = [
+      {
+        id: 'e-loop-n2',
+        source: 'inner-loop',
+        target: 'n2',
+        sourceHandle: 'output',
+        targetHandle: 'input',
+      },
+      {
+        id: 'e-n2-loop',
+        source: 'n2',
+        target: 'inner-loop',
+        sourceHandle: 'output',
+        targetHandle: 'loopBack',
+      },
+      {
+        id: 'e-loop-parent',
+        source: 'inner-loop',
+        target: 'outer',
+        sourceHandle: 'success',
+        targetHandle: 'loopBack',
+      },
+    ];
+    const placement: ContainerPlacement = {
+      containerId: 'outer',
+      sourceNodeId: 'n2',
+      targetNodeId: 'inner-loop',
+      mode: 'sequence',
+    };
+
+    const placed = placeContainerNode({
+      nodes: [containerNode, innerLoop, n2, insertedNode],
+      insertedNode,
+      placement,
+      edges,
+      getNodeDimensions: (node) => getNodeDimensions(node),
+    });
+
+    const placedInner = placed.find((node) => node.id === 'inner-loop');
+    // The loop is the body chain's source — it must not shift right past the
+    // inserted node, even though the linear chain walk from itself terminates
+    // early due to the parent-loopBack branch.
+    expect(placedInner?.position).toEqual({ x: 144, y: 112 });
+  });
+
+  it('still shifts the chain on a plain forward insert when target wires back to container.continue', () => {
+    // Regression: BFS reachability must NOT traverse through the parent
+    // container. In a normal For Each chain `start → n1 → n2 → continue`,
+    // BFS from n2 follows `n2 → container.continue` and would otherwise
+    // hop container → container.start → n1, falsely reporting a cycle and
+    // skipping the shift.
+    const containerNode: Node = {
+      id: 'outer',
+      type: 'foreach',
+      position: { x: 0, y: 0 },
+      style: { width: 1024, height: 320 },
+      data: {},
+    };
+    const n1: Node = {
+      id: 'n1',
+      type: 'task',
+      parentId: 'outer',
+      extent: 'parent',
+      position: { x: 144, y: 112 },
+      measured: { width: 96, height: 96 },
+      data: {},
+    };
+    const n2: Node = {
+      id: 'n2',
+      type: 'task',
+      parentId: 'outer',
+      extent: 'parent',
+      position: { x: 288, y: 112 },
+      measured: { width: 96, height: 96 },
+      data: {},
+    };
+    // Wider rectangle inserted between n1 and n2 — n2 must shift right.
+    const insertedNode: Node = {
+      id: 'inserted',
+      type: 'agent',
+      parentId: 'outer',
+      extent: 'parent',
+      position: { x: 0, y: 112 },
+      measured: { width: 288, height: 96 },
+      data: {},
+    };
+    // Forward chain inside the container, with the conventional loopback to
+    // the container's continue handle from the last child.
+    const edges = [
+      {
+        id: 'e-start-n1',
+        source: 'outer',
+        target: 'n1',
+        sourceHandle: 'start',
+        targetHandle: 'input',
+      },
+      { id: 'e-n1-n2', source: 'n1', target: 'n2', sourceHandle: 'output', targetHandle: 'input' },
+      {
+        id: 'e-n2-continue',
+        source: 'n2',
+        target: 'outer',
+        sourceHandle: 'output',
+        targetHandle: 'continue',
+      },
+    ];
+    const placement: ContainerPlacement = {
+      containerId: 'outer',
+      sourceNodeId: 'n1',
+      targetNodeId: 'n2',
+      mode: 'sequence',
+    };
+
+    const placed = placeContainerNode({
+      nodes: [containerNode, n1, n2, insertedNode],
+      insertedNode,
+      placement,
+      edges,
+      getNodeDimensions: (node) => getNodeDimensions(node),
+    });
+
+    const placedN1 = placed.find((node) => node.id === 'n1');
+    const placedN2 = placed.find((node) => node.id === 'n2');
+    // n1 stays put; n2 moves right to clear the inserted rectangle.
+    expect(placedN1?.position).toEqual({ x: 144, y: 112 });
+    expect(placedN2?.position.x).toBeGreaterThan(288);
+  });
+});

--- a/packages/apollo-react/src/canvas/utils/container.ts
+++ b/packages/apollo-react/src/canvas/utils/container.ts
@@ -1271,9 +1271,27 @@ export function placeContainerNode({
           })
         : fallbackTargetIds)
   );
+  // The upstream source must never shift, even when it appears in the
+  // chain via a cycle (Loop V1 body→…→loopBack chains among children).
+  if (placement.sourceNodeId) {
+    idsToShift.delete(placement.sourceNodeId);
+  }
+  // Back-edge detection (siblings only): when source is visually at or
+  // past target on the x axis, the original edge points backward in flow
+  // (a loopback). Skip the shift; getInsertedPosition places the inserted
+  // node past source, and the chain extends rightward naturally.
+  // Container.start edges (source = container itself) live in a different
+  // coord space and are always forward.
+  const sourceNode = placement.sourceNodeId ? nodesById.get(placement.sourceNodeId) : undefined;
+  const sourceIsContainer = placement.sourceNodeId === placement.containerId;
+  const isBackEdge =
+    !sourceIsContainer &&
+    sourceNode !== undefined &&
+    targetNode !== undefined &&
+    sourceNode.position.x >= targetNode.position.x;
   const requiredTargetLeft = positionedNode.position.x + insertedSize.width + gap;
   const downstreamShift =
-    targetNode && targetNode.position.x < requiredTargetLeft
+    !isBackEdge && targetNode && targetNode.position.x < requiredTargetLeft
       ? snapUpToGrid(requiredTargetLeft - targetNode.position.x)
       : 0;
   const positionedNodes = nodes.map((node) => {


### PR DESCRIPTION
## Summary

  PR #633's downstream-chain shift didn't account for nodes whose original edge is part of a cycle (Loop V1 self-loops, body→…→loopBack chains, both at top-level and inside containers). The shift moved the cycle's source/target away from the inserted node, producing long backward-wrapping edges and, in containers, a layout that wouldn't expand.

  ## Fix

  Two narrow guards in `shiftForEdgeInsertion` and `placeContainerNode`:

  1. **Always exclude `originalEdge.source` from the shift set** — the upstream source must never move, even when it appears in the linear chain via a back-edge.
  2. **Skip the shift entirely on back-edges** (`source.x >= target.x`) — the inserted node is placed past the source via the existing Step-1 / `getInsertedPosition` logic, and the chain extends rightward naturally so the container grows on its own.

  Container.start edges are exempt from the position check (different coordinate space, always forward).

  Both checks are O(1); no extra graph traversal vs. the buggy version.

  ## Tests

  Added regression coverage for:

  - self-loop top-level
  - body-cycle top-level
  - child self-loop in container
  - Loop V1 with branching parent-loopback in container
  - standard child → `container.continue` forward chain (asserts the shift still applies)

  Storybook `Add node panel with all shapes` now includes a While-loop fixture with a pre-wired self-loop edge and a `Loop — While` panel item for manual verification.


## Before

https://github.com/user-attachments/assets/f844393f-1a51-4547-a020-099de3db3fc5

## After

https://github.com/user-attachments/assets/ac56939a-bd6d-4199-8e41-36fc76ffb8f1

