### PR TITLE
fix(apollo-react): fix loop header adornment spacing [MST-9651]

### DIFF
--- a/packages/apollo-react/src/canvas/components/ExecutionStatusIcon/ExecutionStatusIcon.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/ExecutionStatusIcon/ExecutionStatusIcon.stories.tsx
@@ -13,6 +13,7 @@ const meta = {
       options: [
         'InProgress',
         'Cancelled',
+        'UserCancelled',
         'Completed',
         'Paused',
         'Failed',
@@ -55,6 +56,7 @@ export const Default: Story = {
           { status: 'Failed', label: 'Failed', description: 'Execution failed' },
           { status: 'Paused', label: 'Paused', description: 'Temporarily stopped' },
           { status: 'Cancelled', label: 'Cancelled', description: 'Execution cancelled' },
+          { status: 'UserCancelled', label: 'User Cancelled', description: 'Stopped by user' },
           { status: 'Terminated', label: 'Terminated', description: 'Forcefully stopped' },
           { status: 'NotExecuted', label: 'Not Executed', description: 'Not yet started' },
           { status: 'Warning', label: 'Warning', description: 'Needs attention' },
@@ -74,7 +76,7 @@ export const Default: Story = {
             }}
           >
             <div style={{ height: '32px', display: 'flex', alignItems: 'center' }}>
-              <ExecutionStatusIcon status={status as any} size={24} />
+              <ExecutionStatusIcon status={status} size={24} />
             </div>
             <div style={{ textAlign: 'center' }}>
               <div

--- a/packages/apollo-react/src/canvas/components/ExecutionStatusIcon/ExecutionStatusIcon.test.tsx
+++ b/packages/apollo-react/src/canvas/components/ExecutionStatusIcon/ExecutionStatusIcon.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { ExecutionStatusIcon, getExecutionStatusColor } from './ExecutionStatusIcon';
+
+vi.mock('../../utils/icon-registry', () => ({
+  CanvasIcon: ({ icon, color, size }: { icon: string; color?: string; size?: number }) => (
+    <span data-color={color} data-icon={icon} data-size={size} data-testid="canvas-icon" />
+  ),
+}));
+
+vi.mock('@uipath/apollo-wind', () => ({
+  Spinner: () => <span data-testid="spinner" />,
+}));
+
+describe('ExecutionStatusIcon', () => {
+  it('renders UserCancelled with the cancelled glyph and info color', () => {
+    render(<ExecutionStatusIcon status="UserCancelled" size={20} />);
+
+    const icon = screen.getByTestId('canvas-icon');
+    expect(icon).toHaveAttribute('data-icon', 'circle-stop');
+    expect(icon).toHaveAttribute('data-color', 'var(--color-info-icon)');
+    expect(icon).toHaveAttribute('data-size', '20');
+  });
+});
+
+describe('getExecutionStatusColor', () => {
+  it('keeps UserCancelled aligned with info-colored execution states', () => {
+    expect(getExecutionStatusColor('UserCancelled')).toBe('var(--color-info-icon)');
+  });
+});

--- a/packages/apollo-react/src/canvas/components/ExecutionStatusIcon/ExecutionStatusIcon.tsx
+++ b/packages/apollo-react/src/canvas/components/ExecutionStatusIcon/ExecutionStatusIcon.tsx
@@ -49,6 +49,7 @@ export function ExecutionStatusIcon({
   status?:
     | 'InProgress'
     | 'Cancelled'
+    | 'UserCancelled'
     | 'Completed'
     | 'Paused'
     | 'Failed'
@@ -80,6 +81,7 @@ export function ExecutionStatusIcon({
       case 'Terminated':
         return <CanvasIcon icon="circle-x" size={size} color={color} />;
       case 'Cancelled':
+      case 'UserCancelled':
         return <CanvasIcon icon="circle-stop" size={size} color={color} />;
       case 'NotExecuted':
         return <CanvasIcon icon="circle-dashed" size={size} color={color} />;

--- a/packages/apollo-react/src/canvas/components/LoopNode/LoopNode.test.tsx
+++ b/packages/apollo-react/src/canvas/components/LoopNode/LoopNode.test.tsx
@@ -1,0 +1,123 @@
+import { render, screen } from '@testing-library/react';
+import type { Node, NodeProps } from '@uipath/apollo-react/canvas/xyflow/react';
+import { describe, expect, it, vi } from 'vitest';
+import type { LoopNodeData } from './LoopNode.types';
+
+const { mockManifest } = vi.hoisted(() => ({
+  mockManifest: {
+    current: {
+      display: { label: 'Loop', icon: 'repeat', shape: 'container' },
+      handleConfiguration: [],
+    } as Record<string, unknown>,
+  },
+}));
+
+vi.mock('@uipath/apollo-react/canvas/xyflow/react', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@uipath/apollo-react/canvas/xyflow/react')>()),
+  useStore: (selector: unknown) => {
+    const state = {
+      connection: { inProgress: false },
+      nodes: [],
+      parentLookup: new Map(),
+    };
+
+    return typeof selector === 'function' ? selector(state) : false;
+  },
+  useUpdateNodeInternals: () => vi.fn(),
+}));
+
+vi.mock('../../core', () => ({
+  useOptionalNodeTypeRegistry: () => ({
+    getManifest: () => mockManifest.current,
+  }),
+}));
+
+vi.mock('../../hooks', () => ({
+  useNodeExecutionState: () => undefined,
+  useElementValidationStatus: () => undefined,
+}));
+
+vi.mock('../../utils/icon-registry', () => ({
+  CanvasIcon: ({ icon }: { icon: string }) => <span data-testid={`canvas-icon-${icon}`} />,
+}));
+
+vi.mock('../../utils/toolbar-resolver', () => ({
+  resolveToolbar: () => undefined,
+}));
+
+vi.mock('../BaseCanvas/BaseCanvasModeProvider', () => ({
+  useBaseCanvasMode: () => ({ mode: 'design' }),
+}));
+
+vi.mock('../BaseCanvas/ConnectedHandlesContext', () => ({
+  useConnectedHandles: () => new Set(),
+}));
+
+vi.mock('../BaseCanvas/SelectionStateContext', () => ({
+  useSelectionState: () => ({ multipleNodesSelected: false }),
+}));
+
+import { LoopNode } from './LoopNode';
+
+const defaultProps: NodeProps<Node<LoopNodeData>> = {
+  id: 'loop-1',
+  type: 'loop',
+  data: {},
+  selected: false,
+  dragging: false,
+  draggable: true,
+  zIndex: 0,
+  isConnectable: true,
+  positionAbsoluteX: 0,
+  positionAbsoluteY: 0,
+  selectable: true,
+  deletable: true,
+};
+
+function renderLoopNode(props: Partial<React.ComponentProps<typeof LoopNode>> = {}) {
+  render(<LoopNode {...defaultProps} {...props} />);
+  return screen.getByTestId('loop-node-header');
+}
+
+describe('LoopNode header adornment spacing', () => {
+  it('keeps the default header padding when no adornments are visible', () => {
+    const header = renderLoopNode();
+
+    expect(header.style.paddingLeft).toBe('');
+    expect(header.style.paddingRight).toBe('');
+  });
+
+  it('reserves left-side header space when the top-left adornment is visible', () => {
+    const header = renderLoopNode({
+      adornments: {
+        topLeft: <span data-testid="breakpoint-adornment" />,
+      },
+    });
+
+    expect(header.style.paddingLeft).toBe('34px');
+    expect(header.style.paddingRight).toBe('');
+  });
+
+  it('reserves right-side header space when the top-right adornment is visible', () => {
+    const header = renderLoopNode({
+      adornments: {
+        topRight: <span data-testid="execution-count-adornment" />,
+      },
+    });
+
+    expect(header.style.paddingLeft).toBe('');
+    expect(header.style.paddingRight).toBe('34px');
+  });
+
+  it('reserves both sides independently when both top adornments are visible', () => {
+    const header = renderLoopNode({
+      adornments: {
+        topLeft: <span data-testid="breakpoint-adornment" />,
+        topRight: <span data-testid="execution-count-adornment" />,
+      },
+    });
+
+    expect(header.style.paddingLeft).toBe('34px');
+    expect(header.style.paddingRight).toBe('34px');
+  });
+});

--- a/packages/apollo-react/src/canvas/components/LoopNode/LoopNode.tsx
+++ b/packages/apollo-react/src/canvas/components/LoopNode/LoopNode.tsx
@@ -8,6 +8,7 @@ import {
 import { cn } from '@uipath/apollo-wind';
 import { memo, useCallback, useEffect, useMemo, useState } from 'react';
 import { shallow } from 'zustand/shallow';
+import { NODE_BADGE_INSET_SQUARE, NODE_BADGE_SIZE } from '../../constants';
 import { useOptionalNodeTypeRegistry } from '../../core';
 import { useElementValidationStatus, useNodeExecutionState } from '../../hooks';
 import type { HandleGroupManifest } from '../../schema/node-definition';
@@ -42,6 +43,9 @@ import type { LoopIterationState, LoopNodeProps } from './LoopNode.types';
 const DEFAULT_LOOP_ICON = 'repeat';
 const DEFAULT_LOOP_TITLE = 'Loop';
 const EMPTY_DATA: Record<string, unknown> = {};
+const LOOP_HEADER_ADORNMENT_GAP = 8;
+const LOOP_HEADER_ADORNMENT_PADDING =
+  NODE_BADGE_INSET_SQUARE + NODE_BADGE_SIZE + LOOP_HEADER_ADORNMENT_GAP;
 
 const RESIZE_CONTROLS = [
   {
@@ -269,6 +273,8 @@ function LoopNodeComponent(props: LoopNodeProps) {
     }),
     [adornmentsProp, statusContext]
   );
+  const hasTopLeftAdornment = !!adornments.topLeft;
+  const hasTopRightAdornment = !!adornments.topRight;
 
   const resolvedHandleGroups = useMemo(() => {
     const handleConfigurations = resolveLoopHandleConfigurations(
@@ -374,6 +380,8 @@ function LoopNodeComponent(props: LoopNodeProps) {
         loading={isLoading}
         isParallel={isParallel}
         iterationState={iterationStateProp}
+        hasTopLeftAdornment={hasTopLeftAdornment}
+        hasTopRightAdornment={hasTopRightAdornment}
       />
       <BodyFrame isEmpty={showEmptyStateButton} isLoading={isLoading} />
       {showEmptyStateButton ? (
@@ -420,12 +428,16 @@ function Header({
   loading,
   isParallel,
   iterationState,
+  hasTopLeftAdornment,
+  hasTopRightAdornment,
 }: {
   title: string;
   icon?: string;
   loading: boolean;
   isParallel: boolean;
   iterationState?: LoopIterationState;
+  hasTopLeftAdornment: boolean;
+  hasTopRightAdornment: boolean;
 }) {
   const titleContent = loading ? (
     <div className="h-5 w-28 animate-pulse rounded bg-(--canvas-background-overlay)" />
@@ -441,6 +453,14 @@ function Header({
     </span>
   ) : null;
 
+  const headerStyle =
+    hasTopLeftAdornment || hasTopRightAdornment
+      ? {
+          paddingLeft: hasTopLeftAdornment ? LOOP_HEADER_ADORNMENT_PADDING : undefined,
+          paddingRight: hasTopRightAdornment ? LOOP_HEADER_ADORNMENT_PADDING : undefined,
+        }
+      : undefined;
+
   return (
     <div
       className={cn(
@@ -448,6 +468,7 @@ function Header({
         '-mb-2.5 bg-surface-overlay px-3.5 pb-2.5 pt-2.5 text-foreground',
         'active:cursor-grabbing'
       )}
+      style={headerStyle}
       data-testid="loop-node-header"
     >
       <div className="flex min-w-0 items-center gap-2.5">

--- a/packages/apollo-react/src/canvas/storybook-utils/decorators.tsx
+++ b/packages/apollo-react/src/canvas/storybook-utils/decorators.tsx
@@ -18,7 +18,7 @@ import {
   type ValidationStateContextValue,
   ValidationStatusContext,
 } from '../hooks';
-import type { ElementStatus } from '../types/execution';
+import { type ElementStatus, ElementStatusValues } from '../types/execution';
 import type { ValidationErrorSeverity } from '../types/validation';
 import { defaultWorkflowManifest } from './manifests';
 
@@ -27,6 +27,7 @@ import { defaultWorkflowManifest } from './manifests';
  * theme toolbar in `apps/storybook/.storybook/preview.tsx`.
  */
 const DARK_THEMES = new Set(['dark', 'dark-hc', 'future-dark', 'vertex', 'canvas']);
+const EXECUTION_STATUSES = new Set<ElementStatus>(Object.values(ElementStatusValues));
 
 /**
  * Props for execution state configuration.
@@ -66,10 +67,16 @@ export interface CanvasProvidersOptions {
  */
 const defaultExecutionState: ExecutionStateConfig = {
   getNodeExecutionState: (nodeId: string): ElementStatus | undefined =>
-    nodeId.split('-')[1] as ElementStatus,
+    resolveStoryExecutionStatus(nodeId.split('-')[1]),
   getEdgeExecutionState: (edgeId: string, _targetNodeId: string): ElementStatus | undefined =>
-    edgeId.split('-')[1] as ElementStatus,
+    resolveStoryExecutionStatus(edgeId.split('-')[1]),
 };
+
+function resolveStoryExecutionStatus(value: string | undefined): ElementStatus | undefined {
+  return value && EXECUTION_STATUSES.has(value as ElementStatus)
+    ? (value as ElementStatus)
+    : undefined;
+}
 
 /**
  * Default validation state that extracts status from node ID.

--- a/packages/apollo-react/src/canvas/utils/adornment-resolver.test.tsx
+++ b/packages/apollo-react/src/canvas/utils/adornment-resolver.test.tsx
@@ -16,10 +16,10 @@ const baseContext: NodeStatusContext = { nodeId: 'node-1' };
 describe('resolveAdornments', () => {
   // ── No status ───────────────────────────────────────────
 
-  it('returns execution status indicator as default topRight', () => {
+  it('does not reserve a topRight adornment without visible status', () => {
     const result = resolveAdornments(baseContext);
     expect(result.topLeft).toBeUndefined();
-    expect((result.topRight as React.ReactElement)?.type).toBe(ExecutionStatusIndicator);
+    expect(result.topRight).toBeUndefined();
     expect(result.bottomLeft).toBeUndefined();
     expect(result.bottomRight).toBeUndefined();
   });
@@ -144,7 +144,7 @@ describe('resolveAdornments', () => {
     expect((result.topRight as React.ReactElement)?.type).toBe(ValidationWarningIndicator);
   });
 
-  it('falls back to execution indicator for INFO severity', () => {
+  it('does not show topRight adornment for INFO severity without visible status', () => {
     const result = resolveAdornments({
       ...baseContext,
       validationState: {
@@ -152,7 +152,7 @@ describe('resolveAdornments', () => {
         validationError: undefined,
       },
     });
-    expect((result.topRight as React.ReactElement)?.type).toBe(ExecutionStatusIndicator);
+    expect(result.topRight).toBeUndefined();
   });
 
   // ── Priority: execution status > validation ─────────────
@@ -191,12 +191,12 @@ describe('resolveAdornments', () => {
     expect((result.topRight as React.ReactElement)?.type).toBe(ValidationErrorIndicator);
   });
 
-  it('falls back to execution indicator when no validation state', () => {
+  it('does not show topRight adornment when no validation state or visible status exists', () => {
     const result = resolveAdornments({
       ...baseContext,
       validationState: undefined,
     });
-    expect((result.topRight as React.ReactElement)?.type).toBe(ExecutionStatusIndicator);
+    expect(result.topRight).toBeUndefined();
   });
 });
 

--- a/packages/apollo-react/src/canvas/utils/adornment-resolver.tsx
+++ b/packages/apollo-react/src/canvas/utils/adornment-resolver.tsx
@@ -118,7 +118,7 @@ const getDefaultAdornments = (context: NodeStatusContext): NodeAdornments => {
       return (
         <ValidationWarningIndicator message={context.validationState?.validationError?.message} />
       );
-    return <ExecutionStatusIndicator status={status} count={count} />;
+    return undefined;
   };
 
   return {


### PR DESCRIPTION
## Summary

Fixes the loop container header so top-corner adornments do not overlap the loop title area or the iteration/parallel controls.

## Details

The loop node already renders breakpoint and execution/status adornments in the same top-left and top-right badge slots used by other canvas nodes. The overlap happened because the loop header content did not reserve room for those absolute-positioned badge slots. When an execution count/status appeared on the top right, it could sit on top of the iteration navigator and the Parallel badge.

This change keeps the adornments in their existing badge positions and pushes only the loop header content inward on the side that actually has an adornment. A breakpoint on the left shifts the loop icon/title inward; a status/count adornment on the right shifts the iteration navigator and Sequential/Parallel pill inward.

I also tightened the default adornment resolver so it does not emit an empty top-right adornment when there is no visible execution status or validation signal. The Storybook canvas decorator now ignores invalid status fragments such as the `1` in `loop-1`, which prevents stories from showing reserved adornment spacing when no real adornment exists.

## Validation

- `pnpm --filter=@uipath/apollo-react test -- src/canvas/utils/adornment-resolver.test.tsx src/canvas/components/LoopNode/LoopNode.test.tsx src/canvas/components/LoopNode/IterationNavigator.test.tsx`
- `pnpm exec biome check src/canvas/utils/adornment-resolver.tsx src/canvas/utils/adornment-resolver.test.tsx src/canvas/components/LoopNode/LoopNode.tsx src/canvas/components/LoopNode/LoopNode.test.tsx src/canvas/storybook-utils/decorators.tsx`
