### PR TITLE
feat(apollo-react): add case-management trigger node manifest

### DIFF
--- a/packages/apollo-react/src/canvas/components/CaseFlow/CaseTrigger.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/CaseFlow/CaseTrigger.stories.tsx
@@ -1,0 +1,102 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useMemo } from 'react';
+import { NodeRegistryProvider } from '../../core';
+import { createNode, useCanvasStory, withCanvasProviders } from '../../storybook-utils';
+import type { ElementStatus } from '../../types/execution';
+import { BaseCanvas } from '../BaseCanvas';
+import { caseFlowManifest } from './case-flow.manifest';
+
+const TRIGGER_NODE_TYPE = 'uipath.case.trigger';
+
+const TRIGGER_VARIANTS: Array<{
+  id: string;
+  label: string;
+  status?: ElementStatus;
+  icon?: string;
+}> = [
+  { id: 'default', label: 'Default' },
+  { id: 'schedule', label: 'Schedule', icon: 'clock' },
+  { id: 'in-progress', label: 'In Progress', status: 'InProgress' },
+  { id: 'completed', label: 'Completed', status: 'Completed' },
+  { id: 'failed', label: 'Failed', status: 'Failed' },
+  { id: 'paused', label: 'Paused', status: 'Paused' },
+  { id: 'not-executed', label: 'Not Executed', status: 'NotExecuted' },
+  { id: 'timer', label: 'Time Trigger', icon: 'clock' },
+  { id: 'email', label: 'Email Trigger', icon: 'mail' },
+  { id: 'webhook', label: 'Webhook Trigger', icon: 'webhook' },
+];
+
+const STATUS_BY_ID: Record<string, ElementStatus> = Object.fromEntries(
+  TRIGGER_VARIANTS.filter((v): v is typeof v & { status: ElementStatus } => Boolean(v.status)).map(
+    (v) => [v.id, v.status]
+  )
+);
+
+const GRID_ORIGIN = { x: 48, y: 96 };
+const GRID_GAP = { x: 144, y: 160 };
+const GRID_COLUMNS = 5;
+
+const CaseTriggerManifestStory = () => {
+  const initialNodes = useMemo(
+    () =>
+      TRIGGER_VARIANTS.map((variant, index) =>
+        createNode({
+          id: variant.id,
+          type: TRIGGER_NODE_TYPE,
+          position: {
+            x: GRID_ORIGIN.x + (index % GRID_COLUMNS) * GRID_GAP.x,
+            y: GRID_ORIGIN.y + Math.floor(index / GRID_COLUMNS) * GRID_GAP.y,
+          },
+          data: {
+            nodeType: TRIGGER_NODE_TYPE,
+            version: '1.0.0',
+            display: {
+              label: variant.label,
+              ...(variant.icon ? { icon: variant.icon } : {}),
+            },
+          },
+        })
+      ),
+    []
+  );
+
+  const { canvasProps } = useCanvasStory({ initialNodes });
+
+  return <BaseCanvas {...canvasProps} mode="design" />;
+};
+
+const meta = {
+  title: 'Components/CaseFlow/Trigger',
+  component: BaseCanvas,
+  decorators: [
+    // Provide an explicit execution-state resolver so status comes from
+    // TRIGGER_VARIANTS, not from the storybook-util default that derives it
+    // by parsing node IDs.
+    withCanvasProviders({
+      executionState: {
+        getNodeExecutionState: (nodeId) => STATUS_BY_ID[nodeId],
+        getEdgeExecutionState: () => undefined,
+      },
+    }),
+  ],
+  parameters: {
+    layout: 'fullscreen',
+  },
+} satisfies Meta<typeof BaseCanvas>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  // Story-level decorator wraps innermost, shadowing the registry installed by
+  // the meta-level `withCanvasProviders()`. This is what makes `caseFlowManifest`
+  // the manifest under test.
+  decorators: [
+    (Story) => (
+      <NodeRegistryProvider manifest={caseFlowManifest}>
+        <Story />
+      </NodeRegistryProvider>
+    ),
+  ],
+  render: () => <CaseTriggerManifestStory />,
+};

--- a/packages/apollo-react/src/canvas/components/CaseFlow/case-flow.manifest.ts
+++ b/packages/apollo-react/src/canvas/components/CaseFlow/case-flow.manifest.ts
@@ -42,8 +42,6 @@ export const caseManagementTriggerManifest: NodeManifest = {
     description: 'Starts a case instance and triggers a case entered event',
     icon: 'bolt',
     shape: 'circle',
-    color: '#E65100',
-    background: 'linear-gradient(135deg, #FFF3E0 0%, #FFE0B2 100%)',
   },
   handleConfiguration: [
     {
@@ -56,7 +54,7 @@ export const caseManagementTriggerManifest: NodeManifest = {
           constraints: {
             minConnections: 1,
             allowedTargetCategories: ['case-stage'],
-            forbiddenTargetCategories: ['case-trigger', 'case-condition'],
+            forbiddenTargetCategories: ['case-management-trigger', 'case-condition'],
           },
         },
       ],

--- a/packages/apollo-react/src/canvas/components/CaseFlow/case-flow.manifest.ts
+++ b/packages/apollo-react/src/canvas/components/CaseFlow/case-flow.manifest.ts
@@ -1,0 +1,87 @@
+/**
+ * Case Management Flow Node Manifests
+ *
+ * Phase 1 manifests for case-management node types.
+ * See: https://uipath.atlassian.net/wiki/spaces/~5d0b4d163e70300bc9758674/pages/90446398009/Case+Unified+schema+onboarding
+ *
+ * Scope (this file): trigger nodes only.
+ * Stage, exception stage, task, condition, and edge manifests are intentionally out of scope.
+ */
+
+import type { CategoryManifest, NodeManifest } from '../../schema/node-definition';
+
+// ============================================================================
+// Categories
+// ============================================================================
+
+export const caseFlowCategories: CategoryManifest[] = [
+  {
+    id: 'case-management-trigger',
+    name: 'Triggers',
+    sortOrder: 0,
+    color: 'linear-gradient(135deg, #FFF3E0 0%, #FFE0B2 100%)',
+    colorDark: 'linear-gradient(135deg, #E65100 0%, #EF6C00 100%)',
+    icon: 'bolt',
+    tags: ['trigger', 'start', 'case', 'event'],
+  },
+];
+
+// ============================================================================
+// Trigger Nodes
+// ============================================================================
+
+export const caseManagementTriggerManifest: NodeManifest = {
+  nodeType: 'uipath.case.trigger',
+  version: '1.0.0',
+  description: 'Entry point for a case management workflow.',
+  category: 'case-management-trigger',
+  tags: ['trigger', 'start', 'case', 'event', 'timer'],
+  sortOrder: 0,
+  display: {
+    label: 'Trigger',
+    description: 'Starts a case instance and triggers a case entered event',
+    icon: 'bolt',
+    shape: 'circle',
+    color: '#E65100',
+    background: 'linear-gradient(135deg, #FFF3E0 0%, #FFE0B2 100%)',
+  },
+  handleConfiguration: [
+    {
+      position: 'right',
+      handles: [
+        {
+          id: 'output',
+          type: 'source',
+          handleType: 'output',
+          constraints: {
+            minConnections: 1,
+            allowedTargetCategories: ['case-stage'],
+            forbiddenTargetCategories: ['case-trigger', 'case-condition'],
+          },
+        },
+      ],
+    },
+  ],
+  inputDefinition: {
+    serviceType: {
+      type: 'string',
+      enum: ['None', 'Intsvc.EventTrigger', 'timer'],
+      nullable: true,
+      default: 'None',
+    },
+    timerType: { type: 'string', nullable: true },
+    timeCycle: { type: 'string' },
+    context: { type: 'array', items: { type: 'object' } },
+    bindings: { type: 'array', items: { type: 'object' } },
+  },
+};
+
+// ============================================================================
+// Combined Manifest
+// ============================================================================
+
+export const caseFlowManifest = {
+  version: '1.0.0',
+  categories: caseFlowCategories,
+  nodes: [caseManagementTriggerManifest],
+};


### PR DESCRIPTION
## Summary

Phase 1 of the [Case Unified schema onboarding](https://uipath.atlassian.net/wiki/spaces/~5d0b4d163e70300bc9758674/pages/90446398009/Case+Unified+schema+onboarding) — adds the `uipath.case.trigger` manifest and a Storybook example. Scope is limited to **trigger nodes only**; stage, exception stage, task, condition, and edge manifests are intentionally deferred.

- Add `packages/apollo-react/src/canvas/components/CaseFlow/case-flow.manifest.ts` with the `case-management-trigger` category, the `caseManagementTriggerManifest` node manifest (single right-side output handle, `case-stage` target whitelist, `case-management-trigger`/`case-condition` blacklist), and the combined `caseFlowManifest` export — mirroring the shape of `agent-flow.manifest.ts`.
- Add `CaseTrigger.stories.tsx` (Storybook title `Components/CaseFlow/Trigger`) that registers `caseFlowManifest` via `NodeRegistryProvider` and renders manifest-driven `uipath.case.trigger` nodes through `BaseNode` (`useCanvasStory` + `createNode`), showcasing execution-status and icon-override variants.
- Legacy `Components/TriggerNode` story and the `TriggerNode` component are untouched.

<img width="2102" height="1196" alt="image" src="https://github.com/user-attachments/assets/694fe5af-2d84-4ed9-b5ac-419080ad0b71" />


## Test plan

- [ ] `Components/CaseFlow/Trigger / Default` renders 10 trigger nodes in a 5-column grid in Storybook.
- [ ] Status variants (`InProgress`, `Completed`, `Failed`, `Paused`, `NotExecuted`) display the expected execution-state styling.
- [ ] Per-instance `display.icon` overrides (`clock`, `mail`, `webhook`) replace the manifest's default `bolt` icon.
- [ ] Connecting a trigger's right-side output handle to another trigger node is rejected by the constraint validator (forbidden category `case-management-trigger`).
- [ ] Connecting to a node whose category is `case-stage` succeeds (verifiable once a stage manifest lands).
- [ ] `npx tsc --noEmit -p packages/apollo-react/tsconfig.json` reports no new errors.
- [ ] Legacy `Components/TriggerNode / Default` story still renders unchanged.

https://claude.ai/code/session_0157FiTqLMdaPe7BpZQU1Ktw

---
_Generated by [Claude Code](https://claude.ai/code/session_0157FiTqLMdaPe7BpZQU1Ktw)_