### PR TITLE
fix(apollo-vertex): restore hover-prefetch on sidebar links

### DIFF
--- a/apps/apollo-vertex/app/_components/sidebar-hover-prefetch.tsx
+++ b/apps/apollo-vertex/app/_components/sidebar-hover-prefetch.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useEffect } from "react";
+
+// Nextra's docs theme hardcodes `prefetch={false}` on sidebar links
+// (nextra-theme-docs sidebar.js), which disables both viewport and hover
+// prefetch. We restore hover-on-intent prefetching at the DOM level — see
+// Next.js' HoverPrefetchLink pattern in docs/app/guides/prefetching.
+export function SidebarHoverPrefetch() {
+  const router = useRouter();
+
+  useEffect(() => {
+    const prefetched = new Set<string>();
+
+    function handleIntent(event: Event) {
+      const target = event.target;
+      if (!(target instanceof HTMLAnchorElement)) return;
+      if (!target.closest("aside")) return;
+
+      const href = target.getAttribute("href");
+      if (!href || !href.startsWith("/")) return;
+      if (prefetched.has(href)) return;
+
+      prefetched.add(href);
+      router.prefetch(href);
+    }
+
+    document.addEventListener("mouseover", handleIntent);
+    document.addEventListener("focusin", handleIntent);
+
+    return () => {
+      document.removeEventListener("mouseover", handleIntent);
+      document.removeEventListener("focusin", handleIntent);
+    };
+  }, [router]);
+
+  return null;
+}

--- a/apps/apollo-vertex/app/layout.tsx
+++ b/apps/apollo-vertex/app/layout.tsx
@@ -7,6 +7,7 @@ import "nextra-theme-docs/style.css";
 import type { ReactNode } from "react";
 import "./globals.css";
 import { Analytics } from "@vercel/analytics/next";
+import { SidebarHoverPrefetch } from "./_components/sidebar-hover-prefetch";
 import { ThemeSwitcher } from "./_components/theme-switcher";
 import { ThemeWrapper } from "./_components/theme-wrapper";
 
@@ -89,6 +90,7 @@ export default async function RootLayout({
       </Head>
       <body>
         <Analytics />
+        <SidebarHoverPrefetch />
         <ThemeWrapper>
           <Layout
             sidebar={{


### PR DESCRIPTION
## Summary

Sidebar clicks in the Apollo Vertex docs site felt sluggish because `nextra-theme-docs` hardcodes `prefetch={false}` on every sidebar/breadcrumb/pagination link. With browser cache disabled by Next's `vary` headers and ~134 KB RSC payloads per page, every click paid the full edge round-trip (~500 ms from EU).

This adds a small client component mounted in `RootLayout` that delegates `mouseover`/`focusin` on `aside a[href]` to `router.prefetch`, deduped per href. It mirrors Next.js' [HoverPrefetchLink pattern](https://nextjs.org/docs/app/guides/prefetching) without patching the upstream theme — easy to revert if we ever need the bandwidth back.

## Test plan

- [ ] `pnpm --filter apollo-vertex build && pnpm --filter apollo-vertex start`
- [ ] DevTools → Network → filter `_rsc`: hover a sidebar link, confirm one `?_rsc=` request fires
- [ ] Click the same link — instant, no new request (router cache hit)
- [ ] Click an unhovered link — still pays full latency (baseline preserved)
- [ ] Tab through sidebar with keyboard — `focusin` triggers prefetch, navigation feels fast