### PR TITLE
feat(apollo-vertex): persist rows per page in data table [AGVSOL-3072]

### DIFF
--- a/apps/apollo-vertex/registry.json
+++ b/apps/apollo-vertex/registry.json
@@ -1614,7 +1614,7 @@
         "lucide-react",
         "react-i18next"
       ],
-      "registryDependencies": ["button", "popover", "calendar"],
+      "registryDependencies": ["button", "popover", "@uipath/calendar"],
       "files": [
         {
           "path": "registry/date-picker/date-picker.tsx",

--- a/apps/apollo-vertex/registry.json
+++ b/apps/apollo-vertex/registry.json
@@ -1360,6 +1360,10 @@
         {
           "path": "registry/use-data-table/usePersistedSorting.ts",
           "type": "registry:hook"
+        },
+        {
+          "path": "registry/use-data-table/usePersistedPageSize.ts",
+          "type": "registry:hook"
         }
       ]
     },

--- a/apps/apollo-vertex/registry/calendar/calendar.tsx
+++ b/apps/apollo-vertex/registry/calendar/calendar.tsx
@@ -87,7 +87,6 @@ function Calendar({
             : "rounded-md pl-2 pr-1 flex items-center gap-1 text-sm h-8 [&>svg]:text-muted-foreground [&>svg]:size-3.5",
           defaultClassNames.caption_label,
         ),
-        table: "w-full border-collapse",
         weekdays: cn("flex", defaultClassNames.weekdays),
         weekday: cn(
           "text-muted-foreground rounded-md flex-1 font-normal text-[0.8rem] select-none",

--- a/apps/apollo-vertex/registry/use-data-table/useDataTable.tsx
+++ b/apps/apollo-vertex/registry/use-data-table/useDataTable.tsx
@@ -3,13 +3,13 @@
 import type {
   ColumnDef,
   ColumnFiltersState,
-  PaginationState,
   RowSelectionState,
 } from "@tanstack/react-table";
 import { useState } from "react";
 
 import { useColumnVisibility } from "./useColumnVisibility";
 import { usePersistedColumnOrder } from "./usePersistedColumnOrder";
+import { usePersistedPageSize } from "./usePersistedPageSize";
 import { usePersistedSorting } from "./usePersistedSorting";
 
 export interface UseDataTableOptions<TData> {
@@ -53,9 +53,8 @@ export function useDataTable<TData>({
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
   const [globalFilter, setGlobalFilter] = useState("");
-  const [pagination, setPagination] = useState<PaginationState>({
-    pageIndex: 0,
-    pageSize: 10,
+  const { pagination, onPaginationChange } = usePersistedPageSize({
+    storageKey,
   });
 
   return {
@@ -75,6 +74,6 @@ export function useDataTable<TData>({
     globalFilter,
     onGlobalFilterChange: setGlobalFilter,
     pagination,
-    onPaginationChange: setPagination,
+    onPaginationChange,
   };
 }

--- a/apps/apollo-vertex/registry/use-data-table/useEntityDataTable.tsx
+++ b/apps/apollo-vertex/registry/use-data-table/useEntityDataTable.tsx
@@ -3,7 +3,6 @@
 import { useLiveQuery } from "@tanstack/react-db";
 import type {
   ColumnFiltersState,
-  PaginationState,
   RowSelectionState,
 } from "@tanstack/react-table";
 import { useSolution } from "@uipath/vs-core";
@@ -21,6 +20,7 @@ import type {
 import { useColumnVisibility } from "./useColumnVisibility";
 import { useEntityColumns } from "./useEntityColumns";
 import { usePersistedColumnOrder } from "./usePersistedColumnOrder";
+import { usePersistedPageSize } from "./usePersistedPageSize";
 import { usePersistedSorting } from "./usePersistedSorting";
 
 export interface UseEntityDataTableOptions<
@@ -97,9 +97,8 @@ export function useEntityDataTable<
     key: `${ENTITY_TABLE_STORAGE_PREFIX}global-filter-${storageKey}`,
     defaultValue: "",
   });
-  const [pagination, setPagination] = useState<PaginationState>({
-    pageIndex: 0,
-    pageSize: 10,
+  const { pagination, onPaginationChange } = usePersistedPageSize({
+    storageKey,
   });
 
   return {
@@ -119,6 +118,6 @@ export function useEntityDataTable<
     globalFilter,
     onGlobalFilterChange: setGlobalFilter,
     pagination,
-    onPaginationChange: setPagination,
+    onPaginationChange,
   };
 }

--- a/apps/apollo-vertex/registry/use-data-table/usePersistedPageSize.ts
+++ b/apps/apollo-vertex/registry/use-data-table/usePersistedPageSize.ts
@@ -1,0 +1,36 @@
+"use client";
+
+import type { OnChangeFn, PaginationState } from "@tanstack/react-table";
+import { useState } from "react";
+
+import { ENTITY_TABLE_STORAGE_PREFIX } from "@/lib/constants";
+import { useLocalStorage } from "@mantine/hooks";
+
+export interface UsePersistedPageSizeOptions {
+  storageKey: string;
+}
+
+export function usePersistedPageSize({
+  storageKey,
+}: UsePersistedPageSizeOptions) {
+  const [pageSize, setPageSize] = useLocalStorage<number>({
+    key: `${ENTITY_TABLE_STORAGE_PREFIX}page-size-${storageKey}`,
+    defaultValue: 10,
+  });
+
+  const [pageIndex, setPageIndex] = useState(0);
+  const pagination: PaginationState = { pageIndex, pageSize };
+
+  const onPaginationChange: OnChangeFn<PaginationState> = (updaterOrValue) => {
+    const newPagination =
+      typeof updaterOrValue === "function"
+        ? updaterOrValue(pagination)
+        : updaterOrValue;
+    setPageIndex(newPagination.pageIndex);
+    if (newPagination.pageSize !== pageSize) {
+      setPageSize(newPagination.pageSize);
+    }
+  };
+
+  return { pagination, onPaginationChange };
+}

--- a/packages/apollo-wind/src/components/ui/calendar.tsx
+++ b/packages/apollo-wind/src/components/ui/calendar.tsx
@@ -72,7 +72,6 @@ function Calendar({
             : '[&>svg]:text-muted-foreground flex h-8 items-center gap-1 rounded-md pl-2 pr-1 text-sm [&>svg]:size-3.5',
           defaultClassNames.caption_label
         ),
-        table: 'w-full border-collapse',
         weekdays: cn('flex gap-2', defaultClassNames.weekdays),
         weekday: cn(
           'text-muted-foreground flex-1 select-none rounded-md text-[0.8rem] font-normal',


### PR DESCRIPTION
## Context
This comes from a request by Medtronic to be able to persist the page size selection. So in the same way we persist the column selection im thinking we should also persist the page size.

## SS
<img width="1505" height="736" alt="image" src="https://github.com/user-attachments/assets/f4acd7c1-6118-40f2-a49d-638c6076176c" />
