### PR TITLE
fix(apollo-react): constrain loop resize to body bounds

### DIFF
--- a/packages/apollo-react/src/canvas/components/LoopNode/LoopNode.tsx
+++ b/packages/apollo-react/src/canvas/components/LoopNode/LoopNode.tsx
@@ -7,15 +7,18 @@ import {
 } from '@uipath/apollo-react/canvas/xyflow/react';
 import { cn } from '@uipath/apollo-wind';
 import { memo, useCallback, useEffect, useMemo, useState } from 'react';
+import { shallow } from 'zustand/shallow';
 import { useOptionalNodeTypeRegistry } from '../../core';
 import { useElementValidationStatus, useNodeExecutionState } from '../../hooks';
 import type { SuggestionType } from '../../types';
 import { resolveAdornments } from '../../utils/adornment-resolver';
 import {
+  type ContainerResizeMinimums,
   DEFAULT_CONTAINER_HEIGHT,
   DEFAULT_CONTAINER_MIN_HEIGHT,
   DEFAULT_CONTAINER_MIN_WIDTH,
   DEFAULT_CONTAINER_WIDTH,
+  getContainerResizeMinimums,
 } from '../../utils/container';
 import { CanvasIcon } from '../../utils/icon-registry';
 import { resolveDisplay, resolveHandles } from '../../utils/manifest-resolver';
@@ -39,20 +42,42 @@ const DEFAULT_LOOP_TITLE = 'Loop';
 const EMPTY_DATA: Record<string, unknown> = {};
 
 const RESIZE_CONTROLS = [
-  { position: 'top-left', cursor: 'nwse-resize', indicatorClassName: 'top-[-4px] left-[-4px]' },
-  { position: 'top-right', cursor: 'nesw-resize', indicatorClassName: 'top-[-4px] right-[-4px]' },
+  {
+    position: 'top-left',
+    widthSide: 'left',
+    heightSide: 'top',
+    cursor: 'nwse-resize',
+    indicatorClassName: 'top-[-4px] left-[-4px]',
+  },
+  {
+    position: 'top-right',
+    widthSide: 'right',
+    heightSide: 'top',
+    cursor: 'nesw-resize',
+    indicatorClassName: 'top-[-4px] right-[-4px]',
+  },
   {
     position: 'bottom-left',
+    widthSide: 'left',
+    heightSide: 'bottom',
     cursor: 'nesw-resize',
     indicatorClassName: 'bottom-[-4px] left-[-4px]',
   },
   {
     position: 'bottom-right',
+    widthSide: 'right',
+    heightSide: 'bottom',
     cursor: 'nwse-resize',
     indicatorClassName: 'bottom-[-4px] right-[-4px]',
   },
 ] as const;
 const RESIZE_CONTROL_STYLE = { background: 'transparent', border: 'none', zIndex: 100 } as const;
+const DEFAULT_RESIZE_MINIMUMS: ContainerResizeMinimums = {
+  left: DEFAULT_CONTAINER_MIN_WIDTH,
+  right: DEFAULT_CONTAINER_MIN_WIDTH,
+  top: DEFAULT_CONTAINER_MIN_HEIGHT,
+  bottom: DEFAULT_CONTAINER_MIN_HEIGHT,
+};
 
 const ADORNMENT_SLOT_POSITIONS = ['topLeft', 'topRight', 'bottomLeft', 'bottomRight'] as const;
 const ADORNMENT_SLOT_SHAPES: Record<
@@ -82,6 +107,20 @@ function useHasChildNodes(id: string, enabled: boolean): boolean {
       (state: ReactFlowState) => !enabled || state.nodes.some((node) => node.parentId === id),
       [id, enabled]
     )
+  );
+}
+
+function useContainerResizeMinimums(
+  id: string,
+  width: number,
+  height: number
+): ContainerResizeMinimums {
+  return useStore(
+    useCallback(
+      (state: ReactFlowState) => getContainerResizeMinimums({ id, width, height }, state.nodes),
+      [height, id, width]
+    ),
+    shallow
   );
 }
 
@@ -176,6 +215,7 @@ function LoopNodeComponent(props: LoopNodeProps) {
   const isDropTarget = resolvedData.isDropTarget === true;
   const containerWidth = width || DEFAULT_CONTAINER_WIDTH;
   const containerHeight = height || DEFAULT_CONTAINER_HEIGHT;
+  const resizeMinimums = useContainerResizeMinimums(id, containerWidth, containerHeight);
   const nodeSizeStyle = {
     width: containerWidth,
     height: containerHeight,
@@ -292,7 +332,9 @@ function LoopNodeComponent(props: LoopNodeProps) {
         ) : null
       )}
       <ResizeCornerIndicators visible={showResizeControls} />
-      {showResizeControls ? <ResizeControls onResize={handleResize} /> : null}
+      {showResizeControls ? (
+        <ResizeControls minimums={resizeMinimums} onResize={handleResize} />
+      ) : null}
       <Header title={displayTitle} icon={displayIcon} loading={isLoading} isParallel={isParallel} />
       <BodyFrame isEmpty={showEmptyStateButton} isLoading={isLoading} />
       {showEmptyStateButton ? (
@@ -415,19 +457,21 @@ function BodyFrame({ isEmpty, isLoading }: { isEmpty?: boolean; isLoading?: bool
 }
 
 function ResizeControls({
+  minimums = DEFAULT_RESIZE_MINIMUMS,
   onResize,
 }: {
+  minimums?: ContainerResizeMinimums;
   onResize: (_event: unknown, params: { width: number; height: number }) => void;
 }) {
   return (
     <>
-      {RESIZE_CONTROLS.map(({ position, cursor }) => (
+      {RESIZE_CONTROLS.map(({ position, widthSide, heightSide, cursor }) => (
         <NodeResizeControl
           key={position}
           style={RESIZE_CONTROL_STYLE}
           position={position}
-          minWidth={DEFAULT_CONTAINER_MIN_WIDTH}
-          minHeight={DEFAULT_CONTAINER_MIN_HEIGHT}
+          minWidth={minimums[widthSide]}
+          minHeight={minimums[heightSide]}
           onResize={onResize}
         >
           <div

--- a/packages/apollo-react/src/canvas/components/LoopNode/LoopNode.tsx
+++ b/packages/apollo-react/src/canvas/components/LoopNode/LoopNode.tsx
@@ -113,12 +113,22 @@ function useHasChildNodes(id: string, enabled: boolean): boolean {
 function useContainerResizeMinimums(
   id: string,
   width: number,
-  height: number
+  height: number,
+  enabled: boolean
 ): ContainerResizeMinimums {
   return useStore(
     useCallback(
-      (state: ReactFlowState) => getContainerResizeMinimums({ id, width, height }, state.nodes),
-      [height, id, width]
+      (state: ReactFlowState) => {
+        if (!enabled) {
+          return DEFAULT_RESIZE_MINIMUMS;
+        }
+
+        return getContainerResizeMinimums(
+          { id, width, height },
+          Array.from(state.parentLookup.get(id)?.values() ?? [])
+        );
+      },
+      [enabled, height, id, width]
     ),
     shallow
   );
@@ -215,7 +225,13 @@ function LoopNodeComponent(props: LoopNodeProps) {
   const isDropTarget = resolvedData.isDropTarget === true;
   const containerWidth = width || DEFAULT_CONTAINER_WIDTH;
   const containerHeight = height || DEFAULT_CONTAINER_HEIGHT;
-  const resizeMinimums = useContainerResizeMinimums(id, containerWidth, containerHeight);
+  const showResizeControls = selected && !dragging && isDesignMode;
+  const resizeMinimums = useContainerResizeMinimums(
+    id,
+    containerWidth,
+    containerHeight,
+    showResizeControls
+  );
   const nodeSizeStyle = {
     width: containerWidth,
     height: containerHeight,
@@ -273,7 +289,6 @@ function LoopNodeComponent(props: LoopNodeProps) {
   const shouldShowHandles = (isConnecting || selected || isHovered) && !dragging;
 
   const showHandleAddButtons = isDesignMode && !multipleNodesSelected && !isConnecting && !dragging;
-  const showResizeControls = selected && !dragging && isDesignMode;
   const showEmptyStateButton = isDesignMode && !hasChildNodes && !!onAddFirstChild;
 
   const interactionState = resolveInteractionState(dragging, selected, isHovered);

--- a/packages/apollo-react/src/canvas/utils/container.test.ts
+++ b/packages/apollo-react/src/canvas/utils/container.test.ts
@@ -7,6 +7,7 @@ import {
   DEFAULT_CONTAINER_MIN_WIDTH,
   ensureContainersFitChildren,
   getContainerFitGeometry,
+  getContainerResizeMinimums,
   getContainerSafeArea,
   getNodeDimensions,
   placeContainerNode,
@@ -32,6 +33,129 @@ describe('container sizing', () => {
       minWidth: DEFAULT_CONTAINER_MIN_WIDTH,
       minHeight: DEFAULT_CONTAINER_MIN_HEIGHT,
       padding: { left: 144, right: 144, top: 96, bottom: 48 },
+    });
+  });
+
+  it('computes side-specific resize minimums that keep children inside the body', () => {
+    const containerNode: Node = {
+      id: 'loop-1',
+      type: 'loop',
+      position: { x: 0, y: 0 },
+      style: { width: 704, height: 368 },
+      data: {},
+    };
+    const leftTopChild: Node = {
+      id: 'left-top-child',
+      type: 'task',
+      parentId: containerNode.id,
+      position: { x: 176, y: 128 },
+      measured: { width: 96, height: 96 },
+      data: {},
+    };
+    const rightBottomChild: Node = {
+      id: 'right-bottom-child',
+      type: 'task',
+      parentId: containerNode.id,
+      position: { x: 416, y: 192 },
+      measured: { width: 96, height: 96 },
+      data: {},
+    };
+
+    expect(
+      getContainerResizeMinimums(containerNode, [containerNode, leftTopChild, rightBottomChild])
+    ).toEqual({
+      left: 672,
+      right: 656,
+      top: 336,
+      bottom: 336,
+    });
+  });
+
+  it('uses default resize minimums when a container has no visible children', () => {
+    const containerNode: Node = {
+      id: 'loop-1',
+      type: 'loop',
+      position: { x: 0, y: 0 },
+      style: { width: 704, height: 368 },
+      data: {},
+    };
+
+    expect(getContainerResizeMinimums(containerNode, [containerNode])).toEqual({
+      left: DEFAULT_CONTAINER_MIN_WIDTH,
+      right: DEFAULT_CONTAINER_MIN_WIDTH,
+      top: DEFAULT_CONTAINER_MIN_HEIGHT,
+      bottom: DEFAULT_CONTAINER_MIN_HEIGHT,
+    });
+  });
+
+  it('allows resize minimums to exceed current size when children already cross the body', () => {
+    const containerNode: Node = {
+      id: 'loop-1',
+      type: 'loop',
+      position: { x: 0, y: 0 },
+      style: { width: 560, height: 320 },
+      data: {},
+    };
+    const childNode: Node = {
+      id: 'child-1',
+      type: 'task',
+      parentId: containerNode.id,
+      position: { x: 96, y: 64 },
+      measured: { width: 96, height: 96 },
+      data: {},
+    };
+
+    expect(getContainerResizeMinimums(containerNode, [containerNode, childNode])).toMatchObject({
+      left: 608,
+      top: 352,
+    });
+  });
+
+  it('ignores preview, hidden, and ignored child types when computing resize minimums', () => {
+    const containerNode: Node = {
+      id: 'loop-1',
+      type: 'loop',
+      position: { x: 0, y: 0 },
+      style: { width: 704, height: 368 },
+      data: {},
+    };
+    const previewChild: Node = {
+      id: PREVIEW_NODE_ID,
+      type: 'preview',
+      parentId: containerNode.id,
+      position: { x: 0, y: 0 },
+      measured: { width: 96, height: 96 },
+      data: {},
+    };
+    const hiddenChild: Node = {
+      id: 'hidden-child',
+      type: 'task',
+      parentId: containerNode.id,
+      hidden: true,
+      position: { x: 0, y: 0 },
+      measured: { width: 96, height: 96 },
+      data: {},
+    };
+    const ignoredChild: Node = {
+      id: 'ignored-child',
+      type: 'stickyNote',
+      parentId: containerNode.id,
+      position: { x: 0, y: 0 },
+      measured: { width: 96, height: 96 },
+      data: {},
+    };
+
+    expect(
+      getContainerResizeMinimums(
+        containerNode,
+        [containerNode, previewChild, hiddenChild, ignoredChild],
+        { ignoredNodeTypes: ['stickyNote'] }
+      )
+    ).toEqual({
+      left: DEFAULT_CONTAINER_MIN_WIDTH,
+      right: DEFAULT_CONTAINER_MIN_WIDTH,
+      top: DEFAULT_CONTAINER_MIN_HEIGHT,
+      bottom: DEFAULT_CONTAINER_MIN_HEIGHT,
     });
   });
 

--- a/packages/apollo-react/src/canvas/utils/container.test.ts
+++ b/packages/apollo-react/src/canvas/utils/container.test.ts
@@ -88,7 +88,7 @@ describe('container sizing', () => {
     });
   });
 
-  it('allows resize minimums to exceed current size when children already cross the body', () => {
+  it('caps resize minimums at the current size when children already cross the body', () => {
     const containerNode: Node = {
       id: 'loop-1',
       type: 'loop',
@@ -106,8 +106,31 @@ describe('container sizing', () => {
     };
 
     expect(getContainerResizeMinimums(containerNode, [containerNode, childNode])).toMatchObject({
-      left: 608,
-      top: 352,
+      left: 560,
+      top: 320,
+    });
+  });
+
+  it('does not return resize minimums below the defaults when the current size is already smaller', () => {
+    const containerNode: Node = {
+      id: 'loop-1',
+      type: 'loop',
+      position: { x: 0, y: 0 },
+      style: { width: 320, height: 160 },
+      data: {},
+    };
+    const childNode: Node = {
+      id: 'child-1',
+      type: 'task',
+      parentId: containerNode.id,
+      position: { x: 96, y: 64 },
+      measured: { width: 96, height: 96 },
+      data: {},
+    };
+
+    expect(getContainerResizeMinimums(containerNode, [containerNode, childNode])).toMatchObject({
+      left: DEFAULT_CONTAINER_MIN_WIDTH,
+      top: DEFAULT_CONTAINER_MIN_HEIGHT,
     });
   });
 

--- a/packages/apollo-react/src/canvas/utils/container.ts
+++ b/packages/apollo-react/src/canvas/utils/container.ts
@@ -238,8 +238,10 @@ export function getContainerFitGeometry(): ContainerFitGeometry {
   };
 }
 
-function resolveResizeMinimum(minSize: number, requiredSize: number): number {
-  return Math.max(minSize, snapUpToGrid(requiredSize));
+function resolveResizeMinimum(minSize: number, currentSize: number, requiredSize: number): number {
+  const requiredMinimum = Math.max(minSize, snapUpToGrid(requiredSize));
+  const currentResizeFloor = Math.max(minSize, currentSize);
+  return Math.min(currentResizeFloor, requiredMinimum);
 }
 
 /** Returns side-specific minimum sizes for shrinking a container around visible direct children. */
@@ -249,12 +251,10 @@ export function getContainerResizeMinimums(
   {
     minWidth = DEFAULT_CONTAINER_MIN_WIDTH,
     minHeight = DEFAULT_CONTAINER_MIN_HEIGHT,
-    getNodeDimensions: resolveNodeDimensions = getNodeDimensions,
     ignoredNodeTypes = [],
   }: {
     minWidth?: number;
     minHeight?: number;
-    getNodeDimensions?: (node: Node) => NodeDimensions;
     ignoredNodeTypes?: string[];
   } = {}
 ): ContainerResizeMinimums {
@@ -276,7 +276,7 @@ export function getContainerResizeMinimums(
       continue;
     }
 
-    const childSize = resolveNodeDimensions(childNode);
+    const childSize = getNodeDimensions(childNode);
     const nextBounds = {
       left: childNode.position.x,
       right: childNode.position.x + childSize.width,
@@ -309,10 +309,10 @@ export function getContainerResizeMinimums(
   const bottomEdgeLimit = childBounds.bottom + (padding.bottom ?? 0);
 
   return {
-    left: resolveResizeMinimum(minWidth, leftEdgeLimit),
-    right: resolveResizeMinimum(minWidth, rightEdgeLimit),
-    top: resolveResizeMinimum(minHeight, topEdgeLimit),
-    bottom: resolveResizeMinimum(minHeight, bottomEdgeLimit),
+    left: resolveResizeMinimum(minWidth, currentSize.width, leftEdgeLimit),
+    right: resolveResizeMinimum(minWidth, currentSize.width, rightEdgeLimit),
+    top: resolveResizeMinimum(minHeight, currentSize.height, topEdgeLimit),
+    bottom: resolveResizeMinimum(minHeight, currentSize.height, bottomEdgeLimit),
   };
 }
 

--- a/packages/apollo-react/src/canvas/utils/container.ts
+++ b/packages/apollo-react/src/canvas/utils/container.ts
@@ -69,6 +69,14 @@ export interface ContainerSizeChange {
   nextSize: NodeDimensions;
 }
 
+/** Side-specific minimum sizes that prevent manual container resizing from clipping children. */
+export interface ContainerResizeMinimums {
+  left: number;
+  right: number;
+  top: number;
+  bottom: number;
+}
+
 /** Result of fitting one or more containers to their visible children. */
 export interface EnsureContainersFitChildrenResult {
   nodes: Node[];
@@ -227,6 +235,84 @@ export function getContainerFitGeometry(): ContainerFitGeometry {
     minWidth: DEFAULT_CONTAINER_MIN_WIDTH,
     minHeight: DEFAULT_CONTAINER_MIN_HEIGHT,
     padding,
+  };
+}
+
+function resolveResizeMinimum(minSize: number, requiredSize: number): number {
+  return Math.max(minSize, snapUpToGrid(requiredSize));
+}
+
+/** Returns side-specific minimum sizes for shrinking a container around visible direct children. */
+export function getContainerResizeMinimums(
+  containerNode: Pick<Node, 'id' | 'width' | 'height' | 'measured' | 'style'>,
+  nodes: Node[],
+  {
+    minWidth = DEFAULT_CONTAINER_MIN_WIDTH,
+    minHeight = DEFAULT_CONTAINER_MIN_HEIGHT,
+    getNodeDimensions: resolveNodeDimensions = getNodeDimensions,
+    ignoredNodeTypes = [],
+  }: {
+    minWidth?: number;
+    minHeight?: number;
+    getNodeDimensions?: (node: Node) => NodeDimensions;
+    ignoredNodeTypes?: string[];
+  } = {}
+): ContainerResizeMinimums {
+  const currentSize = getNodeDimensions(containerNode, {
+    width: DEFAULT_CONTAINER_WIDTH,
+    height: DEFAULT_CONTAINER_HEIGHT,
+  });
+  const padding = getContainerSafeArea(containerNode, currentSize).padding ?? {};
+  const ignoredTypes = new Set(ignoredNodeTypes);
+  let childBounds: { left: number; right: number; top: number; bottom: number } | undefined;
+
+  for (const childNode of nodes) {
+    if (
+      childNode.id === PREVIEW_NODE_ID ||
+      childNode.hidden ||
+      childNode.parentId !== containerNode.id ||
+      ignoredTypes.has(childNode.type ?? '')
+    ) {
+      continue;
+    }
+
+    const childSize = resolveNodeDimensions(childNode);
+    const nextBounds = {
+      left: childNode.position.x,
+      right: childNode.position.x + childSize.width,
+      top: childNode.position.y,
+      bottom: childNode.position.y + childSize.height,
+    };
+
+    childBounds = childBounds
+      ? {
+          left: Math.min(childBounds.left, nextBounds.left),
+          right: Math.max(childBounds.right, nextBounds.right),
+          top: Math.min(childBounds.top, nextBounds.top),
+          bottom: Math.max(childBounds.bottom, nextBounds.bottom),
+        }
+      : nextBounds;
+  }
+
+  if (!childBounds) {
+    return {
+      left: minWidth,
+      right: minWidth,
+      top: minHeight,
+      bottom: minHeight,
+    };
+  }
+
+  const leftEdgeLimit = currentSize.width - childBounds.left + (padding.left ?? 0);
+  const topEdgeLimit = currentSize.height - childBounds.top + (padding.top ?? 0);
+  const rightEdgeLimit = childBounds.right + (padding.right ?? 0);
+  const bottomEdgeLimit = childBounds.bottom + (padding.bottom ?? 0);
+
+  return {
+    left: resolveResizeMinimum(minWidth, leftEdgeLimit),
+    right: resolveResizeMinimum(minWidth, rightEdgeLimit),
+    top: resolveResizeMinimum(minHeight, topEdgeLimit),
+    bottom: resolveResizeMinimum(minHeight, bottomEdgeLimit),
   };
 }
 


### PR DESCRIPTION
## Summary

This fixes loop/container resizing so each corner handle uses the minimum size for the edges it actually moves. Left/top resize handles can now use available leading slack, while right/bottom handles continue to protect trailing child bounds and safe-area padding.

## What Changed

- Added `getContainerResizeMinimums` and `ContainerResizeMinimums` in `container.ts`.
- The resize helper scans visible direct children, ignores preview/hidden/explicitly ignored child nodes, computes child bounds, applies the loop safe-area padding, snaps required sizes to the grid, and falls back to default minimums for empty containers.
- `LoopNode` now reads side-specific resize minimums from the React Flow store and maps each corner control to the matching horizontal and vertical moving sides.
- Added focused unit coverage for side-specific minimums, empty containers, children already crossing the body bounds, and ignored child types.

## Flow

```mermaid
flowchart TD
  A[LoopNode render] --> B[Read loop size and React Flow nodes]
  B --> C[getContainerResizeMinimums]
  C --> D{Visible direct children?}
  D -- No --> E[Return default minimums for all sides]
  D -- Yes --> F[Compute child bounds inside the loop]
  F --> G[Apply loop safe-area padding]
  G --> H[Calculate left, right, top, and bottom minimums]
  H --> I[Snap minimums to the grid and clamp to defaults]
  I --> J[Map each resize corner to its moving sides]
  J --> K[Pass side-specific minWidth and minHeight to NodeResizeControl]
  K --> L[Resize uses available slack without clipping children]
```

## Validation

- Unit tests added in `container.test.ts` for the new resize minimum behavior.
