### PR TITLE
fix(apollo-react): scope loop inner handle drops

### DIFF
--- a/packages/apollo-react/src/canvas/components/AddNodePanel/AddNodeManager.helpers.test.ts
+++ b/packages/apollo-react/src/canvas/components/AddNodePanel/AddNodeManager.helpers.test.ts
@@ -1,22 +1,22 @@
 import type { Edge, Node } from '@uipath/apollo-react/canvas/xyflow/react';
 import { describe, expect, it } from 'vitest';
 import { PREVIEW_NODE_ID } from '../../constants';
-import type { NodeTypeRegistry } from '../../core';
-import type { NodeManifest, NodeShape } from '../../schema/node-definition';
+import type { NodeLayout } from '../../hooks/useCanvasNodeLayout';
+import type { NodeShape } from '../../schema/node-definition';
+import { getExpandedSize } from '../../utils/collapse';
+import { getContainerFitGeometry, getNodeDimensions } from '../../utils/container';
 import { placeAddedNode } from './AddNodeManager.helpers';
 
-function buildRegistry(manifestsByType: Record<string, { shape?: NodeShape }>): NodeTypeRegistry {
-  const get = (nodeType: string): NodeManifest | undefined => {
-    const entry = manifestsByType[nodeType];
-    if (!entry) return undefined;
-    return {
-      nodeType,
-      version: '1',
-      display: { label: nodeType, ...(entry.shape ? { shape: entry.shape } : {}) },
-      handleConfiguration: [],
-    } as NodeManifest;
+function buildLayout(manifestsByType: Record<string, { shape?: NodeShape }>): NodeLayout {
+  const getShape = (nodeType: string | undefined): NodeShape | undefined =>
+    nodeType ? manifestsByType[nodeType]?.shape : undefined;
+
+  return {
+    getNodeDimensions: (node) => getNodeDimensions(node, getExpandedSize(getShape(node.type))),
+    isContainerNode: (node) => getShape(node.type) === 'container',
+    getContainerFitGeometry: (node) =>
+      getShape(node.type) === 'container' ? getContainerFitGeometry() : null,
   };
-  return { getManifest: get } as unknown as NodeTypeRegistry;
 }
 
 const ORIGINAL_EDGE: Edge = {
@@ -54,7 +54,7 @@ describe('placeAddedNode', () => {
     };
 
     it('shifts the downstream chain right when inserting a wider rectangle', () => {
-      const registry = buildRegistry({
+      const layout = buildLayout({
         'square-source': { shape: 'square' },
         'square-target': { shape: 'square' },
         rectangle: { shape: 'rectangle' },
@@ -73,7 +73,7 @@ describe('placeAddedNode', () => {
         edges: [ORIGINAL_EDGE],
         previewNode,
         insertedNode,
-        registry,
+        layout,
       });
 
       const placedAction = nodes.find((n) => n.id === 'action');
@@ -93,7 +93,7 @@ describe('placeAddedNode', () => {
     });
 
     it('shifts the downstream chain right when inserting a container shape', () => {
-      const registry = buildRegistry({
+      const layout = buildLayout({
         'square-source': { shape: 'square' },
         'square-target': { shape: 'square' },
         loop: { shape: 'container' },
@@ -111,7 +111,7 @@ describe('placeAddedNode', () => {
         edges: [ORIGINAL_EDGE],
         previewNode,
         insertedNode,
-        registry,
+        layout,
       });
 
       const placedAction = nodes.find((n) => n.id === 'action');
@@ -126,7 +126,7 @@ describe('placeAddedNode', () => {
     });
 
     it('cascades the shift through a multi-node downstream chain', () => {
-      const registry = buildRegistry({
+      const layout = buildLayout({
         'square-source': { shape: 'square' },
         'square-target': { shape: 'square' },
         rectangle: { shape: 'rectangle' },
@@ -163,7 +163,7 @@ describe('placeAddedNode', () => {
         edges,
         previewNode,
         insertedNode,
-        registry,
+        layout,
       });
 
       const placedAction = nodes.find((n) => n.id === 'action')!;
@@ -184,7 +184,7 @@ describe('placeAddedNode', () => {
     });
 
     it('does not shift the chain when the inserted node already fits', () => {
-      const registry = buildRegistry({
+      const layout = buildLayout({
         'square-source': { shape: 'square' },
         'square-target': { shape: 'square' },
         square: { shape: 'square' },
@@ -207,7 +207,7 @@ describe('placeAddedNode', () => {
         edges: [{ ...ORIGINAL_EDGE, target: 'action' }],
         previewNode,
         insertedNode,
-        registry,
+        layout,
       });
 
       const placedAction = nodes.find((n) => n.id === 'action');
@@ -220,7 +220,7 @@ describe('placeAddedNode', () => {
       // self-loop (source === target, e.g. Loop("output") → Loop("loopBack")),
       // so shifting the "downstream chain" would move the source away from
       // the inserted node and produce a backward-wrapping edge.
-      const registry = buildRegistry({
+      const layout = buildLayout({
         loop: { shape: 'square' },
         rectangle: { shape: 'rectangle' },
       });
@@ -258,7 +258,7 @@ describe('placeAddedNode', () => {
         edges: [selfLoopEdge],
         previewNode,
         insertedNode,
-        registry,
+        layout,
       });
 
       const placedLoop = nodes.find((n) => n.id === 'loop');
@@ -275,7 +275,7 @@ describe('placeAddedNode', () => {
       // (child → loop), so the loop ends up in chainIds. Without this guard,
       // the loop is shifted right alongside the child, producing the broken
       // backward-wrapping body edge.
-      const registry = buildRegistry({
+      const layout = buildLayout({
         loop: { shape: 'square' },
         rectangle: { shape: 'rectangle' },
       });
@@ -327,7 +327,7 @@ describe('placeAddedNode', () => {
         edges: [bodyEdge, loopBackEdge],
         previewNode,
         insertedNode,
-        registry,
+        layout,
       });
 
       const placedLoop = nodes.find((n) => n.id === 'loop');
@@ -339,7 +339,7 @@ describe('placeAddedNode', () => {
     });
 
     it('does not shift any chain when no originalEdge metadata is present', () => {
-      const registry = buildRegistry({
+      const layout = buildLayout({
         'square-source': { shape: 'square' },
         'square-target': { shape: 'square' },
         rectangle: { shape: 'rectangle' },
@@ -366,7 +366,7 @@ describe('placeAddedNode', () => {
         edges: [ORIGINAL_EDGE],
         previewNode,
         insertedNode,
-        registry,
+        layout,
       });
 
       const placedAction = nodes.find((n) => n.id === 'action');
@@ -380,7 +380,7 @@ describe('placeAddedNode', () => {
 
   describe('non-container placement', () => {
     it('leaves top-level generic additions unchanged when there is no collision', () => {
-      const registry = buildRegistry({
+      const layout = buildLayout({
         resource: { shape: 'circle' },
         task: { shape: 'square' },
       });
@@ -411,7 +411,7 @@ describe('placeAddedNode', () => {
         edges: [],
         previewNode,
         insertedNode,
-        registry,
+        layout,
       });
 
       expect(placedInsertedNode.parentId).toBeUndefined();
@@ -422,7 +422,7 @@ describe('placeAddedNode', () => {
 
   describe('generic parented insertion', () => {
     it('grows a container vertically around an attached child', () => {
-      const registry = buildRegistry({
+      const layout = buildLayout({
         loop: { shape: 'container' },
         resource: { shape: 'circle' },
       });
@@ -457,7 +457,7 @@ describe('placeAddedNode', () => {
         edges: [],
         previewNode,
         insertedNode,
-        registry,
+        layout,
       });
 
       const loopHeight = nodes.find((node) => node.id === 'loop')?.style?.height as
@@ -470,7 +470,7 @@ describe('placeAddedNode', () => {
     });
 
     it('grows a container when an attached child is added above the safe area', () => {
-      const registry = buildRegistry({
+      const layout = buildLayout({
         agent: { shape: 'rectangle' },
         loop: { shape: 'container' },
         resource: { shape: 'circle' },
@@ -515,7 +515,7 @@ describe('placeAddedNode', () => {
         edges: [],
         previewNode,
         insertedNode,
-        registry,
+        layout,
       });
 
       const loopHeight = nodes.find((node) => node.id === 'loop')?.style?.height as
@@ -530,7 +530,7 @@ describe('placeAddedNode', () => {
     });
 
     it('does not resize a parent that is not a container manifest', () => {
-      const registry = buildRegistry({
+      const layout = buildLayout({
         group: { shape: 'square' },
         resource: { shape: 'circle' },
       });
@@ -572,7 +572,7 @@ describe('placeAddedNode', () => {
         edges: [],
         previewNode,
         insertedNode,
-        registry,
+        layout,
       });
 
       expect(nodes.find((node) => node.id === 'group')).toMatchObject({
@@ -585,7 +585,7 @@ describe('placeAddedNode', () => {
     });
 
     it('does not fit containers around ignored node types', () => {
-      const registry = buildRegistry({
+      const layout = buildLayout({
         loop: { shape: 'container' },
         resource: { shape: 'circle' },
         stickyNote: { shape: 'square' },
@@ -630,7 +630,7 @@ describe('placeAddedNode', () => {
         edges: [],
         previewNode,
         insertedNode,
-        registry,
+        layout,
         ignoredNodeTypes: ['stickyNote'],
       });
 

--- a/packages/apollo-react/src/canvas/components/AddNodePanel/AddNodeManager.helpers.ts
+++ b/packages/apollo-react/src/canvas/components/AddNodePanel/AddNodeManager.helpers.ts
@@ -1,7 +1,7 @@
 import type { Edge, Node } from '@uipath/apollo-react/canvas/xyflow/react';
 import { Position } from '@uipath/apollo-react/canvas/xyflow/react';
 import { GRID_SPACING } from '../../constants';
-import type { NodeTypeRegistry } from '../../core';
+import type { NodeLayout } from '../../hooks/useCanvasNodeLayout';
 import type { PreviewNodeConnectionInfo } from '../../hooks/usePreviewNode';
 import type { NodeManifest } from '../../schema';
 import { resolveCollisions } from '../../utils';
@@ -10,11 +10,9 @@ import {
   CONTAINER_SEQUENCE_GAP_PX,
   collectLinearDownstreamSiblings,
   fitContainersAndPushSiblings,
-  getContainerFitGeometry,
   getContainerPlacement,
   getContainerSafeArea,
   getNodeDimensions,
-  isContainerNodeManifest,
   type NodeDimensions,
   placeContainerNode,
 } from '../../utils/container';
@@ -38,19 +36,6 @@ interface AddNodePlacementResult {
  */
 export function getOriginalEdge(previewNode: Node | null | undefined): Edge | null {
   return (previewNode?.data?.originalEdge as Edge | undefined) ?? null;
-}
-
-function getManifestForNode(
-  registry: NodeTypeRegistry | null,
-  node: Node
-): NodeManifest | undefined {
-  return node.type ? registry?.getManifest(node.type) : undefined;
-}
-
-function getManifestAwareNodeDimensions(registry: NodeTypeRegistry | null, node: Node) {
-  const manifest = getManifestForNode(registry, node);
-
-  return getNodeDimensions(node, getExpandedSize(manifest?.display.shape));
 }
 
 function getPrimaryPreviewHandlePosition(
@@ -144,14 +129,11 @@ function resolveScopedCollisions(
   insertedNode: Node,
   options: {
     ignoredNodeTypes?: string[];
-    getNodeSize: (node: Node) => NodeDimensions;
+    getNodeDimensions: (node: Node) => NodeDimensions;
   }
 ): AddNodePlacementResult {
   const siblingNodes = nodes.filter((node) => node.parentId === insertedNode.parentId);
-  const resolvedSiblings = resolveCollisions(siblingNodes, {
-    ignoredNodeTypes: options.ignoredNodeTypes,
-    getNodeSize: options.getNodeSize,
-  });
+  const resolvedSiblings = resolveCollisions(siblingNodes, options);
   const resolvedSiblingById = new Map(resolvedSiblings.map((node) => [node.id, node]));
   const resolvedNodes = nodes.map((node) => resolvedSiblingById.get(node.id) ?? node);
 
@@ -181,13 +163,13 @@ function shiftForEdgeInsertion({
   edges,
   previewNode,
   insertedNode,
-  getNodeSize,
+  getNodeDimensions,
 }: {
   nodes: Node[];
   edges: Edge[];
   previewNode: Node;
   insertedNode: Node;
-  getNodeSize: (node: Node) => NodeDimensions;
+  getNodeDimensions: (node: Node) => NodeDimensions;
 }): { nodes: Node[]; insertedNode: Node } | null {
   const originalEdge = getOriginalEdge(previewNode);
   if (!originalEdge) return null;
@@ -195,13 +177,13 @@ function shiftForEdgeInsertion({
   const targetNode = nodes.find((node) => node.id === originalEdge.target);
   if (!targetNode || targetNode.parentId !== insertedNode.parentId) return null;
 
-  const insertedSize = getNodeSize(insertedNode);
+  const insertedSize = getNodeDimensions(insertedNode);
 
   // Step 1: clear the upstream source.
   let insertedX = insertedNode.position.x;
   const sourceNode = nodes.find((node) => node.id === originalEdge.source);
   if (sourceNode && sourceNode.parentId === insertedNode.parentId) {
-    const sourceSize = getNodeSize(sourceNode);
+    const sourceSize = getNodeDimensions(sourceNode);
     const requiredInsertedLeft =
       sourceNode.position.x + sourceSize.width + TOP_LEVEL_INSERTION_GAP_PX;
     if (insertedX < requiredInsertedLeft) {
@@ -275,17 +257,17 @@ export function placeAddedNode({
   edges,
   previewNode,
   insertedNode,
-  registry,
+  layout,
   ignoredNodeTypes,
 }: {
   nodes: Node[];
   edges: Edge[];
   previewNode: Node;
   insertedNode: Node;
-  registry: NodeTypeRegistry | null;
+  layout: NodeLayout;
   ignoredNodeTypes?: string[];
 }): AddNodePlacementResult {
-  const getDimensions = (node: Node) => getManifestAwareNodeDimensions(registry, node);
+  const { getNodeDimensions, isContainerNode, getContainerFitGeometry } = layout;
   const placement = getContainerPlacement(previewNode);
 
   if (placement) {
@@ -294,16 +276,14 @@ export function placeAddedNode({
     if (!containerNode) {
       return resolveScopedCollisions(nodes, insertedNode, {
         ignoredNodeTypes,
-        getNodeSize: getDimensions,
+        getNodeDimensions,
       });
     }
 
-    const containerManifest = getManifestForNode(registry, containerNode);
-
-    if (!isContainerNodeManifest(containerManifest)) {
+    if (!isContainerNode(containerNode)) {
       return resolveScopedCollisions(nodes, insertedNode, {
         ignoredNodeTypes,
-        getNodeSize: getDimensions,
+        getNodeDimensions,
       });
     }
 
@@ -312,12 +292,9 @@ export function placeAddedNode({
       insertedNode,
       placement,
       edges,
-      getNodeDimensions: getDimensions,
+      getNodeDimensions,
       safeArea: getContainerSafeArea(containerNode),
-      getContainerFitGeometry: (node) =>
-        isContainerNodeManifest(getManifestForNode(registry, node))
-          ? getContainerFitGeometry()
-          : null,
+      getContainerFitGeometry,
       ignoredNodeTypes,
     });
 
@@ -332,7 +309,7 @@ export function placeAddedNode({
     edges,
     previewNode,
     insertedNode,
-    getNodeSize: getDimensions,
+    getNodeDimensions,
   });
 
   const placementResult = resolveScopedCollisions(
@@ -340,7 +317,7 @@ export function placeAddedNode({
     shifted?.insertedNode ?? insertedNode,
     {
       ignoredNodeTypes,
-      getNodeSize: getDimensions,
+      getNodeDimensions,
     }
   );
 
@@ -351,11 +328,8 @@ export function placeAddedNode({
   const fittedNodes = fitContainersAndPushSiblings({
     nodes: placementResult.nodes,
     containerIds: [placementResult.insertedNode.parentId],
-    getContainerFitGeometry: (node) =>
-      isContainerNodeManifest(getManifestForNode(registry, node))
-        ? getContainerFitGeometry()
-        : null,
-    getNodeDimensions: getDimensions,
+    getContainerFitGeometry,
+    getNodeDimensions,
     ignoredNodeTypes,
     gap: CONTAINER_SEQUENCE_GAP_PX,
   });

--- a/packages/apollo-react/src/canvas/components/AddNodePanel/AddNodeManager.tsx
+++ b/packages/apollo-react/src/canvas/components/AddNodePanel/AddNodeManager.tsx
@@ -4,6 +4,7 @@ import type React from 'react';
 import { useCallback, useEffect, useRef } from 'react';
 import { FLOATING_CANVAS_PANEL_OFFSET, PREVIEW_NODE_ID } from '../../constants';
 import { useOptionalNodeTypeRegistry } from '../../core';
+import { useCanvasNodeLayout } from '../../hooks/useCanvasNodeLayout';
 import { usePreviewNode } from '../../hooks/usePreviewNode';
 import { isPreviewEdge } from '../../utils/createPreviewNode';
 import type { BaseNodeData } from '../BaseNode';
@@ -69,6 +70,7 @@ export const AddNodeManager: React.FC<AddNodeManagerProps> = ({
 }) => {
   const reactFlowInstance = useReactFlow();
   const registry = useOptionalNodeTypeRegistry();
+  const nodeLayout = useCanvasNodeLayout();
 
   // Watch for preview node selection
   const { previewNode, previewNodeConnectionInfo } = usePreviewNode();
@@ -210,7 +212,7 @@ export const AddNodeManager: React.FC<AddNodeManagerProps> = ({
           edges: placementEdges,
           previewNode: currentPreviewNode,
           insertedNode: finalNode,
-          registry,
+          layout: nodeLayout,
           ignoredNodeTypes,
         });
         placedNode = placement.insertedNode;
@@ -247,6 +249,7 @@ export const AddNodeManager: React.FC<AddNodeManagerProps> = ({
       previewNodeConnectionInfo,
       reactFlowInstance,
       registry,
+      nodeLayout,
       createNodeData,
       onBeforeNodeAdded,
       onNodeAdded,

--- a/packages/apollo-react/src/canvas/components/HierarchicalCanvas/HierarchicalCanvas.tsx
+++ b/packages/apollo-react/src/canvas/components/HierarchicalCanvas/HierarchicalCanvas.tsx
@@ -26,6 +26,7 @@ import { Breadcrumb } from '../../controls';
 import { useNodeManifests } from '../../core';
 import { useAddNodeOnConnectEnd } from '../../hooks/useAddNodeOnConnectEnd';
 import { useCanvasEvent } from '../../hooks/useCanvasEvents';
+import { useCanvasNodeLayout } from '../../hooks/useCanvasNodeLayout';
 import type { ToolbarActionEvent } from '../../schema/toolbar';
 import { animatedViewportManager } from '../../stores/animatedViewportManager';
 import {
@@ -126,10 +127,6 @@ export const HierarchicalCanvas: React.FC<HierarchicalCanvasProps> = ({
 
   // Build node types mapping from manifests and defaults.
   const nodeManifests = useNodeManifests();
-  const nodeManifestByType = useMemo(
-    () => new Map(nodeManifests.map((manifest) => [manifest.nodeType, manifest])),
-    [nodeManifests]
-  );
   const nodeTypes = useMemo(() => {
     return nodeManifests.reduce(
       (acc, manifest) => {
@@ -139,10 +136,7 @@ export const HierarchicalCanvas: React.FC<HierarchicalCanvasProps> = ({
       { ...DEFAULT_NODE_TYPES } as NodeTypes
     );
   }, [nodeManifests]);
-  const getManifestForNode = useCallback(
-    (node: Node) => (node.type ? nodeManifestByType.get(node.type) : undefined),
-    [nodeManifestByType]
-  );
+  const { getManifestForNode } = useCanvasNodeLayout();
 
   // Optimized selectors to prevent unnecessary re-renders
   const currentCanvas = useCanvasStore(selectCurrentCanvas);

--- a/packages/apollo-react/src/canvas/components/LoopNode/LoopNode.helpers.test.ts
+++ b/packages/apollo-react/src/canvas/components/LoopNode/LoopNode.helpers.test.ts
@@ -1,7 +1,7 @@
 import type { Edge, Node, ReactFlowInstance } from '@uipath/apollo-react/canvas/xyflow/react';
 import { describe, expect, it } from 'vitest';
 import type { NodeManifest } from '../../schema/node-definition';
-import { resolveContainerAddNodePreview } from './LoopNode.helpers';
+import { getInnerHandleContainerId, resolveContainerAddNodePreview } from './LoopNode.helpers';
 
 type PreviewManifest = Pick<NodeManifest, 'display' | 'handleConfiguration'>;
 
@@ -22,6 +22,11 @@ function createReactFlowInstance({
 const loopManifest: PreviewManifest = {
   display: { label: 'Loop', icon: 'repeat', shape: 'container' },
   handleConfiguration: [
+    {
+      position: 'right',
+      boundary: 'outer',
+      handles: [{ id: 'done', type: 'source', handleType: 'output' }],
+    },
     {
       position: 'left',
       boundary: 'inner',
@@ -288,5 +293,145 @@ describe('resolveContainerAddNodePreview', () => {
         },
       },
     });
+  });
+
+  it('keeps empty container inner source handles on the generic add path', () => {
+    const reactFlowInstance = createReactFlowInstance({
+      nodes: [loopNode],
+    });
+
+    const previewOverrides = resolveContainerAddNodePreview({
+      source: { nodeId: loopNode.id, handleId: 'start' },
+      sourceHandleType: 'source',
+      reactFlowInstance,
+      getManifestForNode,
+    });
+
+    expect(previewOverrides).toBeNull();
+  });
+
+  it('does not treat container outer outputs as container-body previews', () => {
+    const reactFlowInstance = createReactFlowInstance({
+      nodes: [loopNode],
+    });
+
+    const previewOverrides = resolveContainerAddNodePreview({
+      source: { nodeId: loopNode.id, handleId: 'done' },
+      sourceHandleType: 'source',
+      reactFlowInstance,
+      getManifestForNode,
+    });
+
+    expect(previewOverrides).toBeNull();
+  });
+
+  it('continues to insert from an occupied container inner source handle', () => {
+    const childNode: Node = {
+      id: 'task-1',
+      type: 'task',
+      parentId: loopNode.id,
+      position: { x: 240, y: 112 },
+      measured: { width: 96, height: 96 },
+      data: {},
+    };
+    const existingEdge: Edge = {
+      id: 'loop-1-task-1',
+      source: loopNode.id,
+      sourceHandle: 'start',
+      target: childNode.id,
+      targetHandle: 'input',
+    };
+    const reactFlowInstance = createReactFlowInstance({
+      nodes: [loopNode, childNode],
+      edges: [existingEdge],
+    });
+
+    const previewOverrides = resolveContainerAddNodePreview({
+      source: { nodeId: loopNode.id, handleId: 'start' },
+      sourceHandleType: 'source',
+      reactFlowInstance,
+      getManifestForNode,
+    });
+
+    expect(previewOverrides).toMatchObject({
+      containerId: loopNode.id,
+      positionMode: 'center',
+      target: {
+        nodeId: childNode.id,
+        handleId: 'input',
+      },
+      data: {
+        originalEdge: existingEdge,
+        placement: {
+          containerId: loopNode.id,
+          sourceNodeId: loopNode.id,
+          targetNodeId: childNode.id,
+          mode: 'sequence',
+        },
+      },
+    });
+  });
+});
+
+describe('getInnerHandleContainerId', () => {
+  const loopNode: Node = {
+    id: 'loop-1',
+    type: 'loop',
+    position: { x: 100, y: 80 },
+    style: { width: 704, height: 368 },
+    data: {},
+  };
+
+  it.each([
+    'start',
+    'continue',
+  ])('returns the container id for inner %s handle drags from the container itself', (handleId) => {
+    const reactFlowInstance = createReactFlowInstance({
+      nodes: [loopNode],
+    });
+
+    expect(
+      getInnerHandleContainerId({
+        source: { nodeId: loopNode.id, handleId },
+        reactFlowInstance,
+        getManifestForNode,
+      })
+    ).toBe(loopNode.id);
+  });
+
+  it('does not scope child node drags', () => {
+    const childNode: Node = {
+      id: 'task-1',
+      type: 'task',
+      parentId: loopNode.id,
+      position: { x: 240, y: 112 },
+      measured: { width: 96, height: 96 },
+      data: {},
+    };
+    const reactFlowInstance = createReactFlowInstance({
+      nodes: [loopNode, childNode],
+    });
+
+    expect(
+      getInnerHandleContainerId({
+        source: { nodeId: childNode.id, handleId: 'output' },
+        reactFlowInstance,
+        getManifestForNode,
+      })
+    ).toBeUndefined();
+  });
+
+  it('does not scope outer container output drags', () => {
+    const reactFlowInstance = createReactFlowInstance({
+      nodes: [loopNode],
+    });
+
+    expect(
+      getInnerHandleContainerId({
+        source: { nodeId: loopNode.id, handleId: 'done' },
+        reactFlowInstance,
+        getManifestForNode,
+      })
+    ).toBeUndefined();
   });
 });

--- a/packages/apollo-react/src/canvas/components/LoopNode/LoopNode.helpers.ts
+++ b/packages/apollo-react/src/canvas/components/LoopNode/LoopNode.helpers.ts
@@ -1,4 +1,5 @@
 import {
+  type Edge,
   type Node,
   Position,
   type ReactFlowInstance,
@@ -126,7 +127,7 @@ function pickPreferredInnerHandle(
   return null;
 }
 
-function resolveClickedHandleType({
+function resolveClickedHandle({
   source,
   reactFlowInstance,
   getManifestForNode,
@@ -134,7 +135,7 @@ function resolveClickedHandleType({
   source: PreviewEndpoint;
   reactFlowInstance: ReactFlowInstance;
   getManifestForNode: ContainerPreviewManifestResolver;
-}): string | undefined {
+}): { boundary: ContainerHandleBoundary; handleType?: string } | undefined {
   if (!source.handleId) return undefined;
 
   const sourceNode = reactFlowInstance.getNode(source.nodeId);
@@ -155,7 +156,12 @@ function resolveClickedHandleType({
 
   for (const group of sourceHandles) {
     const handle = group.handles.find((candidate) => candidate.id === source.handleId);
-    if (handle) return handle.handleType;
+    if (handle) {
+      return {
+        boundary: (group.boundary ?? 'outer') as ContainerHandleBoundary,
+        handleType: handle.handleType,
+      };
+    }
   }
 
   return undefined;
@@ -170,13 +176,15 @@ export function resolveContainerAddNodePreview({
   sourceHandleType,
   reactFlowInstance,
   getManifestForNode,
+  replacedEdge,
 }: {
   source: PreviewEndpoint;
   sourceHandleType: 'source' | 'target';
   reactFlowInstance: ReactFlowInstance;
   getManifestForNode: ContainerPreviewManifestResolver;
+  replacedEdge?: Edge;
 }): PreviewGraphOverrides | null {
-  const clickedHandleType = resolveClickedHandleType({
+  const clickedHandle = resolveClickedHandle({
     source,
     reactFlowInstance,
     getManifestForNode,
@@ -185,7 +193,14 @@ export function resolveContainerAddNodePreview({
   // Container sequence insertion is reserved for workflow outputs. Resource
   // handles and unresolved runtime handles keep the generic attachment preview,
   // scoped by the source node's parent container when one exists.
-  if (clickedHandleType !== 'output') {
+  if (clickedHandle?.handleType !== 'output') {
+    return null;
+  }
+
+  const sourceNode = reactFlowInstance.getNode(source.nodeId);
+  const sourceIsContainer =
+    sourceNode !== undefined && isContainerNodeManifest(getManifestForNode(sourceNode));
+  if (sourceIsContainer && clickedHandle.boundary !== 'inner') {
     return null;
   }
 
@@ -193,6 +208,7 @@ export function resolveContainerAddNodePreview({
     source,
     sourceHandleType,
     reactFlowInstance,
+    replacedEdge,
     isContainerNode: (node) => isContainerNodeManifest(getManifestForNode(node)),
     getContainerSafeArea,
     getContainerContinuationTarget: ({ containerNode }) => {
@@ -214,4 +230,31 @@ export function resolveContainerAddNodePreview({
         : null;
     },
   });
+}
+
+/**
+ * Connect-end drags from a container's own inner handle should keep the
+ * user's drop position and the preview should be parented.
+ */
+export function getInnerHandleContainerId({
+  source,
+  reactFlowInstance,
+  getManifestForNode,
+}: {
+  source: PreviewEndpoint;
+  reactFlowInstance: ReactFlowInstance;
+  getManifestForNode: ContainerPreviewManifestResolver;
+}): string | undefined {
+  const sourceNode = reactFlowInstance.getNode(source.nodeId);
+  if (!sourceNode || !isContainerNodeManifest(getManifestForNode(sourceNode))) {
+    return undefined;
+  }
+
+  const clickedHandle = resolveClickedHandle({
+    source,
+    reactFlowInstance,
+    getManifestForNode,
+  });
+
+  return clickedHandle?.boundary === 'inner' ? sourceNode.id : undefined;
 }

--- a/packages/apollo-react/src/canvas/components/Toolbar/EdgeToolbar/useEdgeToolbarState.test.ts
+++ b/packages/apollo-react/src/canvas/components/Toolbar/EdgeToolbar/useEdgeToolbarState.test.ts
@@ -379,7 +379,7 @@ describe('useEdgeToolbarState', () => {
       expect(vi.mocked(showPreviewGraph).mock.calls[0]?.[0]).not.toHaveProperty('containerId');
     });
 
-    it('should use container sequence placement for edge insertion between container children', () => {
+    it('should use exact edge placement for container insertion when the source handle has multiple outgoing edges', () => {
       const containerNode: Node = {
         id: 'loop-1',
         type: 'loop',
@@ -403,11 +403,27 @@ describe('useEdgeToolbarState', () => {
         measured: { width: 96, height: 96 },
         data: {},
       };
-      const nodes = [containerNode, sourceNode, targetNode];
+      const otherTargetNode: Node = {
+        id: 'node-3',
+        type: 'task',
+        position: { x: 480, y: 240 },
+        parentId: containerNode.id,
+        measured: { width: 96, height: 96 },
+        data: {},
+      };
+      const otherEdge: Edge = {
+        id: 'edge-2',
+        source: sourceNode.id,
+        sourceHandle: 'output',
+        target: otherTargetNode.id,
+        targetHandle: 'input',
+      };
+      const nodes = [containerNode, sourceNode, targetNode, otherTargetNode];
       mockReactFlowInstance.getNode.mockImplementation((id: string) =>
         nodes.find((node) => node.id === id)
       );
       mockReactFlowInstance.getNodes.mockReturnValue(nodes);
+      mockReactFlowInstance.getEdges.mockReturnValue([originalEdge, otherEdge]);
 
       const { result } = renderHook(
         () =>

--- a/packages/apollo-react/src/canvas/components/Toolbar/EdgeToolbar/useEdgeToolbarState.ts
+++ b/packages/apollo-react/src/canvas/components/Toolbar/EdgeToolbar/useEdgeToolbarState.ts
@@ -1,7 +1,7 @@
-import { type Node, type Position, useReactFlow } from '@uipath/apollo-react/canvas/xyflow/react';
+import { type Position, useReactFlow } from '@uipath/apollo-react/canvas/xyflow/react';
 import { useCallback, useMemo } from 'react';
 import { DEFAULT_SOURCE_HANDLE_ID } from '../../../constants';
-import { useOptionalNodeTypeRegistry } from '../../../core';
+import { useCanvasNodeLayout } from '../../../hooks/useCanvasNodeLayout';
 import { showPreviewGraph } from '../../../utils/createPreviewGraph';
 import { isPreviewEdge } from '../../../utils/createPreviewNode';
 import { useBaseCanvasMode } from '../../BaseCanvas/BaseCanvasModeProvider';
@@ -42,13 +42,9 @@ export function useEdgeToolbarState({
   ignoredNodeTypes,
 }: UseEdgeToolbarStateProps): EdgeToolbarState {
   const reactFlow = useReactFlow();
-  const registry = useOptionalNodeTypeRegistry();
+  const { getManifestForNode } = useCanvasNodeLayout();
   const { mode } = useBaseCanvasMode();
   const isDesignMode = mode === 'design';
-  const getManifestForNode = useCallback(
-    (node: Node) => (node.type ? registry?.getManifest(node.type) : undefined),
-    [registry]
-  );
 
   const previewEdge = isPreviewEdge({ id: edgeId, source, target });
 
@@ -69,14 +65,13 @@ export function useEdgeToolbarState({
         nodeId: source,
         handleId: sourceHandleId ?? DEFAULT_SOURCE_HANDLE_ID,
       };
-      const containerOverrides = registry
-        ? resolveContainerAddNodePreview({
-            source: sourceEndpoint,
-            sourceHandleType: 'source',
-            reactFlowInstance: reactFlow,
-            getManifestForNode,
-          })
-        : null;
+      const containerOverrides = resolveContainerAddNodePreview({
+        source: sourceEndpoint,
+        sourceHandleType: 'source',
+        reactFlowInstance: reactFlow,
+        getManifestForNode,
+        replacedEdge: originalEdge,
+      });
 
       showPreviewGraph({
         source: sourceEndpoint,
@@ -99,7 +94,6 @@ export function useEdgeToolbarState({
       source,
       sourceHandleId,
       reactFlow,
-      registry,
       getManifestForNode,
       target,
       targetHandleId,

--- a/packages/apollo-react/src/canvas/hooks/index.ts
+++ b/packages/apollo-react/src/canvas/hooks/index.ts
@@ -2,6 +2,7 @@ export * from './ExecutionStatusContext';
 export * from './ToolbarActionContext';
 export * from './useAddNodeOnConnectEnd';
 export * from './useCanvasEvents';
+export * from './useCanvasNodeLayout';
 export * from './useEdgePath';
 export * from './useExportCanvas';
 export * from './useNavigationState';

--- a/packages/apollo-react/src/canvas/hooks/useAddNodeOnConnectEnd.test.ts
+++ b/packages/apollo-react/src/canvas/hooks/useAddNodeOnConnectEnd.test.ts
@@ -1,12 +1,21 @@
 import { renderHook } from '@testing-library/react';
-import { type FinalConnectionState, Position } from '@uipath/apollo-react/canvas/xyflow/react';
+import {
+  type Edge,
+  type FinalConnectionState,
+  type Node,
+  Position,
+} from '@uipath/apollo-react/canvas/xyflow/react';
 import type { InternalNodeBase } from '@xyflow/system';
+import { createElement, type ReactNode } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NodeRegistryContext, type NodeTypeRegistry } from '../core';
+import type { NodeManifest } from '../schema/node-definition';
 
 const mockReactFlowInstance = {
   screenToFlowPosition: vi.fn(),
   getNode: vi.fn(),
   getNodes: vi.fn(),
+  getEdges: vi.fn(),
   setNodes: vi.fn(),
   setEdges: vi.fn(),
 };
@@ -25,6 +34,54 @@ import * as utils from '../utils';
 import { useAddNodeOnConnectEnd } from './useAddNodeOnConnectEnd';
 
 const mockShowPreviewGraph = vi.mocked(utils.showPreviewGraph);
+
+const loopManifest = {
+  nodeType: 'loop',
+  display: { label: 'Loop', icon: 'repeat', shape: 'container' },
+  handleConfiguration: [
+    {
+      position: 'left',
+      boundary: 'inner',
+      handles: [{ id: 'start', type: 'source', handleType: 'output' }],
+    },
+    {
+      position: 'right',
+      boundary: 'inner',
+      handles: [{ id: 'continue', type: 'target', handleType: 'input' }],
+    },
+  ],
+} as NodeManifest;
+
+function createRegistryWrapper(registry: NodeTypeRegistry) {
+  return function RegistryWrapper({ children }: { children: ReactNode }) {
+    return createElement(NodeRegistryContext.Provider, { value: { registry } }, children);
+  };
+}
+
+const loopNode: Node = {
+  id: 'loop-1',
+  type: 'loop',
+  position: { x: 0, y: 0 },
+  style: { width: 704, height: 368 },
+  data: {},
+};
+
+const loopChildNode: Node = {
+  id: 'task-1',
+  type: 'task',
+  parentId: loopNode.id,
+  position: { x: 240, y: 112 },
+  measured: { width: 96, height: 96 },
+  data: {},
+};
+
+const mockFlowPosition = { x: 100, y: 100 };
+
+function createLoopRegistry(): NodeTypeRegistry {
+  return {
+    getManifest: vi.fn((type: string) => (type === 'loop' ? loopManifest : undefined)),
+  } as unknown as NodeTypeRegistry;
+}
 
 describe('useAddNodeOnConnectEnd', () => {
   const mockFromNode = {
@@ -69,7 +126,25 @@ describe('useAddNodeOnConnectEnd', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockUseReactFlow.mockReturnValue(mockReactFlowInstance);
+    mockReactFlowInstance.getNode.mockReset();
+    mockReactFlowInstance.getNodes.mockReset();
+    mockReactFlowInstance.getEdges.mockReset();
   });
+
+  function mockFlowGraph(nodes: Node[], edges: Edge[] = []) {
+    mockReactFlowInstance.screenToFlowPosition = vi.fn().mockReturnValue(mockFlowPosition);
+    mockReactFlowInstance.getNode.mockImplementation((id: string) =>
+      nodes.find((node) => node.id === id)
+    );
+    mockReactFlowInstance.getNodes.mockReturnValue(nodes);
+    mockReactFlowInstance.getEdges.mockReturnValue(edges);
+  }
+
+  function renderWithLoopRegistry() {
+    return renderHook(() => useAddNodeOnConnectEnd(), {
+      wrapper: createRegistryWrapper(createLoopRegistry()),
+    });
+  }
 
   it('should return a callback function', () => {
     const { result } = renderHook(() => useAddNodeOnConnectEnd());
@@ -222,6 +297,138 @@ describe('useAddNodeOnConnectEnd', () => {
     result.current(mockTouchEventWithChangedTouches, connectionStateBase);
 
     expect(mockShowPreviewGraph).toHaveBeenCalledOnce();
+  });
+
+  it('should parent loop inner start-handle drags without switching to sequence insertion', () => {
+    mockFlowGraph(
+      [loopNode, loopChildNode],
+      [
+        {
+          id: 'loop-1-task-1',
+          source: loopNode.id,
+          sourceHandle: 'start',
+          target: loopChildNode.id,
+          targetHandle: 'input',
+        },
+      ]
+    );
+
+    const { result } = renderWithLoopRegistry();
+
+    result.current(mockMouseEvent, {
+      ...connectionStateBase,
+      fromNode: {
+        ...mockFromNode,
+        id: loopNode.id,
+      },
+      fromHandle: {
+        ...connectionStateBase.fromHandle!,
+        nodeId: loopNode.id,
+        id: 'start',
+      },
+    });
+
+    const previewOptions = mockShowPreviewGraph.mock.calls[0]?.[0];
+
+    expect(previewOptions).toMatchObject({
+      source: {
+        nodeId: loopNode.id,
+        handleId: 'start',
+      },
+      position: mockFlowPosition,
+      sourceHandleType: 'source',
+      handlePosition: Position.Right,
+      ignoredNodeTypes: [],
+      containerId: loopNode.id,
+    });
+    expect(previewOptions).not.toHaveProperty('target');
+    expect(previewOptions).not.toHaveProperty('positionMode');
+    expect(previewOptions).not.toHaveProperty('data');
+  });
+
+  it('should parent loop inner continue-handle drags', () => {
+    mockFlowGraph([loopNode]);
+
+    const { result } = renderWithLoopRegistry();
+
+    result.current(mockMouseEvent, {
+      ...connectionStateBase,
+      fromNode: {
+        ...mockFromNode,
+        id: loopNode.id,
+      },
+      fromHandle: {
+        ...connectionStateBase.fromHandle!,
+        type: 'target',
+        nodeId: loopNode.id,
+        id: 'continue',
+        position: Position.Left,
+      },
+    });
+
+    const previewOptions = mockShowPreviewGraph.mock.calls[0]?.[0];
+
+    expect(previewOptions).toMatchObject({
+      source: {
+        nodeId: loopNode.id,
+        handleId: 'continue',
+      },
+      position: mockFlowPosition,
+      sourceHandleType: 'target',
+      handlePosition: Position.Left,
+      ignoredNodeTypes: [],
+      containerId: loopNode.id,
+    });
+    expect(previewOptions).not.toHaveProperty('target');
+    expect(previewOptions).not.toHaveProperty('positionMode');
+    expect(previewOptions).not.toHaveProperty('data');
+  });
+
+  it('should keep loop child handle drags on the generic drop-position path', () => {
+    mockFlowGraph(
+      [loopNode, loopChildNode],
+      [
+        {
+          id: 'task-1-continue',
+          source: loopChildNode.id,
+          sourceHandle: 'output',
+          target: loopNode.id,
+          targetHandle: 'continue',
+        },
+      ]
+    );
+
+    const { result } = renderWithLoopRegistry();
+
+    result.current(mockMouseEvent, {
+      ...connectionStateBase,
+      fromNode: {
+        ...mockFromNode,
+        id: loopChildNode.id,
+      },
+      fromHandle: {
+        ...connectionStateBase.fromHandle!,
+        nodeId: loopChildNode.id,
+        id: 'output',
+      },
+    });
+
+    const previewOptions = mockShowPreviewGraph.mock.calls[0]?.[0];
+
+    expect(previewOptions).toMatchObject({
+      source: {
+        nodeId: loopChildNode.id,
+        handleId: 'output',
+      },
+      position: mockFlowPosition,
+      sourceHandleType: 'source',
+      handlePosition: Position.Right,
+      ignoredNodeTypes: [],
+    });
+    expect(previewOptions).not.toHaveProperty('containerId');
+    expect(previewOptions).not.toHaveProperty('target');
+    expect(previewOptions).not.toHaveProperty('positionMode');
+    expect(previewOptions).not.toHaveProperty('data');
   });
 
   it('should memoize callback with reactFlowInstance dependency', () => {

--- a/packages/apollo-react/src/canvas/hooks/useAddNodeOnConnectEnd.ts
+++ b/packages/apollo-react/src/canvas/hooks/useAddNodeOnConnectEnd.ts
@@ -1,6 +1,8 @@
 import { type OnConnectEnd, useReactFlow } from '@uipath/apollo-react/canvas/xyflow/react';
 import { useCallback } from 'react';
+import { getInnerHandleContainerId } from '../components/LoopNode/LoopNode.helpers';
 import { showPreviewGraph } from '../utils';
+import { useNodeManifestResolver } from './useCanvasNodeLayout';
 
 const EMPTY_IGNORED_NODE_TYPES: string[] = [];
 
@@ -20,6 +22,7 @@ function getClientPosition(event: MouseEvent | TouchEvent): { x: number; y: numb
  */
 export function useAddNodeOnConnectEnd(ignoredNodeTypes: string[] = EMPTY_IGNORED_NODE_TYPES) {
   const reactFlowInstance = useReactFlow();
+  const getManifestForNode = useNodeManifestResolver();
 
   return useCallback<OnConnectEnd>(
     (event, connectionState) => {
@@ -36,19 +39,26 @@ export function useAddNodeOnConnectEnd(ignoredNodeTypes: string[] = EMPTY_IGNORE
       if (!clientPosition) return;
 
       const flowDropPosition = reactFlowInstance.screenToFlowPosition(clientPosition);
+      const source = {
+        nodeId: connectionState.fromNode.id,
+        handleId: connectionState.fromHandle.id ?? 'output',
+      };
+      const containerId = getInnerHandleContainerId({
+        source,
+        reactFlowInstance,
+        getManifestForNode,
+      });
 
       showPreviewGraph({
-        source: {
-          nodeId: connectionState.fromNode.id,
-          handleId: connectionState.fromHandle.id ?? 'output',
-        },
+        source,
         reactFlowInstance,
         position: flowDropPosition,
         sourceHandleType: connectionState.fromHandle.type,
         handlePosition: connectionState.fromHandle.position,
         ignoredNodeTypes,
+        ...(containerId ? { containerId } : {}),
       });
     },
-    [reactFlowInstance, ignoredNodeTypes]
+    [reactFlowInstance, getManifestForNode, ignoredNodeTypes]
   );
 }

--- a/packages/apollo-react/src/canvas/hooks/useCanvasNodeLayout.ts
+++ b/packages/apollo-react/src/canvas/hooks/useCanvasNodeLayout.ts
@@ -1,0 +1,55 @@
+import type { Node } from '@uipath/apollo-react/canvas/xyflow/react';
+import { useCallback, useMemo } from 'react';
+import { useOptionalNodeTypeRegistry } from '../core';
+import type { NodeManifest } from '../schema/node-definition';
+import { getExpandedSize } from '../utils/collapse';
+import {
+  type ContainerFitGeometry,
+  getContainerFitGeometry as getDefaultContainerFitGeometry,
+  getNodeDimensions as getMeasuredNodeDimensions,
+  isContainerNodeManifest,
+  type NodeDimensions,
+} from '../utils/container';
+
+export type NodeManifestResolver = (node: Node) => NodeManifest | undefined;
+
+export interface NodeLayout {
+  getNodeDimensions: (node: Node) => NodeDimensions;
+  isContainerNode: (node: Node) => boolean;
+  getContainerFitGeometry: (node: Node) => ContainerFitGeometry | null;
+}
+
+export interface CanvasNodeLayout extends NodeLayout {
+  getManifestForNode: NodeManifestResolver;
+}
+
+export function useNodeManifestResolver(): NodeManifestResolver {
+  const registry = useOptionalNodeTypeRegistry();
+
+  return useCallback(
+    (node: Node) => (node.type ? registry?.getManifest(node.type) : undefined),
+    [registry]
+  );
+}
+
+export function useCanvasNodeLayout(): CanvasNodeLayout {
+  const getManifestForNode = useNodeManifestResolver();
+
+  return useMemo(() => {
+    const getNodeDimensions = (node: Node) => {
+      const manifest = getManifestForNode(node);
+
+      return getMeasuredNodeDimensions(node, getExpandedSize(manifest?.display.shape));
+    };
+
+    const isContainerNode = (node: Node) => isContainerNodeManifest(getManifestForNode(node));
+
+    return {
+      getManifestForNode,
+      getNodeDimensions,
+      isContainerNode,
+      getContainerFitGeometry: (node: Node) =>
+        isContainerNode(node) ? getDefaultContainerFitGeometry() : null,
+    };
+  }, [getManifestForNode]);
+}

--- a/packages/apollo-react/src/canvas/utils/NodeUtils.test.ts
+++ b/packages/apollo-react/src/canvas/utils/NodeUtils.test.ts
@@ -698,7 +698,7 @@ describe('NodeUtils', () => {
       ];
 
       const result = resolveCollisions(nodes, {
-        getNodeSize: (node) =>
+        getNodeDimensions: (node) =>
           node.id === 'wide-node'
             ? { width: 160, height: 40 }
             : {

--- a/packages/apollo-react/src/canvas/utils/NodeUtils.ts
+++ b/packages/apollo-react/src/canvas/utils/NodeUtils.ts
@@ -112,7 +112,7 @@ export type CollisionAlgorithmOptions = {
   margin?: number;
   ignoredNodeTypes?: string[];
   /** Allows callers to resolve manifest-aware sizes before collision math runs. */
-  getNodeSize?: (node: Node) => { width: number; height: number };
+  getNodeDimensions?: (node: Node) => { width: number; height: number };
 };
 
 export type CollisionAlgorithm = (nodes: Node[], options?: CollisionAlgorithmOptions) => Node[];
@@ -129,13 +129,13 @@ type Box = {
 function getBoxesFromNodes(
   nodes: Node[],
   margin: number = 0,
-  getNodeSize?: (node: Node) => { width: number; height: number }
+  getNodeDimensions?: (node: Node) => { width: number; height: number }
 ): Box[] {
   const boxes: Box[] = new Array(nodes.length);
 
   for (let i = 0; i < nodes.length; i++) {
     const node = nodes[i]!;
-    const nodeSize = getNodeSize?.(node) ?? {
+    const nodeSize = getNodeDimensions?.(node) ?? {
       width: node.width ?? node.measured?.width ?? DEFAULT_NODE_SIZE,
       height: node.height ?? node.measured?.height ?? DEFAULT_NODE_SIZE,
     };
@@ -163,14 +163,14 @@ export const resolveCollisions: CollisionAlgorithm = (
     overlapThreshold = 0,
     margin = GRID_SPACING * 2,
     ignoredNodeTypes,
-    getNodeSize,
+    getNodeDimensions,
   } = {}
 ) => {
   const ignoredSet = new Set(ignoredNodeTypes);
   const collisionNodes =
     ignoredSet.size > 0 ? nodes.filter((n) => !ignoredSet.has(n.type ?? '')) : nodes;
 
-  const boxes = getBoxesFromNodes(collisionNodes, margin, getNodeSize);
+  const boxes = getBoxesFromNodes(collisionNodes, margin, getNodeDimensions);
   for (let iter = 0; iter < maxIterations; iter++) {
     let moved = false;
 

--- a/packages/apollo-react/src/canvas/utils/container.ts
+++ b/packages/apollo-react/src/canvas/utils/container.ts
@@ -99,6 +99,7 @@ interface ContainerPreviewContext {
 
 interface ContainerPreviewOptions {
   isContainerNode?: (node: Node) => boolean;
+  replacedEdge?: Edge;
   getContainerSafeArea?: (containerNode: Node) => ContainerSafeArea | undefined;
   getContainerContinuationTarget?: (context: {
     containerNode: Node;
@@ -759,6 +760,7 @@ function resolveInsertPreview({
   sourceHandleType,
   reactFlowInstance,
   isContainerNode,
+  replacedEdge: exactReplacedEdge,
   getContainerSafeArea,
   previewNodeSize,
   gap,
@@ -766,24 +768,30 @@ function resolveInsertPreview({
 }: ContainerPreviewContext &
   Pick<
     ContainerPreviewOptions,
-    'isContainerNode' | 'getContainerSafeArea' | 'previewNodeSize' | 'gap' | 'getNodeDimensions'
+    | 'isContainerNode'
+    | 'replacedEdge'
+    | 'getContainerSafeArea'
+    | 'previewNodeSize'
+    | 'gap'
+    | 'getNodeDimensions'
   >): PreviewGraphOverrides | null {
   if (sourceHandleType !== 'source' || !source.handleId) {
     return null;
   }
 
-  const replacedEdge = getSingleOutgoingEdge(
-    source.nodeId,
-    source.handleId,
-    reactFlowInstance.getEdges()
-  );
+  const replacedEdge =
+    exactReplacedEdge ??
+    getSingleOutgoingEdge(source.nodeId, source.handleId, reactFlowInstance.getEdges());
 
   if (!replacedEdge) {
     return null;
   }
 
-  const sourceNode = reactFlowInstance.getNode(replacedEdge.source)!;
-  const targetNode = reactFlowInstance.getNode(replacedEdge.target)!;
+  const sourceNode = reactFlowInstance.getNode(replacedEdge.source);
+  const targetNode = reactFlowInstance.getNode(replacedEdge.target);
+  if (!sourceNode || !targetNode) {
+    return null;
+  }
   const nodes = reactFlowInstance.getNodes();
 
   const containerNode = getContainerNodeForEdge(sourceNode, targetNode, nodes);


### PR DESCRIPTION
## Summary

This PR keeps the existing child-handle drag and handle-button sequence behavior intact, while fixing the loop/container inner-handle drag case where the preview was parented but the actual node could materialize outside the loop.

## Cleanup / API Simplification

- `packages/apollo-react/src/canvas/hooks/useCanvasNodeLayout.ts`
- `packages/apollo-react/src/canvas/hooks/index.ts`
- `packages/apollo-react/src/canvas/components/AddNodePanel/AddNodeManager.helpers.ts`
- `packages/apollo-react/src/canvas/components/AddNodePanel/AddNodeManager.tsx`
- `packages/apollo-react/src/canvas/components/AddNodePanel/AddNodeManager.helpers.test.ts`
- `packages/apollo-react/src/canvas/components/HierarchicalCanvas/HierarchicalCanvas.tsx`
- `packages/apollo-react/src/canvas/utils/NodeUtils.ts`
- `packages/apollo-react/src/canvas/utils/NodeUtils.test.ts`
- `packages/apollo-react/src/canvas/components/Toolbar/EdgeToolbar/useEdgeToolbarState.ts`

## Functional Fixes


- Dragging from a loop's own inner handles now keeps the drop position and parents both preview and actual node into that loop.
- Dragging from a loop child handle stays on the existing drop-position flow.
- Clicking a handle add button keeps sequence insertion behavior.
- Edge toolbar add uses the selected edge, so insertion still works when a source handle has multiple outgoing edges.



## Demo

Before vs After

https://github.com/user-attachments/assets/bce20c37-2f4a-47b6-bed0-d2569eddb551

## Fix Flow

```mermaid
flowchart TD
  A[User starts Add Node] --> B{Gesture}

  B -->|Drag from loop inner handle| C[useAddNodeOnConnectEnd]
  C --> D[getInnerHandleContainerId]
  D -->|inner handle on container itself| E[showPreviewGraph with drop position + containerId]
  E --> F[createPreviewGraph reparents preview into loop]
  F --> G[AddNodeManager copies preview parentId to actual node]

  B -->|Drag from loop child handle| H[useAddNodeOnConnectEnd]
  H --> I[showPreviewGraph with drop position only]
  I --> J[createPreviewGraph infers container from sourceNode.parentId]
  J --> G

  B -->|Click handle add button| K[createAddNodePreview]
  K --> L[resolveContainerAddNodePreview]
  L -->|0 outgoing edge| M[sequence append preview]
  L -->|1 outgoing edge| N[sequence insert preview]
  L -->|multiple outgoing edges| O[generic preview path]

  B -->|Edge toolbar add| P[useEdgeToolbarState]
  P --> Q[resolveContainerAddNodePreview with exact replacedEdge]
  Q --> R[sequence insert preview for selected edge]
```

## Tests

- `pnpm --filter @uipath/apollo-react exec vitest --run src/canvas/hooks/useAddNodeOnConnectEnd.test.ts src/canvas/components/LoopNode/LoopNode.helpers.test.ts src/canvas/components/Toolbar/EdgeToolbar/useEdgeToolbarState.test.ts src/canvas/utils/container.test.ts src/canvas/components/AddNodePanel/AddNodeManager.helpers.test.ts src/canvas/components/AddNodePanel/AddNodeManager.test.tsx src/canvas/utils/NodeUtils.test.ts`
