### PR TITLE
docs(repo): guardrails for apollo-react styling [MST-8401]

### DIFF
--- a/.claude/commands/review.md
+++ b/.claude/commands/review.md
@@ -35,7 +35,7 @@ Create a clear summary of:
 
 ### Step 3: Launch Parallel Reviews
 
-Launch TWO agents in parallel using a single message with multiple Task tool calls:
+Launch THREE agents in parallel using a single message with multiple Task tool calls:
 
 **Agent 1: General Code Review Agent**
 
@@ -98,9 +98,45 @@ For each issue found:
 Return your findings in a structured format."
 ```
 
+**Agent 3: Styled/MUI Migration Guardian**
+
+```
+Prompt: "Review the following code changes specifically for violations of the apollo-react styling standards.
+
+Review Scope: [insert scope]
+
+Changes Summary:
+[insert summary]
+
+## Rules
+
+The apollo-react package is migrating from Emotion/MUI to Tailwind CSS + apollo-wind. No new Emotion or MUI usage is allowed.
+
+Please check for:
+
+1. **New styled/MUI imports (CRITICAL)** — Any new imports from `@emotion/styled`, `@emotion/react`, usage of `styled.*` or `css` helpers, or new `@mui/material/*` component imports that did not exist before the change. Existing MUI theme overrides in `packages/apollo-react/src/theme/` are exempt.
+2. **New Ap* component usage (CRITICAL)** — Any new usage of `Ap*` components imported from `@uipath/apollo-react` (e.g., `ApButton`, `ApTextField`). These are MUI wrappers. New code should use `apollo-wind` components instead.
+3. **New *.styles.ts files (CRITICAL)** — Any newly created styles files using Emotion patterns.
+4. **Significant edits to existing styled/MUI components (MAJOR)** — If a file that uses styled-components or MUI patterns was substantially modified (more than a trivial one-line prop addition), recommend migrating the touched component to Tailwind. Reference the `/migrate-canvas-styled-to-tailwind` skill and the reference files in `packages/apollo-react/src/canvas/components/BaseNode/` for migration patterns.
+
+## Approved patterns
+- Tailwind utility classes as static literal strings in JSX
+- `cn()` from `@uipath/apollo-wind` for conflicting class overrides
+- CSS custom properties (style prop) for dynamic dimensions
+- Existing MUI theme overrides in `packages/apollo-react/src/theme/` (maintenance only)
+
+For each issue found:
+- Severity: critical/major
+- File and line reference
+- Description of the violation
+- Suggested migration approach
+
+Return your findings in a structured format."
+```
+
 ### Step 4: Agent Permissions
 
-Both agents have access to:
+All agents have access to:
 
 - Read tool (to read any file)
 - Glob tool (to find files)
@@ -111,10 +147,10 @@ Both agents have access to:
 
 ### Step 5: Critical Analysis of Review Comments
 
-After both agents complete their reviews:
+After all agents complete their reviews:
 
-1. **Collect all findings** from both agents
-2. **Deduplicate** - If both agents found the same issue, merge into one
+1. **Collect all findings** from all agents
+2. **Deduplicate** - If multiple agents found the same issue, merge into one
 3. **Validate severity** - Think critically about each severity rating:
    - Is this truly critical/major/minor?
    - Does it actually need fixing or is it subjective?
@@ -191,4 +227,4 @@ I can fix [list categories that can be auto-fixed, e.g., 'formatting issues', 'i
 User: `/review`
 Assistant: [Asks for scope selection]
 User: [Selects "Last commit"]
-Assistant: [Gathers changes, launches both agents in parallel, waits for results, analyzes findings, presents comprehensive report]
+Assistant: [Gathers changes, launches agents in parallel, waits for results, analyzes findings, presents comprehensive report]

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -75,7 +75,26 @@ apollo-ui/
 - Prefer composition over inheritance
 - Keep components focused and single-purpose
 - Follow existing patterns in the codebase
-- Material UI components wrapped with `Ap*` prefix
+- **No new Emotion or MUI usage in `apollo-react`** — see Styling Standards below
+
+### Styling Standards (apollo-react)
+
+The `apollo-react` package is migrating from Emotion/MUI to Tailwind CSS + `apollo-wind`. **All new code must use Tailwind patterns.**
+
+**Block PRs that introduce:**
+- New imports from `@emotion/styled`, `@emotion/react`, or usage of `styled.*` / `css` helpers
+- New `*.styles.ts` files
+- New `@mui/material/*` component imports for building UI (existing MUI theme overrides in `theme/` are exempt)
+- New usage of `Ap*` components from `@uipath/apollo-react` (these are MUI wrappers — use `apollo-wind` components instead)
+
+**Flag for migration when:**
+- A PR significantly modifies an existing file that uses styled-components or MUI — recommend migrating the touched component to Tailwind as part of the change
+
+**Approved patterns:**
+- Tailwind utility classes as static literal strings in JSX
+- `cn()` from `@uipath/apollo-wind` for conflicting class overrides
+- CSS custom properties (`style` prop) for dynamic dimensions
+- Existing MUI theme overrides in `packages/apollo-react/src/theme/` (maintenance only)
 
 ### Testing Requirements
 
@@ -156,6 +175,7 @@ When providing suggestions or reviewing code:
 - TypeScript errors
 - Missing tests for critical library functionality
 - Incorrect use of design tokens
+- New Emotion styled-components or MUI component usage in apollo-react (use Tailwind instead)
 
 **Don't block on:**
 - Minor style/formatting (Biome handles this)
@@ -179,6 +199,7 @@ When creating new components, verify:
 - [ ] Has unit tests (if in packages/ or web-packages/)
 - [ ] Has visual regression tests
 - [ ] Documented in package README
+- [ ] No new `@emotion/styled`, `@emotion/react`, or `@mui/material` imports (use Tailwind + apollo-wind)
 
 ## Available Resources
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,24 @@ Use a **fixup/rebase workflow** to keep commits clean and meaningful.
 - **Force push feature branches**: After rebasing, use `git push --force-with-lease` to update the remote branch.
 - **Each commit should be meaningful**: A commit should represent a complete, logical change — not a partial fix or correction.
 
+### Styling Standards — apollo-react
+
+**No new `styled-components` (Emotion) or direct MUI component usage in `apollo-react`.**
+
+The package is actively migrating from Emotion (`@emotion/styled`, `@emotion/react`) and raw MUI components to **Tailwind CSS classes via `apollo-wind`**. All new code must follow the new patterns:
+
+- **Do not** import from `@emotion/styled`, `@emotion/react`, or use `styled.*` / `css` helpers
+- **Do not** create new `*.styles.ts` files
+- **Do not** introduce new MUI component imports (`@mui/material/*`) for building UI — existing MUI theme overrides in `theme/` are exempt
+- **Do not** use `Ap*` components from `@uipath/apollo-react` (these are MUI wrappers) — use `apollo-wind` components instead
+- **Do** use Tailwind utility classes (static literal strings in JSX)
+- **Do** use `cn()` from `@uipath/apollo-wind` only when classes conflict/override
+- **Do** use CSS custom properties for dynamic dimensions (Pattern B from migration guide)
+
+When **significantly editing** an existing component that uses styled/MUI patterns, migrate that component to Tailwind as part of the change. Use the `/migrate-canvas-styled-to-tailwind` skill for guidance.
+
+For the full migration patterns and reference examples, see `.claude/skills/migrate-canvas-styled-to-tailwind/SKILL.md`.
+
 ---
 
 # Apollo v.4 Design System Architecture
@@ -80,7 +98,7 @@ This is the **UiPath/apollo-ui** public repository - the open-source design syst
 
 ### Framework Support
 
-- **React**: Primary component library with Material UI theming
+- **React**: Primary component library with Material UI theming (Material is legacy — migrating to Tailwind/apollo-wind)
 - **Web Components**: Cross-framework components using standard web APIs
 - **Tailwind CSS + shadcn/ui**: Modern styling approach (apollo-wind package)
 
@@ -143,7 +161,7 @@ apollo-ui/
 #### `apollo-react`
 
 - **Purpose**: React component library with Material UI theming
-- **Dependencies**: React, Material UI, apollo-core
+- **Dependencies**: React, Material UI (legacy; new code uses Tailwind via apollo-wind), apollo-core
 - **Structure**:
   ```
   apollo-react/


### PR DESCRIPTION
Updates coding agent files + tools with guardrails for apollo-react styling. We want to prevent any new Styled components and/or MUI usage.