### PR TITLE
fix(repo): cleanup pipelines from private packages removal

### DIFF
--- a/.claude/skills/fix-security-vulnerabilities/SKILL.md
+++ b/.claude/skills/fix-security-vulnerabilities/SKILL.md
@@ -7,7 +7,7 @@ description: Use when fixing npm/pnpm security vulnerabilities, Dependabot alert
 
 ## Overview
 
-Fix each vulnerability by working through five steps in order. Stop as soon as one works. Never use `pnpm update --depth Infinity` — it doesn't reliably re-resolve locked transitive deps.
+Fix each vulnerability by working through five steps in order. Stop as soon as one works. Never use `pnpm update --depth Infinity` — it doesn't reliably re-resolve locked transitive deps. `pnpm update <pkg> -r` (no depth flag) is the right refresh tool when you need to nudge transitives — but verify after, since partial refreshes are common.
 
 **NEVER change audit-level. NEVER add overrides without exhausting the steps below.**
 
@@ -54,21 +54,26 @@ minimumReleaseAgeExclude:
 
 ---
 
-## Step 3: Transitive dependency → update a direct parent
+## Step 3: Transitive dependency → bump something in the chain
 
 If the vulnerable package is transitive (not in any workspace `package.json`):
 
 ```bash
-# Find which of YOUR direct dependencies pulls it in
-pnpm ls <vulnerable-package> --depth=20 2>/dev/null | head -40
+# Walk the full chain — useful to see which ancestor pins the offending range
+pnpm why <vulnerable-package> 2>&1 | head -40
 ```
 
-For each direct dependency in the chain, check if a minor/patch update pulls in a fixed version:
+Check **each ancestor in the chain** (not just direct deps — intermediate transitives also work, e.g. `engine.io-client` updated by `pnpm update <ancestor> -r`) and inspect the constraint type for the package below it:
 
 ```bash
-npm view <direct-dep>@latest version
-npm view <direct-dep>@latest dependencies.<intermediate-or-vuln-package>
+npm view <ancestor>@<locked-version> dependencies --json
+npm view <ancestor>@latest dependencies --json   # compare to latest
 ```
+
+**Constraint type matters:**
+- **caret (`^x.y.z`)** — typically auto-resolves to a new patch in the same major; a fresh `pnpm update -r` often does the job
+- **tilde (`~x.y.z`)** — locks to a specific minor (`>=x.y.z <x.y+1.0`). A tilde-pinned parent can NOT resolve to a higher minor of the child. If the fix is in a higher minor, the **only** options are: bump that parent itself (if a newer parent has widened the tilde) or override (Step 5).
+- **exact** — only the parent bump or override works.
 
 ### 3a. Vet before touching anything
 
@@ -86,37 +91,44 @@ pnpm audit  # verify it's gone
 
 ---
 
-## Step 4: Transitive with ^ range → temp devDep trick
+## Step 4: Refresh the transitive resolution
 
-If no direct dependency update is available but the parent package uses a `^` range for the vulnerable package:
-
-```bash
-# Verify the parent uses ^ (not exact)
-npm view <parent-package>@<locked-version> dependencies.<vulnerable-package>
-# Must output something like "^2.17.0", not "2.17.0"
-```
+When the parent uses `^` and a higher version of the vulnerable package is already valid under that range, force pnpm to re-resolve.
 
 ### 4a. Vet before touching anything
 
-Complete the **full supply-chain vetting protocol** below for `<vulnerable-package>@<fix-version>`. Do not run `pnpm add` until vetting passes.
+Complete the **full supply-chain vetting protocol** below for `<vulnerable-package>@<fix-version>`. Do not run any install command until vetting passes.
 
 If the fix version is younger than 14 days, add it to `minimumReleaseAgeExclude` before installing.
 
 ### 4b. Install (only after vetting passes)
 
+Try the simplest tool first:
+
 ```bash
-# 1. Add temporarily
-pnpm add -D <vulnerable-package>@<fix-version> --filter <workspace-package>
-
-# 2. Verify
-pnpm audit
-
-# 3. Remove — the lockfile entry is now updated
-pnpm remove <vulnerable-package> --filter <workspace-package>
-pnpm audit  # should still be clean
+pnpm update <vulnerable-package> -r
+pnpm audit                                # confirm all paths cleared
+grep -E "^  <vulnerable-package>@" pnpm-lock.yaml | sort -u   # spot any stuck versions
+pnpm why <vulnerable-package>             # only if audit still flags entries — shows which path is stuck
+git diff --stat                           # see scope of side effects before staging
 ```
 
-If the parent uses an exact (non-`^`) version, this trick won't work — skip to Step 5.
+**Side effects of `pnpm update -r` to watch for:**
+- If the target is *also* a direct dep, package.json gets bumped (and alphabetically re-sorted). For transitive-only fixes, package.json should be untouched — if it changed, the target was actually direct and you may want to keep the bump or revert it.
+- Bumping a transitive may cascade — its own transitives can shift. Inspect the lockfile diff before assuming "1 line changed."
+- Peer-dep disambiguation suffixes (the long `(pkg@ver)(pkg2@ver2)` qualifiers in `pnpm-lock.yaml`) can shift across many unrelated entries. Usually cosmetic — confirm by checking that no *actual resolved version* changed (the keys like `pkg@x.y.z:` at the top of each entry block).
+
+**Partial refreshes are common.** `pnpm update -r` often clears most paths but leaves one or two stuck behind tilde-range or exact-version parents. If audit still flags entries:
+
+1. **Inspect the stuck path** with `pnpm why` and look at the constraint at the lowest level that still pins the vulnerable version.
+2. If that constraint is `^`, the temp devDep trick can sometimes nudge it:
+   ```bash
+   pnpm add -D <vulnerable-package>@<fix-version> --filter <workspace-package>
+   pnpm audit
+   pnpm remove <vulnerable-package> --filter <workspace-package>
+   ```
+3. If the stuck constraint is tilde or exact, the trick won't help. Try **bumping the ancestor that holds the tighter range** — if it has a newer version with a widened range, `pnpm update <ancestor> -r` may resolve the child naturally without any override at all. (Real example: `engine.io-client@6.6.4` pinned `ws ~8.18.3`; bumping to `6.6.5` pinned `ws ~8.20.1`, closing the path with no override.)
+4. If nothing in the chain can be moved, fall through to Step 5.
 
 ---
 
@@ -132,10 +144,22 @@ If the fix version is younger than 14 days, add it to `minimumReleaseAgeExclude`
 
 ### 5b. Install (only after vetting passes)
 
+Prefer the most surgical override that fixes the issue:
+
 ```yaml
 # pnpm-workspace.yaml
 overrides:
+  # Most surgical: only override when this specific parent → child path resolves.
+  # Use when only one chain is stuck and other paths already resolved correctly.
+  <parent>><vulnerable-package>: "^<fixed-version>"  # <reason>
+
+  # Blanket: forces all resolutions of the package. Use when multiple paths are stuck
+  # or the same vulnerable range could re-appear in future installs.
   <vulnerable-package>: "^<fixed-version>"  # <reason>: <parent>@<ver> pins exact <old-ver>, no parent update available as of <date>
+
+  # Version-bounded: only override when the existing range would resolve to a vulnerable version.
+  # Safer than blanket when the package has legitimately non-vulnerable older majors in the tree.
+  <vulnerable-package>@>=<vuln-start>: "^<fixed-version>"
 ```
 
 Then `pnpm install`. Then run the full verify section below.
@@ -262,8 +286,9 @@ If `pnpm check:dependencies` fails after a fix, run `pnpm fix:dependencies` to a
 | Every fix | Complete supply-chain vetting with `npm view` before editing files or installing |
 | Package < 14 days old | Vetting required (as always) + add to `minimumReleaseAgeExclude` after vetting passes |
 | Direct dep | Vet, then bump version in package.json |
-| Transitive, direct parent has minor/patch update with fix | Vet parent + transitive dep, then update the direct parent |
-| Transitive, parent uses `^` range | Vet, then temp devDep trick — Step 4 |
-| Transitive, parent uses exact version, no parent update | Vet, then override in pnpm-workspace.yaml |
+| Transitive, any ancestor has a newer version with the fix in range | Vet, then `pnpm update <ancestor> -r` — Step 3 |
+| Transitive, parent uses `^` range | Vet, then `pnpm update <pkg> -r` (Step 4); fall back to temp devDep trick if partial |
+| Transitive, parent uses `~` or exact, but a newer ancestor widens the range | Vet, bump that ancestor — Step 3/4 |
+| Transitive, nothing in chain can be moved | Vet, then targeted override in pnpm-workspace.yaml — Step 5 (prefer `parent>child` syntax over blanket) |
 | No patched version exists | Document and monitor |
 | Any supply-chain check fails | Stop — report findings, do not install |

--- a/.claude/skills/harden-github-action/SKILL.md
+++ b/.claude/skills/harden-github-action/SKILL.md
@@ -25,7 +25,7 @@ Do **not** use this skill for:
 - **Package manager**: pnpm 11.x
 - **Node version**: 22
 - **Workspaces**: Turborepo monorepo (`packages/`, `web-packages/`, `apps/`)
-- **Dual registry**: npm public + GitHub Packages (`@uipath` scope at `https://npm.pkg.github.com`)
+- **Dual-publish, single-install**: packages publish to both npm public and GitHub Packages (`@uipath` scope on GHP). CI **installs** only from npm public — no `.npmrc` in repo, no GHP credentials needed at install time. GHP credentials still flow to publish/cleanup steps.
 - **Composite install action**: `.github/actions/install-node-deps/action.yml` — always prefer this over manual setup
 - **Security scanner**: zizmor (via `security-scan.yml`); suppression config at `zizmor.yml`
 - **Workspace quarantine**: `pnpm-workspace.yaml` has `minimumReleaseAge: 20160` (14 days), `blockExoticSubdeps: true`, and a `minimumReleaseAgeExclude` list managed by the weekly `prune-release-age-exemptions.yml` workflow
@@ -157,9 +157,9 @@ Always use `./.github/actions/install-node-deps` instead of manually setting up 
 ```yaml
 - name: Install Node dependencies
   uses: ./.github/actions/install-node-deps
-  with:
-    registry-token: ${{ github.token }}
 ```
+
+The composite action takes no required inputs. No `registry-token`, no `packages: read` permission, no GHP auth — all `@uipath/*` deps resolve from npm public. If a future change reintroduces GHP-only install deps, restore the input + permission and document why.
 
 **Never:**
 - Run `pnpm install` without `--frozen-lockfile` in CI — the composite action always uses it
@@ -186,9 +186,11 @@ env:
 
 **Three token classes in this repo, each step-scoped:**
 
-- `github.token` with `packages: read` at job level — used for **installing** private `@uipath/*` packages from GHP. Pass it to the composite action's `registry-token` input. Do not re-expose at workflow or job level.
-- GitHub App installation token (`steps.app-token.outputs.token`) — used for `GH_NPM_REGISTRY_TOKEN` in **GHP publish/unpublish** steps and for **git push / PR creation** in release flows. Mint via `actions/create-github-app-token` with `permission-*` inputs scoped to the minimum needed.
+- `${{ github.token }}` (the default GITHUB_TOKEN) — used as `GH_NPM_REGISTRY_TOKEN` for **GHP publish / unpublish / cleanup** steps in `release.yml`, `dev-publish.yml`, and `dev-cleanup.yml`. Requires `packages: write` on the publishing/cleanup job (never the workflow). Lives in the step's `env:` block; do not raise to workflow or job scope.
+- GitHub App installation token (`steps.app-token.outputs.token`) — used **only** for pushing the version-bump commit in `release.yml`'s `commit-version-bump` job, which runs on an isolated runner separated from the release/publish job. Mint via `actions/create-github-app-token` with `permission-contents: write`. Never used for npm/GHP publishing.
 - **npm.org publishing uses OIDC Trusted Publishing — there is no npm token in CI.** The publishing job declares `id-token: write` and the `@uipath/*` package's npm Trusted Publisher entry pins this repo + `release.yml`. pnpm 11 detects the OIDC env vars set by Actions and exchanges them for a short-lived publish token automatically.
+
+**Install needs no token.** Since CI installs only from npm public, the composite install action takes no `registry-token` and jobs do not need `packages: read`.
 
 ---
 
@@ -354,8 +356,6 @@ jobs:
 
       - name: Install Node dependencies
         uses: ./.github/actions/install-node-deps
-        with:
-          registry-token: ${{ github.token }}
 
       - name: Cache Turborepo
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
@@ -395,8 +395,7 @@ Use this checklist when reviewing or hardening any workflow file.
 
 ### Install Pattern
 - [ ] All install steps use `./.github/actions/install-node-deps`
-- [ ] `registry-token: ${{ github.token }}` is passed to the composite action (job must have `packages: read`)
-- [ ] Only `registry-token` is passed to the composite action — `registry-url`/`scope` are baked in
+- [ ] No `registry-token` argument passed and no `packages: read` permission on the job — CI installs from npm public only
 - [ ] No raw `pnpm install` without `--frozen-lockfile`
 - [ ] No `pnpm dlx` / `pnpx` / `npx -y` for packages already in devDependencies — use `pnpm exec`
 

--- a/.github/actions/install-node-deps/action.yml
+++ b/.github/actions/install-node-deps/action.yml
@@ -1,14 +1,11 @@
 name: Install Node dependencies
-description: Sets up pnpm + Node and runs `pnpm install --frozen-lockfile` against the @uipath GHP registry.
+description: Sets up pnpm + Node and runs `pnpm install --frozen-lockfile`.
 
 inputs:
   node-version:
     description: Node major version
     required: false
     default: "22"
-  registry-token:
-    description: GitHub PAT with read:packages for the @uipath GHP registry.
-    required: true
 
 runs:
   using: composite
@@ -21,11 +18,7 @@ runs:
       with:
         node-version: ${{ inputs.node-version }}
         cache: pnpm
-        registry-url: "https://npm.pkg.github.com"
-        scope: "@uipath"
 
     - name: Install dependencies
       shell: bash
-      env:
-        GH_NPM_REGISTRY_TOKEN: ${{ inputs.registry-token }}
       run: pnpm install --frozen-lockfile

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -98,7 +98,6 @@ When any PR touches `.github/workflows/`, `.github/actions/`, `.npmrc`, `pnpm-wo
 
 **Install safety**
 - [ ] Every `pnpm install` uses `--frozen-lockfile` — use `./.github/actions/install-node-deps`, never call pnpm directly
-- [ ] `registry-token: ${{ github.token }}` is passed to the composite install action (job must have `packages: read`)
 - [ ] No bare `pnpm dlx <pkg>` / `npx -y <pkg>` without exact version pin
 - [ ] Approved pinned `pnpm dlx` versions: `shadcn@4.4.0`, `serve@14.2.6`, `tsx@4.20.6` — changes require same review bar as dependency updates
 - [ ] New `minimumReleaseAgeExclude` entries in `pnpm-workspace.yaml` include exact version + reason: `- 'pkg'  # x.y.z — reason`
@@ -134,7 +133,7 @@ Flag these patterns immediately:
 | **`workflow_run` without head-repo guard** | `on: workflow_run` without `if: github.event.workflow_run.head_repository.full_name == github.repository` | No `workflow_run` trigger in repo; add guard if ever introduced |
 | **Maintainer account takeover / burst publish** | Package receives 3+ new versions in a 6-minute window; new maintainer added within last 30 days; unusual publish time | `monitor-npm-publishes.yml` flags version-to-release mismatch; check socket.dev for maintainer changes |
 | **Forged bot commit identity** | Version-bump commit where committer email ≠ `semantic-release-bot@users.noreply.github.com` | Check committer email on release commits; semantic-release-bot identity is fixed in `release.yml` git config step |
-| **Dependency confusion** | `.npmrc` change to `@uipath` registry routing | `@uipath:registry=https://npm.pkg.github.com`; all 4 names claimed on npm.org |
+| **Dependency confusion** | New `.npmrc` adding `@uipath` registry routing, or `publishConfig.registry` change pointing `@uipath` at a non-npm.org registry | No `.npmrc` in repo; all 4 names claimed on npm.org; publish script pins `--@uipath:registry=https://registry.npmjs.org` for the npm.org publish step |
 | **Workflow injection** | `${{ github.event.*.title }}` etc. in `run:` blocks | Pass via `env:` |
 | **Compromised maintainer / day-zero** | Any production dep update without verifying age, changelog, and postinstall scripts | `minimumReleaseAge: 20160` (14d quarantine); `npm audit signatures` |
 | **Fork secret exfiltration** | Missing `fork == false` guard; `pull_request_target` | All publish/secret jobs guarded |

--- a/.github/workflows/apollo-vertex-lint.yml
+++ b/.github/workflows/apollo-vertex-lint.yml
@@ -13,7 +13,6 @@ concurrency:
 
 permissions:
   contents: read
-  packages: read
 
 jobs:
   lint:
@@ -28,8 +27,6 @@ jobs:
 
       - name: Install Node dependencies
         uses: ./.github/actions/install-node-deps
-        with:
-          registry-token: ${{ github.token }}
 
       - name: Lint
         run: pnpm --filter apollo-vertex lint

--- a/.github/workflows/apollo-vertex-registry-check.yml
+++ b/.github/workflows/apollo-vertex-registry-check.yml
@@ -41,7 +41,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      packages: read
     outputs:
       matrix: ${{ steps.matrix.outputs.result }}
     steps:
@@ -52,8 +51,6 @@ jobs:
 
       - name: Install Node dependencies
         uses: ./.github/actions/install-node-deps
-        with:
-          registry-token: ${{ github.token }}
 
       - name: Build registry
         run: pnpm --filter apollo-vertex registry:build
@@ -114,6 +111,9 @@ jobs:
     needs: [detect-changes, prepare]
     if: needs.detect-changes.outputs.has_vertex_changes == 'true' && github.event.pull_request.head.repo.fork == false
     runs-on: ubuntu-latest
+    # Simulates a downstream consumer installing apollo-vertex shadcn components
+    # into a fresh project. Some components pull in @uipath/proteus-client, which
+    # is GHP-only — so this job needs GHP read auth on its setup-node + test step.
     permissions:
       contents: read
       packages: read

--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -10,13 +10,11 @@ concurrency:
 
 permissions:
   contents: read
-  packages: read
 
 jobs:
   commitlint:
     name: Validate Commit Messages
     runs-on: ubuntu-latest
-    # @uipath/* packages on GHP are private — fork PRs cannot install them even with GITHUB_TOKEN.
     if: github.event.pull_request.head.repo.fork == false
     steps:
       - name: Checkout code
@@ -27,8 +25,6 @@ jobs:
 
       - name: Install Node dependencies
         uses: ./.github/actions/install-node-deps
-        with:
-          registry-token: ${{ github.token }}
 
       - name: Validate commit messages
         if: github.event_name == 'pull_request'

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -33,7 +33,6 @@ jobs:
     permissions:
       contents: read
       issues: write
-      packages: read
       pull-requests: write
     steps:
       - name: Checkout
@@ -43,8 +42,6 @@ jobs:
 
       - name: Install Node dependencies
         uses: ./.github/actions/install-node-deps
-        with:
-          registry-token: ${{ github.token }}
 
       - name: Check licenses
         id: check

--- a/.github/workflows/dev-cleanup.yml
+++ b/.github/workflows/dev-cleanup.yml
@@ -34,8 +34,6 @@ jobs:
 
       - name: Install Node dependencies
         uses: ./.github/actions/install-node-deps
-        with:
-          registry-token: ${{ github.token }}
 
       - name: Get published packages from PR comment
         id: packages

--- a/.github/workflows/dev-publish.yml
+++ b/.github/workflows/dev-publish.yml
@@ -25,7 +25,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      packages: read
       issues: read
     outputs:
       has_label: ${{ steps.check-label.outputs.has_label }}
@@ -172,8 +171,6 @@ jobs:
 
       - name: Install Node dependencies
         uses: ./.github/actions/install-node-deps
-        with:
-          registry-token: ${{ github.token }}
 
       - name: Cleanup previous version
         env:
@@ -198,7 +195,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      packages: read
       pull-requests: write
     steps:
       - name: Checkout code
@@ -208,8 +204,6 @@ jobs:
 
       - name: Install Node dependencies
         uses: ./.github/actions/install-node-deps
-        with:
-          registry-token: ${{ github.token }}
 
       - name: Create initial PR comment
         env:
@@ -242,8 +236,6 @@ jobs:
 
       - name: Install Node dependencies
         uses: ./.github/actions/install-node-deps
-        with:
-          registry-token: ${{ github.token }}
 
       # Compute the full version up front so the PR comment row can be updated
       # even when later steps (App token mint, build, publish) fail. Otherwise
@@ -315,7 +307,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      packages: read
       pull-requests: write
     steps:
       - name: Update PR comment with cleanup status

--- a/.github/workflows/notify-vertex-updates.yml
+++ b/.github/workflows/notify-vertex-updates.yml
@@ -8,7 +8,6 @@ on:
 
 permissions:
   contents: read
-  packages: read
 
 jobs:
   notify:
@@ -23,8 +22,6 @@ jobs:
 
       - name: Install Node dependencies
         uses: ./.github/actions/install-node-deps
-        with:
-          registry-token: ${{ github.token }}
 
       - name: Notify changed components
         env:

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -15,14 +15,11 @@ concurrency:
 
 permissions:
   contents: read
-  packages: read
 
 jobs:
   checks:
     name: ${{ matrix.check }}
     runs-on: ubuntu-latest
-    # @uipath/* packages on GHP are private — fork PRs cannot install them even with GITHUB_TOKEN.
-    # To support external contributors, make @uipath/* packages publicly readable on GHP.
     if: github.event.pull_request.head.repo.fork == false
     strategy:
       fail-fast: false
@@ -46,8 +43,6 @@ jobs:
 
       - name: Install Node dependencies
         uses: ./.github/actions/install-node-deps
-        with:
-          registry-token: ${{ github.token }}
 
       - name: Cache Turborepo
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
@@ -161,8 +156,6 @@ jobs:
 
       - name: Install Node dependencies
         uses: ./.github/actions/install-node-deps
-        with:
-          registry-token: ${{ github.token }}
 
       - name: Run Audit All Dependencies
         if: matrix.check == 'Audit All Dependencies'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,8 +44,6 @@ jobs:
         env:
           ACTIONS_ID_TOKEN_REQUEST_URL: ""
           ACTIONS_ID_TOKEN_REQUEST_TOKEN: ""
-        with:
-          registry-token: ${{ github.token }}
 
       - name: Cache Turborepo
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
@@ -81,8 +79,13 @@ jobs:
           git config --global user.name "semantic-release-bot"
           git config --global user.email "semantic-release-bot@users.noreply.github.com"
           # Credential helper reads GITHUB_TOKEN from env on demand. Set only on
-          # the Release step → no leak to later steps that don't push.
-          git config --global credential.helper \
+          # the Release step → no leak to later steps that don't push. The single
+          # quotes are intentional: git invokes the helper later in a fresh shell
+          # which expands $GITHUB_TOKEN at credential-lookup time, not now.
+          # URL-scoped to github.com so a stray `git push` to any other host can't
+          # exfiltrate the token through this helper.
+          # shellcheck disable=SC2016
+          git config --global credential.https://github.com.helper \
             '!f() { test -n "$GITHUB_TOKEN" || exit 1; echo "username=x-access-token"; echo "password=$GITHUB_TOKEN"; }; f'
 
       - name: Release

--- a/.github/workflows/vercel-deploy.yml
+++ b/.github/workflows/vercel-deploy.yml
@@ -92,7 +92,6 @@ jobs:
     continue-on-error: true
     permissions:
       contents: read
-      packages: read
     strategy:
       matrix:
         include:
@@ -125,8 +124,6 @@ jobs:
 
       - name: Install Node dependencies
         uses: ./.github/actions/install-node-deps
-        with:
-          registry-token: ${{ github.token }}
 
       - name: Restore Turborepo cache
         uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4

--- a/.github/workflows/vercel-deploy.yml
+++ b/.github/workflows/vercel-deploy.yml
@@ -89,10 +89,12 @@ jobs:
     runs-on: ubuntu-latest
     needs: pre-deploy
     if: ${{ !cancelled() && (github.event_name == 'push' || (needs.pre-deploy.result == 'success' && github.event.pull_request.head.repo.fork == false)) }}
-    continue-on-error: true
     permissions:
       contents: read
     strategy:
+      # Let every project deploy attempt complete so the PR comment surfaces all outcomes;
+      # a failure in one entry should not cancel the others, but should still fail the workflow.
+      fail-fast: false
       matrix:
         include:
           - project_name: apollo-design
@@ -205,7 +207,6 @@ jobs:
 
       - name: Deploy to Vercel
         id: deploy
-        continue-on-error: true
         run: |
           ERROR_MSG=""
           DEPLOY_URL=""
@@ -213,7 +214,11 @@ jobs:
           # Run from repo root — same reasoning as vercel build above.
           # Vercel applies rootDirectory from project settings to locate
           # the .vercel/output/ directory created by the build step.
-          VERCEL_ARGS=(deploy --prebuilt --yes)
+          # --archive=tgz: package the prebuilt output as a single tarball before
+          # upload. Without it, each file in .vercel/output/ counts as a separate
+          # upload against the 40k/day api-upload-paid quota — Storybook + shadcn
+          # registries blow through that quickly across 5 projects × N PRs/day.
+          VERCEL_ARGS=(deploy --prebuilt --archive=tgz --yes)
           [[ -n "$PROD_FLAG" ]] && VERCEL_ARGS+=("$PROD_FLAG")
           DEPLOY_OUTPUT=$(vercel "${VERCEL_ARGS[@]}" 2>&1)
           DEPLOY_EXIT_CODE=$?
@@ -224,6 +229,13 @@ jobs:
               DEPLOY_OUTPUT="${DEPLOY_OUTPUT//$__secret/***}"
             fi
           done
+
+          # Always echo the full vercel CLI output so the runner log is traceable
+          # without having to download the deploy-result artifact. Collapsible so
+          # successful runs stay tidy.
+          echo "::group::vercel CLI output (exit $DEPLOY_EXIT_CODE)"
+          printf '%s\n' "$DEPLOY_OUTPUT"
+          echo "::endgroup::"
 
           if [ "$DEPLOY_EXIT_CODE" -eq 0 ]; then
             if [ "$PROD_FLAG" == "--prod" ]; then
@@ -241,12 +253,26 @@ jobs:
             } >> "$GITHUB_OUTPUT"
             echo "✅ Deployed ${{ matrix.project_name }} to $DEPLOY_URL" >> "$GITHUB_STEP_SUMMARY"
           else
-            ERROR_MSG=$(echo "$DEPLOY_OUTPUT" | tail -n 5 | tr '\n' ' ')
+            # Prefer the actual `Error: …` line over a blind `tail -n 5`, which
+            # often grabs upload progress bars or Node stack-trace frames and
+            # hides the root cause.
+            ERROR_MSG=$(echo "$DEPLOY_OUTPUT" | grep -m1 -E '^Error: ' || true)
+            if [ -z "$ERROR_MSG" ]; then
+              ERROR_MSG=$(echo "$DEPLOY_OUTPUT" | tail -n 5 | tr '\n' ' ')
+            fi
             if [ "${#ERROR_MSG}" -gt 500 ]; then
               ERROR_MSG="${ERROR_MSG:0:500}..."
             fi
             echo "error_message=$ERROR_MSG" >> "$GITHUB_OUTPUT"
             echo "❌ Failed to deploy ${{ matrix.project_name }}: $ERROR_MSG" >> "$GITHUB_STEP_SUMMARY"
+            # Escape %, CR, LF before interpolating into a workflow command so a
+            # malformed/hostile error string can't break the annotation or inject
+            # a second `::workflow-command::` via an embedded newline. Order
+            # matters: % must be escaped first, since later subs emit %.
+            ERROR_ANNOTATION="${ERROR_MSG//%/%25}"
+            ERROR_ANNOTATION="${ERROR_ANNOTATION//$'\r'/%0D}"
+            ERROR_ANNOTATION="${ERROR_ANNOTATION//$'\n'/%0A}"
+            echo "::error title=Vercel deploy failed for ${{ matrix.project_name }}::$ERROR_ANNOTATION"
             exit 1
           fi
         env:

--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,0 @@
-@uipath:registry=https://npm.pkg.github.com
-//npm.pkg.github.com/:_authToken=${GH_NPM_REGISTRY_TOKEN}
-//npm.pkg.github.com/:always-auth=true

--- a/apps/apollo-vertex/package.json
+++ b/apps/apollo-vertex/package.json
@@ -21,7 +21,7 @@
   "keywords": [],
   "author": "",
   "license": "ISC",
-  "packageManager": "pnpm@11.1.1",
+  "packageManager": "pnpm@11.1.3",
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "node": ">=22",
     "pnpm": ">=11"
   },
-  "packageManager": "pnpm@11.1.1",
+  "packageManager": "pnpm@11.1.3",
   "lint-staged": {
     "*.{js,jsx,ts,tsx,json}": [
       "biome check --write --no-errors-on-unmatched"

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "stylelint-config-standard": "^36.0.1",
     "stylelint-config-tailwindcss": "^1.0.0",
     "tsx": "^4.20.6",
-    "turbo": "^2.6.0",
+    "turbo": "^2.9.14",
     "typescript": "^5.9.3",
     "vitest": "^4.1.5"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6265,7 +6265,7 @@ packages:
       typescript: '*'
 
   '@uipath/uipath-typescript@1.3.1':
-    resolution: {integrity: sha512-fahNaE63XE4yP+pIkwqThSApgU+0AeLw/UvUPDqrHp9xfVSDNCeoGcKaSeUZirNV7TXOkWiLbBRV0MJvSwQAXA==, tarball: https://npm.pkg.github.com/download/@uipath/uipath-typescript/1.3.1/e2296394adccb2cb1467968eacfb501106443100}
+    resolution: {integrity: sha512-fahNaE63XE4yP+pIkwqThSApgU+0AeLw/UvUPDqrHp9xfVSDNCeoGcKaSeUZirNV7TXOkWiLbBRV0MJvSwQAXA==}
     peerDependencies:
       zod: ^4.2.1
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,8 +81,8 @@ importers:
         specifier: ^4.20.6
         version: 4.20.6
       turbo:
-        specifier: ^2.6.0
-        version: 2.6.1
+        specifier: ^2.9.14
+        version: 2.9.14
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -5969,6 +5969,36 @@ packages:
       '@types/node':
         optional: true
 
+  '@turbo/darwin-64@2.9.14':
+    resolution: {integrity: sha512-t7QiPflaEyBE4oayeZtSmu4mEfjgIrcNlNNl1z1dmIVPqEdtA7+CfTf8d7KXsOGPh6aNgWjKxyvQg9uGfDQF+A==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@turbo/darwin-arm64@2.9.14':
+    resolution: {integrity: sha512-d23147mC9BsCPA9mJ0h/ubcpbRgcJBXbcG3+Vq7YLhjz3IXuvQsJ1UXH8f4MD76ZjJ4m/E4aRdJV+MW88CDfbw==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@turbo/linux-64@2.9.14':
+    resolution: {integrity: sha512-P3ZKB5tuUDdDQWuAsACGUR1qv9W7BNWxdxqVJ0kZNuNNPRaVYTPPikLcp79+GiEcW3npsR+KyP38lnQiBc5aSA==}
+    cpu: [x64]
+    os: [linux]
+
+  '@turbo/linux-arm64@2.9.14':
+    resolution: {integrity: sha512-ZRTlzcUMrrPv9ZuDzRF9n60Ym13bKeG9jDB8WjxyLhWNzV+AJQN+zdpIk3NJYf2zQsGUm1mNar2P0elRzLw25g==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@turbo/windows-64@2.9.14':
+    resolution: {integrity: sha512-exanwN6sIduZwykYeiTQj8kCmOhazP5WOz3bvXMcYtjhL6Z3iRWLewKrXCBq0bqwSP3iBMb/AerRCnHI4lx46A==}
+    cpu: [x64]
+    os: [win32]
+
+  '@turbo/windows-arm64@2.9.14':
+    resolution: {integrity: sha512-fVdCsnmYoKICsycbWuuGp6Jvi51/3G/UluFWuAUCvR8PIW5IJkAk5BM9UF8PSm0Q2IphWHFZjYEgjHsh3B9y/g==}
+    cpu: [arm64]
+    os: [win32]
+
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
@@ -6742,8 +6772,8 @@ packages:
   bottleneck@2.19.5:
     resolution: {integrity: sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==}
 
-  brace-expansion@5.0.5:
-    resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
+  brace-expansion@5.0.6:
+    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
     engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
@@ -7713,8 +7743,8 @@ packages:
     resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
     engines: {node: '>= 0.8'}
 
-  engine.io-client@6.6.4:
-    resolution: {integrity: sha512-+kjUJnZGwzewFDw951CDWcwj35vMNf2fcj7xQWOctq1F2i1jkDdVvdFG9kM/BEChymCH36KgjnW0NsL58JYRxw==}
+  engine.io-client@6.6.5:
+    resolution: {integrity: sha512-QCwxUDULPlXv8F6tqMMKx5dNkTe6OaBYRMPYeXKBlyOoKvAmE0ac6pW7fFhSscJ/5SI7666/U/B+MElbsrJlIg==}
 
   engine.io-parser@5.2.3:
     resolution: {integrity: sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==}
@@ -11016,6 +11046,9 @@ packages:
   react-is@19.2.3:
     resolution: {integrity: sha512-qJNJfu81ByyabuG7hPFEbXqNcWSU3+eVus+KJs+0ncpGfMyYdvSmxiJxbWR65lYi1I+/0HBcliO029gc4F+PnA==}
 
+  react-is@19.2.6:
+    resolution: {integrity: sha512-XjBR15BhXuylgWGuslhDKqlSayuqvqBX91BP8pauG8kd1zY8kotkNWbXksTCNRarse4kuGbe2kIY05ARtwNIvw==}
+
   react-joyride@3.0.2:
     resolution: {integrity: sha512-Tm+zXo/O8rFOUkN1yH+t38HqLvOCB8p5JTqgQD3IlLyZGCXzJEnCXtyB/BQIUC7X07kEaw0BqtKjWFzF4fyDVw==}
     peerDependencies:
@@ -12251,38 +12284,8 @@ packages:
     resolution: {integrity: sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==}
     engines: {node: '>=0.6.11 <=0.7.0 || >=0.7.3'}
 
-  turbo-darwin-64@2.6.1:
-    resolution: {integrity: sha512-Dm0HwhyZF4J0uLqkhUyCVJvKM9Rw7M03v3J9A7drHDQW0qAbIGBrUijQ8g4Q9Cciw/BXRRd8Uzkc3oue+qn+ZQ==}
-    cpu: [x64]
-    os: [darwin]
-
-  turbo-darwin-arm64@2.6.1:
-    resolution: {integrity: sha512-U0PIPTPyxdLsrC3jN7jaJUwgzX5sVUBsKLO7+6AL+OASaa1NbT1pPdiZoTkblBAALLP76FM0LlnsVQOnmjYhyw==}
-    cpu: [arm64]
-    os: [darwin]
-
-  turbo-linux-64@2.6.1:
-    resolution: {integrity: sha512-eM1uLWgzv89bxlK29qwQEr9xYWBhmO/EGiH22UGfq+uXr+QW1OvNKKMogSN65Ry8lElMH4LZh0aX2DEc7eC0Mw==}
-    cpu: [x64]
-    os: [linux]
-
-  turbo-linux-arm64@2.6.1:
-    resolution: {integrity: sha512-MFFh7AxAQAycXKuZDrbeutfWM5Ep0CEZ9u7zs4Hn2FvOViTCzIfEhmuJou3/a5+q5VX1zTxQrKGy+4Lf5cdpsA==}
-    cpu: [arm64]
-    os: [linux]
-
-  turbo-windows-64@2.6.1:
-    resolution: {integrity: sha512-buq7/VAN7KOjMYi4tSZT5m+jpqyhbRU2EUTTvp6V0Ii8dAkY2tAAjQN1q5q2ByflYWKecbQNTqxmVploE0LVwQ==}
-    cpu: [x64]
-    os: [win32]
-
-  turbo-windows-arm64@2.6.1:
-    resolution: {integrity: sha512-7w+AD5vJp3R+FB0YOj1YJcNcOOvBior7bcHTodqp90S3x3bLgpr7tE6xOea1e8JkP7GK6ciKVUpQvV7psiwU5Q==}
-    cpu: [arm64]
-    os: [win32]
-
-  turbo@2.6.1:
-    resolution: {integrity: sha512-qBwXXuDT3rA53kbNafGbT5r++BrhRgx3sAo0cHoDAeG9g1ItTmUMgltz3Hy7Hazy1ODqNpR+C7QwqL6DYB52yA==}
+  turbo@2.9.14:
+    resolution: {integrity: sha512-BQqXRr4UoWI3UPFrtznCLykYHxwxWh53iCB57x092jPMjIlW1wnm3N895g5irpiXmnxUhREBB0n6+y8BHhs4nw==}
     hasBin: true
 
   tw-animate-css@1.4.0:
@@ -12863,8 +12866,8 @@ packages:
       utf-8-validate:
         optional: true
 
-  ws@8.18.3:
-    resolution: {integrity: sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==}
+  ws@8.20.1:
+    resolution: {integrity: sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -15411,7 +15414,7 @@ snapshots:
       clsx: 2.1.1
       prop-types: 15.8.1
       react: 19.2.3
-      react-is: 19.2.3
+      react-is: 19.2.6
     optionalDependencies:
       '@types/react': 19.2.8
 
@@ -17792,6 +17795,24 @@ snapshots:
     optionalDependencies:
       '@types/node': 24.10.1
 
+  '@turbo/darwin-64@2.9.14':
+    optional: true
+
+  '@turbo/darwin-arm64@2.9.14':
+    optional: true
+
+  '@turbo/linux-64@2.9.14':
+    optional: true
+
+  '@turbo/linux-arm64@2.9.14':
+    optional: true
+
+  '@turbo/windows-64@2.9.14':
+    optional: true
+
+  '@turbo/windows-arm64@2.9.14':
+    optional: true
+
   '@tybys/wasm-util@0.10.1':
     dependencies:
       tslib: 2.8.1
@@ -18685,7 +18706,7 @@ snapshots:
 
   bottleneck@2.19.5: {}
 
-  brace-expansion@5.0.5:
+  brace-expansion@5.0.6:
     dependencies:
       balanced-match: 4.0.4
 
@@ -19723,12 +19744,12 @@ snapshots:
 
   encodeurl@2.0.0: {}
 
-  engine.io-client@6.6.4:
+  engine.io-client@6.6.5:
     dependencies:
       '@socket.io/component-emitter': 3.1.2
       debug: 4.4.3
       engine.io-parser: 5.2.3
-      ws: 8.18.3
+      ws: 8.20.1
       xmlhttprequest-ssl: 2.1.2
     transitivePeerDependencies:
       - bufferutil
@@ -20727,7 +20748,7 @@ snapshots:
       '@types/ws': 8.18.1
       entities: 7.0.1
       whatwg-mimetype: 3.0.0
-      ws: 8.18.3
+      ws: 8.20.1
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -21499,7 +21520,7 @@ snapshots:
       whatwg-encoding: 3.1.1
       whatwg-mimetype: 4.0.0
       whatwg-url: 15.1.0
-      ws: 8.18.3
+      ws: 8.20.1
       xml-name-validator: 5.0.0
     transitivePeerDependencies:
       - bufferutil
@@ -22455,7 +22476,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.5
+      brace-expansion: 5.0.6
 
   minimist@1.2.7: {}
 
@@ -23637,6 +23658,8 @@ snapshots:
 
   react-is@19.2.3: {}
 
+  react-is@19.2.6: {}
+
   react-joyride@3.0.2(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
       '@fastify/deepmerge': 3.2.1
@@ -24640,7 +24663,7 @@ snapshots:
     dependencies:
       '@socket.io/component-emitter': 3.1.2
       debug: 4.4.3
-      engine.io-client: 6.6.4
+      engine.io-client: 6.6.5
       socket.io-parser: 4.2.6
     transitivePeerDependencies:
       - bufferutil
@@ -24761,7 +24784,7 @@ snapshots:
       recast: 0.23.11
       semver: 7.7.3
       use-sync-external-store: 1.6.0(react@19.2.3)
-      ws: 8.18.3
+      ws: 8.20.1
     optionalDependencies:
       prettier: 3.8.1
     transitivePeerDependencies:
@@ -25308,32 +25331,14 @@ snapshots:
 
   tunnel@0.0.6: {}
 
-  turbo-darwin-64@2.6.1:
-    optional: true
-
-  turbo-darwin-arm64@2.6.1:
-    optional: true
-
-  turbo-linux-64@2.6.1:
-    optional: true
-
-  turbo-linux-arm64@2.6.1:
-    optional: true
-
-  turbo-windows-64@2.6.1:
-    optional: true
-
-  turbo-windows-arm64@2.6.1:
-    optional: true
-
-  turbo@2.6.1:
+  turbo@2.9.14:
     optionalDependencies:
-      turbo-darwin-64: 2.6.1
-      turbo-darwin-arm64: 2.6.1
-      turbo-linux-64: 2.6.1
-      turbo-linux-arm64: 2.6.1
-      turbo-windows-64: 2.6.1
-      turbo-windows-arm64: 2.6.1
+      '@turbo/darwin-64': 2.9.14
+      '@turbo/darwin-arm64': 2.9.14
+      '@turbo/linux-64': 2.9.14
+      '@turbo/linux-arm64': 2.9.14
+      '@turbo/windows-64': 2.9.14
+      '@turbo/windows-arm64': 2.9.14
 
   tw-animate-css@1.4.0: {}
 
@@ -25966,7 +25971,7 @@ snapshots:
 
   ws@7.5.10: {}
 
-  ws@8.18.3: {}
+  ws@8.20.1: {}
 
   wsl-utils@0.1.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -17,7 +17,7 @@ minimumReleaseAge: 20160
 # The version is required — the prune script uses it to decide when to remove the entry.
 minimumReleaseAgeExclude:
   - '@uipath/*'                   # permanent — own scope, always installable immediately
-  - 'postcss'                     # 8.5.14 — security override in pnpm.overrides
+  - 'postcss'                     # 8.5.14 — security override in this file's `overrides:` block
   - 'mermaid'                     # 11.15.0 — GHSA-v2wj-7wpq-c8vv backport patch
   - '@mermaid-js/parser'          # 1.1.1 — required by mermaid 11.15.0 (peer bumped from ^1.1.0 in 11.14.0)
   - 'next'                        # 16.2.6 — locked version too new

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -15,18 +15,8 @@ minimumReleaseAge: 20160
 #
 # Format: - 'pkg'  # <version> — <reason>
 # The version is required — the prune script uses it to decide when to remove the entry.
-# FIXME: Until https://github.com/pnpm/pnpm/issues/11238 is fixed we need the additional exclusions
 minimumReleaseAgeExclude:
-  - '@uipath/*'              # permanent — own scope, always installable immediately
-  - '@mui/system'            # no time information, pnpm seems to ignore the minimumReleaseAgeIgnoreMissingTime #11238
-  - 'eslint'                 # no time information, pnpm seems to ignore the minimumReleaseAgeIgnoreMissingTime #11238
-  - '@microsoft/*'           # no time information, pnpm seems to ignore the minimumReleaseAgeIgnoreMissingTime #11238
-  - '@stencil/core'          # no time information, pnpm seems to ignore the minimumReleaseAgeIgnoreMissingTime #11238
-  - 'lexical'                # no time information, pnpm seems to ignore the minimumReleaseAgeIgnoreMissingTime #11238
-  - '@lexical/*'             # no time information, pnpm seems to ignore the minimumReleaseAgeIgnoreMissingTime #11238
-  - '@fluentui/react-focus'  # no time information, pnpm seems to ignore the minimumReleaseAgeIgnoreMissingTime #11238
-  - 'intl-messageformat'     # no time information, pnpm seems to ignore the minimumReleaseAgeIgnoreMissingTime #11238
-  - '@formatjs/*'            # no time information, pnpm seems to ignore the minimumReleaseAgeIgnoreMissingTime #11238
+  - '@uipath/*'                   # permanent — own scope, always installable immediately
   - 'postcss'                     # 8.5.14 — security override in pnpm.overrides
   - 'mermaid'                     # 11.15.0 — GHSA-v2wj-7wpq-c8vv backport patch
   - '@mermaid-js/parser'          # 1.1.1 — required by mermaid 11.15.0 (peer bumped from ^1.1.0 in 11.14.0)
@@ -43,6 +33,11 @@ minimumReleaseAgeExclude:
   - 'fs-extra'                    # 11.3.5 — locked version too new
   - 'sanitize-html'               # 2.17.4 — GHSA-rpr9-rxv7-x643 (XSS via xmp tag), vetted 2026-05-15: publisher ✓, tag+diff ✓, integrity ✓
   - 'launder'                     # 1.7.1 — co-published with sanitize-html 2.17.4 (ApostropheCMS org, boutell, dayjs only dep), vetted 2026-05-15
+  - 'turbo'                       # 2.9.14 — GHSA-hcf7-66rw-9f5r + GHSA-3qcw-2rhx-2726, vetted 2026-05-20: OIDC provenance ✓, vercel/turborepo release v2.9.14 ✓, lists both advisories
+  - '@turbo/*'                    # 2.9.14 — platform binaries co-published with turbo (scope rename from turbo-*), same OIDC provenance ✓
+  - 'brace-expansion'             # 5.0.6 — GHSA-jxxr-4gwj-5jf2, vetted 2026-05-20: publisher unchanged (juliangruber) ✓, diff is 1-line fix + regression test, no new deps
+  - 'ws'                          # 8.20.1 — GHSA-58qx-3vcg-4xpx, vetted 2026-05-20: publisher unchanged (lpinca) ✓, release notes credit ChALkeR, fix in lib/sender.js + websocket.js with regression tests
+  - 'engine.io-client'            # 6.6.5 — brings ws ~8.20.1 to the @uipath/uipath-typescript chain, vetted 2026-05-20: OIDC provenance ✓, socketio/socket.io tag by darrachequesne, single commit is the ws bump (PR #5439)
 # Refuse transitive git/tarball deps (pnpm 11 default; kept explicit for clarity)
 blockExoticSubdeps: true
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -29,7 +29,9 @@ minimumReleaseAgeExclude:
   - '@formatjs/*'            # no time information, pnpm seems to ignore the minimumReleaseAgeIgnoreMissingTime #11238
   - 'postcss'                     # 8.5.14 — security override in pnpm.overrides
   - 'mermaid'                     # 11.15.0 — GHSA-v2wj-7wpq-c8vv backport patch
+  - '@mermaid-js/parser'          # 1.1.1 — required by mermaid 11.15.0 (peer bumped from ^1.1.0 in 11.14.0)
   - 'next'                        # 16.2.6 — locked version too new
+  - '@next/env'                   # 16.2.6 — co-published with next
   - '@next/swc-darwin-arm64'      # 16.2.6 — co-published with next, optional platform binary
   - '@next/swc-darwin-x64'        # 16.2.6 — co-published with next, optional platform binary
   - '@next/swc-linux-arm64-gnu'   # 16.2.6 — co-published with next, optional platform binary


### PR DESCRIPTION
Now that no install pulls from the @uipath GHP registry, dropping all the install-side auth plumbing.

### GHP install cleanup

- Removed `.npmrc`
- Simplified `install-node-deps` composite action — no `registry-token` input, no GHP `registry-url`/`scope`, no `NODE_AUTH_TOKEN` env
- Dropped `registry-token: ${{ github.token }}` from every workflow caller
- Dropped `packages: read` from jobs that only had it to install
- Surgical lockfile fix: dropped the GHP `tarball:` URL from `@uipath/uipath-typescript@1.3.1` (same integrity hash on npmjs, version unchanged)
- Updated `copilot-instructions.md` and the `harden-github-action` skill to match the new pattern

The `apollo-vertex-registry-check` test-components job is the one exception — it simulates a downstream install of vertex shadcn components, some of which pull `@uipath/proteus-client` (GHP-only). Restored just that job's `packages: read` + setup-node GHP routing + `NODE_AUTH_TOKEN`, with a comment explaining why.

Publish-side plumbing untouched — `release.yml`, `dev-publish.yml`, `dev-cleanup.yml`, and `scripts/publish-*.sh|ts` still publish/unpublish to GHP using `GH_NPM_REGISTRY_TOKEN` (`${{ github.token }}` with `packages: write` job-scoped).

### release.yml credential helper hardening

While in the file, two small defense-in-depth tweaks to the git credential helper used by `semantic-release`:

- URL-scoped to `https://github.com` only — a stray `git push` to any other host can no longer trigger the helper and exfiltrate the token
- Added a `# shellcheck disable=SC2016` directive with the rationale for the single-quoted `$GITHUB_TOKEN` (deferred expansion is intentional — git invokes the helper later in a fresh shell)

### pnpm bump 11.1.1 → 11.1.3

11.1.2 and 11.1.3 close two `minimumReleaseAge` bypass bugs (cached abbreviated metadata; lockfiles produced by older pnpm). 11.1.3 immediately flagged two entries the old version was silently letting through, both added to `minimumReleaseAgeExclude`:

- `@next/env@16.2.6` — co-ships from `vercel/next.js` with the already-exempt `next@16.2.6`
- `@mermaid-js/parser@1.1.1` — hard semver requirement of the already-exempt `mermaid@11.15.0` (peer range bumped from `^1.1.0` in 11.14.0)

### Security fixes (`pnpm audit` was reporting 4 vulnerabilities)

| Severity | Package | Fix |
|---|---|---|
| moderate | turbo (GHSA-hcf7-66rw-9f5r) | bump direct dep `^2.6.0` → `^2.9.14` |
| low | turbo (GHSA-3qcw-2rhx-2726) | same bump |
| moderate | brace-expansion (GHSA-jxxr-4gwj-5jf2) | `pnpm update brace-expansion -r` refreshed all paths from 5.0.5 → 5.0.6 |
| moderate | ws (GHSA-58qx-3vcg-4xpx) | `pnpm update ws -r` cleared most paths; the only stuck path was `@uipath/uipath-typescript → socket.io-client → engine.io-client@6.6.4 → ws ~8.18.3`. Bumped `engine.io-client` to 6.6.5 (latest, which already pins `ws ~8.20.1`) — no override needed |

All exempt entries include the full vetting trail (publisher, provenance, GitHub tag, diff review) in their comments.

### Cleanup: dropped 9 stale `minimumReleaseAgeExclude` FIXME entries

The bug that needed those entries (pnpm/pnpm#11238 — `ERR_PNPM_MISSING_TIME` for packages whose npm metadata lacks per-version `time` fields) is fixed in 11.1.2/11.1.3 release notes and confirmed by user reports on the issue. Verified empirically here: `pnpm install`, `pnpm dedupe --check`, and `pnpm update eslint -r` all complete without `MISSING_TIME` errors on 11.1.3 with the entries removed.

Removed: `@mui/system`, `eslint`, `@microsoft/*`, `@stencil/core`, `lexical`, `@lexical/*`, `@fluentui/react-focus`, `intl-messageformat`, `@formatjs/*`.