### PR TITLE
fix(apollo-react): remove automcomplete and add unique stage name

### DIFF
--- a/packages/apollo-react/src/canvas/components/AddNodePanel/AddNodeManager.helpers.test.ts
+++ b/packages/apollo-react/src/canvas/components/AddNodePanel/AddNodeManager.helpers.test.ts
@@ -45,7 +45,7 @@ describe('placeAddedNode', () => {
       measured: { width: 96, height: 96 },
       data: {},
     };
-    
+
     const action: Node = {
       id: 'action',
       type: 'square-target',

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.test.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.test.tsx
@@ -1038,3 +1038,38 @@ describe('StageNode - Add Task Button', () => {
     expect(screen.getByRole('button', { name: 'Add task' })).not.toBeDisabled();
   });
 });
+
+describe('StageTitleInput - input attributes', () => {
+  const enterEditMode = async (user: ReturnType<typeof userEvent.setup>) => {
+    await user.click(screen.getByRole('button', { name: 'Test Stage' }));
+    return screen.getByDisplayValue('Test Stage') as HTMLInputElement;
+  };
+
+  it('suppresses browser autocomplete on the stage title input', async () => {
+    const user = userEvent.setup();
+    renderStageNode({ onStageTitleChange: vi.fn() });
+
+    const input = await enterEditMode(user);
+    expect(input).toHaveAttribute('autocomplete', 'off');
+  });
+
+  it('uses a per-stage unique name derived from the stage id', async () => {
+    const user = userEvent.setup();
+    renderStageNode({ onStageTitleChange: vi.fn() });
+
+    const input = await enterEditMode(user);
+    expect(input).toHaveAttribute('name', 'stage-title-stage-1');
+  });
+
+  it('generates a different name for each stage so browsers do not group inputs', async () => {
+    const user = userEvent.setup();
+    const { unmount } = renderStageNode({ id: 'stage-a', onStageTitleChange: vi.fn() });
+    let input = await enterEditMode(user);
+    expect(input).toHaveAttribute('name', 'stage-title-stage-a');
+    unmount();
+
+    renderStageNode({ id: 'stage-b', onStageTitleChange: vi.fn() });
+    input = await enterEditMode(user);
+    expect(input).toHaveAttribute('name', 'stage-title-stage-b');
+  });
+});

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNodeHeader.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNodeHeader.tsx
@@ -71,6 +71,7 @@ const StageNodeHeaderInner = ({
         <Row gap={Spacing.SpacingMicro} align="center" flex={1} minW={0}>
           {icon}
           <StageTitleInput
+            stageId={id}
             label={stageDetails.label}
             onChange={isReadOnly ? undefined : onStageTitleChange}
             className="flex-1 min-w-0"

--- a/packages/apollo-react/src/canvas/components/StageNode/StageTitleInput.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageTitleInput.tsx
@@ -74,6 +74,7 @@ export const StageTitleInput = ({
             <input
               ref={inputRef}
               name={`stage-title-${stageId}`}
+              aria-label="Stage title"
               autoComplete="off"
               value={label}
               onInput={handleChange}

--- a/packages/apollo-react/src/canvas/components/StageNode/StageTitleInput.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageTitleInput.tsx
@@ -74,7 +74,7 @@ export const StageTitleInput = ({
             <input
               ref={inputRef}
               name={`stage-title-${stageId}`}
-              aria-label="Stage title"
+              aria-label={`Stage title: ${label}`}
               autoComplete="off"
               value={label}
               onInput={handleChange}

--- a/packages/apollo-react/src/canvas/components/StageNode/StageTitleInput.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageTitleInput.tsx
@@ -4,12 +4,14 @@ import { CanvasTooltip } from '../CanvasTooltip';
 import { useStageNodeLabels } from './useStageNodeLabels';
 
 type StageTitleInputProps = {
+  stageId: string;
   label: string;
   onChange?: (next: string) => void;
   className?: string;
 };
 
 export const StageTitleInput = ({
+  stageId,
   label: labelProp,
   onChange,
   className,
@@ -71,7 +73,8 @@ export const StageTitleInput = ({
           {isEditing ? (
             <input
               ref={inputRef}
-              name="Stage Title"
+              name={`stage-title-${stageId}`}
+              autoComplete="off"
               value={label}
               onInput={handleChange}
               onKeyDown={handleKeyDown}


### PR DESCRIPTION
## Summary

The stage title input on every `StageNode` shared the literal name `"Stage Title"` and had no `autoComplete` opt-out. As a result, browsers (and password managers) treated every stage title across the canvas as the same field, surfacing autofill suggestions and remembering previously-typed stage names — which leaked across stages and across cases.

## Root Cause

`StageTitleInput.tsx` rendered the underlying `<input>` with a hard-coded `name="Stage Title"` and no `autoComplete` attribute. Because every stage rendered an input with the identical `name`, browser heuristics grouped them as the same logical field, enabling autofill/history dropdowns on the canvas.

## Demo

Before
<img width="319" height="186" alt="image" src="https://github.com/user-attachments/assets/6f5945ef-b59c-4a17-aa08-0fbdb17ecfea" />

After
<img width="1110" height="525" alt="Screenshot 2026-05-18 at 10 31 33 AM" src="https://github.com/user-attachments/assets/4499fa06-2225-40f4-82ed-3965ebff06cc" />

## Fix

- Added a required `stageId: string` prop to `StageTitleInput` and threaded the existing stage `id` through from `StageNodeHeader`.
- Replaced the hard-coded `name="Stage Title"` with `name={\`stage-title-\${stageId}\`}`, giving every stage input a unique field name derived from its stage id.
- Set `autoComplete="off"` on the input so browsers do not offer history-based suggestions even when a stage id happens to repeat across documents.

## Validation

- Added a new `StageTitleInput - input attributes` describe block in `StageNode.test.tsx` with three tests that enter edit mode and assert:
  - `autocomplete="off"` is present on the rendered input
  - `name` equals `stage-title-<stageId>` for the default stage id
  - rendering two different stage ids produces two different `name` values, confirming the per-stage uniqueness guarantee
- Manually verified in the canvas playground that browser autofill no longer offers prior stage-name suggestions and that password managers no longer attach to the field.