### PR TITLE
feat(apollo-react): export Api18nProvider

### DIFF
--- a/packages/apollo-react/package.json
+++ b/packages/apollo-react/package.json
@@ -119,7 +119,12 @@
       "require": "./dist/canvas/constants.cjs"
     },
     "./canvas/xyflow/*.css": "./dist/canvas/xyflow/*.css",
-    "./canvas/styles/*.css": "./dist/canvas/styles/*.css"
+    "./canvas/styles/*.css": "./dist/canvas/styles/*.css",
+    "./i18n": {
+      "types": "./dist/i18n/index.d.ts",
+      "import": "./dist/i18n/index.js",
+      "require": "./dist/i18n/index.cjs"
+    }
   },
   "sideEffects": [
     "**/*.css",

--- a/packages/apollo-react/src/index.ts
+++ b/packages/apollo-react/src/index.ts
@@ -1,5 +1,6 @@
 // Core
 export * from './core';
-
+// i18n utilities
+export * from './i18n';
 // Theme utilities
 export * from './material';


### PR DESCRIPTION
Need to export i18n to get Api18nProvider
We are using translation from apollo-ui now which needs this provider otherwise it is showing error

before
error if provider is not added

<img width="2512" height="1383" alt="Screenshot 2026-05-20 at 12 31 29 PM" src="https://github.com/user-attachments/assets/acf69bf3-d13b-418b-93c5-bb75f943f327" />

after

https://github.com/user-attachments/assets/1cf85b53-27a9-4b43-b32f-d670b169427d

