### PR TITLE
fix(apollo-react): add loop node i18n [MST-10256]

### DIFF
--- a/packages/apollo-react/src/canvas/components/LoopNode/IterationNavigator.test.tsx
+++ b/packages/apollo-react/src/canvas/components/LoopNode/IterationNavigator.test.tsx
@@ -1,13 +1,18 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
+import { ApI18nProvider } from '../../../i18n';
 import { IterationNavigator } from './IterationNavigator';
 import type { LoopIterationState } from './LoopNode.types';
+
+function renderWithI18n(ui: React.ReactElement) {
+  return render(<ApI18nProvider component="canvas">{ui}</ApI18nProvider>);
+}
 
 function renderNavigator(iterationState: Partial<LoopIterationState> = {}) {
   const onActiveIndexChange = vi.fn();
 
-  render(
+  renderWithI18n(
     <IterationNavigator
       iterationState={{
         activeIndex: 1,
@@ -37,6 +42,7 @@ describe('IterationNavigator', () => {
     const user = userEvent.setup();
     const { onActiveIndexChange } = renderNavigator({ activeIndex: 99, total: 3 });
 
+    expect(screen.getByRole('group', { name: 'Loop iteration: 3 of 3' })).toBeTruthy();
     expect(screen.getByTestId('loop-iteration-label')).toHaveTextContent('3 / 3');
     expect(screen.getByRole('button', { name: 'Next loop iteration' })).toBeDisabled();
 
@@ -58,7 +64,7 @@ describe('IterationNavigator', () => {
   });
 
   it('disables previous and next at iteration boundaries', () => {
-    const { rerender } = render(
+    const { rerender } = renderWithI18n(
       <IterationNavigator
         iterationState={{
           activeIndex: 0,
@@ -72,13 +78,15 @@ describe('IterationNavigator', () => {
     expect(screen.getByRole('button', { name: 'Next loop iteration' })).not.toBeDisabled();
 
     rerender(
-      <IterationNavigator
-        iterationState={{
-          activeIndex: 2,
-          total: 3,
-          onActiveIndexChange: vi.fn(),
-        }}
-      />
+      <ApI18nProvider component="canvas">
+        <IterationNavigator
+          iterationState={{
+            activeIndex: 2,
+            total: 3,
+            onActiveIndexChange: vi.fn(),
+          }}
+        />
+      </ApI18nProvider>
     );
 
     expect(screen.getByRole('button', { name: 'Previous loop iteration' })).not.toBeDisabled();
@@ -98,5 +106,11 @@ describe('IterationNavigator', () => {
 
     expect(screen.getByRole('button', { name: 'Previous loop iteration' })).toBeDisabled();
     expect(screen.getByRole('button', { name: 'Next loop iteration' })).toBeDisabled();
+  });
+
+  it('preserves the host-provided iteration aria label', () => {
+    renderNavigator({ ariaLabel: 'Current item' });
+
+    expect(screen.getByRole('group', { name: 'Current item: 2 of 3' })).toBeTruthy();
   });
 });

--- a/packages/apollo-react/src/canvas/components/LoopNode/IterationNavigator.tsx
+++ b/packages/apollo-react/src/canvas/components/LoopNode/IterationNavigator.tsx
@@ -1,6 +1,7 @@
 import { cn } from '@uipath/apollo-wind';
 import type { SyntheticEvent } from 'react';
 import { useCallback } from 'react';
+import { useSafeLingui } from '../../../i18n';
 import { clamp } from '../../utils';
 import { CanvasIcon } from '../../utils/icon-registry';
 import type { LoopIterationState } from './LoopNode.types';
@@ -46,12 +47,23 @@ export function IterationNavigator({ iterationState }: IterationNavigatorProps) 
 }
 
 function NavigatorContent({ iterationState }: { iterationState: LoopIterationState }) {
+  const { _ } = useSafeLingui();
   const { activeIndex, total, onActiveIndexChange, disabled, ariaLabel } = iterationState;
   const canInteract = !disabled && typeof onActiveIndexChange === 'function';
   const canGoPrevious = canInteract && activeIndex > 0;
   const canGoNext = canInteract && activeIndex < total - 1;
-  const label = ariaLabel ?? 'Loop iteration';
+  const label = ariaLabel ?? _({ id: 'loop-node.iteration.label', message: 'Loop iteration' });
   const visibleIndex = activeIndex + 1;
+  const statusLabel = _({
+    id: 'loop-node.iteration.status',
+    message: '{label}: {visibleIndex} of {total}',
+    values: { label, visibleIndex, total },
+  });
+  const previousLabel = _({
+    id: 'loop-node.iteration.previous',
+    message: 'Previous loop iteration',
+  });
+  const nextLabel = _({ id: 'loop-node.iteration.next', message: 'Next loop iteration' });
 
   const handlePrevious = useCallback(
     (event: SyntheticEvent) => {
@@ -84,9 +96,7 @@ function NavigatorContent({ iterationState }: { iterationState: LoopIterationSta
       onMouseDown={stopCanvasControlEvent}
       onDoubleClick={stopCanvasControlEvent}
     >
-      <legend className="sr-only">
-        {label}: {visibleIndex} of {total}
-      </legend>
+      <legend className="sr-only">{statusLabel}</legend>
       <button
         type="button"
         className={cn(
@@ -95,7 +105,7 @@ function NavigatorContent({ iterationState }: { iterationState: LoopIterationSta
           canGoPrevious ? 'cursor-pointer opacity-100' : 'cursor-not-allowed opacity-40'
         )}
         disabled={!canGoPrevious}
-        aria-label="Previous loop iteration"
+        aria-label={previousLabel}
         onClick={handlePrevious}
         onPointerDown={stopCanvasControlEvent}
         onMouseDown={stopCanvasControlEvent}
@@ -117,7 +127,7 @@ function NavigatorContent({ iterationState }: { iterationState: LoopIterationSta
           canGoNext ? 'cursor-pointer opacity-100' : 'cursor-not-allowed opacity-40'
         )}
         disabled={!canGoNext}
-        aria-label="Next loop iteration"
+        aria-label={nextLabel}
         onClick={handleNext}
         onPointerDown={stopCanvasControlEvent}
         onMouseDown={stopCanvasControlEvent}

--- a/packages/apollo-react/src/canvas/components/LoopNode/LoopNode.test.tsx
+++ b/packages/apollo-react/src/canvas/components/LoopNode/LoopNode.test.tsx
@@ -134,6 +134,10 @@ function getResizeIndicators() {
 beforeEach(() => {
   mockExecutionState.current = undefined;
   mockGetContainerResizeMinimums.mockClear();
+  mockManifest.current = {
+    display: { label: 'Loop', icon: 'repeat', shape: 'container' },
+    handleConfiguration: [],
+  };
   mockValidationState.current = undefined;
 });
 
@@ -313,5 +317,36 @@ describe('LoopNode resize controls', () => {
     for (const indicator of getResizeIndicators()) {
       expect(indicator).toHaveClass('opacity-0');
     }
+  });
+});
+
+describe('LoopNode localized labels', () => {
+  it('renders the sequential mode label by default', () => {
+    renderLoopNode();
+
+    expect(screen.getByText('Sequential')).toBeTruthy();
+  });
+
+  it('renders the parallel mode label when the loop is parallel', () => {
+    renderLoopNode({ data: { parallel: true } });
+
+    expect(screen.getByText('Parallel')).toBeTruthy();
+  });
+
+  it('uses the localized fallback title when the manifest has no display label', () => {
+    mockManifest.current = {
+      display: { icon: 'repeat', shape: 'container' },
+      handleConfiguration: [],
+    };
+
+    renderLoopNode();
+
+    expect(screen.getByText('Loop')).toBeTruthy();
+  });
+
+  it('exposes a localized accessible label for the empty add button', () => {
+    renderLoopNode({ onAddFirstChild: vi.fn() });
+
+    expect(screen.getByRole('button', { name: 'Add node to loop' })).toBeTruthy();
   });
 });

--- a/packages/apollo-react/src/canvas/components/LoopNode/LoopNode.test.tsx
+++ b/packages/apollo-react/src/canvas/components/LoopNode/LoopNode.test.tsx
@@ -208,18 +208,24 @@ describe('LoopNode header adornment spacing', () => {
     expect(header.style.paddingRight).toBe('34px');
   });
 
-  it('uses a rows icon for sequential mode', () => {
+  it('uses an unrotated text align icon for sequential mode', () => {
     renderLoopNode({ data: { parallel: false } });
 
     expect(screen.getByText('Sequential')).toBeInTheDocument();
-    expect(screen.getByTestId('canvas-icon-rows-3')).toBeInTheDocument();
+    expect(screen.getByTestId('canvas-icon-text-align-justify')).toBeInTheDocument();
+    expect(screen.getByTestId('canvas-icon-text-align-justify').parentElement).not.toHaveClass(
+      'rotate-90'
+    );
   });
 
-  it('uses a columns icon for parallel mode', () => {
+  it('uses a rotated text align icon for parallel mode', () => {
     renderLoopNode({ data: { parallel: true } });
 
     expect(screen.getByText('Parallel')).toBeInTheDocument();
-    expect(screen.getByTestId('canvas-icon-columns-3')).toBeInTheDocument();
+    expect(screen.getByTestId('canvas-icon-text-align-justify')).toBeInTheDocument();
+    expect(screen.getByTestId('canvas-icon-text-align-justify').parentElement).toHaveClass(
+      'rotate-90'
+    );
   });
 });
 
@@ -321,18 +327,6 @@ describe('LoopNode resize controls', () => {
 });
 
 describe('LoopNode localized labels', () => {
-  it('renders the sequential mode label by default', () => {
-    renderLoopNode();
-
-    expect(screen.getByText('Sequential')).toBeTruthy();
-  });
-
-  it('renders the parallel mode label when the loop is parallel', () => {
-    renderLoopNode({ data: { parallel: true } });
-
-    expect(screen.getByText('Parallel')).toBeTruthy();
-  });
-
   it('uses the localized fallback title when the manifest has no display label', () => {
     mockManifest.current = {
       display: { icon: 'repeat', shape: 'container' },

--- a/packages/apollo-react/src/canvas/components/LoopNode/LoopNode.tsx
+++ b/packages/apollo-react/src/canvas/components/LoopNode/LoopNode.tsx
@@ -486,7 +486,6 @@ function Header({
           paddingRight: hasTopRightAdornment ? LOOP_HEADER_ADORNMENT_PADDING : undefined,
         }
       : undefined;
-  const executionModeIcon = isParallel ? 'columns-3' : 'rows-3';
 
   return (
     <div
@@ -505,8 +504,8 @@ function Header({
       <div className="flex shrink-0 items-center gap-2">
         {iterationState ? <IterationNavigator iterationState={iterationState} /> : null}
         <span className="flex h-6 shrink-0 items-center gap-1 rounded-full border border-border bg-surface px-2.5 text-[11px] font-semibold leading-4 text-foreground shadow-sm">
-          <span className="flex shrink-0" aria-hidden>
-            <CanvasIcon icon={executionModeIcon} size={12} />
+          <span className={cn('flex shrink-0', isParallel && 'rotate-90')} aria-hidden>
+            <CanvasIcon icon="text-align-justify" size={12} />
           </span>
           {label}
         </span>

--- a/packages/apollo-react/src/canvas/components/LoopNode/LoopNode.tsx
+++ b/packages/apollo-react/src/canvas/components/LoopNode/LoopNode.tsx
@@ -8,6 +8,7 @@ import {
 import { cn } from '@uipath/apollo-wind';
 import { memo, useCallback, useEffect, useMemo, useState } from 'react';
 import { shallow } from 'zustand/shallow';
+import { useSafeLingui } from '../../../i18n';
 import { NODE_BADGE_INSET_SQUARE, NODE_BADGE_SIZE } from '../../constants';
 import { useOptionalNodeTypeRegistry } from '../../core';
 import { useElementValidationStatus, useNodeExecutionState } from '../../hooks';
@@ -35,13 +36,13 @@ import { getStatusBorder } from '../BaseNode/BaseNodeContainer';
 import { MissingManifestNode } from '../BaseNode/BaseNodeMissingManifest';
 import type { HandleActionEvent } from '../ButtonHandle';
 import { ButtonHandles } from '../ButtonHandle';
+import { CanvasTooltip } from '../CanvasTooltip';
 import { NodeToolbar } from '../Toolbar';
 import { IterationNavigator } from './IterationNavigator';
 import { type ContainerHandleGroup, resolveContainerHandleGroups } from './LoopNode.helpers';
 import type { LoopIterationState, LoopNodeProps } from './LoopNode.types';
 
 const DEFAULT_LOOP_ICON = 'repeat';
-const DEFAULT_LOOP_TITLE = 'Loop';
 const EMPTY_DATA: Record<string, unknown> = {};
 const LOOP_HEADER_ADORNMENT_GAP = 8;
 const LOOP_HEADER_ADORNMENT_PADDING =
@@ -190,6 +191,7 @@ function LoopNodeComponent(props: LoopNodeProps) {
     iterationState: iterationStateProp,
   } = props;
   const nodeTypeRegistry = useOptionalNodeTypeRegistry();
+  const { _ } = useSafeLingui();
   const [isHovered, setIsHovered] = useState(false);
   const [isResizing, setIsResizing] = useState(false);
 
@@ -239,9 +241,16 @@ function LoopNodeComponent(props: LoopNodeProps) {
     [manifest?.display, id, resolvedData]
   );
 
-  const displayTitle = display.label ?? DEFAULT_LOOP_TITLE;
+  const displayTitle = display.label ?? _({ id: 'loop-node.title', message: 'Loop' });
   const displayIcon = display.icon ?? DEFAULT_LOOP_ICON;
   const isParallel = resolvedData.parallel === true;
+  const label = isParallel
+    ? _({ id: 'loop-node.mode.parallel', message: 'Parallel' })
+    : _({ id: 'loop-node.mode.sequential', message: 'Sequential' });
+  const addNodeToLoopLabel = _({
+    id: 'loop-node.add-node',
+    message: 'Add node to loop',
+  });
   const isDropTarget = resolvedData.isDropTarget === true;
   const containerWidth = width || DEFAULT_CONTAINER_WIDTH;
   const containerHeight = height || DEFAULT_CONTAINER_HEIGHT;
@@ -393,6 +402,7 @@ function LoopNodeComponent(props: LoopNodeProps) {
         icon={displayIcon}
         loading={isLoading}
         isParallel={isParallel}
+        label={label}
         iterationState={iterationStateProp}
         hasTopLeftAdornment={hasTopLeftAdornment}
         hasTopRightAdornment={hasTopRightAdornment}
@@ -405,7 +415,7 @@ function LoopNodeComponent(props: LoopNodeProps) {
             '-translate-x-1/2 -translate-y-1/2'
           )}
         >
-          <EmptyState onAddFirstChild={handleEmptyClick} />
+          <EmptyState label={addNodeToLoopLabel} onAddFirstChild={handleEmptyClick} />
         </div>
       ) : null}
       {toolbarConfig && (
@@ -441,6 +451,7 @@ function Header({
   icon,
   loading,
   isParallel,
+  label,
   iterationState,
   hasTopLeftAdornment,
   hasTopRightAdornment,
@@ -449,6 +460,7 @@ function Header({
   icon?: string;
   loading: boolean;
   isParallel: boolean;
+  label: string;
   iterationState?: LoopIterationState;
   hasTopLeftAdornment: boolean;
   hasTopRightAdornment: boolean;
@@ -496,30 +508,32 @@ function Header({
           <span className="flex shrink-0" aria-hidden>
             <CanvasIcon icon={executionModeIcon} size={12} />
           </span>
-          {isParallel ? 'Parallel' : 'Sequential'}
+          {label}
         </span>
       </div>
     </div>
   );
 }
 
-function EmptyState({ onAddFirstChild }: { onAddFirstChild: () => void }) {
+function EmptyState({ label, onAddFirstChild }: { label: string; onAddFirstChild: () => void }) {
   return (
-    <button
-      type="button"
-      onClick={onAddFirstChild}
-      aria-label="Add node to loop"
-      className={cn(
-        'nodrag nopan',
-        'pointer-events-auto flex h-8 w-8 items-center justify-center rounded-xl',
-        'border border-border bg-surface-overlay text-foreground',
-        'shadow-(--canvas-node-shadow-lifted)',
-        'transition-colors',
-        'hover:bg-surface-hover hover:border-brand'
-      )}
-    >
-      <CanvasIcon icon="plus" size={14} />
-    </button>
+    <CanvasTooltip content={label} placement="top">
+      <button
+        type="button"
+        onClick={onAddFirstChild}
+        aria-label={label}
+        className={cn(
+          'nodrag nopan',
+          'pointer-events-auto flex h-8 w-8 items-center justify-center rounded-xl',
+          'border border-border bg-surface-overlay text-foreground',
+          'shadow-(--canvas-node-shadow-lifted)',
+          'transition-colors',
+          'hover:bg-surface-hover hover:border-brand'
+        )}
+      >
+        <CanvasIcon icon="plus" size={14} />
+      </button>
+    </CanvasTooltip>
   );
 }
 

--- a/packages/apollo-react/src/canvas/locales/en.json
+++ b/packages/apollo-react/src/canvas/locales/en.json
@@ -34,5 +34,13 @@
   "sticky-note.toolbar.color": "Color",
   "sticky-note.toolbar.delete": "Delete",
   "sticky-note.toolbar.edit": "Edit",
-  "toolbox.search": "Search"
+  "toolbox.search": "Search",
+  "loop-node.add-node": "Add node to loop",
+  "loop-node.iteration.label": "Loop iteration",
+  "loop-node.iteration.next": "Next loop iteration",
+  "loop-node.iteration.previous": "Previous loop iteration",
+  "loop-node.iteration.status": "{label}: {visibleIndex} of {total}",
+  "loop-node.mode.parallel": "Parallel",
+  "loop-node.mode.sequential": "Sequential",
+  "loop-node.title": "Loop"
 }

--- a/packages/apollo-react/src/i18n/useSafeLingui.test.tsx
+++ b/packages/apollo-react/src/i18n/useSafeLingui.test.tsx
@@ -1,0 +1,65 @@
+import { setupI18n } from '@lingui/core';
+import { I18nProvider } from '@lingui/react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { useSafeLingui } from './useSafeLingui';
+
+type TranslationDescriptor = { id: string; message?: string; values?: Record<string, unknown> };
+type TranslationInput = TranslationDescriptor | string;
+
+function TranslationProbe({ descriptor }: { descriptor: TranslationInput }) {
+  const { _ } = useSafeLingui();
+  const label = typeof descriptor === 'string' ? _(descriptor) : _(descriptor);
+
+  return <span>{label}</span>;
+}
+
+describe('useSafeLingui', () => {
+  it('returns string ids when no provider is mounted', () => {
+    render(<TranslationProbe descriptor="test.message" />);
+
+    expect(screen.getByText('test.message')).toBeInTheDocument();
+  });
+
+  it('returns descriptor messages when no provider is mounted', () => {
+    render(<TranslationProbe descriptor={{ id: 'test.message', message: 'Hello world' }} />);
+
+    expect(screen.getByText('Hello world')).toBeInTheDocument();
+  });
+
+  it('formats descriptor values when no provider is mounted', () => {
+    render(
+      <TranslationProbe
+        descriptor={{
+          id: 'loop-node.iteration.status',
+          message: '{label}: {visibleIndex} of {total}',
+          values: { label: 'Loop iteration', visibleIndex: 1, total: 3 },
+        }}
+      />
+    );
+
+    expect(screen.getByText('Loop iteration: 1 of 3')).toBeInTheDocument();
+  });
+
+  it('uses the mounted Lingui provider when available', () => {
+    const testI18n = setupI18n({
+      locale: 'es',
+      messages: {
+        es: {
+          'test.greeting': 'Hola {name}',
+        },
+      },
+    });
+
+    render(
+      <I18nProvider i18n={testI18n}>
+        <TranslationProbe
+          descriptor={{ id: 'test.greeting', message: 'Hello {name}', values: { name: 'Ada' } }}
+        />
+      </I18nProvider>
+    );
+
+    expect(screen.getByText('Hola Ada')).toBeInTheDocument();
+  });
+});

--- a/packages/apollo-react/src/i18n/useSafeLingui.ts
+++ b/packages/apollo-react/src/i18n/useSafeLingui.ts
@@ -1,3 +1,4 @@
+import { setupI18n } from '@lingui/core';
 import { LinguiContext } from '@lingui/react';
 import { useContext, useMemo } from 'react';
 
@@ -7,10 +8,21 @@ type Translate = {
   (id: string): string;
 };
 
-// Returns the `message` (English default baked into the macro call) when no
+const fallbackI18n = setupI18n({ locale: 'en', messages: { en: {} } });
+
+// Formats the `message` (English default baked into the macro call) when no
 // I18nProvider is mounted upstream. Falls back to `id` if no message is given.
-const fallbackTranslate = ((arg: Descriptor | string): string =>
-  typeof arg === 'string' ? arg : (arg.message ?? arg.id)) as Translate;
+const fallbackTranslate = ((arg: Descriptor | string): string => {
+  if (typeof arg === 'string') {
+    return arg;
+  }
+
+  if (!arg.message) {
+    return arg.id;
+  }
+
+  return fallbackI18n._(arg);
+}) as Translate;
 
 // Drop-in replacement for `useLingui()` from `@lingui/react` that does NOT
 // throw when there is no I18nProvider upstream. Reads `LinguiContext` directly


### PR DESCRIPTION
## Summary

Adds Apollo canvas localization coverage for LoopNode user-facing strings. Loop nodes previously had hardcoded English labels for the fallback title, execution mode badge, iteration navigator controls, and empty-state add button, which meant those strings did not participate in the canvas Lingui catalog.

## Details

The change follows the existing Sticky Note formatting toolbar pattern by resolving labels with `useSafeLingui()` inside Apollo canvas components. `LoopNode` now localizes the fallback `Loop` title, the `Parallel` / `Sequential` mode label, and the empty-loop add affordance. The empty-state plus button now uses `Add node to loop` for both the tooltip and `aria-label`.

`IterationNavigator` now localizes its default group label, previous/next button names, and screen-reader status text while preserving a host-provided `iterationState.ariaLabel` override.

The English canvas catalog has been updated with the new `loop-node.*` message IDs. Flow Workbench consumes this through Apollo `BaseCanvas`, which wraps its canvas subtree with `ApI18nProvider component="canvas"`.

## Validation

- `pnpm --filter=@uipath/apollo-react test -- LoopNode`
