### PR TITLE
perf(apollo-react): stop child nodes re-rendering when a canvas container is dragged

### DIFF
--- a/packages/apollo-react/src/canvas/components/BaseNode/BaseNode.tsx
+++ b/packages/apollo-react/src/canvas/components/BaseNode/BaseNode.tsx
@@ -28,6 +28,7 @@ import { resolveAdornments } from '../../utils/adornment-resolver';
 import { getIcon } from '../../utils/icon-registry';
 import { resolveDisplay, resolveHandles } from '../../utils/manifest-resolver';
 import { selectIsConnecting } from '../../utils/NodeUtils';
+import { areNodePropsEqualIgnoringPosition } from '../../utils/nodePropsEqual';
 import { resolveToolbar } from '../../utils/toolbar-resolver';
 import { useBaseCanvasMode } from '../BaseCanvas/BaseCanvasModeProvider';
 import { useCanvasTheme } from '../BaseCanvas/CanvasThemeContext';
@@ -680,4 +681,4 @@ const BaseNodeComponent = (props: NodeProps<Node<BaseNodeData>>) => {
   return nodeContent;
 };
 
-export const BaseNode = memo(BaseNodeComponent);
+export const BaseNode = memo(BaseNodeComponent, areNodePropsEqualIgnoringPosition);

--- a/packages/apollo-react/src/canvas/components/GroupNode/GroupNode.tsx
+++ b/packages/apollo-react/src/canvas/components/GroupNode/GroupNode.tsx
@@ -3,6 +3,7 @@ import { NodeResizeControl, useReactFlow } from '@uipath/apollo-react/canvas/xyf
 import { memo, useCallback } from 'react';
 import { GRID_SPACING } from '../../constants';
 import { CanvasIcon } from '../../utils/icon-registry';
+import { areNodePropsEqualIgnoringPosition } from '../../utils/nodePropsEqual';
 import {
   BottomCornerIndicators,
   GroupContainer,
@@ -208,4 +209,4 @@ const GroupNodeComponent = ({ id, data, selected }: GroupNodeProps) => {
   );
 };
 
-export const GroupNode = memo(GroupNodeComponent);
+export const GroupNode = memo(GroupNodeComponent, areNodePropsEqualIgnoringPosition);

--- a/packages/apollo-react/src/canvas/components/LoopNode/LoopCanvasNode.tsx
+++ b/packages/apollo-react/src/canvas/components/LoopNode/LoopCanvasNode.tsx
@@ -2,6 +2,7 @@ import type { Node, NodeProps } from '@uipath/apollo-react/canvas/xyflow/react';
 import { useReactFlow } from '@uipath/apollo-react/canvas/xyflow/react';
 import { memo, useCallback, useMemo } from 'react';
 import { useOptionalNodeTypeRegistry } from '../../core';
+import { areNodePropsEqualIgnoringPosition } from '../../utils/nodePropsEqual';
 import { LoopNode } from './LoopNode';
 import { resolveContainerPreviewConnectionHandles } from './LoopNode.helpers';
 import type { LoopNodeData } from './LoopNode.types';
@@ -43,4 +44,4 @@ function LoopCanvasNodeComponent(props: NodeProps<Node<LoopNodeData>>) {
   );
 }
 
-export const LoopCanvasNode = memo(LoopCanvasNodeComponent);
+export const LoopCanvasNode = memo(LoopCanvasNodeComponent, areNodePropsEqualIgnoringPosition);

--- a/packages/apollo-react/src/canvas/components/LoopNode/LoopNode.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/LoopNode/LoopNode.stories.tsx
@@ -109,6 +109,110 @@ function createActivityNode(
   return node;
 }
 
+const makeEdge = (
+  id: string,
+  source: string,
+  sourceHandle: string,
+  target: string,
+  targetHandle: string
+): Edge => ({ id, source, sourceHandle, target, targetHandle });
+
+// Grid geometry for laying out children inside a loop container. Every value is
+// grid-aligned (a multiple of GRID_SPACING = 16) and mirrors the container safe
+// area from utils/container.ts (header + frame inset + body padding + inner
+// handle rail), so children never overlap the header and are never clamped by
+// `extent: 'parent'`.
+const CHILD_GRID = {
+  childSize: 96, // blank-node footprint (DEFAULT_NODE_SIZE)
+  labelAllowance: 32, // room for the label rendered beneath the node shape
+  cellWidth: 176, // childSize + horizontal gap
+  cellHeight: 160, // childSize + label + vertical gap
+  safeLeft: 144, // container left padding (frame + body + inner handle rail)
+  safeTop: 96, // container top padding (header + frame + body)
+  padRight: 144, // mirror safeLeft — the safe area is symmetric horizontally
+  padBottom: 48, // container bottom padding (frame + body)
+} as const;
+
+// Places `labels.length` children in a grid inside a loop and returns the child
+// nodes plus the container size needed to hold them with clean margins.
+function layoutLoopChildren(
+  parentId: string,
+  labels: string[],
+  columns: number
+): { children: Node[]; width: number; height: number } {
+  const rows = Math.ceil(labels.length / columns);
+  const usedColumns = Math.min(columns, labels.length);
+
+  const children = labels.map((label, index) => {
+    const column = index % columns;
+    const row = Math.floor(index / columns);
+    return createActivityNode(
+      `${parentId}-child-${index}`,
+      label,
+      {
+        x: CHILD_GRID.safeLeft + column * CHILD_GRID.cellWidth,
+        y: CHILD_GRID.safeTop + row * CHILD_GRID.cellHeight,
+      },
+      { parentId }
+    );
+  });
+
+  const width =
+    CHILD_GRID.safeLeft +
+    (usedColumns - 1) * CHILD_GRID.cellWidth +
+    CHILD_GRID.childSize +
+    CHILD_GRID.padRight;
+  const height =
+    CHILD_GRID.safeTop +
+    (rows - 1) * CHILD_GRID.cellHeight +
+    CHILD_GRID.childSize +
+    CHILD_GRID.labelAllowance +
+    CHILD_GRID.padBottom;
+
+  return { children, width, height };
+}
+
+// Wires each grid row as an independent left-to-right chain fanning out from the
+// loop's `start` handle and back into its `continue` handle. Because activity
+// nodes have a fixed left input / right output, per-row chains keep every edge
+// short and horizontal instead of snaking diagonally across the grid.
+function loopBodyRowEdges(loopId: string, children: Node[], columns: number): Edge[] {
+  const edges: Edge[] = [];
+
+  for (let start = 0; start < children.length; start += columns) {
+    const rowChildren = children.slice(start, start + columns);
+    const first = rowChildren[0];
+    if (!first) continue;
+
+    const row = start / columns;
+    edges.push(
+      makeEdge(`${loopId}-start-r${row}`, loopId, STORY_LOOP_START_HANDLE_ID, first.id, 'input')
+    );
+
+    for (let i = 0; i < rowChildren.length - 1; i++) {
+      const from = rowChildren[i];
+      const to = rowChildren[i + 1];
+      if (!from || !to) continue;
+      edges.push(makeEdge(`${from.id}-${to.id}`, from.id, 'output', to.id, 'input'));
+    }
+
+    const last = rowChildren[rowChildren.length - 1];
+    if (last) {
+      edges.push(
+        makeEdge(
+          `${last.id}-continue-r${row}`,
+          last.id,
+          'output',
+          loopId,
+          STORY_LOOP_CONTINUE_HANDLE_ID
+        )
+      );
+    }
+  }
+
+  return edges;
+}
+
 interface AutoPreviewSource {
   nodeId: string;
   handleId: string;
@@ -492,6 +596,193 @@ function NestedOuterOutputAppendStory() {
   );
 }
 
+// 24 children — a single loop densely populated to exercise re-render cost when
+// the container is dragged (every child moves with the parent each frame).
+const MANY_CHILD_LABELS = [
+  'Validate input',
+  'Normalize fields',
+  'Lookup account',
+  'Score risk',
+  'Check policy',
+  'Fetch history',
+  'Enrich profile',
+  'Detect anomalies',
+  'Apply rules',
+  'Build payload',
+  'Call service',
+  'Parse response',
+  'Map results',
+  'Update record',
+  'Write audit',
+  'Emit metric',
+  'Queue follow-up',
+  'Notify owner',
+  'Tag outcome',
+  'Archive copy',
+  'Reconcile totals',
+  'Flag exceptions',
+  'Summarize run',
+  'Persist state',
+];
+
+function buildManyChildrenGraph(): { nodes: Node[]; edges: Edge[] } {
+  const columns = 6;
+  const layout = layoutLoopChildren('loop-many', MANY_CHILD_LABELS, columns);
+
+  const loopPosition = { x: 320, y: 96 };
+  const centerY = loopPosition.y + layout.height / 2;
+
+  const loop = createLoopContainerNode(
+    'loop-many',
+    loopPosition,
+    { width: layout.width, height: layout.height },
+    { selected: true, data: { display: { label: 'For Each record' } } }
+  );
+
+  const nodes: Node[] = [
+    createActivityNode('ingress', 'Load records', { x: 32, y: centerY }),
+    loop,
+    ...layout.children,
+    createActivityNode('egress', 'Publish results', {
+      x: loopPosition.x + layout.width + 160,
+      y: centerY,
+    }),
+  ];
+
+  const edges: Edge[] = [
+    makeEdge('ingress-loop', 'ingress', 'output', 'loop-many', 'input'),
+    ...loopBodyRowEdges('loop-many', layout.children, columns),
+    makeEdge('loop-egress', 'loop-many', STORY_LOOP_SUCCESS_HANDLE_ID, 'egress', 'input'),
+  ];
+
+  return { nodes, edges };
+}
+
+function ManyChildrenStory() {
+  const { initialNodes, initialEdges } = useMemo(() => {
+    const graph = buildManyChildrenGraph();
+    return { initialNodes: graph.nodes, initialEdges: graph.edges };
+  }, []);
+
+  return (
+    <LoopCanvasStory
+      initialNodes={initialNodes}
+      initialEdges={initialEdges}
+      storyInfo={{
+        title: 'Loop With Many Children',
+        description:
+          'A single loop containing 24 child nodes laid out in a grid. Drag the loop around — every child moves with it, so this is the stress case for container re-render performance.',
+      }}
+    />
+  );
+}
+
+const INNER_DOCUMENT_LABELS = [
+  'Download file',
+  'Detect type',
+  'Extract text',
+  'OCR scan',
+  'Classify',
+  'Validate',
+];
+
+const INNER_CANDIDATE_LABELS = [
+  'Match entity',
+  'Score match',
+  'Resolve duplicate',
+  'Merge record',
+  'Update index',
+  'Log result',
+];
+
+function NestedLoopsManyChildrenStory() {
+  const { initialNodes, initialEdges } = useMemo(() => {
+    const innerColumns = 2;
+    const innerA = layoutLoopChildren('inner-a', INNER_DOCUMENT_LABELS, innerColumns);
+    const innerB = layoutLoopChildren('inner-b', INNER_CANDIDATE_LABELS, innerColumns);
+
+    // Two inner loops sit side-by-side inside the outer loop, both pinned to the
+    // outer container's safe area; the outer loop is sized to wrap them.
+    const innerGap = 48;
+    const innerAPosition = { x: CHILD_GRID.safeLeft, y: CHILD_GRID.safeTop };
+    const innerBPosition = {
+      x: CHILD_GRID.safeLeft + innerA.width + innerGap,
+      y: CHILD_GRID.safeTop,
+    };
+
+    const outerWidth =
+      CHILD_GRID.safeLeft + innerA.width + innerGap + innerB.width + CHILD_GRID.padRight;
+    const outerHeight =
+      CHILD_GRID.safeTop + Math.max(innerA.height, innerB.height) + CHILD_GRID.padBottom;
+
+    const outerPosition = { x: 320, y: 96 };
+    const centerY = outerPosition.y + outerHeight / 2;
+
+    const outerLoop = createLoopContainerNode(
+      'outer-loop',
+      outerPosition,
+      { width: outerWidth, height: outerHeight },
+      { selected: true, data: { display: { label: 'For Each batch' } } }
+    );
+    const loopA = createLoopContainerNode(
+      'inner-a',
+      innerAPosition,
+      { width: innerA.width, height: innerA.height },
+      { parentId: 'outer-loop', data: { display: { label: 'For Each document' } } }
+    );
+    const loopB = createLoopContainerNode(
+      'inner-b',
+      innerBPosition,
+      { width: innerB.width, height: innerB.height },
+      { parentId: 'outer-loop', data: { display: { label: 'For Each candidate' } } }
+    );
+
+    // Parents must precede their children in the nodes array (React Flow rule).
+    const nodes: Node[] = [
+      createActivityNode('ingress', 'Load batches', { x: 32, y: centerY }),
+      outerLoop,
+      loopA,
+      ...innerA.children,
+      loopB,
+      ...innerB.children,
+      createActivityNode('egress', 'Publish results', {
+        x: outerPosition.x + outerWidth + 160,
+        y: centerY,
+      }),
+    ];
+
+    const edges: Edge[] = [
+      makeEdge('ingress-outer', 'ingress', 'output', 'outer-loop', 'input'),
+      makeEdge('outer-start-inner-a', 'outer-loop', STORY_LOOP_START_HANDLE_ID, 'inner-a', 'input'),
+      ...loopBodyRowEdges('inner-a', innerA.children, innerColumns),
+      makeEdge('inner-a-inner-b', 'inner-a', STORY_LOOP_SUCCESS_HANDLE_ID, 'inner-b', 'input'),
+      ...loopBodyRowEdges('inner-b', innerB.children, innerColumns),
+      makeEdge(
+        'inner-b-outer-continue',
+        'inner-b',
+        STORY_LOOP_SUCCESS_HANDLE_ID,
+        'outer-loop',
+        STORY_LOOP_CONTINUE_HANDLE_ID
+      ),
+      makeEdge('outer-egress', 'outer-loop', STORY_LOOP_SUCCESS_HANDLE_ID, 'egress', 'input'),
+    ];
+
+    return { initialNodes: nodes, initialEdges: edges };
+  }, []);
+
+  return (
+    <LoopCanvasStory
+      initialNodes={initialNodes}
+      initialEdges={initialEdges}
+      storyInfo={{
+        title: 'Nested Loops With Many Children',
+        description:
+          'An outer loop containing two inner loops, each with its own grid of child nodes. Dragging the outer loop moves every descendant (inner loops and their children) — the deepest container re-render stress case.',
+      }}
+    />
+  );
+}
+
 export const Default: Story = {
   render: () => <DefaultStory />,
 };
@@ -502,6 +793,16 @@ export const NestedOuterOutputInsert: Story = {
 
 export const NestedOuterOutputAppend: Story = {
   render: () => <NestedOuterOutputAppendStory />,
+};
+
+export const ManyChildren: Story = {
+  name: 'Loop With Many Children',
+  render: () => <ManyChildrenStory />,
+};
+
+export const NestedLoopsManyChildren: Story = {
+  name: 'Nested Loops With Many Children',
+  render: () => <NestedLoopsManyChildrenStory />,
 };
 
 // ============================================================================

--- a/packages/apollo-react/src/canvas/components/LoopNode/LoopNode.tsx
+++ b/packages/apollo-react/src/canvas/components/LoopNode/LoopNode.tsx
@@ -26,6 +26,7 @@ import {
 import { CanvasIcon } from '../../utils/icon-registry';
 import { resolveDisplay, resolveHandles } from '../../utils/manifest-resolver';
 import { selectIsConnecting, snapToGrid } from '../../utils/NodeUtils';
+import { areNodePropsEqualIgnoringPosition } from '../../utils/nodePropsEqual';
 import { resolveToolbar } from '../../utils/toolbar-resolver';
 import { useBaseCanvasMode } from '../BaseCanvas/BaseCanvasModeProvider';
 import { useConnectedHandles } from '../BaseCanvas/ConnectedHandlesContext';
@@ -445,7 +446,7 @@ function LoopNodeComponent(props: LoopNodeProps) {
   );
 }
 
-export const LoopNode = memo(LoopNodeComponent);
+export const LoopNode = memo(LoopNodeComponent, areNodePropsEqualIgnoringPosition);
 
 function Header({
   title,

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.tsx
@@ -1,4 +1,5 @@
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { areNodePropsEqualIgnoringPosition } from '../../utils/nodePropsEqual';
 import { FloatingCanvasPanel } from '../FloatingCanvasPanel';
 import { NodeContextMenu } from '../NodeContextMenu';
 import { useSetNodeSelection } from '../NodePropertiesPanel/hooks';
@@ -196,4 +197,4 @@ const StageNodeInner = (props: StageNodeProps) => {
   );
 };
 
-export const StageNode = memo(StageNodeInner);
+export const StageNode = memo(StageNodeInner, areNodePropsEqualIgnoringPosition);

--- a/packages/apollo-react/src/canvas/components/TriggerNode/TriggerNode.tsx
+++ b/packages/apollo-react/src/canvas/components/TriggerNode/TriggerNode.tsx
@@ -2,6 +2,7 @@ import { Position, useStore } from '@uipath/apollo-react/canvas/xyflow/react';
 import { memo, useCallback, useMemo, useState } from 'react';
 import type { HandleGroupManifest } from '../../schema/node-definition';
 import { CanvasIcon } from '../../utils/icon-registry';
+import { areNodePropsEqualIgnoringPosition } from '../../utils/nodePropsEqual';
 import { useConnectedHandles } from '../BaseCanvas/ConnectedHandlesContext';
 import { useButtonHandles } from '../ButtonHandle/useButtonHandles';
 import { CanvasTooltip } from '../CanvasTooltip';
@@ -70,4 +71,4 @@ const TriggerNodeComponent = (props: TriggerNodeProps) => {
   );
 };
 
-export const TriggerNode = memo(TriggerNodeComponent);
+export const TriggerNode = memo(TriggerNodeComponent, areNodePropsEqualIgnoringPosition);

--- a/packages/apollo-react/src/canvas/utils/nodePropsEqual.test.tsx
+++ b/packages/apollo-react/src/canvas/utils/nodePropsEqual.test.tsx
@@ -56,6 +56,10 @@ describe('areNodePropsEqualIgnoringPosition', () => {
     ).toBe(false);
   });
 
+  it('returns false when key sets differ and the differing values are both undefined', () => {
+    expect(areNodePropsEqualIgnoringPosition({ foo: undefined }, { bar: undefined })).toBe(false);
+  });
+
   it('returns false when a key is added or removed', () => {
     expect(areNodePropsEqualIgnoringPosition({ id: 'n1' }, { id: 'n1', selected: true })).toBe(
       false

--- a/packages/apollo-react/src/canvas/utils/nodePropsEqual.test.tsx
+++ b/packages/apollo-react/src/canvas/utils/nodePropsEqual.test.tsx
@@ -1,0 +1,124 @@
+import { memo } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { areNodePropsEqualIgnoringPosition } from './nodePropsEqual';
+import { render } from './testing';
+
+describe('areNodePropsEqualIgnoringPosition', () => {
+  it('returns true for the same reference', () => {
+    const props = { id: 'n1', selected: false };
+    expect(areNodePropsEqualIgnoringPosition(props, props)).toBe(true);
+  });
+
+  it('treats props as equal when only positionAbsoluteX/Y differ', () => {
+    expect(
+      areNodePropsEqualIgnoringPosition(
+        { id: 'n1', selected: false, positionAbsoluteX: 0, positionAbsoluteY: 0 },
+        { id: 'n1', selected: false, positionAbsoluteX: 123, positionAbsoluteY: 456 }
+      )
+    ).toBe(true);
+  });
+
+  it('detects changes to a non-position prop', () => {
+    expect(
+      areNodePropsEqualIgnoringPosition(
+        { id: 'n1', selected: false, positionAbsoluteX: 0, positionAbsoluteY: 0 },
+        { id: 'n1', selected: true, positionAbsoluteX: 0, positionAbsoluteY: 0 }
+      )
+    ).toBe(false);
+  });
+
+  it('compares object props (data) by reference', () => {
+    const data = { label: 'A' };
+
+    // Same data reference + moved position => equal (the common drag case).
+    expect(
+      areNodePropsEqualIgnoringPosition(
+        { data, positionAbsoluteX: 0, positionAbsoluteY: 0 },
+        { data, positionAbsoluteX: 9, positionAbsoluteY: 9 }
+      )
+    ).toBe(true);
+
+    // New data reference => not equal, even at the same position.
+    expect(
+      areNodePropsEqualIgnoringPosition(
+        { data, positionAbsoluteX: 0, positionAbsoluteY: 0 },
+        { data: { label: 'A' }, positionAbsoluteX: 0, positionAbsoluteY: 0 }
+      )
+    ).toBe(false);
+  });
+
+  it('returns false when the key sets differ but counts match', () => {
+    expect(
+      areNodePropsEqualIgnoringPosition(
+        { id: 'n1', selected: false },
+        { id: 'n1', dragging: false }
+      )
+    ).toBe(false);
+  });
+
+  it('returns false when a key is added or removed', () => {
+    expect(areNodePropsEqualIgnoringPosition({ id: 'n1' }, { id: 'n1', selected: true })).toBe(
+      false
+    );
+  });
+});
+
+/**
+ * The behavioural guarantee: a node component memoised with this comparator
+ * must NOT re-render when only its absolute position changes (what happens to
+ * every child of a dragged container ~60fps), but MUST re-render when a real
+ * prop such as `data` or `selected` changes.
+ */
+describe('areNodePropsEqualIgnoringPosition as a React.memo comparator', () => {
+  interface DummyNodeProps {
+    positionAbsoluteX: number;
+    positionAbsoluteY: number;
+    data: { label: string };
+    selected: boolean;
+  }
+
+  const makeMemoNode = (onRender: () => void) => {
+    const Inner = (_props: DummyNodeProps) => {
+      onRender();
+      return null;
+    };
+    return memo(Inner, areNodePropsEqualIgnoringPosition);
+  };
+
+  it('does not re-render when only positionAbsoluteX/Y change', () => {
+    const onRender = vi.fn();
+    const Node = makeMemoNode(onRender);
+    const data = { label: 'A' };
+
+    const { rerender } = render(
+      <Node positionAbsoluteX={0} positionAbsoluteY={0} data={data} selected={false} />
+    );
+    expect(onRender).toHaveBeenCalledTimes(1);
+
+    // Simulate consecutive drag frames: the parent moved, so this child's
+    // absolute position changes while data/selection stay identical.
+    rerender(<Node positionAbsoluteX={40} positionAbsoluteY={12} data={data} selected={false} />);
+    rerender(<Node positionAbsoluteX={80} positionAbsoluteY={24} data={data} selected={false} />);
+
+    expect(onRender).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-renders when a non-position prop changes', () => {
+    const onRender = vi.fn();
+    const Node = makeMemoNode(onRender);
+    const data = { label: 'A' };
+
+    const { rerender } = render(
+      <Node positionAbsoluteX={0} positionAbsoluteY={0} data={data} selected={false} />
+    );
+    expect(onRender).toHaveBeenCalledTimes(1);
+
+    // Selection toggled => must re-render.
+    rerender(<Node positionAbsoluteX={0} positionAbsoluteY={0} data={data} selected />);
+    expect(onRender).toHaveBeenCalledTimes(2);
+
+    // New data reference => must re-render.
+    rerender(<Node positionAbsoluteX={0} positionAbsoluteY={0} data={{ label: 'B' }} selected />);
+    expect(onRender).toHaveBeenCalledTimes(3);
+  });
+});

--- a/packages/apollo-react/src/canvas/utils/nodePropsEqual.ts
+++ b/packages/apollo-react/src/canvas/utils/nodePropsEqual.ts
@@ -1,0 +1,43 @@
+/**
+ * React.memo comparator for canvas node components.
+ *
+ * XYFlow v12 passes `positionAbsoluteX` / `positionAbsoluteY` to every custom
+ * node component on each render. When a container node (loop, group, stage) is
+ * dragged, the absolute position of every descendant updates on every animation
+ * frame, so React's default shallow compare sees changed props and re-renders
+ * each child ~60fps for the whole drag — even though our node components never
+ * read the absolute position (XYFlow's NodeWrapper applies the transform, not
+ * the node body). The result is observable lag that scales with the number of
+ * nodes inside the container.
+ *
+ * This comparator shallow-compares all props EXCEPT the absolute-position
+ * fields, so position-only updates no longer re-render the node body.
+ *
+ * IMPORTANT: Any node component that genuinely needs the live absolute position
+ * inside its render/handlers (e.g. BlankCanvasNode) must NOT use this comparator.
+ */
+export function areNodePropsEqualIgnoringPosition(prevProps: object, nextProps: object): boolean {
+  if (prevProps === nextProps) {
+    return true;
+  }
+
+  const prev = prevProps as Record<string, unknown>;
+  const next = nextProps as Record<string, unknown>;
+
+  const prevKeys = Object.keys(prev);
+  const nextKeys = Object.keys(next);
+  if (prevKeys.length !== nextKeys.length) {
+    return false;
+  }
+
+  for (const key of prevKeys) {
+    if (key === 'positionAbsoluteX' || key === 'positionAbsoluteY') {
+      continue;
+    }
+    if (!Object.is(prev[key], next[key])) {
+      return false;
+    }
+  }
+
+  return true;
+}

--- a/packages/apollo-react/src/canvas/utils/nodePropsEqual.ts
+++ b/packages/apollo-react/src/canvas/utils/nodePropsEqual.ts
@@ -34,6 +34,12 @@ export function areNodePropsEqualIgnoringPosition(prevProps: object, nextProps: 
     if (key === 'positionAbsoluteX' || key === 'positionAbsoluteY') {
       continue;
     }
+    // Guard against same-length-but-different key sets, where reading a missing
+    // key on `next` would yield `undefined` and spuriously compare as equal
+    // (e.g. { foo: undefined } vs { bar: undefined }).
+    if (!Object.prototype.hasOwnProperty.call(next, key)) {
+      return false;
+    }
     if (!Object.is(prev[key], next[key])) {
       return false;
     }


### PR DESCRIPTION
## Problem

Dragging a loop (or any container) that contains nodes shows observable lag that scales with the number of children.

**Root cause:** XYFlow v12's `NodeWrapper` passes `positionAbsoluteX` / `positionAbsoluteY` to every custom node component. When a container node (loop/group/stage) is dragged, every descendant's absolute position is recomputed on each animation frame, so the **default `React.memo` shallow compare sees changed props and re-renders every child ~60fps for the entire drag** — even though our node bodies never read the absolute position (XYFlow applies the transform on the wrapper, not inside the node). A loop with N children ≈ N full node re-renders per frame.

## Fix

Add a shared `React.memo` comparator, `areNodePropsEqualIgnoringPosition`, that shallow-compares all props **except** `positionAbsoluteX`/`positionAbsoluteY`, and apply it to the canvas node components:

- `BaseNode`, `LoopNode`, `LoopCanvasNode`, `GroupNode`, `StageNode`, `TriggerNode`

Position-only updates no longer re-render the node body; `data` / `selected` / `dragging` / size changes still do. Edges and handles are unaffected (they react to the store, not the node body).

`BlankCanvasNode` is intentionally **not** changed — it genuinely reads the live absolute position.

This is purely a runtime-performance change: **no visual/appearance difference** (so visual-regression snapshots are unchanged by design).

## Why it's safe

- Verified none of the 6 patched components read `positionAbsoluteX/Y` or `node.position` in render or handlers (only handle-group `position` enums appear).
- The dragged container itself also stops thrashing per-frame; it still re-renders once on drag start/stop via the `dragging` prop.
- Relies on React Flow's standard contract that `node.data` keeps a stable reference across position-only updates.

## Tests & stories

- `nodePropsEqual.test.tsx` — unit tests for the comparator and its behaviour through `React.memo` (no re-render on position-only change; re-renders on `data`/`selected` change).
- Two new LoopNode stories under **Canvas → Components → Nodes → LoopNode**:
  - **Loop With Many Children** — one loop with 24 grid-laid-out children.
  - **Nested Loops With Many Children** — an outer loop containing two inner loops, each with its own grid.
  - Child placement mirrors the container safe area from `utils/container.ts`, so nodes stay grid-aligned, non-overlapping, and within their container (geometry validated).

## Verification

- `tsc` clean, `biome` clean, unit tests pass (incl. existing BaseNode/LoopNode/GroupNode/StageNode suites).
- Validated live in Storybook (react-scan / React DevTools "highlight updates"): with the fix, dragging the loop no longer re-renders the children.

## Follow-ups (not in this PR)

- Centralize the comparator at the `nodeTypes` assembly so new node types opt in automatically.
- Consider applying to `StickyNoteNode` / AgentCanvas nodes for consistency.
- AgentCanvas has a separate O(n²) per-store-change wrapper issue (out of scope here).
- Story files are excluded from CI `tsc`; a `typecheck:stories` / Storybook build step would close that gap.

https://claude.ai/code/session_01WHa5AKDP7te5q46nCyuVhk

---
_Generated by [Claude Code](https://claude.ai/code/session_01WHa5AKDP7te5q46nCyuVhk)_