### PR TITLE
fix(apollo-react): cursor type of sticky note in readOnly [MST-9331]

### DIFF
--- a/packages/apollo-react/src/canvas/components/StickyNoteNode/StickyNoteNode.styles.ts
+++ b/packages/apollo-react/src/canvas/components/StickyNoteNode/StickyNoteNode.styles.ts
@@ -56,7 +56,7 @@ export const StickyNoteContainer = styled.div<{
   backgroundColor: string;
   isEditing: boolean;
   selected?: boolean;
-  readOnly?: boolean;
+  isReadOnly?: boolean;
 }>`
   width: 100%;
   height: 100%;
@@ -66,7 +66,7 @@ export const StickyNoteContainer = styled.div<{
   padding: ${(props) => (props.isEditing ? '8px' : '16px')} 16px 16px 16px;
   display: flex;
   flex-direction: column;
-  cursor: ${(props) => (props.readOnly ? 'pointer' : props.isEditing ? 'text' : 'move')};
+  cursor: ${(props) => (props.isReadOnly ? 'pointer' : props.isEditing ? 'text' : 'move')};
   position: relative;
   /* Ensure resize handles are clickable */
   pointer-events: auto;

--- a/packages/apollo-react/src/canvas/components/StickyNoteNode/StickyNoteNode.styles.ts
+++ b/packages/apollo-react/src/canvas/components/StickyNoteNode/StickyNoteNode.styles.ts
@@ -36,11 +36,11 @@ export const RESIZE_CONTROL_Z_INDEX = 100;
 export const stickyNoteGlobalStyles = css`
   /* Override React Flow's elevateNodesOnSelect behavior for sticky notes */
   /* Edges have z-index: 0, so we use STICKY_NOTE_BELOW_EDGE_Z_INDEX to ensure sticky notes are below edges */
-  .react-flow__node[data-id^='sticky-'] {
+  .react-flow .react-flow__node[data-id^='sticky-'] {
     z-index: ${STICKY_NOTE_BELOW_EDGE_Z_INDEX} !important;
   }
 
-  .react-flow__node.selected[data-id^='sticky-'] {
+  .react-flow .react-flow__node.selected[data-id^='sticky-'] {
     z-index: ${STICKY_NOTE_BELOW_EDGE_Z_INDEX} !important;
   }
 `;
@@ -56,6 +56,7 @@ export const StickyNoteContainer = styled.div<{
   backgroundColor: string;
   isEditing: boolean;
   selected?: boolean;
+  readOnly?: boolean;
 }>`
   width: 100%;
   height: 100%;
@@ -65,7 +66,7 @@ export const StickyNoteContainer = styled.div<{
   padding: ${(props) => (props.isEditing ? '8px' : '16px')} 16px 16px 16px;
   display: flex;
   flex-direction: column;
-  cursor: ${(props) => (props.isEditing ? 'text' : 'move')};
+  cursor: ${(props) => (props.readOnly ? 'pointer' : props.isEditing ? 'text' : 'move')};
   position: relative;
   /* Ensure resize handles are clickable */
   pointer-events: auto;

--- a/packages/apollo-react/src/canvas/components/StickyNoteNode/StickyNoteNode.tsx
+++ b/packages/apollo-react/src/canvas/components/StickyNoteNode/StickyNoteNode.tsx
@@ -359,7 +359,7 @@ const StickyNoteNodeComponent = ({
           borderColor={color}
           isEditing={isEditing}
           selected={selected}
-          readOnly={readOnly}
+          isReadOnly={readOnly}
           onDoubleClick={handleDoubleClick}
         >
           <TopCornerIndicators visible={selected && !readOnly} />

--- a/packages/apollo-react/src/canvas/components/StickyNoteNode/StickyNoteNode.tsx
+++ b/packages/apollo-react/src/canvas/components/StickyNoteNode/StickyNoteNode.tsx
@@ -359,6 +359,7 @@ const StickyNoteNodeComponent = ({
           borderColor={color}
           isEditing={isEditing}
           selected={selected}
+          readOnly={readOnly}
           onDoubleClick={handleDoubleClick}
         >
           <TopCornerIndicators visible={selected && !readOnly} />


### PR DESCRIPTION
cursor should be pointer in readOnly for consistent experience all over nodes

Also increase secificity for sticky note css

before

https://github.com/user-attachments/assets/2f88affb-cd8c-49f3-b710-b895f91c8448

after

https://github.com/user-attachments/assets/0b16a14a-f5d6-40cf-bf3c-b52d3599135e

