### PR TITLE
fix(apollo-react): shrink NodeToolbar to fit a single action [MST-9559]

### DIFF
--- a/packages/apollo-react/src/canvas/components/Toolbar/NodeToolbar/NodeToolbar.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/Toolbar/NodeToolbar/NodeToolbar.stories.tsx
@@ -217,10 +217,8 @@ function DefaultStory() {
         >
           <Column mt={12} gap={12}>
             <Column gap={4}>
-              <span className="text-sm" style={{ fontWeight: 600 }}>
-                Position:
-              </span>
-              <Row gap={4} style={{ flexWrap: 'wrap' }}>
+              <span className="text-sm font-semibold">Position:</span>
+              <Row gap={4} wrap="wrap">
                 {POSITION_OPTIONS.map((value) => (
                   <Button
                     key={value}
@@ -234,10 +232,8 @@ function DefaultStory() {
               </Row>
             </Column>
             <Column gap={4}>
-              <span className="text-sm" style={{ fontWeight: 600 }}>
-                Align:
-              </span>
-              <Row gap={4} style={{ flexWrap: 'wrap' }}>
+              <span className="text-sm font-semibold">Align:</span>
+              <Row gap={4} wrap="wrap">
                 {ALIGN_OPTIONS.map((value) => (
                   <Button
                     key={value}
@@ -299,6 +295,77 @@ function OverflowMenuStory() {
   );
 }
 
+function SingleActionStory() {
+  const initialNodes = useMemo(() => createToolbarNodes(), []);
+  const { canvasProps } = useCanvasStory({ initialNodes });
+
+  const [position, setPosition] = useState<ToolbarPosition>('top');
+  const [align, setAlign] = useState<ToolbarAlign>('center');
+
+  const overrideConfig = useMemo(
+    () => ({
+      toolbarConfig: {
+        actions: [
+          { id: 'breakpoint', icon: 'circle', label: 'Toggle breakpoint', onAction: () => {} },
+        ],
+        position,
+        align,
+      } satisfies NodeToolbarConfig,
+    }),
+    [position, align]
+  );
+
+  return (
+    <BaseNodeOverrideConfigProvider value={overrideConfig}>
+      <BaseCanvas {...canvasProps} mode="design">
+        <StoryInfoPanel
+          title="Single-action Toolbar"
+          description="Toolbar with only one action (mirrors debug mode's breakpoint-only state). The container should shrink to fit the single icon — no empty padding on the main axis."
+          collapsible
+          defaultCollapsed={false}
+          position="top-right"
+        >
+          <Column mt={12} gap={12}>
+            <Column gap={4}>
+              <span className="text-sm font-semibold">Position:</span>
+              <Row gap={4} wrap="wrap">
+                {POSITION_OPTIONS.map((value) => (
+                  <Button
+                    key={value}
+                    size="sm"
+                    variant={position === value ? 'default' : 'secondary'}
+                    onClick={() => setPosition(value)}
+                  >
+                    {value}
+                  </Button>
+                ))}
+              </Row>
+            </Column>
+            <Column gap={4}>
+              <span className="text-sm font-semibold">Align:</span>
+              <Row gap={4} wrap="wrap">
+                {ALIGN_OPTIONS.map((value) => (
+                  <Button
+                    key={value}
+                    size="sm"
+                    variant={align === value ? 'default' : 'secondary'}
+                    onClick={() => setAlign(value)}
+                  >
+                    {value}
+                  </Button>
+                ))}
+              </Row>
+            </Column>
+          </Column>
+        </StoryInfoPanel>
+        <Panel position="bottom-right">
+          <CanvasPositionControls translations={DefaultCanvasTranslations} />
+        </Panel>
+      </BaseCanvas>
+    </BaseNodeOverrideConfigProvider>
+  );
+}
+
 function CustomToolbarStory() {
   const initialNodes = useMemo(
     () => [
@@ -346,6 +413,11 @@ export const Default: Story = {
 export const OverflowMenu: Story = {
   name: 'Toolbar with Overflow Menu',
   render: () => <OverflowMenuStory />,
+};
+
+export const SingleAction: Story = {
+  name: 'Single-action Toolbar',
+  render: () => <SingleActionStory />,
 };
 
 export const CustomToolbarExtensions: Story = {

--- a/packages/apollo-react/src/canvas/components/Toolbar/NodeToolbar/NodeToolbar.tsx
+++ b/packages/apollo-react/src/canvas/components/Toolbar/NodeToolbar/NodeToolbar.tsx
@@ -11,9 +11,9 @@ import { useToolbarState } from './useToolbarState';
 
 const POSITIONER_BASE_CLASS = 'absolute flex pointer-events-none z-10';
 
-// Container enforces a 40px cross-axis (`min-h-10 min-w-10`) in every
-// orientation, so the same offset produces a consistent ~12px gap on every
-// side: 40 (toolbar) + 12 (gap) = 52.
+// Container has a 40px cross-axis minimum (see CONTAINER_DIRECTION_CLASS), so
+// this offset produces a consistent ~12px gap on every side: 40 + 12 = 52.
+// Main-axis is content-driven, letting a single-action toolbar shrink to fit.
 // `--toolbar-offset` (default 0) adds extra displacement to clear handle buttons.
 const POSITIONER_POSITION_CLASS: Record<'top' | 'bottom' | 'left' | 'right', string> = {
   top: 'top-[calc(-52px-var(--toolbar-offset,0px))] left-0 right-0 flex-row',
@@ -32,15 +32,15 @@ const POSITIONER_ALIGN_CLASS: Record<'start' | 'center' | 'end', string> = {
 };
 
 const CONTAINER_BASE_CLASS =
-  'flex items-center gap-1 p-1 min-h-10 min-w-10 shrink-0 bg-(--canvas-background-raised) ' +
+  'flex items-center gap-1 p-1 shrink-0 bg-(--canvas-background-raised) ' +
   'border border-(--canvas-background-overlay) rounded-xl shadow-[0_2px_6px_rgba(0,0,0,0.08)] ' +
   'pointer-events-auto';
 
 const CONTAINER_DIRECTION_CLASS: Record<'top' | 'bottom' | 'left' | 'right', string> = {
-  top: 'flex-row',
-  bottom: 'flex-row',
-  left: 'flex-col',
-  right: 'flex-col',
+  top: 'flex-row min-h-10',
+  bottom: 'flex-row min-h-10',
+  left: 'flex-col min-w-10',
+  right: 'flex-col min-w-10',
 };
 
 const SEPARATOR_BASE_CLASS = 'flex-[0_0_auto] bg-(--canvas-background-overlay) self-center';


### PR DESCRIPTION
## Summary
- `NodeToolbar` had a 40px floor on both axes, so a single-action toolbar (24px icon + 8px padding = 32px) was padded out to 40px wide, leaving empty space on the right (visible in canvas debug mode when only Breakpoint is shown).
- Move the 40px minimum into the orientation-specific class so only the cross-axis is pinned; main-axis is content-driven.
- Add a `SingleAction` Storybook story covering the scenario.

## Demo

https://github.com/user-attachments/assets/8de7627d-18ab-43d2-8838-a8b1e6dea314



Ticket: [MST-9559](https://uipath.atlassian.net/browse/MST-9559)

## Test plan
- [x] Storybook → `Components/NodeToolbar/Single-action Toolbar` — toolbar fits the icon with no trailing empty space across all 4 positions and 3 alignments.
- [x] Storybook → `Components/NodeToolbar/Default Toolbar` — multi-action toolbar unchanged.
- [x] Canvas debug mode on a basic node (e.g. Delay) — breakpoint icon centered in toolbar.

[MST-9559]: https://uipath.atlassian.net/browse/MST-9559?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ