### PR TITLE
feat(apollo-react): case trigger manifest polish + node opt-outs

### DIFF
--- a/packages/apollo-react/src/canvas/components/BaseCanvas/index.ts
+++ b/packages/apollo-react/src/canvas/components/BaseCanvas/index.ts
@@ -2,6 +2,7 @@ export { BaseCanvas } from './BaseCanvas';
 export * from './BaseCanvas.constants';
 export * from './BaseCanvas.hooks';
 export * from './BaseCanvas.types';
+export * from './BaseCanvasModeProvider';
 export * from './CanvasBackground';
 export * from './CanvasProviders';
 export * from './CanvasThemeContext';

--- a/packages/apollo-react/src/canvas/components/BaseNode/BaseNode.test.tsx
+++ b/packages/apollo-react/src/canvas/components/BaseNode/BaseNode.test.tsx
@@ -10,7 +10,13 @@ const DEFAULT_MANIFEST = {
 } as const;
 
 // Hoisted mocks — available inside vi.mock factories
-const { mockUpdateNode, mockHandleConfigs, mockManifest } = vi.hoisted(() => ({
+const {
+  mockUpdateNode,
+  mockHandleConfigs,
+  mockManifest,
+  mockUseButtonHandles,
+  mockOverrideConfig,
+} = vi.hoisted(() => ({
   mockUpdateNode: vi.fn(),
   mockHandleConfigs: { current: undefined as HandleGroupManifest[] | undefined },
   mockManifest: {
@@ -19,6 +25,9 @@ const { mockUpdateNode, mockHandleConfigs, mockManifest } = vi.hoisted(() => ({
       handleConfiguration: [],
     } as Record<string, unknown>,
   },
+  // biome-ignore lint/suspicious/noExplicitAny: hook receives a broad typed options object
+  mockUseButtonHandles: vi.fn() as any,
+  mockOverrideConfig: { current: {} as Record<string, unknown> },
 }));
 
 // xyflow is globally mocked in canvas-mocks.ts; extend with test-specific overrides.
@@ -50,13 +59,21 @@ vi.mock('../BaseCanvas/SelectionStateContext', () => ({
 vi.mock('../BaseCanvas/CanvasThemeContext', () => ({
   useCanvasTheme: () => ({ isDarkMode: false }),
 }));
-vi.mock('../ButtonHandle/useButtonHandles', () => ({ useButtonHandles: () => null }));
+vi.mock('../ButtonHandle/useButtonHandles', () => ({
+  useButtonHandles: (opts: unknown) => {
+    mockUseButtonHandles(opts);
+    return null;
+  },
+}));
 vi.mock('../ButtonHandle/SmartHandle', () => ({
   SmartHandle: () => null,
   SmartHandleProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }));
 vi.mock('./BaseNodeConfigContext', () => ({
-  useBaseNodeOverrideConfig: () => ({ handleConfigurations: mockHandleConfigs.current }),
+  useBaseNodeOverrideConfig: () => ({
+    handleConfigurations: mockHandleConfigs.current,
+    ...mockOverrideConfig.current,
+  }),
 }));
 vi.mock('../../utils/adornment-resolver', () => ({ resolveAdornments: () => ({}) }));
 vi.mock('../../utils/toolbar-resolver', () => ({ resolveToolbar: () => undefined }));
@@ -122,8 +139,10 @@ const makeHandles = (position: Position, count: number): HandleGroupManifest[] =
 describe('BaseNode', () => {
   afterEach(() => {
     mockUpdateNode.mockClear();
+    mockUseButtonHandles.mockClear();
     mockHandleConfigs.current = undefined;
     mockManifest.current = { ...DEFAULT_MANIFEST };
+    mockOverrideConfig.current = {};
   });
 
   describe('Height computation', () => {
@@ -281,6 +300,40 @@ describe('BaseNode', () => {
       render(<BaseNode {...defaultProps} />);
       // No aria-hidden 'M' span — the registered icon takes the slot.
       expect(screen.queryByText('M', { selector: '[aria-hidden="true"]' })).not.toBeInTheDocument();
+    });
+  });
+
+  // BaseNode forwards the consumer-facing `onHandleMouseEnter`/`onHandleMouseLeave`
+  // from `BaseNodeOverrideConfigProvider` into `useButtonHandles` as
+  // `handleMouseEnter`/`handleMouseLeave`. Trigger those by reaching into the
+  // captured hook arguments and invoking them with a synthetic payload.
+  describe('Handle hover handlers', () => {
+    it('forwards onHandleMouseEnter/onHandleMouseLeave overrides and fires with the payload', () => {
+      const onHandleMouseEnter = vi.fn();
+      const onHandleMouseLeave = vi.fn();
+      mockOverrideConfig.current = { onHandleMouseEnter, onHandleMouseLeave };
+
+      render(<BaseNode {...defaultProps} />);
+
+      expect(mockUseButtonHandles).toHaveBeenCalled();
+      const opts = mockUseButtonHandles.mock.calls.at(-1)?.[0] as {
+        handleMouseEnter?: (e: unknown) => void;
+        handleMouseLeave?: (e: unknown) => void;
+      };
+      expect(opts.handleMouseEnter).toBe(onHandleMouseEnter);
+      expect(opts.handleMouseLeave).toBe(onHandleMouseLeave);
+
+      const payload = {
+        handleId: 'output',
+        nodeId: 'test-node',
+        handleType: 'output',
+        position: Position.Right,
+      };
+      opts.handleMouseEnter?.(payload);
+      opts.handleMouseLeave?.(payload);
+
+      expect(onHandleMouseEnter).toHaveBeenCalledWith(payload);
+      expect(onHandleMouseLeave).toHaveBeenCalledWith(payload);
     });
   });
 });

--- a/packages/apollo-react/src/canvas/components/BaseNode/BaseNode.tsx
+++ b/packages/apollo-react/src/canvas/components/BaseNode/BaseNode.tsx
@@ -87,6 +87,8 @@ const BaseNodeComponent = (props: NodeProps<Node<BaseNodeData>>) => {
   // Read runtime configuration from context (provided by parent node components)
   const {
     onHandleAction: onHandleActionProp,
+    onHandleMouseEnter: onHandleMouseEnterProp,
+    onHandleMouseLeave: onHandleMouseLeaveProp,
     shouldShowAddButtonFn: shouldShowAddButtonFnProp,
     shouldShowButtonHandleNotchesFn: shouldShowButtonHandleNotchesFnProp,
     toolbarConfig: toolbarConfigProp,
@@ -480,6 +482,8 @@ const BaseNodeComponent = (props: NodeProps<Node<BaseNodeData>>) => {
     handleConfigurations,
     shouldShowHandles,
     handleAction,
+    handleMouseEnter: onHandleMouseEnterProp,
+    handleMouseLeave: onHandleMouseLeaveProp,
     nodeId: id,
     selected: selected ?? false,
     hovered: isHovered,

--- a/packages/apollo-react/src/canvas/components/BaseNode/BaseNodeConfigContext.tsx
+++ b/packages/apollo-react/src/canvas/components/BaseNode/BaseNodeConfigContext.tsx
@@ -1,7 +1,7 @@
 import { createContext, useContext } from 'react';
 import type { HandleGroupManifest } from '../../schema/node-definition';
 import type { ElementStatusValues } from '../../types/execution';
-import type { HandleActionEvent } from '../ButtonHandle/ButtonHandle';
+import type { HandleActionEvent, HandleMouseEvent } from '../ButtonHandle/ButtonHandle';
 import type { NodeToolbarConfig } from '../Toolbar';
 import type { FooterVariant, NodeAdornments } from './BaseNode.types';
 
@@ -20,6 +20,10 @@ import type { FooterVariant, NodeAdornments } from './BaseNode.types';
 export interface BaseNodeOverrideConfig {
   // Callbacks (Runtime Behavior)
   onHandleAction?: (event: HandleActionEvent) => void;
+  /** Fired when the cursor enters a source handle's inline add button. */
+  onHandleMouseEnter?: (event: HandleMouseEvent) => void;
+  /** Fired when the cursor leaves a source handle's inline add button. */
+  onHandleMouseLeave?: (event: HandleMouseEvent) => void;
   shouldShowAddButtonFn?: (opts: { showAddButton: boolean; selected: boolean }) => boolean;
   shouldShowButtonHandleNotchesFn?: (opts: {
     isConnecting: boolean;

--- a/packages/apollo-react/src/canvas/components/ButtonHandle/ButtonHandle.test.tsx
+++ b/packages/apollo-react/src/canvas/components/ButtonHandle/ButtonHandle.test.tsx
@@ -2,7 +2,8 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { Position } from '@uipath/apollo-react/canvas/xyflow/react';
 import { describe, expect, it, vi } from 'vitest';
-import type { ButtonHandleConfig } from './ButtonHandle';
+import { canvasEventBus } from '../../utils/CanvasEventBus';
+import type { ButtonHandleConfig, HandleMouseEvent } from './ButtonHandle';
 import { ButtonHandles } from './ButtonHandle';
 
 // Mock @xyflow/react Handle component
@@ -378,6 +379,140 @@ describe('ButtonHandles', () => {
       // nodeHeight=80 → exact center (40) is half a grid step off (gridSize=16).
       // Snap rounds to 48 (60%) so the handle stays grid-aligned.
       expect(handleElements[0]).toHaveStyle({ top: '60%' });
+    });
+  });
+
+  describe('Hover handlers', () => {
+    it('invokes onMouseEnter with the HandleMouseEvent payload and emits handle:mouseenter on the bus', async () => {
+      const user = userEvent.setup();
+      const onMouseEnter = vi.fn();
+      const busSpy = vi.fn();
+
+      const unsubscribe = canvasEventBus.on('handle:mouseenter', busSpy);
+
+      const handles: ButtonHandleConfig[] = [
+        {
+          id: 'handle1',
+          type: 'source',
+          handleType: 'output',
+          showButton: true,
+          onAction: vi.fn(),
+          onMouseEnter,
+        },
+      ];
+
+      render(
+        <ButtonHandles
+          handles={handles}
+          nodeId="test-node"
+          position={Position.Right}
+          selected={true}
+          visible={true}
+        />
+      );
+
+      const button = screen.getByRole('button');
+      await user.hover(button);
+
+      const expectedPayload: HandleMouseEvent = {
+        handleId: 'handle1',
+        nodeId: 'test-node',
+        handleType: 'output',
+        position: Position.Right,
+      };
+      expect(onMouseEnter).toHaveBeenCalledWith(expectedPayload);
+      expect(busSpy).toHaveBeenCalledWith(expect.objectContaining(expectedPayload));
+
+      unsubscribe();
+    });
+
+    it('invokes onMouseLeave with the HandleMouseEvent payload and emits handle:mouseleave on the bus', async () => {
+      const user = userEvent.setup();
+      const onMouseLeave = vi.fn();
+      const busSpy = vi.fn();
+
+      const unsubscribe = canvasEventBus.on('handle:mouseleave', busSpy);
+
+      const handles: ButtonHandleConfig[] = [
+        {
+          id: 'handle1',
+          type: 'source',
+          handleType: 'output',
+          showButton: true,
+          onAction: vi.fn(),
+          onMouseLeave,
+        },
+      ];
+
+      render(
+        <ButtonHandles
+          handles={handles}
+          nodeId="test-node"
+          position={Position.Right}
+          selected={true}
+          visible={true}
+        />
+      );
+
+      const button = screen.getByRole('button');
+      await user.hover(button);
+      await user.unhover(button);
+
+      const expectedPayload: HandleMouseEvent = {
+        handleId: 'handle1',
+        nodeId: 'test-node',
+        handleType: 'output',
+        position: Position.Right,
+      };
+      expect(onMouseLeave).toHaveBeenCalledWith(expectedPayload);
+      expect(busSpy).toHaveBeenCalledWith(expect.objectContaining(expectedPayload));
+
+      unsubscribe();
+    });
+
+    it('emits bus events even when no onMouseEnter/onMouseLeave callbacks are wired', async () => {
+      const user = userEvent.setup();
+      const enterSpy = vi.fn();
+      const leaveSpy = vi.fn();
+
+      const unsubscribeEnter = canvasEventBus.on('handle:mouseenter', enterSpy);
+      const unsubscribeLeave = canvasEventBus.on('handle:mouseleave', leaveSpy);
+
+      const handles: ButtonHandleConfig[] = [
+        {
+          id: 'handle1',
+          type: 'source',
+          handleType: 'output',
+          showButton: true,
+          onAction: vi.fn(),
+        },
+      ];
+
+      render(
+        <ButtonHandles
+          handles={handles}
+          nodeId="test-node"
+          position={Position.Right}
+          selected={true}
+          visible={true}
+        />
+      );
+
+      const button = screen.getByRole('button');
+      await user.hover(button);
+      await user.unhover(button);
+
+      const expectedPayload = {
+        handleId: 'handle1',
+        nodeId: 'test-node',
+        handleType: 'output',
+        position: Position.Right,
+      };
+      expect(enterSpy).toHaveBeenCalledWith(expect.objectContaining(expectedPayload));
+      expect(leaveSpy).toHaveBeenCalledWith(expect.objectContaining(expectedPayload));
+
+      unsubscribeEnter();
+      unsubscribeLeave();
     });
   });
 });

--- a/packages/apollo-react/src/canvas/components/ButtonHandle/ButtonHandle.tsx
+++ b/packages/apollo-react/src/canvas/components/ButtonHandle/ButtonHandle.tsx
@@ -22,6 +22,14 @@ export interface HandleActionEvent {
   originalEvent: React.MouseEvent;
 }
 
+/** Payload passed to `onMouseEnter` / `onMouseLeave` handlers on a button handle. */
+export interface HandleMouseEvent {
+  handleId: string;
+  nodeId: string;
+  handleType: HandleType;
+  position: Position;
+}
+
 type ButtonHandleProps = {
   id: string;
   nodeId: string;
@@ -40,6 +48,8 @@ type ButtonHandleProps = {
   index?: number; // 0-based index of this handle on the edge
   total?: number; // Total number of handles on this edge
   onAction?: (event: HandleActionEvent) => void;
+  onMouseEnter?: (event: HandleMouseEvent) => void;
+  onMouseLeave?: (event: HandleMouseEvent) => void;
   showNotches?: boolean;
   customPositionAndOffsets?: HandleConfigurationSpecificPosition;
   nodeWidth?: number;
@@ -63,6 +73,8 @@ const ButtonHandleBase = ({
   index = 0,
   total = 1,
   onAction,
+  onMouseEnter,
+  onMouseLeave,
   showNotches = true,
   customPositionAndOffsets,
   nodeWidth,
@@ -72,6 +84,33 @@ const ButtonHandleBase = ({
   const handleRef = useRef<HTMLDivElement>(null);
   const [isHovered, setIsHovered] = useState(false);
   const isVertical = position === Position.Top || position === Position.Bottom;
+
+  const dispatchMouseEvent = useCallback(
+    (
+      eventName: 'handle:mouseenter' | 'handle:mouseleave',
+      handler: ((event: HandleMouseEvent) => void) | undefined
+    ) => {
+      const payload: HandleMouseEvent = {
+        handleId: id,
+        nodeId,
+        handleType,
+        position: connectionPosition,
+      };
+      handler?.(payload);
+      canvasEventBus.emit(eventName, payload);
+    },
+    [id, nodeId, handleType, connectionPosition]
+  );
+
+  const handleButtonMouseEnter = useCallback(
+    () => dispatchMouseEvent('handle:mouseenter', onMouseEnter),
+    [dispatchMouseEvent, onMouseEnter]
+  );
+
+  const handleButtonMouseLeave = useCallback(
+    () => dispatchMouseEvent('handle:mouseleave', onMouseLeave),
+    [dispatchMouseEvent, onMouseLeave]
+  );
 
   // Calculate position along the edge for multiple handles
   // Use grid-aligned positions when node dimensions are available
@@ -189,6 +228,8 @@ const ButtonHandleBase = ({
             labelVisible={visible}
             position={connectionPosition}
             onAction={handleButtonClick}
+            onMouseEnter={handleButtonMouseEnter}
+            onMouseLeave={handleButtonMouseLeave}
             handleRef={handleRef}
           />
         ) : null}
@@ -246,6 +287,8 @@ const ButtonHandleBase = ({
           labelVisible={visible}
           position={position}
           onAction={handleButtonClick}
+          onMouseEnter={handleButtonMouseEnter}
+          onMouseLeave={handleButtonMouseLeave}
           handleRef={handleRef}
           label={label}
           labelIcon={labelIcon}
@@ -335,6 +378,8 @@ export interface ButtonHandleConfig {
   /** Runtime visibility — controls opacity (e.g. connected handles stay visible). */
   showHandle?: boolean;
   onAction?: (event: HandleActionEvent) => void;
+  onMouseEnter?: (event: HandleMouseEvent) => void;
+  onMouseLeave?: (event: HandleMouseEvent) => void;
   customPositionAndOffsets?: HandleConfigurationSpecificPosition;
 }
 
@@ -425,6 +470,8 @@ const ButtonHandlesBase = ({
             visible={handleVisible}
             showButton={finalSelected && handleVisible && handle.showButton}
             onAction={handle.onAction}
+            onMouseEnter={handle.onMouseEnter}
+            onMouseLeave={handle.onMouseLeave}
             showNotches={showNotches}
             customPositionAndOffsets={customPositionAndOffsets}
             nodeWidth={nodeWidth}

--- a/packages/apollo-react/src/canvas/components/ButtonHandle/HandleButton.test.tsx
+++ b/packages/apollo-react/src/canvas/components/ButtonHandle/HandleButton.test.tsx
@@ -1,4 +1,5 @@
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { Position } from '@uipath/apollo-react/canvas/xyflow/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { HandleButton } from './HandleButton';
@@ -8,10 +9,14 @@ const DRAG_THRESHOLD = 5;
 function renderButton({
   visible = true,
   onAction = vi.fn<(e: React.MouseEvent) => void>(),
+  onMouseEnter,
+  onMouseLeave,
   handleEl,
 }: {
   visible?: boolean;
   onAction?: (event: React.MouseEvent) => void;
+  onMouseEnter?: () => void;
+  onMouseLeave?: () => void;
   handleEl?: HTMLDivElement;
 } = {}) {
   const handleRef = { current: handleEl ?? null } as React.RefObject<HTMLDivElement | null>;
@@ -21,6 +26,8 @@ function renderButton({
       visible={visible}
       position={Position.Right}
       onAction={onAction}
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
       handleRef={handleRef}
     />
   );
@@ -145,5 +152,50 @@ describe('HandleButton drag behaviour', () => {
     fireEvent.pointerUp(document);
     fireEvent.click(button);
     expect(onAction).toHaveBeenCalledOnce();
+  });
+});
+
+describe('HandleButton hover handlers', () => {
+  afterEach(cleanup);
+
+  it('invokes onMouseEnter when the cursor enters the inline button', async () => {
+    const user = userEvent.setup();
+    const onMouseEnter = vi.fn();
+    const { button } = renderButton({ onMouseEnter });
+
+    await user.hover(button);
+
+    expect(onMouseEnter).toHaveBeenCalledOnce();
+  });
+
+  it('invokes onMouseLeave when the cursor leaves the inline button', async () => {
+    const user = userEvent.setup();
+    const onMouseLeave = vi.fn();
+    const { button } = renderButton({ onMouseLeave });
+
+    await user.hover(button);
+    await user.unhover(button);
+
+    expect(onMouseLeave).toHaveBeenCalledOnce();
+  });
+
+  it('still calls onAction on click when hover handlers are wired', async () => {
+    const user = userEvent.setup();
+    const onMouseEnter = vi.fn();
+    const onMouseLeave = vi.fn();
+    const { button, onAction } = renderButton({ onMouseEnter, onMouseLeave });
+
+    await user.hover(button);
+    await user.click(button);
+
+    expect(onAction).toHaveBeenCalledOnce();
+  });
+
+  it('does not throw when hovering with no hover handlers supplied', async () => {
+    const user = userEvent.setup();
+    const { button } = renderButton();
+
+    await expect(user.hover(button)).resolves.toBeUndefined();
+    await expect(user.unhover(button)).resolves.toBeUndefined();
   });
 });

--- a/packages/apollo-react/src/canvas/components/ButtonHandle/HandleButton.tsx
+++ b/packages/apollo-react/src/canvas/components/ButtonHandle/HandleButton.tsx
@@ -37,6 +37,8 @@ export const HandleButton = memo(
     labelVisible,
     position,
     onAction,
+    onMouseEnter,
+    onMouseLeave,
     handleRef,
     label,
     labelIcon,
@@ -47,6 +49,8 @@ export const HandleButton = memo(
     labelVisible?: boolean;
     position: Position;
     onAction: (event: React.MouseEvent) => void;
+    onMouseEnter?: () => void;
+    onMouseLeave?: () => void;
     handleRef?: React.RefObject<HTMLDivElement | null>;
     label?: string;
     labelIcon?: React.ReactNode;
@@ -135,6 +139,8 @@ export const HandleButton = memo(
             aria-label="Add node"
             onClick={handleClick}
             onPointerDown={handlePointerDown}
+            onMouseEnter={onMouseEnter}
+            onMouseLeave={onMouseLeave}
             className="nodrag nopan pointer-events-auto animate-fade-in"
           />
         )}

--- a/packages/apollo-react/src/canvas/components/ButtonHandle/useButtonHandles.test.tsx
+++ b/packages/apollo-react/src/canvas/components/ButtonHandle/useButtonHandles.test.tsx
@@ -1,0 +1,172 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Position } from '@uipath/apollo-react/canvas/xyflow/react';
+import { describe, expect, it, vi } from 'vitest';
+import type { HandleGroupManifest } from '../../schema/node-definition';
+import type { ResolvedHandleGroup } from '../../utils/manifest-resolver';
+import { useButtonHandles } from './useButtonHandles';
+
+vi.mock('@xyflow/react', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@xyflow/react')>()),
+  useNodesData: () => ({}),
+}));
+
+// canvas-mocks.ts globally mocks @uipath/apollo-react/canvas/xyflow/react with a
+// Handle that ignores its children — override here so the inline + button (rendered
+// inside <Handle>) actually mounts.
+vi.mock('@uipath/apollo-react/canvas/xyflow/react', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@uipath/apollo-react/canvas/xyflow/react')>();
+  return {
+    ...actual,
+    // biome-ignore lint/suspicious/noExplicitAny: lightweight Handle stub for tests
+    Handle: ({ children, ...props }: any) => {
+      const domProps = Object.keys(props).reduce((acc: Record<string, unknown>, key) => {
+        if (!key.startsWith('$')) acc[key] = props[key];
+        return acc;
+      }, {});
+      return (
+        <div data-testid="handle" {...domProps}>
+          {children}
+        </div>
+      );
+    },
+  };
+});
+
+vi.mock('../BaseCanvas/ConnectedHandlesContext', () => ({
+  useConnectedHandles: () => new Set<string>(),
+}));
+
+// Pass the manifest groups straight through as ResolvedHandle-shaped objects so
+// per-handle `onMouseEnter`/`onMouseLeave`/`onAction` survive into useButtonHandles.
+vi.mock('../../utils/manifest-resolver', () => ({
+  resolveHandles: (groups: ResolvedHandleGroup[]) =>
+    (groups ?? []).map((group) => ({
+      ...group,
+      visible: group.visible ?? true,
+      handles: group.handles.map((h) => ({
+        ...h,
+        visible: h.visible ?? true,
+      })),
+    })),
+}));
+
+function TestHost({
+  handleConfigurations,
+  handleMouseEnter,
+  handleMouseLeave,
+}: {
+  // Cast through unknown — the test passes resolved-shaped objects (with
+  // onAction/onMouseEnter) and our mock above forwards them as-is, which is
+  // exactly what useButtonHandles consumes at runtime.
+  handleConfigurations: HandleGroupManifest[];
+  handleMouseEnter?: (event: { handleId: string; nodeId: string }) => void;
+  handleMouseLeave?: (event: { handleId: string; nodeId: string }) => void;
+}) {
+  const elements = useButtonHandles({
+    handleConfigurations,
+    shouldShowHandles: true,
+    handleMouseEnter,
+    handleMouseLeave,
+    nodeId: 'test-node',
+    selected: true,
+    hovered: true,
+    showAddButton: true,
+  });
+
+  return <>{elements}</>;
+}
+
+// biome-ignore lint/suspicious/noExplicitAny: per-handle resolved fields are runtime additions on top of the schema-derived HandleManifest
+function makeGroups(handles: any[]): HandleGroupManifest[] {
+  return [
+    {
+      position: Position.Right,
+      handles,
+    },
+  ] as HandleGroupManifest[];
+}
+
+describe('useButtonHandles — handler precedence', () => {
+  it('uses per-handle onMouseEnter when both per-handle and global are provided', async () => {
+    const user = userEvent.setup();
+    const perHandleOnMouseEnter = vi.fn();
+    const globalOnMouseEnter = vi.fn();
+
+    const handleConfigurations = makeGroups([
+      {
+        id: 'output',
+        type: 'source',
+        handleType: 'output',
+        showButton: true,
+        onAction: () => {},
+        onMouseEnter: perHandleOnMouseEnter,
+      },
+    ]);
+
+    render(
+      <TestHost handleConfigurations={handleConfigurations} handleMouseEnter={globalOnMouseEnter} />
+    );
+
+    const button = screen.getByRole('button');
+    await user.hover(button);
+
+    expect(perHandleOnMouseEnter).toHaveBeenCalledOnce();
+    expect(globalOnMouseEnter).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the global handleMouseEnter when per-handle is unset', async () => {
+    const user = userEvent.setup();
+    const globalOnMouseEnter = vi.fn();
+
+    const handleConfigurations = makeGroups([
+      {
+        id: 'output',
+        type: 'source',
+        handleType: 'output',
+        showButton: true,
+        onAction: () => {},
+      },
+    ]);
+
+    render(
+      <TestHost handleConfigurations={handleConfigurations} handleMouseEnter={globalOnMouseEnter} />
+    );
+
+    const button = screen.getByRole('button');
+    await user.hover(button);
+
+    expect(globalOnMouseEnter).toHaveBeenCalledOnce();
+    expect(globalOnMouseEnter).toHaveBeenCalledWith(
+      expect.objectContaining({ handleId: 'output', nodeId: 'test-node' })
+    );
+  });
+
+  it('uses per-handle onMouseLeave when both per-handle and global are provided', async () => {
+    const user = userEvent.setup();
+    const perHandleOnMouseLeave = vi.fn();
+    const globalOnMouseLeave = vi.fn();
+
+    const handleConfigurations = makeGroups([
+      {
+        id: 'output',
+        type: 'source',
+        handleType: 'output',
+        showButton: true,
+        onAction: () => {},
+        onMouseLeave: perHandleOnMouseLeave,
+      },
+    ]);
+
+    render(
+      <TestHost handleConfigurations={handleConfigurations} handleMouseLeave={globalOnMouseLeave} />
+    );
+
+    const button = screen.getByRole('button');
+    await user.hover(button);
+    await user.unhover(button);
+
+    expect(perHandleOnMouseLeave).toHaveBeenCalledOnce();
+    expect(globalOnMouseLeave).not.toHaveBeenCalled();
+  });
+});

--- a/packages/apollo-react/src/canvas/components/ButtonHandle/useButtonHandles.tsx
+++ b/packages/apollo-react/src/canvas/components/ButtonHandle/useButtonHandles.tsx
@@ -4,13 +4,15 @@ import { useMemo } from 'react';
 import type { HandleGroupManifest } from '../../schema/node-definition';
 import { resolveHandles } from '../../utils/manifest-resolver';
 import { useConnectedHandles } from '../BaseCanvas/ConnectedHandlesContext';
-import type { HandleActionEvent } from '../ButtonHandle';
+import type { HandleActionEvent, HandleMouseEvent } from '../ButtonHandle';
 import { ButtonHandles } from '../ButtonHandle';
 
 export const useButtonHandles = ({
   handleConfigurations,
   shouldShowHandles,
   handleAction,
+  handleMouseEnter,
+  handleMouseLeave,
   nodeId,
   selected,
   hovered,
@@ -27,6 +29,8 @@ export const useButtonHandles = ({
   selected: boolean;
   hovered?: boolean;
   handleAction?: (event: HandleActionEvent) => void;
+  handleMouseEnter?: (event: HandleMouseEvent) => void;
+  handleMouseLeave?: (event: HandleMouseEvent) => void;
   showAddButton?: boolean;
   showNotches?: boolean;
   nodeWidth?: number;
@@ -76,6 +80,8 @@ export const useButtonHandles = ({
         showHandle: connectedHandleIds.has(handle.id) || groupVisible,
         // Preserve individual handle's onAction if it exists, otherwise use global handleAction
         onAction: handle.onAction || handleAction,
+        onMouseEnter: handle.onMouseEnter || handleMouseEnter,
+        onMouseLeave: handle.onMouseLeave || handleMouseLeave,
       }));
 
       return (
@@ -105,6 +111,8 @@ export const useButtonHandles = ({
     shouldShowHandles,
     connectedHandleIds,
     handleAction,
+    handleMouseEnter,
+    handleMouseLeave,
     nodeId,
     showAddButton,
     showNotches,

--- a/packages/apollo-react/src/canvas/components/CaseFlow/CaseTrigger.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/CaseFlow/CaseTrigger.stories.tsx
@@ -1,9 +1,11 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import { NodeRegistryProvider } from '../../core';
 import { createNode, useCanvasStory, withCanvasProviders } from '../../storybook-utils';
 import type { ElementStatus } from '../../types/execution';
 import { BaseCanvas } from '../BaseCanvas';
+import { BaseNodeOverrideConfigProvider } from '../BaseNode/BaseNodeConfigContext';
+import type { HandleActionEvent, HandleMouseEvent } from '../ButtonHandle/ButtonHandle';
 import { caseFlowManifest } from './case-flow.manifest';
 
 const TRIGGER_NODE_TYPE = 'uipath.case.trigger';
@@ -99,4 +101,183 @@ export const Default: Story = {
     ),
   ],
   render: () => <CaseTriggerManifestStory />,
+};
+
+// ============================================================================
+// WithHoverPreview — demos `onHandleMouseEnter` / `onHandleMouseLeave` /
+// `onHandleAction` on the trigger's source-handle `+` button. Hovering the `+`
+// adds a translucent "preview" node next to the trigger; unhovering removes it;
+// clicking commits the preview into a solid node. This is the affordance
+// PO.Frontend's case-management canvas uses for its hover-to-preview UX and is
+// the visual baseline for that capability.
+// ============================================================================
+
+const PREVIEW_NODE_ID = 'hover-preview';
+const COMMITTED_NODE_ID = 'hover-committed';
+
+const HoverPreviewStory = () => {
+  const triggerInitialNodes = useMemo(
+    () => [
+      createNode({
+        id: 'trigger',
+        type: TRIGGER_NODE_TYPE,
+        position: { x: 96, y: 160 },
+        data: {
+          nodeType: TRIGGER_NODE_TYPE,
+          version: '1.0.0',
+          display: { label: 'Hover the +' },
+        },
+      }),
+    ],
+    []
+  );
+
+  const { canvasProps, setNodes } = useCanvasStory({ initialNodes: triggerInitialNodes });
+  const [isCommitted, setIsCommitted] = useState(false);
+
+  const overrideConfig = useMemo(
+    () => ({
+      onHandleMouseEnter: (_event: HandleMouseEvent) => {
+        if (isCommitted) return;
+        setNodes((nodes) => {
+          if (nodes.some((n) => n.id === PREVIEW_NODE_ID)) return nodes;
+          return [
+            ...nodes,
+            createNode({
+              id: PREVIEW_NODE_ID,
+              type: TRIGGER_NODE_TYPE,
+              position: { x: 296, y: 160 },
+              data: {
+                nodeType: TRIGGER_NODE_TYPE,
+                version: '1.0.0',
+                display: { label: 'Preview', icon: 'circle-dashed' },
+                // Visual cue for "preview" (translucent). Apollo's BaseNode
+                // doesn't have a first-class translucent variant; story-only
+                // styling is fine here for the visual demo.
+                style: { opacity: 0.4 },
+              },
+            }),
+          ];
+        });
+      },
+      onHandleMouseLeave: (_event: HandleMouseEvent) => {
+        if (isCommitted) return;
+        setNodes((nodes) => nodes.filter((n) => n.id !== PREVIEW_NODE_ID));
+      },
+      onHandleAction: (_event: HandleActionEvent) => {
+        setIsCommitted(true);
+        setNodes((nodes) => [
+          ...nodes.filter((n) => n.id !== PREVIEW_NODE_ID),
+          createNode({
+            id: COMMITTED_NODE_ID,
+            type: TRIGGER_NODE_TYPE,
+            position: { x: 296, y: 160 },
+            data: {
+              nodeType: TRIGGER_NODE_TYPE,
+              version: '1.0.0',
+              display: { label: 'Committed', icon: 'check' },
+            },
+          }),
+        ]);
+      },
+    }),
+    [isCommitted, setNodes]
+  );
+
+  return (
+    <BaseNodeOverrideConfigProvider value={overrideConfig}>
+      <BaseCanvas {...canvasProps} mode="design" />
+    </BaseNodeOverrideConfigProvider>
+  );
+};
+
+export const WithHoverPreview: Story = {
+  decorators: [
+    (Story) => (
+      <NodeRegistryProvider manifest={caseFlowManifest}>
+        <Story />
+      </NodeRegistryProvider>
+    ),
+  ],
+  render: () => <HoverPreviewStory />,
+};
+
+// ============================================================================
+// WithToolbarAction — demos the `change-trigger-type` action wired into
+// `caseManagementTriggerManifest.toolbarExtensions.design`. Selecting the
+// trigger reveals the apollo toolbar with the action; clicking it logs to the
+// console and bumps an in-story counter for visual feedback.
+// ============================================================================
+
+const ToolbarActionStory = () => {
+  const initialNodes = useMemo(
+    () => [
+      createNode({
+        id: 'trigger',
+        type: TRIGGER_NODE_TYPE,
+        position: { x: 160, y: 160 },
+        data: {
+          nodeType: TRIGGER_NODE_TYPE,
+          version: '1.0.0',
+          display: { label: 'Select me' },
+        },
+      }),
+    ],
+    []
+  );
+
+  const { canvasProps } = useCanvasStory({ initialNodes });
+  const [actionCount, setActionCount] = useState(0);
+
+  return (
+    <div style={{ position: 'relative', width: '100%', height: '100%' }}>
+      <div
+        style={{
+          position: 'absolute',
+          top: 12,
+          right: 12,
+          zIndex: 10,
+          padding: '8px 12px',
+          background: 'rgba(0,0,0,0.6)',
+          color: 'white',
+          borderRadius: 4,
+          fontFamily: 'sans-serif',
+          fontSize: 12,
+        }}
+      >
+        change-trigger-type fired: {actionCount}
+      </div>
+      <BaseNodeOverrideConfigProvider
+        value={{
+          toolbarConfig: {
+            actions: [
+              {
+                id: 'change-trigger-type',
+                icon: 'square-mouse-pointer',
+                label: 'Change trigger type',
+                onAction: () => {
+                  // biome-ignore lint/suspicious/noConsole: visual-demo logging in a story
+                  console.log('[CaseTrigger] change-trigger-type fired');
+                  setActionCount((n) => n + 1);
+                },
+              },
+            ],
+          },
+        }}
+      >
+        <BaseCanvas {...canvasProps} mode="design" />
+      </BaseNodeOverrideConfigProvider>
+    </div>
+  );
+};
+
+export const WithToolbarAction: Story = {
+  decorators: [
+    (Story) => (
+      <NodeRegistryProvider manifest={caseFlowManifest}>
+        <Story />
+      </NodeRegistryProvider>
+    ),
+  ],
+  render: () => <ToolbarActionStory />,
 };

--- a/packages/apollo-react/src/canvas/components/CaseFlow/case-flow.manifest.ts
+++ b/packages/apollo-react/src/canvas/components/CaseFlow/case-flow.manifest.ts
@@ -51,6 +51,7 @@ export const caseManagementTriggerManifest: NodeManifest = {
           id: 'output',
           type: 'source',
           handleType: 'output',
+          showButton: true,
           constraints: {
             minConnections: 1,
             allowedTargetCategories: ['case-stage'],
@@ -71,6 +72,17 @@ export const caseManagementTriggerManifest: NodeManifest = {
     timeCycle: { type: 'string' },
     context: { type: 'array', items: { type: 'object' } },
     bindings: { type: 'array', items: { type: 'object' } },
+  },
+  toolbarExtensions: {
+    design: {
+      actions: [
+        {
+          id: 'change-trigger-type',
+          icon: 'square-mouse-pointer',
+          label: 'Change trigger type',
+        },
+      ],
+    },
   },
 };
 

--- a/packages/apollo-react/src/canvas/components/CaseFlow/index.ts
+++ b/packages/apollo-react/src/canvas/components/CaseFlow/index.ts
@@ -1,0 +1,5 @@
+export {
+  caseFlowCategories,
+  caseFlowManifest,
+  caseManagementTriggerManifest,
+} from './case-flow.manifest';

--- a/packages/apollo-react/src/canvas/components/index.ts
+++ b/packages/apollo-react/src/canvas/components/index.ts
@@ -6,6 +6,7 @@ export * from './ButtonHandle';
 export * from './CanvasModeToolbar';
 export * from './CanvasPositionControls';
 export * from './CanvasZoomControls';
+export * from './CaseFlow';
 export * from './CodedAgent';
 export * from './Edges';
 export * from './ExecutionStatusIcon';

--- a/packages/apollo-react/src/canvas/utils/CanvasEventBus.ts
+++ b/packages/apollo-react/src/canvas/utils/CanvasEventBus.ts
@@ -1,6 +1,11 @@
+import type { Position } from '@uipath/apollo-react/canvas/xyflow/react';
+import type { HandleType } from '../components/ButtonHandle/HandleNotch';
+
 // Canvas Event Bus - Type-safe global event system
 export interface CanvasEvents {
   'handle:action': CanvasHandleActionEvent;
+  'handle:mouseenter': CanvasHandleMouseEvent;
+  'handle:mouseleave': CanvasHandleMouseEvent;
   'node:select': { nodeId: string };
   'node:delete': { nodeId: string };
 }
@@ -8,9 +13,18 @@ export interface CanvasEvents {
 export interface CanvasHandleActionEvent {
   handleId: string;
   nodeId: string;
-  handleType: 'artifact' | 'input' | 'output';
-  position: 'top' | 'bottom' | 'left' | 'right';
+  handleType: HandleType;
+  position: Position;
   timestamp?: number; // Added automatically by event bus
+}
+
+/** Payload for `handle:mouseenter` / `handle:mouseleave` events emitted by `canvasEventBus`. */
+export interface CanvasHandleMouseEvent {
+  handleId: string;
+  nodeId: string;
+  handleType: HandleType;
+  position: Position;
+  timestamp?: number;
 }
 
 type EventName = keyof CanvasEvents;

--- a/packages/apollo-react/src/canvas/utils/manifest-resolver.ts
+++ b/packages/apollo-react/src/canvas/utils/manifest-resolver.ts
@@ -10,7 +10,7 @@
  * - Resolved: Final merged result used for rendering
  */
 
-import type { HandleActionEvent } from '../components/ButtonHandle/ButtonHandle';
+import type { HandleActionEvent, HandleMouseEvent } from '../components/ButtonHandle/ButtonHandle';
 import type { HandleGroupManifest, HandleManifest } from '../schema/node-definition/handle';
 import type { NodeDisplayManifest } from '../schema/node-definition/node-manifest';
 import type { InstanceDisplayConfig } from '../schema/node-instance';
@@ -59,6 +59,10 @@ export interface ResolvedHandle extends Omit<HandleManifest, 'repeat' | 'itemVar
   visible: boolean;
   /** Optional callback for button handle actions (runtime only) */
   onAction?: (event: HandleActionEvent) => void;
+  /** Optional callback fired when the cursor enters the inline add button (runtime only) */
+  onMouseEnter?: (event: HandleMouseEvent) => void;
+  /** Optional callback fired when the cursor leaves the inline add button (runtime only) */
+  onMouseLeave?: (event: HandleMouseEvent) => void;
 }
 
 /**


### PR DESCRIPTION
Superseded by #776 — case-trigger polish + node opt-out primitives now live on `claude/case-flow-polish` (based on `main`, which already includes the `caseFlowManifest` exposure work via b73d03f).

`claude/adoring-brown-ZGpZ5` has been reset to just `36bee11` (the earlier caseFlowManifest exposure work, now redundant with `b73d03f` on main).