### PR TITLE
feat(apollo-react): add Sequential header to StageNode tasks section [MST-10115]

### DIFF
--- a/packages/apollo-react/src/canvas/components/StageNode/StageNodeSequentialTaskGroups.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNodeSequentialTaskGroups.tsx
@@ -23,6 +23,8 @@ import type { NodeMenuItem } from '../NodeContextMenu';
 import { DraggableTask } from './DraggableTask';
 import { useStageTaskDragHandler } from './hooks/useStageTaskDragHandler';
 import {
+  StageAdditionalTasksHeaderSection,
+  StageAdditionalTasksSection,
   StageParallelBracket,
   StageParallelLabel,
   StageTaskGroupContainer,
@@ -180,64 +182,69 @@ export const StageNodeSequentialTaskGroups = ({
     return null;
   }
   return (
-    <DndContext
-      collisionDetection={closestCenter}
-      sensors={sensors}
-      onDragStart={handleDragStart}
-      onDragMove={handleDragMove}
-      onDragOver={handleDragOver}
-      onDragEnd={handleDragEnd}
-      onDragCancel={handleDragCancel}
-    >
-      <SortableContext items={sequentialTaskIds} strategy={verticalListSortingStrategy}>
-        {/* Disable dragging and panning the canvas when dragging a task */}
-        <StageTaskList className="nodrag nopan">
-          {sequentialTaskGroups.map((taskGroup, groupIndex) => {
-            const isParallel = taskGroup.length > 1;
-            return (
-              <Row key={`group-${groupIndex}`} gap={Spacing.SpacingS}>
-                {isParallel && <StageParallelBracket />}
-                <StageTaskGroupContainer isParallel={isParallel}>
-                  {isParallel && (
-                    <StageParallelLabel>
-                      <span className="text-xs">{labels.parallel}</span>
-                    </StageParallelLabel>
-                  )}
-                  {taskGroup.map((task, taskIndex) => {
-                    const taskExecution = execution?.taskStatus?.[task.id];
-                    return (
-                      <DraggableTask
-                        key={task.id}
-                        task={task}
-                        taskExecution={taskExecution}
-                        isSelected={selectedTaskId === task.id}
-                        isParallel={isParallel}
-                        groupIndex={groupIndex}
-                        taskIndex={taskIndex}
-                        onTaskClick={handleTaskClick}
-                        projectedDepth={
-                          task.id === activeDragId && projected ? projected.depth : undefined
-                        }
-                        isDragDisabled={!onTaskReorder || isReadOnly}
-                        isTaskLoading={loadingTaskIds?.has(task.id)}
-                        {...(hasContextMenu &&
-                          !isReadOnly && {
-                            getContextMenuItems: buildContextMenuItems,
-                          })}
-                      />
-                    );
-                  })}
-                </StageTaskGroupContainer>
-              </Row>
-            );
-          })}
-        </StageTaskList>
-      </SortableContext>
-      <StageTaskDragOverlay
-        activeTask={activeSequentialTask?.task}
-        isActiveTaskParallel={isActiveTaskParallel}
-        taskWidthStyle={taskWidthStyle}
-      />
-    </DndContext>
+    <StageAdditionalTasksSection>
+      <StageAdditionalTasksHeaderSection>
+        <span className="text-xs font-bold text-foreground-muted">{labels.sequentialTasks}</span>
+      </StageAdditionalTasksHeaderSection>
+      <DndContext
+        collisionDetection={closestCenter}
+        sensors={sensors}
+        onDragStart={handleDragStart}
+        onDragMove={handleDragMove}
+        onDragOver={handleDragOver}
+        onDragEnd={handleDragEnd}
+        onDragCancel={handleDragCancel}
+      >
+        <SortableContext items={sequentialTaskIds} strategy={verticalListSortingStrategy}>
+          {/* Disable dragging and panning the canvas when dragging a task */}
+          <StageTaskList className="nodrag nopan">
+            {sequentialTaskGroups.map((taskGroup, groupIndex) => {
+              const isParallel = taskGroup.length > 1;
+              return (
+                <Row key={`group-${groupIndex}`} gap={Spacing.SpacingS}>
+                  {isParallel && <StageParallelBracket />}
+                  <StageTaskGroupContainer isParallel={isParallel}>
+                    {isParallel && (
+                      <StageParallelLabel>
+                        <span className="text-xs">{labels.parallel}</span>
+                      </StageParallelLabel>
+                    )}
+                    {taskGroup.map((task, taskIndex) => {
+                      const taskExecution = execution?.taskStatus?.[task.id];
+                      return (
+                        <DraggableTask
+                          key={task.id}
+                          task={task}
+                          taskExecution={taskExecution}
+                          isSelected={selectedTaskId === task.id}
+                          isParallel={isParallel}
+                          groupIndex={groupIndex}
+                          taskIndex={taskIndex}
+                          onTaskClick={handleTaskClick}
+                          projectedDepth={
+                            task.id === activeDragId && projected ? projected.depth : undefined
+                          }
+                          isDragDisabled={!onTaskReorder || isReadOnly}
+                          isTaskLoading={loadingTaskIds?.has(task.id)}
+                          {...(hasContextMenu &&
+                            !isReadOnly && {
+                              getContextMenuItems: buildContextMenuItems,
+                            })}
+                        />
+                      );
+                    })}
+                  </StageTaskGroupContainer>
+                </Row>
+              );
+            })}
+          </StageTaskList>
+        </SortableContext>
+        <StageTaskDragOverlay
+          activeTask={activeSequentialTask?.task}
+          isActiveTaskParallel={isActiveTaskParallel}
+          taskWidthStyle={taskWidthStyle}
+        />
+      </DndContext>
+    </StageAdditionalTasksSection>
   );
 };

--- a/packages/apollo-react/src/canvas/components/StageNode/useStageNodeLabels.ts
+++ b/packages/apollo-react/src/canvas/components/StageNode/useStageNodeLabels.ts
@@ -10,6 +10,7 @@ export interface StageNodeLabels {
   deleteTask: string;
   adhocTasks: string;
   eventDrivenTasks: string;
+  sequentialTasks: string;
   parallel: string;
   untitledStage: string;
   contextMenu: StageContextMenuLabels;
@@ -30,6 +31,7 @@ export function useStageNodeLabels(): StageNodeLabels {
         id: 'stage-node.event-driven-tasks',
         message: 'Event-driven tasks',
       }),
+      sequentialTasks: _({ id: 'stage-node.sequential-tasks', message: 'Sequential tasks' }),
       parallel: _({ id: 'stage-node.parallel', message: 'Parallel' }),
       untitledStage: _({ id: 'stage-node.untitled-stage', message: 'Untitled stage' }),
       contextMenu: {


### PR DESCRIPTION
## Summary
- Sequential tasks in `StageNode` had their own section but no header, unlike Event-driven and Ad hoc tasks. This adds a "Sequential" header with the same markup/styling.
- Wraps the sequential DnD content in `StageAdditionalTasksSection` + `StageAdditionalTasksHeaderSection`, matching the Event-driven and Ad hoc sections (`text-xs font-bold text-foreground-muted`).
- Adds a new i18n label `stage-node.sequential-tasks` → "Sequential".

Jira: [MST-10115](https://uipath.atlassian.net/browse/MST-10115)

## Test plan
- [ ] Render a `StageNode` containing sequential, event-driven, and ad hoc tasks; verify all three sections display headers with consistent styling.
- [ ] Render a `StageNode` with only sequential tasks; verify the "Sequential" header appears.
- [ ] Verify drag-and-drop reordering of sequential tasks still works (the DnD context now lives inside the wrapper).
- [ ] Verify spacing between sections is unchanged (the existing `marginTop` gating on `sequentialTaskGroups.length > 0` is untouched).


<img width="419" height="632" alt="Screenshot 2026-05-21 at 1 33 11 PM" src="https://github.com/user-attachments/assets/f60066d0-d037-4749-9499-101c0392d241" />


---
_Generated by [Claude Code](https://claude.ai/code/session_01Y4Lcv6P89fJiMiDozxa5RH)_

[MST-10115]: https://uipath.atlassian.net/browse/MST-10115?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ