### PR TITLE
feat(apollo-react): add Toolbox quickActions slot

### DIFF
--- a/packages/apollo-react/src/canvas/components/Toolbox/QuickActionsRow.test.tsx
+++ b/packages/apollo-react/src/canvas/components/Toolbox/QuickActionsRow.test.tsx
@@ -1,0 +1,148 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen, type UserEvent, userEvent } from '../../utils/testing';
+import type { ListItem } from './ListView';
+import type { ToolboxQuickAction } from './QuickActionsRow';
+import { Toolbox } from './Toolbox';
+
+const mockItems: ListItem[] = [
+  {
+    id: 'item-1',
+    name: 'Item 1',
+    data: { value: 'data-1' },
+    icon: { name: 'star' },
+  },
+];
+
+const baseProps = {
+  title: 'Test Toolbox',
+  initialItems: mockItems,
+  onClose: vi.fn(),
+  onItemSelect: vi.fn(),
+};
+
+describe('Toolbox quickActions', () => {
+  let user: UserEvent;
+
+  beforeEach(() => {
+    user = userEvent.setup();
+  });
+
+  it('does not render the quick actions row when quickActions is undefined', () => {
+    render(<Toolbox {...baseProps} />);
+
+    expect(screen.queryByTestId('toolbox-quick-actions')).not.toBeInTheDocument();
+  });
+
+  it('does not render the quick actions row when quickActions is empty', () => {
+    render(<Toolbox {...baseProps} quickActions={[]} />);
+
+    expect(screen.queryByTestId('toolbox-quick-actions')).not.toBeInTheDocument();
+  });
+
+  it('renders all leading actions and no separator when only leading actions exist', () => {
+    const actions: ToolboxQuickAction[] = [
+      { id: 'a', title: 'Action A', icon: <span>A</span> },
+      { id: 'b', title: 'Action B', icon: <span>B</span> },
+      { id: 'c', title: 'Action C', icon: <span>C</span> },
+    ];
+
+    render(<Toolbox {...baseProps} quickActions={actions} />);
+
+    expect(screen.getByTestId('toolbox-quick-actions')).toBeInTheDocument();
+    expect(screen.getByTestId('toolbox-quick-action-a')).toBeInTheDocument();
+    expect(screen.getByTestId('toolbox-quick-action-b')).toBeInTheDocument();
+    expect(screen.getByTestId('toolbox-quick-action-c')).toBeInTheDocument();
+    expect(screen.queryByTestId('toolbox-quick-actions-separator')).not.toBeInTheDocument();
+  });
+
+  it('renders a separator between leading and trailing actions', () => {
+    const actions: ToolboxQuickAction[] = [
+      { id: 'a', title: 'Action A', icon: <span>A</span> },
+      { id: 'b', title: 'Action B', icon: <span>B</span> },
+      { id: 'connect', title: 'Connect', icon: <span>C</span>, trailing: true },
+    ];
+
+    render(<Toolbox {...baseProps} quickActions={actions} />);
+
+    expect(screen.getByTestId('toolbox-quick-actions-separator')).toBeInTheDocument();
+    expect(screen.getByTestId('toolbox-quick-action-connect')).toBeInTheDocument();
+  });
+
+  it('does not render a separator when only trailing actions exist', () => {
+    const actions: ToolboxQuickAction[] = [
+      { id: 'connect', title: 'Connect', icon: <span>C</span>, trailing: true },
+    ];
+
+    render(<Toolbox {...baseProps} quickActions={actions} />);
+
+    expect(screen.getByTestId('toolbox-quick-action-connect')).toBeInTheDocument();
+    expect(screen.queryByTestId('toolbox-quick-actions-separator')).not.toBeInTheDocument();
+  });
+
+  it('fires onClick when an action button is clicked', async () => {
+    const onClick = vi.fn();
+    const actions: ToolboxQuickAction[] = [
+      { id: 'a', title: 'Action A', icon: <span>A</span>, onClick },
+    ];
+
+    render(<Toolbox {...baseProps} quickActions={actions} />);
+
+    await user.click(screen.getByTestId('toolbox-quick-action-a'));
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('fires onMouseEnter and onMouseLeave on hover', async () => {
+    const onMouseEnter = vi.fn();
+    const onMouseLeave = vi.fn();
+    const actions: ToolboxQuickAction[] = [
+      { id: 'a', title: 'Action A', icon: <span>A</span>, onMouseEnter, onMouseLeave },
+    ];
+
+    render(<Toolbox {...baseProps} quickActions={actions} />);
+
+    const button = screen.getByTestId('toolbox-quick-action-a');
+    await user.hover(button);
+    expect(onMouseEnter).toHaveBeenCalled();
+
+    await user.unhover(button);
+    expect(onMouseLeave).toHaveBeenCalled();
+  });
+
+  it('disables the button and suppresses onClick when disabled is true', async () => {
+    const onClick = vi.fn();
+    const actions: ToolboxQuickAction[] = [
+      { id: 'a', title: 'Action A', icon: <span>A</span>, onClick, disabled: true },
+    ];
+
+    render(<Toolbox {...baseProps} quickActions={actions} />);
+
+    const button = screen.getByTestId('toolbox-quick-action-a');
+    expect(button).toBeDisabled();
+
+    await user.click(button);
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
+  it('uses title as aria-label on each button', () => {
+    const actions: ToolboxQuickAction[] = [
+      { id: 'a', title: 'Add element', icon: <span>A</span> },
+      { id: 'b', title: 'Delete element', icon: <span>B</span> },
+    ];
+
+    render(<Toolbox {...baseProps} quickActions={actions} />);
+
+    expect(screen.getByRole('button', { name: 'Add element' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Delete element' })).toBeInTheDocument();
+  });
+
+  it('renders the quick actions row above the title', () => {
+    const actions: ToolboxQuickAction[] = [{ id: 'a', title: 'Action A', icon: <span>A</span> }];
+
+    render(<Toolbox {...baseProps} quickActions={actions} />);
+
+    const row = screen.getByTestId('toolbox-quick-actions');
+    const title = screen.getByText('Test Toolbox');
+
+    expect(row.compareDocumentPosition(title) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+});

--- a/packages/apollo-react/src/canvas/components/Toolbox/QuickActionsRow.tsx
+++ b/packages/apollo-react/src/canvas/components/Toolbox/QuickActionsRow.tsx
@@ -1,4 +1,3 @@
-import styled from '@emotion/styled';
 import { Button } from '@uipath/apollo-wind';
 import { memo, type MouseEvent, type ReactNode } from 'react';
 import { TOOLBOX_PADDING_X } from '../../constants';
@@ -18,26 +17,6 @@ export type ToolboxQuickAction = {
 interface QuickActionsRowProps {
   actions: ToolboxQuickAction[];
 }
-
-const Container = styled.div`
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 12px;
-  min-height: 44px;
-  padding: 0 ${TOOLBOX_PADDING_X}px 8px;
-  margin: 0 -${TOOLBOX_PADDING_X}px;
-  border-bottom: 1px solid var(--canvas-border-de-emp);
-  flex-shrink: 0;
-`;
-
-const Separator = styled.div`
-  width: 1px;
-  align-self: stretch;
-  margin: 0 4px;
-  background: var(--canvas-border-de-emp);
-  flex-shrink: 0;
-`;
 
 function QuickActionButton({ action, wide }: { action: ToolboxQuickAction; wide?: boolean }) {
   return (
@@ -67,16 +46,23 @@ export const QuickActionsRow = memo(function QuickActionsRow({ actions }: QuickA
   const trailing = actions.filter((a) => a.trailing);
 
   return (
-    <Container data-testid="toolbox-quick-actions">
+    <div
+      className="flex items-center justify-center gap-3 min-h-11 pb-2 border-b border-border shrink-0"
+      style={{ paddingInline: TOOLBOX_PADDING_X, marginInline: -TOOLBOX_PADDING_X }}
+      data-testid="toolbox-quick-actions"
+    >
       {leading.map((action) => (
         <QuickActionButton key={action.id} action={action} />
       ))}
       {trailing.length > 0 && leading.length > 0 && (
-        <Separator data-testid="toolbox-quick-actions-separator" />
+        <div
+          className="w-px self-stretch mx-1 bg-border shrink-0"
+          data-testid="toolbox-quick-actions-separator"
+        />
       )}
       {trailing.map((action) => (
         <QuickActionButton key={action.id} action={action} wide />
       ))}
-    </Container>
+    </div>
   );
 });

--- a/packages/apollo-react/src/canvas/components/Toolbox/QuickActionsRow.tsx
+++ b/packages/apollo-react/src/canvas/components/Toolbox/QuickActionsRow.tsx
@@ -1,0 +1,82 @@
+import styled from '@emotion/styled';
+import { Button } from '@uipath/apollo-wind';
+import { memo, type MouseEvent, type ReactNode } from 'react';
+import { TOOLBOX_PADDING_X } from '../../constants';
+import { CanvasTooltip } from '../CanvasTooltip';
+
+export type ToolboxQuickAction = {
+  id: string;
+  title: string;
+  icon: ReactNode;
+  onClick?: (e: MouseEvent<HTMLButtonElement>) => void;
+  onMouseEnter?: () => void;
+  onMouseLeave?: () => void;
+  trailing?: boolean;
+  disabled?: boolean;
+};
+
+interface QuickActionsRowProps {
+  actions: ToolboxQuickAction[];
+}
+
+const Container = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  min-height: 44px;
+  padding: 0 ${TOOLBOX_PADDING_X}px 8px;
+  margin: 0 -${TOOLBOX_PADDING_X}px;
+  border-bottom: 1px solid var(--canvas-border-de-emp);
+  flex-shrink: 0;
+`;
+
+const Separator = styled.div`
+  width: 1px;
+  align-self: stretch;
+  margin: 0 4px;
+  background: var(--canvas-border-de-emp);
+  flex-shrink: 0;
+`;
+
+function QuickActionButton({ action, wide }: { action: ToolboxQuickAction; wide?: boolean }) {
+  return (
+    <CanvasTooltip content={action.title}>
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon"
+        className={wide ? 'h-9 w-14 aspect-auto [&_svg]:size-6' : 'h-9 w-9 [&_svg]:size-6'}
+        aria-label={action.title}
+        disabled={action.disabled}
+        onClick={action.onClick}
+        onMouseEnter={action.onMouseEnter}
+        onMouseLeave={action.onMouseLeave}
+        data-testid={`toolbox-quick-action-${action.id}`}
+      >
+        {action.icon}
+      </Button>
+    </CanvasTooltip>
+  );
+}
+
+export const QuickActionsRow = memo(function QuickActionsRow({ actions }: QuickActionsRowProps) {
+  if (!actions.length) return null;
+
+  const leading = actions.filter((a) => !a.trailing);
+  const trailing = actions.filter((a) => a.trailing);
+
+  return (
+    <Container data-testid="toolbox-quick-actions">
+      {leading.map((action) => (
+        <QuickActionButton key={action.id} action={action} />
+      ))}
+      {trailing.length > 0 && leading.length > 0 && (
+        <Separator data-testid="toolbox-quick-actions-separator" />
+      )}
+      {trailing.map((action) => (
+        <QuickActionButton key={action.id} action={action} wide />
+      ))}
+    </Container>
+  );
+});

--- a/packages/apollo-react/src/canvas/components/Toolbox/Toolbox.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/Toolbox/Toolbox.stories.tsx
@@ -1,0 +1,91 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import {
+  BpmnBoundaryEventDefault,
+  BpmnEndEventDefault,
+  BpmnGatewayExclusive,
+  FigureRectangle54,
+} from '../../../icons';
+import { ConnectorHandleIcon } from '../../icons';
+import { withCanvasProviders } from '../../storybook-utils';
+import type { ListItem } from './ListView';
+import type { ToolboxQuickAction } from './QuickActionsRow';
+import { Toolbox } from './Toolbox';
+
+const meta: Meta<typeof Toolbox> = {
+  title: 'Canvas/Toolbox',
+  component: Toolbox,
+  parameters: {
+    layout: 'centered',
+  },
+  decorators: [withCanvasProviders()],
+};
+
+export default meta;
+type Story = StoryObj<typeof Toolbox>;
+
+const SAMPLE_ITEMS: ListItem[] = [
+  { id: 'task', name: 'Task', icon: { name: 'square' }, data: {} },
+  { id: 'call-activity', name: 'Call Activity', icon: { name: 'box' }, data: {} },
+  { id: 'gateway', name: 'Gateway', icon: { name: 'diamond' }, data: {} },
+  { id: 'event', name: 'Event', icon: { name: 'circle' }, data: {} },
+  { id: 'subprocess', name: 'Subprocess', icon: { name: 'layers' }, data: {} },
+];
+
+export const Default: Story = {
+  args: {
+    title: 'Add element',
+    initialItems: SAMPLE_ITEMS,
+    onClose: () => {},
+    onItemSelect: () => {},
+  },
+};
+
+/**
+ * Pairs a row of icon shortcuts with the picker so high-frequency shapes are
+ * one click away. Trailing actions appear after a separator — used in the
+ * BPMN canvas-element-picker to surface the "Connect" tool alongside the
+ * shape buttons. Other canvas teams adding fast-access tools above a Toolbox
+ * picker can pass them via `quickActions` instead of stacking another row
+ * outside the popover.
+ */
+export const WithQuickActions: Story = {
+  args: {
+    title: 'Add element',
+    initialItems: SAMPLE_ITEMS,
+    onClose: () => {},
+    onItemSelect: () => {},
+    quickActions: [
+      {
+        id: 'task',
+        title: 'Task',
+        icon: <FigureRectangle54 size={20} />,
+        onClick: () => {},
+      },
+      {
+        id: 'gateway',
+        title: 'Exclusive gateway',
+        icon: <BpmnGatewayExclusive size={20} />,
+        onClick: () => {},
+      },
+      {
+        id: 'intermediate-event',
+        title: 'Intermediate event',
+        icon: <BpmnBoundaryEventDefault size={20} />,
+        onClick: () => {},
+      },
+      {
+        id: 'end-event',
+        title: 'End event',
+        icon: <BpmnEndEventDefault size={20} />,
+        onClick: () => {},
+      },
+      {
+        id: 'connect',
+        title: 'Connect',
+        icon: <ConnectorHandleIcon w={20} h={20} />,
+        onClick: () => {},
+        trailing: true,
+      },
+    ] satisfies ToolboxQuickAction[],
+  },
+};

--- a/packages/apollo-react/src/canvas/components/Toolbox/Toolbox.styles.ts
+++ b/packages/apollo-react/src/canvas/components/Toolbox/Toolbox.styles.ts
@@ -33,7 +33,7 @@ export const AnimatedContainer = styled.div`
   display: flex;
   flex-direction: column;
   overflow: hidden;
-  min-height: 300px;
+  min-height: 200px;
 `;
 
 export const AnimatedContent = styled.div<{ entering?: boolean; direction?: 'forward' | 'back' }>`
@@ -41,7 +41,7 @@ export const AnimatedContent = styled.div<{ entering?: boolean; direction?: 'for
   display: flex;
   flex-direction: column;
   animation: ${(props) => (props.entering ? `slideIn-${props.direction}` : 'none')} 0.15s ease-out;
-  min-height: 300px;
+  min-height: 200px;
 
   @keyframes slideIn-forward {
     from {

--- a/packages/apollo-react/src/canvas/components/Toolbox/Toolbox.tsx
+++ b/packages/apollo-react/src/canvas/components/Toolbox/Toolbox.tsx
@@ -11,6 +11,7 @@ import {
 } from '../../constants';
 import { Header } from './Header';
 import { type ListItem, ListView, type ListViewHandle, type RenderItem } from './ListView';
+import { QuickActionsRow, type ToolboxQuickAction } from './QuickActionsRow';
 import { SearchBox } from './SearchBox';
 import { AnimatedContainer, AnimatedContent } from './Toolbox.styles';
 
@@ -67,6 +68,13 @@ export interface ToolboxProps<T> {
   onItemHover?: (item: ListItem<T>) => void;
   onBack?: () => void;
   onSearch?: ToolboxSearchHandler<T>;
+  /**
+   * Optional row of icon shortcuts rendered above the title. Apollo controls
+   * the visuals so the strip stays consistent across consumers; pass the
+   * leading actions plain and set `trailing: true` on actions that should
+   * appear after the visual separator.
+   */
+  quickActions?: ToolboxQuickAction[];
 }
 
 function getNextSelectableIndex(
@@ -126,6 +134,7 @@ export function Toolbox<T>({
   loading,
   fullWidth = false,
   fullHeight = false,
+  quickActions,
 }: ToolboxProps<T>) {
   const [items, setItems] = useState<ListItem<T>[]>(initialItems);
   const [search, setSearch] = useState('');
@@ -596,6 +605,7 @@ export function Toolbox<T>({
         w={fullWidth ? '100%' : TOOLBOX_WIDTH}
         h={fullHeight ? '100%' : TOOLBOX_HEIGHT}
       >
+        {quickActions && quickActions.length > 0 && <QuickActionsRow actions={quickActions} />}
         <Header
           title={currentParentItem?.name || title}
           onBack={handleBackTransition}

--- a/packages/apollo-react/src/canvas/components/Toolbox/index.ts
+++ b/packages/apollo-react/src/canvas/components/Toolbox/index.ts
@@ -1,2 +1,3 @@
 export type { ListItem } from './ListView';
+export type { ToolboxQuickAction } from './QuickActionsRow';
 export * from './Toolbox';

--- a/packages/apollo-react/src/canvas/icons/ConnectorHandleIcon.tsx
+++ b/packages/apollo-react/src/canvas/icons/ConnectorHandleIcon.tsx
@@ -1,0 +1,25 @@
+interface ConnectorHandleIconProps {
+  w?: number | string;
+  h?: number | string;
+}
+
+export const ConnectorHandleIcon = ({ w = 36, h = 24 }: ConnectorHandleIconProps = {}) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    style={{ width: w, height: h, flexShrink: 0 }}
+    viewBox="0 0 36 24"
+    fill="none"
+    role="img"
+  >
+    <circle cx="5" cy="12" r="2.25" fill="currentColor" />
+    <path d="M7.5 12H31" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" />
+    <path
+      d="M27.5 8L31 12L27.5 16"
+      stroke="currentColor"
+      strokeWidth="1.6"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      fill="none"
+    />
+  </svg>
+);

--- a/packages/apollo-react/src/canvas/icons/index.ts
+++ b/packages/apollo-react/src/canvas/icons/index.ts
@@ -10,6 +10,7 @@ export { CaseManagementProject } from './CaseManagementProject';
 export { CasePlanIcon } from './CasePlanIcon';
 export { CodedAgentIcon } from './CodedAgentIcon';
 export { ConnectorBuilderProject } from './ConnectorBuilderProject';
+export { ConnectorHandleIcon } from './ConnectorHandleIcon';
 export { ContextIcon } from './ContextIcon';
 export { ControlFlowIcon } from './ControlFlowIcon';
 export { ConversationalAgentIcon } from './ConversationalAgentIcon';


### PR DESCRIPTION
## Summary

Adds an optional `quickActions` prop to `Toolbox` that renders a row of icon shortcuts inside the popover chrome — a leading group plus an optional trailing group separated by a vertical divider. Canvas consumers can now absorb fast-access icon strips into the existing Toolbox padding rather than stacking them above the popover where they get clipped against canvas edges.

Motivation: PO.Frontend's BPMN canvas-element picker (`HandleQuickAddPopover`) currently renders an icon strip *outside* `<Toolbox>` via a separate `<IconRowBorder>` wrapper. When the picker opens near the top of the canvas, that extra row gets clipped by the canvas's `overflow: hidden`. Pulling the row into Toolbox's chrome reduces total popover height by ~50 px and lets floating-ui's flip placement fit more often.

## Demo
<img width="447" height="736" alt="image" src="https://github.com/user-attachments/assets/8af6c7e1-d96c-43d0-adb4-3446318762d5" />


## What's in the diff

- **`Toolbox.tsx`** — new optional prop `quickActions?: ToolboxQuickAction[]`. When set, renders `<QuickActionsRow>` inside the existing `<Column>` above the title. No-op when omitted.
- **`QuickActionsRow.tsx`** — new component. Renders an apollo-wind ghost-`Button` per action wrapped in `CanvasTooltip`. Trailing actions render after a vertical separator; leading-only and trailing-only configurations are both supported.
- **`Toolbox.styles.ts`** — `min-height: 300px → 200px` on `AnimatedContainer` + `AnimatedContent`. The 300 floor was never enforced for current consumers (Toolbox at 440 px height has 324 px available for the inner list — flex:1 already exceeds 300). 200 only matters when `quickActions` are added; existing consumers see no functional change.
- **`ConnectorHandleIcon.tsx`** — new BPMN-style sequence-flow arrow (dot + line + arrowhead, 36×24 viewBox). Used by the trailing "Connect" action in the BPMN picker.
- **`Toolbox.stories.tsx`** — new `Default` and `WithQuickActions` stories so the slot is discoverable in the design system.
- **`QuickActionsRow.test.tsx`** — 10 tests covering leading-only, trailing-only, separator presence, click/hover wiring, disabled state.

## Backwards compatibility

- `quickActions` is optional — existing consumers (e.g. `AddNodePanel` in apollo-ui, multiple Toolbox usages in PO.Frontend) are unaffected.
- The `min-height` reduction is functionally a no-op for current consumers since `flex: 1` always provides ≥ 300 px at the standard `TOOLBOX_HEIGHT` of 440 px. 200 only kicks in when quickActions add ~56 px above the inner list.
- 1452/1452 apollo-react tests pass.

## Test plan

- [x] `pnpm test` in `packages/apollo-react` — 1452/1452 passing
- [x] Manually verified in PO.Frontend with a local apollo-react build — BPMN canvas-element picker renders the icon row inside Toolbox chrome, popover height fits within canvas bounds, click/hover wiring intact
- [x] Storybook story renders both `Default` and `WithQuickActions` variants
- [ ] Reviewer to sanity-check the storybook visuals on Chromatic / preview deploy