### PR TITLE
fix(apollo-react): part 1 adding time remaining tooltip

### DIFF
--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.stories.tsx
@@ -764,6 +764,7 @@ export const InteractiveTaskManagement: Story = {
               '2': {
                 status: 'InProgress',
                 duration: '1h 15m',
+                durationTooltip: '45m remaining',
                 retryDuration: '15m',
                 badge: 'Retry',
                 badgeStatus: 'warning',

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.types.ts
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.types.ts
@@ -106,8 +106,8 @@ export interface StageTaskExecution {
   message?: string;
   label?: string;
   duration?: string;
-  /** Tooltip shown on hover over the duration text (e.g. a wait-for-timer countdown). */
-  durationTooltip?: React.ReactNode;
+  /** Tooltip text shown on hover over the duration text (e.g. a wait-for-timer countdown). */
+  durationTooltip?: string;
   retryDuration?: string;
   badge?: string;
   badgeStatus?: 'warning' | 'info' | 'error';

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.types.ts
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.types.ts
@@ -106,6 +106,8 @@ export interface StageTaskExecution {
   message?: string;
   label?: string;
   duration?: string;
+  /** Tooltip shown on hover over the duration text (e.g. a wait-for-timer countdown). */
+  durationTooltip?: React.ReactNode;
   retryDuration?: string;
   badge?: string;
   badgeStatus?: 'warning' | 'info' | 'error';

--- a/packages/apollo-react/src/canvas/components/StageNode/TaskContent.test.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/TaskContent.test.tsx
@@ -90,3 +90,27 @@ describe('TaskContent - execution status tooltip', () => {
     expect(screen.getByRole('button', { name: 'Not started' })).toBeInTheDocument();
   });
 });
+
+describe('TaskContent - duration tooltip', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('wraps the duration text with a tooltip showing the durationTooltip content', () => {
+    renderTaskContent({
+      taskExecution: { status: 'InProgress', duration: '6s', durationTooltip: '4s remaining' },
+    });
+
+    const durationText = screen.getByText('6s');
+    const tooltipWrapper = durationText.closest('[data-testid="canvas-tooltip"]');
+    expect(tooltipWrapper).toHaveAttribute('data-tooltip-content', '4s remaining');
+  });
+
+  it('renders the duration with empty tooltip content when no durationTooltip is supplied', () => {
+    renderTaskContent({ taskExecution: { status: 'Completed', duration: '6s' } });
+
+    const durationText = screen.getByText('6s');
+    const tooltipWrapper = durationText.closest('[data-testid="canvas-tooltip"]');
+    expect(tooltipWrapper).toHaveAttribute('data-tooltip-content', '');
+  });
+});

--- a/packages/apollo-react/src/canvas/components/StageNode/TaskContent.test.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/TaskContent.test.tsx
@@ -106,11 +106,11 @@ describe('TaskContent - duration tooltip', () => {
     expect(tooltipWrapper).toHaveAttribute('data-tooltip-content', '4s remaining');
   });
 
-  it('renders the duration with empty tooltip content when no durationTooltip is supplied', () => {
+  it('renders the duration text without a tooltip wrapper when no durationTooltip is supplied', () => {
     renderTaskContent({ taskExecution: { status: 'Completed', duration: '6s' } });
 
     const durationText = screen.getByText('6s');
     const tooltipWrapper = durationText.closest('[data-testid="canvas-tooltip"]');
-    expect(tooltipWrapper).toHaveAttribute('data-tooltip-content', '');
+    expect(tooltipWrapper).toBeNull();
   });
 });

--- a/packages/apollo-react/src/canvas/components/StageNode/TaskContent.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/TaskContent.tsx
@@ -120,6 +120,9 @@ export const TaskContent = memo(
     const showPlayButtonSmall = onTaskPlay && hasExecutionStatus;
     const taskStatusFallbackName = hasExecutionStatus ? getStatusName(taskExecution?.status) : '';
     const taskStatusTooltip = taskExecution?.message || taskStatusFallbackName;
+    const durationLabel = taskExecution?.duration ? (
+      <span className="text-xs text-foreground-muted">{taskExecution.duration}</span>
+    ) : null;
 
     return (
       <Column
@@ -171,15 +174,18 @@ export const TaskContent = memo(
         {taskExecution && hasSecondRowContent && (
           <Row align="center" justify="space-between">
             <Row gap={'2px'}>
-              {taskExecution?.duration && (
-                <CanvasTooltip
-                  content={taskExecution.durationTooltip}
-                  placement="top"
-                  hide={isDragging}
-                >
-                  <span className="text-xs text-foreground-muted">{taskExecution.duration}</span>
-                </CanvasTooltip>
-              )}
+              {durationLabel &&
+                (taskExecution?.durationTooltip ? (
+                  <CanvasTooltip
+                    content={taskExecution.durationTooltip}
+                    placement="top"
+                    hide={isDragging}
+                  >
+                    {durationLabel}
+                  </CanvasTooltip>
+                ) : (
+                  durationLabel
+                ))}
               {taskExecution?.retryDuration && (
                 <StageTaskRetryDuration status={taskExecution.badgeStatus ?? 'warning'}>
                   <span className="text-xs">{`(+${taskExecution.retryDuration})`}</span>

--- a/packages/apollo-react/src/canvas/components/StageNode/TaskContent.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/TaskContent.tsx
@@ -172,7 +172,13 @@ export const TaskContent = memo(
           <Row align="center" justify="space-between">
             <Row gap={'2px'}>
               {taskExecution?.duration && (
-                <span className="text-xs text-foreground-muted">{taskExecution.duration}</span>
+                <CanvasTooltip
+                  content={taskExecution.durationTooltip}
+                  placement="top"
+                  hide={isDragging}
+                >
+                  <span className="text-xs text-foreground-muted">{taskExecution.duration}</span>
+                </CanvasTooltip>
               )}
               {taskExecution?.retryDuration && (
                 <StageTaskRetryDuration status={taskExecution.badgeStatus ?? 'warning'}>

--- a/packages/apollo-react/src/canvas/components/StageNode/TaskContent.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/TaskContent.tsx
@@ -120,9 +120,13 @@ export const TaskContent = memo(
     const showPlayButtonSmall = onTaskPlay && hasExecutionStatus;
     const taskStatusFallbackName = hasExecutionStatus ? getStatusName(taskExecution?.status) : '';
     const taskStatusTooltip = taskExecution?.message || taskStatusFallbackName;
-    const durationLabel = taskExecution?.duration ? (
-      <span className="text-xs text-foreground-muted">{taskExecution.duration}</span>
-    ) : null;
+    const durationLabel = useMemo(
+      () =>
+        taskExecution?.duration ? (
+          <span className="text-xs text-foreground-muted">{taskExecution.duration}</span>
+        ) : null,
+      [taskExecution?.duration]
+    );
 
     return (
       <Column


### PR DESCRIPTION
## Description
Part 1 (apollo-react library surface): adds an optional durationTooltip?: React.ReactNode to StageTaskExecution and wraps the task's elapsed-duration text in CanvasTooltip, so wait-for-timer (and other) task nodes can surface remaining time on hover. When durationTooltip is unset, CanvasTooltip renders nothing on hover, so existing nodes are unchanged. The consuming app computes and passes the remaining-time value (Part 2).

## Demo
<img width="816" height="612" alt="image" src="https://github.com/user-attachments/assets/654d1cd6-3178-4a66-b0ee-a926ac8ad6b5" />

## Risks of rolling out
Low — additive, optional prop; fully backwards compatible. No feature flags, no API removals. Behavior is unchanged when durationTooltip is absent

## Feature flag

- [ ] If this introduces a new feature flag, make sure first to create it in [Gitops](http://flags.uipath.com/) and specify the flag in alpha, staging and prod

## Tests
<!-- Areas to test: Management/FPS, Standalone, StudioWeb  -->

- [ ] I validated theme and locale
- [ ] I added unit tests
- [ ] I added component tests
- [ ] I added Playwright E2E tests
- [ ] I manually tested my changes or added other kinds of tests (Please add details below)

<!-- JIRA START -->
## Jira
[MST-10227](https://uipath.atlassian.net/browse/MST-10227)

<!-- JIRA END -->

[MST-10506]: https://uipath.atlassian.net/browse/MST-10506?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[MST-10227]: https://uipath.atlassian.net/browse/MST-10227?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ