### PR TITLE
fix(apollo-react): remove readonly for seq task + add condition icon [MST-8473]

### DIFF
--- a/packages/apollo-react/src/canvas/components/BaseNode/BaseNode.test.tsx
+++ b/packages/apollo-react/src/canvas/components/BaseNode/BaseNode.test.tsx
@@ -89,7 +89,7 @@ vi.mock('./NodeLabel', () => ({
   NodeLabel: ({ label }: { label?: string }) => <div data-testid="node-label">{label}</div>,
 }));
 
-import { HandleGroupManifest } from '../../schema';
+import type { HandleGroupManifest } from '../../schema';
 import { BaseNode } from './BaseNode';
 
 const defaultProps: NodeProps<Node<BaseNodeData>> = {

--- a/packages/apollo-react/src/canvas/components/BaseNode/BaseNodeContainer.tsx
+++ b/packages/apollo-react/src/canvas/components/BaseNode/BaseNodeContainer.tsx
@@ -3,7 +3,7 @@ import { useMemo } from 'react';
 import type { NodeShape } from '../../schema';
 import type { SuggestionType } from '../../types';
 import type { ElementStatusValues } from '../../types/execution';
-import { ValidationErrorSeverity } from '../../types/validation';
+import type { ValidationErrorSeverity } from '../../types/validation';
 
 export const getStatusBorder = (
   status?: ElementStatusValues | ValidationErrorSeverity | SuggestionType

--- a/packages/apollo-react/src/canvas/components/StageNode/DraggableTask.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/DraggableTask.tsx
@@ -10,7 +10,6 @@ import {
   StageTaskDragPlaceholderWrapper,
   StageTaskWrapper,
 } from './StageNode.styles';
-import { StageTaskEntryConditionIcon } from './StageTaskEntryConditionIcon';
 import { TaskContent } from './TaskContent';
 import { TaskMenu, type TaskMenuHandle } from './TaskMenu';
 
@@ -26,7 +25,6 @@ const DraggableTaskComponent = ({
   isDragDisabled,
   projectedDepth,
   isTaskLoading,
-  isReadOnly,
 }: DraggableTaskProps) => {
   const zoom = useStore((s) => s.transform[2]);
   const taskRef = useRef<HTMLDivElement>(null);
@@ -97,9 +95,8 @@ const DraggableTaskComponent = ({
       onClick={handleClick}
       {...(getContextMenuItems && !isTaskLoading && { onContextMenu: handleContextMenu })}
     >
-      <TaskContent task={task} taskExecution={taskExecution} isReadOnly={isReadOnly} />
+      <TaskContent task={task} taskExecution={taskExecution} />
 
-      <StageTaskEntryConditionIcon task={task} />
       {getContextMenuItems && (
         <TaskMenu
           ref={menuRef}

--- a/packages/apollo-react/src/canvas/components/StageNode/DraggableTask.types.ts
+++ b/packages/apollo-react/src/canvas/components/StageNode/DraggableTask.types.ts
@@ -14,5 +14,4 @@ export interface DraggableTaskProps {
   isDragDisabled?: boolean;
   projectedDepth?: number;
   isTaskLoading?: boolean;
-  isReadOnly?: boolean;
 }

--- a/packages/apollo-react/src/canvas/components/StageNode/EventDrivenTask.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/EventDrivenTask.tsx
@@ -2,7 +2,6 @@ import { memo, useCallback, useRef } from 'react';
 import type { NodeMenuItem } from '../NodeContextMenu';
 import { StageTask } from './StageNode.styles';
 import type { StageTaskExecution, StageTaskItem } from './StageNode.types';
-import { StageTaskEntryConditionIcon } from './StageTaskEntryConditionIcon';
 import { TaskContent } from './TaskContent';
 import { TaskMenu, type TaskMenuHandle } from './TaskMenu';
 
@@ -48,7 +47,6 @@ const EventDrivenTaskItemComponent = ({
     >
       <TaskContent task={task} taskExecution={taskExecution} />
 
-      <StageTaskEntryConditionIcon task={task} />
       {getContextMenuItems && (
         <TaskMenu
           ref={menuRef}

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.stories.tsx
@@ -1798,6 +1798,7 @@ export const AdhocTasks: Story = {
                   label: 'Ad hoc - KYC Check',
                   icon: <VerificationIcon />,
                   isAdhoc: true,
+                  hasEntryCondition: true,
                 },
               ],
               [
@@ -1887,12 +1888,14 @@ export const AdhocTasks: Story = {
                   label: 'Ad hoc - Verify Address',
                   icon: <VerificationIcon />,
                   isAdhoc: true,
+                  hasEntryCondition: true,
                 },
                 {
                   id: '2',
                   label: 'Ad hoc - Verify Identity',
                   icon: <VerificationIcon />,
                   isAdhoc: true,
+                  hasEntryCondition: true,
                 },
               ],
               [
@@ -1901,6 +1904,7 @@ export const AdhocTasks: Story = {
                   label: 'Ad hoc - Bkgd Check',
                   icon: <VerificationIcon />,
                   isAdhoc: true,
+                  hasEntryCondition: true,
                 },
               ],
               [
@@ -1911,7 +1915,14 @@ export const AdhocTasks: Story = {
                   isAdhoc: true,
                 },
               ],
-              [{ id: '5', label: 'Regular Processing', icon: <ProcessIcon /> }],
+              [
+                {
+                  id: '5',
+                  label: 'Regular Processing',
+                  icon: <ProcessIcon />,
+                  hasEntryCondition: true,
+                },
+              ],
             ],
           },
           execution: {
@@ -2167,6 +2178,7 @@ export const TasksBySection: Story = {
                   label: 'Ad hoc - Verify Address',
                   icon: <VerificationIcon />,
                   taskGroupType: 'adhoc',
+                  hasEntryCondition: true,
                 },
               ],
               [

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNodeAllTaskGroups.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNodeAllTaskGroups.tsx
@@ -1,7 +1,7 @@
 import { Spacing } from '@uipath/apollo-core';
 import { Column } from '@uipath/apollo-react/canvas/layouts';
 import { Button } from '@uipath/apollo-wind';
-import { CSSProperties, memo, RefObject, useCallback, useMemo } from 'react';
+import { type CSSProperties, memo, type RefObject, useCallback, useMemo } from 'react';
 import { GroupModificationType } from '../../utils';
 import { useStageTasksByGroups } from './hooks/useStageTasksByGroups';
 import { StageContent } from './StageNode.styles';

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNodeSequentialTaskGroups.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNodeSequentialTaskGroups.tsx
@@ -13,7 +13,7 @@ import {
 } from '@dnd-kit/sortable';
 import { Spacing } from '@uipath/apollo-core';
 import { Row } from '@uipath/apollo-react/canvas/layouts';
-import { CSSProperties, useCallback, useMemo } from 'react';
+import { type CSSProperties, useCallback, useMemo } from 'react';
 import {
   GroupModificationType,
   moveGroupDown,
@@ -220,7 +220,6 @@ export const StageNodeSequentialTaskGroups = ({
                           !isReadOnly && {
                             getContextMenuItems: buildContextMenuItems,
                           })}
-                        isReadOnly={isReadOnly}
                       />
                     );
                   })}

--- a/packages/apollo-react/src/canvas/components/StageNode/StageTaskEntryConditionIcon.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageTaskEntryConditionIcon.tsx
@@ -1,8 +1,14 @@
 import { EntryConditionIcon } from '../../icons';
 import { CanvasTooltip } from '../CanvasTooltip';
-import { StageTaskItem } from './StageNode.types';
+import type { StageTaskItem } from './StageNode.types';
 
-export const StageTaskEntryConditionIcon = ({ task }: { task: StageTaskItem }) => {
+export const StageTaskEntryConditionIcon = ({
+  task,
+  small,
+}: {
+  task: StageTaskItem;
+  small?: boolean;
+}) => {
   if (!task.hasEntryCondition) {
     return null;
   }
@@ -12,11 +18,12 @@ export const StageTaskEntryConditionIcon = ({ task }: { task: StageTaskItem }) =
         style={{
           display: 'flex',
           alignItems: 'center',
+          justifyContent: 'center',
           color: 'var(--color-icon-default)',
           flexShrink: 0,
         }}
       >
-        <EntryConditionIcon w={20} h={20} />
+        <EntryConditionIcon w={small ? 16 : 20} h={small ? 16 : 20} />
       </span>
     </CanvasTooltip>
   );

--- a/packages/apollo-react/src/canvas/components/StageNode/TaskContent.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/TaskContent.tsx
@@ -8,6 +8,7 @@ import { CanvasTooltip } from '../CanvasTooltip';
 import { ExecutionStatusIcon } from '../ExecutionStatusIcon';
 import { StageTaskIcon, StageTaskRetryDuration } from './StageNode.styles';
 import type { StageTaskExecution, StageTaskItem } from './StageNode.types';
+import { StageTaskEntryConditionIcon } from './StageTaskEntryConditionIcon';
 
 const ProcessCanvasIcon = () => (
   <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
@@ -106,11 +107,10 @@ export interface TaskContentProps {
   taskExecution?: StageTaskExecution;
   isDragging?: boolean;
   onTaskPlay?: (taskId: string) => Promise<void>;
-  isReadOnly?: boolean;
 }
 
 export const TaskContent = memo(
-  ({ task, taskExecution, isDragging, onTaskPlay, isReadOnly }: TaskContentProps) => {
+  ({ task, taskExecution, isDragging, onTaskPlay }: TaskContentProps) => {
     const hasExecutionStatus = !!taskExecution?.status;
     const hasSecondRowContent =
       taskExecution &&
@@ -147,15 +147,18 @@ export const TaskContent = memo(
                   <Button
                     variant="ghost"
                     size="icon"
-                    className="h-6 w-6"
+                    className="h-4 w-4"
                     aria-label={taskExecution.message}
                   >
                     <ExecutionStatusIcon status={taskExecution.status} />
                   </Button>
                 </CanvasTooltip>
               ) : (
-                !isReadOnly && <ExecutionStatusIcon status={taskExecution.status} />
+                <ExecutionStatusIcon status={taskExecution.status} />
               ))}
+            {!hasSecondRowContent && (
+              <StageTaskEntryConditionIcon task={task} small={!!hasExecutionStatus} />
+            )}
             {showPlayButtonSmall && !hasSecondRowContent && (
               <TaskPlayButton taskId={task.id} onTaskPlay={onTaskPlay} small />
             )}
@@ -182,6 +185,7 @@ export const TaskContent = memo(
                   {generateBadgeText(taskExecution) ?? ''}
                 </Badge>
               )}
+              <StageTaskEntryConditionIcon task={task} small />
               {showPlayButtonSmall && (
                 <TaskPlayButton taskId={task.id} onTaskPlay={onTaskPlay} small />
               )}

--- a/packages/apollo-react/src/canvas/components/StageNode/hooks/useStageTaskDragHandler.ts
+++ b/packages/apollo-react/src/canvas/components/StageNode/hooks/useStageTaskDragHandler.ts
@@ -1,7 +1,7 @@
-import { DragEndEvent, DragMoveEvent, DragOverEvent, DragStartEvent } from '@dnd-kit/core';
+import type { DragEndEvent, DragMoveEvent, DragOverEvent, DragStartEvent } from '@dnd-kit/core';
 import { useStoreApi } from '@xyflow/react';
 import { useCallback, useMemo, useState } from 'react';
-import { StageTaskGroup, StageTaskItem } from '../StageNode.types';
+import type { StageTaskGroup, StageTaskItem } from '../StageNode.types';
 import { flattenTasks, getProjection, reorderTasks } from '../StageNode.utils';
 
 export const useStageTaskDragHandler = ({

--- a/packages/apollo-react/src/canvas/components/StageNode/hooks/useStageTasksByGroups.ts
+++ b/packages/apollo-react/src/canvas/components/StageNode/hooks/useStageTasksByGroups.ts
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import { StageTaskItem } from '../StageNode.types';
+import type { StageTaskItem } from '../StageNode.types';
 
 export const useStageTasksByGroups = (allTasks: StageTaskItem[][]) => {
   const sequentialTaskGroups = useMemo(


### PR DESCRIPTION
## Description
Remove the readonly check for sequential task and add condition icons in the correct location

With execution status
<img width="1732" height="719" alt="image" src="https://github.com/user-attachments/assets/6aae7d60-14da-4d70-8d9f-1c56518a3de8" />

Condition icons
<img width="1200" height="647" alt="image" src="https://github.com/user-attachments/assets/7d896489-9ed5-43af-8623-509f3305d4b0" />
<img width="1668" height="716" alt="image" src="https://github.com/user-attachments/assets/cb2bab4d-4024-4294-917f-072275b2a536" />



