### PR TITLE
feat(apollo-react): add stage and task status tooltip [MST-10211]

### DIFF
--- a/apps/storybook/.storybook/preview.tsx
+++ b/apps/storybook/.storybook/preview.tsx
@@ -1,6 +1,7 @@
 import CssBaseline from '@mui/material/CssBaseline';
 import { ThemeProvider } from '@mui/material/styles';
 import type { Preview } from '@storybook/react';
+import { SUPPORTED_LOCALES } from '@uipath/apollo-react/i18n';
 import {
   apolloMaterialUiThemeDark,
   apolloMaterialUiThemeDarkHC,
@@ -61,6 +62,23 @@ const allThemes: ThemeMode[] = [
   'canvas',
 ];
 
+// Human-readable display names for the locale toolbar.
+const LOCALE_LABELS: Record<(typeof SUPPORTED_LOCALES)[number], string> = {
+  en: 'English',
+  es: 'Español',
+  pt: 'Português',
+  de: 'Deutsch',
+  fr: 'Français',
+  ja: '日本語',
+  ko: '한국어',
+  ru: 'Русский',
+  tr: 'Türkçe',
+  'zh-CN': '中文 (简体)',
+  'zh-TW': '中文 (繁體)',
+  'pt-BR': 'Português (Brasil)',
+  'es-MX': 'Español (México)',
+};
+
 // Map every theme to its closest MUI equivalent (used by stories with `parameters.material`)
 const muiThemeMap: Record<ThemeMode, typeof apolloMaterialUiThemeLight> = {
   light: apolloMaterialUiThemeLight,
@@ -107,6 +125,7 @@ const preview: Preview = {
   initialGlobals: {
     theme: 'future-dark',
     reactScan: 'off',
+    locale: 'en',
   },
   parameters: {
     backgrounds: { disable: true },
@@ -228,11 +247,23 @@ const preview: Preview = {
         },
       },
     }),
+    // Locale toolbar — sets <html lang>, which `ApI18nProvider` picks up as its
+    // fallback locale (see packages/apollo-react/src/i18n/ApI18nProvider.tsx).
+    locale: {
+      description: 'Locale for ApI18nProvider (sets <html lang>)',
+      toolbar: {
+        title: 'Locale',
+        icon: 'globe',
+        items: SUPPORTED_LOCALES.map((code) => ({ value: code, title: LOCALE_LABELS[code] })),
+        dynamicTitle: true,
+      },
+    },
   },
   decorators: [
     (Story, context) => {
       const theme = (context.globals.theme ?? 'future-dark') as ThemeMode;
       const reactScanEnabled = context.globals.reactScan === 'on';
+      const locale = (context.globals.locale ?? 'en') as (typeof SUPPORTED_LOCALES)[number];
 
       // Apply theme class to <body>. All themes (core and element) use <body>:
       // - Core themes match body.light/body.dark in apollo-core theme-variables.css
@@ -258,6 +289,12 @@ const preview: Preview = {
         }
       }, [reactScanEnabled]);
 
+      // Write synchronously during the decorator render so the freshly-mounted ApI18nProvider
+      // (forced by the `key={locale}` below) sees the new value on its first render.
+      if (typeof document !== 'undefined' && document.documentElement.lang !== locale) {
+        document.documentElement.lang = locale;
+      }
+
       const isFullscreen = context.parameters?.layout === 'fullscreen';
       const useMaterial = context.parameters?.material === true;
 
@@ -269,7 +306,7 @@ const preview: Preview = {
           <ThemeProvider theme={muiTheme}>
             <CssBaseline />
             <GlobalStyles />
-            <div style={{ height: '100%', width: '100%' }}>
+            <div key={locale} style={{ height: '100%', width: '100%' }}>
               <Story />
             </div>
           </ThemeProvider>
@@ -277,7 +314,7 @@ const preview: Preview = {
       }
 
       return (
-        <div className={isFullscreen ? 'h-screen' : 'p-1'}>
+        <div key={locale} className={isFullscreen ? 'h-screen' : 'p-1'}>
           <Story />
         </div>
       );

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.stories.tsx
@@ -16,7 +16,6 @@ import {
   DropdownMenuTrigger,
 } from '@uipath/apollo-wind';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { SUPPORTED_LOCALES, type SupportedLocale } from '../../../i18n';
 import { DefaultCanvasTranslations } from '../../types';
 import {
   createGroupModificationHandlers,
@@ -36,11 +35,9 @@ import { StageHeaderChipType, type StageNodeProps, type StageTaskItem } from './
 const DefaultCanvasDecorator = ({
   initialNodes,
   initialEdges = [],
-  locale,
 }: {
   initialNodes: Node[];
   initialEdges?: Edge[];
-  locale?: SupportedLocale;
 }) => {
   const [nodes, _setNodes, onNodesChange] = useNodesState(initialNodes);
   const [edges, setEdges, onEdgesChange] = useEdgesState(initialEdges);
@@ -68,7 +65,6 @@ const DefaultCanvasDecorator = ({
           nodeTypes={nodeTypes}
           edgeTypes={edgeTypes}
           mode="design"
-          locale={locale}
           connectionMode={ConnectionMode.Strict}
           defaultEdgeOptions={defaultEdgeOptions}
           connectionLineComponent={StageConnectionEdge}
@@ -83,9 +79,7 @@ const DefaultCanvasDecorator = ({
   );
 };
 
-type StageNodeStoryArgs = StageNodeProps & { locale?: SupportedLocale };
-
-const meta: Meta<StageNodeStoryArgs> = {
+const meta: Meta<StageNodeProps> = {
   title: 'Components/Nodes/StageNode',
   component: StageNode,
   parameters: {
@@ -114,27 +108,13 @@ const meta: Meta<StageNodeStoryArgs> = {
 
       const initialEdges = context.parameters?.edges || [];
 
-      return (
-        <DefaultCanvasDecorator
-          initialNodes={initialNodes}
-          initialEdges={initialEdges}
-          locale={context.args.locale}
-        />
-      );
+      return <DefaultCanvasDecorator initialNodes={initialNodes} initialEdges={initialEdges} />;
     },
   ],
   args: {
     stageDetails: {
       label: 'Default Stage',
       tasks: [],
-    },
-    locale: 'en',
-  },
-  argTypes: {
-    locale: {
-      control: 'select',
-      options: [...SUPPORTED_LOCALES],
-      description: 'Locale forwarded to ApI18nProvider.',
     },
   },
 };
@@ -543,7 +523,6 @@ export const ExecutionStatus: Story = {
           execution: {
             stageStatus: {
               status: 'NotExecuted',
-              label: 'Not started',
             },
             taskStatus: {},
           },
@@ -1077,7 +1056,7 @@ const initialTasks: StageTaskItem[][] = [
   [{ id: 'task-5', label: 'Final Approval', icon: <ProcessIcon /> }],
 ];
 
-const DraggableTaskReorderingStory = ({ locale }: { locale?: SupportedLocale }) => {
+const DraggableTaskReorderingStory = () => {
   const nodeTypes = useMemo(() => ({ stage: StageNodeWrapper }), []);
   const edgeTypes = useMemo(() => ({ stage: StageEdge }), []);
 
@@ -1182,7 +1161,6 @@ const DraggableTaskReorderingStory = ({ locale }: { locale?: SupportedLocale }) 
           nodeTypes={nodeTypes}
           edgeTypes={edgeTypes}
           mode="design"
-          locale={locale}
           connectionMode={ConnectionMode.Strict}
           defaultEdgeOptions={{ type: 'stage' }}
           connectionLineComponent={StageConnectionEdge}
@@ -1203,7 +1181,7 @@ export const DraggableTaskReordering: Story = {
   parameters: {
     useCustomRender: true,
   },
-  render: (args) => <DraggableTaskReorderingStory locale={args.locale} />,
+  render: () => <DraggableTaskReorderingStory />,
 };
 
 const initialTasksForAddReplace: StageTaskItem[][] = [
@@ -1260,7 +1238,7 @@ const availableTaskOptions: ListItem[] = [
   },
 ];
 
-const AddAndReplaceTasksStory = ({ locale }: { locale?: SupportedLocale }) => {
+const AddAndReplaceTasksStory = () => {
   const nodeTypes = useMemo(() => ({ stage: StageNodeWrapper }), []);
   const edgeTypes = useMemo(() => ({ stage: StageEdge }), []);
 
@@ -1566,7 +1544,6 @@ const AddAndReplaceTasksStory = ({ locale }: { locale?: SupportedLocale }) => {
           nodeTypes={nodeTypes}
           edgeTypes={edgeTypes}
           mode="design"
-          locale={locale}
           connectionMode={ConnectionMode.Strict}
           defaultEdgeOptions={{ type: 'stage' }}
           connectionLineComponent={StageConnectionEdge}
@@ -1602,10 +1579,10 @@ export const AddAndReplaceTasks: Story = {
   parameters: {
     useCustomRender: true,
   },
-  render: (args) => <AddAndReplaceTasksStory locale={args.locale} />,
+  render: () => <AddAndReplaceTasksStory />,
 };
 
-const InlineTitleEditStory = ({ locale }: { locale?: SupportedLocale }) => {
+const InlineTitleEditStory = () => {
   const nodeTypes = useMemo(() => ({ stage: StageNodeWrapper }), []);
   const edgeTypes = useMemo(() => ({ stage: StageEdge }), []);
 
@@ -1696,7 +1673,6 @@ const InlineTitleEditStory = ({ locale }: { locale?: SupportedLocale }) => {
           nodeTypes={nodeTypes}
           edgeTypes={edgeTypes}
           mode="design"
-          locale={locale}
           connectionMode={ConnectionMode.Strict}
           defaultEdgeOptions={{ type: 'stage' }}
           connectionLineComponent={StageConnectionEdge}
@@ -1717,7 +1693,7 @@ export const EditableStageTitle: Story = {
   parameters: {
     useCustomRender: true,
   },
-  render: (args) => <InlineTitleEditStory locale={args.locale} />,
+  render: () => <InlineTitleEditStory />,
 };
 
 // Simulate async children fetch (2s delay)
@@ -1744,7 +1720,7 @@ const loadedTaskOptionsWithChildren: ListItem[] = [
   { id: 'script', name: 'Script', data: { type: 'script' }, children: (id) => fetchChildren(id) },
 ];
 
-const AddTaskLoadingStory = ({ locale }: { locale?: SupportedLocale }) => {
+const AddTaskLoadingStory = () => {
   const nodeTypes = useMemo(() => ({ stage: StageNodeWrapper }), []);
   const edgeTypes = useMemo(() => ({ stage: StageEdge }), []);
   const setNodesRef = useRef<React.Dispatch<React.SetStateAction<Node[]>>>(null!);
@@ -1978,7 +1954,6 @@ const AddTaskLoadingStory = ({ locale }: { locale?: SupportedLocale }) => {
           nodeTypes={nodeTypes}
           edgeTypes={edgeTypes}
           mode="design"
-          locale={locale}
           connectionMode={ConnectionMode.Strict}
           defaultEdgeOptions={{ type: 'stage' }}
           connectionLineComponent={StageConnectionEdge}
@@ -1999,7 +1974,7 @@ export const AddTaskLoading: Story = {
   parameters: {
     useCustomRender: true,
   },
-  render: (args) => <AddTaskLoadingStory locale={args.locale} />,
+  render: () => <AddTaskLoadingStory />,
 };
 
 export const AdhocTasks: Story = {

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.test.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.test.tsx
@@ -1037,6 +1037,42 @@ describe('StageNode - Add Task Button', () => {
   });
 });
 
+describe('StageNode - Stage status icon tooltip', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders the status icon with the status name as aria-label and tooltip when no host label is supplied', () => {
+    renderStageNode({
+      execution: { stageStatus: { status: 'InProgress' }, taskStatus: {} },
+    });
+
+    const statusButton = screen.getByRole('button', { name: 'In progress' });
+    expect(statusButton).toBeInTheDocument();
+  });
+
+  it('uses the host-supplied error label as the aria-label so screen readers match the tooltip', () => {
+    renderStageNode({
+      execution: {
+        stageStatus: { status: 'Failed', label: 'Activity X threw NullReferenceException' },
+        taskStatus: {},
+      },
+    });
+
+    expect(
+      screen.getByRole('button', { name: 'Activity X threw NullReferenceException' })
+    ).toBeInTheDocument();
+  });
+
+  it('uses "In progress" as the aria-label for the InProgress status', () => {
+    renderStageNode({
+      execution: { stageStatus: { status: 'InProgress' as const }, taskStatus: {} },
+    });
+
+    expect(screen.getByRole('button', { name: 'In progress' })).toBeInTheDocument();
+  });
+});
+
 describe('StageTitleInput - input attributes', () => {
   const enterEditMode = async (user: ReturnType<typeof userEvent.setup>) => {
     await user.click(screen.getByRole('button', { name: 'Test Stage' }));

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNodeHeader.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNodeHeader.tsx
@@ -12,6 +12,7 @@ import { StageChip, StageHeader } from './StageNode.styles';
 import type { StageNodeProps, StageSlaIcon, StageStatus } from './StageNode.types';
 import { StageHeaderChipType } from './StageNode.types';
 import { StageTitleInput } from './StageTitleInput';
+import { useExecutionStatusLabel } from './useExecutionStatusLabel';
 import { useStageNodeLabels } from './useStageNodeLabels';
 
 const SLA_ICON_CONFIG: Record<StageSlaIcon, { icon: string; iconColor: string }> = {
@@ -46,6 +47,7 @@ const StageNodeHeaderInner = ({
   handleTaskAddClick: (event: React.MouseEvent) => void;
 }) => {
   const labels = useStageNodeLabels();
+  const getStatusName = useExecutionStatusLabel();
   const {
     id,
     stageDetails,
@@ -64,6 +66,8 @@ const StageNodeHeaderInner = ({
   const slaText = execution?.stageStatus?.slaText;
   const slaIcon = execution?.stageStatus?.slaIcon;
   const slaIndicator = slaIcon ? SLA_ICON_CONFIG[slaIcon] : undefined;
+  const statusFallbackName = status ? getStatusName(status) : '';
+  const statusTooltip = statusLabel || statusFallbackName;
 
   return (
     <StageHeader isException={isException} data-testid={`stage-header-${id}`}>
@@ -79,8 +83,8 @@ const StageNodeHeaderInner = ({
         </Row>
         <Row gap={Spacing.SpacingMicro} align="start" py={Padding.PadS}>
           {status && (
-            <CanvasTooltip content={statusLabel} placement="top">
-              <Button variant="ghost" size="icon" className="h-6 w-6" aria-label={statusLabel}>
+            <CanvasTooltip content={statusTooltip} placement="top">
+              <Button variant="ghost" size="icon" className="h-6 w-6" aria-label={statusTooltip}>
                 {status === 'NotExecuted' ? (
                   <CanvasIcon
                     icon="hourglass"

--- a/packages/apollo-react/src/canvas/components/StageNode/TaskContent.test.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/TaskContent.test.tsx
@@ -1,0 +1,92 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen } from '../../utils/testing';
+import type { StageTaskExecution, StageTaskItem } from './StageNode.types';
+import { TaskContent } from './TaskContent';
+
+// Surface CanvasTooltip content into the DOM so assertions don't depend on
+// Radix's pointer-event-driven open/close logic (unreliable in jsdom).
+vi.mock('../CanvasTooltip', () => ({
+  CanvasTooltip: ({
+    content,
+    children,
+  }: {
+    content: React.ReactNode;
+    children: React.ReactNode;
+  }) => (
+    <span
+      data-testid="canvas-tooltip"
+      data-tooltip-content={typeof content === 'string' ? content : ''}
+    >
+      {children}
+    </span>
+  ),
+}));
+
+const baseTask: StageTaskItem = { id: 'task-1', label: 'Run extraction' };
+
+const renderTaskContent = (overrides?: {
+  task?: Partial<StageTaskItem>;
+  taskExecution?: StageTaskExecution;
+}) =>
+  render(
+    <TaskContent
+      task={{ ...baseTask, ...overrides?.task }}
+      taskExecution={overrides?.taskExecution}
+    />
+  );
+
+describe('TaskContent - execution status tooltip', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('does not render a status icon button when no execution status is provided', () => {
+    renderTaskContent();
+    // The label-only button (truncation tooltip wrapper) doesn't have aria-label
+    // matching a status; no button exists for the status icon.
+    expect(screen.queryByRole('button', { name: 'In progress' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Completed' })).not.toBeInTheDocument();
+  });
+
+  it('renders a status icon button with the status name as aria-label when no host message is supplied', () => {
+    renderTaskContent({ taskExecution: { status: 'Completed' } });
+    expect(screen.getByRole('button', { name: 'Completed' })).toBeInTheDocument();
+  });
+
+  it('uses the host-supplied message as the aria-label so screen readers match the tooltip', () => {
+    renderTaskContent({
+      taskExecution: { status: 'Failed', message: 'Activity X threw NullReferenceException' },
+    });
+    expect(
+      screen.getByRole('button', { name: 'Activity X threw NullReferenceException' })
+    ).toBeInTheDocument();
+  });
+
+  it('uses the host-supplied message as tooltip content', () => {
+    renderTaskContent({
+      taskExecution: { status: 'Failed', message: 'Activity X threw NullReferenceException' },
+    });
+
+    const button = screen.getByRole('button', {
+      name: 'Activity X threw NullReferenceException',
+    });
+    const tooltipWrapper = button.closest('[data-testid="canvas-tooltip"]');
+    expect(tooltipWrapper).toHaveAttribute(
+      'data-tooltip-content',
+      'Activity X threw NullReferenceException'
+    );
+  });
+
+  it('falls back to the status name as tooltip content when no host message is supplied', () => {
+    renderTaskContent({ taskExecution: { status: 'InProgress' } });
+
+    const button = screen.getByRole('button', { name: 'In progress' });
+    const tooltipWrapper = button.closest('[data-testid="canvas-tooltip"]');
+    expect(tooltipWrapper).toHaveAttribute('data-tooltip-content', 'In progress');
+  });
+
+  it('labels NotExecuted as "Not started"', () => {
+    renderTaskContent({ taskExecution: { status: 'NotExecuted' } });
+    expect(screen.getByRole('button', { name: 'Not started' })).toBeInTheDocument();
+  });
+});

--- a/packages/apollo-react/src/canvas/components/StageNode/TaskContent.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/TaskContent.tsx
@@ -9,6 +9,7 @@ import { ExecutionStatusIcon } from '../ExecutionStatusIcon';
 import { StageTaskIcon, StageTaskRetryDuration } from './StageNode.styles';
 import type { StageTaskExecution, StageTaskItem } from './StageNode.types';
 import { StageTaskEntryConditionIcon } from './StageTaskEntryConditionIcon';
+import { useExecutionStatusLabel } from './useExecutionStatusLabel';
 
 const ProcessCanvasIcon = () => (
   <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
@@ -111,11 +112,14 @@ export interface TaskContentProps {
 
 export const TaskContent = memo(
   ({ task, taskExecution, isDragging, onTaskPlay }: TaskContentProps) => {
+    const getStatusName = useExecutionStatusLabel();
     const hasExecutionStatus = !!taskExecution?.status;
     const hasSecondRowContent =
       taskExecution &&
       (taskExecution.duration || taskExecution.retryDuration || taskExecution.badge);
     const showPlayButtonSmall = onTaskPlay && hasExecutionStatus;
+    const taskStatusFallbackName = hasExecutionStatus ? getStatusName(taskExecution?.status) : '';
+    const taskStatusTooltip = taskExecution?.message || taskStatusFallbackName;
 
     return (
       <Column
@@ -141,21 +145,18 @@ export const TaskContent = memo(
             </CanvasTooltip>
           </Row>
           <Row align="center" gap={Spacing.SpacingXs} style={{ flexShrink: 0 }}>
-            {hasExecutionStatus &&
-              (taskExecution.message ? (
-                <CanvasTooltip content={taskExecution.message} placement="top">
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    className="h-4 w-4"
-                    aria-label={taskExecution.message}
-                  >
-                    <ExecutionStatusIcon status={taskExecution.status} />
-                  </Button>
-                </CanvasTooltip>
-              ) : (
-                <ExecutionStatusIcon status={taskExecution.status} />
-              ))}
+            {hasExecutionStatus && (
+              <CanvasTooltip content={taskStatusTooltip} placement="top">
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-4 w-4"
+                  aria-label={taskStatusTooltip}
+                >
+                  <ExecutionStatusIcon status={taskExecution.status} />
+                </Button>
+              </CanvasTooltip>
+            )}
             {!hasSecondRowContent && (
               <StageTaskEntryConditionIcon task={task} small={!!hasExecutionStatus} />
             )}

--- a/packages/apollo-react/src/canvas/components/StageNode/useExecutionStatusLabel.test.ts
+++ b/packages/apollo-react/src/canvas/components/StageNode/useExecutionStatusLabel.test.ts
@@ -1,0 +1,30 @@
+import { renderHook } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { useExecutionStatusLabel } from './useExecutionStatusLabel';
+
+describe('useExecutionStatusLabel', () => {
+  it('returns localized labels for every renderable execution status', () => {
+    const { result } = renderHook(() => useExecutionStatusLabel());
+    const getLabel = result.current;
+
+    expect(getLabel('InProgress')).toBe('In progress');
+    expect(getLabel('Completed')).toBe('Completed');
+    expect(getLabel('Paused')).toBe('Paused');
+    expect(getLabel('Failed')).toBe('Failed');
+    expect(getLabel('Cancelled')).toBe('Cancelled');
+    expect(getLabel('UserCancelled')).toBe('Cancelled');
+    expect(getLabel('Terminated')).toBe('Terminated');
+    expect(getLabel('NotExecuted')).toBe('Not started');
+    expect(getLabel('Warning')).toBe('Warning');
+  });
+
+  it('returns an empty string for undefined or unknown statuses', () => {
+    const { result } = renderHook(() => useExecutionStatusLabel());
+    const getLabel = result.current;
+
+    expect(getLabel(undefined)).toBe('');
+    // Unknown statuses still type-check via the string union, but in practice the
+    // upstream API can return values we don't render an icon for; treat them as empty.
+    expect(getLabel('Unknown' as never)).toBe('');
+  });
+});

--- a/packages/apollo-react/src/canvas/components/StageNode/useExecutionStatusLabel.ts
+++ b/packages/apollo-react/src/canvas/components/StageNode/useExecutionStatusLabel.ts
@@ -1,0 +1,41 @@
+import { useCallback } from 'react';
+import { useSafeLingui } from '../../../i18n';
+import type { StageStatus, StageTaskStatus } from './StageNode.types';
+
+/**
+ * Returns a function that maps a stage/task execution status to its localized,
+ * human-readable label (e.g. "In progress", "Completed"). Used for tooltip text
+ * and `aria-label` on the execution-state icons.
+ *
+ * Falls back to English via `useSafeLingui` when no `I18nProvider` is mounted.
+ */
+export function useExecutionStatusLabel() {
+  const { _ } = useSafeLingui();
+
+  return useCallback(
+    (status: StageStatus | StageTaskStatus | undefined): string => {
+      switch (status) {
+        case 'InProgress':
+          return _({ id: 'stage-node.status.in-progress', message: 'In progress' });
+        case 'Completed':
+          return _({ id: 'stage-node.status.completed', message: 'Completed' });
+        case 'Paused':
+          return _({ id: 'stage-node.status.paused', message: 'Paused' });
+        case 'Failed':
+          return _({ id: 'stage-node.status.failed', message: 'Failed' });
+        case 'Cancelled':
+        case 'UserCancelled':
+          return _({ id: 'stage-node.status.cancelled', message: 'Cancelled' });
+        case 'Terminated':
+          return _({ id: 'stage-node.status.terminated', message: 'Terminated' });
+        case 'NotExecuted':
+          return _({ id: 'stage-node.status.not-executed', message: 'Not started' });
+        case 'Warning':
+          return _({ id: 'stage-node.status.warning', message: 'Warning' });
+        default:
+          return '';
+      }
+    },
+    [_]
+  );
+}

--- a/packages/apollo-react/src/canvas/components/StickyNoteNode/StickyNoteNode.tsx
+++ b/packages/apollo-react/src/canvas/components/StickyNoteNode/StickyNoteNode.tsx
@@ -8,6 +8,7 @@ import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkBreaks from 'remark-breaks';
 import remarkGfm from 'remark-gfm';
+import { useSafeLingui } from '../../../i18n';
 import { GRID_SPACING } from '../../constants';
 import { NodeViewportOverlay } from '../NodeViewportOverlay';
 import type { ToolbarAction } from '../Toolbar';
@@ -63,6 +64,7 @@ const StickyNoteNodeComponent = ({
   onColorChange,
   onResize,
 }: StickyNoteNodeProps) => {
+  const { _ } = useSafeLingui();
   const { updateNodeData, deleteElements } = useReactFlow();
   const [isEditing, setIsEditing] = useState(!readOnly && (data.autoFocus ?? false));
   const [isResizing, setIsResizing] = useState(false);
@@ -261,13 +263,13 @@ const StickyNoteNodeComponent = ({
       {
         id: 'delete',
         icon: <CanvasIcon icon="trash" size={14} />,
-        label: 'Delete',
+        label: _({ id: 'sticky-note.toolbar.delete', message: 'Delete' }),
         onAction: handleDelete,
       },
       {
         id: 'edit',
         icon: <CanvasIcon icon="pencil" size={14} />,
-        label: 'Edit',
+        label: _({ id: 'sticky-note.toolbar.edit', message: 'Edit' }),
         onAction: handleEditClick,
       },
       { id: 'separator' },
@@ -285,7 +287,7 @@ const StickyNoteNodeComponent = ({
             }}
           />
         ),
-        label: 'Color',
+        label: _({ id: 'sticky-note.toolbar.color', message: 'Color' }),
         onAction: handleToggleColorPicker,
       },
     ];
@@ -296,7 +298,7 @@ const StickyNoteNodeComponent = ({
       position: 'top' as const,
       align: 'center' as const,
     };
-  }, [handleEditClick, handleToggleColorPicker, color, handleDelete]);
+  }, [_, handleEditClick, handleToggleColorPicker, color, handleDelete]);
 
   return (
     <>

--- a/packages/apollo-react/src/canvas/locales/en.json
+++ b/packages/apollo-react/src/canvas/locales/en.json
@@ -15,6 +15,14 @@
   "stage-node.remove-from-parallel-group": "Remove from parallel group",
   "stage-node.remove-group-from-stage": "Remove group from stage",
   "stage-node.replace-task": "Replace task",
+  "stage-node.status.cancelled": "Cancelled",
+  "stage-node.status.completed": "Completed",
+  "stage-node.status.failed": "Failed",
+  "stage-node.status.in-progress": "In progress",
+  "stage-node.status.not-executed": "Not started",
+  "stage-node.status.paused": "Paused",
+  "stage-node.status.terminated": "Terminated",
+  "stage-node.status.warning": "Warning",
   "stage-node.ungroup-parallel-tasks": "Ungroup parallel tasks",
   "stage-node.untitled-stage": "Untitled stage",
   "sticky-note.formatting.bold": "Bold ({boldShortcut})",
@@ -23,5 +31,8 @@
   "sticky-note.formatting.bullet-list": "Bullet list",
   "sticky-note.formatting.numbered-list": "Numbered list",
   "sticky-note.formatting.toolbar": "Text formatting",
+  "sticky-note.toolbar.color": "Color",
+  "sticky-note.toolbar.delete": "Delete",
+  "sticky-note.toolbar.edit": "Edit",
   "toolbox.search": "Search"
 }


### PR DESCRIPTION
added general locale prop to affectively check the localization effect.
added localization to some sticky note left out strings
added stage and tasks status icons tooltip


https://github.com/user-attachments/assets/8ae33bfb-88be-4851-8726-8fee6a31a9bd

