### PR TITLE
fix(apollo-react): support nested loop outer handle insertion

### DIFF
--- a/packages/apollo-react/src/canvas/components/LoopNode/LoopNode.helpers.test.ts
+++ b/packages/apollo-react/src/canvas/components/LoopNode/LoopNode.helpers.test.ts
@@ -325,6 +325,99 @@ describe('resolveContainerAddNodePreview', () => {
     expect(previewOverrides).toBeNull();
   });
 
+  it('uses the parent container sequence for nested container outer outputs', () => {
+    const innerLoopNode: Node = {
+      id: 'inner-loop',
+      type: 'loop',
+      parentId: loopNode.id,
+      position: { x: 160, y: 112 },
+      style: { width: 560, height: 320 },
+      data: {},
+    };
+    const targetNode: Node = {
+      id: 'task-1',
+      type: 'task',
+      parentId: loopNode.id,
+      position: { x: 800, y: 112 },
+      measured: { width: 96, height: 96 },
+      data: {},
+    };
+    const existingEdge: Edge = {
+      id: 'inner-loop-task-1',
+      source: innerLoopNode.id,
+      sourceHandle: 'done',
+      target: targetNode.id,
+      targetHandle: 'input',
+    };
+    const reactFlowInstance = createReactFlowInstance({
+      nodes: [loopNode, innerLoopNode, targetNode],
+      edges: [existingEdge],
+    });
+
+    const previewOverrides = resolveContainerAddNodePreview({
+      source: { nodeId: innerLoopNode.id, handleId: 'done' },
+      sourceHandleType: 'source',
+      reactFlowInstance,
+      getManifestForNode,
+    });
+
+    expect(previewOverrides).toMatchObject({
+      containerId: loopNode.id,
+      positionMode: 'center',
+      target: {
+        nodeId: targetNode.id,
+        handleId: 'input',
+      },
+      data: {
+        originalEdge: existingEdge,
+        placement: {
+          containerId: loopNode.id,
+          sourceNodeId: innerLoopNode.id,
+          targetNodeId: targetNode.id,
+          mode: 'sequence',
+        },
+      },
+    });
+  });
+
+  it('appends nested container outer outputs through the parent container continuation', () => {
+    const innerLoopNode: Node = {
+      id: 'inner-loop',
+      type: 'loop',
+      parentId: loopNode.id,
+      position: { x: 160, y: 112 },
+      style: { width: 560, height: 320 },
+      data: {},
+    };
+    const reactFlowInstance = createReactFlowInstance({
+      nodes: [loopNode, innerLoopNode],
+    });
+
+    const previewOverrides = resolveContainerAddNodePreview({
+      source: { nodeId: innerLoopNode.id, handleId: 'done' },
+      sourceHandleType: 'source',
+      reactFlowInstance,
+      getManifestForNode,
+    });
+
+    expect(previewOverrides).toMatchObject({
+      containerId: loopNode.id,
+      positionMode: 'center',
+      target: {
+        nodeId: loopNode.id,
+        handleId: 'continue',
+      },
+      data: {
+        placement: {
+          containerId: loopNode.id,
+          sourceNodeId: innerLoopNode.id,
+          targetNodeId: loopNode.id,
+          mode: 'sequence',
+        },
+      },
+    });
+  });
+
   it('continues to insert from an occupied container inner source handle', () => {
     const childNode: Node = {
       id: 'task-1',

--- a/packages/apollo-react/src/canvas/components/LoopNode/LoopNode.helpers.ts
+++ b/packages/apollo-react/src/canvas/components/LoopNode/LoopNode.helpers.ts
@@ -200,7 +200,10 @@ export function resolveContainerAddNodePreview({
   const sourceNode = reactFlowInstance.getNode(source.nodeId);
   const sourceIsContainer =
     sourceNode !== undefined && isContainerNodeManifest(getManifestForNode(sourceNode));
-  if (sourceIsContainer && clickedHandle.boundary !== 'inner') {
+  const allowedContainerId =
+    sourceIsContainer && clickedHandle.boundary !== 'inner' ? sourceNode?.parentId : undefined;
+
+  if (sourceIsContainer && clickedHandle.boundary !== 'inner' && !allowedContainerId) {
     return null;
   }
 
@@ -209,6 +212,7 @@ export function resolveContainerAddNodePreview({
     sourceHandleType,
     reactFlowInstance,
     replacedEdge,
+    allowedContainerId,
     isContainerNode: (node) => isContainerNodeManifest(getManifestForNode(node)),
     getContainerSafeArea,
     getContainerContinuationTarget: ({ containerNode }) => {

--- a/packages/apollo-react/src/canvas/components/LoopNode/LoopNode.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/LoopNode/LoopNode.stories.tsx
@@ -3,10 +3,10 @@ import {
   type Edge,
   type Node,
   Panel,
-  type Position,
+  Position,
   useReactFlow,
 } from '@uipath/apollo-react/canvas/xyflow/react';
-import { useCallback, useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { useAddNodeOnConnectEnd, useCanvasEvent } from '../../hooks';
 import { createNode, useCanvasStory, withCanvasProviders } from '../../storybook-utils';
 import { DefaultCanvasTranslations } from '../../types';
@@ -33,6 +33,7 @@ const LOOP_TYPE = 'uipath.control-flow.foreach';
 const ACTIVITY_TYPE = 'uipath.blank-node';
 const STORY_LOOP_START_HANDLE_ID = 'start';
 const STORY_LOOP_CONTINUE_HANDLE_ID = 'continue';
+const STORY_LOOP_SUCCESS_HANDLE_ID = 'success';
 
 const snapPoint = (point: { x: number; y: number }) => ({
   x: snapToGrid(point.x),
@@ -48,7 +49,7 @@ function createLoopContainerNode(
   id: string,
   position: { x: number; y: number },
   size: { width: number; height: number },
-  options?: { selected?: boolean; data?: LoopNodeData }
+  options?: { parentId?: string; selected?: boolean; data?: LoopNodeData }
 ): Node<LoopNodeData> {
   const snappedSize = snapSize(size);
   const display = {
@@ -60,6 +61,7 @@ function createLoopContainerNode(
     id,
     type: LOOP_TYPE,
     position: snapPoint(position),
+    parentId: options?.parentId,
     selected: options?.selected ?? false,
     data: {
       ...options?.data,
@@ -92,10 +94,100 @@ function createActivityNode(
   return node;
 }
 
-function DefaultStory() {
+interface AutoPreviewSource {
+  nodeId: string;
+  handleId: string;
+  position?: Position;
+}
+
+interface LoopCanvasStoryProps {
+  initialNodes: Node[];
+  initialEdges: Edge[];
+  autoPreviewSource?: AutoPreviewSource;
+}
+
+function LoopCanvasStory({ initialNodes, initialEdges, autoPreviewSource }: LoopCanvasStoryProps) {
   const reactFlow = useReactFlow();
   const handleAddNodeOnConnectEnd = useAddNodeOnConnectEnd();
+  const autoPreviewedRef = useRef(false);
 
+  const { canvasProps, nodeTypeRegistry } = useCanvasStory({
+    initialNodes,
+    initialEdges,
+  });
+
+  const loopPreviewOptions = useMemo(
+    () => ({
+      getManifestForNode: (node: Node) =>
+        node.type ? nodeTypeRegistry.getManifest(node.type) : undefined,
+    }),
+    [nodeTypeRegistry]
+  );
+
+  useEffect(() => {
+    if (!autoPreviewSource || autoPreviewedRef.current) return;
+
+    const frame = window.requestAnimationFrame(() => {
+      if (autoPreviewedRef.current) return;
+
+      autoPreviewedRef.current = true;
+      createAddNodePreview(
+        autoPreviewSource.nodeId,
+        autoPreviewSource.handleId,
+        reactFlow,
+        autoPreviewSource.position ?? Position.Right,
+        'source',
+        [],
+        loopPreviewOptions
+      );
+    });
+
+    return () => {
+      window.cancelAnimationFrame(frame);
+    };
+  }, [autoPreviewSource, loopPreviewOptions, reactFlow]);
+
+  const handleHandleAction = useCallback(
+    (event: CanvasHandleActionEvent) => {
+      const { handleId, nodeId, position, handleType } = event;
+      if (!handleId || !nodeId) return;
+
+      createAddNodePreview(
+        nodeId,
+        handleId,
+        reactFlow,
+        position as Position,
+        handleType === 'input' ? 'target' : 'source',
+        [],
+        loopPreviewOptions
+      );
+    },
+    [loopPreviewOptions, reactFlow]
+  );
+
+  useCanvasEvent('handle:action', handleHandleAction);
+
+  const handlePaneClick = useCallback(() => {
+    removePreviewFromReactFlow(reactFlow);
+  }, [reactFlow]);
+
+  return (
+    <BaseCanvas
+      {...canvasProps}
+      mode="design"
+      deleteKeyCode={['Backspace', 'Delete']}
+      onConnectEnd={handleAddNodeOnConnectEnd}
+      onPaneClick={handlePaneClick}
+    >
+      <AddNodeManager />
+      <Panel position="bottom-right">
+        <CanvasPositionControls translations={DefaultCanvasTranslations} />
+      </Panel>
+    </BaseCanvas>
+  );
+}
+
+function DefaultStory() {
   const initialNodes = useMemo<Node[]>(
     () => [
       createActivityNode('ingress', 'Load records', { x: 32, y: 256 }),
@@ -156,59 +248,211 @@ function DefaultStory() {
     []
   );
 
-  const { canvasProps, nodeTypeRegistry } = useCanvasStory({
-    initialNodes,
-    initialEdges,
-  });
+  return <LoopCanvasStory initialNodes={initialNodes} initialEdges={initialEdges} />;
+}
 
-  const loopPreviewOptions = useMemo(
-    () => ({
-      getManifestForNode: (node: Node) =>
-        node.type ? nodeTypeRegistry.getManifest(node.type) : undefined,
-    }),
-    [nodeTypeRegistry]
+function NestedOuterOutputInsertStory() {
+  const initialNodes = useMemo<Node[]>(
+    () => [
+      createActivityNode('ingress', 'Load records', { x: 32, y: 288 }),
+      createLoopContainerNode(
+        'outer-loop',
+        { x: 192, y: 80 },
+        { width: 1040, height: 496 },
+        {
+          selected: true,
+          data: { display: { label: 'For Each claim' } },
+        }
+      ),
+      createLoopContainerNode(
+        'inner-loop',
+        { x: 128, y: 112 },
+        { width: 496, height: 304 },
+        {
+          parentId: 'outer-loop',
+          data: { display: { label: 'For Each attachment' } },
+        }
+      ),
+      createActivityNode(
+        'inner-child',
+        'Classify attachment',
+        { x: 176, y: 112 },
+        { parentId: 'inner-loop' }
+      ),
+      createActivityNode(
+        'review',
+        'Review finding',
+        { x: 720, y: 216 },
+        { parentId: 'outer-loop' }
+      ),
+      createActivityNode('egress', 'Publish results', { x: 1296, y: 288 }),
+    ],
+    []
   );
 
-  const handleHandleAction = useCallback(
-    (event: CanvasHandleActionEvent) => {
-      const { handleId, nodeId, position, handleType } = event;
-      if (!handleId || !nodeId) return;
-
-      createAddNodePreview(
-        nodeId,
-        handleId,
-        reactFlow,
-        position as Position,
-        handleType === 'input' ? 'target' : 'source',
-        [],
-        loopPreviewOptions
-      );
-    },
-    [loopPreviewOptions, reactFlow]
+  const initialEdges = useMemo<Edge[]>(
+    () => [
+      {
+        id: 'ingress-outer-loop',
+        source: 'ingress',
+        sourceHandle: 'output',
+        target: 'outer-loop',
+        targetHandle: 'input',
+      },
+      {
+        id: 'outer-loop-inner-loop',
+        source: 'outer-loop',
+        sourceHandle: STORY_LOOP_START_HANDLE_ID,
+        target: 'inner-loop',
+        targetHandle: 'input',
+      },
+      {
+        id: 'inner-loop-inner-child',
+        source: 'inner-loop',
+        sourceHandle: STORY_LOOP_START_HANDLE_ID,
+        target: 'inner-child',
+        targetHandle: 'input',
+      },
+      {
+        id: 'inner-child-inner-loop',
+        source: 'inner-child',
+        sourceHandle: 'output',
+        target: 'inner-loop',
+        targetHandle: STORY_LOOP_CONTINUE_HANDLE_ID,
+      },
+      {
+        id: 'inner-loop-review',
+        source: 'inner-loop',
+        sourceHandle: STORY_LOOP_SUCCESS_HANDLE_ID,
+        target: 'review',
+        targetHandle: 'input',
+      },
+      {
+        id: 'review-outer-loop',
+        source: 'review',
+        sourceHandle: 'output',
+        target: 'outer-loop',
+        targetHandle: STORY_LOOP_CONTINUE_HANDLE_ID,
+      },
+      {
+        id: 'outer-loop-egress',
+        source: 'outer-loop',
+        sourceHandle: STORY_LOOP_SUCCESS_HANDLE_ID,
+        target: 'egress',
+        targetHandle: 'input',
+      },
+    ],
+    []
   );
-
-  useCanvasEvent('handle:action', handleHandleAction);
-
-  const handlePaneClick = useCallback(() => {
-    removePreviewFromReactFlow(reactFlow);
-  }, [reactFlow]);
 
   return (
-    <BaseCanvas
-      {...canvasProps}
-      mode="design"
-      deleteKeyCode={['Backspace', 'Delete']}
-      onConnectEnd={handleAddNodeOnConnectEnd}
-      onPaneClick={handlePaneClick}
-    >
-      <AddNodeManager />
-      <Panel position="bottom-right">
-        <CanvasPositionControls translations={DefaultCanvasTranslations} />
-      </Panel>
-    </BaseCanvas>
+    <LoopCanvasStory
+      initialNodes={initialNodes}
+      initialEdges={initialEdges}
+      autoPreviewSource={{
+        nodeId: 'inner-loop',
+        handleId: STORY_LOOP_SUCCESS_HANDLE_ID,
+        position: Position.Right,
+      }}
+    />
+  );
+}
+
+function NestedOuterOutputAppendStory() {
+  const initialNodes = useMemo<Node[]>(
+    () => [
+      createActivityNode('ingress', 'Load records', { x: 32, y: 272 }),
+      createLoopContainerNode(
+        'outer-loop',
+        { x: 224, y: 96 },
+        { width: 896, height: 448 },
+        {
+          selected: true,
+          data: { display: { label: 'For Each claim' } },
+        }
+      ),
+      createLoopContainerNode(
+        'inner-loop',
+        { x: 160, y: 112 },
+        { width: 544, height: 304 },
+        {
+          parentId: 'outer-loop',
+          data: { display: { label: 'For Each attachment' } },
+        }
+      ),
+      createActivityNode(
+        'inner-child',
+        'Classify attachment',
+        { x: 176, y: 112 },
+        { parentId: 'inner-loop' }
+      ),
+      createActivityNode('egress', 'Publish results', { x: 1216, y: 272 }),
+    ],
+    []
+  );
+
+  const initialEdges = useMemo<Edge[]>(
+    () => [
+      {
+        id: 'ingress-outer-loop',
+        source: 'ingress',
+        sourceHandle: 'output',
+        target: 'outer-loop',
+        targetHandle: 'input',
+      },
+      {
+        id: 'outer-loop-inner-loop',
+        source: 'outer-loop',
+        sourceHandle: STORY_LOOP_START_HANDLE_ID,
+        target: 'inner-loop',
+        targetHandle: 'input',
+      },
+      {
+        id: 'inner-loop-inner-child',
+        source: 'inner-loop',
+        sourceHandle: STORY_LOOP_START_HANDLE_ID,
+        target: 'inner-child',
+        targetHandle: 'input',
+      },
+      {
+        id: 'inner-child-inner-loop',
+        source: 'inner-child',
+        sourceHandle: 'output',
+        target: 'inner-loop',
+        targetHandle: STORY_LOOP_CONTINUE_HANDLE_ID,
+      },
+      {
+        id: 'outer-loop-egress',
+        source: 'outer-loop',
+        sourceHandle: STORY_LOOP_SUCCESS_HANDLE_ID,
+        target: 'egress',
+        targetHandle: 'input',
+      },
+    ],
+    []
+  );
+
+  return (
+    <LoopCanvasStory
+      initialNodes={initialNodes}
+      initialEdges={initialEdges}
+      autoPreviewSource={{
+        nodeId: 'inner-loop',
+        handleId: STORY_LOOP_SUCCESS_HANDLE_ID,
+        position: Position.Right,
+      }}
+    />
   );
 }
 
 export const Default: Story = {
   render: () => <DefaultStory />,
+};
+
+export const NestedOuterOutputInsert: Story = {
+  render: () => <NestedOuterOutputInsertStory />,
+};
+
+export const NestedOuterOutputAppend: Story = {
+  render: () => <NestedOuterOutputAppendStory />,
 };

--- a/packages/apollo-react/src/canvas/components/LoopNode/LoopNode.tsx
+++ b/packages/apollo-react/src/canvas/components/LoopNode/LoopNode.tsx
@@ -10,6 +10,7 @@ import { memo, useCallback, useEffect, useMemo, useState } from 'react';
 import { shallow } from 'zustand/shallow';
 import { useOptionalNodeTypeRegistry } from '../../core';
 import { useElementValidationStatus, useNodeExecutionState } from '../../hooks';
+import type { HandleGroupManifest } from '../../schema/node-definition';
 import type { SuggestionType } from '../../types';
 import { resolveAdornments } from '../../utils/adornment-resolver';
 import {
@@ -154,6 +155,18 @@ function useContainerNodeInternalsRefresh(
   }, [id, handleGroups, updateNodeInternals, width, height]);
 }
 
+/** Match BaseNode priority: data override, then manifest defaults. */
+function resolveLoopHandleConfigurations(
+  manifestHandleConfigurations: HandleGroupManifest[] | undefined,
+  data: Record<string, unknown>
+): HandleGroupManifest[] {
+  if (Array.isArray(data.handleConfigurations)) {
+    return data.handleConfigurations as HandleGroupManifest[];
+  }
+
+  return manifestHandleConfigurations ?? [];
+}
+
 function LoopNodeComponent(props: LoopNodeProps) {
   const {
     id,
@@ -255,10 +268,13 @@ function LoopNodeComponent(props: LoopNodeProps) {
     [adornmentsProp, statusContext]
   );
 
-  const resolvedHandleGroups = useMemo(
-    () => (manifest ? resolveHandles(manifest.handleConfiguration, resolvedData) : []),
-    [manifest, resolvedData]
-  );
+  const resolvedHandleGroups = useMemo(() => {
+    const handleConfigurations = resolveLoopHandleConfigurations(
+      manifest?.handleConfiguration,
+      resolvedData
+    );
+    return resolveHandles(handleConfigurations, { ...resolvedData, nodeId: id });
+  }, [manifest?.handleConfiguration, id, resolvedData]);
   const containerHandleGroups = useMemo(
     () => resolveContainerHandleGroups(resolvedHandleGroups),
     [resolvedHandleGroups]

--- a/packages/apollo-react/src/canvas/utils/container.ts
+++ b/packages/apollo-react/src/canvas/utils/container.ts
@@ -107,6 +107,7 @@ interface ContainerPreviewContext {
 
 interface ContainerPreviewOptions {
   isContainerNode?: (node: Node) => boolean;
+  allowedContainerId?: string;
   replacedEdge?: Edge;
   getContainerSafeArea?: (containerNode: Node) => ContainerSafeArea | undefined;
   getContainerContinuationTarget?: (context: {
@@ -846,6 +847,7 @@ function resolveInsertPreview({
   sourceHandleType,
   reactFlowInstance,
   isContainerNode,
+  allowedContainerId,
   replacedEdge: exactReplacedEdge,
   getContainerSafeArea,
   previewNodeSize,
@@ -855,6 +857,7 @@ function resolveInsertPreview({
   Pick<
     ContainerPreviewOptions,
     | 'isContainerNode'
+    | 'allowedContainerId'
     | 'replacedEdge'
     | 'getContainerSafeArea'
     | 'previewNodeSize'
@@ -882,6 +885,9 @@ function resolveInsertPreview({
 
   const containerNode = getContainerNodeForEdge(sourceNode, targetNode, nodes);
   if (!containerNode) {
+    return null;
+  }
+  if (allowedContainerId && containerNode.id !== allowedContainerId) {
     return null;
   }
   if (isContainerNode && !isContainerNode(containerNode)) {
@@ -945,6 +951,9 @@ function resolveAppendPreview({
 
   const nodes = reactFlowInstance.getNodes();
   const containerNode = nodes.find((node) => node.id === sourceNode.parentId)!;
+  if (options.allowedContainerId && containerNode.id !== options.allowedContainerId) {
+    return null;
+  }
   if (options.isContainerNode && !options.isContainerNode(containerNode)) {
     return null;
   }


### PR DESCRIPTION
## Summary

This PR tackles two loop-handle issues:

- Support nested loop outer handle insertion: dragging from a nested loop outer output now resolves the add-node preview inside the parent loop sequence. The preview code uses an `allowedContainerId` guard so nested loop inserts stay scoped to the parent container.
- Error handle support for loop: LoopNode now honors runtime `data.handleConfigurations`, while inheriting manifest boundary and custom position metadata. It also passes `nodeId` into handle resolution, so dynamic handles such as error outputs can render and behave consistently with loop/container handles.

## Companion Flow Workbench Change

- Paired with Flow Workbench PR https://github.com/UiPath/flow-workbench/pull/1481, which preserves container metadata (`boundary` and `customPositionAndOffsets`) when Flow Workbench resolves manifest handles into runtime `data.handleConfigurations`.

## Flow

```mermaid
flowchart LR
  A[Drag from loop handle] --> B{Nested loop outer handle?}
  B -- Yes --> C[Scope preview to parent loop]
  B -- No parent --> D[Keep top-level outer container ignored]
  C --> E{Existing next node?}
  E -- Yes --> F[Insert preview into sequence]
  E -- No --> G[Append to parent continuation]
  H[Loop runtime handle config] --> I[Merge manifest boundary and offsets]
  I --> J[Resolve normal and error handles]
```

## Validation

`pnpm --filter @uipath/apollo-react exec vitest --run src/canvas/components/LoopNode/LoopNode.helpers.test.ts`

Result: 1 file passed, 15 tests passed.
