### PR TITLE
fix(apollo-react): add resize lifecycle callbacks [MST-10602]

### DIFF
--- a/packages/apollo-react/src/canvas/components/LoopNode/LoopNode.test.tsx
+++ b/packages/apollo-react/src/canvas/components/LoopNode/LoopNode.test.tsx
@@ -28,6 +28,7 @@ vi.mock('@uipath/apollo-react/canvas/xyflow/react', async (importOriginal) => ({
     children,
     minHeight,
     minWidth,
+    onResize,
     onResizeEnd,
     onResizeStart,
     position,
@@ -35,6 +36,10 @@ vi.mock('@uipath/apollo-react/canvas/xyflow/react', async (importOriginal) => ({
     children?: React.ReactNode;
     minHeight?: number;
     minWidth?: number;
+    onResize?: (
+      event: React.MouseEvent<HTMLDivElement>,
+      params: { width: number; height: number }
+    ) => void;
     onResizeEnd?: () => void;
     onResizeStart?: () => void;
     position?: string;
@@ -44,6 +49,7 @@ vi.mock('@uipath/apollo-react/canvas/xyflow/react', async (importOriginal) => ({
       data-min-height={minHeight}
       data-min-width={minWidth}
       onMouseDown={onResizeStart}
+      onMouseMove={(event) => onResize?.(event, { width: 130, height: 77 })}
       onMouseUp={onResizeEnd}
     >
       {children}
@@ -343,6 +349,32 @@ describe('LoopNode resize controls', () => {
     for (const indicator of getResizeIndicators()) {
       expect(indicator).toHaveClass('opacity-0');
     }
+  });
+
+  it('calls onResizeStart once when resize starts', () => {
+    const onResizeStart = vi.fn();
+    renderLoopNode({ onResizeStart });
+
+    fireEvent.mouseDown(screen.getByTestId('node-resize-control-bottom-right'));
+
+    expect(onResizeStart).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls public onResizeEnd after resize end and preserves live onResize', async () => {
+    const onResize = vi.fn();
+    const onResizeEnd = vi.fn();
+    renderLoopNode({ onResize, onResizeEnd });
+
+    const resizeControl = screen.getByTestId('node-resize-control-bottom-right');
+    fireEvent.mouseMove(resizeControl);
+    fireEvent.mouseUp(resizeControl);
+
+    expect(onResize).toHaveBeenCalledWith({ width: 128, height: 80 });
+    expect(onResizeEnd).not.toHaveBeenCalled();
+
+    await Promise.resolve();
+
+    expect(onResizeEnd).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/packages/apollo-react/src/canvas/components/LoopNode/LoopNode.tsx
+++ b/packages/apollo-react/src/canvas/components/LoopNode/LoopNode.tsx
@@ -319,7 +319,9 @@ function LoopNodeComponent(props: LoopNodeProps) {
   }, [onResizeStart]);
   const handleResizeEnd = useCallback(() => {
     setIsResizing(false);
-    queueMicrotask(() => onResizeEnd?.());
+    if (onResizeEnd) {
+      queueMicrotask(onResizeEnd);
+    }
   }, [onResizeEnd]);
 
   const handleEmptyClick = useCallback(() => {

--- a/packages/apollo-react/src/canvas/components/LoopNode/LoopNode.tsx
+++ b/packages/apollo-react/src/canvas/components/LoopNode/LoopNode.tsx
@@ -184,6 +184,8 @@ function LoopNodeComponent(props: LoopNodeProps) {
     height = 0,
     onAddFirstChild,
     onResize,
+    onResizeStart,
+    onResizeEnd,
     toolbarConfig: toolbarConfigProp,
     adornments: adornmentsProp,
     executionStatusOverride,
@@ -311,8 +313,14 @@ function LoopNodeComponent(props: LoopNodeProps) {
     },
     [onResize]
   );
-  const handleResizeStart = useCallback(() => setIsResizing(true), []);
-  const handleResizeEnd = useCallback(() => setIsResizing(false), []);
+  const handleResizeStart = useCallback(() => {
+    setIsResizing(true);
+    onResizeStart?.();
+  }, [onResizeStart]);
+  const handleResizeEnd = useCallback(() => {
+    setIsResizing(false);
+    queueMicrotask(() => onResizeEnd?.());
+  }, [onResizeEnd]);
 
   const handleEmptyClick = useCallback(() => {
     onAddFirstChild?.();

--- a/packages/apollo-react/src/canvas/components/LoopNode/LoopNode.types.ts
+++ b/packages/apollo-react/src/canvas/components/LoopNode/LoopNode.types.ts
@@ -33,4 +33,6 @@ export interface LoopNodeConfig {
 export interface LoopNodeProps extends NodeProps<Node<LoopNodeData>>, LoopNodeConfig {
   onAddFirstChild?: () => void;
   onResize?: (size: LoopNodeResizeSize) => void;
+  onResizeStart?: () => void;
+  onResizeEnd?: () => void;
 }

--- a/packages/apollo-react/src/canvas/components/StickyNoteNode/StickyNoteNode.test.tsx
+++ b/packages/apollo-react/src/canvas/components/StickyNoteNode/StickyNoteNode.test.tsx
@@ -1,0 +1,82 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@uipath/apollo-react/canvas/xyflow/react', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@uipath/apollo-react/canvas/xyflow/react')>()),
+  NodeResizeControl: ({
+    children,
+    onResizeEnd,
+    onResizeStart,
+    position,
+  }: {
+    children?: React.ReactNode;
+    onResizeEnd?: (
+      event: React.MouseEvent<HTMLDivElement>,
+      params: { width: number; height: number }
+    ) => void;
+    onResizeStart?: () => void;
+    position?: string;
+  }) => (
+    <div
+      data-testid={`node-resize-control-${position}`}
+      onMouseDown={onResizeStart}
+      onMouseUp={(event) => onResizeEnd?.(event, { width: 256, height: 192 })}
+    >
+      {children}
+    </div>
+  ),
+  useReactFlow: () => ({
+    deleteElements: vi.fn(),
+    updateNodeData: vi.fn(),
+  }),
+}));
+
+import { StickyNoteNode, type StickyNoteNodeProps } from './StickyNoteNode';
+
+const defaultProps: StickyNoteNodeProps = {
+  id: 'sticky-note-1',
+  type: 'stickyNote',
+  data: {
+    color: 'yellow',
+    content: 'Remember the resize lifecycle',
+  },
+  selected: false,
+  dragging: false,
+  draggable: true,
+  zIndex: 0,
+  isConnectable: true,
+  positionAbsoluteX: 0,
+  positionAbsoluteY: 0,
+  selectable: true,
+  deletable: true,
+};
+
+function renderStickyNoteNode(props: Partial<StickyNoteNodeProps> = {}) {
+  render(<StickyNoteNode {...defaultProps} {...props} />);
+}
+
+describe('StickyNoteNode resize lifecycle', () => {
+  it('calls onResizeStart once when resize starts', () => {
+    const onResizeStart = vi.fn();
+    renderStickyNoteNode({ onResizeStart });
+
+    fireEvent.mouseDown(screen.getByTestId('node-resize-control-bottom-right'));
+
+    expect(onResizeStart).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls public onResizeEnd after resize end and preserves existing onResize', async () => {
+    const onResize = vi.fn();
+    const onResizeEnd = vi.fn();
+    renderStickyNoteNode({ onResize, onResizeEnd });
+
+    fireEvent.mouseUp(screen.getByTestId('node-resize-control-bottom-right'));
+
+    expect(onResize).toHaveBeenCalledWith(256, 192);
+    expect(onResizeEnd).not.toHaveBeenCalled();
+
+    await Promise.resolve();
+
+    expect(onResizeEnd).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/apollo-react/src/canvas/components/StickyNoteNode/StickyNoteNode.test.tsx
+++ b/packages/apollo-react/src/canvas/components/StickyNoteNode/StickyNoteNode.test.tsx
@@ -1,5 +1,10 @@
 import { fireEvent, render, screen } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockDeleteElements, mockUpdateNodeData } = vi.hoisted(() => ({
+  mockDeleteElements: vi.fn(),
+  mockUpdateNodeData: vi.fn(),
+}));
 
 vi.mock('@uipath/apollo-react/canvas/xyflow/react', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@uipath/apollo-react/canvas/xyflow/react')>()),
@@ -26,8 +31,8 @@ vi.mock('@uipath/apollo-react/canvas/xyflow/react', async (importOriginal) => ({
     </div>
   ),
   useReactFlow: () => ({
-    deleteElements: vi.fn(),
-    updateNodeData: vi.fn(),
+    deleteElements: mockDeleteElements,
+    updateNodeData: mockUpdateNodeData,
   }),
 }));
 
@@ -55,6 +60,18 @@ function renderStickyNoteNode(props: Partial<StickyNoteNodeProps> = {}) {
   render(<StickyNoteNode {...defaultProps} {...props} />);
 }
 
+function startEditing() {
+  fireEvent.doubleClick(screen.getByText('Remember the resize lifecycle'));
+  const textarea = screen.getByRole('textbox');
+  textarea.focus();
+  return textarea;
+}
+
+beforeEach(() => {
+  mockDeleteElements.mockReset();
+  mockUpdateNodeData.mockReset();
+});
+
 describe('StickyNoteNode resize lifecycle', () => {
   it('calls onResizeStart once when resize starts', () => {
     const onResizeStart = vi.fn();
@@ -78,5 +95,38 @@ describe('StickyNoteNode resize lifecycle', () => {
     await Promise.resolve();
 
     expect(onResizeEnd).toHaveBeenCalledTimes(1);
+  });
+
+  it('commits pending text edits before resize start', () => {
+    const events: string[] = [];
+    const onContentChange = vi.fn(() => events.push('content-change'));
+    const onResizeStart = vi.fn(() => events.push('resize-start'));
+    mockUpdateNodeData.mockImplementation(() => events.push('update-node-data'));
+    renderStickyNoteNode({ onContentChange, onResizeStart });
+
+    const textarea = startEditing();
+    fireEvent.change(textarea, { target: { value: 'Updated note text' } });
+    fireEvent.mouseDown(screen.getByTestId('node-resize-control-bottom-right'));
+
+    expect(events).toEqual(['content-change', 'update-node-data', 'resize-start']);
+    expect(onContentChange).toHaveBeenCalledWith('Updated note text');
+    expect(mockUpdateNodeData).toHaveBeenCalledWith('sticky-note-1', {
+      content: 'Updated note text',
+    });
+  });
+
+  it('does not emit a content update on resize start when text is unchanged', () => {
+    const events: string[] = [];
+    const onContentChange = vi.fn(() => events.push('content-change'));
+    const onResizeStart = vi.fn(() => events.push('resize-start'));
+    mockUpdateNodeData.mockImplementation(() => events.push('update-node-data'));
+    renderStickyNoteNode({ onContentChange, onResizeStart });
+
+    startEditing();
+    fireEvent.mouseDown(screen.getByTestId('node-resize-control-bottom-right'));
+
+    expect(events).toEqual(['resize-start']);
+    expect(onContentChange).not.toHaveBeenCalled();
+    expect(mockUpdateNodeData).not.toHaveBeenCalled();
   });
 });

--- a/packages/apollo-react/src/canvas/components/StickyNoteNode/StickyNoteNode.tsx
+++ b/packages/apollo-react/src/canvas/components/StickyNoteNode/StickyNoteNode.tsx
@@ -47,6 +47,8 @@ export interface StickyNoteNodeProps extends NodeProps {
   onContentChange?: (content: string) => void;
   onColorChange?: (color: StickyNoteColor) => void;
   onResize?: (width: number, height: number) => void;
+  onResizeStart?: () => void;
+  onResizeEnd?: () => void;
 }
 
 const minWidth = GRID_SPACING * 8;
@@ -63,6 +65,8 @@ const StickyNoteNodeComponent = ({
   onContentChange,
   onColorChange,
   onResize,
+  onResizeStart,
+  onResizeEnd,
 }: StickyNoteNodeProps) => {
   const { _ } = useSafeLingui();
   const { updateNodeData, deleteElements } = useReactFlow();
@@ -193,14 +197,16 @@ const StickyNoteNodeComponent = ({
   // Resize handlers
   const handleResizeStart = useCallback(() => {
     setIsResizing(true);
-  }, []);
+    onResizeStart?.();
+  }, [onResizeStart]);
 
   const handleResizeEnd = useCallback(
     (_event: ResizeDragEvent, params: ResizeParams) => {
       setIsResizing(false);
       onResize?.(params.width, params.height);
+      queueMicrotask(() => onResizeEnd?.());
     },
-    [onResize]
+    [onResize, onResizeEnd]
   );
 
   // Color change handler

--- a/packages/apollo-react/src/canvas/components/StickyNoteNode/StickyNoteNode.tsx
+++ b/packages/apollo-react/src/canvas/components/StickyNoteNode/StickyNoteNode.tsx
@@ -196,9 +196,12 @@ const StickyNoteNodeComponent = ({
 
   // Resize handlers
   const handleResizeStart = useCallback(() => {
+    if (isEditing) {
+      textAreaRef.current?.blur();
+    }
     setIsResizing(true);
     onResizeStart?.();
-  }, [onResizeStart]);
+  }, [isEditing, onResizeStart]);
 
   const handleResizeEnd = useCallback(
     (_event: ResizeDragEvent, params: ResizeParams) => {

--- a/packages/apollo-react/src/canvas/components/StickyNoteNode/StickyNoteNode.tsx
+++ b/packages/apollo-react/src/canvas/components/StickyNoteNode/StickyNoteNode.tsx
@@ -207,7 +207,9 @@ const StickyNoteNodeComponent = ({
     (_event: ResizeDragEvent, params: ResizeParams) => {
       setIsResizing(false);
       onResize?.(params.width, params.height);
-      queueMicrotask(() => onResizeEnd?.());
+      if (onResizeEnd) {
+        queueMicrotask(onResizeEnd);
+      }
     },
     [onResize, onResizeEnd]
   );


### PR DESCRIPTION
## Summary

- Add resize lifecycle callbacks to StickyNoteNode and LoopNode.
- Defer public resize-end callbacks with `queueMicrotask` so consumers commit after React Flow's final dimensions update.
- Add focused component tests for lifecycle callbacks and existing resize behavior.

## Verification

- `pnpm --filter @uipath/apollo-react exec vitest --run src/canvas/components/LoopNode/LoopNode.test.tsx src/canvas/components/StickyNoteNode/StickyNoteNode.test.tsx`
- `pnpm --filter @uipath/apollo-react exec tsc --noEmit`
