### PR TITLE
feat(repo): add --skip-npm flag to publish:dev command [MST-9852]

### DIFF
--- a/scripts/publish-dev.ts
+++ b/scripts/publish-dev.ts
@@ -2,9 +2,11 @@
 /**
  * Publish a package with a dev version suffix.
  *
- * Usage: pnpm publish:dev <package-name> <suffix>
+ * Usage: pnpm publish:dev [--skip-npm] <package-name> <suffix>
  * Example: pnpm publish:dev @uipath/apollo-react test
- *   -> Publishes @uipath/apollo-react@3.19.3-test
+ *   -> Publishes @uipath/apollo-react@3.19.3-test to npm + GitHub
+ * Example: pnpm publish:dev --skip-npm @uipath/apollo-react test
+ *   -> Publishes @uipath/apollo-react@3.19.3-test to GitHub only
  */
 
 import { execFileSync } from 'node:child_process';
@@ -14,11 +16,30 @@ import { join } from 'node:path';
 import { type PackageJson, findPackagePath, getAllPackageNames } from './package-utils.js';
 
 function main() {
+  const args = process.argv.slice(2);
+  const skipNpm = args.includes('--skip-npm');
+  const positionalArgs = args.filter((arg) => arg !== '--skip-npm');
+
+  if (positionalArgs.length < 2) {
+    console.error('Usage: pnpm publish:dev [--skip-npm] <package-name> <suffix>');
+    console.error('Example: pnpm publish:dev @uipath/apollo-react test');
+    console.error('Example: pnpm publish:dev --skip-npm @uipath/apollo-react test');
+    console.error('\nOptions:');
+    console.error('  --skip-npm  Skip publishing to npm (only publish to GitHub Package Registry)');
+    console.error('\nAvailable packages:');
+    for (const name of getAllPackageNames()) {
+      console.error(`  - ${name}`);
+    }
+    process.exit(1);
+  }
+
+  const [packageName, suffix] = positionalArgs as [string, string];
+
   // Validate authentication tokens are available
   const npmToken = process.env.NPM_AUTH_TOKEN || process.env.NPM_TOKEN;
   const ghToken = process.env.GH_NPM_REGISTRY_TOKEN;
 
-  if (!npmToken) {
+  if (!skipNpm && !npmToken) {
     console.error('Error: NPM_AUTH_TOKEN or NPM_TOKEN environment variable is required.');
     console.error('');
     console.error('To publish to npm.org, you need an npm automation token.');
@@ -26,6 +47,8 @@ function main() {
     console.error('  export NPM_AUTH_TOKEN=your_npm_token_here');
     console.error('');
     console.error('See CONTRIBUTING.md for instructions on creating an npm token.');
+    console.error('');
+    console.error('Tip: Use --skip-npm to publish only to GitHub Package Registry.');
     process.exit(1);
   }
 
@@ -37,20 +60,6 @@ function main() {
     console.error('  export GH_NPM_REGISTRY_TOKEN=your_github_token_here');
     process.exit(1);
   }
-
-  const args = process.argv.slice(2);
-
-  if (args.length < 2) {
-    console.error('Usage: pnpm publish:dev <package-name> <suffix>');
-    console.error('Example: pnpm publish:dev @uipath/apollo-react test');
-    console.error('\nAvailable packages:');
-    for (const name of getAllPackageNames()) {
-      console.error(`  - ${name}`);
-    }
-    process.exit(1);
-  }
-
-  const [packageName, suffix] = args as [string, string];
 
   // Validate suffix (alphanumeric, may contain hyphens and dots, must not start with hyphen/dot)
   if (!/^[a-zA-Z0-9][a-zA-Z0-9.-]*$/.test(suffix)) {
@@ -86,9 +95,8 @@ function main() {
     writeFileSync(packageJsonPath, JSON.stringify(pkg, null, 2) + '\n');
     console.log(`Updated version to ${devVersion}`);
 
-    // Publish with 'dev' tag to both registries
-    // Note: Assumes package is already built (run `pnpm build` first)
-    console.log('\nPublishing with tag "dev" to both registries...');
+    const registries = skipNpm ? 'GitHub Package Registry' : 'both registries';
+    console.log(`\nPublishing with tag "dev" to ${registries}...`);
 
     const publishArgs = [
       '--no-git-checks',
@@ -96,28 +104,28 @@ function main() {
       '--tag', 'dev',
     ];
 
-    // Publish to npm
-    console.log('\n📦 Publishing to npm...');
-    execFileSync(
-      'pnpm',
-      [
-        'publish',
-        ...publishArgs,
-        '--@uipath:registry=https://registry.npmjs.org'
-      ],
-      {
-        cwd: packagePath,
-        stdio: 'inherit',
-        env: {
-          ...process.env,
-          NPM_AUTH_TOKEN: npmToken,
-          NODE_AUTH_TOKEN: npmToken,
-        },
-      }
-    );
-    console.log('✓ Published to npm');
+    if (!skipNpm) {
+      console.log('\n📦 Publishing to npm...');
+      execFileSync(
+        'pnpm',
+        [
+          'publish',
+          ...publishArgs,
+          '--@uipath:registry=https://registry.npmjs.org'
+        ],
+        {
+          cwd: packagePath,
+          stdio: 'inherit',
+          env: {
+            ...process.env,
+            NPM_AUTH_TOKEN: npmToken,
+            NODE_AUTH_TOKEN: npmToken,
+          },
+        }
+      );
+      console.log('✓ Published to npm');
+    }
 
-    // Publish to GitHub Package Registry
     console.log('\n📦 Publishing to GitHub Package Registry...');
     execFileSync(
       'pnpm',
@@ -138,7 +146,7 @@ function main() {
     );
     console.log('✓ Published to GitHub Package Registry');
 
-    console.log(`\n✓ Successfully published ${packageName}@${devVersion} to both registries`);
+    console.log(`\n✓ Successfully published ${packageName}@${devVersion} to ${registries}`);
 
   } catch (error) {
     console.error('\n✗ Publish failed');

--- a/scripts/publish-dev.ts
+++ b/scripts/publish-dev.ts
@@ -13,7 +13,7 @@ import { execFileSync } from 'node:child_process';
 import { readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
-import { type PackageJson, findPackagePath, getAllPackageNames } from './package-utils.js';
+import { findPackagePath, getAllPackageNames, type PackageJson } from './package-utils.js';
 
 function main() {
   const args = process.argv.slice(2);
@@ -95,24 +95,16 @@ function main() {
     writeFileSync(packageJsonPath, JSON.stringify(pkg, null, 2) + '\n');
     console.log(`Updated version to ${devVersion}`);
 
-    const registries = skipNpm ? 'GitHub Package Registry' : 'both registries';
+    const registries = skipNpm ? 'GitHub Package Registry' : 'both registries (GitHub, npm)';
     console.log(`\nPublishing with tag "dev" to ${registries}...`);
 
-    const publishArgs = [
-      '--no-git-checks',
-      '--access', 'public',
-      '--tag', 'dev',
-    ];
+    const publishArgs = ['--no-git-checks', '--access', 'public', '--tag', 'dev'];
 
     if (!skipNpm) {
       console.log('\n📦 Publishing to npm...');
       execFileSync(
         'pnpm',
-        [
-          'publish',
-          ...publishArgs,
-          '--@uipath:registry=https://registry.npmjs.org'
-        ],
+        ['publish', ...publishArgs, '--@uipath:registry=https://registry.npmjs.org'],
         {
           cwd: packagePath,
           stdio: 'inherit',
@@ -129,11 +121,7 @@ function main() {
     console.log('\n📦 Publishing to GitHub Package Registry...');
     execFileSync(
       'pnpm',
-      [
-        'publish',
-        ...publishArgs,
-        '--@uipath:registry=https://npm.pkg.github.com'
-      ],
+      ['publish', ...publishArgs, '--@uipath:registry=https://npm.pkg.github.com'],
       {
         cwd: packagePath,
         stdio: 'inherit',
@@ -147,7 +135,6 @@ function main() {
     console.log('✓ Published to GitHub Package Registry');
 
     console.log(`\n✓ Successfully published ${packageName}@${devVersion} to ${registries}`);
-
   } catch (error) {
     console.error('\n✗ Publish failed');
     console.error(error);


### PR DESCRIPTION
## Summary
- Add `--skip-npm` flag to `publish:dev` script, allowing dev packages to be published to GitHub Package Registry only — without requiring an npm authentication token
- This lowers the barrier for contributors who need to publish dev/test packages but don't have npm org credentials

## Test plan
- [x] `pnpm publish:dev @uipath/apollo-react test` still publishes to both npm and GitHub (existing behavior)
- [x] `pnpm publish:dev --skip-npm @uipath/apollo-react test` publishes to GitHub only, skipping npm auth check
- [x] Running without required args prints updated usage with `--skip-npm` option

🤖 Generated with [Claude Code](https://claude.com/claude-code)