### PR TITLE
fix(apollo-react): sticky note loop layering [MST-9649]

### DIFF
--- a/packages/apollo-react/src/canvas/components/StickyNoteNode/StickyNoteNode.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/StickyNoteNode/StickyNoteNode.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import type { Edge, Node } from '@uipath/apollo-react/canvas/xyflow/react';
 import { Panel, Position } from '@uipath/apollo-react/canvas/xyflow/react';
 import { useMemo } from 'react';
-import { useCanvasStory, withCanvasProviders } from '../../storybook-utils';
+import { StoryInfoPanel, useCanvasStory, withCanvasProviders } from '../../storybook-utils';
 import { DefaultCanvasTranslations } from '../../types';
 import { BaseCanvas } from '../BaseCanvas';
 import { CanvasPositionControls } from '../CanvasPositionControls';
@@ -21,6 +21,11 @@ const meta: Meta = {
 
 export default meta;
 type Story = StoryObj<typeof meta>;
+
+const LOOP_TYPE = 'uipath.control-flow.foreach';
+const STORY_LOOP_START_HANDLE_ID = 'start';
+const STORY_LOOP_CONTINUE_HANDLE_ID = 'continue';
+const STORY_LOOP_SUCCESS_HANDLE_ID = 'success';
 
 // ============================================================================
 // Helper Functions
@@ -181,6 +186,49 @@ function createBaseNode(
     },
     zIndex: 0,
   };
+}
+
+function createLoopContainerNode(
+  id: string,
+  label: string,
+  position: { x: number; y: number },
+  size: { width: number; height: number },
+  options?: { parentId?: string; selected?: boolean }
+): Node {
+  return {
+    id,
+    type: LOOP_TYPE,
+    position,
+    parentId: options?.parentId,
+    selected: options?.selected ?? false,
+    data: {
+      display: {
+        label,
+        shape: 'container',
+      },
+    },
+    style: size,
+  };
+}
+
+function createLoopActivityNode(
+  id: string,
+  label: string,
+  position: { x: number; y: number },
+  parentId?: string
+): Node {
+  const node = createBaseNode(id, 'play', label, '', position, [
+    {
+      position: Position.Left,
+      handles: [{ id: 'input', type: 'target', handleType: 'input', label: 'Input' }],
+    },
+    {
+      position: Position.Right,
+      handles: [{ id: 'output', type: 'source', handleType: 'output', label: 'Output' }],
+    },
+  ]);
+
+  return parentId ? { ...node, parentId } : node;
 }
 
 function createPipelineNodes(): Node[] {
@@ -423,6 +471,135 @@ function WithBaseNodesStory() {
   );
 }
 
+function StickyNotesInLoopContainersStory() {
+  const initialNodes = useMemo<Node[]>(
+    () => [
+      createLoopActivityNode('ingress', 'Load records', { x: 32, y: 384 }),
+      createLoopContainerNode(
+        'outer-loop',
+        'For Each claim',
+        { x: 224, y: 128 },
+        { width: 1104, height: 608 },
+        { selected: true }
+      ),
+      createLoopContainerNode(
+        'inner-loop',
+        'For Each attachment',
+        { x: 96, y: 160 },
+        { width: 544, height: 288 },
+        { parentId: 'outer-loop' }
+      ),
+      createLoopActivityNode('inner-child', 'Classify attachment', { x: 176, y: 96 }, 'inner-loop'),
+      createLoopActivityNode('edge-left', 'Read metadata', { x: 176, y: 448 }, 'outer-loop'),
+      createLoopActivityNode('edge-right', 'Validate claim', { x: 800, y: 448 }, 'outer-loop'),
+      createLoopActivityNode('review', 'Review finding', { x: 800, y: 256 }, 'outer-loop'),
+      createStickyNote(
+        'sticky-nested-loop-note',
+        'pink',
+        '**Nested loop sticky**\n\nInside the inner loop body with a base node nearby.',
+        { x: 400, y: 368 },
+        { width: 288, height: 176 }
+      ),
+      createStickyNote(
+        'sticky-edge-overlap-note',
+        'green',
+        '**Edge overlap sticky**\n\nThe Read metadata → Validate claim edge intentionally crosses this note.',
+        { x: 600, y: 592 },
+        { width: 320, height: 128 }
+      ),
+      createStickyNote(
+        'sticky-outside-control-note',
+        'blue',
+        '**Outside control**\n\nCompare hover, selection, toolbar, and resize behavior here.',
+        { x: 600, y: 768 },
+        { width: 320, height: 128 }
+      ),
+      createLoopActivityNode('egress', 'Publish results', { x: 1440, y: 384 }),
+    ],
+    []
+  );
+
+  const initialEdges = useMemo<Edge[]>(
+    () => [
+      {
+        id: 'ingress-outer-loop',
+        source: 'ingress',
+        sourceHandle: 'output',
+        target: 'outer-loop',
+        targetHandle: 'input',
+      },
+      {
+        id: 'outer-loop-inner-loop',
+        source: 'outer-loop',
+        sourceHandle: STORY_LOOP_START_HANDLE_ID,
+        target: 'inner-loop',
+        targetHandle: 'input',
+      },
+      {
+        id: 'inner-loop-inner-child',
+        source: 'inner-loop',
+        sourceHandle: STORY_LOOP_START_HANDLE_ID,
+        target: 'inner-child',
+        targetHandle: 'input',
+      },
+      {
+        id: 'inner-child-inner-loop',
+        source: 'inner-child',
+        sourceHandle: 'output',
+        target: 'inner-loop',
+        targetHandle: STORY_LOOP_CONTINUE_HANDLE_ID,
+      },
+      {
+        id: 'inner-loop-review',
+        source: 'inner-loop',
+        sourceHandle: STORY_LOOP_SUCCESS_HANDLE_ID,
+        target: 'review',
+        targetHandle: 'input',
+      },
+      {
+        id: 'edge-left-edge-right',
+        source: 'edge-left',
+        sourceHandle: 'output',
+        target: 'edge-right',
+        targetHandle: 'input',
+      },
+      {
+        id: 'review-outer-loop',
+        source: 'review',
+        sourceHandle: 'output',
+        target: 'outer-loop',
+        targetHandle: STORY_LOOP_CONTINUE_HANDLE_ID,
+      },
+      {
+        id: 'outer-loop-egress',
+        source: 'outer-loop',
+        sourceHandle: STORY_LOOP_SUCCESS_HANDLE_ID,
+        target: 'egress',
+        targetHandle: 'input',
+      },
+    ],
+    []
+  );
+
+  const { canvasProps } = useCanvasStory({
+    initialNodes,
+    initialEdges,
+    additionalNodeTypes: nodeTypes,
+  });
+
+  return (
+    <BaseCanvas {...canvasProps} mode="design">
+      <Panel position="bottom-right">
+        <CanvasPositionControls translations={DefaultCanvasTranslations} />
+      </Panel>
+      <StoryInfoPanel
+        title="Sticky Notes In Loop Containers"
+        description="Validation story for sticky notes inside selected/nested loops, sticky notes crossed by workflow edges, and an outside-loop control note."
+      />
+    </BaseCanvas>
+  );
+}
+
 function WithCallbacksStory() {
   const initialNodes = useMemo<Node<StickyNoteData>[]>(
     () => [
@@ -489,6 +666,10 @@ export const Default: Story = {
 
 export const WithBaseNodes: Story = {
   render: () => <WithBaseNodesStory />,
+};
+
+export const StickyNotesInLoopContainers: Story = {
+  render: () => <StickyNotesInLoopContainersStory />,
 };
 
 export const WithCallbacks: Story = {

--- a/packages/apollo-react/src/canvas/components/StickyNoteNode/StickyNoteNode.tsx
+++ b/packages/apollo-react/src/canvas/components/StickyNoteNode/StickyNoteNode.tsx
@@ -9,6 +9,7 @@ import ReactMarkdown from 'react-markdown';
 import remarkBreaks from 'remark-breaks';
 import remarkGfm from 'remark-gfm';
 import { GRID_SPACING } from '../../constants';
+import { NodeViewportOverlay } from '../NodeViewportOverlay';
 import type { ToolbarAction } from '../Toolbar';
 import { NodeToolbar } from '../Toolbar';
 import { FormattingToolbar } from './FormattingToolbar';
@@ -410,41 +411,53 @@ const StickyNoteNodeComponent = ({
         </StickyNoteContainer>
 
         {!readOnly && selected && !dragging && !isResizing && (
-          <NodeToolbar nodeId={id} config={toolbarConfig} expanded={true} />
+          <NodeToolbar nodeId={id} config={toolbarConfig} expanded={true} portalToNodeOverlay />
         )}
-        <AnimatePresence>
-          {!readOnly && selected && !dragging && !isResizing && isColorPickerOpen && (
-            <div
-              style={{
-                position: 'absolute',
-                top: -40,
-                left: '50%',
-                transform: 'translateX(40px)',
-                zIndex: 1000,
-              }}
-            >
-              <ColorPickerPanel
-                initial={{ opacity: 0, y: 10 }}
-                animate={{ opacity: 1, y: 0 }}
-                exit={{ opacity: 0, y: 10 }}
-                transition={{ duration: 0.15, ease: 'easeOut' }}
-              >
-                {Object.keys(STICKY_NOTE_COLORS).map((stickyColorKey) => {
-                  const colorName = stickyColorKey as StickyNoteColor;
-                  return (
-                    <ColorOption
-                      key={stickyColorKey}
-                      color={STICKY_NOTE_COLORS[colorName]}
-                      isSelected={colorKey === colorName}
-                      onClick={() => handleColorChange(colorName)}
-                      title={colorName.charAt(0).toUpperCase() + colorName.slice(1)}
-                    />
-                  );
-                })}
-              </ColorPickerPanel>
-            </div>
-          )}
-        </AnimatePresence>
+        {!readOnly && selected && !dragging && !isResizing && (
+          <NodeViewportOverlay nodeId={id} layer="nodeToolbar">
+            <AnimatePresence>
+              {isColorPickerOpen && (
+                <div
+                  className="nodrag nopan nowheel"
+                  style={{
+                    position: 'absolute',
+                    top: -40,
+                    left: '50%',
+                    transform: 'translateX(40px)',
+                    zIndex: 1000,
+                    pointerEvents: 'auto',
+                  }}
+                  onMouseDown={(e) => {
+                    e.preventDefault();
+                    e.stopPropagation();
+                  }}
+                  onClick={(e) => e.stopPropagation()}
+                >
+                  <ColorPickerPanel
+                    initial={{ opacity: 0, y: 10 }}
+                    animate={{ opacity: 1, y: 0 }}
+                    exit={{ opacity: 0, y: 10 }}
+                    transition={{ duration: 0.15, ease: 'easeOut' }}
+                  >
+                    {Object.keys(STICKY_NOTE_COLORS).map((stickyColorKey) => {
+                      const colorName = stickyColorKey as StickyNoteColor;
+                      return (
+                        <ColorOption
+                          type="button"
+                          key={stickyColorKey}
+                          color={STICKY_NOTE_COLORS[colorName]}
+                          isSelected={colorKey === colorName}
+                          onClick={() => handleColorChange(colorName)}
+                          title={colorName.charAt(0).toUpperCase() + colorName.slice(1)}
+                        />
+                      );
+                    })}
+                  </ColorPickerPanel>
+                </div>
+              )}
+            </AnimatePresence>
+          </NodeViewportOverlay>
+        )}
       </StickyNoteWrapper>
     </>
   );

--- a/packages/apollo-react/src/canvas/styles/reactflow-reset.css
+++ b/packages/apollo-react/src/canvas/styles/reactflow-reset.css
@@ -39,11 +39,17 @@
  * React Flow's selected-node z-index bump (+1000) and connection-line z-index (1001).
  * React Flow sets z-index inline, so `!important` is required to override it.
  *
- * Excluded node prefixes (must stay below edges regardless of hover):
- *   - sticky-  (sticky notes)
+ * Exclusions:
+ *   - loop containers need to stay below sticky notes even when selected
+ *   - sticky notes own annotation/active annotation layers in StickyNoteNode.styles
  */
-.react-flow__node:not(.parent):not([data-id^="sticky-"]):hover {
+.react-flow__node:not(.parent):not([data-id^="sticky-"]):not(:has([data-loop-container])):hover {
   z-index: 1002 !important;
+}
+
+/* Keep loop shells behind sticky-note annotations; empty loop body still hit-tests to the loop. */
+.react-flow__node:has([data-loop-container]) {
+  z-index: -20 !important;
 }
 
 /**


### PR DESCRIPTION
## Summary

This change fixes sticky note interactions when a sticky note is placed visually inside a loop container.

The fix keeps loop shells from stacking above sticky notes, and moves selected sticky-note controls into the viewport overlay layer so the toolbar and color picker remain clickable even when the note overlaps a selected loop, workflow nodes, or loop edges.

## What changed

- Keeps loop container React Flow nodes behind sticky-note annotations by excluding loop containers from the hover z-index bump and lowering loop shell z-index.
- Portals the selected sticky note toolbar through `NodeToolbar`'s node overlay support.
- Renders the sticky note color picker through `NodeViewportOverlay` and marks it `nodrag nopan nowheel` so color options remain interactive.
- Adds a single combined `StickyNotesInLoopContainers` Storybook scenario covering:
  - sticky note inside a selected nested loop
  - sticky note centered behind a base node and its label
  - sticky note crossed by a workflow edge
  - sticky note outside the loop as a control case

## Demo

https://github.com/user-attachments/assets/5ff5d55f-573e-4bd8-a8a2-2d0f3a40cb45




## Diagram

```mermaid
flowchart LR
  subgraph Before["Before"]
    SelectedLoopBefore["Selected loop shell"] -->|"stacked above"| StickyBefore["Sticky note"]
    SelectedLoopBefore -->|"blocked"| ToolbarBefore["Toolbar / color picker"]
  end

  subgraph After["After"]
    LoopShell["Loop shell"] -->|"kept below"| StickyBody["Sticky note body"]
    StickyBody -->|"selected"| OverlayLayer["Node viewport overlay"]
    OverlayLayer --> Toolbar["Toolbar"]
    OverlayLayer --> ColorPicker["Color picker"]
  end
```

## User impact

Before this change, selecting a loop shell could leave the loop container stacked above a sticky note inside the loop body, making the sticky note difficult or impossible to select, edit, resize, drag, or use through its toolbar/color picker.

After this change, sticky notes remain usable when visually placed inside loop containers, while loop body hit-testing still works where the loop body is empty.

## Validation

- Storybook validation with `StickyNotesInLoopContainers`
- Playwright screenshot checks for the combined loop/sticky-note scenario
- `pnpm exec tsc -p tsconfig.json --noEmit`
