### PR TITLE
chore(apollo-react): expose ./i18n subpath export

### DIFF
--- a/packages/apollo-react/package.json
+++ b/packages/apollo-react/package.json
@@ -68,6 +68,11 @@
       "import": "./dist/canvas/index.js",
       "require": "./dist/canvas/index.cjs"
     },
+    "./i18n": {
+      "types": "./dist/i18n/index.d.ts",
+      "import": "./dist/i18n/index.js",
+      "require": "./dist/i18n/index.cjs"
+    },
     "./canvas/xyflow/react": {
       "types": "./dist/canvas/xyflow/react.d.ts",
       "import": "./dist/canvas/xyflow/react.js",

--- a/packages/apollo-react/src/i18n/ApI18nProvider.tsx
+++ b/packages/apollo-react/src/i18n/ApI18nProvider.tsx
@@ -24,8 +24,10 @@ export type SupportedLocale = (typeof SUPPORTED_LOCALES)[number];
 
 export interface ApI18nProviderProps {
   /**
-   * Component path relative to src/ where locales are stored.
-   * Example: 'material/components/ap-chat'
+   * Apollo-react component group whose pre-built lingui catalogs should be
+   * activated. Must be a key registered in `locale-registry.ts`
+   * (e.g. `'canvas'`, `'material/components/ap-chat'`). Unknown values log
+   * an error and activate empty messages.
    */
   component: string;
   /**
@@ -40,22 +42,21 @@ export interface ApI18nProviderProps {
 }
 
 /**
- * Component-scoped i18n provider for Apollo components.
+ * Activates apollo-react's pre-built lingui catalogs for a given component
+ * group. Wrap any apollo-react UI (e.g. <ApChat>, canvas components) so its
+ * strings render in the active locale.
  *
- * @internal This is an internal API scoped to specific components.
- * Not exposed in the public package exports.
+ * `component` must be a key registered in `locale-registry.ts`. Mutates the
+ * shared `@lingui/core` i18n singleton, so host apps running their own
+ * lingui setup should keep a single source of truth.
  *
  * @example
  * ```tsx
- * import { ApI18nProvider } from '../../../i18n';
+ * import { ApI18nProvider } from '@uipath/apollo-react/i18n';
  *
- * function MyComponent() {
- *   return (
- *     <ApI18nProvider component="material/components/ap-chat">
- *       <ApChat chatServiceInstance={chatService} />
- *     </ApI18nProvider>
- *   );
- * }
+ * <ApI18nProvider component="material/components/ap-chat">
+ *   <ApChat chatServiceInstance={chatService} />
+ * </ApI18nProvider>
  * ```
  */
 export function ApI18nProvider({ component, locale: propLocale, children }: ApI18nProviderProps) {

--- a/packages/apollo-react/src/i18n/ApI18nProvider.tsx
+++ b/packages/apollo-react/src/i18n/ApI18nProvider.tsx
@@ -43,7 +43,7 @@ export interface ApI18nProviderProps {
 
 /**
  * Activates apollo-react's pre-built lingui catalogs for a given component
- * group. Wrap any apollo-react UI (e.g. <ApChat>, canvas components) so its
+ * group. Wrap any apollo-react UI (e.g. `<ApChat>`, canvas components) so its
  * strings render in the active locale.
  *
  * `component` must be a key registered in `locale-registry.ts`. Mutates the


### PR DESCRIPTION
Follow up to: https://github.com/UiPath/apollo-ui/pull/702 so that we can use `<ApI18nProvider>` in PO.Frontend.

To be consumed by: https://github.com/UiPath/PO.Frontend/pull/5462