### PR TITLE
fix(apollo-react): exclude sticky notes from hover z-index override [MST-9488]

### DIFF
--- a/packages/apollo-react/src/canvas/styles/reactflow-reset.css
+++ b/packages/apollo-react/src/canvas/styles/reactflow-reset.css
@@ -38,8 +38,11 @@
  * neighboring node wrappers or connected edge SVGs. This intentionally clears
  * React Flow's selected-node z-index bump (+1000) and connection-line z-index (1001).
  * React Flow sets z-index inline, so `!important` is required to override it.
+ *
+ * Excluded node prefixes (must stay below edges regardless of hover):
+ *   - sticky-  (sticky notes)
  */
-.react-flow__node:not(.parent):hover {
+.react-flow__node:not(.parent):not([data-id^='sticky-']):hover {
   z-index: 1002 !important;
 }
 

--- a/packages/apollo-react/src/canvas/styles/reactflow-reset.css
+++ b/packages/apollo-react/src/canvas/styles/reactflow-reset.css
@@ -42,7 +42,7 @@
  * Excluded node prefixes (must stay below edges regardless of hover):
  *   - sticky-  (sticky notes)
  */
-.react-flow__node:not(.parent):not([data-id^='sticky-']):hover {
+.react-flow__node:not(.parent):not([data-id^="sticky-"]):hover {
   z-index: 1002 !important;
 }
 


### PR DESCRIPTION
This PR excludes sticky notes from the `z-index: 1002` on hover rule, which competed with the `z-index: -10` rule specifically for sticky notes. in VSIX, the latter loaded first, which caused it to be overridden by the `z-index: 1002` rule.

### Before

Sticky notes rendered above Flow nodes on hover in VSIX, making it difficult to click any nodes that are over the sticky note.

https://github.com/user-attachments/assets/087fa335-74e6-4fa8-953d-2954a95971cb


### After

Sticky notes always stay under other nodes/edges regardless of hover state.

https://github.com/user-attachments/assets/31f1ebe0-26cc-4d3a-ab1f-b7a4a1f313ee
