### PR TITLE
fix(apollo-vertex): suppress data-table row onClick after text drag-select

### DIFF
--- a/apps/apollo-vertex/registry/data-table/data-table.tsx
+++ b/apps/apollo-vertex/registry/data-table/data-table.tsx
@@ -129,6 +129,12 @@ function DataTable<TData, TValue>({
   const isRowSelectionEnabled = !!(rowSelection && onRowSelectionChange);
   const isPaginationEnabled = !!(pagination && onPaginationChange);
 
+  // Distinguish a click from a drag-select. A pure click can still register a
+  // 1–2px Range due to mouse drift, so we only suppress onRowClick when the
+  // pointer actually moved beyond a small threshold AND a Range exists.
+  // https://github.com/mui/mui-x/issues/1172
+  const pressOriginRef = React.useRef<{ x: number; y: number } | null>(null);
+
   const resetPageIndex = () => {
     onPaginationChange?.((prev) =>
       prev.pageIndex === 0 ? prev : { ...prev, pageIndex: 0 },
@@ -289,7 +295,24 @@ function DataTable<TData, TValue>({
                       getRowClassName?.(row.original),
                     )}
                     {...(onRowClick && {
-                      onClick: () => onRowClick(row.original),
+                      onMouseDown: (e: React.MouseEvent) => {
+                        pressOriginRef.current = {
+                          x: e.clientX,
+                          y: e.clientY,
+                        };
+                      },
+                      onClick: (e: React.MouseEvent<HTMLTableRowElement>) => {
+                        const origin = pressOriginRef.current;
+                        pressOriginRef.current = null;
+                        const moved =
+                          !!origin &&
+                          (Math.abs(e.clientX - origin.x) > 5 ||
+                            Math.abs(e.clientY - origin.y) > 5);
+                        if (moved && window.getSelection()?.type === "Range") {
+                          return;
+                        }
+                        onRowClick(row.original);
+                      },
                     })}
                   >
                     {row.getVisibleCells().map((cell) => (

--- a/apps/apollo-vertex/templates/DataTableTemplate.tsx
+++ b/apps/apollo-vertex/templates/DataTableTemplate.tsx
@@ -310,8 +310,15 @@ function DataTableTemplateContent() {
     <div className="p-4">
       <DataTable
         {...tableState}
+        getRowId={(payment) => payment.id}
         expanded={expanded}
         onExpandedChange={setExpanded}
+        onRowClick={(payment) =>
+          setExpanded((prev) => {
+            if (prev === true) return { [payment.id]: false };
+            return { ...prev, [payment.id]: !prev[payment.id] };
+          })
+        }
         renderExpandedRow={(row) => {
           const payment = row.original;
           return (


### PR DESCRIPTION
## Summary
- Finishing a text selection inside a clickable data-table row was firing `onRowClick` on mouseup. The row now skips the click when the pointer moved beyond a small threshold AND the resulting `window.getSelection()` is a `Range` — so real drag-selects are ignored, but a shaky click that incidentally produces a 1–2px Range still fires.
- Wires `onRowClick` (toggles row expansion via a new `getRowId`) into `DataTableTemplate` so the behavior is exercisable in the docs demo.
- See https://github.com/mui/mui-x/issues/1172 — no major table library handles this natively; the Range + distance combo is the maintainers' recommended userland fix.