### PR TITLE
feat(apollo-react): display sla status and remaining time in stage node [MST-9616]

### DIFF
--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.stories.tsx
@@ -567,6 +567,111 @@ export const ExecutionStatus: Story = {
   },
 };
 
+export const SLAStates: Story = {
+  name: 'SLA States',
+  parameters: {
+    nodes: [
+      {
+        id: '0',
+        type: 'stage',
+        position: { x: 48, y: 96 },
+        width: 304,
+        data: {
+          stageDetails: {
+            label: 'Stage 1',
+            isReadOnly: true,
+            tasks: [],
+          },
+          execution: {
+            stageStatus: {
+              slaText: 'SLA: None',
+            },
+            taskStatus: {},
+          },
+        },
+      },
+      {
+        id: '1',
+        type: 'stage',
+        position: { x: 400, y: 96 },
+        width: 304,
+        data: {
+          stageDetails: {
+            label: 'Closing',
+            isReadOnly: true,
+            tasks: [
+              [{ id: '1', label: 'Prepare closing docs', icon: <DocumentIcon /> }],
+              [{ id: '2', label: 'eSign envelope', icon: <DocumentIcon /> }],
+              [{ id: '3', label: 'Review closing docs', icon: <DocumentIcon /> }],
+            ],
+          },
+          execution: {
+            stageStatus: {
+              status: 'InProgress',
+              label: 'In progress',
+              slaText: 'SLA: 10 days remaining',
+              slaStatus: 'ok',
+            },
+            taskStatus: {},
+          },
+        },
+      },
+      {
+        id: '2',
+        type: 'stage',
+        position: { x: 752, y: 96 },
+        width: 304,
+        data: {
+          stageDetails: {
+            label: 'Closing',
+            isReadOnly: true,
+            tasks: [
+              [{ id: '1', label: 'Prepare closing docs', icon: <DocumentIcon /> }],
+              [{ id: '2', label: 'eSign envelope', icon: <DocumentIcon /> }],
+              [{ id: '3', label: 'Review closing docs', icon: <DocumentIcon /> }],
+            ],
+          },
+          execution: {
+            stageStatus: {
+              status: 'InProgress',
+              label: 'In progress',
+              slaText: 'SLA: 1 day remaining',
+              slaStatus: 'warning',
+            },
+            taskStatus: {},
+          },
+        },
+      },
+      {
+        id: '3',
+        type: 'stage',
+        position: { x: 1104, y: 96 },
+        width: 304,
+        data: {
+          stageDetails: {
+            label: 'Closing',
+            isReadOnly: true,
+            tasks: [
+              [{ id: '1', label: 'Prepare closing docs', icon: <DocumentIcon /> }],
+              [{ id: '2', label: 'eSign envelope', icon: <DocumentIcon /> }],
+              [{ id: '3', label: 'Review closing docs', icon: <DocumentIcon /> }],
+            ],
+          },
+          execution: {
+            stageStatus: {
+              status: 'InProgress',
+              label: 'In progress',
+              slaText: 'SLA: 1 day overdue',
+              slaStatus: 'overdue',
+            },
+            taskStatus: {},
+          },
+        },
+      },
+    ],
+  },
+};
+
 export const InteractiveTaskManagement: Story = {
   name: 'Interactive Task Management',
   parameters: {

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.stories.tsx
@@ -610,7 +610,6 @@ export const SLAStates: Story = {
               status: 'InProgress',
               label: 'In progress',
               slaText: 'SLA: 10 days remaining',
-              slaStatus: 'ok',
             },
             taskStatus: {},
           },
@@ -636,7 +635,7 @@ export const SLAStates: Story = {
               status: 'InProgress',
               label: 'In progress',
               slaText: 'SLA: 1 day remaining',
-              slaStatus: 'warning',
+              slaIcon: 'warning',
             },
             taskStatus: {},
           },
@@ -662,7 +661,7 @@ export const SLAStates: Story = {
               status: 'InProgress',
               label: 'In progress',
               slaText: 'SLA: 1 day overdue',
-              slaStatus: 'overdue',
+              slaIcon: 'error',
             },
             taskStatus: {},
           },
@@ -793,6 +792,92 @@ export const InteractiveTaskManagement: Story = {
           },
           onTaskClick: (taskId: string) => {
             window.alert(`Task clicked: ${taskId} (execution mode - read only)`);
+          },
+        },
+      },
+    ],
+  },
+};
+
+export const ExecutionModeWithSla: Story = {
+  name: 'Execution Mode - Runtime vs SLA',
+  parameters: {
+    nodes: [
+      {
+        id: 'exec-runtime-only',
+        type: 'stage',
+        position: { x: 48, y: 96 },
+        width: 304,
+        data: {
+          stageDetails: {
+            label: 'Runtime only',
+            isReadOnly: true,
+            tasks: [
+              [{ id: '1', label: 'Prepare closing docs', icon: <DocumentIcon /> }],
+              [{ id: '2', label: 'eSign envelope', icon: <DocumentIcon /> }],
+              [{ id: '3', label: 'Review closing docs', icon: <DocumentIcon /> }],
+            ],
+          },
+          execution: {
+            stageStatus: {
+              status: 'InProgress',
+              label: 'In progress',
+              duration: 'Duration: 2h 15m',
+            },
+            taskStatus: {},
+          },
+        },
+      },
+      {
+        id: 'exec-sla-only',
+        type: 'stage',
+        position: { x: 400, y: 96 },
+        width: 304,
+        data: {
+          stageDetails: {
+            label: 'SLA only',
+            isReadOnly: true,
+            tasks: [
+              [{ id: '1', label: 'Prepare closing docs', icon: <DocumentIcon /> }],
+              [{ id: '2', label: 'eSign envelope', icon: <DocumentIcon /> }],
+              [{ id: '3', label: 'Review closing docs', icon: <DocumentIcon /> }],
+            ],
+          },
+          execution: {
+            stageStatus: {
+              status: 'InProgress',
+              label: 'In progress',
+              slaText: 'SLA: 1 day remaining',
+              slaIcon: 'warning',
+            },
+            taskStatus: {},
+          },
+        },
+      },
+      {
+        id: 'exec-runtime-and-sla',
+        type: 'stage',
+        position: { x: 752, y: 96 },
+        width: 304,
+        data: {
+          stageDetails: {
+            label: 'Runtime + SLA (both)',
+            isReadOnly: true,
+            tasks: [
+              [{ id: '1', label: 'Prepare closing docs', icon: <DocumentIcon /> }],
+              [{ id: '2', label: 'eSign envelope', icon: <DocumentIcon /> }],
+              [{ id: '3', label: 'Review closing docs', icon: <DocumentIcon /> }],
+            ],
+          },
+          execution: {
+            stageStatus: {
+              status: 'InProgress',
+              label: 'In progress',
+              duration: 'Duration: 2h 15m',
+              slaText: 'SLA: 1 day remaining',
+              slaIcon: 'warning',
+            },
+            taskStatus: {},
           },
         },
       },

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.stories.tsx
@@ -188,7 +188,7 @@ export const Default: Story = {
           },
           execution: {
             stageStatus: {
-              duration: 'SLA: None',
+              slaText: 'SLA: None',
             },
           },
           onTaskAdd: () => {
@@ -212,7 +212,7 @@ export const Default: Story = {
           },
           execution: {
             stageStatus: {
-              duration: 'SLA: None',
+              slaText: 'SLA: None',
             },
           },
           onAddTaskFromToolbox: (taskItem: ListItem) => {
@@ -391,7 +391,7 @@ export const ExecutionStatus: Story = {
           execution: {
             stageStatus: {
               status: 'Completed',
-              duration: 'SLA: 4h',
+              slaText: 'SLA: 4h',
             },
             taskStatus: {
               '1': { status: 'Completed', label: 'KYC and AML Checks', duration: '2h 15m' },
@@ -427,7 +427,7 @@ export const ExecutionStatus: Story = {
           execution: {
             stageStatus: {
               status: 'Completed',
-              duration: 'SLA: 6h 15m',
+              slaText: 'SLA: 6h 15m',
             },
             taskStatus: {
               '1': {
@@ -480,7 +480,7 @@ export const ExecutionStatus: Story = {
             stageStatus: {
               status: 'InProgress',
               label: 'In progress',
-              duration: 'SLA: 2h 15m',
+              slaText: 'SLA: 2h 15m',
             },
             taskStatus: {
               '1': { status: 'Completed', label: 'Report Ordering', duration: '2h 15m' },
@@ -2119,7 +2119,7 @@ export const AdhocTasks: Story = {
             stageStatus: {
               status: 'InProgress',
               label: 'In progress',
-              duration: 'SLA: 3h 45m',
+              slaText: 'SLA: 3h 45m',
             },
             taskStatus: {
               '1': {
@@ -2395,7 +2395,7 @@ export const TasksBySection: Story = {
             stageStatus: {
               status: 'InProgress',
               label: 'In progress',
-              duration: 'SLA: 3h 45m',
+              slaText: 'SLA: 3h 45m',
             },
             taskStatus: {
               '1': {
@@ -2634,7 +2634,7 @@ export const WithRulesTags: Story = {
             ],
           },
           execution: {
-            stageStatus: { status: 'Completed', label: 'Completed', duration: 'SLA: 4h' },
+            stageStatus: { status: 'Completed', label: 'Completed', slaText: 'SLA: 4h' },
           },
         },
       },
@@ -2667,7 +2667,7 @@ export const WithRulesTags: Story = {
             ],
           },
           execution: {
-            stageStatus: { status: 'InProgress', label: 'In progress', duration: 'SLA: 2h' },
+            stageStatus: { status: 'InProgress', label: 'In progress', slaText: 'SLA: 2h' },
           },
         },
       },

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.styles.ts
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.styles.ts
@@ -69,7 +69,7 @@ export const StageContainer = styled.div<{
 export const StageHeader = styled.div<{ isException?: boolean }>`
   position: relative;
   display: flex;
-  justify-content: space-between;
+  flex-direction: column;
   padding: ${Spacing.SpacingS} ${Spacing.SpacingBase};
   border-bottom: solid 1px var(--canvas-border-de-emp);
   background: ${(props) => (props.isException ? 'var(--color-background-secondary)' : 'var(--canvas-background)')};

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.test.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.test.tsx
@@ -848,6 +848,106 @@ describe('StageNode - ReadOnly Mode', () => {
   });
 });
 
+describe('StageNode - SLA Indicator', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const getSlaIndicator = () => screen.getByTestId('stage-sla-stage-1');
+
+  it('does not render the SLA indicator when slaText is undefined', () => {
+    renderStageNode({
+      execution: { stageStatus: {}, taskStatus: {} },
+    });
+
+    expect(screen.queryByTestId('stage-sla-stage-1')).not.toBeInTheDocument();
+  });
+
+  it('does not render the SLA indicator when only duration is provided', () => {
+    renderStageNode({
+      execution: {
+        stageStatus: { duration: 'Duration: 1h 30m' },
+        taskStatus: {},
+      },
+    });
+
+    expect(screen.queryByTestId('stage-sla-stage-1')).not.toBeInTheDocument();
+  });
+
+  it('renders slaText without an icon when slaStatus is omitted', () => {
+    renderStageNode({
+      execution: {
+        stageStatus: { slaText: 'SLA: 10 days remaining' },
+        taskStatus: {},
+      },
+    });
+
+    const indicator = getSlaIndicator();
+    expect(indicator).toHaveTextContent('SLA: 10 days remaining');
+    expect(indicator).toHaveAttribute('data-sla-status', 'ok');
+    expect(indicator.querySelector('svg')).toBeNull();
+  });
+
+  it('renders slaText without an icon when slaStatus is "ok"', () => {
+    renderStageNode({
+      execution: {
+        stageStatus: { slaText: 'SLA: 10 days remaining', slaStatus: 'ok' },
+        taskStatus: {},
+      },
+    });
+
+    const indicator = getSlaIndicator();
+    expect(indicator).toHaveAttribute('data-sla-status', 'ok');
+    expect(indicator.querySelector('svg')).toBeNull();
+  });
+
+  it('renders a warning icon and text when slaStatus is "warning"', () => {
+    renderStageNode({
+      execution: {
+        stageStatus: { slaText: 'SLA: 1 day remaining', slaStatus: 'warning' },
+        taskStatus: {},
+      },
+    });
+
+    const indicator = getSlaIndicator();
+    expect(indicator).toHaveTextContent('SLA: 1 day remaining');
+    expect(indicator).toHaveAttribute('data-sla-status', 'warning');
+    expect(indicator.querySelector('svg')).not.toBeNull();
+  });
+
+  it('renders an error icon and text when slaStatus is "overdue"', () => {
+    renderStageNode({
+      execution: {
+        stageStatus: { slaText: 'SLA: 1 day overdue', slaStatus: 'overdue' },
+        taskStatus: {},
+      },
+    });
+
+    const indicator = getSlaIndicator();
+    expect(indicator).toHaveTextContent('SLA: 1 day overdue');
+    expect(indicator).toHaveAttribute('data-sla-status', 'overdue');
+    expect(indicator.querySelector('svg')).not.toBeNull();
+  });
+
+  it('renders both duration and slaText as independent lines when both are provided', () => {
+    renderStageNode({
+      execution: {
+        stageStatus: {
+          duration: 'Duration: 1h 30m',
+          slaText: 'SLA: 1 day remaining',
+          slaStatus: 'warning',
+        },
+        taskStatus: {},
+      },
+    });
+
+    expect(screen.getByText('Duration: 1h 30m')).toBeInTheDocument();
+    const indicator = getSlaIndicator();
+    expect(indicator).toHaveTextContent('SLA: 1 day remaining');
+    expect(indicator).toHaveAttribute('data-sla-status', 'warning');
+  });
+});
+
 describe('StageNode - Header Chips', () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.test.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.test.tsx
@@ -874,7 +874,7 @@ describe('StageNode - SLA Indicator', () => {
     expect(screen.queryByTestId('stage-sla-stage-1')).not.toBeInTheDocument();
   });
 
-  it('renders slaText without an icon when slaStatus is omitted', () => {
+  it('renders slaText without an icon when slaIcon is omitted', () => {
     renderStageNode({
       execution: {
         stageStatus: { slaText: 'SLA: 10 days remaining' },
@@ -884,48 +884,35 @@ describe('StageNode - SLA Indicator', () => {
 
     const indicator = getSlaIndicator();
     expect(indicator).toHaveTextContent('SLA: 10 days remaining');
-    expect(indicator).toHaveAttribute('data-sla-status', 'ok');
+    expect(indicator).not.toHaveAttribute('data-sla-icon');
     expect(indicator.querySelector('svg')).toBeNull();
   });
 
-  it('renders slaText without an icon when slaStatus is "ok"', () => {
+  it('renders a warning icon and text when slaIcon is "warning"', () => {
     renderStageNode({
       execution: {
-        stageStatus: { slaText: 'SLA: 10 days remaining', slaStatus: 'ok' },
-        taskStatus: {},
-      },
-    });
-
-    const indicator = getSlaIndicator();
-    expect(indicator).toHaveAttribute('data-sla-status', 'ok');
-    expect(indicator.querySelector('svg')).toBeNull();
-  });
-
-  it('renders a warning icon and text when slaStatus is "warning"', () => {
-    renderStageNode({
-      execution: {
-        stageStatus: { slaText: 'SLA: 1 day remaining', slaStatus: 'warning' },
+        stageStatus: { slaText: 'SLA: 1 day remaining', slaIcon: 'warning' },
         taskStatus: {},
       },
     });
 
     const indicator = getSlaIndicator();
     expect(indicator).toHaveTextContent('SLA: 1 day remaining');
-    expect(indicator).toHaveAttribute('data-sla-status', 'warning');
+    expect(indicator).toHaveAttribute('data-sla-icon', 'warning');
     expect(indicator.querySelector('svg')).not.toBeNull();
   });
 
-  it('renders an error icon and text when slaStatus is "overdue"', () => {
+  it('renders an error icon and text when slaIcon is "error"', () => {
     renderStageNode({
       execution: {
-        stageStatus: { slaText: 'SLA: 1 day overdue', slaStatus: 'overdue' },
+        stageStatus: { slaText: 'SLA: 1 day overdue', slaIcon: 'error' },
         taskStatus: {},
       },
     });
 
     const indicator = getSlaIndicator();
     expect(indicator).toHaveTextContent('SLA: 1 day overdue');
-    expect(indicator).toHaveAttribute('data-sla-status', 'overdue');
+    expect(indicator).toHaveAttribute('data-sla-icon', 'error');
     expect(indicator.querySelector('svg')).not.toBeNull();
   });
 
@@ -935,7 +922,7 @@ describe('StageNode - SLA Indicator', () => {
         stageStatus: {
           duration: 'Duration: 1h 30m',
           slaText: 'SLA: 1 day remaining',
-          slaStatus: 'warning',
+          slaIcon: 'warning',
         },
         taskStatus: {},
       },
@@ -944,7 +931,7 @@ describe('StageNode - SLA Indicator', () => {
     expect(screen.getByText('Duration: 1h 30m')).toBeInTheDocument();
     const indicator = getSlaIndicator();
     expect(indicator).toHaveTextContent('SLA: 1 day remaining');
-    expect(indicator).toHaveAttribute('data-sla-status', 'warning');
+    expect(indicator).toHaveAttribute('data-sla-icon', 'warning');
   });
 });
 

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.types.ts
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.types.ts
@@ -18,6 +18,8 @@ enum ElementStatusValues {
 export type StageStatus = `${ElementStatusValues}`;
 export type StageTaskStatus = `${ElementStatusValues}`;
 
+export type StageSlaStatus = 'ok' | 'warning' | 'overdue';
+
 export interface StageTaskItem {
   id: string;
   label: string;
@@ -66,6 +68,8 @@ export interface StageNodeBaseProps {
       status?: StageStatus;
       label?: string;
       duration?: string;
+      slaText?: string;
+      slaStatus?: StageSlaStatus;
     };
     taskStatus: Record<string, StageTaskExecution>;
   };

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.types.ts
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.types.ts
@@ -18,7 +18,7 @@ enum ElementStatusValues {
 export type StageStatus = `${ElementStatusValues}`;
 export type StageTaskStatus = `${ElementStatusValues}`;
 
-export type StageSlaStatus = 'ok' | 'warning' | 'overdue';
+export type StageSlaIcon = 'warning' | 'error';
 
 export interface StageTaskItem {
   id: string;
@@ -69,7 +69,7 @@ export interface StageNodeBaseProps {
       label?: string;
       duration?: string;
       slaText?: string;
-      slaStatus?: StageSlaStatus;
+      slaIcon?: StageSlaIcon;
     };
     taskStatus: Record<string, StageTaskExecution>;
   };

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNodeHeader.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNodeHeader.tsx
@@ -14,18 +14,15 @@ import {
   StageTitleContainer,
   StageTitleInput,
 } from './StageNode.styles';
-import type { StageNodeProps, StageSlaStatus, StageStatus } from './StageNode.types';
+import type { StageNodeProps, StageSlaIcon, StageStatus } from './StageNode.types';
 import { StageHeaderChipType } from './StageNode.types';
 
-const SLA_STATUS_CONFIG: Record<
-  Exclude<StageSlaStatus, 'ok'>,
-  { icon: string; iconColor: string }
-> = {
+const SLA_ICON_CONFIG: Record<StageSlaIcon, { icon: string; iconColor: string }> = {
   warning: {
     icon: 'triangle-alert',
     iconColor: 'var(--canvas-warning-icon)',
   },
-  overdue: {
+  error: {
     icon: 'circle-alert',
     iconColor: 'var(--canvas-error-icon)',
   },
@@ -69,8 +66,8 @@ const StageNodeHeaderInner = ({
   const statusLabel = execution?.stageStatus?.label;
   const stageDuration = execution?.stageStatus?.duration;
   const slaText = execution?.stageStatus?.slaText;
-  const slaStatus = execution?.stageStatus?.slaStatus;
-  const slaIndicator = slaStatus && slaStatus !== 'ok' ? SLA_STATUS_CONFIG[slaStatus] : undefined;
+  const slaIcon = execution?.stageStatus?.slaIcon;
+  const slaIndicator = slaIcon ? SLA_ICON_CONFIG[slaIcon] : undefined;
 
   const isStageTitleEditable = !!onStageTitleChange && !isReadOnly;
 
@@ -166,7 +163,7 @@ const StageNodeHeaderInner = ({
             <span
               className="inline-flex items-center gap-1 text-xs text-foreground-muted"
               data-testid={`stage-sla-${id}`}
-              data-sla-status={slaStatus ?? 'ok'}
+              data-sla-icon={slaIcon}
             >
               {slaIndicator && (
                 <CanvasIcon icon={slaIndicator.icon} size={16} color={slaIndicator.iconColor} />

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNodeHeader.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNodeHeader.tsx
@@ -1,5 +1,5 @@
 import { Icon, Padding, Spacing } from '@uipath/apollo-core';
-import { Column, Row } from '@uipath/apollo-react/canvas/layouts';
+import { Row } from '@uipath/apollo-react/canvas/layouts';
 import { Button, cn } from '@uipath/apollo-wind';
 import { memo, useCallback, useEffect, useRef, useState } from 'react';
 import { EntryConditionIcon, ExitConditionIcon, ReturnToOriginIcon } from '../../icons';
@@ -7,13 +7,7 @@ import { CanvasIcon } from '../../utils/icon-registry';
 import { CanvasTooltip } from '../CanvasTooltip';
 import { ExecutionStatusIcon } from '../ExecutionStatusIcon';
 import { getExecutionStatusColor } from '../ExecutionStatusIcon/ExecutionStatusIcon';
-import {
-  StageChip,
-  StageHeader,
-  StageHeaderChipsRow,
-  StageTitleContainer,
-  StageTitleInput,
-} from './StageNode.styles';
+import { StageChip, StageHeader, StageTitleContainer, StageTitleInput } from './StageNode.styles';
 import type { StageNodeProps, StageSlaIcon, StageStatus } from './StageNode.types';
 import { StageHeaderChipType } from './StageNode.types';
 
@@ -135,10 +129,10 @@ const StageNodeHeaderInner = ({
 
   return (
     <StageHeader isException={isException} data-testid={`stage-header-${id}`}>
-      <Row gap={Spacing.SpacingMicro} align="center" flex={1} minW={0}>
-        {icon}
-        <Column py={2} flex={1} minW={0}>
-          <span className={cn('text-sm', !isStageTitleEditing && 'font-bold')}>
+      <div className="flex items-start justify-between gap-1">
+        <Row gap={Spacing.SpacingMicro} align="center" flex={1} minW={0}>
+          {icon}
+          <span className={cn('text-sm', !isStageTitleEditing && 'font-bold', 'flex-1 min-w-0 py-0.5')}>
             <CanvasTooltip content={label} placement="top" delay>
               <StageTitleContainer isEditing={isStageTitleEditing}>
                 <StageTitleInput
@@ -158,7 +152,41 @@ const StageNodeHeaderInner = ({
               </StageTitleContainer>
             </CanvasTooltip>
           </span>
-          {stageDuration && <span className="text-xs text-foreground-muted">{stageDuration}</span>}
+        </Row>
+        <Row gap={Spacing.SpacingMicro} align="start" py={Padding.PadS}>
+          {status && (
+            <CanvasTooltip content={statusLabel} placement="top">
+              <Button variant="ghost" size="icon" className="h-6 w-6" aria-label={statusLabel}>
+                {status === 'NotExecuted' ? (
+                  <CanvasIcon
+                    icon="hourglass"
+                    size={20}
+                    color={getExecutionStatusColor('NotExecuted')}
+                  />
+                ) : (
+                  <ExecutionStatusIcon status={status} size={20} />
+                )}
+              </Button>
+            </CanvasTooltip>
+          )}
+          {(onTaskAdd || onAddTaskFromToolbox) && !isReadOnly && (
+            <CanvasTooltip content={addTaskLabel} placement="top">
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-6 w-6"
+                onClick={handleTaskAddClick}
+                aria-label={addTaskLabel}
+                disabled={isAddTaskDisabled}
+              >
+                <CanvasIcon icon="plus" size={20} />
+              </Button>
+            </CanvasTooltip>
+          )}
+        </Row>
+      </div>
+      {(slaText || (stageDetails.headerChips && stageDetails.headerChips.length > 0)) && (
+        <div className="mt-1 flex flex-wrap items-center justify-between gap-2">
           {slaText && (
             <span
               className="inline-flex items-center gap-1 text-xs text-foreground-muted"
@@ -172,7 +200,7 @@ const StageNodeHeaderInner = ({
             </span>
           )}
           {stageDetails.headerChips && stageDetails.headerChips.length > 0 && (
-            <StageHeaderChipsRow>
+            <div className="flex flex-wrap items-center gap-1">
               {stageDetails.headerChips.map((chip) => {
                 const button = (
                   <StageChip
@@ -197,41 +225,11 @@ const StageNodeHeaderInner = ({
                 }
                 return button;
               })}
-            </StageHeaderChipsRow>
+            </div>
           )}
-        </Column>
-      </Row>
-      <Row gap={Spacing.SpacingMicro} align="start" py={Padding.PadS}>
-        {status && (
-          <CanvasTooltip content={statusLabel} placement="top">
-            <Button variant="ghost" size="icon" className="h-6 w-6" aria-label={statusLabel}>
-              {status === 'NotExecuted' ? (
-                <CanvasIcon
-                  icon="hourglass"
-                  size={20}
-                  color={getExecutionStatusColor('NotExecuted')}
-                />
-              ) : (
-                <ExecutionStatusIcon status={status} size={20} />
-              )}
-            </Button>
-          </CanvasTooltip>
-        )}
-        {(onTaskAdd || onAddTaskFromToolbox) && !isReadOnly && (
-          <CanvasTooltip content={addTaskLabel} placement="top">
-            <Button
-              variant="ghost"
-              size="icon"
-              className="h-6 w-6"
-              onClick={handleTaskAddClick}
-              aria-label={addTaskLabel}
-              disabled={isAddTaskDisabled}
-            >
-              <CanvasIcon icon="plus" size={20} />
-            </Button>
-          </CanvasTooltip>
-        )}
-      </Row>
+        </div>
+      )}
+      {stageDuration && <span className="mt-1 text-xs text-foreground-muted">{stageDuration}</span>}
     </StageHeader>
   );
 };

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNodeHeader.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNodeHeader.tsx
@@ -19,17 +19,15 @@ import { StageHeaderChipType } from './StageNode.types';
 
 const SLA_STATUS_CONFIG: Record<
   Exclude<StageSlaStatus, 'ok'>,
-  { icon: string; iconColor: string; textClass: string }
+  { icon: string; iconColor: string }
 > = {
   warning: {
     icon: 'triangle-alert',
     iconColor: 'var(--canvas-warning-icon)',
-    textClass: 'text-[color:var(--canvas-warning-text)]',
   },
   overdue: {
     icon: 'circle-alert',
     iconColor: 'var(--canvas-error-icon)',
-    textClass: 'text-[color:var(--canvas-error-text)]',
   },
 };
 
@@ -166,10 +164,7 @@ const StageNodeHeaderInner = ({
           {stageDuration && <span className="text-xs text-foreground-muted">{stageDuration}</span>}
           {slaText && (
             <span
-              className={cn(
-                'inline-flex items-center gap-1 text-xs',
-                slaIndicator ? slaIndicator.textClass : 'text-foreground-muted'
-              )}
+              className="inline-flex items-center gap-1 text-xs text-foreground-muted"
               data-testid={`stage-sla-${id}`}
               data-sla-status={slaStatus ?? 'ok'}
             >

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNodeHeader.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNodeHeader.tsx
@@ -14,8 +14,24 @@ import {
   StageTitleContainer,
   StageTitleInput,
 } from './StageNode.styles';
-import type { StageNodeProps, StageStatus } from './StageNode.types';
+import type { StageNodeProps, StageSlaStatus, StageStatus } from './StageNode.types';
 import { StageHeaderChipType } from './StageNode.types';
+
+const SLA_STATUS_CONFIG: Record<
+  Exclude<StageSlaStatus, 'ok'>,
+  { icon: string; iconColor: string; textClass: string }
+> = {
+  warning: {
+    icon: 'triangle-alert',
+    iconColor: 'var(--canvas-warning-icon)',
+    textClass: 'text-[color:var(--canvas-warning-text)]',
+  },
+  overdue: {
+    icon: 'circle-alert',
+    iconColor: 'var(--canvas-error-icon)',
+    textClass: 'text-[color:var(--canvas-error-text)]',
+  },
+};
 
 const CHIP_ICONS: Record<StageHeaderChipType, React.ReactElement> = {
   [StageHeaderChipType.Entry]: <EntryConditionIcon w={Icon.IconXs} h={Icon.IconXs} />,
@@ -54,6 +70,9 @@ const StageNodeHeaderInner = ({
   const icon = stageDetails?.icon;
   const statusLabel = execution?.stageStatus?.label;
   const stageDuration = execution?.stageStatus?.duration;
+  const slaText = execution?.stageStatus?.slaText;
+  const slaStatus = execution?.stageStatus?.slaStatus;
+  const slaIndicator = slaStatus && slaStatus !== 'ok' ? SLA_STATUS_CONFIG[slaStatus] : undefined;
 
   const isStageTitleEditable = !!onStageTitleChange && !isReadOnly;
 
@@ -145,6 +164,21 @@ const StageNodeHeaderInner = ({
             </CanvasTooltip>
           </span>
           {stageDuration && <span className="text-xs text-foreground-muted">{stageDuration}</span>}
+          {slaText && (
+            <span
+              className={cn(
+                'inline-flex items-center gap-1 text-xs',
+                slaIndicator ? slaIndicator.textClass : 'text-foreground-muted'
+              )}
+              data-testid={`stage-sla-${id}`}
+              data-sla-status={slaStatus ?? 'ok'}
+            >
+              {slaIndicator && (
+                <CanvasIcon icon={slaIndicator.icon} size={16} color={slaIndicator.iconColor} />
+              )}
+              {slaText}
+            </span>
+          )}
           {stageDetails.headerChips && stageDetails.headerChips.length > 0 && (
             <StageHeaderChipsRow>
               {stageDetails.headerChips.map((chip) => {

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNodeHeader.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNodeHeader.tsx
@@ -132,7 +132,9 @@ const StageNodeHeaderInner = ({
       <div className="flex items-start justify-between gap-1">
         <Row gap={Spacing.SpacingMicro} align="center" flex={1} minW={0}>
           {icon}
-          <span className={cn('text-sm', !isStageTitleEditing && 'font-bold', 'flex-1 min-w-0 py-0.5')}>
+          <span
+            className={cn('text-sm', !isStageTitleEditing && 'font-bold', 'flex-1 min-w-0 py-0.5')}
+          >
             <CanvasTooltip content={label} placement="top" delay>
               <StageTitleContainer isEditing={isStageTitleEditing}>
                 <StageTitleInput


### PR DESCRIPTION
## Description
StageNode exposes two new optional fields on execution.stageStatus to render an SLA line in the stage card header:
- `slaText` (string) — the formatted SLA line shown to the user (e.g. "SLA: 10 days remaining", "SLA: 1 day overdue", "SLA: None"). The consumer is responsible for formatting from the API's `slaDueTime`.
- `slaIcon` ('warning' | 'error') — optional indicator icon: 
- omitted → no icon, gray text only  
-  'warning' → triangle-alert icon + warning color
- 'error' → circle-alert icon (error color) 

In the scenario for displaying SLA time on the Stage nodes, it should only display in Case Apps and Case Instances. Case rules icons should not be shown in the scenario of Debug or case instance.

<img width="1419" height="580" alt="Screenshot 2026-05-13 at 11 20 07 AM" src="https://github.com/user-attachments/assets/e82527f9-7295-4097-a318-0992ba6ece36" />
<img width="1430" height="355" alt="Screenshot 2026-05-13 at 11 23 54 AM" src="https://github.com/user-attachments/assets/eca7f87b-3d4e-4dc5-aa4c-3d281437f8f1" />


