### PR TITLE
fix(apollo-react): changed the icon order to match stage properties

### DIFF
--- a/packages/apollo-react/src/canvas/components/StageNode/StageNodeHeader.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNodeHeader.tsx
@@ -28,10 +28,17 @@ const SLA_ICON_CONFIG: Record<StageSlaIcon, { icon: string; iconColor: string }>
 
 const CHIP_ICONS: Record<StageHeaderChipType, React.ReactElement> = {
   [StageHeaderChipType.Entry]: <EntryConditionIcon w={Icon.IconXs} h={Icon.IconXs} />,
-  [StageHeaderChipType.Exit]: <ExitConditionIcon w={Icon.IconXs} h={Icon.IconXs} />,
   [StageHeaderChipType.Completion]: <ChecklistIcon size={16} />,
+  [StageHeaderChipType.Exit]: <ExitConditionIcon w={Icon.IconXs} h={Icon.IconXs} />,
   [StageHeaderChipType.ReturnToOrigin]: <ReturnToOriginIcon w={Icon.IconXs} h={Icon.IconXs} />,
 };
+
+const CHIP_ORDER: StageHeaderChipType[] = [
+  StageHeaderChipType.Entry,
+  StageHeaderChipType.Completion,
+  StageHeaderChipType.Exit,
+  StageHeaderChipType.ReturnToOrigin,
+];
 
 const StageNodeHeaderInner = ({
   props,
@@ -129,30 +136,32 @@ const StageNodeHeaderInner = ({
           )}
           {stageDetails.headerChips && stageDetails.headerChips.length > 0 && (
             <div className="flex flex-wrap items-center gap-1">
-              {stageDetails.headerChips.map((chip) => {
-                const button = (
-                  <StageChip
-                    key={chip.type}
-                    type="button"
-                    aria-label={typeof chip.tooltip === 'string' ? chip.tooltip : chip.type}
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      chip.onClick?.();
-                    }}
-                  >
-                    {CHIP_ICONS[chip.type]}
-                    {chip.count !== undefined && <span className="text-xs">{chip.count}</span>}
-                  </StageChip>
-                );
-                if (chip.tooltip) {
-                  return (
-                    <CanvasTooltip key={chip.type} placement="bottom" content={chip.tooltip}>
-                      {button}
-                    </CanvasTooltip>
+              {[...stageDetails.headerChips]
+                .sort((left, right) => CHIP_ORDER.indexOf(left.type) - CHIP_ORDER.indexOf(right.type))
+                .map((chip) => {
+                  const button = (
+                    <StageChip
+                      key={chip.type}
+                      type="button"
+                      aria-label={typeof chip.tooltip === 'string' ? chip.tooltip : chip.type}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        chip.onClick?.();
+                      }}
+                    >
+                      {CHIP_ICONS[chip.type]}
+                      {chip.count !== undefined && <span className="text-xs">{chip.count}</span>}
+                    </StageChip>
                   );
-                }
-                return button;
-              })}
+                  if (chip.tooltip) {
+                    return (
+                      <CanvasTooltip key={chip.type} placement="bottom" content={chip.tooltip}>
+                        {button}
+                      </CanvasTooltip>
+                    );
+                  }
+                  return button;
+                })}
             </div>
           )}
         </div>


### PR DESCRIPTION
## Description
Added a .sort to order the icons. Updated [StageNodeHeader.tsx] with order array.

## Demo
<img width="664" height="234" alt="image" src="https://github.com/user-attachments/assets/018163a1-9103-48b4-9a42-7f267ee151d4" />

## Risks of rolling out
<!--
* Add risks of rolling out, including any additions/removals of feature flags or APIs
* Be mindful of backwards compatibility scenarios
-->

## Feature flag

- [ ] If this introduces a new feature flag, make sure first to create it in [Gitops](http://flags.uipath.com/) and specify the flag in alpha, staging and prod

## Tests
<!-- Areas to test: Management/FPS, Standalone, StudioWeb  -->

- [ ] I validated theme and locale
- [ ] I added unit tests
- [ ] I added component tests
- [ ] I added Playwright E2E tests
- [ ] I manually tested my changes or added other kinds of tests (Please add details below)