### PR TITLE
fix(apollo-vertex): drop global anchor color override

### DIFF
--- a/apps/apollo-vertex/app/globals.css
+++ b/apps/apollo-vertex/app/globals.css
@@ -28,14 +28,4 @@
   body {
     @apply bg-background text-foreground;
   }
-  a {
-    color: var(--primary);
-    text-decoration: none;
-    &:hover {
-      text-decoration: underline;
-    }
-  }
-  .dark a {
-    color: var(--primary-400);
-  }
 }


### PR DESCRIPTION
## Summary
- Removed the base-layer `a { color: var(--primary) }` rule (and its `.dark` counterpart) in `apps/apollo-vertex/app/globals.css` that was forcing the navbar "Apollo Vertex" logo and inline MDX links to a cyan-leaning hue, out of step with the sidebar's blue.
- Anchors now inherit Nextra's link color, so the navbar logo and sidebar nav read as the same blue and inline links across the docs stay consistent.

## Test plan
- [ ] Run `pnpm dev:apollo-vertex` and confirm the navbar "Apollo Vertex" text matches the sidebar's active link blue in light and dark mode.
- [ ] Spot-check inline MDX links across a few docs pages to confirm they still look correct.