### PR TITLE
fix: add isPlaceholder support to StageTask component [MST-9695]

### DIFF
--- a/packages/apollo-react/src/canvas/components/StageNode/AdhocTask.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/AdhocTask.tsx
@@ -44,6 +44,7 @@ const AdhocTaskItemComponent = ({
       data-testid={`stage-task-${task.id}`}
       selected={isSelected}
       status={taskExecution?.status}
+      isPlaceholder={task.isPlaceholder}
       onClick={handleClick}
       {...(getContextMenuItems && !isTaskLoading && { onContextMenu: handleContextMenu })}
     >

--- a/packages/apollo-react/src/canvas/components/StageNode/DraggableTask.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/DraggableTask.tsx
@@ -92,6 +92,7 @@ const DraggableTaskComponent = ({
       status={taskExecution?.status}
       isParallel={isParallel}
       isDragEnabled={!isDragDisabled}
+      isPlaceholder={task.isPlaceholder}
       onClick={handleClick}
       {...(getContextMenuItems && !isTaskLoading && { onContextMenu: handleContextMenu })}
     >

--- a/packages/apollo-react/src/canvas/components/StageNode/EventDrivenTask.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/EventDrivenTask.tsx
@@ -42,6 +42,7 @@ const EventDrivenTaskItemComponent = ({
       data-testid={`stage-task-${task.id}`}
       selected={isSelected}
       status={taskExecution?.status}
+      isPlaceholder={task.isPlaceholder}
       onClick={handleClick}
       {...(getContextMenuItems && !isTaskLoading && { onContextMenu: handleContextMenu })}
     >

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.stories.tsx
@@ -2402,6 +2402,15 @@ export const TasksBySection: Story = {
               slaText: 'SLA: 3h 45m',
             },
             taskStatus: {
+              '1': {
+                status: 'Completed',
+                label: 'Verify Address',
+                duration: '1h 20m',
+                retryDuration: '35m',
+                badge: 'Reworked',
+                badgeStatus: 'warning',
+                retryCount: 2,
+              },
               '2': {
                 status: 'Failed',
                 label: 'Verify Identity',

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.stories.tsx
@@ -2402,15 +2402,6 @@ export const TasksBySection: Story = {
               slaText: 'SLA: 3h 45m',
             },
             taskStatus: {
-              '1': {
-                status: 'Completed',
-                label: 'Verify Address',
-                duration: '1h 20m',
-                retryDuration: '35m',
-                badge: 'Reworked',
-                badgeStatus: 'warning',
-                retryCount: 2,
-              },
               '2': {
                 status: 'Failed',
                 label: 'Verify Identity',

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.stories.tsx
@@ -2207,6 +2207,7 @@ export const TasksBySection: Story = {
                   label: 'Parallel task 1',
                   icon: <DocumentIcon />,
                   taskGroupType: 'sequential',
+                  isPlaceholder: true,
                 },
                 {
                   id: '4',
@@ -2253,6 +2254,7 @@ export const TasksBySection: Story = {
                   label: 'Ad hoc - Risk Assessment',
                   icon: <VerificationIcon />,
                   taskGroupType: 'adhoc',
+                  isPlaceholder: true,
                 },
               ],
               [
@@ -2310,6 +2312,7 @@ export const TasksBySection: Story = {
                   icon: <VerificationIcon />,
                   taskGroupType: 'event-driven',
                   hasEntryCondition: true,
+                  isPlaceholder: true,
                 },
               ],
               [
@@ -2369,6 +2372,7 @@ export const TasksBySection: Story = {
                   icon: <VerificationIcon />,
                   taskGroupType: 'adhoc',
                   hasEntryCondition: true,
+                  isPlaceholder: true,
                 },
               ],
               [

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.styles.ts
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.styles.ts
@@ -173,6 +173,7 @@ export const StageTask = styled.div<{
   selected?: boolean;
   isParallel?: boolean;
   isDragEnabled?: boolean;
+  isPlaceholder?: boolean;
 }>`
   position: relative;
   display: flex;
@@ -180,7 +181,8 @@ export const StageTask = styled.div<{
   gap: ${Spacing.SpacingXs};
   padding: ${Padding.PadS} ${Padding.PadM};
   background: var(--canvas-background);
-  border: 1px solid var(--canvas-border-de-emp);
+  border: 1px ${({ isPlaceholder }) => (isPlaceholder ? 'dashed' : 'solid')}
+    var(--canvas-border-de-emp);
   border-radius: ${Spacing.SpacingXs};
   color: var(--canvas-foreground);
   transition: all 0.2s ease;

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.types.ts
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.types.ts
@@ -25,6 +25,7 @@ export interface StageTaskItem {
   label: string;
   icon?: React.ReactElement;
   isAdhoc?: boolean;
+  isPlaceholder?: boolean;
   taskGroupType?: 'sequential' | 'event-driven' | 'adhoc';
   hasEntryCondition?: boolean;
 }


### PR DESCRIPTION
## Summary

Add support for rendering placeholder tasks with a dotted border style in the StageTask component. This allows visual distinction between regular tasks and placeholder/template tasks in the canvas.

## Changes

- **StageNode.styles.ts**: Updated `StageTask` styled component to accept `isPlaceholder` prop and conditionally render border as `dotted` when true, `solid` otherwise
- **StageNode.types.ts**: Added `isPlaceholder?: boolean` property to `StageTaskItem` interface
- **AdhocTask.tsx**: Pass `isPlaceholder` prop from task to `StageTask` component
- **DraggableTask.tsx**: Pass `isPlaceholder` prop from task to `StageTask` component
- **EventDrivenTask.tsx**: Pass `isPlaceholder` prop from task to `StageTask` component

## Implementation Details

The `isPlaceholder` prop is threaded through the task component hierarchy, allowing the styled component to conditionally apply a dotted border style for visual differentiation. This is a non-breaking change that defaults to `undefined` (solid border behavior) when not specified.

## Demo
<img width="1430" height="567" alt="image" src="https://github.com/user-attachments/assets/a31bbe02-cca5-41f2-bbc6-0303df39bb0e" />

https://claude.ai/code/session_01MibYP16gqMifBDDg2oWogb