### PR TITLE
feat(apollo-react): snap loop to grid [MST-10131, MST-10177]

### DIFF
--- a/packages/apollo-react/src/canvas/components/AddNodePanel/AddNodeManager.helpers.ts
+++ b/packages/apollo-react/src/canvas/components/AddNodePanel/AddNodeManager.helpers.ts
@@ -287,7 +287,7 @@ export function placeAddedNode({
       });
     }
 
-    const resolvedNodes = placeContainerNode({
+    const placedNodes = placeContainerNode({
       nodes,
       insertedNode,
       placement,
@@ -298,10 +298,33 @@ export function placeAddedNode({
       ignoredNodeTypes,
     });
 
-    return {
-      nodes: resolvedNodes,
-      insertedNode: resolvedNodes.find((node) => node.id === insertedNode.id)!,
-    };
+    // The preview is sized at `DEFAULT_NODE_SIZE` (96x96) but the materialized
+    // node can be much larger — a container node is 560x320 by default — so a
+    // True target placed by `calculateAutoPosition` for the 96-tall preview can
+    // overlap a False target sibling once both materialize. Resolve sibling
+    // collisions after fit so multi-output branches don't stack.
+    const placedInsertedNode = placedNodes.find((node) => node.id === insertedNode.id)!;
+    const resolved = resolveScopedCollisions(placedNodes, placedInsertedNode, {
+      ignoredNodeTypes,
+      getNodeDimensions,
+    });
+    // After siblings shift apart, the container may again need to grow.
+    if (resolved.insertedNode.parentId) {
+      const refitted = fitContainersAndPushSiblings({
+        nodes: resolved.nodes,
+        containerIds: [resolved.insertedNode.parentId],
+        getContainerFitGeometry,
+        getNodeDimensions,
+        ignoredNodeTypes,
+        gap: CONTAINER_SEQUENCE_GAP_PX,
+      });
+      return {
+        nodes: refitted,
+        insertedNode:
+          refitted.find((node) => node.id === resolved.insertedNode.id) ?? resolved.insertedNode,
+      };
+    }
+    return resolved;
   }
 
   const shifted = shiftForEdgeInsertion({

--- a/packages/apollo-react/src/canvas/components/AddNodePanel/AddNodeManager.test.tsx
+++ b/packages/apollo-react/src/canvas/components/AddNodePanel/AddNodeManager.test.tsx
@@ -910,6 +910,11 @@ describe('AddNodeManager', () => {
 
     screen.getByTestId('select-node').click();
 
+    // Materializes at source.right + gap (160 + 96 + 48 = 304) — `placeContainerNode`
+    // takes the preview's y (so handle-aware spread is preserved) but pushes x
+    // forward to clear the upstream source, matching `shiftForEdgeInsertion`'s
+    // behavior in the non-container path. Without this push, wide materializations
+    // (e.g. a 760px Agent) would stack on top of the source.
     expect(mockNodes.find((node) => node.id === 'test-node-1234567890')).toMatchObject({
       parentId: 'loop-1',
       extent: 'parent',

--- a/packages/apollo-react/src/canvas/components/ButtonHandle/ButtonHandle.test.tsx
+++ b/packages/apollo-react/src/canvas/components/ButtonHandle/ButtonHandle.test.tsx
@@ -375,8 +375,9 @@ describe('ButtonHandles', () => {
       const handleElements = screen.getAllByTestId('handle');
       expect(handleElements).toHaveLength(1);
 
-      // Single handle is always placed at the exact node center, regardless of grid.
-      expect(handleElements[0]).toHaveStyle({ top: '50%' });
+      // nodeHeight=80 → exact center (40) is half a grid step off (gridSize=16).
+      // Snap rounds to 48 (60%) so the handle stays grid-aligned.
+      expect(handleElements[0]).toHaveStyle({ top: '60%' });
     });
   });
 });

--- a/packages/apollo-react/src/canvas/components/ButtonHandle/ButtonHandleStyleUtils.test.ts
+++ b/packages/apollo-react/src/canvas/components/ButtonHandle/ButtonHandleStyleUtils.test.ts
@@ -878,6 +878,16 @@ describe('ButtonHandleStyleUtils', () => {
       expect(calculateGridAlignedHandlePositions(96, 1)).toEqual([48]);
     });
 
+    it('should snap single handle to grid when nodeSize is not grid-aligned', () => {
+      // 312px node: ideal center 156 is off-grid by 4. Snap → 160.
+      expect(calculateGridAlignedHandlePositions(312, 1)).toEqual([160]);
+    });
+
+    it('should snap single handle to grid when nodeSize is odd', () => {
+      // 321px: half is 160.5. Snap → 160.
+      expect(calculateGridAlignedHandlePositions(321, 1)).toEqual([160]);
+    });
+
     it('should calculate equidistant positions for 2 handles', () => {
       // 2 handles, gridSize=8: ideal=96/3=32, rounded=32, span=32, start=(96-32)/2=32
       // Positions: 32, 64

--- a/packages/apollo-react/src/canvas/components/ButtonHandle/ButtonHandleStyleUtils.ts
+++ b/packages/apollo-react/src/canvas/components/ButtonHandle/ButtonHandleStyleUtils.ts
@@ -53,7 +53,11 @@ export const calculateGridAlignedHandlePositions = (
 ): number[] => {
   if (numHandles === 0) return [];
   if (nodeSize <= 0) return [];
-  if (numHandles === 1) return [nodeSize / 2];
+  if (numHandles === 1) {
+    // Snap to grid so a single handle stays aligned when `nodeSize` is odd or
+    // off-grid (e.g. a 312px container would otherwise place its handle at 156).
+    return [Math.round(nodeSize / 2 / gridSize) * gridSize];
+  }
 
   const idealSpacing = nodeSize / (numHandles + 1);
 

--- a/packages/apollo-react/src/canvas/components/ButtonHandle/ButtonHandleStyleUtils.ts
+++ b/packages/apollo-react/src/canvas/components/ButtonHandle/ButtonHandleStyleUtils.ts
@@ -56,7 +56,7 @@ export const calculateGridAlignedHandlePositions = (
   if (numHandles === 1) {
     // Snap to grid so a single handle stays aligned when `nodeSize` is odd or
     // off-grid (e.g. a 312px container would otherwise place its handle at 156).
-    return [Math.round(nodeSize / 2 / gridSize) * gridSize];
+    return [snapToGrid(nodeSize / 2, gridSize)];
   }
 
   const idealSpacing = nodeSize / (numHandles + 1);

--- a/packages/apollo-react/src/canvas/components/LoopNode/LoopNode.helpers.test.ts
+++ b/packages/apollo-react/src/canvas/components/LoopNode/LoopNode.helpers.test.ts
@@ -224,7 +224,6 @@ describe('resolveContainerAddNodePreview', () => {
 
     expect(previewOverrides).toMatchObject({
       containerId: loopNode.id,
-      positionMode: 'center',
       target: {
         nodeId: loopNode.id,
         handleId: 'continue',
@@ -238,6 +237,8 @@ describe('resolveContainerAddNodePreview', () => {
         },
       },
     });
+    expect(previewOverrides).not.toHaveProperty('positionMode');
+    expect(previewOverrides).not.toHaveProperty('position');
   });
 
   it('continues to insert workflow output handles between container children', () => {
@@ -402,7 +403,6 @@ describe('resolveContainerAddNodePreview', () => {
 
     expect(previewOverrides).toMatchObject({
       containerId: loopNode.id,
-      positionMode: 'center',
       target: {
         nodeId: loopNode.id,
         handleId: 'continue',
@@ -416,6 +416,8 @@ describe('resolveContainerAddNodePreview', () => {
         },
       },
     });
+    expect(previewOverrides).not.toHaveProperty('positionMode');
+    expect(previewOverrides).not.toHaveProperty('position');
   });
 
   it('continues to insert from an occupied container inner source handle', () => {

--- a/packages/apollo-react/src/canvas/utils/NodeUtils.test.ts
+++ b/packages/apollo-react/src/canvas/utils/NodeUtils.test.ts
@@ -299,6 +299,55 @@ describe('NodeUtils', () => {
       expect(result).toEqual({ x: 150, y: 120 });
     });
 
+    it('should detect overlap against nodes that have no measured dimensions yet', () => {
+      // Reproduces the "click +True then +False" bug: a freshly-committed node
+      // doesn't have `measured` populated until React Flow re-measures the
+      // DOM. Without a fallback, overlap detection used 0 for its size and
+      // never detected the collision, so the next preview landed on top.
+      const nodes: Node[] = [
+        {
+          id: 'just-committed',
+          position: { x: 100, y: 100 },
+          // No measured, no width/height — fresh from setNodes.
+          data: {},
+        },
+      ];
+
+      const result = getNonOverlappingPositionForDirection(
+        nodes,
+        { x: 100, y: 100 },
+        { width: 96, height: 96 },
+        'right'
+      );
+
+      expect(result.y).toBeGreaterThan(100);
+    });
+
+    it('should prefer `width`/`height` over DEFAULT_NODE_SIZE when measured is missing', () => {
+      const nodes: Node[] = [
+        {
+          id: 'wide',
+          position: { x: 100, y: 100 },
+          width: 200,
+          height: 60,
+          data: {},
+        },
+      ];
+
+      const newPosition = { x: 250, y: 100 };
+
+      const result = getNonOverlappingPositionForDirection(
+        nodes,
+        newPosition,
+        { width: 96, height: 96 },
+        'right'
+      );
+
+      // Existing node spans x=100..300; new at x=250 (width 96) overlaps it.
+      // Without the width fallback, this overlap would be missed.
+      expect(result.y).toBeGreaterThan(100);
+    });
+
     it('should handle all directions correctly', () => {
       const nodes: Node[] = [
         {

--- a/packages/apollo-react/src/canvas/utils/NodeUtils.ts
+++ b/packages/apollo-react/src/canvas/utils/NodeUtils.ts
@@ -57,15 +57,21 @@ export function getNonOverlappingPositionForDirection(
   ignoredNodeTypes: string[] = [],
   overflowDirection: { x: 'left' | 'right'; y: 'up' | 'down' } = { x: 'right', y: 'down' }
 ): XYPosition {
-  const isOverlapping = nodes.some(
-    (node) =>
-      node.id !== PREVIEW_NODE_ID &&
-      !ignoredNodeTypes.includes(node.type ?? '') &&
+  const isOverlapping = nodes.some((node) => {
+    if (node.id === PREVIEW_NODE_ID || ignoredNodeTypes.includes(node.type ?? '')) return false;
+    // Fall back to width/height and DEFAULT_NODE_SIZE when `measured` isn't
+    // populated yet — React Flow measures asynchronously, so a node committed
+    // by the previous Add Node click can still have `measured` undefined when
+    // the next click runs overlap detection.
+    const nodeWidth = node.measured?.width ?? node.width ?? DEFAULT_NODE_SIZE;
+    const nodeHeight = node.measured?.height ?? node.height ?? DEFAULT_NODE_SIZE;
+    return (
       node.position.x < newNodePosition.x + newNodeStyle.width &&
-      node.position.x + (node.measured?.width ?? 0) > newNodePosition.x &&
+      node.position.x + nodeWidth > newNodePosition.x &&
       node.position.y < newNodePosition.y + newNodeStyle.height &&
-      node.position.y + (node.measured?.height ?? 0) > newNodePosition.y
-  );
+      node.position.y + nodeHeight > newNodePosition.y
+    );
+  });
 
   if (isOverlapping) {
     // Shift toward the closest perpendicular edge of the source node.

--- a/packages/apollo-react/src/canvas/utils/container.test.ts
+++ b/packages/apollo-react/src/canvas/utils/container.test.ts
@@ -489,8 +489,12 @@ describe('container sizing', () => {
     expect(result.nodes.find((node) => node.id === 'inner')).toMatchObject({
       style: { width: DEFAULT_CONTAINER_WIDTH, height: DEFAULT_CONTAINER_HEIGHT },
     });
+    // Outer grows upward (its `position.y` moves negative by the cumulative
+    // leadingShift) so children don't visually jump down in canvas space.
+    // height = 320 + leadingShiftY(160), width = 144 + 560 + 144 = 848.
     expect(result.nodes.find((node) => node.id === 'outer')).toMatchObject({
-      style: { width: 848, height: 464 },
+      position: { x: 0, y: -160 },
+      style: { width: 848, height: 480 },
     });
   });
 });
@@ -816,12 +820,13 @@ describe('placeContainerNode cyclic edges', () => {
       data: {},
     };
     // Wider rectangle inserted between n1 and n2 — n2 must shift right.
+    // Position is what the preview pass already computed: right of n1 by gap.
     const insertedNode: Node = {
       id: 'inserted',
       type: 'agent',
       parentId: 'outer',
       extent: 'parent',
-      position: { x: 0, y: 112 },
+      position: { x: 288, y: 112 },
       measured: { width: 288, height: 96 },
       data: {},
     };

--- a/packages/apollo-react/src/canvas/utils/container.test.ts
+++ b/packages/apollo-react/src/canvas/utils/container.test.ts
@@ -3,8 +3,10 @@ import { describe, expect, it } from 'vitest';
 import { PREVIEW_NODE_ID } from '../constants';
 import {
   type ContainerPlacement,
+  DEFAULT_CONTAINER_HEIGHT,
   DEFAULT_CONTAINER_MIN_HEIGHT,
   DEFAULT_CONTAINER_MIN_WIDTH,
+  DEFAULT_CONTAINER_WIDTH,
   ensureContainersFitChildren,
   getContainerFitGeometry,
   getContainerResizeMinimums,
@@ -30,8 +32,8 @@ describe('container sizing', () => {
       height: 224,
     });
     expect(getContainerFitGeometry()).toMatchObject({
-      minWidth: DEFAULT_CONTAINER_MIN_WIDTH,
-      minHeight: DEFAULT_CONTAINER_MIN_HEIGHT,
+      minWidth: DEFAULT_CONTAINER_WIDTH,
+      minHeight: DEFAULT_CONTAINER_HEIGHT,
       padding: { left: 144, right: 144, top: 96, bottom: 48 },
     });
   });
@@ -485,10 +487,10 @@ describe('container sizing', () => {
       y: 96,
     });
     expect(result.nodes.find((node) => node.id === 'inner')).toMatchObject({
-      style: { width: 400, height: 320 },
+      style: { width: DEFAULT_CONTAINER_WIDTH, height: DEFAULT_CONTAINER_HEIGHT },
     });
     expect(result.nodes.find((node) => node.id === 'outer')).toMatchObject({
-      style: { width: 704, height: 464 },
+      style: { width: 848, height: 464 },
     });
   });
 });

--- a/packages/apollo-react/src/canvas/utils/container.ts
+++ b/packages/apollo-react/src/canvas/utils/container.ts
@@ -225,7 +225,12 @@ export function getContainerSafeArea(
   };
 }
 
-/** Returns the default fit rules for loop/container nodes. */
+/**
+ * Default fit rules for loop/container nodes. `minWidth`/`minHeight` are the
+ * intrinsic default footprint (what a fresh empty container renders at), so
+ * auto-fit and tidy don't shrink past the empty-state size. The absolute
+ * resize floor (`DEFAULT_CONTAINER_MIN_*`) is enforced by `getContainerResizeMinimums`.
+ */
 export function getContainerFitGeometry(): ContainerFitGeometry {
   const padding = getContainerSafeArea({
     width: DEFAULT_CONTAINER_WIDTH,
@@ -233,8 +238,8 @@ export function getContainerFitGeometry(): ContainerFitGeometry {
   }).padding!;
 
   return {
-    minWidth: DEFAULT_CONTAINER_MIN_WIDTH,
-    minHeight: DEFAULT_CONTAINER_MIN_HEIGHT,
+    minWidth: DEFAULT_CONTAINER_WIDTH,
+    minHeight: DEFAULT_CONTAINER_HEIGHT,
     padding,
   };
 }

--- a/packages/apollo-react/src/canvas/utils/container.ts
+++ b/packages/apollo-react/src/canvas/utils/container.ts
@@ -67,6 +67,13 @@ export interface ContainerSizeChange {
   containerId: string;
   previousSize: NodeDimensions;
   nextSize: NodeDimensions;
+  /**
+   * Canvas-space delta applied to the container's own `position`. Non-zero when
+   * leading-edge growth shifted the container's top-left outward so children
+   * stay put in canvas. Consumers reconstructing pre-shift rects must add
+   * `positionDelta` back to `position`.
+   */
+  positionDelta?: { x: number; y: number };
 }
 
 /** Side-specific minimum sizes that prevent manual container resizing from clipping children. */
@@ -379,12 +386,21 @@ export function ensureContainersFitChildren(
     getNodeDimensions: resolveNodeDimensions = getNodeDimensions,
     ignoredNodeTypes = [],
     includeAncestors = true,
+    includePreviewNode = false,
   }: {
     containerIds?: Iterable<string>;
     getContainerFitGeometry?: (containerNode: Node) => ContainerFitGeometry | null | undefined;
     getNodeDimensions?: (node: Node) => NodeDimensions;
     ignoredNodeTypes?: string[];
     includeAncestors?: boolean;
+    /**
+     * Include `PREVIEW_NODE_ID` when computing the container's required size
+     * and `leadingShift`. Defaults to `false` because the preview is normally
+     * transient and shouldn't grow the container. The Add-Node-preview flow
+     * passes `true` so a preview placed above/below the source still triggers
+     * the container to grow and shift siblings.
+     */
+    includePreviewNode?: boolean;
   } = {}
 ): EnsureContainersFitChildrenResult {
   let nextNodes = nodes;
@@ -434,9 +450,11 @@ export function ensureContainersFitChildren(
 
     for (const childNode of nextNodes) {
       // Transient, hidden, and ignored children should not force a persisted
-      // container size.
+      // container size — unless the caller opts in via `includePreviewNode`
+      // (used by the Add-Node-preview flow to grow the container while the
+      // preview is on screen).
       if (
-        childNode.id === PREVIEW_NODE_ID ||
+        (childNode.id === PREVIEW_NODE_ID && !includePreviewNode) ||
         childNode.hidden ||
         childNode.parentId !== containerId ||
         ignoredTypes.has(childNode.type ?? '')
@@ -448,11 +466,18 @@ export function ensureContainersFitChildren(
       childrenToFit.push({ node: childNode, size: childSize });
       childIdsToShift.add(childNode.id);
 
-      if (padding.left !== undefined) {
-        leadingShiftX = Math.max(leadingShiftX, padding.left - childNode.position.x);
-      }
-      if (padding.top !== undefined) {
-        leadingShiftY = Math.max(leadingShiftY, padding.top - childNode.position.y);
+      // In preview mode, only the preview's own bbox drives growth — existing
+      // children aren't re-checked, so the container only expands if the
+      // preview itself lands past the safe area. Everyone still gets shifted
+      // by `leadingShift` below to keep canvas-space positions stable.
+      const driveLeadingShift = includePreviewNode ? childNode.id === PREVIEW_NODE_ID : true;
+      if (driveLeadingShift) {
+        if (padding.left !== undefined) {
+          leadingShiftX = Math.max(leadingShiftX, padding.left - childNode.position.x);
+        }
+        if (padding.top !== undefined) {
+          leadingShiftY = Math.max(leadingShiftY, padding.top - childNode.position.y);
+        }
       }
     }
 
@@ -491,7 +516,20 @@ export function ensureContainersFitChildren(
 
     nextNodes = nextNodes.map((node) => {
       if (node.id === containerId) {
-        return withNodeDimensions(node, nextSize);
+        const resized = withNodeDimensions(node, nextSize);
+        if (!shouldShiftChildren) return resized;
+        // Grow the container in the leading direction by also moving its own
+        // top-left outward, while children's local positions shift inward by
+        // the same amount. Net canvas-space movement of every child is zero —
+        // visually the container's top/left edge expands and the children
+        // stay put, instead of children appearing to jump down/right.
+        return {
+          ...resized,
+          position: {
+            x: (node.position?.x ?? 0) - leadingShiftX,
+            y: (node.position?.y ?? 0) - leadingShiftY,
+          },
+        };
       }
 
       if (shouldShiftChildren && childIdsToShift.has(node.id)) {
@@ -507,11 +545,17 @@ export function ensureContainersFitChildren(
       return node;
     });
     nodesById.set(containerId, nextNodes.find((node) => node.id === containerId)!);
-    if (nextSize.width !== currentSize.width || nextSize.height !== currentSize.height) {
+    // Emit a change record whenever size OR position moved — `fitContainersAndPushSiblings`
+    // uses `changes.length === 0` as an early-out, and `pushSiblingsAfterContainerGrowth`
+    // needs `positionDelta` to reconstruct the pre-shift rect when computing oldRight/oldBottom.
+    const sizeChanged =
+      nextSize.width !== currentSize.width || nextSize.height !== currentSize.height;
+    if (sizeChanged || shouldShiftChildren) {
       changes.push({
         containerId,
         previousSize: currentSize,
         nextSize,
+        positionDelta: shouldShiftChildren ? { x: -leadingShiftX, y: -leadingShiftY } : undefined,
       });
     }
   }
@@ -535,16 +579,6 @@ function clampTopLeftToSafeArea(
     x: clamp(position.x, safeArea.x, maxX),
     y: clamp(position.y, safeArea.y, maxY),
   };
-}
-
-function clampTopToSafeArea(
-  top: number,
-  safeArea: ContainerSafeArea,
-  nodeSize: NodeDimensions
-): number {
-  const maxY = safeArea.y + Math.max(0, safeArea.height - nodeSize.height);
-
-  return clamp(top, safeArea.y, maxY);
 }
 
 function rangesOverlap(startA: number, endA: number, startB: number, endB: number): boolean {
@@ -899,6 +933,8 @@ function resolveInsertPreview({
     return null;
   }
 
+  // For an edge insertion, place the preview between source and target —
+  // `calculateAutoPosition`'s overlap avoidance would shove it off the chain.
   const containerPlacement = getPreviewPlacement({
     sourceNode,
     targetNode,
@@ -919,8 +955,6 @@ function resolveInsertPreview({
   return {
     position: containerPlacement.centerPosition,
     positionMode: 'center',
-    // Store the replaced edge so the preview graph can hide exactly that edge
-    // while preserving enough data for Add Node to reconnect through the node.
     data: { originalEdge: replacedEdge, [PLACEMENT_DATA_KEY]: placement },
     target: {
       nodeId: replacedEdge.target,
@@ -973,34 +1007,23 @@ function resolveAppendPreview({
     return null;
   }
 
-  const targetNode =
-    continuationTarget.nodeId === containerNode.id
-      ? containerNode
-      : reactFlowInstance.getNode(continuationTarget.nodeId);
-  const containerPlacement = getPreviewPlacement({
-    sourceNode,
-    targetNode,
-    containerNode,
-    nodes,
-    safeArea: options.getContainerSafeArea?.(containerNode),
-    previewNodeSize: options.previewNodeSize,
-    gap: options.gap,
-    avoidSiblings: options.avoidSiblings ?? true,
-    getNodeDimensions: options.getNodeDimensions,
-  });
   const placement: ContainerPlacement = {
-    containerId: containerPlacement.containerId,
+    containerId: containerNode.id,
     sourceNodeId: sourceNode.id,
     targetNodeId: continuationTarget.nodeId,
     mode: 'sequence',
   };
 
+  // No `position`/`positionMode` → `createPreviewNode` runs `calculateAutoPosition`,
+  // which anchors on the clicked handle and applies `computeSpreadOffset` for
+  // multi-output sources (Decision True/False). This is the same logic used
+  // for non-container previews; `reparentPreviewNodeToContainer` then converts
+  // to container-local coords and `placeContainerNode` (on materialize) grows
+  // the container via `fitContainersAndPushSiblings`.
   return {
-    position: containerPlacement.centerPosition,
-    positionMode: 'center',
     data: { [PLACEMENT_DATA_KEY]: placement },
     target: continuationTarget,
-    containerId: containerPlacement.containerId,
+    containerId: containerNode.id,
   };
 }
 
@@ -1104,66 +1127,6 @@ function getPreviewPlacement({
 // Materialized placement
 // -----------------------------------------------------------------------------
 
-function getNodeCenterY(position: XYPosition, nodeSize: NodeDimensions): number {
-  return position.y + nodeSize.height / 2;
-}
-
-function getInsertedPosition({
-  sourceNode,
-  targetNode,
-  insertedNode,
-  containerNode,
-  nodes,
-  safeArea,
-  insertedNodeSize,
-  gap,
-  getNodeDimensions,
-}: {
-  sourceNode?: Node;
-  targetNode?: Node;
-  insertedNode: Node;
-  containerNode: Node;
-  nodes: Node[];
-  safeArea: ContainerSafeArea;
-  insertedNodeSize: NodeDimensions;
-  gap: number;
-  getNodeDimensions: (node: Node) => NodeDimensions;
-}): XYPosition {
-  const sourcePosition = getLocalNodePosition(sourceNode, containerNode, nodes);
-  const targetPosition = getLocalNodePosition(targetNode, containerNode, nodes);
-  const sourceSize = sourceNode ? getNodeDimensions(sourceNode) : undefined;
-  const targetSize = targetNode ? getNodeDimensions(targetNode) : undefined;
-  const sourceIsContainer = sourceNode?.id === containerNode.id;
-  const targetIsContainer = targetNode?.id === containerNode.id;
-
-  if (sourcePosition && sourceSize && !sourceIsContainer) {
-    return {
-      x: Math.max(safeArea.x, snapToGrid(sourcePosition.x + sourceSize.width + gap)),
-      y: clampTopToSafeArea(
-        snapToGrid(getNodeCenterY(sourcePosition, sourceSize) - insertedNodeSize.height / 2),
-        safeArea,
-        insertedNodeSize
-      ),
-    };
-  }
-
-  if (targetPosition && targetSize && !targetIsContainer) {
-    return {
-      x: Math.max(safeArea.x, snapToGrid(targetPosition.x - insertedNodeSize.width - gap)),
-      y: clampTopToSafeArea(
-        snapToGrid(getNodeCenterY(targetPosition, targetSize) - insertedNodeSize.height / 2),
-        safeArea,
-        insertedNodeSize
-      ),
-    };
-  }
-
-  return {
-    x: Math.max(safeArea.x, snapToGrid(insertedNode.position.x)),
-    y: clampTopToSafeArea(snapToGrid(insertedNode.position.y), safeArea, insertedNodeSize),
-  };
-}
-
 function getNodeDepth(node: Node | undefined, nodesById: Map<string, Node>): number {
   let depth = 0;
   let parentId = node?.parentId;
@@ -1225,16 +1188,22 @@ function pushSiblingsAfterContainerGrowth({
     if (widthDelta <= 0 && heightDelta <= 0) continue;
 
     const containerNode = nextNodes.find((node) => node.id === change.containerId)!;
-    const oldRight = containerNode.position.x + change.previousSize.width;
+    // When leading-edge growth was applied, `containerNode.position` has already
+    // moved outward by `positionDelta`. Reconstruct the pre-shift position so
+    // `oldRight/oldBottom` reflect the rect siblings actually saw before this fit.
+    const positionDelta = change.positionDelta ?? { x: 0, y: 0 };
+    const prevPosition = {
+      x: containerNode.position.x - positionDelta.x,
+      y: containerNode.position.y - positionDelta.y,
+    };
+    const oldRight = prevPosition.x + change.previousSize.width;
     const newRight = containerNode.position.x + change.nextSize.width;
-    const oldBottom = containerNode.position.y + change.previousSize.height;
+    const oldBottom = prevPosition.y + change.previousSize.height;
     const newBottom = containerNode.position.y + change.nextSize.height;
-    const containerLeft = containerNode.position.x;
-    const containerRight =
-      containerNode.position.x + Math.max(change.previousSize.width, change.nextSize.width);
-    const containerTop = containerNode.position.y;
-    const containerBottom =
-      containerNode.position.y + Math.max(change.previousSize.height, change.nextSize.height);
+    const containerLeft = Math.min(containerNode.position.x, prevPosition.x);
+    const containerRight = Math.max(newRight, oldRight);
+    const containerTop = Math.min(containerNode.position.y, prevPosition.y);
+    const containerBottom = Math.max(newBottom, oldBottom);
 
     nextNodes = nextNodes.map((node) => {
       if (node.id === containerNode.id || node.parentId !== containerNode.parentId) {
@@ -1385,6 +1354,22 @@ export function placeContainerNode({
   const nodesById = new Map(nodes.map((node) => [node.id, node]));
   const insertedSize = resolveNodeDimensions(insertedNode);
   const resolvedSafeArea = getSafeArea(containerNode, safeArea);
+  const upstreamSource =
+    placement.sourceNodeId && placement.sourceNodeId !== placement.containerId
+      ? nodesById.get(placement.sourceNodeId)
+      : undefined;
+  // Sequence mode: trust the preview's y (so handle-aware spread is preserved
+  // for Decision True/False), but ensure x sits past `source.right + gap`.
+  // The preview is sized at 96px and clamped to the container's current safe
+  // area, so for wide materializations (e.g. a 760px Agent) the preview's x
+  // would otherwise stack the new node on top of the source. Mirrors step 1
+  // of `shiftForEdgeInsertion` in the non-container path.
+  const sequenceX = upstreamSource
+    ? Math.max(
+        insertedNode.position.x,
+        snapUpToGrid(upstreamSource.position.x + resolveNodeDimensions(upstreamSource).width + gap)
+      )
+    : insertedNode.position.x;
   const positionedNode =
     placement.mode === 'first-child'
       ? {
@@ -1395,20 +1380,9 @@ export function placeContainerNode({
             insertedSize
           ),
         }
-      : {
-          ...insertedNode,
-          position: getInsertedPosition({
-            sourceNode: placement.sourceNodeId ? nodesById.get(placement.sourceNodeId) : undefined,
-            targetNode: placement.targetNodeId ? nodesById.get(placement.targetNodeId) : undefined,
-            insertedNode,
-            containerNode,
-            nodes,
-            safeArea: resolvedSafeArea,
-            insertedNodeSize: insertedSize,
-            gap,
-            getNodeDimensions: resolveNodeDimensions,
-          }),
-        };
+      : sequenceX !== insertedNode.position.x
+        ? { ...insertedNode, position: { ...insertedNode.position, x: sequenceX } }
+        : insertedNode;
   const targetNode =
     placement.targetNodeId && placement.targetNodeId !== placement.containerId
       ? nodesById.get(placement.targetNodeId)
@@ -1435,17 +1409,16 @@ export function placeContainerNode({
   }
   // Back-edge detection (siblings only): when source is visually at or
   // past target on the x axis, the original edge points backward in flow
-  // (a loopback). Skip the shift; getInsertedPosition places the inserted
-  // node past source, and the chain extends rightward naturally.
+  // (a loopback). Skip the shift; the preview placed the inserted node
+  // past source, and the chain extends rightward naturally.
   // Container.start edges (source = container itself) live in a different
   // coord space and are always forward.
-  const sourceNode = placement.sourceNodeId ? nodesById.get(placement.sourceNodeId) : undefined;
   const sourceIsContainer = placement.sourceNodeId === placement.containerId;
   const isBackEdge =
     !sourceIsContainer &&
-    sourceNode !== undefined &&
+    upstreamSource !== undefined &&
     targetNode !== undefined &&
-    sourceNode.position.x >= targetNode.position.x;
+    upstreamSource.position.x >= targetNode.position.x;
   const requiredTargetLeft = positionedNode.position.x + insertedSize.width + gap;
   const downstreamShift =
     !isBackEdge && targetNode && targetNode.position.x < requiredTargetLeft

--- a/packages/apollo-react/src/canvas/utils/container.ts
+++ b/packages/apollo-react/src/canvas/utils/container.ts
@@ -68,10 +68,11 @@ export interface ContainerSizeChange {
   previousSize: NodeDimensions;
   nextSize: NodeDimensions;
   /**
-   * Canvas-space delta applied to the container's own `position`. Non-zero when
-   * leading-edge growth shifted the container's top-left outward so children
-   * stay put in canvas. Consumers reconstructing pre-shift rects must add
-   * `positionDelta` back to `position`.
+   * Signed canvas-space delta `newPosition - oldPosition` applied to the
+   * container's own `position`. Non-zero when leading-edge growth shifted
+   * the container's top-left outward so children stay put in canvas.
+   * Consumers reconstructing the pre-shift rect compute it as
+   * `oldPosition = currentPosition - positionDelta`.
    */
   positionDelta?: { x: number; y: number };
 }
@@ -386,21 +387,12 @@ export function ensureContainersFitChildren(
     getNodeDimensions: resolveNodeDimensions = getNodeDimensions,
     ignoredNodeTypes = [],
     includeAncestors = true,
-    includePreviewNode = false,
   }: {
     containerIds?: Iterable<string>;
     getContainerFitGeometry?: (containerNode: Node) => ContainerFitGeometry | null | undefined;
     getNodeDimensions?: (node: Node) => NodeDimensions;
     ignoredNodeTypes?: string[];
     includeAncestors?: boolean;
-    /**
-     * Include `PREVIEW_NODE_ID` when computing the container's required size
-     * and `leadingShift`. Defaults to `false` because the preview is normally
-     * transient and shouldn't grow the container. The Add-Node-preview flow
-     * passes `true` so a preview placed above/below the source still triggers
-     * the container to grow and shift siblings.
-     */
-    includePreviewNode?: boolean;
   } = {}
 ): EnsureContainersFitChildrenResult {
   let nextNodes = nodes;
@@ -450,11 +442,9 @@ export function ensureContainersFitChildren(
 
     for (const childNode of nextNodes) {
       // Transient, hidden, and ignored children should not force a persisted
-      // container size — unless the caller opts in via `includePreviewNode`
-      // (used by the Add-Node-preview flow to grow the container while the
-      // preview is on screen).
+      // container size.
       if (
-        (childNode.id === PREVIEW_NODE_ID && !includePreviewNode) ||
+        childNode.id === PREVIEW_NODE_ID ||
         childNode.hidden ||
         childNode.parentId !== containerId ||
         ignoredTypes.has(childNode.type ?? '')
@@ -466,18 +456,11 @@ export function ensureContainersFitChildren(
       childrenToFit.push({ node: childNode, size: childSize });
       childIdsToShift.add(childNode.id);
 
-      // In preview mode, only the preview's own bbox drives growth — existing
-      // children aren't re-checked, so the container only expands if the
-      // preview itself lands past the safe area. Everyone still gets shifted
-      // by `leadingShift` below to keep canvas-space positions stable.
-      const driveLeadingShift = includePreviewNode ? childNode.id === PREVIEW_NODE_ID : true;
-      if (driveLeadingShift) {
-        if (padding.left !== undefined) {
-          leadingShiftX = Math.max(leadingShiftX, padding.left - childNode.position.x);
-        }
-        if (padding.top !== undefined) {
-          leadingShiftY = Math.max(leadingShiftY, padding.top - childNode.position.y);
-        }
+      if (padding.left !== undefined) {
+        leadingShiftX = Math.max(leadingShiftX, padding.left - childNode.position.x);
+      }
+      if (padding.top !== undefined) {
+        leadingShiftY = Math.max(leadingShiftY, padding.top - childNode.position.y);
       }
     }
 

--- a/packages/apollo-react/src/canvas/utils/container.ts
+++ b/packages/apollo-react/src/canvas/utils/container.ts
@@ -1183,10 +1183,6 @@ function pushSiblingsAfterContainerGrowth({
   // pass so a sibling that's both right-of and below-of a doubly-growing
   // container is visited once.
   for (const change of sortContainerSizeChanges(changes, nextNodes)) {
-    const widthDelta = change.nextSize.width - change.previousSize.width;
-    const heightDelta = change.nextSize.height - change.previousSize.height;
-    if (widthDelta <= 0 && heightDelta <= 0) continue;
-
     const containerNode = nextNodes.find((node) => node.id === change.containerId)!;
     // When leading-edge growth was applied, `containerNode.position` has already
     // moved outward by `positionDelta`. Reconstruct the pre-shift position so
@@ -1200,6 +1196,12 @@ function pushSiblingsAfterContainerGrowth({
     const newRight = containerNode.position.x + change.nextSize.width;
     const oldBottom = prevPosition.y + change.previousSize.height;
     const newBottom = containerNode.position.y + change.nextSize.height;
+    // Use edge deltas (not size deltas) so leading-only growth — where
+    // position moves outward and size grows by the same amount, leaving
+    // newRight === oldRight — doesn't push right/bottom siblings unnecessarily.
+    const rightDelta = newRight - oldRight;
+    const bottomDelta = newBottom - oldBottom;
+    if (rightDelta <= 0 && bottomDelta <= 0) continue;
     const containerLeft = Math.min(containerNode.position.x, prevPosition.x);
     const containerRight = Math.max(newRight, oldRight);
     const containerTop = Math.min(containerNode.position.y, prevPosition.y);
@@ -1214,9 +1216,9 @@ function pushSiblingsAfterContainerGrowth({
       let nextX = node.position.x;
       let nextY = node.position.y;
 
-      // Width grew: only siblings that sit to the right and overlap the
-      // container's vertical band can be visually covered by the new width.
-      if (widthDelta > 0 && node.position.x >= oldRight) {
+      // Right edge advanced: only siblings that sit to the right and overlap
+      // the container's vertical band can be visually covered.
+      if (rightDelta > 0 && node.position.x >= oldRight) {
         const verticallyOverlaps = rangesOverlap(
           node.position.y,
           node.position.y + nodeSize.height,
@@ -1224,13 +1226,12 @@ function pushSiblingsAfterContainerGrowth({
           containerBottom
         );
         if (verticallyOverlaps) {
-          nextX = Math.max(node.position.x + widthDelta, snapUpToGrid(newRight + gap));
+          nextX = Math.max(node.position.x + rightDelta, snapUpToGrid(newRight + gap));
         }
       }
 
-      // Height grew: mirror logic along Y. Sibling must sit below and
-      // horizontally overlap the container's column.
-      if (heightDelta > 0 && node.position.y >= oldBottom) {
+      // Bottom edge advanced: mirror logic along Y.
+      if (bottomDelta > 0 && node.position.y >= oldBottom) {
         const horizontallyOverlaps = rangesOverlap(
           node.position.x,
           node.position.x + nodeSize.width,
@@ -1238,7 +1239,7 @@ function pushSiblingsAfterContainerGrowth({
           containerRight
         );
         if (horizontallyOverlaps) {
-          nextY = Math.max(node.position.y + heightDelta, snapUpToGrid(newBottom + gap));
+          nextY = Math.max(node.position.y + bottomDelta, snapUpToGrid(newBottom + gap));
         }
       }
 

--- a/packages/apollo-react/src/canvas/utils/createPreviewGraph.ts
+++ b/packages/apollo-react/src/canvas/utils/createPreviewGraph.ts
@@ -4,7 +4,6 @@ import type {
   Position,
   ReactFlowInstance,
 } from '@uipath/apollo-react/canvas/xyflow/react';
-import { ensureContainersFitChildren, getContainerFitGeometry } from './container';
 import type { CSSProperties } from 'react';
 import { DEFAULT_SOURCE_HANDLE_ID, PREVIEW_NODE_ID } from '../constants';
 import {
@@ -89,12 +88,13 @@ function inferPreviewContainerId(sourceNode: Node, targetNode?: Node): string | 
 
 /**
  * Converts an absolute preview position into container-local coordinates and
- * parents the preview to the container with `extent: 'parent'`. The preview's
- * position is guaranteed valid by `applyPreviewGraphToReactFlow` running
- * `ensureContainersFitChildren({ includePreviewNode: true })` in the same
- * `setNodes` updater — that pass grows the container and shifts the preview
- * into the safe area before xyflow ever sees it, so `extent: 'parent'`'s
- * clamp is always a no-op.
+ * parents the preview to the container with `extent: 'parent'`. When the
+ * preview's handle-aware position lands past the container's body (e.g.
+ * Decision +True spread above the container), xyflow's clamp pulls it back
+ * to the nearest edge of the container body — the preview shows the
+ * approximate landing area inside the current container; the materialize
+ * pass then grows the container and places the real node at its true
+ * post-spread position.
  */
 export function reparentPreviewNodeToContainer(
   previewNode: Node,
@@ -222,28 +222,12 @@ export function applyPreviewGraphToReactFlow(
   const originalEdge = preview.node.data?.originalEdge as Edge | undefined;
 
   setTimeout(() => {
-    reactFlowInstance.setNodes((nodes) => {
-      const nextNodes = [
-        ...nodes
-          .filter((node) => node.id !== PREVIEW_NODE_ID)
-          .map((node) => ({ ...node, selected: false })),
-        preview.node,
-      ];
-      // When the preview is parented to a container, grow the container and
-      // shift its existing children so a preview placed above/below the
-      // source's row stays visually inside the (now-larger) container body.
-      // `includePreviewNode: true` overrides the default skip so the preview's
-      // negative-y drives the leadingShift.
-      if (preview.node.parentId) {
-        const fitResult = ensureContainersFitChildren(nextNodes, {
-          containerIds: [preview.node.parentId],
-          getContainerFitGeometry: () => getContainerFitGeometry(),
-          includePreviewNode: true,
-        });
-        return fitResult.nodes;
-      }
-      return nextNodes;
-    });
+    reactFlowInstance.setNodes((nodes) => [
+      ...nodes
+        .filter((node) => node.id !== PREVIEW_NODE_ID)
+        .map((node) => ({ ...node, selected: false })),
+      preview.node,
+    ]);
 
     reactFlowInstance.setEdges((edges) => [
       ...edges.filter((edge) => !isPreviewEdge(edge) && edge.id !== originalEdge?.id),

--- a/packages/apollo-react/src/canvas/utils/createPreviewGraph.ts
+++ b/packages/apollo-react/src/canvas/utils/createPreviewGraph.ts
@@ -4,6 +4,7 @@ import type {
   Position,
   ReactFlowInstance,
 } from '@uipath/apollo-react/canvas/xyflow/react';
+import { ensureContainersFitChildren, getContainerFitGeometry } from './container';
 import type { CSSProperties } from 'react';
 import { DEFAULT_SOURCE_HANDLE_ID, PREVIEW_NODE_ID } from '../constants';
 import {
@@ -88,7 +89,12 @@ function inferPreviewContainerId(sourceNode: Node, targetNode?: Node): string | 
 
 /**
  * Converts an absolute preview position into container-local coordinates and
- * constrains the preview to the container parent.
+ * parents the preview to the container with `extent: 'parent'`. The preview's
+ * position is guaranteed valid by `applyPreviewGraphToReactFlow` running
+ * `ensureContainersFitChildren({ includePreviewNode: true })` in the same
+ * `setNodes` updater — that pass grows the container and shifts the preview
+ * into the safe area before xyflow ever sees it, so `extent: 'parent'`'s
+ * clamp is always a no-op.
  */
 export function reparentPreviewNodeToContainer(
   previewNode: Node,
@@ -216,12 +222,28 @@ export function applyPreviewGraphToReactFlow(
   const originalEdge = preview.node.data?.originalEdge as Edge | undefined;
 
   setTimeout(() => {
-    reactFlowInstance.setNodes((nodes) => [
-      ...nodes
-        .filter((node) => node.id !== PREVIEW_NODE_ID)
-        .map((node) => ({ ...node, selected: false })),
-      preview.node,
-    ]);
+    reactFlowInstance.setNodes((nodes) => {
+      const nextNodes = [
+        ...nodes
+          .filter((node) => node.id !== PREVIEW_NODE_ID)
+          .map((node) => ({ ...node, selected: false })),
+        preview.node,
+      ];
+      // When the preview is parented to a container, grow the container and
+      // shift its existing children so a preview placed above/below the
+      // source's row stays visually inside the (now-larger) container body.
+      // `includePreviewNode: true` overrides the default skip so the preview's
+      // negative-y drives the leadingShift.
+      if (preview.node.parentId) {
+        const fitResult = ensureContainersFitChildren(nextNodes, {
+          containerIds: [preview.node.parentId],
+          getContainerFitGeometry: () => getContainerFitGeometry(),
+          includePreviewNode: true,
+        });
+        return fitResult.nodes;
+      }
+      return nextNodes;
+    });
 
     reactFlowInstance.setEdges((edges) => [
       ...edges.filter((edge) => !isPreviewEdge(edge) && edge.id !== originalEdge?.id),


### PR DESCRIPTION
Bundles the loop grid-snap fix with a broader rework of the Add-Node placement flow so previews and materialized nodes behave the same in containers as they do outside.

## 1. Loop grid snap

Loop containers now stay on the 16px grid so their inner handles and child rails don't drift off-grid at certain sizes.

## 2. Container default size for tidy logic

`getContainerFitGeometry` now floors at `DEFAULT_CONTAINER_WIDTH/HEIGHT` (560×320) instead of `MIN_*` (400×224). Tidy/auto-fit grows to the default size; manual resize still respects the lower MIN floor.

## 3. Add-Node placement parity (container vs non-container)

Several iterations brought the in-container Add-Node flow in line with the well-tested non-container behavior:

- **Handle-aware placement in containers**: `resolveAppendPreview` no longer overrides `position`/`positionMode`, so `calculateAutoPosition` runs with `computeSpreadOffset`. Decision True/False (and other multi-output handles) now spread above/below the source row inside containers exactly like outside. `resolveInsertPreview` keeps the edge-midpoint placement for the edge-replacement case.
- **Push past source on materialize**: `placeContainerNode` now ensures the inserted node's x clears `source.right + gap`, mirroring `shiftForEdgeInsertion` step 1 in the non-container path. Wide materializations like a 760px Agent no longer stack vertically on top of the source when the 96px-preview's position lands close.
- **Sibling collisions resolved**: `placeAddedNode` runs `resolveScopedCollisions` + refit after `placeContainerNode` so parallel branches don't overlap.
- **Container grows in the leading direction on commit**: when a materialized node lands above/left of the container body, `ensureContainersFitChildren` shifts the container's own `position` outward and shifts children's local positions inward by the same amount — existing children stay put in canvas space; only the container's top/left edge expands. The new `positionDelta` field on `ContainerSizeChange` lets `pushSiblingsAfterContainerGrowth` reconstruct the pre-shift rect via edge deltas (so leading-only growth doesn't push right/bottom siblings).
- **Preview clamps to current container body**: previews keep `extent: 'parent'`, so xyflow clamps them inside the container during preview. The actual handle-aware position is realized on commit (with growth applied), avoiding any container mutation from a preview the user might cancel.
- **Race-condition fix**: `getNonOverlappingPositionForDirection` falls back to `width`/`DEFAULT_NODE_SIZE` when `measured` is undefined. Fixes a silent stacking bug where a node committed by one Add Node click was invisible to the next click's overlap detection (React Flow measures asynchronously).

## BEFORE (snapping):

https://github.com/user-attachments/assets/55c3eb55-5d68-4a1d-9ba2-b36ab9b6263d

## AFTER (snapping):

https://github.com/user-attachments/assets/518ca688-5302-4d51-b88b-ae7f44c68fa7

## BEFORE (container add):

https://github.com/user-attachments/assets/cd2d8756-2e4e-4679-a7fd-9c1c63f3afef

## AFTER (container add):

https://github.com/user-attachments/assets/0854105f-4ebf-40ea-ad34-6ee80b187504


## Test plan

- [x] All 1580 unit tests pass.
- [x] Decision +True / +False inside a container places previews above/below as in non-container.
- [x] Insert between two siblings inside a container places preview on the edge midpoint.
- [x] Wide materializations (e.g. Agent → Agent) chain horizontally inside containers.
- [x] Container grows correctly in the leading direction on commit; existing children don't visibly move.
- [x] Cancelling a preview leaves container geometry unchanged.
- [x] Loop handles snap to grid at all container heights.