### PR TITLE
fix(apollo-react): move canvas tooltip higher in stack

### DIFF
--- a/packages/apollo-react/src/canvas/components/CanvasTooltip.tsx
+++ b/packages/apollo-react/src/canvas/components/CanvasTooltip.tsx
@@ -143,7 +143,7 @@ export function CanvasTooltip({
     <Tooltip open={effectiveOpen} onOpenChange={handleOpenChange} delayDuration={delay ? 700 : 200}>
       <TooltipTrigger asChild>{triggerWithHandlers}</TooltipTrigger>
       <TooltipPortal>
-        <TooltipContent side={placement} className="max-w-xs break-words">
+        <TooltipContent side={placement} className="z-1200 max-w-xs break-words">
           {content}
         </TooltipContent>
       </TooltipPortal>


### PR DESCRIPTION
Moves z-index for CanvasTooltip to `1200` which is above the `1100` used for FloatingCanvasPanel.

Before:
<img width="696" height="250" alt="Screenshot 2026-05-08 at 11 34 53 AM" src="https://github.com/user-attachments/assets/f7792c4e-d85c-4ee6-ab0a-7425ff9d00e8" />

After:
<img width="633" height="247" alt="Screenshot 2026-05-08 at 11 34 47 AM" src="https://github.com/user-attachments/assets/fcfcfb2b-779c-427a-8048-39339f98059e" />
