### PR TITLE
fix(apollo-react): stickyNote style selector [MST-9292]

### DIFF
--- a/packages/apollo-react/src/canvas/components/StickyNoteNode/StickyNoteNode.styles.ts
+++ b/packages/apollo-react/src/canvas/components/StickyNoteNode/StickyNoteNode.styles.ts
@@ -36,11 +36,8 @@ export const RESIZE_CONTROL_Z_INDEX = 100;
 export const stickyNoteGlobalStyles = css`
   /* Override React Flow's elevateNodesOnSelect behavior for sticky notes */
   /* Edges have z-index: 0, so we use STICKY_NOTE_BELOW_EDGE_Z_INDEX to ensure sticky notes are below edges */
-  .react-flow .react-flow__node[data-id^='sticky-'] {
-    z-index: ${STICKY_NOTE_BELOW_EDGE_Z_INDEX} !important;
-  }
-
-  .react-flow .react-flow__node.selected[data-id^='sticky-'] {
+  .react-flow .react-flow__node:has([data-sticky-note]),
+  .react-flow .react-flow__node.selected:has([data-sticky-note]) {
     z-index: ${STICKY_NOTE_BELOW_EDGE_Z_INDEX} !important;
   }
 `;

--- a/packages/apollo-react/src/canvas/components/StickyNoteNode/StickyNoteNode.tsx
+++ b/packages/apollo-react/src/canvas/components/StickyNoteNode/StickyNoteNode.tsx
@@ -301,7 +301,7 @@ const StickyNoteNodeComponent = ({
   return (
     <>
       <Global styles={stickyNoteGlobalStyles} />
-      <StickyNoteWrapper>
+      <StickyNoteWrapper data-sticky-note>
         {!readOnly && (
           <>
             {/* Top-left resize control */}

--- a/packages/apollo-react/src/canvas/styles/reactflow-reset.css
+++ b/packages/apollo-react/src/canvas/styles/reactflow-reset.css
@@ -43,7 +43,9 @@
  *   - loop containers need to stay below sticky notes even when selected
  *   - sticky notes own annotation/active annotation layers in StickyNoteNode.styles
  */
-.react-flow__node:not(.parent):not([data-id^="sticky-"]):not(:has([data-loop-container])):hover {
+.react-flow__node:not(.parent):not(:has([data-sticky-note])):not(
+    :has([data-loop-container])
+  ):hover {
   z-index: 1002 !important;
 }
 


### PR DESCRIPTION
changed the selector for stickyNote styling
remove data-id as dependency and use specific attribute for styling



https://github.com/user-attachments/assets/0b574a3c-43b8-453f-be60-d5b9bbf3bec7



