### PR TITLE
fix(apollo-react): preserve status borders on hover

### DIFF
--- a/packages/apollo-react/src/canvas/components/BaseNode/BaseNodeContainer.test.tsx
+++ b/packages/apollo-react/src/canvas/components/BaseNode/BaseNodeContainer.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { BaseContainer } from './BaseNodeContainer';
+
+describe('BaseContainer status border hover treatment', () => {
+  it('preserves a resolved status border while hovered', () => {
+    render(
+      <BaseContainer isHovered executionStatus="Completed">
+        <span>content</span>
+      </BaseContainer>
+    );
+
+    const container = screen.getByTestId('base-container');
+
+    expect(container).toHaveClass('border-success');
+    expect(container).toHaveClass('shadow-(--canvas-node-shadow-hover)');
+    expect(container).not.toHaveClass('border-border-hover');
+  });
+
+  it('keeps the hover border for neutral statuses without a resolved status border', () => {
+    render(
+      <BaseContainer isHovered executionStatus="NotExecuted">
+        <span>content</span>
+      </BaseContainer>
+    );
+
+    const container = screen.getByTestId('base-container');
+
+    expect(container).toHaveClass('border-border-hover');
+    expect(container).toHaveClass('shadow-(--canvas-node-shadow-hover)');
+  });
+});

--- a/packages/apollo-react/src/canvas/components/BaseNode/BaseNodeContainer.tsx
+++ b/packages/apollo-react/src/canvas/components/BaseNode/BaseNodeContainer.tsx
@@ -64,29 +64,31 @@ export const BaseContainer = ({
 
   // cn() is needed here because border-color classes from getStatusBorder,
   // hover, and selection states intentionally override the base `border-border`.
-  const className = useMemo(
-    () =>
-      cn(
-        'relative flex items-center cursor-pointer bg-surface-overlay border border-border',
-        'w-(--node-w) h-(--node-h) rounded-(--node-radius)',
-        'shadow-(--canvas-node-shadow-rest) outline-offset-0 transition-[box-shadow,border-color] duration-150',
-        shape === 'rectangle'
-          ? 'flex-row justify-start gap-3 p-(--node-gap)'
-          : 'flex-col justify-center',
-        hasFooter && 'flex-wrap',
-        getStatusBorder(activeStatus),
-        isHovered && 'shadow-(--canvas-node-shadow-hover) border-border-hover',
-        isSelected && 'outline outline-2 outline-foreground-accent-muted',
-        interactionState === 'disabled' && 'opacity-50 cursor-not-allowed',
-        interactionState === 'drag' && 'cursor-grabbing shadow-(--canvas-node-shadow-lifted)',
-        // Decorative stacked layer for drillable / collapsed nodes. Purely visual:
-        // a ::before pseudo inherits the container's radius/size, sits behind at
-        // -z-10, and is offset down so only a thin arc peeks out below the card.
-        isStacked &&
-          'before:content-[""] before:absolute before:inset-x-0 before:top-0 before:h-full before:rounded-[inherit] before:bg-surface-overlay before:border before:border-brand before:translate-y-[6px] before:-z-10 before:pointer-events-none'
-      ),
-    [shape, hasFooter, activeStatus, isSelected, isHovered, isStacked, interactionState]
-  );
+  const className = useMemo(() => {
+    const statusBorder = getStatusBorder(activeStatus);
+    const hasStatusBorder = statusBorder.length > 0;
+
+    return cn(
+      'relative flex items-center cursor-pointer bg-surface-overlay border border-border',
+      'w-(--node-w) h-(--node-h) rounded-(--node-radius)',
+      'shadow-(--canvas-node-shadow-rest) outline-offset-0 transition-[box-shadow,border-color] duration-150',
+      shape === 'rectangle'
+        ? 'flex-row justify-start gap-3 p-(--node-gap)'
+        : 'flex-col justify-center',
+      hasFooter && 'flex-wrap',
+      statusBorder,
+      isHovered && 'shadow-(--canvas-node-shadow-hover)',
+      isHovered && !hasStatusBorder && 'border-border-hover',
+      isSelected && 'outline outline-2 outline-foreground-accent-muted',
+      interactionState === 'disabled' && 'opacity-50 cursor-not-allowed',
+      interactionState === 'drag' && 'cursor-grabbing shadow-(--canvas-node-shadow-lifted)',
+      // Decorative stacked layer for drillable / collapsed nodes. Purely visual:
+      // a ::before pseudo inherits the container's radius/size, sits behind at
+      // -z-10, and is offset down so only a thin arc peeks out below the card.
+      isStacked &&
+        'before:content-[""] before:absolute before:inset-x-0 before:top-0 before:h-full before:rounded-[inherit] before:bg-surface-overlay before:border before:border-brand before:translate-y-[6px] before:-z-10 before:pointer-events-none'
+    );
+  }, [shape, hasFooter, activeStatus, isSelected, isHovered, isStacked, interactionState]);
 
   return (
     <div

--- a/packages/apollo-react/src/canvas/components/LoopNode/LoopNode.test.tsx
+++ b/packages/apollo-react/src/canvas/components/LoopNode/LoopNode.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import type { Node, NodeProps } from '@uipath/apollo-react/canvas/xyflow/react';
 import { describe, expect, it, vi } from 'vitest';
 import type { LoopNodeData } from './LoopNode.types';
@@ -79,6 +79,10 @@ function renderLoopNode(props: Partial<React.ComponentProps<typeof LoopNode>> = 
   return screen.getByTestId('loop-node-header');
 }
 
+function getLoopContainer() {
+  return document.querySelector('[data-loop-container]') as HTMLElement;
+}
+
 describe('LoopNode header adornment spacing', () => {
   it('keeps the default header padding when no adornments are visible', () => {
     const header = renderLoopNode();
@@ -119,5 +123,28 @@ describe('LoopNode header adornment spacing', () => {
 
     expect(header.style.paddingLeft).toBe('34px');
     expect(header.style.paddingRight).toBe('34px');
+  });
+});
+
+describe('LoopNode status border hover treatment', () => {
+  it('preserves a resolved status border while hovered', () => {
+    renderLoopNode({ executionStatusOverride: 'Completed' });
+
+    const container = getLoopContainer();
+    fireEvent.mouseEnter(container);
+
+    expect(container).toHaveClass('border-success');
+    expect(container).toHaveClass('shadow-(--canvas-node-shadow-hover)');
+    expect(container).not.toHaveClass('border-border-hover');
+  });
+
+  it('keeps the hover border for neutral statuses without a resolved status border', () => {
+    renderLoopNode({ executionStatusOverride: 'NotExecuted' });
+
+    const container = getLoopContainer();
+    fireEvent.mouseEnter(container);
+
+    expect(container).toHaveClass('border-border-hover');
+    expect(container).toHaveClass('shadow-(--canvas-node-shadow-hover)');
   });
 });

--- a/packages/apollo-react/src/canvas/components/LoopNode/LoopNode.tsx
+++ b/packages/apollo-react/src/canvas/components/LoopNode/LoopNode.tsx
@@ -316,6 +316,9 @@ function LoopNodeComponent(props: LoopNodeProps) {
   const showEmptyStateButton = isDesignMode && !hasChildNodes && !!onAddFirstChild;
 
   const interactionState = resolveInteractionState(dragging, selected, isHovered);
+  const activeStatus = suggestionType ?? validationState?.validationStatus ?? executionStatus;
+  const statusBorder = getStatusBorder(activeStatus);
+  const hasStatusBorder = statusBorder.length > 0;
 
   if (!manifest) {
     return (
@@ -350,8 +353,9 @@ function LoopNodeComponent(props: LoopNodeProps) {
         'group/loop-shell relative box-border flex h-full w-full flex-col overflow-visible rounded-[20px] border bg-transparent',
         'transition-[border-color,box-shadow,opacity] shadow-(--canvas-node-shadow-rest)',
         'border-border',
-        getStatusBorder(suggestionType ?? validationState?.validationStatus ?? executionStatus),
-        isHovered && 'shadow-(--canvas-node-shadow-hover) border-border-hover',
+        statusBorder,
+        isHovered && 'shadow-(--canvas-node-shadow-hover)',
+        isHovered && !hasStatusBorder && 'border-border-hover',
         selected && 'outline outline-2 outline-foreground-accent-muted',
         isDropTarget && 'bg-surface-hover outline outline-2 outline-brand',
         interactionState === 'drag' && 'cursor-grabbing shadow-(--canvas-node-shadow-lifted)'


### PR DESCRIPTION
## Summary

Preserve canvas node status border colors when a node is hovered.

Base nodes and loop nodes were applying `getStatusBorder(...)` first and then appending the generic hover border class. Because the class names are merged through `cn()` / `tailwind-merge`, `border-border-hover` won over status classes such as `border-success`, `border-warning`, and `border-error`. That meant users could lose the execution, validation, or suggestion status signal just by hovering the node.

## Fix

The hover shadow now applies independently from the hover border. The generic hover border is only added when `getStatusBorder(...)` resolves to no border class.

That condition is intentionally based on the resolved border class rather than the raw status value, so neutral truthy statuses such as `NotExecuted` still receive normal hover treatment while real status borders remain visible.

The same logic is applied to both `BaseContainer` and `LoopNode`.


## Demo


https://github.com/user-attachments/assets/8ad058b7-9fbb-48a9-b7a1-524078fc9778



## Validation

- Added focused tests for `BaseContainer` hover/status border merging.
- Added focused tests for `LoopNode` hover/status border merging.
- Ran `pnpm --filter @uipath/apollo-react exec vitest --run src/canvas/components/BaseNode/BaseNodeContainer.test.tsx src/canvas/components/LoopNode/LoopNode.test.tsx`.
- Ran package-level `pnpm exec biome check --write` on the touched files.
