### PR TITLE
fix(storybook): update templates and global header for consistency

### DIFF
--- a/packages/apollo-wind/src/components/custom/global-header.tsx
+++ b/packages/apollo-wind/src/components/custom/global-header.tsx
@@ -92,8 +92,8 @@ function HeaderIconButton({
 
 function NotificationsDropdown({ themeClass }: { themeClass: string }) {
   return (
-    <DropdownMenu>
-      <DropdownMenuTrigger asChild>
+    <Popover>
+      <PopoverTrigger asChild>
         <button
           type="button"
           className="flex h-8 w-8 items-center justify-center rounded-lg text-foreground-muted transition-colors hover:text-foreground"
@@ -101,41 +101,56 @@ function NotificationsDropdown({ themeClass }: { themeClass: string }) {
         >
           <Bell className="h-5 w-5" />
         </button>
-      </DropdownMenuTrigger>
-      <DropdownMenuContent
+      </PopoverTrigger>
+      <PopoverContent
         align="end"
         sideOffset={8}
-        className={cn(themeClass, 'w-72 border-border bg-surface-overlay')}
+        className={cn(themeClass, 'w-72 border-border bg-surface-overlay p-0')}
       >
         <div className="px-3 py-2">
           <p className="text-sm font-semibold text-foreground">Notifications</p>
         </div>
-        <DropdownMenuSeparator className="bg-border-subtle" />
-        <DropdownMenuItem className="flex items-start gap-3 px-3 py-2.5 text-foreground-muted focus:bg-surface-hover focus:text-foreground">
-          <Info className="mt-0.5 h-4 w-4 shrink-0 text-brand-foreground" />
-          <div className="flex flex-col gap-0.5">
-            <span className="text-sm font-medium text-foreground">System update available</span>
-            <span className="text-xs text-foreground-muted">A new version is ready to install</span>
-          </div>
-        </DropdownMenuItem>
-        <DropdownMenuItem className="flex items-start gap-3 px-3 py-2.5 text-foreground-muted focus:bg-surface-hover focus:text-foreground">
-          <CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0 text-green-500" />
-          <div className="flex flex-col gap-0.5">
-            <span className="text-sm font-medium text-foreground">Flow completed</span>
-            <span className="text-xs text-foreground-muted">
-              Invoice processing finished successfully
-            </span>
-          </div>
-        </DropdownMenuItem>
-        <DropdownMenuItem className="flex items-start gap-3 px-3 py-2.5 text-foreground-muted focus:bg-surface-hover focus:text-foreground">
-          <AlertCircle className="mt-0.5 h-4 w-4 shrink-0 text-amber-500" />
-          <div className="flex flex-col gap-0.5">
-            <span className="text-sm font-medium text-foreground">Action required</span>
-            <span className="text-xs text-foreground-muted">Review pending approval requests</span>
-          </div>
-        </DropdownMenuItem>
-      </DropdownMenuContent>
-    </DropdownMenu>
+        <div className="h-px bg-border-subtle" />
+        <div className="flex flex-col py-1">
+          <button
+            type="button"
+            className="flex items-start gap-3 px-3 py-2.5 text-left transition-colors hover:bg-surface-hover"
+          >
+            <Info className="mt-0.5 h-4 w-4 shrink-0 text-brand-foreground" />
+            <div className="flex flex-col gap-0.5">
+              <span className="text-sm font-medium text-foreground">System update available</span>
+              <span className="text-xs text-foreground-muted">
+                A new version is ready to install
+              </span>
+            </div>
+          </button>
+          <button
+            type="button"
+            className="flex items-start gap-3 px-3 py-2.5 text-left transition-colors hover:bg-surface-hover"
+          >
+            <CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0 text-green-500" />
+            <div className="flex flex-col gap-0.5">
+              <span className="text-sm font-medium text-foreground">Flow completed</span>
+              <span className="text-xs text-foreground-muted">
+                Invoice processing finished successfully
+              </span>
+            </div>
+          </button>
+          <button
+            type="button"
+            className="flex items-start gap-3 px-3 py-2.5 text-left transition-colors hover:bg-surface-hover"
+          >
+            <AlertCircle className="mt-0.5 h-4 w-4 shrink-0 text-amber-500" />
+            <div className="flex flex-col gap-0.5">
+              <span className="text-sm font-medium text-foreground">Action required</span>
+              <span className="text-xs text-foreground-muted">
+                Review pending approval requests
+              </span>
+            </div>
+          </button>
+        </div>
+      </PopoverContent>
+    </Popover>
   );
 }
 

--- a/packages/apollo-wind/src/templates/Admin/admin.stories.tsx
+++ b/packages/apollo-wind/src/templates/Admin/admin.stories.tsx
@@ -43,6 +43,7 @@ import {
 } from '@/components/ui/dropdown-menu';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import {
   Pagination,
   PaginationContent,
@@ -248,10 +249,10 @@ type Story = StoryObj<typeof meta>;
 
 function AdminMenuNav() {
   const menuItems = [
-    { label: 'Manage Access', icon: <Users className="h-4 w-4 shrink-0" /> },
-    { label: 'Data Management', icon: <Globe className="h-4 w-4 shrink-0" /> },
+    { label: 'Manage access', icon: <Users className="h-4 w-4 shrink-0" /> },
+    { label: 'Data management', icon: <Globe className="h-4 w-4 shrink-0" /> },
     { label: 'Settings', icon: <HelpCircle className="h-4 w-4 shrink-0" /> },
-    { label: 'Audit Logs', icon: <RefreshCw className="h-4 w-4 shrink-0" /> },
+    { label: 'Audit logs', icon: <RefreshCw className="h-4 w-4 shrink-0" /> },
     { label: 'Integrations', icon: <Code className="h-4 w-4 shrink-0" /> },
   ];
 
@@ -1520,7 +1521,7 @@ function DataManagementDemo({ theme }: { theme: Theme }) {
   ];
 
   return (
-    <AdminTemplate theme={theme} title="Data Management" menuContent={<AdminMenuNav />}>
+    <AdminTemplate theme={theme} title="Data management" menuContent={<AdminMenuNav />}>
       {/* Page header with actions */}
       <div className="flex items-center justify-between border-b border-border-subtle px-6 py-4">
         <h1 className="text-xl font-semibold text-foreground">Products</h1>
@@ -1550,7 +1551,7 @@ function DataManagementDemo({ theme }: { theme: Theme }) {
               className={cn(themeClass, 'border-border bg-surface-raised text-foreground')}
             >
               <DialogHeader>
-                <DialogTitle className="text-foreground">Add New Product</DialogTitle>
+                <DialogTitle className="text-foreground">Add new product</DialogTitle>
                 <DialogDescription className="text-foreground-muted">
                   Enter the details for the new product.
                 </DialogDescription>
@@ -1628,25 +1629,16 @@ function DataManagementDemo({ theme }: { theme: Theme }) {
 
       {/* Tabs + filter bar */}
       <div className="flex items-center justify-between border-b border-border-subtle px-6 py-3">
-        <div className="flex gap-1">
-          {statusTabs.map((tab) => (
-            <button
-              type="button"
-              key={tab.value}
-              className={`flex items-center gap-2 rounded-lg px-3 py-1.5 text-sm font-medium transition-colors ${
-                activeTab === tab.value
-                  ? 'bg-surface-hover text-foreground'
-                  : 'text-foreground-muted hover:text-foreground'
-              }`}
-              onClick={() => setActiveTab(tab.value)}
-            >
-              {tab.label}
-              <span className="rounded-full bg-surface-overlay px-1.5 py-0.5 text-xs">
-                {tab.count}
-              </span>
-            </button>
-          ))}
-        </div>
+        <Tabs value={activeTab} onValueChange={setActiveTab}>
+          <TabsList>
+            {statusTabs.map((tab) => (
+              <TabsTrigger key={tab.value} value={tab.value} className="gap-2">
+                {tab.label}
+                <span className="rounded-full bg-muted px-1.5 py-0.5 text-xs">{tab.count}</span>
+              </TabsTrigger>
+            ))}
+          </TabsList>
+        </Tabs>
 
         <div className="flex items-center gap-2">
           <Select value={categoryFilter} onValueChange={setCategoryFilter}>

--- a/packages/apollo-wind/src/templates/Delegate/delegate.stories.tsx
+++ b/packages/apollo-wind/src/templates/Delegate/delegate.stories.tsx
@@ -304,7 +304,7 @@ function SettingsContent() {
           <div className="mx-auto max-w-2xl">
             {/* Page header */}
             <div className="mb-8">
-              <h1 className="text-2xl font-semibold text-foreground">Manage Profile</h1>
+              <h1 className="text-2xl font-semibold text-foreground">Manage profile</h1>
               <p className="mt-1 text-sm text-foreground-muted">
                 Update your profile information and preferences.
               </p>
@@ -313,7 +313,7 @@ function SettingsContent() {
             <div className="flex flex-col gap-8">
               {/* Profile Image */}
               <div className="flex flex-col gap-2">
-                <span className="text-sm font-medium text-foreground">Profile Image</span>
+                <span className="text-sm font-medium text-foreground">Profile image</span>
                 <div className="flex items-center gap-4">
                   <div className="flex h-16 w-16 items-center justify-center rounded-full bg-surface-overlay">
                     <User className="h-7 w-7 text-foreground-muted" />
@@ -323,7 +323,7 @@ function SettingsContent() {
                     className="flex h-9 items-center gap-2 rounded-lg border border-border bg-surface px-4 text-sm font-medium text-foreground-muted transition-colors hover:border-border-hover hover:text-foreground"
                   >
                     <Upload className="h-4 w-4" />
-                    Select Image
+                    Select image
                   </button>
                 </div>
               </div>
@@ -334,7 +334,7 @@ function SettingsContent() {
               {/* Your Name */}
               <div className="flex flex-col gap-2">
                 <label htmlFor="profile-name" className="text-sm font-medium text-foreground">
-                  Your Name
+                  Your name
                 </label>
                 <Input
                   id="profile-name"
@@ -346,7 +346,7 @@ function SettingsContent() {
               {/* Your Email */}
               <div className="flex flex-col gap-2">
                 <label htmlFor="profile-email" className="text-sm font-medium text-foreground">
-                  Your Email
+                  Your email
                 </label>
                 <Input
                   id="profile-email"
@@ -371,7 +371,7 @@ function SettingsContent() {
                   id="profile-language"
                   className="h-10 max-w-md appearance-none rounded-md border border-border bg-surface-overlay px-3 text-sm text-foreground focus:outline-none focus:ring-1 focus:ring-ring"
                 >
-                  <option>Select Language</option>
+                  <option>Select language</option>
                   <option>English</option>
                   <option>Spanish</option>
                   <option>French</option>
@@ -385,7 +385,7 @@ function SettingsContent() {
 
               {/* Theme Settings */}
               <div className="flex flex-col gap-3">
-                <span className="text-sm font-medium text-foreground">Theme Settings</span>
+                <span className="text-sm font-medium text-foreground">Theme settings</span>
                 <p className="text-sm text-foreground-muted">
                   Choose your preferred theme for the interface.
                 </p>

--- a/packages/apollo-wind/src/templates/Maestro/maestro.stories.tsx
+++ b/packages/apollo-wind/src/templates/Maestro/maestro.stories.tsx
@@ -160,7 +160,7 @@ function SectionHeader({ title }: { title: string }) {
         type="button"
         className="text-sm font-medium text-foreground-muted transition-colors hover:text-foreground"
       >
-        View All
+        View all
       </button>
     </div>
   );

--- a/packages/apollo-wind/src/templates/Studio/studio.stories.tsx
+++ b/packages/apollo-wind/src/templates/Studio/studio.stories.tsx
@@ -783,7 +783,7 @@ function CanvasAgentPanel() {
   return (
     <div className="flex h-full flex-col">
       <div className="shrink-0 px-4 py-3">
-        <h3 className="text-sm font-semibold text-foreground">New Agent</h3>
+        <h3 className="text-sm font-semibold text-foreground">New agent</h3>
       </div>
       <div className="border-t border-border-subtle" />
       <div className="flex-1 overflow-y-auto space-y-5 px-4 py-4">


### PR DESCRIPTION
## Summary

- **Sentence case** applied to all UI copy across Admin, Delegate, Maestro, and Studio template stories (14 fixes total — nav labels, page headings, button text, form labels)
- **Admin > Data Management tabs** replaced the custom hand-rolled `<button>` tab bar with the Wind `Tabs` / `TabsList` / `TabsTrigger` component for consistent theming (`bg-muted`, `data-[state=active]:bg-background` tokens)
- **Notifications popover** in `global-header.tsx` swapped from `DropdownMenu` to `Popover` — semantically appropriate since it's a titled panel with rich notification cards, not an action menu

## Test plan

- [ ] Open Storybook → Templates/Admin — confirm tabs use the Wind Tabs component and all copy is sentence case
- [ ] Open Storybook → Templates/Delegate → Settings — confirm form labels and section headings are sentence case
- [ ] Open Storybook → Templates/Maestro — confirm "View all" is lowercase
- [ ] Open Storybook → Templates/Studio — confirm "New agent" panel heading is lowercase
- [ ] Click the Bell icon in any template header — confirm Notifications opens as a Popover (titled panel, not a menu)
- [ ] Confirm Help and Avatar dropdowns are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)