### PR TITLE
fix(apollo-react): loop node resize handles [MST-10254]

### DIFF
--- a/packages/apollo-react/src/canvas/components/LoopNode/LoopNode.test.tsx
+++ b/packages/apollo-react/src/canvas/components/LoopNode/LoopNode.test.tsx
@@ -4,19 +4,51 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { ValidationErrorSeverity } from '../../types/validation';
 import type { LoopNodeData } from './LoopNode.types';
 
-const { mockExecutionState, mockManifest, mockValidationState } = vi.hoisted(() => ({
-  mockExecutionState: { current: undefined as unknown },
-  mockManifest: {
-    current: {
-      display: { label: 'Loop', icon: 'repeat', shape: 'container' },
-      handleConfiguration: [],
-    } as Record<string, unknown>,
-  },
-  mockValidationState: { current: undefined as unknown },
-}));
+const { mockExecutionState, mockGetContainerResizeMinimums, mockManifest, mockValidationState } =
+  vi.hoisted(() => ({
+    mockExecutionState: { current: undefined as unknown },
+    mockGetContainerResizeMinimums: vi.fn(() => ({
+      left: 410,
+      right: 420,
+      top: 230,
+      bottom: 240,
+    })),
+    mockManifest: {
+      current: {
+        display: { label: 'Loop', icon: 'repeat', shape: 'container' },
+        handleConfiguration: [],
+      } as Record<string, unknown>,
+    },
+    mockValidationState: { current: undefined as unknown },
+  }));
 
 vi.mock('@uipath/apollo-react/canvas/xyflow/react', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@uipath/apollo-react/canvas/xyflow/react')>()),
+  NodeResizeControl: ({
+    children,
+    minHeight,
+    minWidth,
+    onResizeEnd,
+    onResizeStart,
+    position,
+  }: {
+    children?: React.ReactNode;
+    minHeight?: number;
+    minWidth?: number;
+    onResizeEnd?: () => void;
+    onResizeStart?: () => void;
+    position?: string;
+  }) => (
+    <div
+      data-testid={`node-resize-control-${position}`}
+      data-min-height={minHeight}
+      data-min-width={minWidth}
+      onMouseDown={onResizeStart}
+      onMouseUp={onResizeEnd}
+    >
+      {children}
+    </div>
+  ),
   useStore: (selector: unknown) => {
     const state = {
       connection: { inProgress: false },
@@ -27,6 +59,11 @@ vi.mock('@uipath/apollo-react/canvas/xyflow/react', async (importOriginal) => ({
     return typeof selector === 'function' ? selector(state) : false;
   },
   useUpdateNodeInternals: () => vi.fn(),
+}));
+
+vi.mock('../../utils/container', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../utils/container')>()),
+  getContainerResizeMinimums: mockGetContainerResizeMinimums,
 }));
 
 vi.mock('../../core', () => ({
@@ -86,8 +123,17 @@ function getLoopContainer() {
   return document.querySelector('[data-loop-container]') as HTMLElement;
 }
 
+function getResizeControls() {
+  return screen.queryAllByTestId(/^node-resize-control-/);
+}
+
+function getResizeIndicators() {
+  return screen.queryAllByTestId(/^loop-resize-corner-indicator-/);
+}
+
 beforeEach(() => {
   mockExecutionState.current = undefined;
+  mockGetContainerResizeMinimums.mockClear();
   mockValidationState.current = undefined;
 });
 
@@ -157,6 +203,20 @@ describe('LoopNode header adornment spacing', () => {
 
     expect(header.style.paddingRight).toBe('34px');
   });
+
+  it('uses a rows icon for sequential mode', () => {
+    renderLoopNode({ data: { parallel: false } });
+
+    expect(screen.getByText('Sequential')).toBeInTheDocument();
+    expect(screen.getByTestId('canvas-icon-rows-3')).toBeInTheDocument();
+  });
+
+  it('uses a columns icon for parallel mode', () => {
+    renderLoopNode({ data: { parallel: true } });
+
+    expect(screen.getByText('Parallel')).toBeInTheDocument();
+    expect(screen.getByTestId('canvas-icon-columns-3')).toBeInTheDocument();
+  });
 });
 
 describe('LoopNode status border hover treatment', () => {
@@ -179,5 +239,79 @@ describe('LoopNode status border hover treatment', () => {
 
     expect(container).toHaveClass('border-border-hover');
     expect(container).toHaveClass('shadow-(--canvas-node-shadow-hover)');
+  });
+});
+
+describe('LoopNode resize controls', () => {
+  it('renders resize controls before the loop is selected', () => {
+    renderLoopNode({ selected: false });
+
+    expect(getResizeControls()).toHaveLength(4);
+  });
+
+  it('does not compute child-aware resize minimums for an idle unselected loop', () => {
+    renderLoopNode({ selected: false });
+
+    expect(getResizeControls()).toHaveLength(4);
+    expect(mockGetContainerResizeMinimums).not.toHaveBeenCalled();
+  });
+
+  it('computes child-aware resize minimums when the loop is selected', () => {
+    renderLoopNode({ selected: true });
+
+    expect(mockGetContainerResizeMinimums).toHaveBeenCalledTimes(1);
+    expect(screen.getByTestId('node-resize-control-bottom-right')).toHaveAttribute(
+      'data-min-width',
+      '420'
+    );
+  });
+
+  it('computes child-aware resize minimums while the loop is hovered', () => {
+    renderLoopNode({ selected: false });
+
+    fireEvent.mouseEnter(getLoopContainer());
+
+    expect(mockGetContainerResizeMinimums).toHaveBeenCalledTimes(1);
+  });
+
+  it('hides resize indicators before the loop is selected', () => {
+    renderLoopNode({ selected: false });
+
+    expect(getResizeIndicators()).toHaveLength(4);
+    for (const indicator of getResizeIndicators()) {
+      expect(indicator).toHaveClass('opacity-0');
+    }
+  });
+
+  it('shows resize indicators when the loop is selected', () => {
+    renderLoopNode({ selected: true });
+
+    expect(getResizeIndicators()).toHaveLength(4);
+    for (const indicator of getResizeIndicators()) {
+      expect(indicator).toHaveClass('opacity-100');
+    }
+  });
+
+  it('does not render resize controls while dragging', () => {
+    renderLoopNode({ dragging: true, selected: true });
+
+    expect(getResizeControls()).toHaveLength(0);
+  });
+
+  it('keeps resize minimums and indicators active during an unselected resize', () => {
+    renderLoopNode({ selected: false });
+
+    fireEvent.mouseDown(screen.getByTestId('node-resize-control-bottom-right'));
+
+    expect(mockGetContainerResizeMinimums).toHaveBeenCalledTimes(1);
+    for (const indicator of getResizeIndicators()) {
+      expect(indicator).toHaveClass('opacity-100');
+    }
+
+    fireEvent.mouseUp(screen.getByTestId('node-resize-control-bottom-right'));
+
+    for (const indicator of getResizeIndicators()) {
+      expect(indicator).toHaveClass('opacity-0');
+    }
   });
 });

--- a/packages/apollo-react/src/canvas/components/LoopNode/LoopNode.tsx
+++ b/packages/apollo-react/src/canvas/components/LoopNode/LoopNode.tsx
@@ -191,6 +191,7 @@ function LoopNodeComponent(props: LoopNodeProps) {
   } = props;
   const nodeTypeRegistry = useOptionalNodeTypeRegistry();
   const [isHovered, setIsHovered] = useState(false);
+  const [isResizing, setIsResizing] = useState(false);
 
   const resolvedData = data ?? EMPTY_DATA;
   const isLoading = !!resolvedData.loading;
@@ -244,12 +245,14 @@ function LoopNodeComponent(props: LoopNodeProps) {
   const isDropTarget = resolvedData.isDropTarget === true;
   const containerWidth = width || DEFAULT_CONTAINER_WIDTH;
   const containerHeight = height || DEFAULT_CONTAINER_HEIGHT;
-  const showResizeControls = selected && !dragging && isDesignMode;
+  const resizeControlsMounted = isDesignMode && !dragging;
+  const resizeControlsVisible = resizeControlsMounted && (selected || isResizing);
+  const resizeMinimumsEnabled = resizeControlsMounted && (selected || isHovered || isResizing);
   const resizeMinimums = useContainerResizeMinimums(
     id,
     containerWidth,
     containerHeight,
-    showResizeControls
+    resizeMinimumsEnabled
   );
   const nodeSizeStyle = {
     width: containerWidth,
@@ -299,6 +302,8 @@ function LoopNodeComponent(props: LoopNodeProps) {
     },
     [onResize]
   );
+  const handleResizeStart = useCallback(() => setIsResizing(true), []);
+  const handleResizeEnd = useCallback(() => setIsResizing(false), []);
 
   const handleEmptyClick = useCallback(() => {
     onAddFirstChild?.();
@@ -374,9 +379,14 @@ function LoopNodeComponent(props: LoopNodeProps) {
           </BaseBadgeSlot>
         ) : null
       )}
-      <ResizeCornerIndicators visible={showResizeControls} />
-      {showResizeControls ? (
-        <ResizeControls minimums={resizeMinimums} onResize={handleResize} />
+      <ResizeCornerIndicators visible={resizeControlsVisible} />
+      {resizeControlsMounted ? (
+        <ResizeControls
+          minimums={resizeMinimums}
+          onResize={handleResize}
+          onResizeStart={handleResizeStart}
+          onResizeEnd={handleResizeEnd}
+        />
       ) : null}
       <Header
         title={displayTitle}
@@ -464,6 +474,7 @@ function Header({
           paddingRight: hasTopRightAdornment ? LOOP_HEADER_ADORNMENT_PADDING : undefined,
         }
       : undefined;
+  const executionModeIcon = isParallel ? 'columns-3' : 'rows-3';
 
   return (
     <div
@@ -482,8 +493,8 @@ function Header({
       <div className="flex shrink-0 items-center gap-2">
         {iterationState ? <IterationNavigator iterationState={iterationState} /> : null}
         <span className="flex h-6 shrink-0 items-center gap-1 rounded-full border border-border bg-surface px-2.5 text-[11px] font-semibold leading-4 text-foreground shadow-sm">
-          <span className={cn('flex shrink-0', isParallel && 'rotate-90')} aria-hidden>
-            <CanvasIcon icon="align-justify" size={11} />
+          <span className="flex shrink-0" aria-hidden>
+            <CanvasIcon icon={executionModeIcon} size={12} />
           </span>
           {isParallel ? 'Parallel' : 'Sequential'}
         </span>
@@ -533,9 +544,13 @@ function BodyFrame({ isEmpty, isLoading }: { isEmpty?: boolean; isLoading?: bool
 function ResizeControls({
   minimums = DEFAULT_RESIZE_MINIMUMS,
   onResize,
+  onResizeStart,
+  onResizeEnd,
 }: {
   minimums?: ContainerResizeMinimums;
   onResize: (_event: unknown, params: { width: number; height: number }) => void;
+  onResizeStart: () => void;
+  onResizeEnd: () => void;
 }) {
   return (
     <>
@@ -546,7 +561,9 @@ function ResizeControls({
           position={position}
           minWidth={minimums[widthSide]}
           minHeight={minimums[heightSide]}
+          onResizeStart={onResizeStart}
           onResize={onResize}
+          onResizeEnd={onResizeEnd}
         >
           <div
             className="absolute bottom-0 right-0 h-5 w-5 pointer-events-auto"
@@ -565,6 +582,7 @@ function ResizeCornerIndicators({ visible }: { visible: boolean }) {
         <div
           key={position}
           aria-hidden
+          data-testid={`loop-resize-corner-indicator-${position}`}
           className={cn(
             'pointer-events-none absolute h-2 w-2 rounded-full bg-brand transition-opacity',
             indicatorClassName,


### PR DESCRIPTION
## Summary

Address feedback from Gunter

```
Resize handle usability problems

Must select loop first before resize handles appear

Corner resize should work without pre-selection
```

## Problem

Loop containers previously gated both the visual corner indicators and the actual `NodeResizeControl` elements behind the selected state. That meant an unselected loop had no resize controls mounted, so users needed one click to select the loop and a second drag to resize it. Sticky notes already support first-drag corner resizing, so loop nodes felt less direct and inconsistent.

## Root Cause

`LoopNode` used a single `showResizeControls` boolean for multiple concerns: whether resize controls should be mounted, whether resize indicators should be visible, and when child-aware resize minimums should be computed. Because that boolean included `selected`, unselected loop nodes never rendered their resize controls.

## Fix

- Split loop resize state into separate mounted, visible, and child-aware minimum flags.
- Keep resize controls mounted in design mode while the loop is not dragging.
- Keep corner indicators visible when the loop is selected or while an unselected resize is actively in progress.
- Keep child-aware minimum sizing enabled only when selected, hovered, or actively resizing so idle unselected loops do not recompute container resize minimums on every React Flow store update.
- Added focused tests for unselected controls, selected indicators, hidden idle indicators, active-resize indicators, dynamic minimum gating, and dragging suppression.

## Validation

- `pnpm --filter @uipath/apollo-react test -- LoopNode.test.tsx`
- `git diff --check`
