### PR TITLE
feat(apollo-react): add CanvasPropertiesPanel control component

### DIFF
--- a/packages/apollo-react/src/canvas/controls/CanvasPropertiesPanel/CanvasPropertiesPanel.stories.tsx
+++ b/packages/apollo-react/src/canvas/controls/CanvasPropertiesPanel/CanvasPropertiesPanel.stories.tsx
@@ -1,0 +1,276 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { useState } from 'react';
+import { CanvasPropertiesPanel } from './CanvasPropertiesPanel';
+import type {
+  CanvasPropertiesPanelBehavior,
+  CanvasPropertiesPanelItem,
+  CanvasPropertiesPanelLayout,
+  CanvasPropertiesPanelPreset,
+} from './CanvasPropertiesPanel';
+
+const meta: Meta<typeof CanvasPropertiesPanel> = {
+  title: 'Components/Controls/CanvasPropertiesPanel',
+  component: CanvasPropertiesPanel,
+  parameters: {
+    layout: 'fullscreen',
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof CanvasPropertiesPanel>;
+
+const DEFAULT_PANELS: CanvasPropertiesPanelItem[] = [
+  { label: 'Parameters', enabled: false },
+  { label: 'Input', enabled: false },
+  { label: 'Output', enabled: false },
+];
+
+const CanvasBackground = ({ children }: { children: React.ReactNode }) => (
+  <div
+    className="min-h-screen flex items-center justify-center p-10"
+    style={{ backgroundColor: 'var(--surface, var(--color-background))' }}
+  >
+    {children}
+  </div>
+);
+
+const StateLabel = ({ children }: { children: React.ReactNode }) => (
+  <span className="mb-3 block text-sm text-foreground-subtle">{children}</span>
+);
+
+// ─── Default (interactive) ────────────────────────────────────────────────────
+
+export const Default: Story = {
+  render: () => {
+    const [panels, setPanels] = useState<CanvasPropertiesPanelItem[]>(DEFAULT_PANELS);
+    const [behavior, setBehavior] = useState<CanvasPropertiesPanelBehavior>('auto-hide');
+    const [layout, setLayout] = useState<CanvasPropertiesPanelLayout | undefined>(undefined);
+
+    return (
+      <CanvasBackground>
+        <CanvasPropertiesPanel
+          label="Properties"
+          panels={panels}
+          behavior={behavior}
+          layout={layout}
+          onBehaviorChange={setBehavior}
+          onLayoutChange={setLayout}
+          onPanelToggle={(lbl, enabled) =>
+            setPanels((prev) => prev.map((p) => (p.label === lbl ? { ...p, enabled } : p)))
+          }
+        />
+      </CanvasBackground>
+    );
+  },
+};
+
+// ─── States (doc layout) ─────────────────────────────────────────────────────
+
+export const States: Story = {
+  render: () => {
+    const [panels, setPanels] = useState<CanvasPropertiesPanelItem[]>(DEFAULT_PANELS);
+    const [behavior, setBehavior] = useState<CanvasPropertiesPanelBehavior>('auto-hide');
+    const [layout, setLayout] = useState<CanvasPropertiesPanelLayout | undefined>(undefined);
+
+    return (
+      <CanvasBackground>
+        <div className="flex gap-24 items-start">
+          {/* Default State */}
+          <div>
+            <StateLabel>Default State</StateLabel>
+            <CanvasPropertiesPanel label="Properties" />
+          </div>
+
+          {/* Clicked State — static doc snapshot */}
+          <div>
+            <StateLabel>Clicked State with popover</StateLabel>
+            <_PropertiesPanelOpenSnapshot
+              panels={panels}
+              behavior={behavior}
+              layout={layout}
+              onBehaviorChange={setBehavior}
+              onLayoutChange={setLayout}
+              onPanelToggle={(lbl, enabled) =>
+                setPanels((prev) => prev.map((p) => (p.label === lbl ? { ...p, enabled } : p)))
+              }
+            />
+          </div>
+        </div>
+      </CanvasBackground>
+    );
+  },
+};
+
+// ─── With Presets ─────────────────────────────────────────────────────────────
+
+export const WithPresets: Story = {
+  render: () => {
+    const [panels, setPanels] = useState<CanvasPropertiesPanelItem[]>([
+      { label: 'Parameters', enabled: true },
+      { label: 'Input', enabled: false },
+      { label: 'Output', enabled: true },
+    ]);
+    const [behavior, setBehavior] = useState<CanvasPropertiesPanelBehavior>('always-persist');
+    const [layout, setLayout] = useState<CanvasPropertiesPanelLayout | undefined>('right');
+    const [presets, setPresets] = useState<CanvasPropertiesPanelPreset[]>([
+      { id: '1', label: 'Compact view' },
+      { id: '2', label: 'Debug layout' },
+    ]);
+
+    return (
+      <CanvasBackground>
+        <CanvasPropertiesPanel
+          label="Properties"
+          panels={panels}
+          behavior={behavior}
+          layout={layout}
+          presets={presets}
+          canSavePreset
+          onBehaviorChange={setBehavior}
+          onLayoutChange={setLayout}
+          onPanelToggle={(lbl, enabled) =>
+            setPanels((prev) => prev.map((p) => (p.label === lbl ? { ...p, enabled } : p)))
+          }
+          onPresetDelete={(id) => setPresets((prev) => prev.filter((p) => p.id !== id))}
+          onSavePreset={() => alert('Save preset modal would open here')}
+        />
+      </CanvasBackground>
+    );
+  },
+};
+
+// ─── Internal: static open-state snapshot for doc purposes ───────────────────
+
+function _PropertiesPanelOpenSnapshot({
+  panels,
+  behavior,
+  onBehaviorChange,
+  onLayoutChange,
+  onPanelToggle,
+}: {
+  panels: CanvasPropertiesPanelItem[];
+  behavior: CanvasPropertiesPanelBehavior;
+  layout: CanvasPropertiesPanelLayout | undefined;
+  onBehaviorChange: (b: CanvasPropertiesPanelBehavior) => void;
+  onLayoutChange: (l: CanvasPropertiesPanelLayout) => void;
+  onPanelToggle: (label: string, enabled: boolean) => void;
+}) {
+  return (
+    <div className="flex flex-col items-start gap-1">
+      {/* Trigger — in active/open state */}
+      <div
+        className="w-fit flex flex-row items-center rounded-xl border border-border-subtle bg-surface-raised p-1"
+        style={{ boxShadow: '0 2px 6px rgba(0,0,0,0.08)' }}
+      >
+        <button
+          type="button"
+          className="flex h-8 items-center rounded-lg px-2.5 text-xs font-medium text-foreground-muted"
+        >
+          Properties
+        </button>
+        <div className="mx-0.5 h-4 w-px shrink-0 bg-border-subtle" />
+        <button
+          type="button"
+          className="grid size-8 place-items-center rounded-lg bg-surface-overlay text-foreground"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="14"
+            height="14"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <line x1="21" y1="4" x2="14" y2="4" />
+            <line x1="10" y1="4" x2="3" y2="4" />
+            <line x1="21" y1="12" x2="12" y2="12" />
+            <line x1="8" y1="12" x2="3" y2="12" />
+            <line x1="21" y1="20" x2="16" y2="20" />
+            <line x1="12" y1="20" x2="3" y2="20" />
+            <line x1="14" y1="2" x2="14" y2="6" />
+            <line x1="8" y1="10" x2="8" y2="14" />
+            <line x1="16" y1="18" x2="16" y2="22" />
+          </svg>
+        </button>
+      </div>
+
+      {/* Menu — inline for static snapshot */}
+      <div
+        className="w-56 overflow-y-auto rounded-xl border border-border-subtle bg-surface-raised"
+        style={{ boxShadow: '0 4px 16px rgba(0,0,0,0.12)' }}
+      >
+        {/* Panel toggles */}
+        <div>
+          {panels.map(({ label, enabled }) => (
+            <button
+              key={label}
+              type="button"
+              onClick={() => onPanelToggle(label, !enabled)}
+              className="flex w-full items-center justify-between px-3 py-2 text-xs text-foreground-muted transition hover:bg-surface-overlay hover:text-foreground"
+            >
+              <span>{label}</span>
+              <span
+                className={`size-2 rounded-full ${enabled ? 'bg-foreground-accent' : 'bg-surface-overlay'}`}
+              />
+            </button>
+          ))}
+        </div>
+
+        {/* Panel Behavior */}
+        <div className="border-t border-border-subtle">
+          <p className="px-3 pb-1 pt-2 text-[10px] font-semibold uppercase tracking-wide text-foreground-subtle">
+            Panel behavior
+          </p>
+          {[
+            { value: 'auto-hide' as const, label: 'Auto hide' },
+            { value: 'always-persist' as const, label: 'Always persist' },
+          ].map(({ value, label }) => (
+            <button
+              key={value}
+              type="button"
+              onClick={() => onBehaviorChange(value)}
+              className="flex w-full items-center justify-between px-3 py-2 text-xs text-foreground-muted transition hover:bg-surface-overlay hover:text-foreground"
+            >
+              <span>{label}</span>
+              <span
+                className={`size-2 rounded-full ${behavior === value ? 'bg-foreground-accent' : 'bg-surface-overlay'}`}
+              />
+            </button>
+          ))}
+        </div>
+
+        {/* Default Layouts */}
+        <div className="border-t border-border-subtle">
+          <p className="px-3 pb-1 pt-2 text-[10px] font-semibold uppercase tracking-wide text-foreground-subtle">
+            Default layouts
+          </p>
+          {[
+            { value: 'right' as const, name: 'Default — Right' },
+            { value: 'bottom' as const, name: 'Default — Bottom' },
+            { value: 'split' as const, name: 'Default — Split' },
+          ].map(({ value, name }) => (
+            <button
+              key={value}
+              type="button"
+              onClick={() => onLayoutChange(value)}
+              className="flex w-full items-center px-3 py-2 text-xs text-foreground-muted transition hover:bg-surface-overlay hover:text-foreground"
+            >
+              {name}
+            </button>
+          ))}
+        </div>
+
+        {/* Saved Presets */}
+        <div className="border-t border-border-subtle">
+          <p className="px-3 pb-1 pt-2 text-[10px] font-semibold uppercase tracking-wide text-foreground-subtle">
+            Saved presets
+          </p>
+          <p className="px-3 pb-2 text-[11px] text-foreground-subtle">No saved presets yet.</p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/apollo-react/src/canvas/controls/CanvasPropertiesPanel/CanvasPropertiesPanel.tsx
+++ b/packages/apollo-react/src/canvas/controls/CanvasPropertiesPanel/CanvasPropertiesPanel.tsx
@@ -1,0 +1,270 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { cn } from '@uipath/apollo-wind';
+import { CanvasIcon } from '../../utils/icon-registry';
+
+export type CanvasPropertiesPanelItem = {
+  label: string;
+  enabled?: boolean;
+};
+
+export type CanvasPropertiesPanelBehavior = 'auto-hide' | 'always-persist';
+export type CanvasPropertiesPanelLayout = 'right' | 'bottom' | 'split';
+export type CanvasPropertiesPanelPreset = { id: string; label: string };
+
+export type CanvasPropertiesPanelProps = {
+  label?: string;
+  panels?: CanvasPropertiesPanelItem[];
+  behavior?: CanvasPropertiesPanelBehavior;
+  layout?: CanvasPropertiesPanelLayout;
+  presets?: CanvasPropertiesPanelPreset[];
+  /** Called when the "Properties" label text is clicked. */
+  onPropertiesClick?: () => void;
+  onBehaviorChange?: (behavior: CanvasPropertiesPanelBehavior) => void;
+  onLayoutChange?: (layout: CanvasPropertiesPanelLayout) => void;
+  onPanelToggle?: (label: string, enabled: boolean) => void;
+  onPresetApply?: (preset: CanvasPropertiesPanelPreset) => void;
+  onPresetDelete?: (id: string) => void;
+  onSavePreset?: () => void;
+  /** When true a "Save as preset" button is shown at the bottom of the presets section. */
+  canSavePreset?: boolean;
+};
+
+type MenuPos = { right: number; top?: number; bottom?: number };
+
+const ITEM_CLASS =
+  'flex w-full items-center justify-between px-3 py-2 text-xs text-foreground-muted transition hover:bg-surface-overlay hover:text-foreground';
+
+const ITEM_NO_DOT_CLASS =
+  'flex w-full items-center px-3 py-2 text-xs text-foreground-muted transition hover:bg-surface-overlay hover:text-foreground';
+
+const SECTION_HEADING_CLASS =
+  'px-3 pb-1 pt-2 text-[10px] font-semibold uppercase tracking-wide text-foreground-subtle';
+
+export function CanvasPropertiesPanel({
+  label = 'Properties',
+  panels = [],
+  behavior = 'auto-hide',
+  presets = [],
+  onPropertiesClick,
+  onBehaviorChange,
+  onLayoutChange,
+  onPanelToggle,
+  onPresetApply,
+  onPresetDelete,
+  onSavePreset,
+  canSavePreset = false,
+}: CanvasPropertiesPanelProps) {
+  const [menuOpen, setMenuOpen] = useState(false);
+  const [menuPos, setMenuPos] = useState<MenuPos | null>(null);
+  const btnRef = useRef<HTMLButtonElement>(null);
+
+  const handleToggle = useCallback(() => {
+    if (!menuOpen && btnRef.current) {
+      const rect = btnRef.current.getBoundingClientRect();
+      const upward = rect.bottom + 420 > window.innerHeight;
+      setMenuPos({
+        right: window.innerWidth - rect.right,
+        top: upward ? undefined : rect.bottom + 8,
+        bottom: upward ? window.innerHeight - rect.top + 8 : undefined,
+      });
+    }
+    setMenuOpen((v) => !v);
+  }, [menuOpen]);
+
+  // Close on outside click
+  useEffect(() => {
+    if (!menuOpen) return;
+    const handlePointerDown = (e: PointerEvent) => {
+      if (
+        btnRef.current &&
+        !btnRef.current.closest('[data-canvas-properties-panel-root]')?.contains(e.target as Node)
+      ) {
+        setMenuOpen(false);
+      }
+    };
+    document.addEventListener('pointerdown', handlePointerDown, true);
+    return () => document.removeEventListener('pointerdown', handlePointerDown, true);
+  }, [menuOpen]);
+
+  const menuPortal =
+    menuOpen &&
+    menuPos &&
+    createPortal(
+      <div
+        data-canvas-properties-panel-menu
+        className="w-56 overflow-y-auto max-h-[70vh] rounded-xl border border-border-subtle bg-surface-raised"
+        style={{
+          position: 'fixed',
+          right: menuPos.right,
+          top: menuPos.top,
+          bottom: menuPos.bottom,
+          zIndex: 9999,
+          boxShadow: '0 4px 16px rgba(0,0,0,0.12)',
+        }}
+      >
+        {/* Per-panel toggles */}
+        {panels.length > 0 && (
+          <div>
+            {panels.map(({ label: panelLabel, enabled }) => (
+              <button
+                key={panelLabel}
+                type="button"
+                onClick={() => {
+                  onPanelToggle?.(panelLabel, !enabled);
+                  setMenuOpen(false);
+                }}
+                className={ITEM_CLASS}
+              >
+                <span>{panelLabel}</span>
+                <span
+                  className={cn(
+                    'size-2 rounded-full',
+                    enabled ? 'bg-foreground-accent' : 'bg-surface-overlay'
+                  )}
+                />
+              </button>
+            ))}
+          </div>
+        )}
+
+        {/* Panel Behavior */}
+        <div className={cn(panels.length > 0 && 'border-t border-border-subtle')}>
+          <p className={SECTION_HEADING_CLASS}>Panel behavior</p>
+          {(
+            [
+              { value: 'auto-hide', label: 'Auto hide' },
+              { value: 'always-persist', label: 'Always persist' },
+            ] as { value: CanvasPropertiesPanelBehavior; label: string }[]
+          ).map(({ value, label: behaviorLabel }) => (
+            <button
+              key={value}
+              type="button"
+              onClick={() => {
+                onBehaviorChange?.(value);
+                setMenuOpen(false);
+              }}
+              className={ITEM_CLASS}
+            >
+              <span>{behaviorLabel}</span>
+              <span
+                className={cn(
+                  'size-2 rounded-full',
+                  behavior === value ? 'bg-foreground-accent' : 'bg-surface-overlay'
+                )}
+              />
+            </button>
+          ))}
+        </div>
+
+        {/* Default Layouts */}
+        <div className="border-t border-border-subtle">
+          <p className={SECTION_HEADING_CLASS}>Default layouts</p>
+          {(
+            [
+              { value: 'right', name: 'Default — Right' },
+              { value: 'bottom', name: 'Default — Bottom' },
+              { value: 'split', name: 'Default — Split' },
+            ] as { value: CanvasPropertiesPanelLayout; name: string }[]
+          ).map(({ value, name }) => (
+            <button
+              key={value}
+              type="button"
+              onClick={() => {
+                onLayoutChange?.(value);
+                setMenuOpen(false);
+              }}
+              className={ITEM_NO_DOT_CLASS}
+            >
+              {name}
+            </button>
+          ))}
+        </div>
+
+        {/* Saved Presets */}
+        <div className="border-t border-border-subtle">
+          <p className={SECTION_HEADING_CLASS}>Saved presets</p>
+          {presets.length === 0 && (
+            <p className="px-3 pb-2 text-[11px] text-foreground-subtle">No saved presets yet.</p>
+          )}
+          {presets.map((preset) => (
+            <div key={preset.id} className="flex items-center gap-1 px-2 py-1">
+              <button
+                type="button"
+                onClick={() => {
+                  onPresetApply?.(preset);
+                  setMenuOpen(false);
+                }}
+                className="min-w-0 flex-1 truncate rounded px-1.5 py-1 text-left text-xs text-foreground-muted transition hover:bg-surface-overlay hover:text-foreground"
+              >
+                {preset.label}
+              </button>
+              <button
+                type="button"
+                title="Delete preset"
+                onClick={() => onPresetDelete?.(preset.id)}
+                className="grid size-6 shrink-0 place-items-center rounded text-foreground-subtle transition hover:text-foreground"
+              >
+                <CanvasIcon icon="trash-2" size={11} />
+              </button>
+            </div>
+          ))}
+          {canSavePreset && (
+            <button
+              type="button"
+              onClick={() => {
+                onSavePreset?.();
+                setMenuOpen(false);
+              }}
+              className="flex w-full items-center gap-2 px-3 py-2 text-xs text-foreground-muted transition hover:bg-surface-overlay hover:text-foreground"
+            >
+              <CanvasIcon icon="plus" size={12} />
+              <span>Save as preset</span>
+            </button>
+          )}
+        </div>
+      </div>,
+      document.body
+    );
+
+  return (
+    <div
+      data-canvas-properties-panel-root
+      className="w-fit flex flex-row items-center rounded-xl border border-border-subtle bg-surface-raised p-1"
+      style={{ boxShadow: '0 2px 6px rgba(0,0,0,0.08)' }}
+    >
+      {/* Properties label button */}
+      <button
+        type="button"
+        onClick={onPropertiesClick}
+        className="flex h-8 items-center rounded-lg px-2.5 text-xs font-medium text-foreground-muted transition hover:bg-surface-overlay hover:text-foreground"
+      >
+        {label}
+      </button>
+
+      {/* Vertical divider */}
+      <div className="mx-0.5 h-4 w-px shrink-0 bg-border-subtle" />
+
+      {/* Sliders icon — opens the config menu */}
+      <div className="relative">
+        <button
+          ref={btnRef}
+          type="button"
+          title="Panel options"
+          onClick={handleToggle}
+          className={cn(
+            'grid size-8 place-items-center rounded-lg transition',
+            menuOpen
+              ? 'bg-surface-overlay text-foreground'
+              : 'text-foreground-muted hover:bg-surface-overlay hover:text-foreground'
+          )}
+        >
+          <CanvasIcon icon="sliders-horizontal" size={14} />
+        </button>
+        {menuPortal}
+      </div>
+    </div>
+  );
+}
+
+CanvasPropertiesPanel.displayName = 'CanvasPropertiesPanel';

--- a/packages/apollo-react/src/canvas/controls/CanvasPropertiesPanel/index.ts
+++ b/packages/apollo-react/src/canvas/controls/CanvasPropertiesPanel/index.ts
@@ -1,4 +1,3 @@
-export { Breadcrumb } from './Breadcrumb';
 export { CanvasPropertiesPanel } from './CanvasPropertiesPanel';
 export type {
   CanvasPropertiesPanelProps,


### PR DESCRIPTION
## Summary

- Adds a new `CanvasPropertiesPanel` control component to `packages/apollo-react/src/canvas/controls/`
- Pill-trigger (Properties label + sliders icon) + fixed-positioned popover menu, pixel-matched to the flow-prototype reference
- Pure Tailwind using apollo-wind Future design tokens (`bg-surface-raised`, `text-foreground-muted`, `border-border-subtle`, `bg-foreground-accent`, etc.) — no Emotion
- Popover sections: per-panel toggles (Parameters / Input / Output), Panel Behavior (auto-hide / always-persist), Default Layouts (Right / Bottom / Split), Saved Presets with optional save + delete actions
- Storybook story at `Canvas/Components/Controls/CanvasPropertiesPanel` with Default (interactive), States (doc layout), and WithPresets variants

## Test plan

- [ ] Open Storybook → `Canvas > Components > Controls > CanvasPropertiesPanel`
- [ ] **Default**: click the sliders icon — popover opens anchored to the button, closes on outside click
- [ ] **States**: confirm two-column layout — Default State (pill only) and Clicked State with full popover rendered inline
- [ ] **WithPresets**: confirm preset list renders with delete buttons and "Save as preset" row
- [ ] Toggle a panel item (Parameters / Input / Output) — dot flips between accent and overlay
- [ ] Toggle behavior — blue dot moves between Auto hide / Always persist
- [ ] Confirm `w-fit` keeps trigger pill sized to content (not full-width)
- [ ] TypeScript: `pnpm --filter @uipath/apollo-react exec tsc --noEmit` passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)