### PR TITLE
fix(apollo-react): use safeLingui to get fallBack english strings

### DIFF
--- a/packages/apollo-react/src/canvas/components/StageNode/useStageNodeLabels.ts
+++ b/packages/apollo-react/src/canvas/components/StageNode/useStageNodeLabels.ts
@@ -1,5 +1,5 @@
-import { useLingui } from '@lingui/react';
 import { useMemo } from 'react';
+import { useSafeLingui } from '../../../i18n';
 import type { StageContextMenuLabels } from './StageNodeTaskUtilities';
 
 export interface StageNodeLabels {
@@ -16,7 +16,7 @@ export interface StageNodeLabels {
 }
 
 export function useStageNodeLabels(): StageNodeLabels {
-  const { _ } = useLingui();
+  const { _ } = useSafeLingui();
 
   return useMemo(
     () => ({

--- a/packages/apollo-react/src/canvas/components/StickyNoteNode/FormattingToolbar.tsx
+++ b/packages/apollo-react/src/canvas/components/StickyNoteNode/FormattingToolbar.tsx
@@ -1,6 +1,6 @@
-import { useLingui } from '@lingui/react';
 import { CanvasIcon } from '@uipath/apollo-react/canvas';
 import { memo, type RefObject, useCallback } from 'react';
+import { useSafeLingui } from '../../../i18n';
 import { CanvasTooltip } from '../CanvasTooltip';
 import type { ActiveFormats } from './markdown-formatting';
 import {
@@ -31,7 +31,7 @@ const FormattingToolbarComponent = ({
   activeFormats,
   onFormat,
 }: FormattingToolbarProps) => {
-  const { _ } = useLingui();
+  const { _ } = useSafeLingui();
   const mod = getModifierKey();
   const shift = isMac() ? '⇧' : '+Shift+';
 

--- a/packages/apollo-react/src/canvas/components/Toolbox/Toolbox.tsx
+++ b/packages/apollo-react/src/canvas/components/Toolbox/Toolbox.tsx
@@ -1,7 +1,7 @@
-import { useLingui } from '@lingui/react';
 import { useNavigationStack } from '@uipath/apollo-react/canvas/hooks';
 import { Column } from '@uipath/apollo-react/canvas/layouts';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useSafeLingui } from '../../../i18n';
 import { useListRef } from 'react-window';
 import {
   TOOLBOX_GAP,
@@ -156,7 +156,7 @@ export function Toolbox<T>({
   quickActions,
   renderEmptyState,
 }: ToolboxProps<T>) {
-  const { _ } = useLingui();
+  const { _ } = useSafeLingui();
   const searchPlaceholder = _({ id: 'toolbox.search', message: 'Search' });
   const [items, setItems] = useState<ListItem<T>[]>(initialItems);
   const [search, setSearch] = useState('');

--- a/packages/apollo-react/src/i18n/index.ts
+++ b/packages/apollo-react/src/i18n/index.ts
@@ -1,2 +1,3 @@
 export type { ApI18nProviderProps, SupportedLocale } from './ApI18nProvider';
 export { ApI18nProvider, SUPPORTED_LOCALES, useApI18n } from './ApI18nProvider';
+export { useSafeLingui } from './useSafeLingui';

--- a/packages/apollo-react/src/i18n/useSafeLingui.ts
+++ b/packages/apollo-react/src/i18n/useSafeLingui.ts
@@ -1,0 +1,25 @@
+import { LinguiContext } from '@lingui/react';
+import { useContext, useMemo } from 'react';
+
+type Descriptor = { id: string; message?: string; values?: Record<string, unknown> };
+type Translate = {
+  (descriptor: Descriptor): string;
+  (id: string): string;
+};
+
+// Returns the `message` (English default baked into the macro call) when no
+// I18nProvider is mounted upstream. Falls back to `id` if no message is given.
+const fallbackTranslate = ((arg: Descriptor | string): string =>
+  typeof arg === 'string' ? arg : (arg.message ?? arg.id)) as Translate;
+
+// Drop-in replacement for `useLingui()` from `@lingui/react` that does NOT
+// throw when there is no I18nProvider upstream. Reads `LinguiContext` directly
+// and returns the real translator when available, otherwise a fallback that
+// returns the English `message` baked into each descriptor.
+//
+// Use this in design-system components that need to render in hosts that
+// haven't (yet) wrapped them in `ApI18nProvider` / `I18nProvider`.
+export function useSafeLingui(): { _: Translate } {
+  const ctx = useContext(LinguiContext);
+  return useMemo(() => ({ _: (ctx?._ as Translate | undefined) ?? fallbackTranslate }), [ctx]);
+}


### PR DESCRIPTION
We are getting lingui error when ApI18nProvider is not used

created a safe fallback if not provided

before

<img width="2512" height="1383" alt="Screenshot 2026-05-20 at 3 51 29 PM" src="https://github.com/user-attachments/assets/22b86c67-f698-41ea-856b-89f2162cd0f8" />

after

<img width="2512" height="1383" alt="Screenshot 2026-05-20 at 3 51 09 PM" src="https://github.com/user-attachments/assets/36050320-096a-46df-bc35-6e648cb57eb5" />
