### PR TITLE
fix(apollo-react): hide warning icon and realign with 16px grid [MST-9425][MST-9419]

### DIFF
--- a/packages/apollo-react/src/canvas/components/StageNode/DraggableTask.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/DraggableTask.tsx
@@ -26,6 +26,7 @@ const DraggableTaskComponent = ({
   isDragDisabled,
   projectedDepth,
   isTaskLoading,
+  isReadOnly,
 }: DraggableTaskProps) => {
   const zoom = useStore((s) => s.transform[2]);
   const taskRef = useRef<HTMLDivElement>(null);
@@ -96,7 +97,7 @@ const DraggableTaskComponent = ({
       onClick={handleClick}
       {...(getContextMenuItems && !isTaskLoading && { onContextMenu: handleContextMenu })}
     >
-      <TaskContent task={task} taskExecution={taskExecution} />
+      <TaskContent task={task} taskExecution={taskExecution} isReadOnly={isReadOnly} />
 
       <StageTaskEntryConditionIcon task={task} />
       {getContextMenuItems && (

--- a/packages/apollo-react/src/canvas/components/StageNode/DraggableTask.types.ts
+++ b/packages/apollo-react/src/canvas/components/StageNode/DraggableTask.types.ts
@@ -14,4 +14,5 @@ export interface DraggableTaskProps {
   isDragDisabled?: boolean;
   projectedDepth?: number;
   isTaskLoading?: boolean;
+  isReadOnly?: boolean;
 }

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNodeAllTaskGroups.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNodeAllTaskGroups.tsx
@@ -145,15 +145,20 @@ const StageNodeAllTaskGroupsInner = ({
       eventDrivenTaskGroups.length === 0 ? (
         <Column py={2}>
           {(onTaskAdd || onAddTaskFromToolbox) && !isReadOnly ? (
-            <Button variant="link" onClick={handleTaskAddClick} style={{ maxWidth: 'fit-content' }}>
+            <Button
+              variant="link"
+              size="sm"
+              onClick={handleTaskAddClick}
+              style={{ maxWidth: 'fit-content', padding: 0 }}
+            >
               {defaultContent}
             </Button>
           ) : (
-            <span className="text-xs text-foreground-muted">{defaultContent}</span>
+            <span className="text-xs text-foreground-muted h-9">{defaultContent}</span>
           )}
         </Column>
       ) : (
-        <Column>
+        <Column py={2}>
           <StageNodeSequentialTaskGroups
             props={props}
             sequentialTaskGroups={sequentialTaskGroups}

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNodeSequentialTaskGroups.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNodeSequentialTaskGroups.tsx
@@ -220,6 +220,7 @@ export const StageNodeSequentialTaskGroups = ({
                           !isReadOnly && {
                             getContextMenuItems: buildContextMenuItems,
                           })}
+                        isReadOnly={isReadOnly}
                       />
                     );
                   })}

--- a/packages/apollo-react/src/canvas/components/StageNode/TaskContent.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/TaskContent.tsx
@@ -106,10 +106,11 @@ export interface TaskContentProps {
   taskExecution?: StageTaskExecution;
   isDragging?: boolean;
   onTaskPlay?: (taskId: string) => Promise<void>;
+  isReadOnly?: boolean;
 }
 
 export const TaskContent = memo(
-  ({ task, taskExecution, isDragging, onTaskPlay }: TaskContentProps) => {
+  ({ task, taskExecution, isDragging, onTaskPlay, isReadOnly }: TaskContentProps) => {
     const hasExecutionStatus = !!taskExecution?.status;
     const hasSecondRowContent =
       taskExecution &&
@@ -117,79 +118,77 @@ export const TaskContent = memo(
     const showPlayButtonSmall = onTaskPlay && hasExecutionStatus;
 
     return (
-      <>
-        <Column
-          flex={1}
-          style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
-          gap={Padding.PadXs}
-        >
-          <Row align="center" justify="space-between">
-            {/* disable tooltip when dragging to avoid tooltip flickering */}
-            <Row
-              gap={Spacing.SpacingXs}
-              align="center"
-              style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
+      <Column
+        flex={1}
+        style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
+        gap={Padding.PadXs}
+      >
+        <Row align="center" justify="space-between">
+          {/* disable tooltip when dragging to avoid tooltip flickering */}
+          <Row
+            gap={Spacing.SpacingXs}
+            align="center"
+            style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
+          >
+            <StageTaskIcon>{task.icon ?? <ProcessCanvasIcon />}</StageTaskIcon>
+            <CanvasTooltip
+              content={task.label}
+              placement="top"
+              smartTooltip
+              {...(isDragging && { isOpen: false })}
             >
-              <StageTaskIcon>{task.icon ?? <ProcessCanvasIcon />}</StageTaskIcon>
-              <CanvasTooltip
-                content={task.label}
-                placement="top"
-                smartTooltip
-                {...(isDragging && { isOpen: false })}
-              >
-                <span className="text-sm truncate">{task.label}</span>
-              </CanvasTooltip>
-            </Row>
-            <Row align="center" gap={Spacing.SpacingXs} style={{ flexShrink: 0 }}>
-              {hasExecutionStatus &&
-                (taskExecution.message ? (
-                  <CanvasTooltip content={taskExecution.message} placement="top">
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      className="h-6 w-6"
-                      aria-label={taskExecution.message}
-                    >
-                      <ExecutionStatusIcon status={taskExecution.status} />
-                    </Button>
-                  </CanvasTooltip>
-                ) : (
-                  <ExecutionStatusIcon status={taskExecution.status} />
-                ))}
-              {showPlayButtonSmall && !hasSecondRowContent && (
-                <TaskPlayButton taskId={task.id} onTaskPlay={onTaskPlay} small />
+              <span className="text-sm truncate">{task.label}</span>
+            </CanvasTooltip>
+          </Row>
+          <Row align="center" gap={Spacing.SpacingXs} style={{ flexShrink: 0 }}>
+            {hasExecutionStatus &&
+              (taskExecution.message ? (
+                <CanvasTooltip content={taskExecution.message} placement="top">
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="h-6 w-6"
+                    aria-label={taskExecution.message}
+                  >
+                    <ExecutionStatusIcon status={taskExecution.status} />
+                  </Button>
+                </CanvasTooltip>
+              ) : (
+                !isReadOnly && <ExecutionStatusIcon status={taskExecution.status} />
+              ))}
+            {showPlayButtonSmall && !hasSecondRowContent && (
+              <TaskPlayButton taskId={task.id} onTaskPlay={onTaskPlay} small />
+            )}
+            {onTaskPlay && !hasExecutionStatus && (
+              <TaskPlayButton taskId={task.id} onTaskPlay={onTaskPlay} />
+            )}
+          </Row>
+        </Row>
+        {taskExecution && hasSecondRowContent && (
+          <Row align="center" justify="space-between">
+            <Row gap={'2px'}>
+              {taskExecution?.duration && (
+                <span className="text-xs text-foreground-muted">{taskExecution.duration}</span>
               )}
-              {onTaskPlay && !hasExecutionStatus && (
-                <TaskPlayButton taskId={task.id} onTaskPlay={onTaskPlay} />
+              {taskExecution?.retryDuration && (
+                <StageTaskRetryDuration status={taskExecution.badgeStatus ?? 'warning'}>
+                  <span className="text-xs">{`(+${taskExecution.retryDuration})`}</span>
+                </StageTaskRetryDuration>
+              )}
+            </Row>
+            <Row align="center" gap={Spacing.SpacingXs}>
+              {taskExecution?.badge && (
+                <Badge variant={taskExecution.badgeStatus}>
+                  {generateBadgeText(taskExecution) ?? ''}
+                </Badge>
+              )}
+              {showPlayButtonSmall && (
+                <TaskPlayButton taskId={task.id} onTaskPlay={onTaskPlay} small />
               )}
             </Row>
           </Row>
-          {taskExecution && hasSecondRowContent && (
-            <Row align="center" justify="space-between">
-              <Row gap={'2px'}>
-                {taskExecution?.duration && (
-                  <span className="text-xs text-foreground-muted">{taskExecution.duration}</span>
-                )}
-                {taskExecution?.retryDuration && (
-                  <StageTaskRetryDuration status={taskExecution.badgeStatus ?? 'warning'}>
-                    <span className="text-xs">{`(+${taskExecution.retryDuration})`}</span>
-                  </StageTaskRetryDuration>
-                )}
-              </Row>
-              <Row align="center" gap={Spacing.SpacingXs}>
-                {taskExecution?.badge && (
-                  <Badge variant={taskExecution.badgeStatus}>
-                    {generateBadgeText(taskExecution) ?? ''}
-                  </Badge>
-                )}
-                {showPlayButtonSmall && (
-                  <TaskPlayButton taskId={task.id} onTaskPlay={onTaskPlay} small />
-                )}
-              </Row>
-            </Row>
-          )}
-        </Column>
-      </>
+        )}
+      </Column>
     );
   }
 );


### PR DESCRIPTION
## Description
Hide the warning icon during readonly mode and realign with the 16px grid

Heights are the same and are aligned with 16px grid
<img width="979" height="333" alt="image" src="https://github.com/user-attachments/assets/5fbe3a75-7d8e-4f06-ba6c-95021f85c964" />
