### PR TITLE
feat(apollo-react): case trigger manifest polish + node opt-outs

### DIFF
--- a/packages/apollo-react/src/canvas/components/BaseNode/BaseNode.tsx
+++ b/packages/apollo-react/src/canvas/components/BaseNode/BaseNode.tsx
@@ -310,6 +310,7 @@ const BaseNodeComponent = (props: NodeProps<Node<BaseNodeData>>) => {
   const displayShape = display.shape ?? 'square';
   const displayBackground = display.background;
   const displayColor = display.color;
+  const displayShadow = display.shadow ?? true;
   const displayIconBackground = isDarkMode
     ? (display.iconBackgroundDark ?? display.iconBackground)
     : display.iconBackground;
@@ -610,6 +611,7 @@ const BaseNodeComponent = (props: NodeProps<Node<BaseNodeData>>) => {
         hasFooter={hasFooter}
         background={displayBackground}
         loading={data.loading}
+        shadow={displayShadow}
       >
         {(Icon || data.loading) && (
           <BaseInnerShape

--- a/packages/apollo-react/src/canvas/components/BaseNode/BaseNodeContainer.test.tsx
+++ b/packages/apollo-react/src/canvas/components/BaseNode/BaseNodeContainer.test.tsx
@@ -30,3 +30,33 @@ describe('BaseContainer status border hover treatment', () => {
     expect(container).toHaveClass('shadow-(--canvas-node-shadow-hover)');
   });
 });
+
+describe('BaseContainer shadow opt-out', () => {
+  it('renders the rest shadow by default', () => {
+    render(
+      <BaseContainer>
+        <span>content</span>
+      </BaseContainer>
+    );
+
+    expect(screen.getByTestId('base-container')).toHaveClass('shadow-(--canvas-node-shadow-rest)');
+  });
+
+  it('omits every shadow utility class when shadow is disabled', () => {
+    render(
+      <BaseContainer shadow={false} isHovered interactionState="drag">
+        <span>content</span>
+      </BaseContainer>
+    );
+
+    const container = screen.getByTestId('base-container');
+
+    // None of the rest/hover/drag elevation classes should be present, even
+    // though both the hover and drag states that normally add a shadow are active.
+    expect(container).not.toHaveClass('shadow-(--canvas-node-shadow-rest)');
+    expect(container).not.toHaveClass('shadow-(--canvas-node-shadow-hover)');
+    expect(container).not.toHaveClass('shadow-(--canvas-node-shadow-lifted)');
+    // Non-shadow drag styling still applies.
+    expect(container).toHaveClass('cursor-grabbing');
+  });
+});

--- a/packages/apollo-react/src/canvas/components/BaseNode/BaseNodeContainer.tsx
+++ b/packages/apollo-react/src/canvas/components/BaseNode/BaseNodeContainer.tsx
@@ -44,6 +44,7 @@ interface BaseContainerProps {
   hasFooter?: boolean;
   background?: string;
   loading?: boolean;
+  shadow?: boolean;
   children: React.ReactNode;
 }
 
@@ -59,6 +60,7 @@ export const BaseContainer = ({
   hasFooter,
   background,
   loading,
+  shadow = true,
   children,
 }: BaseContainerProps) => {
   const activeStatus = suggestionType ?? validationStatus ?? executionStatus;
@@ -72,24 +74,26 @@ export const BaseContainer = ({
     return cn(
       'relative flex items-center cursor-pointer bg-surface-overlay border border-border',
       'w-(--node-w) h-(--node-h) rounded-(--node-radius)',
-      'shadow-(--canvas-node-shadow-rest) outline-offset-0 transition-[box-shadow,border-color] duration-150',
+      'outline-offset-0 transition-[box-shadow,border-color] duration-150',
+      shadow && 'shadow-(--canvas-node-shadow-rest)',
       shape === 'rectangle'
         ? 'flex-row justify-start gap-3 p-(--node-gap)'
         : 'flex-col justify-center',
       hasFooter && 'flex-wrap',
       statusBorder,
-      isHovered && 'shadow-(--canvas-node-shadow-hover)',
+      shadow && isHovered && 'shadow-(--canvas-node-shadow-hover)',
       isHovered && !hasStatusBorder && 'border-border-hover',
       isSelected && 'outline outline-2 outline-foreground-accent-muted',
       interactionState === 'disabled' && 'opacity-50 cursor-not-allowed',
-      interactionState === 'drag' && 'cursor-grabbing shadow-(--canvas-node-shadow-lifted)',
+      interactionState === 'drag' &&
+        cn('cursor-grabbing', shadow && 'shadow-(--canvas-node-shadow-lifted)'),
       // Decorative stacked layer for drillable / collapsed nodes. Purely visual:
       // a ::before pseudo inherits the container's radius/size, sits behind at
       // -z-10, and is offset down so only a thin arc peeks out below the card.
       isStacked &&
         'before:content-[""] before:absolute before:inset-x-0 before:top-0 before:h-full before:rounded-[inherit] before:bg-surface-overlay before:border before:border-brand before:translate-y-[6px] before:-z-10 before:pointer-events-none'
     );
-  }, [shape, hasFooter, activeStatus, isSelected, isHovered, isStacked, interactionState]);
+  }, [shape, hasFooter, activeStatus, isSelected, isHovered, isStacked, interactionState, shadow]);
 
   return (
     <div

--- a/packages/apollo-react/src/canvas/components/CaseFlow/case-flow.manifest.ts
+++ b/packages/apollo-react/src/canvas/components/CaseFlow/case-flow.manifest.ts
@@ -21,7 +21,7 @@ export const caseFlowCategories: CategoryManifest[] = [
     sortOrder: 0,
     color: 'linear-gradient(135deg, #FFF3E0 0%, #FFE0B2 100%)',
     colorDark: 'linear-gradient(135deg, #E65100 0%, #EF6C00 100%)',
-    icon: 'bolt',
+    icon: 'zap',
     tags: ['trigger', 'start', 'case', 'event'],
   },
 ];
@@ -40,7 +40,7 @@ export const caseManagementTriggerManifest: NodeManifest = {
   display: {
     label: 'Trigger',
     description: 'Starts a case instance and triggers a case entered event',
-    icon: 'bolt',
+    icon: 'zap',
     shape: 'circle',
   },
   handleConfiguration: [

--- a/packages/apollo-react/src/canvas/components/CaseFlow/case-flow.manifest.ts
+++ b/packages/apollo-react/src/canvas/components/CaseFlow/case-flow.manifest.ts
@@ -84,6 +84,10 @@ export const caseManagementTriggerManifest: NodeManifest = {
       ],
     },
   },
+  suppressDefaultToolbarActions: {
+    design: ['breakpoint'],
+    debug: ['breakpoint'],
+  },
 };
 
 // ============================================================================

--- a/packages/apollo-react/src/canvas/components/CaseFlow/case-flow.manifest.ts
+++ b/packages/apollo-react/src/canvas/components/CaseFlow/case-flow.manifest.ts
@@ -42,6 +42,7 @@ export const caseManagementTriggerManifest: NodeManifest = {
     description: 'Starts a case instance and triggers a case entered event',
     icon: 'zap',
     shape: 'circle',
+    shadow: false,
   },
   handleConfiguration: [
     {

--- a/packages/apollo-react/src/canvas/schema/node-definition/node-manifest.ts
+++ b/packages/apollo-react/src/canvas/schema/node-definition/node-manifest.ts
@@ -55,6 +55,13 @@ export const nodeDisplayManifestSchema = z.object({
 
   /** Icon color */
   iconColor: z.string().optional(),
+
+  /**
+   * Whether to render the node's elevation shadow (rest, hover, and drag states).
+   * Defaults to `true`. Set to `false` for flat nodes that should sit visually
+   * flush with the canvas (e.g. trigger entry points).
+   */
+  shadow: z.boolean().optional(),
 });
 
 /**

--- a/packages/apollo-react/src/canvas/schema/node-definition/node-manifest.ts
+++ b/packages/apollo-react/src/canvas/schema/node-definition/node-manifest.ts
@@ -103,6 +103,14 @@ export const nodeManifestSchema = z.object({
   /** Toolbar extensions per mode (adds to global defaults) */
   toolbarExtensions: toolbarConfigurationSchema.optional(),
 
+  /**
+   * Default toolbar action IDs to suppress per mode (removes from global defaults).
+   * Keyed by mode; each value is the list of `id`s to hide.
+   * Example: `{ design: ['breakpoint'], debug: ['breakpoint'] }` hides the breakpoint
+   * button on this node in both modes.
+   */
+  suppressDefaultToolbarActions: z.record(z.string(), z.array(z.string())).optional(),
+
   /** Input defaults for the node */
   inputDefaults: z.record(z.string(), z.unknown()).optional(),
 

--- a/packages/apollo-react/src/canvas/schema/node-instance/base.ts
+++ b/packages/apollo-react/src/canvas/schema/node-instance/base.ts
@@ -49,6 +49,7 @@ export const displayConfigSchema = z
     centerAdornmentComponent: z.any().optional(), // React.ReactNode
     footerComponent: z.any().optional(), // React.ReactNode
     footerVariant: z.string().optional(), // FooterVariant enum
+    shadow: z.boolean().optional(),
   })
   .catchall(z.unknown()); // Allow additional properties
 

--- a/packages/apollo-react/src/canvas/utils/toolbar-resolver.tsx
+++ b/packages/apollo-react/src/canvas/utils/toolbar-resolver.tsx
@@ -161,14 +161,25 @@ export function resolveToolbar(
   context: ExtendedNodeContext,
   nodeData?: Record<string, unknown>
 ): NodeToolbarConfig | undefined {
-  const { nodeType, toolbarExtensions: manifestToolbarExtensions } = manifest;
+  const {
+    nodeType,
+    toolbarExtensions: manifestToolbarExtensions,
+    suppressDefaultToolbarActions,
+  } = manifest;
 
   // Get mode from module-level store for filtering/defaults
   // (UIX doesn't pass custom properties through its context)
   const { mode } = getToolbarActionStore();
 
-  // Step 1: Get mode defaults (applies to all nodes)
-  const modeDefaults = toolbarRegistry.getModeDefaults(mode);
+  // Step 1: Get mode defaults (applies to all nodes), minus any IDs the manifest suppresses
+  const rawDefaults = toolbarRegistry.getModeDefaults(mode);
+  const suppressed = new Set(suppressDefaultToolbarActions?.[mode] ?? []);
+  const modeDefaults: ModeToolbarConfig = suppressed.size
+    ? {
+        actions: rawDefaults.actions.filter((a) => !suppressed.has(a.id)),
+        overflowActions: rawDefaults.overflowActions?.filter((a) => !suppressed.has(a.id)),
+      }
+    : rawDefaults;
 
   // Step 2: Get node-type-specific extensions
   const nodeExtensions = manifestToolbarExtensions?.[mode];


### PR DESCRIPTION
## Summary

Polish for the case management trigger manifest plus two small, additive manifest primitives that let any manifest-driven node opt out of global node chrome.

Builds on `b73d03f` (caseFlowManifest exposure + handle hover handlers), already on `main`.

### Case trigger manifest fixes
- Icon: switched from `bolt` (Lucide's gear glyph) to `zap` (the lightning bolt) — matches design.
- Hide the global `breakpoint` toolbar button in both `design` and `debug` modes (breakpoints on a workflow entry point have no useful semantics).
- Render the trigger flat against the canvas (no elevation shadow).

### Manifest primitives (additive, no behavior change for existing manifests)
- **`NodeManifest.suppressDefaultToolbarActions?: Record<mode, string[]>`** — opt-out counterpart to `toolbarExtensions`. `toolbar-resolver` filters matching action IDs out of `DEFAULT_MODE_TOOLBARS` per mode before merging the manifest's own extensions.
- **`display.shadow?: boolean`** (default `true`) on both `NodeDisplayManifest` and `InstanceDisplayConfig`. When `false`, `BaseContainer` drops the three `--canvas-node-shadow-*` utility classes (rest, hover, drag).

Future case-management manifests (stage, condition, task) inherit these opt-outs by copying the same `display.shadow: false` and `suppressDefaultToolbarActions: { design: ['breakpoint'], debug: ['breakpoint'] }` shape.

## Test plan
- [ ] `pnpm --filter @uipath/apollo-react typecheck` passes (verified locally)
- [ ] `pnpm --filter @uipath/apollo-react test` — existing `BaseNodeContainer` shadow assertions still pass (default `shadow={true}` preserves prior behavior; verified locally)
- [ ] Storybook: open `CaseTrigger` stories — verify lightning-bolt icon, no shadow on the trigger node, no breakpoint button in either design or debug mode
- [ ] Storybook: any other manifest-driven node (e.g. Decision, BaseNode gallery) — verify shadow + breakpoint still render as before
- [ ] Visual regression suite

<img width="1023" height="499" alt="image" src="https://github.com/user-attachments/assets/9a264297-e1c9-4437-ab04-f5662de107ab" />


https://claude.ai/code/session_01Bqe5vMVWU5dK5STpRPFqba

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bqe5vMVWU5dK5STpRPFqba)_