### PR TITLE
feat(apollo-wind): add renderCategoryLabel and renderItemLabel props to TreeView

### DIFF
--- a/packages/apollo-wind/src/components/ui/tree-view.stories.tsx
+++ b/packages/apollo-wind/src/components/ui/tree-view.stories.tsx
@@ -1,8 +1,8 @@
 import type { Meta } from '@storybook/react-vite';
-import { Folder, File, Globe, Pencil } from 'lucide-react';
+import { File, Folder, Globe, Pencil } from 'lucide-react';
 import TreeView, {
-  type TreeViewItem,
   type TreeViewIconMap,
+  type TreeViewItem,
   type TreeViewMenuItem,
 } from './tree-view';
 
@@ -27,6 +27,7 @@ A hierarchical tree component for displaying and selecting items like file explo
 - **Item actions** – Add \`actions\` for Edit/Delete; rendered in a compact dropdown (single "more" icon) to prevent horizontal scroll
 - **Context menu** – Right-click with \`menuItems\` for custom actions
 - **Access checkboxes** – \`showCheckboxes\` for check/uncheck with \`onCheckChange\`
+- **Custom row renderers** – \`renderCategoryLabel\` and \`renderItemLabel\` replace the row content (icon, name, badge, meta) for category and leaf rows respectively. Chevron, checkboxes and actions menu stay in place. Falls back to the default row content (icon + name + optional badge + meta) when omitted.
 
 ## Layout
 
@@ -277,4 +278,146 @@ export const WithContextMenu = {
       />
     );
   },
+};
+
+// ============================================================================
+// With Custom Category and Item Renderer
+// ============================================================================
+
+export const WithCustomCategoryAndItemRenderer = {
+  name: 'With custom category and item renderer',
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Uses `renderCategoryLabel` and `renderItemLabel` to fully customize the row content (icon, name, badge, meta) for category and leaf rows. The chevron, checkboxes and actions menu remain controlled by the component.',
+      },
+    },
+  },
+  render: () => (
+    <TreeView
+      data={sampleData}
+      title="Custom renderers"
+      renderCategoryLabel={(item) => (
+        <div className="flex items-center gap-2 flex-1 min-w-0">
+          <Globe className="h-4 w-4 text-blue-600" />
+          <span className="flex-1 min-w-0 truncate font-semibold uppercase tracking-wide text-xs">
+            {item.name}
+          </span>
+          {item.children && (
+            <span className="shrink-0 text-xs text-muted-foreground">
+              {item.children.length} items
+            </span>
+          )}
+        </div>
+      )}
+      renderItemLabel={(item) => (
+        <div className="flex items-center gap-2 flex-1 min-w-0">
+          <File className="h-4 w-4 text-emerald-600" />
+          <span className="flex-1 min-w-0 truncate font-mono text-sm">{item.name}</span>
+          <span className="shrink-0 text-xs text-muted-foreground italic">leaf</span>
+        </div>
+      )}
+    />
+  ),
+};
+
+// ============================================================================
+// With Custom Renderers and Single Selection
+// ============================================================================
+
+export const WithCustomRenderersAndSingleSelection = {
+  name: 'With custom renderers and single selection',
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Custom `renderCategoryLabel` and `renderItemLabel` combined with `selectionMode="single"` and `showSelectionCheckboxes`. Only one leaf can be selected at a time; the selection checkbox is still rendered by the component alongside the custom content.',
+      },
+    },
+  },
+  render: () => (
+    <TreeView
+      data={sampleData}
+      title="Custom renderers + single selection"
+      selectionMode="single"
+      showSelectionCheckboxes
+      renderCategoryLabel={(item) => (
+        <div className="flex items-center gap-2 flex-1 min-w-0">
+          <Folder className="h-4 w-4 text-amber-600" />
+          <span className="flex-1 min-w-0 truncate font-semibold uppercase tracking-wide text-xs">
+            {item.name}
+          </span>
+          {item.children && (
+            <span className="shrink-0 text-xs text-muted-foreground">
+              {item.children.length} items
+            </span>
+          )}
+        </div>
+      )}
+      renderItemLabel={(item) => (
+        <div className="flex items-center gap-2 flex-1 min-w-0">
+          <File className="h-4 w-4 text-emerald-600" />
+          <span className="flex-1 min-w-0 truncate font-mono text-sm">{item.name}</span>
+          <span className="shrink-0 text-xs text-muted-foreground italic">leaf</span>
+        </div>
+      )}
+      onSelectionChange={(items) =>
+        console.log(
+          'Selected:',
+          items.map((i) => i.name)
+        )
+      }
+    />
+  ),
+};
+
+// ============================================================================
+// With Custom Renderers and Multiple Selection
+// ============================================================================
+
+export const WithCustomRenderersAndMultipleSelection = {
+  name: 'With custom renderers and multiple selection',
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Custom `renderCategoryLabel` and `renderItemLabel` combined with `selectionMode="multiple"` (default) and `showSelectionCheckboxes`. Supports shift/ctrl-click and drag-select; the "X selected" badge still appears on collapsed folders alongside the custom content.',
+      },
+    },
+  },
+  render: () => (
+    <TreeView
+      data={sampleData}
+      title="Custom renderers + multiple selection"
+      selectionMode="multiple"
+      showSelectionCheckboxes
+      renderCategoryLabel={(item) => (
+        <div className="flex items-center gap-2 flex-1 min-w-0">
+          <Folder className="h-4 w-4 text-amber-600" />
+          <span className="flex-1 min-w-0 truncate font-semibold uppercase tracking-wide text-xs">
+            {item.name}
+          </span>
+          {item.children && (
+            <span className="shrink-0 text-xs text-muted-foreground">
+              {item.children.length} items
+            </span>
+          )}
+        </div>
+      )}
+      renderItemLabel={(item) => (
+        <div className="flex items-center gap-2 flex-1 min-w-0">
+          <File className="h-4 w-4 text-emerald-600" />
+          <span className="flex-1 min-w-0 truncate font-mono text-sm">{item.name}</span>
+          <span className="shrink-0 text-xs text-muted-foreground italic">leaf</span>
+        </div>
+      )}
+      onSelectionChange={(items) =>
+        console.log(
+          'Selected:',
+          items.map((i) => i.name)
+        )
+      }
+    />
+  ),
 };

--- a/packages/apollo-wind/src/components/ui/tree-view.test.tsx
+++ b/packages/apollo-wind/src/components/ui/tree-view.test.tsx
@@ -1,0 +1,182 @@
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import TreeView, { type TreeViewItem } from './tree-view';
+
+const simpleTree: TreeViewItem[] = [
+  {
+    id: 'cat-1',
+    name: 'Folder A',
+    type: 'folder',
+    children: [
+      { id: 'leaf-1', name: 'File 1', type: 'file' },
+      { id: 'leaf-2', name: 'File 2', type: 'file' },
+    ],
+  },
+  { id: 'leaf-top', name: 'Top File', type: 'file' },
+];
+
+const nestedTree: TreeViewItem[] = [
+  {
+    id: 'cat-outer',
+    name: 'Outer',
+    type: 'folder',
+    children: [
+      {
+        id: 'cat-inner',
+        name: 'Inner',
+        type: 'folder',
+        children: [{ id: 'leaf-deep', name: 'Deep File', type: 'file' }],
+      },
+    ],
+  },
+];
+
+describe('TreeView – renderCategoryLabel / renderItemLabel', () => {
+  it('renders default item.name for category and leaf rows when no custom renderers are provided', () => {
+    render(<TreeView data={simpleTree} />);
+
+    expect(screen.getByText('Folder A')).toBeInTheDocument();
+    expect(screen.getByText('Top File')).toBeInTheDocument();
+  });
+
+  it('calls renderCategoryLabel for category rows and renders its output', () => {
+    const renderCategoryLabel = vi.fn((item: TreeViewItem) => (
+      <span data-testid={`cat-${item.id}`}>CATEGORY:{item.name}</span>
+    ));
+
+    render(<TreeView data={simpleTree} renderCategoryLabel={renderCategoryLabel} />);
+
+    expect(screen.getByTestId('cat-cat-1')).toHaveTextContent('CATEGORY:Folder A');
+    const calledIds = renderCategoryLabel.mock.calls.map(([item]) => item.id);
+    expect(calledIds).toContain('cat-1');
+  });
+
+  it('calls renderItemLabel for leaf rows and renders its output', () => {
+    const renderItemLabel = vi.fn((item: TreeViewItem) => (
+      <span data-testid={`leaf-${item.id}`}>LEAF:{item.name}</span>
+    ));
+
+    render(<TreeView data={simpleTree} renderItemLabel={renderItemLabel} />);
+
+    expect(screen.getByTestId('leaf-leaf-top')).toHaveTextContent('LEAF:Top File');
+    const calledIds = renderItemLabel.mock.calls.map(([item]) => item.id);
+    expect(calledIds).toContain('leaf-top');
+  });
+
+  it('keeps renderers scope-isolated (category renderer never sees leaves and vice versa)', () => {
+    const renderCategoryLabel = vi.fn((item: TreeViewItem) => <span>{item.name}</span>);
+    const renderItemLabel = vi.fn((item: TreeViewItem) => <span>{item.name}</span>);
+
+    render(
+      <TreeView
+        data={simpleTree}
+        renderCategoryLabel={renderCategoryLabel}
+        renderItemLabel={renderItemLabel}
+      />
+    );
+
+    for (const [item] of renderCategoryLabel.mock.calls) {
+      expect(item.children).toBeDefined();
+    }
+    for (const [item] of renderItemLabel.mock.calls) {
+      expect(item.children).toBeUndefined();
+    }
+  });
+
+  it('threads both renderers to nested descendants', async () => {
+    const user = userEvent.setup();
+    const renderCategoryLabel = vi.fn((item: TreeViewItem) => (
+      <span data-testid={`cat-${item.id}`}>{item.name}</span>
+    ));
+    const renderItemLabel = vi.fn((item: TreeViewItem) => (
+      <span data-testid={`leaf-${item.id}`}>{item.name}</span>
+    ));
+
+    render(
+      <TreeView
+        data={nestedTree}
+        renderCategoryLabel={renderCategoryLabel}
+        renderItemLabel={renderItemLabel}
+      />
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Expand' }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('cat-cat-inner')).toBeInTheDocument();
+      expect(screen.getByTestId('leaf-leaf-deep')).toBeInTheDocument();
+    });
+  });
+
+  it('preserves chevron expand/collapse when renderCategoryLabel is provided', async () => {
+    const user = userEvent.setup();
+    render(
+      <TreeView
+        data={simpleTree}
+        renderCategoryLabel={(item) => <span>CATEGORY:{item.name}</span>}
+      />
+    );
+
+    expect(screen.queryByText('File 1')).not.toBeInTheDocument();
+
+    const row = document.querySelector('[data-id="cat-1"]') as HTMLElement;
+    expect(row).not.toBeNull();
+    const chevron = within(row).getAllByRole('button')[0]!;
+    await user.click(chevron);
+
+    await waitFor(() => {
+      expect(screen.getByText('File 1')).toBeInTheDocument();
+    });
+  });
+
+  it('preserves the access-rights checkbox on a category when renderCategoryLabel is provided', () => {
+    render(
+      <TreeView
+        data={simpleTree}
+        showCheckboxes
+        renderCategoryLabel={(item) => <span>CATEGORY:{item.name}</span>}
+      />
+    );
+
+    expect(screen.getByLabelText('Toggle access for Folder A')).toBeInTheDocument();
+  });
+
+  it('does not render a selection checkbox on category rows (leaf-only by design)', () => {
+    render(
+      <TreeView
+        data={simpleTree}
+        selectionMode="multiple"
+        showSelectionCheckboxes
+        renderCategoryLabel={(item) => <span>CATEGORY:{item.name}</span>}
+      />
+    );
+
+    expect(screen.queryByLabelText('Select Folder A')).not.toBeInTheDocument();
+    expect(screen.getByLabelText('Select Top File')).toBeInTheDocument();
+  });
+
+  it('preserves the selection checkbox on a leaf when renderItemLabel is provided', async () => {
+    const user = userEvent.setup();
+    const handleSelectionChange = vi.fn();
+
+    render(
+      <TreeView
+        data={simpleTree}
+        selectionMode="multiple"
+        showSelectionCheckboxes
+        onSelectionChange={handleSelectionChange}
+        renderItemLabel={(item) => <span>LEAF:{item.name}</span>}
+      />
+    );
+
+    const checkbox = screen.getByLabelText('Select Top File');
+    await user.click(checkbox);
+
+    await waitFor(() => {
+      expect(handleSelectionChange).toHaveBeenCalled();
+    });
+    const lastCall = handleSelectionChange.mock.calls.at(-1)?.[0] as TreeViewItem[];
+    expect(lastCall.map((i) => i.id)).toContain('leaf-top');
+  });
+});

--- a/packages/apollo-wind/src/components/ui/tree-view.tsx
+++ b/packages/apollo-wind/src/components/ui/tree-view.tsx
@@ -1,32 +1,31 @@
 'use client';
 
+import { AnimatePresence, motion } from 'framer-motion';
+import { Box, ChevronRight, Folder, Info, MoreHorizontal, Search, X } from 'lucide-react';
 import * as React from 'react';
-import { useState, useRef, useEffect, useCallback, useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
-import { Collapsible, CollapsibleTrigger, CollapsibleContent } from '@/components/ui/collapsible';
-import { Folder, ChevronRight, Box, Search, MoreHorizontal, Info } from 'lucide-react';
-import { motion, AnimatePresence } from 'framer-motion';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
 import {
   ContextMenu,
   ContextMenuContent,
   ContextMenuItem,
   ContextMenuTrigger,
 } from '@/components/ui/context-menu';
-import { X } from 'lucide-react';
-import { HoverCard, HoverCardContent, HoverCardTrigger } from '@/components/ui/hover-card';
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
-  DropdownMenuTrigger,
   DropdownMenuSub,
   DropdownMenuSubContent,
   DropdownMenuSubTrigger,
+  DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
-import { Badge } from '@/components/ui/badge';
-import { cn } from '@/lib';
+import { HoverCard, HoverCardContent, HoverCardTrigger } from '@/components/ui/hover-card';
 import { Input } from '@/components/ui/input';
-import { Checkbox } from '@/components/ui/checkbox';
+import { cn } from '@/lib';
 
 /**
  * Action shown in the item's dropdown menu (Edit, Delete, etc.).
@@ -110,6 +109,10 @@ export interface TreeViewProps {
   onCheckChange?: (item: TreeViewItem, checked: boolean) => void;
   iconMap?: TreeViewIconMap;
   menuItems?: TreeViewMenuItem[];
+  /** Custom renderer for category rows (items with children). Replaces icon, name, badge and meta; chevron, checkboxes and actions menu are preserved. Falls back to the default row content (icon + name + optional badge + meta) when omitted. */
+  renderCategoryLabel?: (item: TreeViewItem) => React.ReactNode;
+  /** Custom renderer for leaf rows (items without children). Replaces icon, name, badge and meta; checkboxes and actions menu are preserved. Falls back to the default row content (icon + name + optional badge + meta) when omitted. */
+  renderItemLabel?: (item: TreeViewItem) => React.ReactNode;
 }
 
 interface TreeItemProps {
@@ -131,6 +134,8 @@ interface TreeItemProps {
   iconMap?: TreeViewIconMap;
   menuItems?: TreeViewMenuItem[];
   getSelectedItems: () => TreeViewItem[];
+  renderCategoryLabel?: (item: TreeViewItem) => React.ReactNode;
+  renderItemLabel?: (item: TreeViewItem) => React.ReactNode;
 }
 
 // Helper function to build a map of all items by ID
@@ -208,6 +213,8 @@ function TreeItem({
   iconMap = defaultIconMap,
   menuItems,
   getSelectedItems,
+  renderCategoryLabel,
+  renderItemLabel,
 }: TreeItemProps): React.ReactElement {
   const isOpen = expandedIds.has(item.id);
   const isSelected = selectedIds.has(item.id);
@@ -465,13 +472,19 @@ function TreeItem({
                       )}
                     </button>
                   )}
-                  {renderIcon()}
-                  <span className="flex-1 min-w-0 truncate">{item.name}</span>
-                  {item.badge && <span className="shrink-0 ml-1">{item.badge}</span>}
-                  {item.meta && (
-                    <span className="text-xs text-muted-foreground shrink-0 ml-1 truncate max-w-[6rem]">
-                      {item.meta}
-                    </span>
+                  {renderCategoryLabel ? (
+                    renderCategoryLabel(item)
+                  ) : (
+                    <>
+                      {renderIcon()}
+                      <span className="flex-1 min-w-0 truncate">{item.name}</span>
+                      {item.badge && <span className="shrink-0 ml-1">{item.badge}</span>}
+                      {item.meta && (
+                        <span className="text-xs text-muted-foreground shrink-0 ml-1 truncate max-w-[6rem]">
+                          {item.meta}
+                        </span>
+                      )}
+                    </>
                   )}
                   {selectedCount !== null && selectedCount > 0 && (
                     <Badge
@@ -623,13 +636,19 @@ function TreeItem({
                       )}
                     </button>
                   )}
-                  {renderIcon()}
-                  <span className="flex-1 min-w-0 truncate">{item.name}</span>
-                  {item.badge && <span className="shrink-0 ml-1">{item.badge}</span>}
-                  {item.meta && (
-                    <span className="text-xs text-muted-foreground shrink-0 ml-1 truncate max-w-[6rem]">
-                      {item.meta}
-                    </span>
+                  {renderItemLabel ? (
+                    renderItemLabel(item)
+                  ) : (
+                    <>
+                      {renderIcon()}
+                      <span className="flex-1 min-w-0 truncate">{item.name}</span>
+                      {item.badge && <span className="shrink-0 ml-1">{item.badge}</span>}
+                      {item.meta && (
+                        <span className="text-xs text-muted-foreground shrink-0 ml-1 truncate max-w-[6rem]">
+                          {item.meta}
+                        </span>
+                      )}
+                    </>
                   )}
                   {(item.actions?.length ?? 0) > 0 ? (
                     <DropdownMenu>
@@ -751,6 +770,8 @@ function TreeItem({
                           iconMap={iconMap}
                           menuItems={menuItems}
                           getSelectedItems={getSelectedItems}
+                          renderCategoryLabel={renderCategoryLabel}
+                          renderItemLabel={renderItemLabel}
                         />
                       ))}
                     </motion.div>
@@ -815,6 +836,8 @@ export default function TreeView({
   onAction,
   onCheckChange,
   menuItems,
+  renderCategoryLabel,
+  renderItemLabel,
 }: TreeViewProps) {
   const [currentMousePos, setCurrentMousePos] = useState<number>(0);
   const [dragStart, setDragStart] = useState<number | null>(null);
@@ -1215,6 +1238,8 @@ export default function TreeView({
               iconMap={iconMap}
               menuItems={menuItems}
               getSelectedItems={getSelectedItems}
+              renderCategoryLabel={renderCategoryLabel}
+              renderItemLabel={renderItemLabel}
             />
           ))}
         </section>


### PR DESCRIPTION
## Description

Add two new optional props on `TreeView` that let consumers fully customize the content of a row (icon, name, badge, meta) while the component keeps owning interaction affordances (chevron, checkboxes, selection badge, actions dropdown):

- `renderCategoryLabel?: (item) => ReactNode` — replaces content on rows **with children**.
- `renderItemLabel?: (item) => ReactNode` — replaces content on rows **without children** (leaves).

Both are additive — when omitted, rows fall back to the existing default layout.

## Implementation

- **`tree-view.tsx`** — Added `renderCategoryLabel` / `renderItemLabel` to `TreeViewProps` and `TreeItemProps`, threaded them through the recursive `TreeItem` so nested rows inherit the renderers. Each render branch (category at line ~475, leaf at line ~639) uses the prop when present, otherwise renders the existing icon + name + badge + meta. Chevron, access-rights checkbox, selection checkbox, "X selected" badge and the actions dropdown all sit **outside** the renderer's slot, so they survive unchanged.
- **`tree-view.stories.tsx`** — Three new stories demonstrating the renderers in isolation, with single selection, and with multi-select; docs bullet added to the "Features" list.
- **`tree-view.test.tsx`** — New test file covering the renderer contract.

## How it's tested

`pnpm vitest run src/components/ui/tree-view.test.tsx` — **9 / 9 passing**:

- renders default `item.name` for category and leaf rows when no renderers are provided
- calls `renderCategoryLabel` for category rows with the matching item
- calls `renderItemLabel` for leaf rows with the matching item
- keeps renderers scope-isolated (category renderer never sees leaves, and vice versa)
- threads both renderers to nested descendants
- preserves chevron expand/collapse when `renderCategoryLabel` is provided
- preserves the access-rights checkbox on a category when `renderCategoryLabel` is provided
- does not render a selection checkbox on category rows (leaf-only by design)
- preserves the selection checkbox on a leaf when `renderItemLabel` is provided

Stories were exercised in Storybook to confirm visual behavior of the three new examples.