### PR TITLE
fix(apollo-react): hide loop execution adornment

### DIFF
--- a/packages/apollo-react/src/canvas/components/LoopNode/LoopNode.test.tsx
+++ b/packages/apollo-react/src/canvas/components/LoopNode/LoopNode.test.tsx
@@ -1,15 +1,18 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import type { Node, NodeProps } from '@uipath/apollo-react/canvas/xyflow/react';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ValidationErrorSeverity } from '../../types/validation';
 import type { LoopNodeData } from './LoopNode.types';
 
-const { mockManifest } = vi.hoisted(() => ({
+const { mockExecutionState, mockManifest, mockValidationState } = vi.hoisted(() => ({
+  mockExecutionState: { current: undefined as unknown },
   mockManifest: {
     current: {
       display: { label: 'Loop', icon: 'repeat', shape: 'container' },
       handleConfiguration: [],
     } as Record<string, unknown>,
   },
+  mockValidationState: { current: undefined as unknown },
 }));
 
 vi.mock('@uipath/apollo-react/canvas/xyflow/react', async (importOriginal) => ({
@@ -33,8 +36,8 @@ vi.mock('../../core', () => ({
 }));
 
 vi.mock('../../hooks', () => ({
-  useNodeExecutionState: () => undefined,
-  useElementValidationStatus: () => undefined,
+  useNodeExecutionState: () => mockExecutionState.current,
+  useElementValidationStatus: () => mockValidationState.current,
 }));
 
 vi.mock('../../utils/icon-registry', () => ({
@@ -83,6 +86,11 @@ function getLoopContainer() {
   return document.querySelector('[data-loop-container]') as HTMLElement;
 }
 
+beforeEach(() => {
+  mockExecutionState.current = undefined;
+  mockValidationState.current = undefined;
+});
+
 describe('LoopNode header adornment spacing', () => {
   it('keeps the default header padding when no adornments are visible', () => {
     const header = renderLoopNode();
@@ -122,6 +130,31 @@ describe('LoopNode header adornment spacing', () => {
     });
 
     expect(header.style.paddingLeft).toBe('34px');
+    expect(header.style.paddingRight).toBe('34px');
+  });
+
+  it('does not reserve right-side header space for execution status adornment', () => {
+    mockExecutionState.current = 'Completed';
+
+    const header = renderLoopNode();
+
+    expect(header.style.paddingRight).toBe('');
+  });
+
+  it('still reserves right-side header space for validation adornment', () => {
+    mockExecutionState.current = 'Completed';
+    mockValidationState.current = {
+      validationStatus: ValidationErrorSeverity.ERROR,
+      validationError: {
+        code: 'REQUIRED',
+        message: 'URL is required',
+        description: 'URL is required',
+        severity: ValidationErrorSeverity.ERROR,
+      },
+    };
+
+    const header = renderLoopNode();
+
     expect(header.style.paddingRight).toBe('34px');
   });
 });

--- a/packages/apollo-react/src/canvas/components/LoopNode/LoopNode.tsx
+++ b/packages/apollo-react/src/canvas/components/LoopNode/LoopNode.tsx
@@ -268,7 +268,7 @@ function LoopNodeComponent(props: LoopNodeProps) {
 
   const adornments: NodeAdornments = useMemo(
     () => ({
-      ...resolveAdornments(statusContext),
+      ...resolveAdornments(statusContext, { hideExecutionStatusAdornment: true }),
       ...(adornmentsProp ?? {}),
     }),
     [adornmentsProp, statusContext]

--- a/packages/apollo-react/src/canvas/utils/adornment-resolver.test.tsx
+++ b/packages/apollo-react/src/canvas/utils/adornment-resolver.test.tsx
@@ -39,6 +39,17 @@ describe('resolveAdornments', () => {
     expect((result.topRight as React.ReactElement)?.type).toBe(ExecutionStatusIndicator);
   });
 
+  it('can hide execution status adornment', () => {
+    const result = resolveAdornments(
+      {
+        ...baseContext,
+        executionState: { status: 'Failed', count: 2 },
+      },
+      { hideExecutionStatusAdornment: true }
+    );
+    expect(result.topRight).toBeUndefined();
+  });
+
   // ── Breakpoint (topLeft) ────────────────────────────────
 
   it('shows breakpoint when debug is true', () => {
@@ -172,6 +183,26 @@ describe('resolveAdornments', () => {
       },
     });
     expect((result.topRight as React.ReactElement)?.type).toBe(ExecutionStatusIndicator);
+  });
+
+  it('falls back to validation when execution status adornment is hidden', () => {
+    const result = resolveAdornments(
+      {
+        ...baseContext,
+        executionState: 'Completed',
+        validationState: {
+          validationStatus: ValidationErrorSeverity.ERROR,
+          validationError: {
+            code: 'REQUIRED',
+            message: 'URL is required',
+            description: 'URL is required',
+            severity: ValidationErrorSeverity.ERROR,
+          },
+        },
+      },
+      { hideExecutionStatusAdornment: true }
+    );
+    expect((result.topRight as React.ReactElement)?.type).toBe(ValidationErrorIndicator);
   });
 
   it('validation shown when no execution state', () => {

--- a/packages/apollo-react/src/canvas/utils/adornment-resolver.tsx
+++ b/packages/apollo-react/src/canvas/utils/adornment-resolver.tsx
@@ -89,7 +89,14 @@ export function ValidationWarningIndicator({ message }: { message?: string }) {
   );
 }
 
-const getDefaultAdornments = (context: NodeStatusContext): NodeAdornments => {
+export interface ResolveAdornmentsOptions {
+  hideExecutionStatusAdornment?: boolean;
+}
+
+const getDefaultAdornments = (
+  context: NodeStatusContext,
+  options: ResolveAdornmentsOptions
+): NodeAdornments => {
   const executionState = context.executionState;
 
   const status = typeof executionState === 'object' ? executionState?.status : executionState;
@@ -107,8 +114,8 @@ const getDefaultAdornments = (context: NodeStatusContext): NodeAdornments => {
     context.validationState?.validationStatus === ValidationErrorSeverity.WARNING;
 
   const getTopRight = () => {
-    // An active execution status (anything other than 'None') takes priority
-    if (status && status !== 'None')
+    // An active execution status (anything other than 'None') takes priority when enabled.
+    if (!options.hideExecutionStatusAdornment && status && status !== 'None')
       return <ExecutionStatusIndicator status={status} count={count} />;
     if (hasValidationError)
       return (
@@ -129,7 +136,10 @@ const getDefaultAdornments = (context: NodeStatusContext): NodeAdornments => {
   };
 };
 
-export function resolveAdornments(context: NodeStatusContext) {
+export function resolveAdornments(
+  context: NodeStatusContext,
+  options: ResolveAdornmentsOptions = {}
+) {
   // TODO: for now, always return default adornments
-  return getDefaultAdornments(context);
+  return getDefaultAdornments(context, options);
 }


### PR DESCRIPTION
## Summary

This hides the default execution-status adornment for loop nodes while preserving validation adornments and the rest of the execution-state behavior.

Loop nodes now have an iteration navigator in the header, so the floating top-right execution badge can compete with the navigator and make execution counts feel ambiguous. The loop still needs execution state for status borders, toolbar conditions, breakpoint/start-point/pinned-output metadata, and other runtime behavior.

## Root Cause

The shared adornment resolver always gave active execution status priority in the `topRight` slot. `LoopNode` used that same default resolver, so it inherited the normal-node execution badge even though its header now has loop-specific runtime controls.

## Demo

Before 

<img width="1440" height="796" alt="image" src="https://github.com/user-attachments/assets/1a73e8c0-f81c-40f8-b1de-e01cdabd5deb" />


After

<img width="1247" height="761" alt="image" src="https://github.com/user-attachments/assets/99e7dea5-1028-43c4-8baf-7613dbecc85e" />


## Fix

Added a backwards-compatible `hideExecutionStatusAdornment` option to `resolveAdornments`. The default remains unchanged for all existing callers. `LoopNode` opts into the option so only the default execution-status top-right adornment is hidden; validation error and warning adornments still fall through and render in the same slot.

## Validation

Ran targeted tests:

```sh
pnpm --filter @uipath/apollo-react exec vitest --run src/canvas/utils/adornment-resolver.test.tsx src/canvas/components/LoopNode/LoopNode.test.tsx
```

Result: 2 test files passed, 31 tests passed.
