### PR TITLE
fix(apollo-react): center 'No tasks' text on read-only stage [MST-10234]

### DIFF
--- a/packages/apollo-react/src/canvas/components/StageNode/StageNodeAllTaskGroups.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNodeAllTaskGroups.tsx
@@ -163,7 +163,9 @@ const StageNodeAllTaskGroupsInner = ({
               {defaultContent}
             </Button>
           ) : (
-            <span className="text-xs text-foreground-muted h-9">{defaultContent}</span>
+            <span className="inline-flex items-center h-9 text-sm font-medium text-foreground-muted">
+              {defaultContent}
+            </span>
           )}
         </Column>
       ) : (


### PR DESCRIPTION
## Summary
- On a read-only stage with no tasks, the placeholder text rendered as a plain `<span>` with `text-xs h-9` and no flex centering, so it sat at the top of its box and was smaller than the editable "Add first task" link.
- Updated the span to match the `Button variant="link" size="sm"` box — `inline-flex items-center h-9 text-sm font-medium` — while keeping `text-foreground-muted` for the gray color.

## Test plan
- [ ] Open a stage card with no tasks in read-only mode and confirm the "No tasks" text is vertically centered and visually aligned like the "Add first task" link, just in gray.
- [ ] Open an editable empty stage and confirm the "Add first task" link is unchanged.

<img width="381" height="250" alt="image" src="https://github.com/user-attachments/assets/7eed161f-68d0-4189-9eb7-b4e68fa581b5" />



---
_Generated by [Claude Code](https://claude.ai/code/session_013jQhGhJEK8ka35Tw2WoR13)_