### PR TITLE
fix(storybook): apply sentence case to Wind component story copy

### DIFF
--- a/packages/apollo-wind/src/components/ui/alert-dialog.stories.tsx
+++ b/packages/apollo-wind/src/components/ui/alert-dialog.stories.tsx
@@ -182,7 +182,7 @@ export const Examples = {
           </AlertDialogHeader>
           <AlertDialogFooter>
             <AlertDialogCancel>Stay on page</AlertDialogCancel>
-            <AlertDialogAction>Leave Without Saving</AlertDialogAction>
+            <AlertDialogAction>Leave without saving</AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>

--- a/packages/apollo-wind/src/components/ui/alert-dialog.stories.tsx
+++ b/packages/apollo-wind/src/components/ui/alert-dialog.stories.tsx
@@ -32,7 +32,7 @@ export const Basic = {
   render: () => (
     <AlertDialog>
       <AlertDialogTrigger asChild>
-        <Button variant="outline">Show Dialog</Button>
+        <Button variant="outline">Show dialog</Button>
       </AlertDialogTrigger>
       <AlertDialogContent>
         <AlertDialogHeader>
@@ -60,7 +60,7 @@ export const Destructive = {
   render: () => (
     <AlertDialog>
       <AlertDialogTrigger asChild>
-        <Button variant="destructive">Delete Account</Button>
+        <Button variant="destructive">Delete account</Button>
       </AlertDialogTrigger>
       <AlertDialogContent>
         <AlertDialogHeader>
@@ -73,7 +73,7 @@ export const Destructive = {
         <AlertDialogFooter>
           <AlertDialogCancel>Cancel</AlertDialogCancel>
           <AlertDialogAction className={buttonVariants({ variant: 'destructive' })}>
-            Delete Account
+            Delete account
           </AlertDialogAction>
         </AlertDialogFooter>
       </AlertDialogContent>
@@ -102,7 +102,7 @@ export const Sizes = {
             <AlertDialogDescription>Your unsaved changes will be lost.</AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
-            <AlertDialogCancel>Keep Editing</AlertDialogCancel>
+            <AlertDialogCancel>Keep editing</AlertDialogCancel>
             <AlertDialogAction>Discard</AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>
@@ -125,7 +125,7 @@ export const Sizes = {
           </AlertDialogHeader>
           <AlertDialogFooter>
             <AlertDialogCancel>Cancel</AlertDialogCancel>
-            <AlertDialogAction>Save Changes</AlertDialogAction>
+            <AlertDialogAction>Save changes</AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
@@ -148,8 +148,8 @@ export const Sizes = {
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
-            <AlertDialogCancel>Go Back</AlertDialogCancel>
-            <AlertDialogAction>Publish to Production</AlertDialogAction>
+            <AlertDialogCancel>Go back</AlertDialogCancel>
+            <AlertDialogAction>Publish to production</AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
@@ -181,7 +181,7 @@ export const Examples = {
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
-            <AlertDialogCancel>Stay on Page</AlertDialogCancel>
+            <AlertDialogCancel>Stay on page</AlertDialogCancel>
             <AlertDialogAction>Leave Without Saving</AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>
@@ -248,9 +248,9 @@ export const Examples = {
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
-            <AlertDialogCancel>Keep Settings</AlertDialogCancel>
+            <AlertDialogCancel>Keep settings</AlertDialogCancel>
             <AlertDialogAction className={buttonVariants({ variant: 'destructive' })}>
-              Reset All
+              Reset all
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>

--- a/packages/apollo-wind/src/components/ui/button.stories.tsx
+++ b/packages/apollo-wind/src/components/ui/button.stories.tsx
@@ -81,7 +81,7 @@ export const WithIcon: Story = {
     <div className="flex flex-row justify-center items-center gap-2">
       <Button size="lg">
         <Mail />
-        Send Email
+        Send email
       </Button>
       <Button>
         <Download />
@@ -89,7 +89,7 @@ export const WithIcon: Story = {
       </Button>
       <Button size="sm">
         <Plus />
-        Add Item
+        Add item
       </Button>
       <Button size="xs">
         <Settings />

--- a/packages/apollo-wind/src/components/ui/command.stories.tsx
+++ b/packages/apollo-wind/src/components/ui/command.stories.tsx
@@ -211,7 +211,7 @@ export const CommandWithShortcuts = {
           </CommandItem>
           <CommandItem>
             <Plus className="mr-2 h-4 w-4" />
-            <span>New File</span>
+            <span>New file</span>
             <CommandShortcut>⌘N</CommandShortcut>
           </CommandItem>
           <CommandItem>
@@ -322,7 +322,7 @@ export const CommandPaletteUsage = {
               </CommandItem>
               <CommandItem>
                 <Moon className="mr-2 h-4 w-4" />
-                <span>Dark Mode</span>
+                <span>Dark mode</span>
               </CommandItem>
             </CommandGroup>
           </CommandList>

--- a/packages/apollo-wind/src/components/ui/context-menu.stories.tsx
+++ b/packages/apollo-wind/src/components/ui/context-menu.stories.tsx
@@ -168,7 +168,7 @@ export const Submenu = {
             Share
           </ContextMenuSubTrigger>
           <ContextMenuSubContent className="w-44">
-            <ContextMenuItem>Copy Link</ContextMenuItem>
+            <ContextMenuItem>Copy link</ContextMenuItem>
             <ContextMenuItem>Email</ContextMenuItem>
             <ContextMenuItem>Slack</ContextMenuItem>
             <ContextMenuItem>Teams</ContextMenuItem>
@@ -286,11 +286,11 @@ export const Groups = {
             <ContextMenuLabel>Actions</ContextMenuLabel>
             <ContextMenuItem>
               <FolderOpen className="mr-2 h-4 w-4" />
-              New Folder
+              New folder
             </ContextMenuItem>
             <ContextMenuItem>
               <FileText className="mr-2 h-4 w-4" />
-              New File
+              New file
             </ContextMenuItem>
           </ContextMenuGroup>
         </ContextMenuContent>
@@ -350,7 +350,7 @@ export const Examples = {
                   Share
                 </ContextMenuSubTrigger>
                 <ContextMenuSubContent className="w-44">
-                  <ContextMenuItem>Copy Link</ContextMenuItem>
+                  <ContextMenuItem>Copy link</ContextMenuItem>
                   <ContextMenuItem>Email</ContextMenuItem>
                   <ContextMenuItem>Slack</ContextMenuItem>
                 </ContextMenuSubContent>

--- a/packages/apollo-wind/src/components/ui/dialog.stories.tsx
+++ b/packages/apollo-wind/src/components/ui/dialog.stories.tsx
@@ -31,11 +31,11 @@ export const BasicDialog = {
   render: () => (
     <Dialog>
       <DialogTrigger asChild>
-        <Button variant="outline">Edit Profile</Button>
+        <Button variant="outline">Edit profile</Button>
       </DialogTrigger>
       <DialogContent>
         <DialogHeader>
-          <DialogTitle>Edit Profile</DialogTitle>
+          <DialogTitle>Edit profile</DialogTitle>
           <DialogDescription>
             Make changes to your profile here. Click save when you're done.
           </DialogDescription>
@@ -58,7 +58,7 @@ export const BasicDialog = {
           <DialogClose asChild>
             <Button variant="outline">Cancel</Button>
           </DialogClose>
-          <Button>Save Changes</Button>
+          <Button>Save changes</Button>
         </DialogFooter>
       </DialogContent>
     </Dialog>
@@ -320,7 +320,7 @@ export const StickyFooterDialog = {
   render: () => (
     <Dialog>
       <DialogTrigger asChild>
-        <Button variant="outline">Invite Members</Button>
+        <Button variant="outline">Invite members</Button>
       </DialogTrigger>
       <DialogContent className="sm:max-w-lg max-h-[85vh] flex flex-col gap-0 p-0">
         <DialogHeader className="px-6 pt-6 pb-4">

--- a/packages/apollo-wind/src/components/ui/dropdown-menu.stories.tsx
+++ b/packages/apollo-wind/src/components/ui/dropdown-menu.stories.tsx
@@ -60,8 +60,8 @@ export const BasicDropdown = {
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent className="w-48">
-        <DropdownMenuItem>New File</DropdownMenuItem>
-        <DropdownMenuItem>New Folder</DropdownMenuItem>
+        <DropdownMenuItem>New file</DropdownMenuItem>
+        <DropdownMenuItem>New folder</DropdownMenuItem>
         <DropdownMenuSeparator />
         <DropdownMenuItem>Import</DropdownMenuItem>
         <DropdownMenuItem>Export</DropdownMenuItem>
@@ -108,7 +108,7 @@ export const DropdownWithActions = {
             Share
           </DropdownMenuSubTrigger>
           <DropdownMenuSubContent className="w-44">
-            <DropdownMenuItem>Copy Link</DropdownMenuItem>
+            <DropdownMenuItem>Copy link</DropdownMenuItem>
             <DropdownMenuItem>Email</DropdownMenuItem>
             <DropdownMenuItem>Slack</DropdownMenuItem>
           </DropdownMenuSubContent>
@@ -149,7 +149,7 @@ export const DropdownWithCheckboxes = {
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent className="w-48">
-          <DropdownMenuLabel>Toggle Columns</DropdownMenuLabel>
+          <DropdownMenuLabel>Toggle columns</DropdownMenuLabel>
           <DropdownMenuSeparator />
           <DropdownMenuCheckboxItem checked disabled>
             Name
@@ -227,7 +227,7 @@ export const DropdownForProfile = {
         <DropdownMenuSeparator />
         <DropdownMenuItem>
           <LogOut className="mr-2 h-4 w-4" />
-          Log Out
+          Log out
           <DropdownMenuShortcut>⇧⌘Q</DropdownMenuShortcut>
         </DropdownMenuItem>
       </DropdownMenuContent>
@@ -289,7 +289,7 @@ export const FileActions = {
                     Share
                   </DropdownMenuSubTrigger>
                   <DropdownMenuSubContent className="w-40">
-                    <DropdownMenuItem>Copy Link</DropdownMenuItem>
+                    <DropdownMenuItem>Copy link</DropdownMenuItem>
                     <DropdownMenuItem>Email</DropdownMenuItem>
                     <DropdownMenuItem>Slack</DropdownMenuItem>
                   </DropdownMenuSubContent>
@@ -341,11 +341,11 @@ export const UserMenu = {
           <DropdownMenuSeparator />
           <DropdownMenuItem>
             <User className="mr-2 h-4 w-4" />
-            My Profile
+            My profile
           </DropdownMenuItem>
           <DropdownMenuItem>
             <Settings className="mr-2 h-4 w-4" />
-            Account Settings
+            Account settings
           </DropdownMenuItem>
           <DropdownMenuSeparator />
           <DropdownMenuCheckboxItem
@@ -357,12 +357,12 @@ export const UserMenu = {
             ) : (
               <Sun className="mr-2 h-4 w-4" />
             )}
-            Dark Mode
+            Dark mode
           </DropdownMenuCheckboxItem>
           <DropdownMenuSeparator />
           <DropdownMenuItem>
             <HelpCircle className="mr-2 h-4 w-4" />
-            Help Center
+            Help center
           </DropdownMenuItem>
           <DropdownMenuItem>
             <LogOut className="mr-2 h-4 w-4" />

--- a/packages/apollo-wind/src/components/ui/empty-state.stories.tsx
+++ b/packages/apollo-wind/src/components/ui/empty-state.stories.tsx
@@ -40,7 +40,7 @@ export const WithAction: Story = {
     title: 'No messages',
     description: 'Your inbox is empty. Start a conversation to see messages here.',
     action: {
-      label: 'New Message',
+      label: 'New message',
       onClick: () => alert('Create new message'),
     },
   },
@@ -52,11 +52,11 @@ export const WithMultipleActions: Story = {
     title: 'No team members',
     description: 'Invite team members to collaborate on this project.',
     action: {
-      label: 'Invite Members',
+      label: 'Invite members',
       onClick: () => alert('Invite members'),
     },
     secondaryAction: {
-      label: 'Learn More',
+      label: 'Learn more',
       onClick: () => alert('Learn more'),
     },
   },
@@ -68,7 +68,7 @@ export const SearchNoResults: Story = {
     title: 'No results found',
     description: "Try adjusting your search or filter to find what you're looking for.",
     action: {
-      label: 'Clear Search',
+      label: 'Clear search',
       onClick: () => alert('Clear search'),
     },
   },
@@ -80,7 +80,7 @@ export const EmptyCart: Story = {
     title: 'Your cart is empty',
     description: 'Add items to your cart to continue shopping.',
     action: {
-      label: 'Browse Products',
+      label: 'Browse products',
       onClick: () => alert('Browse products'),
     },
   },
@@ -100,7 +100,7 @@ export const LongDescription: Story = {
     description:
       'Upload documents to keep all your important files in one place. You can upload PDFs, Word documents, spreadsheets, and more. Drag and drop files or click the button below to get started.',
     action: {
-      label: 'Upload Documents',
+      label: 'Upload documents',
       onClick: () => alert('Upload documents'),
     },
   },
@@ -137,7 +137,7 @@ export const ComposableActions: Story = {
     >
       <Button>Create project</Button>
       <Button variant="outline">Import project</Button>
-      <Button variant="outline">Learn More</Button>
+      <Button variant="outline">Learn more</Button>
     </EmptyState>
   ),
 };

--- a/packages/apollo-wind/src/components/ui/file-upload.stories.tsx
+++ b/packages/apollo-wind/src/components/ui/file-upload.stories.tsx
@@ -36,7 +36,7 @@ export const WithLabel = {
 
     return (
       <div className="w-[400px] space-y-2">
-        <Label>Upload Documents</Label>
+        <Label>Upload documents</Label>
         <FileUpload onFilesChange={setFiles} />
       </div>
     );

--- a/packages/apollo-wind/src/components/ui/sheet.stories.tsx
+++ b/packages/apollo-wind/src/components/ui/sheet.stories.tsx
@@ -101,11 +101,11 @@ export const WithForm = {
   render: () => (
     <Sheet>
       <SheetTrigger asChild>
-        <Button variant="outline">Edit Profile</Button>
+        <Button variant="outline">Edit profile</Button>
       </SheetTrigger>
       <SheetContent className="flex flex-col">
         <SheetHeader>
-          <SheetTitle>Edit Profile</SheetTitle>
+          <SheetTitle>Edit profile</SheetTitle>
           <SheetDescription>
             Update your personal information. Click save when you're done.
           </SheetDescription>
@@ -132,7 +132,7 @@ export const WithForm = {
           <SheetClose asChild>
             <Button variant="outline">Cancel</Button>
           </SheetClose>
-          <Button>Save Changes</Button>
+          <Button>Save changes</Button>
         </SheetFooter>
       </SheetContent>
     </Sheet>


### PR DESCRIPTION
## Summary

Audited all Wind component story files and updated multi-word UI text to follow sentence case — only the first word capitalised, consistent with UiPath content guidelines.

## Files changed

**button.stories.tsx**
- "Send Email" → "Send email"
- "Add Item" → "Add item"

**alert-dialog.stories.tsx**
- "Show Dialog" → "Show dialog"
- "Delete Account" → "Delete account" (×2)
- "Keep Editing" → "Keep editing"
- "Save Changes" → "Save changes"
- "Go Back" → "Go back"
- "Publish to Production" → "Publish to production"
- "Stay on Page" → "Stay on page"
- "Keep Settings" → "Keep settings"
- "Reset All" → "Reset all"
- "Leave Without Saving" → "Leave without saving"

**dialog.stories.tsx**
- "Edit Profile" → "Edit profile" (trigger + title)
- "Save Changes" → "Save changes"
- "Invite Members" → "Invite members"

**sheet.stories.tsx**
- "Edit Profile" → "Edit profile" (trigger + title)
- "Save Changes" → "Save changes"

**dropdown-menu.stories.tsx**
- "New File" → "New file"
- "New Folder" → "New folder"
- "Copy Link" → "Copy link" (×2)
- "Toggle Columns" → "Toggle columns"
- "Log Out" → "Log out"
- "My Profile" → "My profile"
- "Account Settings" → "Account settings"
- "Dark Mode" → "Dark mode"
- "Help Center" → "Help center"

**context-menu.stories.tsx**
- "Copy Link" → "Copy link" (×2)
- "New Folder" → "New folder"
- "New File" → "New file"

**command.stories.tsx**
- "New File" → "New file"
- "Dark Mode" → "Dark mode"

**empty-state.stories.tsx**
- "New Message" → "New message"
- "Invite Members" → "Invite members"
- "Learn More" → "Learn more" (×2)
- "Clear Search" → "Clear search"
- "Browse Products" → "Browse products"
- "Upload Documents" → "Upload documents"

**file-upload.stories.tsx**
- "Upload Documents" → "Upload documents"

## Test plan

- [ ] Spot-check a few stories in Storybook to confirm labels read correctly
- [ ] Confirm no functional changes — these are display string updates only
- [ ] Check CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)