### PR TITLE
fix(canvas): prevent stage node drag when selecting title text [MST-9699]

### DIFF
--- a/packages/apollo-react/src/canvas/components/StageNode/StageNodeHeader.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNodeHeader.tsx
@@ -138,6 +138,10 @@ const StageNodeHeaderInner = ({
             <CanvasTooltip content={label} placement="top" delay>
               <StageTitleContainer isEditing={isStageTitleEditing}>
                 <StageTitleInput
+                  // `nodrag` prevents xyflow from interpreting drag-select
+                  // (highlighting text) inside the editable title as a node
+                  // drag, which would otherwise move the entire stage block.
+                  className="nodrag"
                   name="Stage Title"
                   isStageTitleEditable={isStageTitleEditable}
                   value={label}


### PR DESCRIPTION
CLAUDE BUG BURN-DOWN

## Summary

Fixes [MST-9699](https://uipath.atlassian.net/browse/MST-9699) — *"Dragging to highlight the full stage name will drag the entire stage block around."*

When a user clicked into the editable title of a `StageNode` and dragged their cursor to highlight the text, xyflow interpreted the pointer drag as a node drag and moved the entire stage block.

## Root cause

xyflow uses the `nodrag` CSS class as the opt-out hook for descendant elements that should not initiate a node drag. The `<StageTitleInput>` rendered in `StageNodeHeader.tsx` did not have this class, so any mouse drag inside the input bubbled up to xyflow and was treated as a node drag.

## Fix

Add `className="nodrag"` to the `StageTitleInput` element in `packages/apollo-react/src/canvas/components/StageNode/StageNodeHeader.tsx`.

This matches the existing pattern used elsewhere in the canvas codebase, e.g.:
- `BaseNode/NodeLabel.tsx` (editable label/sub-label textareas use `nodrag nowheel`)
- `StageNode/StageNodeSequentialTaskGroups.tsx` (task list uses `nodrag nopan`)

The fix is a single-line addition; no behavioral changes outside the intended one.

## Test plan

- [ ] CI: type-check, lint, unit tests, storybook build pass
- [ ] Manual: open a Maestro case-management canvas, add a new stage, click to edit the stage name, drag-select the entire stage name with the mouse — verify the stage block does **not** move and the text becomes selected as expected
- [ ] Manual: confirm editing/saving the stage name (typing, Enter, blur) still works unchanged
- [ ] Manual: confirm the rest of the stage header (status icon, add-task button, chips) and stage drag-from-empty-area still behave as before

## Notes

- Could not run `lint` / `tsc` / `pnpm test` locally — this environment is not a git checkout. Relying on the repo's CI to validate.
- Reporter hint in the ticket suggested `e.stopPropagation()` / `e.preventDefault()` in a drag handler, but the idiomatic xyflow solution in this codebase is the `nodrag` class — same effect, no custom event plumbing, and consistent with `NodeLabel.tsx`.

Claude session: https://claude.ai/code/session_013jkurrpKiBqFMhYeJdPPoR

---
_Generated by [Claude Code](https://claude.ai/code/session_013jkurrpKiBqFMhYeJdPPoR)_

[MST-9699]: https://uipath.atlassian.net/browse/MST-9699?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ