### PR TITLE
fix(apollo-react): loop resource attachment fitting [MST-9332]

### DIFF
--- a/packages/apollo-react/src/canvas/components/AddNodePanel/AddNodeManager.helpers.test.ts
+++ b/packages/apollo-react/src/canvas/components/AddNodePanel/AddNodeManager.helpers.test.ts
@@ -377,4 +377,270 @@ describe('placeAddedNode', () => {
       expect(placedAction?.position).toBeDefined();
     });
   });
+
+  describe('non-container placement', () => {
+    it('leaves top-level generic additions unchanged when there is no collision', () => {
+      const registry = buildRegistry({
+        resource: { shape: 'circle' },
+        task: { shape: 'square' },
+      });
+      const task: Node = {
+        id: 'task',
+        type: 'task',
+        position: { x: 96, y: 96 },
+        measured: { width: 96, height: 96 },
+        data: {},
+      };
+      const previewNode: Node = {
+        id: PREVIEW_NODE_ID,
+        type: 'preview',
+        position: { x: 320, y: 240 },
+        width: 96,
+        height: 96,
+        data: {},
+      };
+      const insertedNode: Node = {
+        id: 'resource',
+        type: 'resource',
+        position: { x: 320, y: 240 },
+        data: {},
+      };
+
+      const { nodes, insertedNode: placedInsertedNode } = placeAddedNode({
+        nodes: [task, insertedNode],
+        edges: [],
+        previewNode,
+        insertedNode,
+        registry,
+      });
+
+      expect(placedInsertedNode.parentId).toBeUndefined();
+      expect(placedInsertedNode.position).toEqual({ x: 320, y: 240 });
+      expect(nodes.find((node) => node.id === 'task')?.position).toEqual({ x: 96, y: 96 });
+    });
+  });
+
+  describe('generic parented insertion', () => {
+    it('grows a container vertically around an attached child', () => {
+      const registry = buildRegistry({
+        loop: { shape: 'container' },
+        resource: { shape: 'circle' },
+      });
+      const loop: Node = {
+        id: 'loop',
+        type: 'loop',
+        position: { x: 0, y: 0 },
+        style: { width: 560, height: 320 },
+        data: {},
+      };
+      const previewNode: Node = {
+        id: PREVIEW_NODE_ID,
+        type: 'preview',
+        parentId: 'loop',
+        extent: 'parent',
+        position: { x: 240, y: 300 },
+        width: 96,
+        height: 96,
+        data: {},
+      };
+      const insertedNode: Node = {
+        id: 'resource',
+        type: 'resource',
+        parentId: 'loop',
+        extent: 'parent',
+        position: { x: 240, y: 300 },
+        data: {},
+      };
+
+      const { nodes, insertedNode: placedInsertedNode } = placeAddedNode({
+        nodes: [loop, insertedNode],
+        edges: [],
+        previewNode,
+        insertedNode,
+        registry,
+      });
+
+      const loopHeight = nodes.find((node) => node.id === 'loop')?.style?.height as
+        | number
+        | undefined;
+
+      expect(placedInsertedNode.parentId).toBe('loop');
+      expect(loopHeight).toBeGreaterThan(320);
+      expect(loopHeight).toBeGreaterThanOrEqual(placedInsertedNode.position.y + 96);
+    });
+
+    it('grows a container when an attached child is added above the safe area', () => {
+      const registry = buildRegistry({
+        agent: { shape: 'rectangle' },
+        loop: { shape: 'container' },
+        resource: { shape: 'circle' },
+      });
+      const loop: Node = {
+        id: 'loop',
+        type: 'loop',
+        position: { x: 0, y: 0 },
+        style: { width: 560, height: 320 },
+        data: {},
+      };
+      const agent: Node = {
+        id: 'agent',
+        type: 'agent',
+        parentId: 'loop',
+        extent: 'parent',
+        position: { x: 240, y: 112 },
+        measured: { width: 288, height: 96 },
+        data: {},
+      };
+      const previewNode: Node = {
+        id: PREVIEW_NODE_ID,
+        type: 'preview',
+        parentId: 'loop',
+        extent: 'parent',
+        position: { x: 240, y: 32 },
+        width: 96,
+        height: 96,
+        data: {},
+      };
+      const insertedNode: Node = {
+        id: 'resource',
+        type: 'resource',
+        parentId: 'loop',
+        extent: 'parent',
+        position: { x: 240, y: 32 },
+        data: {},
+      };
+
+      const { nodes, insertedNode: placedInsertedNode } = placeAddedNode({
+        nodes: [loop, agent, insertedNode],
+        edges: [],
+        previewNode,
+        insertedNode,
+        registry,
+      });
+
+      const loopHeight = nodes.find((node) => node.id === 'loop')?.style?.height as
+        | number
+        | undefined;
+      const placedAgent = nodes.find((node) => node.id === 'agent');
+
+      expect(placedInsertedNode.parentId).toBe('loop');
+      expect(placedInsertedNode.position.y).toBeGreaterThanOrEqual(96);
+      expect(placedAgent?.position.y).toBeGreaterThan(112);
+      expect(loopHeight).toBeGreaterThan(320);
+    });
+
+    it('does not resize a parent that is not a container manifest', () => {
+      const registry = buildRegistry({
+        group: { shape: 'square' },
+        resource: { shape: 'circle' },
+      });
+      const group: Node = {
+        id: 'group',
+        type: 'group',
+        position: { x: 0, y: 0 },
+        style: { width: 320, height: 220 },
+        data: {},
+      };
+      const siblingBelow: Node = {
+        id: 'sibling-below',
+        type: 'resource',
+        position: { x: 0, y: 260 },
+        measured: { width: 96, height: 96 },
+        data: {},
+      };
+      const previewNode: Node = {
+        id: PREVIEW_NODE_ID,
+        type: 'preview',
+        parentId: 'group',
+        extent: 'parent',
+        position: { x: 300, y: 240 },
+        width: 96,
+        height: 96,
+        data: {},
+      };
+      const insertedNode: Node = {
+        id: 'resource',
+        type: 'resource',
+        parentId: 'group',
+        extent: 'parent',
+        position: { x: 300, y: 240 },
+        data: {},
+      };
+
+      const { nodes } = placeAddedNode({
+        nodes: [group, siblingBelow, insertedNode],
+        edges: [],
+        previewNode,
+        insertedNode,
+        registry,
+      });
+
+      expect(nodes.find((node) => node.id === 'group')).toMatchObject({
+        style: { width: 320, height: 220 },
+      });
+      expect(nodes.find((node) => node.id === 'sibling-below')?.position).toEqual({
+        x: 0,
+        y: 260,
+      });
+    });
+
+    it('does not fit containers around ignored node types', () => {
+      const registry = buildRegistry({
+        loop: { shape: 'container' },
+        resource: { shape: 'circle' },
+        stickyNote: { shape: 'square' },
+      });
+      const loop: Node = {
+        id: 'loop',
+        type: 'loop',
+        position: { x: 0, y: 0 },
+        style: { width: 560, height: 320 },
+        data: {},
+      };
+      const ignoredStickyNote: Node = {
+        id: 'sticky-note',
+        type: 'stickyNote',
+        parentId: 'loop',
+        extent: 'parent',
+        position: { x: 0, y: 0 },
+        measured: { width: 96, height: 96 },
+        data: {},
+      };
+      const previewNode: Node = {
+        id: PREVIEW_NODE_ID,
+        type: 'preview',
+        parentId: 'loop',
+        extent: 'parent',
+        position: { x: 240, y: 112 },
+        width: 96,
+        height: 96,
+        data: {},
+      };
+      const insertedNode: Node = {
+        id: 'resource',
+        type: 'resource',
+        parentId: 'loop',
+        extent: 'parent',
+        position: { x: 240, y: 112 },
+        data: {},
+      };
+
+      const { nodes } = placeAddedNode({
+        nodes: [loop, ignoredStickyNote, insertedNode],
+        edges: [],
+        previewNode,
+        insertedNode,
+        registry,
+        ignoredNodeTypes: ['stickyNote'],
+      });
+
+      expect(nodes.find((node) => node.id === 'loop')).toMatchObject({
+        style: { width: 560, height: 320 },
+      });
+      expect(nodes.find((node) => node.id === 'sticky-note')?.position).toEqual({
+        x: 0,
+        y: 0,
+      });
+    });
+  });
 });

--- a/packages/apollo-react/src/canvas/components/AddNodePanel/AddNodeManager.helpers.ts
+++ b/packages/apollo-react/src/canvas/components/AddNodePanel/AddNodeManager.helpers.ts
@@ -7,7 +7,9 @@ import type { NodeManifest } from '../../schema';
 import { resolveCollisions } from '../../utils';
 import { getExpandedSize } from '../../utils/collapse';
 import {
+  CONTAINER_SEQUENCE_GAP_PX,
   collectLinearDownstreamSiblings,
+  fitContainersAndPushSiblings,
   getContainerFitGeometry,
   getContainerPlacement,
   getContainerSafeArea,
@@ -316,6 +318,7 @@ export function placeAddedNode({
         isContainerNodeManifest(getManifestForNode(registry, node))
           ? getContainerFitGeometry()
           : null,
+      ignoredNodeTypes,
     });
 
     return {
@@ -332,8 +335,35 @@ export function placeAddedNode({
     getNodeSize: getDimensions,
   });
 
-  return resolveScopedCollisions(shifted?.nodes ?? nodes, shifted?.insertedNode ?? insertedNode, {
+  const placementResult = resolveScopedCollisions(
+    shifted?.nodes ?? nodes,
+    shifted?.insertedNode ?? insertedNode,
+    {
+      ignoredNodeTypes,
+      getNodeSize: getDimensions,
+    }
+  );
+
+  if (!placementResult.insertedNode.parentId) {
+    return placementResult;
+  }
+
+  const fittedNodes = fitContainersAndPushSiblings({
+    nodes: placementResult.nodes,
+    containerIds: [placementResult.insertedNode.parentId],
+    getContainerFitGeometry: (node) =>
+      isContainerNodeManifest(getManifestForNode(registry, node))
+        ? getContainerFitGeometry()
+        : null,
+    getNodeDimensions: getDimensions,
     ignoredNodeTypes,
-    getNodeSize: getDimensions,
+    gap: CONTAINER_SEQUENCE_GAP_PX,
   });
+
+  return {
+    nodes: fittedNodes,
+    insertedNode:
+      fittedNodes.find((node) => node.id === placementResult.insertedNode.id) ??
+      placementResult.insertedNode,
+  };
 }

--- a/packages/apollo-react/src/canvas/components/LoopNode/LoopNode.helpers.test.ts
+++ b/packages/apollo-react/src/canvas/components/LoopNode/LoopNode.helpers.test.ts
@@ -105,6 +105,98 @@ describe('resolveContainerAddNodePreview', () => {
     expect(previewOverrides).toBeNull();
   });
 
+  it('keeps unresolved handles on the generic attachment path inside containers', () => {
+    const agentNode: Node = {
+      id: 'agent-1',
+      type: 'agent',
+      parentId: loopNode.id,
+      position: { x: 240, y: 112 },
+      measured: { width: 288, height: 96 },
+      data: {},
+    };
+    const reactFlowInstance = createReactFlowInstance({
+      nodes: [loopNode, agentNode],
+    });
+
+    const previewOverrides = resolveContainerAddNodePreview({
+      source: { nodeId: agentNode.id, handleId: 'runtime-tools' },
+      sourceHandleType: 'source',
+      reactFlowInstance,
+      getManifestForNode,
+    });
+
+    expect(previewOverrides).toBeNull();
+  });
+
+  it('uses per-instance handle configuration when classifying clicked handles', () => {
+    const taskNode: Node = {
+      id: 'task-1',
+      type: 'task',
+      parentId: loopNode.id,
+      position: { x: 240, y: 112 },
+      measured: { width: 96, height: 96 },
+      data: {
+        handleConfigurations: [
+          {
+            position: 'right',
+            handles: [{ id: 'runtime-output', type: 'source', handleType: 'output' }],
+          },
+        ],
+      },
+    };
+    const reactFlowInstance = createReactFlowInstance({
+      nodes: [loopNode, taskNode],
+    });
+
+    const previewOverrides = resolveContainerAddNodePreview({
+      source: { nodeId: taskNode.id, handleId: 'runtime-output' },
+      sourceHandleType: 'source',
+      reactFlowInstance,
+      getManifestForNode,
+    });
+
+    expect(previewOverrides).toMatchObject({
+      containerId: loopNode.id,
+      target: {
+        nodeId: loopNode.id,
+        handleId: 'continue',
+      },
+      data: {
+        placement: {
+          containerId: loopNode.id,
+          sourceNodeId: taskNode.id,
+          targetNodeId: loopNode.id,
+          mode: 'sequence',
+        },
+      },
+    });
+  });
+
+  it('treats an empty per-instance handle configuration as an explicit override', () => {
+    const taskNode: Node = {
+      id: 'task-1',
+      type: 'task',
+      parentId: loopNode.id,
+      position: { x: 240, y: 112 },
+      measured: { width: 96, height: 96 },
+      data: {
+        handleConfigurations: [],
+      },
+    };
+    const reactFlowInstance = createReactFlowInstance({
+      nodes: [loopNode, taskNode],
+    });
+
+    const previewOverrides = resolveContainerAddNodePreview({
+      source: { nodeId: taskNode.id, handleId: 'output' },
+      sourceHandleType: 'source',
+      reactFlowInstance,
+      getManifestForNode,
+    });
+
+    expect(previewOverrides).toBeNull();
+  });
+
   it('continues to append workflow output handles to the container continuation', () => {
     const taskNode: Node = {
       id: 'task-1',

--- a/packages/apollo-react/src/canvas/components/LoopNode/LoopNode.helpers.test.ts
+++ b/packages/apollo-react/src/canvas/components/LoopNode/LoopNode.helpers.test.ts
@@ -1,0 +1,200 @@
+import type { Edge, Node, ReactFlowInstance } from '@uipath/apollo-react/canvas/xyflow/react';
+import { describe, expect, it } from 'vitest';
+import type { NodeManifest } from '../../schema/node-definition';
+import { resolveContainerAddNodePreview } from './LoopNode.helpers';
+
+type PreviewManifest = Pick<NodeManifest, 'display' | 'handleConfiguration'>;
+
+function createReactFlowInstance({
+  nodes,
+  edges = [],
+}: {
+  nodes: Node[];
+  edges?: Edge[];
+}): ReactFlowInstance {
+  return {
+    getNode: (id: string) => nodes.find((node) => node.id === id),
+    getNodes: () => nodes,
+    getEdges: () => edges,
+  } as unknown as ReactFlowInstance;
+}
+
+const loopManifest: PreviewManifest = {
+  display: { label: 'Loop', icon: 'repeat', shape: 'container' },
+  handleConfiguration: [
+    {
+      position: 'left',
+      boundary: 'inner',
+      handles: [{ id: 'start', type: 'source', handleType: 'output' }],
+    },
+    {
+      position: 'right',
+      boundary: 'inner',
+      handles: [{ id: 'continue', type: 'target', handleType: 'input' }],
+    },
+  ],
+};
+
+const agentManifest: PreviewManifest = {
+  display: { label: 'Agent', icon: 'agent', shape: 'rectangle' },
+  handleConfiguration: [
+    {
+      position: 'bottom',
+      handles: [{ id: 'tools', type: 'source', handleType: 'artifact', label: 'Tools' }],
+    },
+    {
+      position: 'right',
+      handles: [{ id: 'success', type: 'source', handleType: 'output', label: 'Agent' }],
+    },
+  ],
+};
+
+const taskManifest: PreviewManifest = {
+  display: { label: 'Task', icon: 'box', shape: 'square' },
+  handleConfiguration: [
+    {
+      position: 'left',
+      handles: [{ id: 'input', type: 'target', handleType: 'input' }],
+    },
+    {
+      position: 'right',
+      handles: [{ id: 'output', type: 'source', handleType: 'output' }],
+    },
+  ],
+};
+
+const manifestsByType: Record<string, PreviewManifest> = {
+  agent: agentManifest,
+  loop: loopManifest,
+  task: taskManifest,
+};
+
+function getManifestForNode(node: Node): PreviewManifest | undefined {
+  return node.type ? manifestsByType[node.type] : undefined;
+}
+
+describe('resolveContainerAddNodePreview', () => {
+  const loopNode: Node = {
+    id: 'loop-1',
+    type: 'loop',
+    position: { x: 100, y: 80 },
+    style: { width: 704, height: 368 },
+    data: {},
+  };
+
+  it('keeps artifact handle previews on the generic attachment path inside containers', () => {
+    const agentNode: Node = {
+      id: 'agent-1',
+      type: 'agent',
+      parentId: loopNode.id,
+      position: { x: 240, y: 112 },
+      measured: { width: 288, height: 96 },
+      data: {},
+    };
+    const reactFlowInstance = createReactFlowInstance({
+      nodes: [loopNode, agentNode],
+    });
+
+    const previewOverrides = resolveContainerAddNodePreview({
+      source: { nodeId: agentNode.id, handleId: 'tools' },
+      sourceHandleType: 'source',
+      reactFlowInstance,
+      getManifestForNode,
+    });
+
+    expect(previewOverrides).toBeNull();
+  });
+
+  it('continues to append workflow output handles to the container continuation', () => {
+    const taskNode: Node = {
+      id: 'task-1',
+      type: 'task',
+      parentId: loopNode.id,
+      position: { x: 240, y: 112 },
+      measured: { width: 96, height: 96 },
+      data: {},
+    };
+    const reactFlowInstance = createReactFlowInstance({
+      nodes: [loopNode, taskNode],
+    });
+
+    const previewOverrides = resolveContainerAddNodePreview({
+      source: { nodeId: taskNode.id, handleId: 'output' },
+      sourceHandleType: 'source',
+      reactFlowInstance,
+      getManifestForNode,
+    });
+
+    expect(previewOverrides).toMatchObject({
+      containerId: loopNode.id,
+      positionMode: 'center',
+      target: {
+        nodeId: loopNode.id,
+        handleId: 'continue',
+      },
+      data: {
+        placement: {
+          containerId: loopNode.id,
+          sourceNodeId: taskNode.id,
+          targetNodeId: loopNode.id,
+          mode: 'sequence',
+        },
+      },
+    });
+  });
+
+  it('continues to insert workflow output handles between container children', () => {
+    const sourceNode: Node = {
+      id: 'task-1',
+      type: 'task',
+      parentId: loopNode.id,
+      position: { x: 160, y: 112 },
+      measured: { width: 96, height: 96 },
+      data: {},
+    };
+    const targetNode: Node = {
+      id: 'task-2',
+      type: 'task',
+      parentId: loopNode.id,
+      position: { x: 432, y: 112 },
+      measured: { width: 96, height: 96 },
+      data: {},
+    };
+    const existingEdge: Edge = {
+      id: 'task-1-task-2',
+      source: sourceNode.id,
+      sourceHandle: 'output',
+      target: targetNode.id,
+      targetHandle: 'input',
+    };
+    const reactFlowInstance = createReactFlowInstance({
+      nodes: [loopNode, sourceNode, targetNode],
+      edges: [existingEdge],
+    });
+
+    const previewOverrides = resolveContainerAddNodePreview({
+      source: { nodeId: sourceNode.id, handleId: 'output' },
+      sourceHandleType: 'source',
+      reactFlowInstance,
+      getManifestForNode,
+    });
+
+    expect(previewOverrides).toMatchObject({
+      containerId: loopNode.id,
+      positionMode: 'center',
+      target: {
+        nodeId: targetNode.id,
+        handleId: 'input',
+      },
+      data: {
+        originalEdge: existingEdge,
+        placement: {
+          containerId: loopNode.id,
+          sourceNodeId: sourceNode.id,
+          targetNodeId: targetNode.id,
+          mode: 'sequence',
+        },
+      },
+    });
+  });
+});

--- a/packages/apollo-react/src/canvas/components/LoopNode/LoopNode.helpers.ts
+++ b/packages/apollo-react/src/canvas/components/LoopNode/LoopNode.helpers.ts
@@ -3,7 +3,7 @@ import {
   Position,
   type ReactFlowInstance,
 } from '@uipath/apollo-react/canvas/xyflow/react';
-import type { NodeManifest } from '../../schema/node-definition';
+import type { HandleGroupManifest, NodeManifest } from '../../schema/node-definition';
 import {
   CONTAINER_FRAME_INSET_PX,
   getContainerSafeArea,
@@ -141,9 +141,14 @@ function resolveClickedHandleType({
   if (!sourceNode) return undefined;
 
   const sourceManifest = getManifestForNode(sourceNode);
-  if (!sourceManifest) return undefined;
+  const dataHandleConfiguration = (sourceNode.data as Record<string, unknown>)
+    ?.handleConfigurations;
+  const handleConfiguration = Array.isArray(dataHandleConfiguration)
+    ? (dataHandleConfiguration as HandleGroupManifest[])
+    : sourceManifest?.handleConfiguration;
+  if (!handleConfiguration) return undefined;
 
-  const sourceHandles = resolveHandles(sourceManifest.handleConfiguration, {
+  const sourceHandles = resolveHandles(handleConfiguration, {
     ...sourceNode.data,
     nodeId: sourceNode.id,
   });
@@ -178,9 +183,9 @@ export function resolveContainerAddNodePreview({
   });
 
   // Container sequence insertion is reserved for workflow outputs. Resource
-  // handles (artifact/input semantics) keep the generic attachment preview,
+  // handles and unresolved runtime handles keep the generic attachment preview,
   // scoped by the source node's parent container when one exists.
-  if (clickedHandleType && clickedHandleType !== 'output') {
+  if (clickedHandleType !== 'output') {
     return null;
   }
 

--- a/packages/apollo-react/src/canvas/components/LoopNode/LoopNode.helpers.ts
+++ b/packages/apollo-react/src/canvas/components/LoopNode/LoopNode.helpers.ts
@@ -126,6 +126,36 @@ function pickPreferredInnerHandle(
   return null;
 }
 
+function resolveClickedHandleType({
+  source,
+  reactFlowInstance,
+  getManifestForNode,
+}: {
+  source: PreviewEndpoint;
+  reactFlowInstance: ReactFlowInstance;
+  getManifestForNode: ContainerPreviewManifestResolver;
+}): string | undefined {
+  if (!source.handleId) return undefined;
+
+  const sourceNode = reactFlowInstance.getNode(source.nodeId);
+  if (!sourceNode) return undefined;
+
+  const sourceManifest = getManifestForNode(sourceNode);
+  if (!sourceManifest) return undefined;
+
+  const sourceHandles = resolveHandles(sourceManifest.handleConfiguration, {
+    ...sourceNode.data,
+    nodeId: sourceNode.id,
+  });
+
+  for (const group of sourceHandles) {
+    const handle = group.handles.find((candidate) => candidate.id === source.handleId);
+    if (handle) return handle.handleType;
+  }
+
+  return undefined;
+}
+
 /**
  * Produces preview-graph overrides for Add Node operations that interact with a
  * loop/container node.
@@ -141,6 +171,19 @@ export function resolveContainerAddNodePreview({
   reactFlowInstance: ReactFlowInstance;
   getManifestForNode: ContainerPreviewManifestResolver;
 }): PreviewGraphOverrides | null {
+  const clickedHandleType = resolveClickedHandleType({
+    source,
+    reactFlowInstance,
+    getManifestForNode,
+  });
+
+  // Container sequence insertion is reserved for workflow outputs. Resource
+  // handles (artifact/input semantics) keep the generic attachment preview,
+  // scoped by the source node's parent container when one exists.
+  if (clickedHandleType && clickedHandleType !== 'output') {
+    return null;
+  }
+
   return resolveContainerPreview({
     source,
     sourceHandleType,

--- a/packages/apollo-react/src/canvas/components/Toolbar/EdgeToolbar/useEdgeToolbarState.test.ts
+++ b/packages/apollo-react/src/canvas/components/Toolbar/EdgeToolbar/useEdgeToolbarState.test.ts
@@ -75,7 +75,16 @@ function createContainerRegistry(): NodeTypeRegistry {
         : {
             nodeType,
             display: { label: 'Task', shape: 'square' },
-            handleConfiguration: [],
+            handleConfiguration: [
+              {
+                position: 'left',
+                handles: [{ id: 'input', type: 'target', handleType: 'input' }],
+              },
+              {
+                position: 'right',
+                handles: [{ id: 'output', type: 'source', handleType: 'output' }],
+              },
+            ],
           }
     ),
   } as unknown as NodeTypeRegistry;

--- a/packages/apollo-react/src/canvas/utils/container.test.ts
+++ b/packages/apollo-react/src/canvas/utils/container.test.ts
@@ -66,6 +66,7 @@ describe('container sizing', () => {
     expect(result.nodes.find((node) => node.id === containerNode.id)).toMatchObject({
       style: { width: 720, height: 384 },
     });
+    expect(result.nodes.find((node) => node.id === childNode.id)).toBe(childNode);
   });
 
   it('shifts children down and grows when a child starts above the safe area', () => {
@@ -213,6 +214,74 @@ describe('container sizing', () => {
     expect(result.changes).toEqual([]);
     expect(result.nodes.find((node) => node.id === containerNode.id)).toMatchObject({
       style: { width: 560, height: 320 },
+    });
+    expect(result.nodes.find((node) => node.id === PREVIEW_NODE_ID)?.position).toEqual({
+      x: 0,
+      y: 0,
+    });
+    expect(result.nodes.find((node) => node.id === 'hidden-child')?.position).toEqual({
+      x: 0,
+      y: 0,
+    });
+    expect(result.nodes.find((node) => node.id === 'ignored-child')?.position).toEqual({
+      x: 0,
+      y: 0,
+    });
+  });
+
+  it('does not shift preview, hidden, or ignored children when applying leading padding', () => {
+    const containerNode: Node = {
+      id: 'loop-1',
+      type: 'loop',
+      position: { x: 0, y: 0 },
+      style: { width: 560, height: 320 },
+      data: {},
+    };
+    const topChild: Node = {
+      id: 'top-child',
+      type: 'task',
+      parentId: containerNode.id,
+      position: { x: 144, y: 32 },
+      measured: { width: 96, height: 96 },
+      data: {},
+    };
+    const previewChild: Node = {
+      id: PREVIEW_NODE_ID,
+      type: 'preview',
+      parentId: containerNode.id,
+      position: { x: 0, y: 0 },
+      measured: { width: 96, height: 96 },
+      data: {},
+    };
+    const hiddenChild: Node = {
+      id: 'hidden-child',
+      type: 'task',
+      parentId: containerNode.id,
+      hidden: true,
+      position: { x: 0, y: 0 },
+      measured: { width: 96, height: 96 },
+      data: {},
+    };
+    const ignoredChild: Node = {
+      id: 'ignored-child',
+      type: 'stickyNote',
+      parentId: containerNode.id,
+      position: { x: 0, y: 0 },
+      measured: { width: 96, height: 96 },
+      data: {},
+    };
+
+    const result = ensureContainersFitChildren(
+      [containerNode, topChild, previewChild, hiddenChild, ignoredChild],
+      {
+        getContainerFitGeometry: () => getContainerFitGeometry(),
+        ignoredNodeTypes: ['stickyNote'],
+      }
+    );
+
+    expect(result.nodes.find((node) => node.id === 'top-child')?.position).toEqual({
+      x: 144,
+      y: 96,
     });
     expect(result.nodes.find((node) => node.id === PREVIEW_NODE_ID)?.position).toEqual({
       x: 0,

--- a/packages/apollo-react/src/canvas/utils/container.test.ts
+++ b/packages/apollo-react/src/canvas/utils/container.test.ts
@@ -1,5 +1,6 @@
 import type { Node } from '@uipath/apollo-react/canvas/xyflow/react';
 import { describe, expect, it } from 'vitest';
+import { PREVIEW_NODE_ID } from '../constants';
 import {
   type ContainerPlacement,
   DEFAULT_CONTAINER_MIN_HEIGHT,
@@ -30,7 +31,7 @@ describe('container sizing', () => {
     expect(getContainerFitGeometry()).toMatchObject({
       minWidth: DEFAULT_CONTAINER_MIN_WIDTH,
       minHeight: DEFAULT_CONTAINER_MIN_HEIGHT,
-      padding: { right: 144, bottom: 48 },
+      padding: { left: 144, right: 144, top: 96, bottom: 48 },
     });
   });
 
@@ -64,6 +65,214 @@ describe('container sizing', () => {
     ]);
     expect(result.nodes.find((node) => node.id === containerNode.id)).toMatchObject({
       style: { width: 720, height: 384 },
+    });
+  });
+
+  it('shifts children down and grows when a child starts above the safe area', () => {
+    const containerNode: Node = {
+      id: 'loop-1',
+      type: 'loop',
+      position: { x: 0, y: 0 },
+      style: { width: 704, height: 320 },
+      data: {},
+    };
+    const topChild: Node = {
+      id: 'top-child',
+      type: 'task',
+      parentId: containerNode.id,
+      position: { x: 240, y: 32 },
+      measured: { width: 96, height: 96 },
+      data: {},
+    };
+    const bodyChild: Node = {
+      id: 'body-child',
+      type: 'task',
+      parentId: containerNode.id,
+      position: { x: 384, y: 112 },
+      measured: { width: 96, height: 96 },
+      data: {},
+    };
+
+    const result = ensureContainersFitChildren([containerNode, topChild, bodyChild], {
+      getContainerFitGeometry: () => getContainerFitGeometry(),
+    });
+
+    expect(result.changes).toEqual([
+      expect.objectContaining({
+        containerId: containerNode.id,
+        previousSize: { width: 704, height: 320 },
+        nextSize: { width: 704, height: 384 },
+      }),
+    ]);
+    expect(result.nodes.find((node) => node.id === 'top-child')?.position).toEqual({
+      x: 240,
+      y: 96,
+    });
+    expect(result.nodes.find((node) => node.id === 'body-child')?.position).toEqual({
+      x: 384,
+      y: 176,
+    });
+  });
+
+  it('shifts children right and grows when a child starts left of the safe area', () => {
+    const containerNode: Node = {
+      id: 'loop-1',
+      type: 'loop',
+      position: { x: 0, y: 0 },
+      style: { width: 560, height: 320 },
+      data: {},
+    };
+    const leftChild: Node = {
+      id: 'left-child',
+      type: 'task',
+      parentId: containerNode.id,
+      position: { x: 96, y: 112 },
+      measured: { width: 96, height: 96 },
+      data: {},
+    };
+    const bodyChild: Node = {
+      id: 'body-child',
+      type: 'task',
+      parentId: containerNode.id,
+      position: { x: 240, y: 112 },
+      measured: { width: 96, height: 96 },
+      data: {},
+    };
+
+    const result = ensureContainersFitChildren([containerNode, leftChild, bodyChild], {
+      getContainerFitGeometry: () => getContainerFitGeometry(),
+    });
+
+    expect(result.changes).toEqual([
+      expect.objectContaining({
+        containerId: containerNode.id,
+        previousSize: { width: 560, height: 320 },
+        nextSize: { width: 608, height: 320 },
+      }),
+    ]);
+    expect(result.nodes.find((node) => node.id === 'left-child')?.position).toEqual({
+      x: 144,
+      y: 112,
+    });
+    expect(result.nodes.find((node) => node.id === 'body-child')?.position).toEqual({
+      x: 288,
+      y: 112,
+    });
+  });
+
+  it('ignores preview, hidden, and ignored child types when fitting', () => {
+    const containerNode: Node = {
+      id: 'loop-1',
+      type: 'loop',
+      position: { x: 0, y: 0 },
+      style: { width: 560, height: 320 },
+      data: {},
+    };
+    const bodyChild: Node = {
+      id: 'body-child',
+      type: 'task',
+      parentId: containerNode.id,
+      position: { x: 144, y: 112 },
+      measured: { width: 96, height: 96 },
+      data: {},
+    };
+    const previewChild: Node = {
+      id: PREVIEW_NODE_ID,
+      type: 'preview',
+      parentId: containerNode.id,
+      position: { x: 0, y: 0 },
+      measured: { width: 96, height: 96 },
+      data: {},
+    };
+    const hiddenChild: Node = {
+      id: 'hidden-child',
+      type: 'task',
+      parentId: containerNode.id,
+      hidden: true,
+      position: { x: 0, y: 0 },
+      measured: { width: 96, height: 96 },
+      data: {},
+    };
+    const ignoredChild: Node = {
+      id: 'ignored-child',
+      type: 'stickyNote',
+      parentId: containerNode.id,
+      position: { x: 0, y: 0 },
+      measured: { width: 96, height: 96 },
+      data: {},
+    };
+
+    const result = ensureContainersFitChildren(
+      [containerNode, bodyChild, previewChild, hiddenChild, ignoredChild],
+      {
+        getContainerFitGeometry: () => getContainerFitGeometry(),
+        ignoredNodeTypes: ['stickyNote'],
+      }
+    );
+
+    expect(result.changes).toEqual([]);
+    expect(result.nodes.find((node) => node.id === containerNode.id)).toMatchObject({
+      style: { width: 560, height: 320 },
+    });
+    expect(result.nodes.find((node) => node.id === PREVIEW_NODE_ID)?.position).toEqual({
+      x: 0,
+      y: 0,
+    });
+    expect(result.nodes.find((node) => node.id === 'hidden-child')?.position).toEqual({
+      x: 0,
+      y: 0,
+    });
+    expect(result.nodes.find((node) => node.id === 'ignored-child')?.position).toEqual({
+      x: 0,
+      y: 0,
+    });
+  });
+
+  it('fits ancestors after a nested container grows from leading padding', () => {
+    const outerContainer: Node = {
+      id: 'outer',
+      type: 'loop',
+      position: { x: 0, y: 0 },
+      style: { width: 704, height: 320 },
+      data: {},
+    };
+    const innerContainer: Node = {
+      id: 'inner',
+      type: 'loop',
+      parentId: outerContainer.id,
+      extent: 'parent',
+      position: { x: 144, y: 32 },
+      style: { width: 400, height: 224 },
+      data: {},
+    };
+    const innerChild: Node = {
+      id: 'inner-child',
+      type: 'task',
+      parentId: innerContainer.id,
+      extent: 'parent',
+      position: { x: 144, y: 0 },
+      measured: { width: 96, height: 96 },
+      data: {},
+    };
+
+    const result = ensureContainersFitChildren([outerContainer, innerContainer, innerChild], {
+      containerIds: [innerContainer.id],
+      getContainerFitGeometry: () => getContainerFitGeometry(),
+    });
+
+    expect(result.nodes.find((node) => node.id === 'inner-child')?.position).toEqual({
+      x: 144,
+      y: 96,
+    });
+    expect(result.nodes.find((node) => node.id === 'inner')?.position).toEqual({
+      x: 144,
+      y: 96,
+    });
+    expect(result.nodes.find((node) => node.id === 'inner')).toMatchObject({
+      style: { width: 400, height: 320 },
+    });
+    expect(result.nodes.find((node) => node.id === 'outer')).toMatchObject({
+      style: { width: 704, height: 464 },
     });
   });
 });

--- a/packages/apollo-react/src/canvas/utils/container.ts
+++ b/packages/apollo-react/src/canvas/utils/container.ts
@@ -31,14 +31,16 @@ export interface NodeDimensions {
 
 /**
  * Sizing rules used when a container needs to grow around its children.
- * Padding is trailing-only because child positions are already relative to the
- * container's top-left corner.
+ * Leading padding shifts children into the safe area before size is computed;
+ * trailing padding reserves room after the children.
  */
 export interface ContainerFitGeometry {
   minWidth: number;
   minHeight: number;
   padding?: {
+    left?: number;
     right?: number;
+    top?: number;
     bottom?: number;
   };
 }
@@ -223,10 +225,7 @@ export function getContainerFitGeometry(): ContainerFitGeometry {
   return {
     minWidth: DEFAULT_CONTAINER_MIN_WIDTH,
     minHeight: DEFAULT_CONTAINER_MIN_HEIGHT,
-    padding: {
-      right: padding.right,
-      bottom: padding.bottom,
-    },
+    padding,
   };
 }
 
@@ -335,6 +334,9 @@ export function ensureContainersFitChildren(
     const padding = geometry.padding ?? {};
     let requiredWidth = geometry.minWidth;
     let requiredHeight = geometry.minHeight;
+    let leadingShiftX = 0;
+    let leadingShiftY = 0;
+    const childrenToFit: Array<{ node: Node; size: NodeDimensions }> = [];
 
     for (const childNode of nextNodes) {
       // Transient, hidden, and ignored children should not force a persisted
@@ -349,34 +351,72 @@ export function ensureContainersFitChildren(
       }
 
       const childSize = resolveNodeDimensions(childNode);
+      childrenToFit.push({ node: childNode, size: childSize });
+
+      if (padding.left !== undefined) {
+        leadingShiftX = Math.max(leadingShiftX, padding.left - childNode.position.x);
+      }
+      if (padding.top !== undefined) {
+        leadingShiftY = Math.max(leadingShiftY, padding.top - childNode.position.y);
+      }
+    }
+
+    leadingShiftX = leadingShiftX > 0 ? snapUpToGrid(leadingShiftX) : 0;
+    leadingShiftY = leadingShiftY > 0 ? snapUpToGrid(leadingShiftY) : 0;
+
+    for (const { node: childNode, size: childSize } of childrenToFit) {
       requiredWidth = Math.max(
         requiredWidth,
-        childNode.position.x + childSize.width + (padding.right ?? 0)
+        childNode.position.x + leadingShiftX + childSize.width + (padding.right ?? 0)
       );
       requiredHeight = Math.max(
         requiredHeight,
-        childNode.position.y + childSize.height + (padding.bottom ?? 0)
+        childNode.position.y + leadingShiftY + childSize.height + (padding.bottom ?? 0)
       );
     }
+
+    requiredWidth = Math.max(requiredWidth, currentSize.width + leadingShiftX);
+    requiredHeight = Math.max(requiredHeight, currentSize.height + leadingShiftY);
 
     const nextSize = {
       width: Math.max(currentSize.width, snapUpToGrid(requiredWidth)),
       height: Math.max(currentSize.height, snapUpToGrid(requiredHeight)),
     };
 
-    if (nextSize.width === currentSize.width && nextSize.height === currentSize.height) {
+    if (
+      nextSize.width === currentSize.width &&
+      nextSize.height === currentSize.height &&
+      leadingShiftX === 0 &&
+      leadingShiftY === 0
+    ) {
       continue;
     }
 
-    nextNodes = nextNodes.map((node) =>
-      node.id === containerId ? withNodeDimensions(node, nextSize) : node
-    );
-    nodesById.set(containerId, nextNodes.find((node) => node.id === containerId)!);
-    changes.push({
-      containerId,
-      previousSize: currentSize,
-      nextSize,
+    nextNodes = nextNodes.map((node) => {
+      if (node.id === containerId) {
+        return withNodeDimensions(node, nextSize);
+      }
+
+      if (node.parentId === containerId && node.id !== PREVIEW_NODE_ID) {
+        return {
+          ...node,
+          position: {
+            x: node.position.x + leadingShiftX,
+            y: node.position.y + leadingShiftY,
+          },
+        };
+      }
+
+      return node;
     });
+    nodesById.set(containerId, nextNodes.find((node) => node.id === containerId)!);
+    if (nextSize.width !== currentSize.width || nextSize.height !== currentSize.height) {
+      changes.push({
+        containerId,
+        previousSize: currentSize,
+        nextSize,
+      });
+    }
   }
 
   return { nodes: nextNodes, changes };
@@ -1133,17 +1173,19 @@ function pushSiblingsAfterContainerGrowth({
   return { nodes: nextNodes, shifted };
 }
 
-function fitContainersAndPushSiblings({
+export function fitContainersAndPushSiblings({
   nodes,
   containerIds,
   getContainerFitGeometry,
   getNodeDimensions,
+  ignoredNodeTypes,
   gap,
 }: {
   nodes: Node[];
   containerIds: Iterable<string>;
   getContainerFitGeometry: (containerNode: Node) => ContainerFitGeometry | null | undefined;
   getNodeDimensions: (node: Node) => NodeDimensions;
+  ignoredNodeTypes?: string[];
   gap: number;
 }): Node[] {
   let nextNodes = nodes;
@@ -1156,6 +1198,7 @@ function fitContainersAndPushSiblings({
       containerIds,
       getContainerFitGeometry,
       getNodeDimensions,
+      ignoredNodeTypes,
       includeAncestors: true,
     });
 
@@ -1211,6 +1254,7 @@ export function placeContainerNode({
   getNodeDimensions: resolveNodeDimensions = getNodeDimensions,
   gap = CONTAINER_SEQUENCE_GAP_PX,
   downstreamNodeIds,
+  ignoredNodeTypes,
   edges,
 }: {
   nodes: Node[];
@@ -1221,6 +1265,7 @@ export function placeContainerNode({
   getNodeDimensions?: (node: Node) => NodeDimensions;
   gap?: number;
   downstreamNodeIds?: Iterable<string>;
+  ignoredNodeTypes?: string[];
   edges?: Edge[];
 }): Node[] {
   const containerNode = nodes.find((node) => node.id === placement.containerId)!;
@@ -1314,6 +1359,7 @@ export function placeContainerNode({
     containerIds: [placement.containerId],
     getContainerFitGeometry: resolveContainerFitGeometry,
     getNodeDimensions: resolveNodeDimensions,
+    ignoredNodeTypes,
     gap,
   });
 }

--- a/packages/apollo-react/src/canvas/utils/container.ts
+++ b/packages/apollo-react/src/canvas/utils/container.ts
@@ -337,6 +337,7 @@ export function ensureContainersFitChildren(
     let leadingShiftX = 0;
     let leadingShiftY = 0;
     const childrenToFit: Array<{ node: Node; size: NodeDimensions }> = [];
+    const childIdsToShift = new Set<string>();
 
     for (const childNode of nextNodes) {
       // Transient, hidden, and ignored children should not force a persisted
@@ -352,6 +353,7 @@ export function ensureContainersFitChildren(
 
       const childSize = resolveNodeDimensions(childNode);
       childrenToFit.push({ node: childNode, size: childSize });
+      childIdsToShift.add(childNode.id);
 
       if (padding.left !== undefined) {
         leadingShiftX = Math.max(leadingShiftX, padding.left - childNode.position.x);
@@ -392,12 +394,14 @@ export function ensureContainersFitChildren(
       continue;
     }
 
+    const shouldShiftChildren = leadingShiftX !== 0 || leadingShiftY !== 0;
+
     nextNodes = nextNodes.map((node) => {
       if (node.id === containerId) {
         return withNodeDimensions(node, nextSize);
       }
 
-      if (node.parentId === containerId && node.id !== PREVIEW_NODE_ID) {
+      if (shouldShiftChildren && childIdsToShift.has(node.id)) {
         return {
           ...node,
           position: {

--- a/packages/apollo-react/src/canvas/utils/createPreviewGraph.test.ts
+++ b/packages/apollo-react/src/canvas/utils/createPreviewGraph.test.ts
@@ -152,6 +152,72 @@ describe('createPreviewGraph', () => {
     expect(preview?.node.position.x).toBeGreaterThan(childNode.position.x);
   });
 
+  it('keeps child attachment previews in the parent container on the clicked handle side', () => {
+    const containerNode: Node = {
+      id: 'loop-node',
+      type: 'loop',
+      position: { x: 100, y: 50 },
+      data: {},
+    };
+    const agentNode: Node = {
+      id: 'agent-node',
+      type: 'agent',
+      parentId: containerNode.id,
+      position: { x: 240, y: 120 },
+      measured: { width: 288, height: 96 },
+      data: {},
+    };
+    const reactFlowInstance = createReactFlowInstance({
+      nodes: [containerNode, agentNode],
+    });
+
+    const bottomPreview = createPreviewGraph({
+      source: {
+        nodeId: agentNode.id,
+        handleId: 'tools',
+      },
+      reactFlowInstance,
+      handlePosition: Position.Bottom,
+    });
+
+    expect(bottomPreview?.node).toMatchObject({
+      id: PREVIEW_NODE_ID,
+      parentId: containerNode.id,
+      extent: 'parent',
+    });
+    expect(bottomPreview?.node.position.y).toBeGreaterThan(agentNode.position.y + 96);
+    expect(bottomPreview?.edges).toHaveLength(1);
+    expect(bottomPreview?.edges[0]).toMatchObject({
+      source: agentNode.id,
+      sourceHandle: 'tools',
+      target: PREVIEW_NODE_ID,
+      targetHandle: 'input',
+    });
+
+    const topPreview = createPreviewGraph({
+      source: {
+        nodeId: agentNode.id,
+        handleId: 'memory',
+      },
+      reactFlowInstance,
+      handlePosition: Position.Top,
+    });
+
+    expect(topPreview?.node).toMatchObject({
+      id: PREVIEW_NODE_ID,
+      parentId: containerNode.id,
+      extent: 'parent',
+    });
+    expect(topPreview?.node.position.y).toBeLessThan(agentNode.position.y);
+    expect(topPreview?.edges).toHaveLength(1);
+    expect(topPreview?.edges[0]).toMatchObject({
+      source: agentNode.id,
+      sourceHandle: 'memory',
+      target: PREVIEW_NODE_ID,
+      targetHandle: 'input',
+    });
+  });
+
   it('filters original edges only when the preview graph is applied', () => {
     vi.useFakeTimers();
 


### PR DESCRIPTION
## Summary

Fixes add-node behavior for agent resource handles inside loop/container nodes. Resource handles such as Memory, Tools, Context, and Escalations now stay on the generic attachment path instead of being interpreted as loop sequence insertions to the container continuation handle.

The root cause was that container preview overrides treated any source handle inside a loop as a sequence intent. That created a preview connected to Continue and also filtered the toolbox as if the next node had to satisfy the workflow continuation edge. Once the preview was corrected, materializing top/bottom attachments exposed a second geometry gap: container fitting only handled trailing bottom/right overflow, so attachments above the safe area did not create vertical space.

## Demo

Before - 

https://github.com/user-attachments/assets/e82ee8b6-ba01-4399-b99c-10c255acc7a4


After -

https://github.com/user-attachments/assets/36a7d84f-bed7-4295-8714-24f590cab222


## Changes

- Restrict loop sequence preview overrides to workflow output handles.
- Let resource-handle previews remain parented to their containing loop on the clicked handle side.
- Run container fit/push for generic parented additions, not only sequence placements.
- Extend container fit geometry to account for leading top/left padding by shifting children into the safe area and growing the container to preserve trailing room.
- Thread ignored node types through container fit/push so ignored decorations do not resize containers.

## Validation

- `pnpm --filter @uipath/apollo-react exec vitest --run src/canvas/components/AddNodePanel/AddNodeManager.helpers.test.ts src/canvas/utils/container.test.ts`
- `pnpm --filter @uipath/apollo-react exec vitest --run src/canvas/components/AddNodePanel/AddNodeManager.test.tsx src/canvas/components/Toolbar/EdgeToolbar/useEdgeToolbarState.test.ts src/canvas/components/LoopNode/LoopNode.helpers.test.ts src/canvas/utils/createPreviewGraph.test.ts`
- `pnpm --filter @uipath/apollo-react exec biome check src/canvas/components/AddNodePanel/AddNodeManager.helpers.ts src/canvas/components/AddNodePanel/AddNodeManager.helpers.test.ts src/canvas/utils/container.ts src/canvas/utils/container.test.ts`
- `pnpm --filter @uipath/apollo-react exec tsc --noEmit --pretty false -p tsconfig.json`
- `git diff --check`