### PR TITLE
feat(apollo-wind): add maxRef to slider for dynamic max from another field

### DIFF
--- a/packages/apollo-wind/src/components/forms/field-renderer.test.tsx
+++ b/packages/apollo-wind/src/components/forms/field-renderer.test.tsx
@@ -228,6 +228,115 @@ describe('FormFieldRenderer', () => {
     });
   });
 
+  describe('slider field', () => {
+    it('renders with static max', () => {
+      const field: FieldMetadata = {
+        name: 'temperature',
+        type: 'slider',
+        label: 'Temperature',
+        min: 0,
+        max: 1,
+        step: 0.1,
+      };
+
+      render(
+        <FormWrapper defaultValues={{ temperature: 0.5 }}>
+          <FormFieldRenderer field={field} context={createMockContext()} customComponents={{}} />
+        </FormWrapper>
+      );
+
+      const slider = screen.getByRole('slider');
+      expect(slider).toHaveAttribute('aria-valuemax', '1');
+      expect(slider).toHaveAttribute('aria-valuenow', '0.5');
+    });
+
+    it('falls back to 100 when neither max nor maxRef is provided', () => {
+      const field: FieldMetadata = {
+        name: 'value',
+        type: 'slider',
+        label: 'Value',
+      };
+
+      render(
+        <FormWrapper defaultValues={{ value: 50 }}>
+          <FormFieldRenderer field={field} context={createMockContext()} customComponents={{}} />
+        </FormWrapper>
+      );
+
+      expect(screen.getByRole('slider')).toHaveAttribute('aria-valuemax', '100');
+    });
+
+    it('derives max from another form field via maxRef', () => {
+      const field: FieldMetadata = {
+        name: 'maxTokens',
+        type: 'slider',
+        label: 'Max tokens',
+        min: 0,
+        maxRef: { fromField: 'modelMaxTokens', fallback: 1000 },
+      };
+
+      render(
+        <FormWrapper defaultValues={{ maxTokens: 500, modelMaxTokens: 32768 }}>
+          <FormFieldRenderer field={field} context={createMockContext()} customComponents={{}} />
+        </FormWrapper>
+      );
+
+      expect(screen.getByRole('slider')).toHaveAttribute('aria-valuemax', '32768');
+    });
+
+    it('uses maxRef.fallback when watched field is missing', () => {
+      const field: FieldMetadata = {
+        name: 'maxTokens',
+        type: 'slider',
+        label: 'Max tokens',
+        maxRef: { fromField: 'modelMaxTokens', fallback: 16384 },
+      };
+
+      render(
+        <FormWrapper defaultValues={{ maxTokens: 500 }}>
+          <FormFieldRenderer field={field} context={createMockContext()} customComponents={{}} />
+        </FormWrapper>
+      );
+
+      expect(screen.getByRole('slider')).toHaveAttribute('aria-valuemax', '16384');
+    });
+
+    it('uses maxRef.fallback when watched value is not a positive number', () => {
+      const field: FieldMetadata = {
+        name: 'maxTokens',
+        type: 'slider',
+        label: 'Max tokens',
+        maxRef: { fromField: 'modelMaxTokens', fallback: 8192 },
+      };
+
+      render(
+        <FormWrapper defaultValues={{ maxTokens: 500, modelMaxTokens: 'not-a-number' }}>
+          <FormFieldRenderer field={field} context={createMockContext()} customComponents={{}} />
+        </FormWrapper>
+      );
+
+      expect(screen.getByRole('slider')).toHaveAttribute('aria-valuemax', '8192');
+    });
+
+    it('maxRef takes precedence over static max', () => {
+      const field: FieldMetadata = {
+        name: 'maxTokens',
+        type: 'slider',
+        label: 'Max tokens',
+        max: 999,
+        maxRef: { fromField: 'modelMaxTokens', fallback: 16384 },
+      };
+
+      render(
+        <FormWrapper defaultValues={{ maxTokens: 500, modelMaxTokens: 4096 }}>
+          <FormFieldRenderer field={field} context={createMockContext()} customComponents={{}} />
+        </FormWrapper>
+      );
+
+      expect(screen.getByRole('slider')).toHaveAttribute('aria-valuemax', '4096');
+    });
+  });
+
   describe('visibility rules', () => {
     it('hides field when visibility rule evaluates to false', () => {
       const field: FieldMetadata = {

--- a/packages/apollo-wind/src/components/forms/field-renderer.tsx
+++ b/packages/apollo-wind/src/components/forms/field-renderer.tsx
@@ -660,9 +660,7 @@ function SliderField({ field, formField, error, disabled, required }: SliderFiel
     <FormField>
       <div className="flex justify-between">
         <FormLabel required={required}>{field.label}</FormLabel>
-        <span className="text-sm text-muted-foreground">
-          {displayValue as React.ReactNode}
-        </span>
+        <span className="text-sm text-muted-foreground">{displayValue as React.ReactNode}</span>
       </div>
       <Slider
         value={[(displayValue as number) ?? field.min ?? 0]}

--- a/packages/apollo-wind/src/components/forms/field-renderer.tsx
+++ b/packages/apollo-wind/src/components/forms/field-renderer.tsx
@@ -632,11 +632,8 @@ interface SliderFieldProps {
 
 function SliderField({ field, formField, error, disabled, required }: SliderFieldProps) {
   const { watch } = useFormContext();
-  // watch() requires a defined name; pass a dummy `__none__` path when
-  // maxRef is absent and ignore the value. react-hook-form returns undefined
-  // for unknown fields, which is what resolveSliderMax expects.
-  const watchedMax = watch(field.maxRef?.fromField ?? '__apolloWindSliderMaxRefNone__');
-  const resolvedMax = resolveSliderMax(field, field.maxRef ? watchedMax : undefined);
+  const watchedMax = field.maxRef ? watch(field.maxRef.fromField) : undefined;
+  const resolvedMax = resolveSliderMax(field, watchedMax);
 
   // Clamp the form value if the resolved max drops below it (e.g. user
   // switched to a model with a lower token cap).
@@ -648,7 +645,7 @@ function SliderField({ field, formField, error, disabled, required }: SliderFiel
     if (typeof v === 'number' && v > resolvedMax) {
       formField.onChange(resolvedMax);
     }
-  }, [resolvedMax, formField]);
+  }, [resolvedMax, formField.value, formField.onChange]);
 
   const displayValue = (() => {
     const v = formField.value;

--- a/packages/apollo-wind/src/components/forms/field-renderer.tsx
+++ b/packages/apollo-wind/src/components/forms/field-renderer.tsx
@@ -5,6 +5,7 @@ import type {
   FormContext,
   FieldOption,
   CustomFieldComponentProps,
+  SliderFieldMetadata,
 } from './form-schema';
 import { hasOptions, isCustomField } from './form-schema';
 import { RulesEngine } from './rules-engine';
@@ -502,24 +503,13 @@ function FieldByType({ field, formField, error, disabled, required, options }: F
 
     case 'slider':
       return (
-        <FormField>
-          <div className="flex justify-between">
-            <FormLabel required={required}>{field.label}</FormLabel>
-            <span className="text-sm text-muted-foreground">
-              {formField.value as React.ReactNode}
-            </span>
-          </div>
-          <Slider
-            value={[formField.value as number]}
-            onValueChange={(values) => formField.onChange(values[0])}
-            min={field.min || 0}
-            max={field.max || 100}
-            step={field.step || 1}
-            disabled={disabled}
-          />
-          <FormDescription>{field.description}</FormDescription>
-          <FormError>{error}</FormError>
-        </FormField>
+        <SliderField
+          field={field}
+          formField={formField}
+          error={error}
+          disabled={disabled}
+          required={required}
+        />
       );
 
     case 'date':
@@ -618,4 +608,90 @@ function FormDescription({ children }: { children?: React.ReactNode }) {
 function FormError({ children }: { children?: React.ReactNode }) {
   if (!children) return null;
   return <p className="text-sm text-destructive">{children}</p>;
+}
+
+// ============================================================================
+// Slider field — extracted so it can subscribe to another form field via
+// useFormContext().watch() and run an effect to clamp the value when the
+// resolved max drops below the current value.
+// ============================================================================
+
+interface SliderFieldProps {
+  field: SliderFieldMetadata;
+  formField: {
+    value: unknown;
+    onChange: (value: unknown) => void;
+    onBlur: () => void;
+    name: string;
+    ref: React.Ref<unknown>;
+  };
+  error?: string;
+  disabled: boolean;
+  required: boolean;
+}
+
+function SliderField({ field, formField, error, disabled, required }: SliderFieldProps) {
+  const { watch } = useFormContext();
+  // watch() requires a defined name; pass a dummy `__none__` path when
+  // maxRef is absent and ignore the value. react-hook-form returns undefined
+  // for unknown fields, which is what resolveSliderMax expects.
+  const watchedMax = watch(field.maxRef?.fromField ?? '__apolloWindSliderMaxRefNone__');
+  const resolvedMax = resolveSliderMax(field, field.maxRef ? watchedMax : undefined);
+
+  // Clamp the form value if the resolved max drops below it (e.g. user
+  // switched to a model with a lower token cap).
+  const prevMaxRef = useRef(resolvedMax);
+  useEffect(() => {
+    if (resolvedMax === prevMaxRef.current) return;
+    prevMaxRef.current = resolvedMax;
+    const v = formField.value;
+    if (typeof v === 'number' && v > resolvedMax) {
+      formField.onChange(resolvedMax);
+    }
+  }, [resolvedMax, formField]);
+
+  const displayValue = (() => {
+    const v = formField.value;
+    if (typeof v === 'number') return Math.min(v, resolvedMax);
+    return v;
+  })();
+
+  return (
+    <FormField>
+      <div className="flex justify-between">
+        <FormLabel required={required}>{field.label}</FormLabel>
+        <span className="text-sm text-muted-foreground">
+          {displayValue as React.ReactNode}
+        </span>
+      </div>
+      <Slider
+        value={[(displayValue as number) ?? field.min ?? 0]}
+        onValueChange={(values) => formField.onChange(values[0])}
+        min={field.min || 0}
+        max={resolvedMax}
+        step={field.step || 1}
+        disabled={disabled}
+      />
+      <FormDescription>{field.description}</FormDescription>
+      <FormError>{error}</FormError>
+    </FormField>
+  );
+}
+
+/**
+ * Resolve the slider's effective max. Priority:
+ *   1. `field.maxRef` — use the watched value if it's a finite positive number,
+ *      otherwise `maxRef.fallback`.
+ *   2. `field.max` — static numeric max.
+ *   3. 100 — historical default.
+ */
+function resolveSliderMax(field: SliderFieldMetadata, watchedValue: unknown): number {
+  if (field.maxRef) {
+    if (typeof watchedValue === 'number' && Number.isFinite(watchedValue) && watchedValue > 0) {
+      return watchedValue;
+    }
+    if (typeof field.maxRef.fallback === 'number') return field.maxRef.fallback;
+  }
+  if (typeof field.max === 'number') return field.max;
+  return 100;
 }

--- a/packages/apollo-wind/src/components/forms/form-schema.ts
+++ b/packages/apollo-wind/src/components/forms/form-schema.ts
@@ -221,10 +221,27 @@ export interface SwitchFieldMetadata extends BaseFieldMetadata {
   type: 'switch';
 }
 
+/**
+ * Reference to another form field's value, used to drive a numeric property
+ * (e.g. a slider's `max`) at render time.
+ */
+export interface FieldRef {
+  /** Form field path to watch (react-hook-form name). */
+  fromField: string;
+  /** Used when the watched value is missing or not a finite positive number. */
+  fallback?: number;
+}
+
 export interface SliderFieldMetadata extends BaseFieldMetadata {
   type: 'slider';
   min?: number;
   max?: number;
+  /**
+   * Dynamic upper bound sourced from another form field. Takes precedence
+   * over `max` when present. The watched field's value is used as the slider's
+   * `max` when it's a finite positive number; otherwise `fallback` is used.
+   */
+  maxRef?: FieldRef;
   step?: number;
 }
 

--- a/packages/apollo-wind/src/components/forms/metadata-form.stories.tsx
+++ b/packages/apollo-wind/src/components/forms/metadata-form.stories.tsx
@@ -242,6 +242,65 @@ export const CompactLayout: Story = {
 };
 
 // ============================================================================
+// SLIDER WITH DYNAMIC MAX (maxRef)
+// ============================================================================
+
+const sliderMaxRefSchema: FormSchema = {
+  id: 'slider-max-ref',
+  title: 'Slider with dynamic max',
+  description:
+    "The slider's `max` is bound to the value of the 'Available capacity' field via " +
+    '`maxRef`. Change the number input above to see the slider re-scale (and clamp the ' +
+    'current value if it now exceeds the new max).',
+  sections: [
+    {
+      id: 's1',
+      fields: [
+        {
+          name: 'availableCapacity',
+          type: 'number',
+          label: 'Available capacity (stand-in for e.g. model.maxTokens at runtime)',
+          min: 0,
+          defaultValue: 16384,
+        },
+        {
+          name: 'tokens',
+          type: 'slider',
+          label: 'Token allocation',
+          min: 0,
+          step: 100,
+          maxRef: { fromField: 'availableCapacity', fallback: 1000 },
+          defaultValue: 8000,
+        },
+      ],
+    },
+  ],
+  initialData: { availableCapacity: 16384, tokens: 8000 },
+};
+
+/**
+ * Slider with dynamic max (`maxRef`)
+ *
+ * Demonstrates the new additive `maxRef` option on `SliderFieldMetadata`. The
+ * slider's upper bound is sourced from another form field at render time:
+ *
+ * ```ts
+ * { type: 'slider', maxRef: { fromField: 'availableCapacity', fallback: 1000 } }
+ * ```
+ *
+ * Try lowering the "Available capacity" value below the slider's current value
+ * — the slider both rescales and auto-clamps the form value via `onChange`.
+ */
+export const SliderWithDynamicMax: Story = {
+  args: {
+    schema: sliderMaxRefSchema,
+    onSubmit: async (data) => {
+      console.log('Submitted:', data);
+    },
+  },
+};
+
+// ============================================================================
 // FIELD TYPES SHOWCASE
 // ============================================================================
 

--- a/packages/apollo-wind/src/components/forms/metadata-form.stories.tsx
+++ b/packages/apollo-wind/src/components/forms/metadata-form.stories.tsx
@@ -269,7 +269,7 @@ const sliderMaxRefSchema: FormSchema = {
           label: 'Token allocation',
           min: 0,
           step: 100,
-          maxRef: { fromField: 'availableCapacity', fallback: 1000 },
+          maxRef: { fromField: 'availableCapacity', fallback: 16384 },
           defaultValue: 8000,
         },
       ],


### PR DESCRIPTION
## Summary

`SliderFieldMetadata.max` was a static number — fine for fixed ranges (e.g. `temperature: 0..1`) but a poor fit when the upper bound depends on another field. The motivating case: an agent's `maxTokenPerResponse` slider should cap at the selected model's `maxTokens`, but the available models (and their token caps) only exist at runtime.

This PR adds an additive, back-compat `maxRef` option that lets the slider read its `max` from another form field at render time.

## Changes

- **`form-schema.ts`** — Adds `FieldRef` interface and `SliderFieldMetadata.maxRef?: FieldRef`. Existing static `max?: number` is untouched, so consumers using the plain numeric form keep working with no migration.
- **`field-renderer.tsx`** — Extracts the `case 'slider'` body into a `SliderField` sub-component (slider needs hooks now). It calls `useFormContext().watch(maxRef.fromField)` and resolves max as: watched value if finite and positive → `maxRef.fallback` → static `max` → 100. If the resolved max drops below the current form value (e.g. user switches to a model with a lower cap), the value is clamped via `onChange`.
- **`field-renderer.test.tsx`** — 6 new tests covering static max, default fallback, maxRef resolution, watched-field-missing fallback, watched-field-non-numeric fallback, and maxRef precedence over static max.

## Usage

```ts
{
  name: 'inputs.maxTokenPerResponse',
  type: 'slider',
  label: 'Max. tokens per response',
  min: 0,
  step: 1,
  // Watches `inputs.modelMaxTokens` — caller wires this hidden field via
  // setValue() whenever the model picker selection changes.
  maxRef: { fromField: 'inputs.modelMaxTokens', fallback: 16384 },
}
```

## Test plan

- [x] `pnpm exec tsc --noEmit` — clean
- [x] `pnpm test` (apollo-wind) — 909 passed (was 903; +6 new)
- [x] `pnpm lint` — no new diagnostics introduced
- [ ] Reviewer sanity check: static `max: 100` slider still renders identically (covered by existing tests but worth a manual eyeball in Storybook)