### PR TITLE
feat(apollo-wind): apply future theme overrides to FileUpload

### DIFF
--- a/packages/apollo-wind/src/components/ui/file-upload.tsx
+++ b/packages/apollo-wind/src/components/ui/file-upload.tsx
@@ -217,11 +217,15 @@ export function FileUpload({
         role="group"
         aria-label="File upload area"
         className={cn(
+          // Base styles (all themes)
           'relative flex flex-col items-center justify-center w-full h-32 px-4 py-6 border-2 border-dashed rounded-lg cursor-pointer transition-colors',
+          // Future Dark / Future Light overrides
+          'future:rounded-xl',
           isDragging
             ? 'border-primary bg-primary/5'
-            : 'border-input bg-background hover:bg-accent/50',
-          disabled && 'opacity-50 cursor-not-allowed hover:bg-background'
+            : 'border-input bg-background hover:bg-accent/50 future:border-border future:bg-surface-raised future:hover:bg-surface-overlay',
+          disabled &&
+            'opacity-50 cursor-not-allowed hover:bg-background future:hover:bg-surface-raised'
         )}
         onDragEnter={handleDragEnter}
         onDragOver={handleDragOver}
@@ -267,8 +271,10 @@ export function FileUpload({
               <div
                 key={index}
                 className={cn(
-                  'flex flex-col p-3 rounded-md',
-                  fileError ? 'bg-destructive/10 border border-destructive/20' : 'bg-accent/50'
+                  'flex flex-col p-3 rounded-md future:rounded-xl',
+                  fileError
+                    ? 'bg-destructive/10 border border-destructive/20'
+                    : 'bg-accent/50 future:bg-surface-raised'
                 )}
               >
                 <div className="flex items-center justify-between">


### PR DESCRIPTION
## Summary

- Adds `future:` theme overrides to the `FileUpload` component to match the `Input` and `Textarea` treatment
- Ensures visual consistency across form input components in Future Light and Future Dark themes

**Changes in Future Light / Future Dark:**

Drop zone:
- Background becomes `surface-raised` (`future:bg-surface-raised`)
- Hover state uses `surface-overlay` (`future:hover:bg-surface-overlay`)
- Dashed border softened to `border-border` (`future:border-border`)
- Corners more rounded (`future:rounded-xl`)

File list items (after files are selected):
- Background becomes `surface-raised` (`future:bg-surface-raised`)
- Corners more rounded (`future:rounded-xl`)

All other themes (Light, Dark, Light HC, Dark HC, Wireframe, Vertex, Canvas) are unchanged. Error and drag-active states are also unchanged as they use semantic tokens that work correctly across all themes.

## Test plan

- [ ] Open `?path=/story/wind-components-core-file-upload--default` in Storybook
- [ ] Toggle to **Future Light** and **Future Dark** — confirm drop zone matches Input/Textarea style (surface-raised bg, rounded-xl, softened border)
- [ ] Upload a file and confirm the file list item also uses surface-raised background in future themes
- [ ] Toggle to **Light** and **Dark** — confirm no visual change from before
- [ ] Check CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)