### PR TITLE
fix(apollo-react): stage title focus [MST-9622]

### DIFF
--- a/packages/apollo-react/src/canvas/components/CanvasTooltip.test.tsx
+++ b/packages/apollo-react/src/canvas/components/CanvasTooltip.test.tsx
@@ -4,7 +4,11 @@ import { render, screen } from '../utils/testing';
 import { CanvasTooltip, CanvasTooltipProviderMarker } from './CanvasTooltip';
 
 vi.mock('@uipath/apollo-wind/components/ui/tooltip', () => ({
-  Tooltip: ({ children }: PropsWithChildren) => <div data-testid="tooltip">{children}</div>,
+  Tooltip: ({ children, open }: PropsWithChildren<{ open?: boolean }>) => (
+    <div data-testid="tooltip" data-open={open ? 'true' : 'false'}>
+      {children}
+    </div>
+  ),
   TooltipContent: ({ children }: PropsWithChildren) => (
     <div data-testid="tooltip-content">{children}</div>
   ),
@@ -18,7 +22,7 @@ vi.mock('@uipath/apollo-wind/components/ui/tooltip', () => ({
 }));
 
 describe('CanvasTooltip', () => {
-  it('returns children directly when content is empty', () => {
+  it('keeps the wrapper mounted but closed when content is empty whitespace', () => {
     render(
       <CanvasTooltip content=" ">
         <button type="button">Click me</button>
@@ -26,10 +30,10 @@ describe('CanvasTooltip', () => {
     );
 
     expect(screen.getByRole('button', { name: 'Click me' })).toBeInTheDocument();
-    expect(screen.queryByTestId('tooltip')).not.toBeInTheDocument();
+    expect(screen.getByTestId('tooltip')).toHaveAttribute('data-open', 'false');
   });
 
-  it('returns children directly when content is false', () => {
+  it('keeps the wrapper mounted but closed when content is false', () => {
     render(
       <CanvasTooltip content={false}>
         <button type="button">Click me</button>
@@ -37,10 +41,10 @@ describe('CanvasTooltip', () => {
     );
 
     expect(screen.getByRole('button', { name: 'Click me' })).toBeInTheDocument();
-    expect(screen.queryByTestId('tooltip')).not.toBeInTheDocument();
+    expect(screen.getByTestId('tooltip')).toHaveAttribute('data-open', 'false');
   });
 
-  it('returns children directly when content is null', () => {
+  it('keeps the wrapper mounted but closed when content is null', () => {
     render(
       <CanvasTooltip content={null}>
         <button type="button">Click me</button>
@@ -48,7 +52,41 @@ describe('CanvasTooltip', () => {
     );
 
     expect(screen.getByRole('button', { name: 'Click me' })).toBeInTheDocument();
-    expect(screen.queryByTestId('tooltip')).not.toBeInTheDocument();
+    expect(screen.getByTestId('tooltip')).toHaveAttribute('data-open', 'false');
+  });
+
+  it('forces the popup closed when content is empty even with isOpen={true}', () => {
+    render(
+      <CanvasTooltip content="" isOpen={true}>
+        <button type="button">Click me</button>
+      </CanvasTooltip>
+    );
+
+    expect(screen.getByRole('button', { name: 'Click me' })).toBeInTheDocument();
+    expect(screen.getByTestId('tooltip')).toHaveAttribute('data-open', 'false');
+  });
+
+  it('does not remount the wrapper when content transitions through empty', () => {
+    const { rerender } = render(
+      <CanvasTooltip content="Hello">
+        <button type="button">Click me</button>
+      </CanvasTooltip>
+    );
+    const initialWrapper = screen.getByTestId('tooltip');
+
+    rerender(
+      <CanvasTooltip content="">
+        <button type="button">Click me</button>
+      </CanvasTooltip>
+    );
+    expect(screen.getByTestId('tooltip')).toBe(initialWrapper);
+
+    rerender(
+      <CanvasTooltip content="Hello again">
+        <button type="button">Click me</button>
+      </CanvasTooltip>
+    );
+    expect(screen.getByTestId('tooltip')).toBe(initialWrapper);
   });
 
   it('renders tooltip without its own TooltipProvider when inside CanvasTooltipProviderMarker', () => {

--- a/packages/apollo-react/src/canvas/components/CanvasTooltip.tsx
+++ b/packages/apollo-react/src/canvas/components/CanvasTooltip.tsx
@@ -120,6 +120,9 @@ export function CanvasTooltip({
     [smartTooltip, truncationDetection.check]
   );
 
+  const isEmptyContent =
+    content == null || content === false || (typeof content === 'string' && content.trim() === '');
+
   // Priority ordering matches ApTooltip: isOpen > hide > smartTooltip
   const isTooltipHidden = useMemo(() => {
     if (isOpen != null) return !isOpen;
@@ -128,16 +131,9 @@ export function CanvasTooltip({
     return false;
   }, [isOpen, hide, smartTooltip, isTruncated]);
 
-  const effectiveOpen = isTooltipHidden ? false : (isOpen ?? hoverOpen);
+  const effectiveOpen = isEmptyContent || isTooltipHidden ? false : (isOpen ?? hoverOpen);
 
   const hasProvider = useContext(HasTooltipProviderContext);
-
-  const isEmptyContent =
-    content == null || content === false || (typeof content === 'string' && content.trim() === '');
-
-  if (isEmptyContent) {
-    return children;
-  }
 
   const tooltip = (
     <Tooltip open={effectiveOpen} onOpenChange={handleOpenChange} delayDuration={delay ? 700 : 200}>

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNodeHeader.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNodeHeader.tsx
@@ -135,7 +135,7 @@ const StageNodeHeaderInner = ({
           <span
             className={cn('text-sm', !isStageTitleEditing && 'font-bold', 'flex-1 min-w-0 py-0.5')}
           >
-            <CanvasTooltip content={label} placement="top" delay>
+            <CanvasTooltip content={label} placement="top" hide={isStageTitleEditing} delay>
               <StageTitleContainer isEditing={isStageTitleEditing}>
                 <StageTitleInput
                   name="Stage Title"


### PR DESCRIPTION
fixed the unfocusing of stage title when title gets empty.
It was the issue from canvasTooltip which was rerendering again when content gets or empty or refilled

before

https://github.com/user-attachments/assets/2754b699-4e91-46a2-bf03-2f8ba9a85569

after

https://github.com/user-attachments/assets/42af9fe0-0363-4e68-920f-daae30f60edd



