### PR TITLE
feat(apollo-wind): apply future theme overrides to Pagination

### DIFF
--- a/packages/apollo-wind/src/components/ui/pagination.tsx
+++ b/packages/apollo-wind/src/components/ui/pagination.tsx
@@ -43,6 +43,9 @@ const PaginationLink = ({
         size,
       }),
       'aspect-square p-0',
+      // Future Dark / Future Light overrides
+      'future:rounded-xl',
+      isActive && 'future:bg-surface-raised future:border-transparent',
       className
     )}
     {...props}
@@ -82,7 +85,7 @@ PaginationNext.displayName = 'PaginationNext';
 const PaginationEllipsis = ({ className, ...props }: React.ComponentProps<'span'>) => (
   <span
     aria-hidden
-    className={cn('flex h-9 w-9 items-center justify-center', className)}
+    className={cn('flex h-9 w-9 items-center justify-center future:h-10 future:w-10', className)}
     {...props}
   >
     <MoreHorizontal className="h-4 w-4" />


### PR DESCRIPTION
## Summary

Adds `future:` theme overrides to the `Pagination` component to match the `Input`, `Textarea`, and `FileUpload` treatment, ensuring visual consistency across components in Future Light and Future Dark themes.

**Changes in Future Light / Future Dark:**

Page links (`PaginationLink`):
- Corners more rounded (`future:rounded-xl`) — matches button future style
- Active page gets `surface-raised` background (`future:bg-surface-raised`) so it stands out without relying on the border (which button already softens to `border-border-subtle` in future themes)
- Active page border set to transparent (`future:border-transparent`) since background handles the active indicator

Ellipsis (`PaginationEllipsis`):
- Height and width updated to `h-10 w-10` (`future:h-10 future:w-10`) to align with button default height in future themes

Note: text color changes on `ghost`/`outline` variants (`future:text-muted-foreground`, `future:hover:text-foreground`) are already inherited from `buttonVariants`.

All other themes are unchanged.

## Test plan

- [ ] Open `?path=/story/wind-components-core-pagination--default` in Storybook
- [ ] Toggle to **Future Light** and **Future Dark** — confirm page links use `rounded-xl`, active page has raised background, and ellipsis aligns in height with other items
- [ ] Toggle to **Light** and **Dark** — confirm no visual change from before
- [ ] Check CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)