### PR TITLE
feat(apollo-vertex): dashboard card renderers — InsightCardBody and typed card content components

### DIFF
--- a/apps/apollo-vertex/templates/dashboard/AutopilotInsight.tsx
+++ b/apps/apollo-vertex/templates/dashboard/AutopilotInsight.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+interface AutopilotInsightProps {
+  onClose: () => void;
+  sourceCardTitle: string;
+}
+
+export function AutopilotInsight({
+  onClose,
+  sourceCardTitle,
+}: AutopilotInsightProps) {
+  return (
+    <Card
+      variant="glass"
+      className="!bg-white/90 dark:!bg-card h-full overflow-hidden relative"
+    >
+      {/* Close button */}
+      <button
+        type="button"
+        onClick={onClose}
+        className="absolute top-5 right-5 z-20 size-7 rounded-md flex items-center justify-center text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-all"
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          className="size-4"
+        >
+          <path d="M18 6 6 18" />
+          <path d="m6 6 12 12" />
+        </svg>
+      </button>
+
+      <CardHeader className="!gap-2">
+        <div className="flex items-center gap-2">
+          <img
+            src="/Autopilot_dark.svg"
+            alt="Autopilot"
+            className="size-5 block dark:hidden"
+          />
+          <img
+            src="/Autopilot_light.svg"
+            alt="Autopilot"
+            className="size-5 hidden dark:block"
+          />
+          <CardTitle className="text-sm font-bold tracking-tight">
+            Autopilot Insight
+          </CardTitle>
+        </div>
+        <p className="text-xs text-muted-foreground">
+          Analyzing {sourceCardTitle}
+        </p>
+      </CardHeader>
+
+      <CardContent className="flex-1 flex flex-col">
+        {/* Placeholder for future chat UX responses */}
+        <div className="flex-1 border border-dashed border-muted-foreground/15 bg-muted/30 rounded-lg flex items-center justify-center">
+          <div className="text-center">
+            <p className="text-sm text-muted-foreground/60">
+              Autopilot response area
+            </p>
+            <p className="text-xs text-muted-foreground/40 mt-1">
+              Chat UX content will appear here
+            </p>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/apollo-vertex/templates/dashboard/DashboardCards.tsx
+++ b/apps/apollo-vertex/templates/dashboard/DashboardCards.tsx
@@ -1,0 +1,288 @@
+import { AlertTriangle, CheckCircle, Clock, XCircle } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Progress } from "@/components/ui/progress";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+
+// --- Types ---
+
+export interface KpiItem {
+  label: string;
+  value: string;
+  icon: LucideIcon;
+  change: string;
+}
+
+// --- Sample data ---
+
+const invoices = [
+  {
+    id: "INV-4021",
+    vendor: "Acme Corp",
+    amount: "$12,450.00",
+    status: "Processed" as const,
+    date: "Mar 18, 2026",
+  },
+  {
+    id: "INV-4020",
+    vendor: "Global Supplies Ltd",
+    amount: "$3,280.50",
+    status: "Pending" as const,
+    date: "Mar 18, 2026",
+  },
+  {
+    id: "INV-4019",
+    vendor: "TechParts Inc",
+    amount: "$8,920.00",
+    status: "In Review" as const,
+    date: "Mar 17, 2026",
+  },
+  {
+    id: "INV-4018",
+    vendor: "Office Depot",
+    amount: "$1,150.75",
+    status: "Processed" as const,
+    date: "Mar 17, 2026",
+  },
+  {
+    id: "INV-4017",
+    vendor: "CloudServ Solutions",
+    amount: "$24,000.00",
+    status: "Failed" as const,
+    date: "Mar 16, 2026",
+  },
+  {
+    id: "INV-4016",
+    vendor: "Metro Logistics",
+    amount: "$6,780.00",
+    status: "Processed" as const,
+    date: "Mar 16, 2026",
+  },
+];
+
+const statusVariant: Record<
+  string,
+  "default" | "secondary" | "destructive" | "outline"
+> = {
+  Processed: "default",
+  Pending: "secondary",
+  Failed: "destructive",
+  "In Review": "outline",
+};
+
+const statusIcon: Record<string, typeof CheckCircle> = {
+  Processed: CheckCircle,
+  Pending: Clock,
+  Failed: XCircle,
+  "In Review": AlertTriangle,
+};
+
+const activityBars = [
+  { label: "Mon", height: 60 },
+  { label: "Tue", height: 85 },
+  { label: "Wed", height: 45 },
+  { label: "Thu", height: 92 },
+  { label: "Fri", height: 78 },
+  { label: "Sat", height: 30 },
+  { label: "Sun", height: 15 },
+];
+
+const recentActivity = [
+  { text: "INV-4021 processed successfully", time: "2 min ago" },
+  { text: "INV-4020 submitted for review", time: "15 min ago" },
+  { text: "Batch processing completed (42 invoices)", time: "1 hr ago" },
+  { text: "INV-4017 failed — missing PO number", time: "3 hrs ago" },
+];
+
+const pipelineStages = [
+  { label: "OCR Extraction", value: 96 },
+  { label: "Field Validation", value: 88 },
+  { label: "Approval Routing", value: 72 },
+  { label: "Final Review", value: 64 },
+];
+
+const complianceChecks = [
+  { label: "Income Verification", pass: 98 },
+  { label: "Credit Score Threshold", pass: 96 },
+  { label: "Debt-to-Income Ratio", pass: 91 },
+  { label: "Collateral Appraisal", pass: 87 },
+  { label: "Document Completeness", pass: 94 },
+];
+
+// --- Card components ---
+
+export function KpiCards({ kpis }: { kpis: KpiItem[] }) {
+  return (
+    <>
+      {kpis.map((kpi) => (
+        <Card key={kpi.label} variant="glass">
+          <CardHeader className="pb-2">
+            <div className="flex items-center justify-between">
+              <CardTitle className="text-sm font-medium text-muted-foreground">
+                {kpi.label}
+              </CardTitle>
+              <kpi.icon className="w-4 h-4 text-muted-foreground" />
+            </div>
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">{kpi.value}</div>
+            <p className="text-xs text-muted-foreground mt-1">
+              <span className="text-emerald-500">{kpi.change}</span> from last
+              week
+            </p>
+          </CardContent>
+        </Card>
+      ))}
+    </>
+  );
+}
+
+export function InvoiceTable() {
+  return (
+    <Card variant="glass">
+      <CardHeader>
+        <CardTitle>Recent Invoices</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Invoice</TableHead>
+              <TableHead>Vendor</TableHead>
+              <TableHead>Amount</TableHead>
+              <TableHead>Status</TableHead>
+              <TableHead>Date</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {invoices.map((inv) => {
+              const StatusIcon = statusIcon[inv.status];
+              return (
+                <TableRow key={inv.id}>
+                  <TableCell className="font-medium">{inv.id}</TableCell>
+                  <TableCell>{inv.vendor}</TableCell>
+                  <TableCell>{inv.amount}</TableCell>
+                  <TableCell>
+                    <Badge
+                      variant={statusVariant[inv.status]}
+                      className="gap-1"
+                    >
+                      <StatusIcon className="w-3 h-3" />
+                      {inv.status}
+                    </Badge>
+                  </TableCell>
+                  <TableCell className="text-muted-foreground">
+                    {inv.date}
+                  </TableCell>
+                </TableRow>
+              );
+            })}
+          </TableBody>
+        </Table>
+      </CardContent>
+    </Card>
+  );
+}
+
+export function ActivityBarChart() {
+  return (
+    <Card variant="glass">
+      <CardHeader>
+        <CardTitle>Processing Activity</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="flex items-end gap-3 h-32">
+          {activityBars.map((bar) => (
+            <div
+              key={bar.label}
+              className="flex-1 flex flex-col items-center gap-1"
+            >
+              <div
+                className="w-full bg-primary/80 rounded-t-sm"
+                style={{ height: `${bar.height}%` }}
+              />
+              <span className="text-xs text-muted-foreground">{bar.label}</span>
+            </div>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+export function ActivityFeed() {
+  return (
+    <Card variant="glass">
+      <CardHeader>
+        <CardTitle>Recent Activity</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="space-y-4">
+          {recentActivity.map((event) => (
+            <div key={event.text} className="flex items-start gap-3">
+              <div className="mt-1.5 w-2 h-2 rounded-full bg-primary shrink-0" />
+              <div className="flex-1 min-w-0">
+                <p className="text-sm">{event.text}</p>
+                <p className="text-xs text-muted-foreground">{event.time}</p>
+              </div>
+            </div>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+export function PipelineProgress() {
+  return (
+    <Card variant="glass">
+      <CardHeader>
+        <CardTitle>Processing Pipeline</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="space-y-4">
+          {pipelineStages.map((stage) => (
+            <div key={stage.label}>
+              <div className="flex items-center justify-between text-sm mb-1.5">
+                <span>{stage.label}</span>
+                <span className="text-muted-foreground">{stage.value}%</span>
+              </div>
+              <Progress value={stage.value} />
+            </div>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+export function ComplianceProgress() {
+  return (
+    <Card variant="glass">
+      <CardHeader>
+        <CardTitle>Compliance Pass Rates</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="space-y-4">
+          {complianceChecks.map((check) => (
+            <div key={check.label}>
+              <div className="flex items-center justify-between text-sm mb-1.5">
+                <span>{check.label}</span>
+                <span className="text-muted-foreground">{check.pass}%</span>
+              </div>
+              <Progress value={check.pass} />
+            </div>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/apollo-vertex/templates/dashboard/DashboardLoading.tsx
+++ b/apps/apollo-vertex/templates/dashboard/DashboardLoading.tsx
@@ -1,0 +1,135 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+type Phase = "logo" | "skeleton" | "done";
+
+interface DashboardLoadingProps {
+  children: React.ReactNode;
+  triggerReplay?: number;
+}
+
+function LogoPhase({ exiting }: { exiting: boolean }) {
+  return (
+    <div
+      className={`absolute inset-0 flex flex-col items-center justify-center transition-all duration-500 ${
+        exiting ? "opacity-0 scale-95" : "opacity-100 scale-100"
+      }`}
+    >
+      {/* Morphing glow */}
+      <div className="absolute">
+        <div className="size-40 rounded-full bg-gradient-to-br from-insight-500/30 to-primary-400/30 blur-3xl animate-pulse" />
+      </div>
+      <div className="absolute">
+        <div
+          className="size-32 rounded-full bg-gradient-to-tr from-primary-400/20 to-insight-500/20 blur-2xl"
+          style={{ animation: "morph 4s ease-in-out infinite" }}
+        />
+      </div>
+
+      {/* App icon */}
+      <div className="relative size-16 rounded-2xl bg-gradient-to-br from-insight-500 to-primary-400 border-2 border-white/10 flex items-center justify-center shadow-lg">
+        <img
+          src="/UiPath.svg"
+          alt="UiPath"
+          className="size-8 brightness-0 invert"
+        />
+      </div>
+
+      {/* Loading text */}
+      <p className="mt-6 text-sm text-muted-foreground animate-pulse">
+        Creating your overview...
+      </p>
+
+      <style>{`
+        @keyframes morph {
+          0%, 100% { border-radius: 60% 40% 30% 70% / 60% 30% 70% 40%; transform: rotate(0deg) scale(1); }
+          25% { border-radius: 30% 60% 70% 40% / 50% 60% 30% 60%; transform: rotate(45deg) scale(1.1); }
+          50% { border-radius: 50% 60% 30% 60% / 30% 40% 70% 60%; transform: rotate(90deg) scale(0.95); }
+          75% { border-radius: 60% 30% 50% 40% / 70% 50% 40% 60%; transform: rotate(135deg) scale(1.05); }
+        }
+      `}</style>
+    </div>
+  );
+}
+
+function SkeletonPhase({ exiting }: { exiting: boolean }) {
+  return (
+    <div
+      className={`absolute inset-0 p-6 transition-all duration-500 ${
+        exiting ? "opacity-0 scale-[0.99]" : "opacity-100 scale-100"
+      }`}
+    >
+      <div className="space-y-2 mb-6">
+        <div className="h-3 w-32 rounded-full bg-muted animate-pulse" />
+        <div className="h-7 w-64 rounded-full bg-muted animate-pulse" />
+      </div>
+      <div className="grid grid-cols-2 gap-1 h-[calc(100%-80px)]">
+        <div className="flex flex-col gap-1">
+          <div className="flex-1 rounded-2xl bg-muted/50 animate-pulse" />
+          <div className="h-14 rounded-2xl bg-muted/50 animate-pulse" />
+        </div>
+        <div className="grid grid-cols-2 grid-rows-2 gap-1">
+          <div className="rounded-2xl bg-muted/50 animate-pulse" />
+          <div className="rounded-2xl bg-muted/50 animate-pulse" />
+          <div className="rounded-2xl bg-muted/50 animate-pulse" />
+          <div className="rounded-2xl bg-muted/50 animate-pulse" />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function DashboardLoading({
+  children,
+  triggerReplay,
+}: DashboardLoadingProps) {
+  const [phase, setPhase] = useState<Phase>("done");
+  const [exiting, setExiting] = useState(false);
+
+  useEffect(() => {
+    if (triggerReplay === 0) return;
+    if (triggerReplay) {
+      setExiting(false);
+      setPhase("logo");
+    }
+  }, [triggerReplay]);
+
+  useEffect(() => {
+    if (phase === "done") return;
+
+    if (phase === "logo") {
+      const timer = setTimeout(() => {
+        setExiting(true);
+        setTimeout(() => {
+          setExiting(false);
+          setPhase("skeleton");
+        }, 500);
+      }, 2000);
+      return () => clearTimeout(timer);
+    }
+
+    if (phase === "skeleton") {
+      const timer = setTimeout(() => {
+        setExiting(true);
+        setTimeout(() => {
+          setPhase("done");
+        }, 500);
+      }, 1000);
+      return () => clearTimeout(timer);
+    }
+  }, [phase]);
+
+  if (phase === "done") {
+    return (
+      <div className="animate-in fade-in duration-500 h-full">{children}</div>
+    );
+  }
+
+  return (
+    <div className="relative h-full">
+      {phase === "logo" && <LogoPhase exiting={exiting} />}
+      {phase === "skeleton" && <SkeletonPhase exiting={exiting} />}
+    </div>
+  );
+}

--- a/apps/apollo-vertex/templates/dashboard/glow-config.ts
+++ b/apps/apollo-vertex/templates/dashboard/glow-config.ts
@@ -1,0 +1,294 @@
+export interface GlowConfig {
+  start: string;
+  end: string;
+  containerOpacity: number;
+  fillOpacity: number;
+  startStopOpacity: number;
+  endStopOpacity: number;
+  endOffset: number;
+}
+
+export interface CardGradient {
+  enabled: boolean;
+  start: string;
+  end: string;
+  angle: number;
+  opacity: number;
+}
+
+export interface CardConfig {
+  overviewBg: string;
+  overviewOpacity: number;
+  overviewGradient: CardGradient;
+  insightBg: string;
+  insightOpacity: number;
+  insightGradient: CardGradient;
+  promptBg: string;
+  promptOpacity: number;
+  promptGradient: CardGradient;
+  borderVisible: boolean;
+  backdropBlur: boolean;
+}
+
+export const defaultLightGlow: GlowConfig = {
+  start: "var(--insight-500)",
+  end: "var(--primary-400)",
+  containerOpacity: 70,
+  fillOpacity: 0.3,
+  startStopOpacity: 1,
+  endStopOpacity: 1,
+  endOffset: 0.35,
+};
+
+export const defaultDarkGlow: GlowConfig = {
+  start: "var(--insight-700)",
+  end: "var(--primary-600)",
+  containerOpacity: 45,
+  fillOpacity: 1,
+  startStopOpacity: 1,
+  endStopOpacity: 0.4,
+  endOffset: 0.5,
+};
+
+export type CardSize = "sm" | "md" | "lg";
+
+export type InsightCardType = "kpi" | "chart";
+export type ChartType =
+  | "donut"
+  | "horizontal-bars"
+  | "sparkline"
+  | "area"
+  | "stacked-bar";
+
+export interface InsightCardContent {
+  type: InsightCardType;
+  chartType: ChartType;
+  title: string;
+}
+
+export type CardInteraction = "static" | "expand" | "navigate";
+
+export interface InsightCardConfig {
+  size: CardSize;
+  visible: boolean;
+  content: InsightCardContent;
+  interaction: CardInteraction;
+  navigateTo?: string;
+}
+
+export interface LayoutConfig {
+  gap: number;
+  overviewRatio: number;
+  promptRatio: number;
+  insightCards: [
+    InsightCardConfig,
+    InsightCardConfig,
+    InsightCardConfig,
+    InsightCardConfig,
+  ];
+  padding: number;
+  containerBg: string;
+}
+
+export const defaultLayout: LayoutConfig = {
+  gap: 4,
+  overviewRatio: 4,
+  promptRatio: 1,
+  insightCards: [
+    {
+      size: "sm",
+      visible: true,
+      interaction: "static",
+      content: {
+        type: "kpi",
+        chartType: "donut",
+        title: "Upfront decision efficiency",
+      },
+    },
+    {
+      size: "md",
+      visible: true,
+      interaction: "expand",
+      content: {
+        type: "chart",
+        chartType: "horizontal-bars",
+        title: "Top issues",
+      },
+    },
+    {
+      size: "md",
+      visible: true,
+      interaction: "expand",
+      content: {
+        type: "chart",
+        chartType: "stacked-bar",
+        title: "Pipeline",
+      },
+    },
+    {
+      size: "sm",
+      visible: true,
+      interaction: "static",
+      content: {
+        type: "kpi",
+        chartType: "donut",
+        title: "SLA compliance",
+      },
+    },
+  ],
+  padding: 24,
+  containerBg: "none",
+};
+
+const defaultGradient: CardGradient = {
+  enabled: false,
+  start: "var(--insight-500)",
+  end: "var(--primary-400)",
+  angle: 135,
+  opacity: 100,
+};
+
+export const insightOptions = [
+  { label: "300", value: "var(--insight-300)" },
+  { label: "400", value: "var(--insight-400)" },
+  { label: "500", value: "var(--insight-500)" },
+  { label: "600", value: "var(--insight-600)" },
+  { label: "700", value: "var(--insight-700)" },
+  { label: "800", value: "var(--insight-800)" },
+  { label: "900", value: "var(--insight-900)" },
+];
+
+export const primaryOptions = [
+  { label: "300", value: "var(--primary-300)" },
+  { label: "400", value: "var(--primary-400)" },
+  { label: "500", value: "var(--primary-500)" },
+  { label: "600", value: "var(--primary-600)" },
+  { label: "700", value: "var(--primary-700)" },
+  { label: "800", value: "var(--primary-800)" },
+  { label: "900", value: "var(--primary-900)" },
+];
+
+export const cardTypeOptions = [
+  { label: "KPI", value: "kpi" },
+  { label: "Chart", value: "chart" },
+];
+
+export const interactionOptions = [
+  { label: "Static", value: "static" },
+  { label: "Expand", value: "expand" },
+  { label: "Navigate", value: "navigate" },
+];
+
+export const chartTypeOptions = [
+  { label: "Donut", value: "donut" },
+  { label: "Horizontal Bars", value: "horizontal-bars" },
+  { label: "Sparkline", value: "sparkline" },
+  { label: "Area", value: "area" },
+  { label: "Stacked Bar", value: "stacked-bar" },
+];
+
+export const sizeOptions = [
+  { label: "Small (1 col)", value: "sm" },
+  { label: "Medium (1 col)", value: "md" },
+  { label: "Large (full)", value: "lg" },
+];
+
+export const containerBgOptions = [
+  { label: "None", value: "none" },
+  { label: "white", value: "white" },
+  { label: "sidebar", value: "sidebar" },
+  { label: "card", value: "card" },
+  { label: "background", value: "background" },
+  { label: "muted", value: "muted" },
+];
+
+export const bgColorOptions = [
+  { label: "white", value: "white" },
+  { label: "sidebar", value: "sidebar" },
+  { label: "card", value: "card" },
+  { label: "background", value: "background" },
+  { label: "muted", value: "muted" },
+];
+
+export function cardBgStyle(
+  bg: string,
+  opacity: number,
+  gradient: CardGradient,
+): React.CSSProperties {
+  if (gradient.enabled) {
+    const alpha = gradient.opacity / 100;
+    const style = {
+      "--card-bg-override": `linear-gradient(${gradient.angle}deg, color-mix(in srgb, ${gradient.start} ${alpha * 100}%, transparent), color-mix(in srgb, ${gradient.end} ${alpha * 100}%, transparent))`,
+      borderColor: "transparent",
+    };
+    // oxlint-disable-next-line typescript-eslint(no-unsafe-type-assertion) -- CSS custom properties require assertion
+    return style as unknown as React.CSSProperties;
+  }
+  const value =
+    bg === "white"
+      ? `rgba(255,255,255,${opacity / 100})`
+      : `color-mix(in srgb, var(--${bg}) ${opacity}%, transparent)`;
+  // oxlint-disable-next-line typescript-eslint(no-unsafe-type-assertion) -- CSS custom properties require assertion
+  return { "--card-bg-override": value } as unknown as React.CSSProperties;
+}
+
+export function getInsightCardClasses(
+  content: InsightCardContent,
+  viewMode: "desktop" | "compact" | "stacked" = "desktop",
+): {
+  cardClassName: string;
+  contentClassName: string;
+} {
+  if (content.type === "kpi") {
+    const isCompact = viewMode === "compact";
+    return {
+      cardClassName: isCompact ? "!gap-0" : "!gap-4",
+      contentClassName: isCompact
+        ? "flex-1 flex flex-col overflow-hidden"
+        : "flex-1 flex flex-col",
+    };
+  }
+  const isBarChart = content.chartType === "horizontal-bars";
+  return {
+    cardClassName: content.chartType === "donut" ? "!gap-0" : "",
+    contentClassName: isBarChart ? "flex-1" : "flex-1 flex flex-col",
+  };
+}
+
+export const defaultDarkCards: CardConfig = {
+  overviewBg: "sidebar",
+  overviewOpacity: 69,
+  overviewGradient: { ...defaultGradient, opacity: 30 },
+  insightBg: "sidebar",
+  insightOpacity: 60,
+  insightGradient: { ...defaultGradient },
+  promptBg: "sidebar",
+  promptOpacity: 80,
+  promptGradient: { ...defaultGradient },
+  borderVisible: false,
+  backdropBlur: true,
+};
+
+const CARD_SIZES = new Set<string>(["sm", "md", "lg"]);
+const INSIGHT_CARD_TYPES = new Set<string>(["kpi", "chart"]);
+const CHART_TYPES = new Set<string>([
+  "donut",
+  "horizontal-bars",
+  "sparkline",
+  "area",
+  "stacked-bar",
+]);
+const CARD_INTERACTIONS = new Set<string>(["static", "expand", "navigate"]);
+
+export function isCardSize(v: string): v is CardSize {
+  return CARD_SIZES.has(v);
+}
+export function isInsightCardType(v: string): v is InsightCardType {
+  return INSIGHT_CARD_TYPES.has(v);
+}
+export function isChartType(v: string): v is ChartType {
+  return CHART_TYPES.has(v);
+}
+export function isCardInteraction(v: string): v is CardInteraction {
+  return CARD_INTERACTIONS.has(v);
+}

--- a/apps/apollo-vertex/templates/dashboard/insight-card-renderers.tsx
+++ b/apps/apollo-vertex/templates/dashboard/insight-card-renderers.tsx
@@ -1,0 +1,445 @@
+"use client";
+
+import { useRef, useState, useEffect } from "react";
+import { Badge } from "@/components/ui/badge";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/registry/tooltip/tooltip";
+import type { InsightCardContent } from "./glow-config";
+import { useDashboardData } from "./DashboardDataProvider";
+import type { InsightCardData } from "./dashboard-data";
+
+type ViewMode = "desktop" | "compact" | "stacked";
+
+// --- Truncated text with conditional tooltip ---
+
+function TruncatedText({
+  children,
+  className,
+}: {
+  children: string | undefined;
+  className?: string;
+}) {
+  const textRef = useRef<HTMLParagraphElement>(null);
+  const [isTruncated, setIsTruncated] = useState(false);
+
+  useEffect(() => {
+    const el = textRef.current;
+    if (!el) return;
+    const check = () => setIsTruncated(el.scrollHeight > el.clientHeight);
+    check();
+    const observer = new ResizeObserver(check);
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [children]);
+
+  const textEl = (
+    <p ref={textRef} className={`line-clamp-2 ${className ?? ""}`}>
+      {children}
+    </p>
+  );
+
+  if (!isTruncated) return textEl;
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>{textEl}</TooltipTrigger>
+      <TooltipContent side="bottom" className="max-w-64">
+        {children}
+      </TooltipContent>
+    </Tooltip>
+  );
+}
+
+// --- Sample data per card type ---
+
+const sparklinePoints = [4, 7, 5, 9, 6, 8, 12, 10, 14, 11, 15, 13];
+const areaPoints = [3, 5, 4, 8, 6, 9, 7, 11, 10, 14, 12, 16];
+
+// --- Renderers ---
+
+function KpiContent({
+  cardData,
+  viewMode,
+}: {
+  cardData: InsightCardData;
+  viewMode: ViewMode;
+}) {
+  if (viewMode === "compact") {
+    return (
+      <>
+        <div className="flex items-end gap-3">
+          <div className="text-5xl font-normal tracking-tight leading-none bg-gradient-to-r from-insight-800 to-primary-600 dark:from-insight-500 dark:to-primary-400 bg-clip-text text-transparent">
+            {cardData.kpiNumber}
+          </div>
+          <Badge variant="secondary" status="info" className="mb-1">
+            {cardData.kpiBadge}
+          </Badge>
+        </div>
+        <TruncatedText className="text-xs font-normal text-muted-foreground mt-auto">
+          {cardData.kpiDescription}
+        </TruncatedText>
+      </>
+    );
+  }
+
+  return (
+    <>
+      <div className="text-5xl font-normal tracking-tight leading-none bg-gradient-to-r from-insight-800 to-primary-600 dark:from-insight-500 dark:to-primary-400 bg-clip-text text-transparent">
+        {cardData.kpiNumber}
+      </div>
+      <div className="mt-auto">
+        <Badge variant="secondary" status="info" className="mb-2">
+          {cardData.kpiBadge}
+        </Badge>
+        <p className="text-xs font-normal text-muted-foreground">
+          {cardData.kpiDescription}
+        </p>
+      </div>
+    </>
+  );
+}
+
+function DonutContent() {
+  return (
+    <div className="flex items-center justify-center flex-1">
+      <div className="relative size-3/4 aspect-square">
+        <svg viewBox="0 0 36 36" className="size-full -rotate-90">
+          <circle
+            cx="18"
+            cy="18"
+            r="15.5"
+            fill="none"
+            className="stroke-muted"
+            strokeWidth="2"
+          />
+          <circle
+            cx="18"
+            cy="18"
+            r="15.5"
+            fill="none"
+            className="stroke-chart-1"
+            strokeWidth="2"
+            strokeDasharray="97.39"
+            strokeDashoffset={97.39 * (1 - 0.47)}
+            strokeLinecap="round"
+          />
+        </svg>
+        <div className="absolute inset-0 flex flex-col items-center justify-center">
+          <span className="text-2xl font-normal tracking-tight leading-none">
+            47%
+          </span>
+          <span className="text-[10px] text-muted-foreground mt-0.5">
+            funded
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function HorizontalBarsContent({
+  cardData,
+  viewMode,
+  isExpanded = false,
+}: {
+  cardData: InsightCardData;
+  viewMode: ViewMode;
+  isExpanded?: boolean;
+}) {
+  const bars = cardData.bars ?? [];
+  const chartColors = [
+    "bg-chart-1",
+    "bg-chart-2",
+    "bg-chart-3",
+    "bg-chart-4",
+    "bg-chart-5",
+  ];
+  const barsWithColor = bars.map((b, i) => ({
+    ...b,
+    color: chartColors[i % chartColors.length],
+  }));
+
+  if (viewMode === "compact" && !isExpanded) {
+    const total = barsWithColor.reduce((sum, s) => sum + s.value, 0);
+    return (
+      <div className="flex flex-col gap-3">
+        <div className="h-3 w-full rounded-full overflow-hidden flex">
+          {barsWithColor.map((issue) => (
+            <div
+              key={issue.label}
+              className={`${issue.color} relative`}
+              style={{ flex: issue.value }}
+            >
+              <div
+                className={`absolute inset-0 ${issue.color} opacity-35 dark:opacity-55 blur-[4px]`}
+              />
+            </div>
+          ))}
+        </div>
+        <div className="flex flex-wrap items-center gap-x-4 gap-y-1">
+          {barsWithColor.map((issue) => {
+            const pct = Math.round((issue.value / total) * 100);
+            return (
+              <div key={issue.label} className="flex items-center gap-1.5">
+                <div className={`size-2 rounded-full ${issue.color}`} />
+                <span className="text-[10px] text-muted-foreground">
+                  {issue.label} {pct}%
+                </span>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-5">
+      {barsWithColor.map((issue) => (
+        <div key={issue.label}>
+          <div className="flex items-center justify-between text-xs mb-1.5">
+            <span className="font-medium">{issue.label}</span>
+            <span className="font-bold">{issue.value}%</span>
+          </div>
+          <div className="h-1 w-full rounded-full bg-muted dark:bg-foreground/10 relative">
+            <div
+              className={`h-full rounded-full ${issue.color} relative`}
+              style={{ width: `${issue.value}%` }}
+            >
+              <div
+                className={`absolute inset-0 ${issue.color} rounded-full opacity-35 dark:opacity-55 blur-[4px]`}
+              />
+            </div>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function SparklineContent() {
+  const max = Math.max(...sparklinePoints);
+  const h = 40;
+  const w = 120;
+  const step = w / (sparklinePoints.length - 1);
+  const points = sparklinePoints
+    .map((v, i) => `${i * step},${h - (v / max) * h}`)
+    .join(" ");
+
+  return (
+    <div className="flex items-center justify-center flex-1">
+      <svg viewBox={`0 0 ${w} ${h}`} className="w-full h-16" fill="none">
+        <polyline
+          points={points}
+          className="stroke-chart-1"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          fill="none"
+        />
+      </svg>
+    </div>
+  );
+}
+
+function AreaContent() {
+  const max = Math.max(...areaPoints);
+  const h = 40;
+  const w = 120;
+  const step = w / (areaPoints.length - 1);
+  const linePoints = areaPoints
+    .map((v, i) => `${i * step},${h - (v / max) * h}`)
+    .join(" ");
+  const areaPath = `0,${h} ${linePoints} ${w},${h}`;
+
+  return (
+    <div className="flex items-center justify-center flex-1">
+      <svg viewBox={`0 0 ${w} ${h}`} className="w-full h-16" fill="none">
+        <polygon points={areaPath} className="fill-chart-1/20" />
+        <polyline
+          points={linePoints}
+          className="stroke-chart-1"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          fill="none"
+        />
+      </svg>
+    </div>
+  );
+}
+
+function StackedBarContent({
+  cardData,
+  viewMode,
+  isExpanded = false,
+}: {
+  cardData: InsightCardData;
+  viewMode: ViewMode;
+  isExpanded?: boolean;
+}) {
+  const chartColors = [
+    "bg-chart-1",
+    "bg-chart-2",
+    "bg-chart-3",
+    "bg-chart-4",
+    "bg-chart-5",
+  ];
+  const rawBars = cardData.stackedBars ?? [];
+  const legend = (cardData.stackedLegend ?? []).map((label, i) => ({
+    label,
+    color: chartColors[i % chartColors.length],
+  }));
+  const barData = rawBars.map((bar) => ({
+    label: bar.label,
+    segments: bar.segments.map((value, i) => ({
+      value,
+      color: chartColors[i % chartColors.length],
+    })),
+  }));
+  const maxTotal = Math.max(
+    ...barData.map((d) => d.segments.reduce((sum, s) => sum + s.value, 0)),
+  );
+
+  if (viewMode === "compact" && !isExpanded) {
+    // Summary: aggregate all days into one horizontal stacked bar
+    const totals = barData.reduce(
+      (acc, day) => {
+        for (const seg of day.segments) {
+          const key = seg.color;
+          acc[key] = (acc[key] ?? 0) + seg.value;
+        }
+        return acc;
+      },
+      {} as Record<string, number>,
+    );
+    const grandTotal = Object.values(totals).reduce((a, b) => a + b, 0);
+
+    return (
+      <div className="flex flex-col gap-3">
+        <div className="h-3 w-full rounded-full overflow-hidden flex">
+          {legend.map((item) => (
+            <div
+              key={item.color}
+              className={`${item.color} relative`}
+              style={{ flex: totals[item.color] ?? 0 }}
+            >
+              <div
+                className={`absolute inset-0 ${item.color} opacity-35 dark:opacity-55 blur-[4px]`}
+              />
+            </div>
+          ))}
+        </div>
+        <div className="flex items-center justify-between">
+          {legend.map((item) => {
+            const val = totals[item.color] ?? 0;
+            const pct = Math.round((val / grandTotal) * 100);
+            return (
+              <div key={item.label} className="flex items-center gap-1.5">
+                <div className={`size-2 rounded-full ${item.color}`} />
+                <span className="text-[10px] text-muted-foreground">
+                  {item.label} {pct}%
+                </span>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col h-full">
+      <div className="flex items-end justify-between flex-1 min-h-0">
+        {barData.map((bar) => {
+          const total = bar.segments.reduce((sum, s) => sum + s.value, 0);
+          const pct = (total / maxTotal) * 100;
+          return (
+            <div
+              key={bar.label}
+              className="w-4 flex flex-col items-center gap-1 h-full"
+            >
+              <div
+                className="w-full flex flex-col-reverse rounded-t-sm overflow-visible relative mt-auto"
+                style={{ height: `${pct}%` }}
+              >
+                <div className="absolute inset-0 flex flex-col-reverse rounded-t-sm overflow-hidden">
+                  {bar.segments.map((seg) => (
+                    <div
+                      key={seg.color}
+                      className={`${seg.color} relative`}
+                      style={{ flex: seg.value }}
+                    />
+                  ))}
+                </div>
+                <div className="absolute inset-0 flex flex-col-reverse rounded-t-sm opacity-35 dark:opacity-55 blur-[4px]">
+                  {bar.segments.map((seg) => (
+                    <div
+                      key={`glow-${seg.color}`}
+                      className={seg.color}
+                      style={{ flex: seg.value }}
+                    />
+                  ))}
+                </div>
+              </div>
+              <span className="text-[10px] text-muted-foreground">
+                {bar.label}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+      <div className="flex items-center gap-4 mt-auto pt-4">
+        {legend.map((item) => (
+          <div key={item.label} className="flex items-center gap-1.5">
+            <div className={`size-2 rounded-full ${item.color}`} />
+            <span className="text-[10px] text-muted-foreground">
+              {item.label}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export function InsightCardBody({
+  content,
+  cardIndex,
+  viewMode = "desktop",
+  isExpanded = false,
+}: {
+  content: InsightCardContent;
+  cardIndex: number;
+  viewMode?: ViewMode;
+  isExpanded?: boolean;
+}) {
+  const { data } = useDashboardData();
+  const cardData = data.insightCards[cardIndex] ?? data.insightCards[0];
+
+  if (content.type === "kpi") {
+    return <KpiContent cardData={cardData} viewMode={viewMode} />;
+  }
+  if (content.chartType === "horizontal-bars")
+    return (
+      <HorizontalBarsContent
+        cardData={cardData}
+        viewMode={viewMode}
+        isExpanded={isExpanded}
+      />
+    );
+  if (content.chartType === "donut") return <DonutContent />;
+  if (content.chartType === "sparkline") return <SparklineContent />;
+  if (content.chartType === "stacked-bar")
+    return (
+      <StackedBarContent
+        cardData={cardData}
+        viewMode={viewMode}
+        isExpanded={isExpanded}
+      />
+    );
+  return <AreaContent />;
+}


### PR DESCRIPTION
## Summary

Adds the rendering logic that turns raw data into card content. `InsightCardBody` decides whether a card should show a KPI number, a horizontal bar chart, a donut, a sparkline, or an area chart based on the card's `type` and `chartType` fields. This is the layer between the data model (PR 1) and the visual cards (PR 5) — nothing is visible in the UI yet since InsightGrid hasn't been added, but the renderer logic can be read and reviewed independently.

## Stacked on
#731

## Test plan
- [ ] No TypeScript errors in `insight-card-renderers.tsx`
- [ ] All card `type` and `chartType` combinations are handled

🤖 Generated with [Claude Code](https://claude.com/claude-code)