### PR TITLE
feat(apollo-wind): apply future theme overrides to Textarea

### DIFF
--- a/packages/apollo-wind/src/components/ui/textarea.tsx
+++ b/packages/apollo-wind/src/components/ui/textarea.tsx
@@ -9,7 +9,10 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
     return (
       <textarea
         className={cn(
+          // Base styles (all themes)
           'flex min-h-[80px] w-full rounded-md border border-input bg-transparent px-3 py-2 text-base transition-colors placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
+          // Future Dark / Future Light overrides
+          'future:rounded-xl future:border-0 future:bg-surface-raised future:text-sm future:placeholder:text-foreground-muted future:placeholder:font-normal future:focus-visible:ring-offset-2 future:focus-visible:ring-offset-background',
           className
         )}
         ref={ref}


### PR DESCRIPTION
## Summary

- Adds `future:` theme overrides to the `Textarea` component to match the existing `Input` component treatment
- Ensures visual consistency between `Input` and `Textarea` in Future Light and Future Dark themes

**Changes in Future Light / Future Dark:**
- Border removed (`future:border-0`)
- Background becomes `surface-raised` (`future:bg-surface-raised`)
- Corners more rounded (`future:rounded-xl`)
- Text size normalized to `sm` (`future:text-sm`)
- Placeholder uses `foreground-muted` color and normal weight (`future:placeholder:text-foreground-muted future:placeholder:font-normal`)
- Focus ring gets offset from background (`future:focus-visible:ring-offset-2 future:focus-visible:ring-offset-background`)

All other themes (Light, Dark, Light HC, Dark HC, Wireframe, Vertex, Canvas) are unchanged.

## Test plan

- [ ] Open `?path=/story/wind-components-core-textarea--default` in Storybook
- [ ] Toggle to **Future Light** and **Future Dark** — confirm textarea matches the Input style (no border, raised background, rounded-xl)
- [ ] Toggle to **Light** and **Dark** — confirm no visual change from before
- [ ] Check CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)