### PR TITLE
fix(apollo-react): flush sticky note edit before resize [MST-10602]

### DIFF
--- a/packages/apollo-react/src/canvas/components/StickyNoteNode/StickyNoteNode.test.tsx
+++ b/packages/apollo-react/src/canvas/components/StickyNoteNode/StickyNoteNode.test.tsx
@@ -1,10 +1,21 @@
 import { fireEvent, render, screen } from '@testing-library/react';
+import { useLayoutEffect, useRef, useState } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { StickyNoteData } from './StickyNoteNode.types';
 
-const { mockDeleteElements, mockUpdateNodeData } = vi.hoisted(() => ({
-  mockDeleteElements: vi.fn(),
-  mockUpdateNodeData: vi.fn(),
-}));
+const { deferredUpdate, mockDeleteElements, mockUpdateNodeData } = vi.hoisted(() => {
+  const deferredUpdate: {
+    handler?: (id: string, data: Record<string, unknown>) => void;
+  } = {};
+
+  return {
+    deferredUpdate,
+    mockDeleteElements: vi.fn(),
+    mockUpdateNodeData: vi.fn((id: string, data: Record<string, unknown>) => {
+      deferredUpdate.handler?.(id, data);
+    }),
+  };
+});
 
 vi.mock('@uipath/apollo-react/canvas/xyflow/react', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@uipath/apollo-react/canvas/xyflow/react')>()),
@@ -67,9 +78,57 @@ function startEditing() {
   return textarea;
 }
 
+function DeferredUpdateHarness({
+  onStartContent,
+}: {
+  onStartContent: (content: string | undefined) => void;
+}) {
+  const [nodeData, setNodeData] = useState<StickyNoteData>(defaultProps.data);
+  const nodeDataRef = useRef<StickyNoteData>(defaultProps.data);
+  const queueRef = useRef<Record<string, unknown>[]>([]);
+  const [, rerender] = useState(0);
+
+  useLayoutEffect(() => {
+    deferredUpdate.handler = (_id, data) => {
+      queueRef.current.push(data);
+      rerender((value) => value + 1);
+    };
+
+    return () => {
+      deferredUpdate.handler = undefined;
+    };
+  }, []);
+
+  useLayoutEffect(() => {
+    if (queueRef.current.length === 0) return;
+
+    const updates = queueRef.current;
+    queueRef.current = [];
+    const nextData = updates.reduce<StickyNoteData>(
+      (current, update) => ({ ...current, ...update }),
+      nodeDataRef.current
+    );
+
+    nodeDataRef.current = nextData;
+    setNodeData(nextData);
+  });
+
+  return (
+    <StickyNoteNode
+      {...defaultProps}
+      data={nodeData}
+      onResizeStart={() => onStartContent(nodeDataRef.current.content)}
+    />
+  );
+}
+
 beforeEach(() => {
+  deferredUpdate.handler = undefined;
   mockDeleteElements.mockReset();
   mockUpdateNodeData.mockReset();
+  mockUpdateNodeData.mockImplementation((id: string, data: Record<string, unknown>) => {
+    deferredUpdate.handler?.(id, data);
+  });
 });
 
 describe('StickyNoteNode resize lifecycle', () => {
@@ -113,6 +172,21 @@ describe('StickyNoteNode resize lifecycle', () => {
     expect(mockUpdateNodeData).toHaveBeenCalledWith('sticky-note-1', {
       content: 'Updated note text',
     });
+    expect(onContentChange).toHaveBeenCalledTimes(1);
+    expect(mockUpdateNodeData).toHaveBeenCalledTimes(1);
+  });
+
+  it('flushes pending text into controlled node data before resize start', () => {
+    const onStartContent = vi.fn();
+
+    render(<DeferredUpdateHarness onStartContent={onStartContent} />);
+
+    const textarea = startEditing();
+    fireEvent.change(textarea, { target: { value: 'Updated text' } });
+    fireEvent.mouseDown(screen.getByTestId('node-resize-control-bottom-right'));
+
+    expect(onStartContent).toHaveBeenCalledWith('Updated text');
+    expect(mockUpdateNodeData).toHaveBeenCalledTimes(1);
   });
 
   it('does not emit a content update on resize start when text is unchanged', () => {
@@ -126,6 +200,18 @@ describe('StickyNoteNode resize lifecycle', () => {
     fireEvent.mouseDown(screen.getByTestId('node-resize-control-bottom-right'));
 
     expect(events).toEqual(['resize-start']);
+    expect(onContentChange).not.toHaveBeenCalled();
+    expect(mockUpdateNodeData).not.toHaveBeenCalled();
+  });
+
+  it('does not commit canceled edits when Escape blurs the textarea', () => {
+    const onContentChange = vi.fn();
+    renderStickyNoteNode({ onContentChange });
+
+    const textarea = startEditing();
+    fireEvent.change(textarea, { target: { value: 'Discard this edit' } });
+    fireEvent.keyDown(textarea, { key: 'Escape' });
+
     expect(onContentChange).not.toHaveBeenCalled();
     expect(mockUpdateNodeData).not.toHaveBeenCalled();
   });

--- a/packages/apollo-react/src/canvas/components/StickyNoteNode/StickyNoteNode.test.tsx
+++ b/packages/apollo-react/src/canvas/components/StickyNoteNode/StickyNoteNode.test.tsx
@@ -1,21 +1,10 @@
 import { fireEvent, render, screen } from '@testing-library/react';
-import { useLayoutEffect, useRef, useState } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import type { StickyNoteData } from './StickyNoteNode.types';
 
-const { deferredUpdate, mockDeleteElements, mockUpdateNodeData } = vi.hoisted(() => {
-  const deferredUpdate: {
-    handler?: (id: string, data: Record<string, unknown>) => void;
-  } = {};
-
-  return {
-    deferredUpdate,
-    mockDeleteElements: vi.fn(),
-    mockUpdateNodeData: vi.fn((id: string, data: Record<string, unknown>) => {
-      deferredUpdate.handler?.(id, data);
-    }),
-  };
-});
+const { mockDeleteElements, mockUpdateNodeData } = vi.hoisted(() => ({
+  mockDeleteElements: vi.fn(),
+  mockUpdateNodeData: vi.fn(),
+}));
 
 vi.mock('@uipath/apollo-react/canvas/xyflow/react', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@uipath/apollo-react/canvas/xyflow/react')>()),
@@ -78,57 +67,9 @@ function startEditing() {
   return textarea;
 }
 
-function DeferredUpdateHarness({
-  onStartContent,
-}: {
-  onStartContent: (content: string | undefined) => void;
-}) {
-  const [nodeData, setNodeData] = useState<StickyNoteData>(defaultProps.data);
-  const nodeDataRef = useRef<StickyNoteData>(defaultProps.data);
-  const queueRef = useRef<Record<string, unknown>[]>([]);
-  const [, rerender] = useState(0);
-
-  useLayoutEffect(() => {
-    deferredUpdate.handler = (_id, data) => {
-      queueRef.current.push(data);
-      rerender((value) => value + 1);
-    };
-
-    return () => {
-      deferredUpdate.handler = undefined;
-    };
-  }, []);
-
-  useLayoutEffect(() => {
-    if (queueRef.current.length === 0) return;
-
-    const updates = queueRef.current;
-    queueRef.current = [];
-    const nextData = updates.reduce<StickyNoteData>(
-      (current, update) => ({ ...current, ...update }),
-      nodeDataRef.current
-    );
-
-    nodeDataRef.current = nextData;
-    setNodeData(nextData);
-  });
-
-  return (
-    <StickyNoteNode
-      {...defaultProps}
-      data={nodeData}
-      onResizeStart={() => onStartContent(nodeDataRef.current.content)}
-    />
-  );
-}
-
 beforeEach(() => {
-  deferredUpdate.handler = undefined;
   mockDeleteElements.mockReset();
   mockUpdateNodeData.mockReset();
-  mockUpdateNodeData.mockImplementation((id: string, data: Record<string, unknown>) => {
-    deferredUpdate.handler?.(id, data);
-  });
 });
 
 describe('StickyNoteNode resize lifecycle', () => {
@@ -173,19 +114,6 @@ describe('StickyNoteNode resize lifecycle', () => {
       content: 'Updated note text',
     });
     expect(onContentChange).toHaveBeenCalledTimes(1);
-    expect(mockUpdateNodeData).toHaveBeenCalledTimes(1);
-  });
-
-  it('flushes pending text into controlled node data before resize start', () => {
-    const onStartContent = vi.fn();
-
-    render(<DeferredUpdateHarness onStartContent={onStartContent} />);
-
-    const textarea = startEditing();
-    fireEvent.change(textarea, { target: { value: 'Updated text' } });
-    fireEvent.mouseDown(screen.getByTestId('node-resize-control-bottom-right'));
-
-    expect(onStartContent).toHaveBeenCalledWith('Updated text');
     expect(mockUpdateNodeData).toHaveBeenCalledTimes(1);
   });
 

--- a/packages/apollo-react/src/canvas/components/StickyNoteNode/StickyNoteNode.tsx
+++ b/packages/apollo-react/src/canvas/components/StickyNoteNode/StickyNoteNode.tsx
@@ -5,6 +5,7 @@ import { NodeResizeControl, useReactFlow } from '@uipath/apollo-react/canvas/xyf
 import type { ResizeDragEvent, ResizeParams } from '@uipath/apollo-react/canvas/xyflow/system';
 import { AnimatePresence } from 'motion/react';
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { flushSync } from 'react-dom';
 import ReactMarkdown from 'react-markdown';
 import remarkBreaks from 'remark-breaks';
 import remarkGfm from 'remark-gfm';
@@ -75,6 +76,7 @@ const StickyNoteNodeComponent = ({
   const [isColorPickerOpen, setIsColorPickerOpen] = useState(false);
   const [localContent, setLocalContent] = useState(data.content || '');
   const textAreaRef = useRef<HTMLTextAreaElement>(null);
+  const skipBlurRef = useRef<string | null>(null);
   const { ref: markdownRef, scrollCaptureProps } = useScrollCapture();
   const colorButtonRef = useRef<HTMLDivElement>(null);
   const [activeFormats, setActiveFormats] = useState<ActiveFormats>({
@@ -132,13 +134,21 @@ const StickyNoteNodeComponent = ({
   const handleBlur = useCallback(() => {
     setIsEditing(false);
     if (readOnly) return;
-    if (localContent !== data.content) {
-      onContentChange?.(localContent);
-      updateNodeData(id, { content: localContent });
+
+    const content = textAreaRef.current?.value ?? localContent;
+    if (skipBlurRef.current === content) {
+      skipBlurRef.current = null;
+      return;
+    }
+
+    if (content !== data.content) {
+      onContentChange?.(content);
+      updateNodeData(id, { content });
     }
   }, [id, localContent, data.content, updateNodeData, onContentChange, readOnly]);
 
   const handleChange = useCallback((e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    skipBlurRef.current = null;
     setLocalContent(e.target.value);
   }, []);
 
@@ -169,6 +179,7 @@ const StickyNoteNodeComponent = ({
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
       if (e.key === 'Escape') {
+        skipBlurRef.current = textAreaRef.current?.value ?? localContent;
         setIsEditing(false);
         setLocalContent(data.content || '');
         textAreaRef.current?.blur();
@@ -191,17 +202,36 @@ const StickyNoteNodeComponent = ({
       }
       shortcutKeyDown(e);
     },
-    [data.content, shortcutKeyDown, handleFormat]
+    [data.content, localContent, shortcutKeyDown, handleFormat]
   );
 
   // Resize handlers
   const handleResizeStart = useCallback(() => {
     if (isEditing) {
+      const content = textAreaRef.current?.value ?? localContent;
+
+      if (!readOnly && content !== data.content) {
+        skipBlurRef.current = content;
+        flushSync(() => {
+          onContentChange?.(content);
+          updateNodeData(id, { content });
+        });
+      }
+
       textAreaRef.current?.blur();
     }
     setIsResizing(true);
     onResizeStart?.();
-  }, [isEditing, onResizeStart]);
+  }, [
+    data.content,
+    id,
+    isEditing,
+    localContent,
+    onContentChange,
+    onResizeStart,
+    readOnly,
+    updateNodeData,
+  ]);
 
   const handleResizeEnd = useCallback(
     (_event: ResizeDragEvent, params: ResizeParams) => {


### PR DESCRIPTION
## Summary
- Flush pending sticky note text into React Flow state before resize history starts
- Skip the following blur commit so the edit is not recorded twice
- Cover deferred controlled-node updates and Escape-cancel behavior

## Demo


https://github.com/user-attachments/assets/7c51f2d3-451e-4e38-9005-96edf10aa0b4



## Flow
```mermaid
flowchart TD
  A["User edits sticky note"] --> B["Resize handle mouseDown"]
  B --> C["handleResizeStart"]

  C --> D{"Is editing?"}
  D -- No --> J["setIsResizing(true)"]
  D -- Yes --> E["Read live textarea value"]

  E --> F{"Changed and not readOnly?"}
  F -- No --> H["Blur textarea"]
  F -- Yes --> G["flushSync commit text<br/>onContentChange + updateNodeData"]

  G --> G1["Controlled node data updates<br/>before resize history starts"]
  G1 --> H

  H --> I["handleBlur fires"]
  I --> I1{"skipBlurRef matches?"}
  I1 -- Yes --> I2["Skip duplicate commit"]
  I1 -- No --> I3["Normal blur commit if needed"]

  I2 --> J
  I3 --> J

  J --> K["onResizeStart"]
  K --> L["Flow Workbench starts resize transaction<br/>with latest sticky note content"]
  L --> M["Resize drag updates size"]
  M --> N["handleResizeEnd"]
  N --> O["onResize(width, height)"]
  O --> P["queueMicrotask(onResizeEnd)"]
  P --> Q["Transaction closes after resize updates settle"]
```

## Checks
- pnpm --filter @uipath/apollo-react exec vitest --run src/canvas/components/StickyNoteNode/StickyNoteNode.test.tsx src/canvas/components/LoopNode/LoopNode.test.tsx
- pnpm --filter @uipath/apollo-react exec tsc --noEmit
- pnpm --filter @uipath/apollo-react exec biome check src/canvas/components/StickyNoteNode/StickyNoteNode.tsx src/canvas/components/StickyNoteNode/StickyNoteNode.test.tsx
