### PR TITLE
feat(apollo-react): route SequenceEdge through edge.data.bendPoints [MST-6513]

### DIFF
--- a/packages/apollo-react/src/canvas/components/Edges/SequenceEdge.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/Edges/SequenceEdge.stories.tsx
@@ -6,9 +6,9 @@
  */
 
 import type { Meta, StoryObj } from '@storybook/react';
-import type { Edge, EdgeTypes, Node } from '@uipath/apollo-react/canvas/xyflow/react';
+import type { Edge, EdgeTypes, Node, OnNodeDrag } from '@uipath/apollo-react/canvas/xyflow/react';
 import { Panel, Position } from '@uipath/apollo-react/canvas/xyflow/react';
-import { useMemo } from 'react';
+import { type Dispatch, type SetStateAction, useCallback, useMemo } from 'react';
 import { useCanvasStory, withCanvasProviders } from '../../storybook-utils';
 import { DefaultCanvasTranslations } from '../../types';
 import { BaseCanvas } from '../BaseCanvas';
@@ -529,6 +529,136 @@ function PlainLineStory() {
 
   return (
     <BaseCanvas {...canvasProps} edgeTypes={edgeTypes} mode="design">
+      <Panel position="bottom-right">
+        <CanvasPositionControls translations={DefaultCanvasTranslations} />
+      </Panel>
+    </BaseCanvas>
+  );
+}
+
+// Bend points are valid only for the layout they were routed in. Once a node is
+// dragged, drop the bends on its connected edges so they fall back to the live
+// smooth-step path and follow the drag (mirrors the host's drag-start handling).
+function useClearBendsOnDragStart(setEdges: Dispatch<SetStateAction<Edge[]>>): OnNodeDrag {
+  return useCallback(
+    (_event, _node, draggedNodes) => {
+      const movedIds = new Set(draggedNodes.map((n) => n.id));
+      setEdges((eds) =>
+        eds.map((edge) => {
+          if (!movedIds.has(edge.source) && !movedIds.has(edge.target)) return edge;
+          if (edge.data?.bendPoints == null) return edge;
+          const { bendPoints: _removed, ...rest } = edge.data;
+          return { ...edge, data: rest };
+        })
+      );
+    },
+    [setEdges]
+  );
+}
+
+// ============================================================================
+// Bend Points Story (routed edges)
+// ============================================================================
+
+function BendPointsStory() {
+  const initialNodes = useMemo(
+    () => [
+      createStickyNote(
+        'sticky-bend',
+        'yellow',
+        '**Bend Points**\nSet `data.bendPoints` (interior corners, in flow coords) to route an edge around obstacles. The path anchors on the live handle positions and threads through the bends with rounded corners. Absent ⇒ standard smooth-step.',
+        { x: 100, y: 60 },
+        { width: 640, height: 480 }
+      ),
+      // Source routes down-and-around an obstacle to the target. Kept well below
+      // the description text so nodes don't overlap it.
+      createNode({
+        id: 'bend-source',
+        label: 'Source',
+        x: 150,
+        y: 240,
+        sourcePositions: [Position.Right],
+      }),
+      // Obstacle sitting on the straight-line path between source and target
+      createNode({ id: 'bend-obstacle', label: 'Obstacle', x: 390, y: 270 }),
+      createNode({
+        id: 'bend-target',
+        label: 'Target',
+        x: 610,
+        y: 410,
+        targetPositions: [Position.Left],
+      }),
+
+      createStickyNote(
+        'sticky-bend-compare',
+        'white',
+        '**No bend points (default)**\nStraight smooth-step would cut through an obstacle.',
+        { x: 100, y: 580 },
+        { width: 640, height: 200 }
+      ),
+      createNode({
+        id: 'bend-compare-source',
+        label: 'Source',
+        x: 150,
+        y: 650,
+        sourcePositions: [Position.Right],
+      }),
+      createNode({
+        id: 'bend-compare-target',
+        label: 'Target',
+        x: 610,
+        y: 650,
+        targetPositions: [Position.Left],
+      }),
+    ],
+    []
+  );
+
+  const initialEdges: Edge[] = useMemo(
+    () => [
+      {
+        id: 'e-bend-routed',
+        source: 'bend-source',
+        target: 'bend-target',
+        sourceHandle: `out-${Position.Right}`,
+        targetHandle: `in-${Position.Left}`,
+        type: 'sequence',
+        // Interior corners: out from the source, down the left of the obstacle,
+        // then right underneath it into the target (handle centres at node +48).
+        data: {
+          bendPoints: [
+            { x: 340, y: 288 },
+            { x: 340, y: 458 },
+            { x: 570, y: 458 },
+          ],
+        },
+      },
+      {
+        id: 'e-bend-compare',
+        source: 'bend-compare-source',
+        target: 'bend-compare-target',
+        sourceHandle: `out-${Position.Right}`,
+        targetHandle: `in-${Position.Left}`,
+        type: 'sequence',
+      },
+    ],
+    []
+  );
+
+  const { canvasProps, setEdges } = useCanvasStory({
+    initialNodes,
+    initialEdges,
+    additionalNodeTypes: nodeTypes,
+  });
+  const onNodeDragStart = useClearBendsOnDragStart(setEdges);
+
+  return (
+    <BaseCanvas
+      {...canvasProps}
+      edgeTypes={edgeTypes}
+      mode="design"
+      onNodeDragStart={onNodeDragStart}
+    >
       <Panel position="bottom-right">
         <CanvasPositionControls translations={DefaultCanvasTranslations} />
       </Panel>
@@ -1166,6 +1296,18 @@ export const PlainLine: Story = {
       description: {
         story:
           'Demonstrates a SequenceEdge parameterized to render as a plain line. `data.hideArrowHead: true` omits the directional arrow at the target so both ends terminate plainly (useful for artifact / annotation edges). `data.hideToolbar: true` suppresses the mid-edge insert toolbar. Everything else about SequenceEdge (path, label, status animations, diff styling) is unchanged.',
+      },
+    },
+  },
+};
+
+export const BendPoints: Story = {
+  render: () => <BendPointsStory />,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Demonstrates a SequenceEdge routed through layout-provided `data.bendPoints`. The path anchors on the live handle positions and threads through the interior corners with rounded turns, letting the edge avoid obstacle nodes. When bendPoints are absent the edge uses the standard smooth-step path.',
       },
     },
   },

--- a/packages/apollo-react/src/canvas/components/Edges/SequenceEdge.tsx
+++ b/packages/apollo-react/src/canvas/components/Edges/SequenceEdge.tsx
@@ -1,4 +1,8 @@
-import { type EdgeProps, Position } from '@uipath/apollo-react/canvas/xyflow/react';
+import {
+  type EdgeProps,
+  Position,
+  type XYPosition,
+} from '@uipath/apollo-react/canvas/xyflow/react';
 import { memo, useRef, useState } from 'react';
 import { useEdgeExecutionState, useEdgePath, useElementValidationStatus } from '../../hooks';
 import type { NodeExecutionStateWithDebug } from '../../types/execution';
@@ -105,6 +109,7 @@ export const SequenceEdge = memo(function SequenceEdge({
     targetX: hideArrowHead ? targetX + offsetX : targetX,
     targetY: hideArrowHead ? targetY + offsetY : targetY,
     targetPosition,
+    bendPoints: data?.bendPoints as XYPosition[] | undefined,
   });
 
   // Edge toolbar state

--- a/packages/apollo-react/src/canvas/components/Edges/SequenceEdge.tsx
+++ b/packages/apollo-react/src/canvas/components/Edges/SequenceEdge.tsx
@@ -109,7 +109,8 @@ export const SequenceEdge = memo(function SequenceEdge({
     targetX: hideArrowHead ? targetX + offsetX : targetX,
     targetY: hideArrowHead ? targetY + offsetY : targetY,
     targetPosition,
-    bendPoints: data?.bendPoints as XYPosition[] | undefined,
+    // `data` is loosely typed on EdgeProps; guard so a malformed value can't crash useEdgePath.
+    bendPoints: Array.isArray(data?.bendPoints) ? (data?.bendPoints as XYPosition[]) : undefined,
   });
 
   // Edge toolbar state

--- a/packages/apollo-react/src/canvas/hooks/useEdgePath.test.ts
+++ b/packages/apollo-react/src/canvas/hooks/useEdgePath.test.ts
@@ -569,11 +569,12 @@ describe('useEdgePath', () => {
       expect(result.current.edgePath).toContain('Q 150 200');
     });
 
-    it('shifts bends forward to keep the riser a source-offset past a right handle', () => {
+    it('shifts bends forward to keep the riser past the end of a right handle', () => {
       // Reproduces the real ELK output: right handle at x=556, but ELK's riser is
       // at x=544 (behind the handle) → the exit would route backward into the node.
-      // The riser is pushed out by the exit gap (the source-offset magnitude, 8px)
-      // to sourceX + 8 = 564, clearing the handle like the smooth-step exit does.
+      // The riser is pushed out to start.x + EXIT_OFFSET = (556 - 8) + 28 = 576, so
+      // the throw-out clears the `+` handle button before turning — the same place
+      // the smooth-step edges turn.
       const { result } = renderHook(() =>
         useEdgePath({
           ...baseBendParams,
@@ -588,9 +589,166 @@ describe('useEdgePath', () => {
         })
       );
 
-      expect(result.current.edgePath).toContain('Q 564 208');
-      expect(result.current.edgePath).toContain('Q 564 320');
+      expect(result.current.edgePath).toContain('Q 576 208');
+      expect(result.current.edgePath).toContain('Q 576 320');
       expect(result.current.edgePath).not.toContain('544');
+    });
+
+    it('shifts bends back to keep the approach clear of a left target handle', () => {
+      const { result } = renderHook(() =>
+        useEdgePath({
+          ...baseBendParams,
+          bendPoints: [
+            { x: 190, y: 100 },
+            { x: 190, y: 200 },
+          ],
+        })
+      );
+
+      expect(result.current.edgePath).toContain('Q 172 100');
+      expect(result.current.edgePath).toContain('Q 172 200');
+      expect(result.current.edgePath).not.toContain('190');
+    });
+
+    it('shifts only the last riser for target clearance, leaving the source exit in place', () => {
+      const { result } = renderHook(() =>
+        useEdgePath({
+          ...baseBendParams, // source Right @ (100,100), target Left
+          targetX: 300,
+          targetY: 300,
+          bendPoints: [
+            { x: 150, y: 100 },
+            { x: 150, y: 200 },
+            { x: 290, y: 200 },
+            { x: 290, y: 300 },
+          ],
+        })
+      );
+
+      // Source exit keeps its natural gap (first riser untouched).
+      expect(result.current.edgePath).toContain('Q 150 100');
+      expect(result.current.edgePath).toContain('Q 150 200');
+      // Last riser pulled back to clear the target handle.
+      expect(result.current.edgePath).toContain('Q 272 200');
+      expect(result.current.edgePath).toContain('Q 272 300');
+      expect(result.current.edgePath).not.toContain('290');
+    });
+
+    // Polyline vertices = M start, each Q corner, final L end. Orthogonal iff
+    // every consecutive pair shares an axis.
+    const isOrthogonalPath = (path: string): boolean => {
+      const pts: Array<[number, number]> = [];
+      const m = /^M (-?[\d.]+) (-?[\d.]+)/.exec(path);
+      if (m) pts.push([Number(m[1]), Number(m[2])]);
+      for (const q of path.matchAll(/Q (-?[\d.]+) (-?[\d.]+)/g))
+        pts.push([Number(q[1]), Number(q[2])]);
+      const ls = [...path.matchAll(/L (-?[\d.]+) (-?[\d.]+)/g)];
+      const lastL = ls[ls.length - 1];
+      if (lastL) pts.push([Number(lastL[1]), Number(lastL[2])]);
+      return pts.every((p, i) => i === 0 || pts[i - 1][0] === p[0] || pts[i - 1][1] === p[1]);
+    };
+
+    it('drops colinear bends so the riser shift stays orthogonal', () => {
+      const { result } = renderHook(() =>
+        useEdgePath({
+          ...baseBendParams, // source Right @ (100,100), target Left
+          targetX: 700,
+          targetY: 100,
+          bendPoints: [
+            { x: 300, y: 100 },
+            { x: 300, y: 200 },
+            { x: 500, y: 200 },
+            { x: 500, y: 100 },
+            { x: 680, y: 100 },
+          ],
+        })
+      );
+
+      expect(isOrthogonalPath(result.current.edgePath)).toBe(true);
+      expect(result.current.edgePath).toContain('Q 500 200');
+      expect(result.current.edgePath).toContain('Q 500 100');
+      expect(result.current.edgePath).not.toContain('680');
+    });
+
+    it('keeps a cross-axis route orthogonal when the target shift fires', () => {
+      const { result } = renderHook(() =>
+        useEdgePath({
+          ...baseBendParams,
+          targetX: 300,
+          targetY: 300,
+          targetPosition: Position.Bottom,
+          bendPoints: [
+            { x: 200, y: 100 },
+            { x: 200, y: 310 },
+            { x: 300, y: 310 },
+          ],
+        })
+      );
+
+      expect(isOrthogonalPath(result.current.edgePath)).toBe(true);
+      expect(result.current.edgePath).toContain('Q 200 328');
+      expect(result.current.edgePath).toContain('Q 300 328');
+    });
+
+    it('handles a single bend (L-shape) without a diagonal', () => {
+      const { result } = renderHook(() =>
+        useEdgePath({
+          ...baseBendParams,
+          targetX: 300,
+          targetY: 300,
+          targetPosition: Position.Top,
+          bendPoints: [{ x: 300, y: 100 }],
+        })
+      );
+
+      expect(isOrthogonalPath(result.current.edgePath)).toBe(true);
+    });
+
+    it('drops non-finite bends and never emits NaN in the path', () => {
+      const { result } = renderHook(() =>
+        useEdgePath({
+          ...baseBendParams,
+          bendPoints: [
+            { x: 150, y: 100 },
+            { x: Number.NaN, y: 150 },
+            { x: 150, y: 200 },
+          ],
+        })
+      );
+
+      expect(result.current.edgePath).not.toContain('NaN');
+      expect(result.current.edgePath).not.toContain('Infinity');
+    });
+
+    it('falls back to smooth-step when every bend is non-finite', () => {
+      const { result } = renderHook(() =>
+        useEdgePath({
+          ...baseBendParams,
+          bendPoints: [{ x: Number.NaN, y: Number.NaN }],
+        })
+      );
+
+      expect(result.current.isLoopEdge).toBe(false);
+      expect(mockGetSmoothStepPath).toHaveBeenCalled();
+    });
+
+    it('re-snaps the opposite end after an overlapping cross-axis shift', () => {
+      // 2-bend Right → Bottom: the shared riser is moved by the target shift,
+      // knocking the source bend off start.y; the re-snap must restore it.
+      const { result } = renderHook(() =>
+        useEdgePath({
+          ...baseBendParams,
+          targetX: 300,
+          targetY: 300,
+          targetPosition: Position.Bottom,
+          bendPoints: [
+            { x: 300, y: 100 },
+            { x: 300, y: 315 },
+          ],
+        })
+      );
+
+      expect(isOrthogonalPath(result.current.edgePath)).toBe(true);
     });
 
     it('leaves interior bends untouched (only first/last snap to handles)', () => {

--- a/packages/apollo-react/src/canvas/hooks/useEdgePath.test.ts
+++ b/packages/apollo-react/src/canvas/hooks/useEdgePath.test.ts
@@ -572,8 +572,8 @@ describe('useEdgePath', () => {
     it('shifts bends forward to keep the riser a source-offset past a right handle', () => {
       // Reproduces the real ELK output: right handle at x=556, but ELK's riser is
       // at x=544 (behind the handle) → the exit would route backward into the node.
-      // The riser is pushed to sourceX + sourceOffset (556 + 8 = 564) so it clears
-      // the handle by the same gap the smooth-step exit uses.
+      // The riser is pushed out by the exit gap (the source-offset magnitude, 8px)
+      // to sourceX + 8 = 564, clearing the handle like the smooth-step exit does.
       const { result } = renderHook(() =>
         useEdgePath({
           ...baseBendParams,

--- a/packages/apollo-react/src/canvas/hooks/useEdgePath.test.ts
+++ b/packages/apollo-react/src/canvas/hooks/useEdgePath.test.ts
@@ -501,4 +501,177 @@ describe('useEdgePath', () => {
       expect(result.current.edgePath).toBeDefined();
     });
   });
+
+  describe('bend-point edges', () => {
+    const baseBendParams = {
+      sourceNodeId: 'node-1',
+      sourceHandleId: 'output',
+      sourceX: 100,
+      sourceY: 100,
+      sourcePosition: Position.Right,
+      targetNodeId: 'node-2',
+      targetHandleId: 'input',
+      targetX: 200,
+      targetY: 200,
+      targetPosition: Position.Left,
+    };
+
+    it('should route through interior bend points instead of using getSmoothStepPath', () => {
+      const { result } = renderHook(() =>
+        useEdgePath({
+          ...baseBendParams,
+          bendPoints: [
+            { x: 150, y: 100 },
+            { x: 150, y: 200 },
+          ],
+        })
+      );
+
+      expect(result.current.isLoopEdge).toBe(false);
+      expect(mockGetSmoothStepPath).not.toHaveBeenCalled();
+      // Path is anchored on the (source-offset) start: 100 + (-8) for Position.Right
+      expect(result.current.edgePath.startsWith('M 92 100')).toBe(true);
+      // Each bend is the apex of a rounded (quadratic) corner
+      expect(result.current.edgePath).toContain('Q 150 100');
+      expect(result.current.edgePath).toContain('Q 150 200');
+      // Path terminates at the target endpoint
+      expect(result.current.edgePath).toContain('200 200');
+    });
+
+    it("snaps the first bend onto the source handle's axis (horizontal exit)", () => {
+      // ELK placed its source port 16px below the rendered handle (y 116 vs 100);
+      // the first bend must snap to the handle's y so the exit stays horizontal.
+      const { result } = renderHook(() =>
+        useEdgePath({
+          ...baseBendParams,
+          bendPoints: [
+            { x: 150, y: 116 },
+            { x: 150, y: 200 },
+          ],
+        })
+      );
+
+      expect(result.current.edgePath).toContain('Q 150 100');
+    });
+
+    it("snaps the last bend onto the target handle's axis (horizontal entry)", () => {
+      // ELK placed its target port 16px above the rendered handle (y 184 vs 200).
+      const { result } = renderHook(() =>
+        useEdgePath({
+          ...baseBendParams,
+          bendPoints: [
+            { x: 150, y: 100 },
+            { x: 150, y: 184 },
+          ],
+        })
+      );
+
+      expect(result.current.edgePath).toContain('Q 150 200');
+    });
+
+    it('shifts bends forward to keep the riser a source-offset past a right handle', () => {
+      // Reproduces the real ELK output: right handle at x=556, but ELK's riser is
+      // at x=544 (behind the handle) → the exit would route backward into the node.
+      // The riser is pushed to sourceX + sourceOffset (556 + 8 = 564) so it clears
+      // the handle by the same gap the smooth-step exit uses.
+      const { result } = renderHook(() =>
+        useEdgePath({
+          ...baseBendParams,
+          sourceX: 556,
+          sourceY: 208,
+          targetX: 820,
+          targetY: 320,
+          bendPoints: [
+            { x: 544, y: 208 },
+            { x: 544, y: 320 },
+          ],
+        })
+      );
+
+      expect(result.current.edgePath).toContain('Q 564 208');
+      expect(result.current.edgePath).toContain('Q 564 320');
+      expect(result.current.edgePath).not.toContain('544');
+    });
+
+    it('leaves interior bends untouched (only first/last snap to handles)', () => {
+      const { result } = renderHook(() =>
+        useEdgePath({
+          ...baseBendParams,
+          bendPoints: [
+            { x: 150, y: 100 },
+            { x: 175, y: 150 },
+            { x: 150, y: 200 },
+          ],
+        })
+      );
+
+      // The middle bend is preserved exactly.
+      expect(result.current.edgePath).toContain('Q 175 150');
+    });
+
+    it('should fall back to smooth-step path when bendPoints is an empty array', () => {
+      const { result } = renderHook(() => useEdgePath({ ...baseBendParams, bendPoints: [] }));
+
+      expect(result.current.isLoopEdge).toBe(false);
+      expect(mockGetSmoothStepPath).toHaveBeenCalled();
+    });
+
+    it('should fall back to smooth-step path when bendPoints is undefined', () => {
+      renderHook(() => useEdgePath(baseBendParams));
+
+      expect(mockGetSmoothStepPath).toHaveBeenCalled();
+    });
+
+    it('should ignore bendPoints for self-loop edges', () => {
+      const { result } = renderHook(() =>
+        useEdgePath({
+          ...baseBendParams,
+          targetNodeId: 'node-1', // self-loop
+          bendPoints: [{ x: 150, y: 300 }],
+        })
+      );
+
+      expect(result.current.isLoopEdge).toBe(true);
+      expect(mockGetSmoothStepPath).not.toHaveBeenCalled();
+    });
+
+    it('should ignore bendPoints for loopBack edges', () => {
+      const { result } = renderHook(() =>
+        useEdgePath({
+          ...baseBendParams,
+          targetHandleId: 'loopBack',
+          bendPoints: [{ x: 150, y: 300 }],
+        })
+      );
+
+      expect(result.current.isLoopEdge).toBe(true);
+      expect(mockGetSmoothStepPath).not.toHaveBeenCalled();
+    });
+
+    it('should recompute the path when bendPoints change', () => {
+      const initial = [
+        { x: 150, y: 100 },
+        { x: 175, y: 150 },
+        { x: 150, y: 200 },
+      ];
+      const { result, rerender } = renderHook((props) => useEdgePath(props), {
+        initialProps: { ...baseBendParams, bendPoints: initial },
+      });
+
+      const firstResult = result.current;
+
+      // Move the (interior, un-snapped) middle bend's x from 175 → 185.
+      rerender({
+        ...baseBendParams,
+        bendPoints: [
+          { x: 150, y: 100 },
+          { x: 185, y: 150 },
+          { x: 150, y: 200 },
+        ],
+      });
+
+      expect(result.current).not.toBe(firstResult);
+      expect(result.current.edgePath).toContain('Q 185 150');
+    });
+  });
 });

--- a/packages/apollo-react/src/canvas/hooks/useEdgePath.ts
+++ b/packages/apollo-react/src/canvas/hooks/useEdgePath.ts
@@ -27,7 +27,30 @@ const snapToGrid = (value: number): number => {
 
 const BEND_CORNER_RADIUS = GRID_SPACING;
 
+const GAP_OFFSET = 28;
+
 const distance = (a: XYPosition, b: XYPosition): number => Math.hypot(b.x - a.x, b.y - a.y);
+
+const isColinear = (a: XYPosition, b: XYPosition, c: XYPosition): boolean =>
+  (a.x === b.x && b.x === c.x) || (a.y === b.y && b.y === c.y);
+
+const dropColinearBends = (
+  interior: XYPosition[],
+  start: XYPosition,
+  end: XYPosition
+): XYPosition[] => {
+  const kept: XYPosition[] = [];
+  let prev = start;
+  for (let i = 0; i < interior.length; i++) {
+    const cur = interior[i];
+    if (!cur) continue;
+    const next = interior[i + 1] ?? end;
+    if (isColinear(prev, cur, next)) continue;
+    kept.push(cur);
+    prev = cur;
+  }
+  return kept;
+};
 
 // A point `d` units from `from` along the direction toward `to`.
 const pointToward = (from: XYPosition, to: XYPosition, d: number): XYPosition => {
@@ -168,7 +191,10 @@ export function useEdgePath({
     let labelX: number;
     let labelY: number;
 
-    const hasBendPoints = !needsCustomPath && bendPoints != null && bendPoints.length > 0;
+    // Keep only finite bends so a malformed/non-finite point can't corrupt the
+    // SVG path; with none left we fall through to the smooth-step path.
+    const finiteBends = bendPoints?.filter((p) => Number.isFinite(p?.x) && Number.isFinite(p?.y));
+    const hasBendPoints = !needsCustomPath && finiteBends != null && finiteBends.length > 0;
 
     if (needsCustomPath) {
       // Use larger height and right extension for success edges
@@ -195,46 +221,81 @@ export function useEdgePath({
       };
       const end: XYPosition = { x: targetX, y: targetY };
 
-      // Copy the bends — they're shared edge data and we mutate below (snap + shift).
-      const interior: XYPosition[] = bendPoints.map((p) => ({ x: p.x, y: p.y }));
+      // Copy the bends (shared edge data, mutated below) and drop colinear points
+      // so the first/last two are the genuine exit/entry risers the shifts assume.
+      const interior: XYPosition[] = dropColinearBends(
+        finiteBends.map((p) => ({ x: p.x, y: p.y })),
+        start,
+        end
+      );
       const isSrcHorizontal = sourcePosition === Position.Left || sourcePosition === Position.Right;
       const isTgtHorizontal = targetPosition === Position.Left || targetPosition === Position.Right;
       const firstBend = interior[0];
       const lastBend = interior[interior.length - 1];
 
       // Snap the first/last bend onto the handle's perpendicular axis so the
-      // exit/entry segments stay orthogonal despite ELK's port vs handle offset.
-      if (firstBend) {
+      // exit/entry segments stay orthogonal. Re-run after the shifts (see below).
+      const snapFirstToSource = (): void => {
+        if (!firstBend) return;
         if (isSrcHorizontal) firstBend.y = start.y;
         else firstBend.x = start.x;
-      }
-      if (lastBend) {
+      };
+      const snapLastToTarget = (): void => {
+        if (!lastBend) return;
         if (isTgtHorizontal) lastBend.y = end.y;
         else lastBend.x = end.x;
-      }
+      };
+      snapFirstToSource();
+      snapLastToTarget();
 
-      // Keep the riser at least the source-offset past the handle in the exit
-      // direction; otherwise it lands on/behind the protruding handle and routes
-      // back into the node. Shift every bend by the shortfall to preserve shape.
-      if (firstBend) {
-        const exitGap = Math.abs(
-          isSrcHorizontal ? SOURCE_OFFSETS[sourcePosition].x : SOURCE_OFFSETS[sourcePosition].y
-        );
-        let dx = 0;
-        let dy = 0;
-        if (sourcePosition === Position.Right) dx = Math.max(0, sourceX + exitGap - firstBend.x);
-        else if (sourcePosition === Position.Left)
-          dx = Math.min(0, sourceX - exitGap - firstBend.x);
-        else if (sourcePosition === Position.Bottom)
-          dy = Math.max(0, sourceY + exitGap - firstBend.y);
-        else if (sourcePosition === Position.Top) dy = Math.min(0, sourceY - exitGap - firstBend.y);
-        if (dx !== 0 || dy !== 0) {
-          for (const p of interior) {
+      // Translate the bends in [from, to] by (dx, dy) — moving a riser's two
+      // endpoints together keeps it and its neighbours orthogonal.
+      const shiftBends = (from: number, to: number, dx: number, dy: number): void => {
+        if (dx === 0 && dy === 0) return;
+        for (let i = from; i <= to; i++) {
+          const p = interior[i];
+          if (p) {
             p.x += dx;
             p.y += dy;
           }
         }
+      };
+
+      // Pull the last riser back so the approach clears the target handle (only
+      // when ELK's last bend is closer than GAP_OFFSET). Touches just the last
+      // riser, leaving the source exit untouched.
+      if (lastBend) {
+        let dx = 0;
+        let dy = 0;
+        if (targetPosition === Position.Left) dx = Math.min(0, end.x - GAP_OFFSET - lastBend.x);
+        else if (targetPosition === Position.Right)
+          dx = Math.max(0, end.x + GAP_OFFSET - lastBend.x);
+        else if (targetPosition === Position.Top) dy = Math.min(0, end.y - GAP_OFFSET - lastBend.y);
+        else if (targetPosition === Position.Bottom)
+          dy = Math.max(0, end.y + GAP_OFFSET - lastBend.y);
+        shiftBends(interior.length - 2, interior.length - 1, dx, dy);
       }
+
+      // Push the first riser past the handle so the throw-out clears the `+`
+      // button before turning — measured from `start` with the same GAP_OFFSET
+      // getSmoothStepPath uses, so bend and smooth-step edges exit alike.
+      if (firstBend) {
+        let dx = 0;
+        let dy = 0;
+        if (sourcePosition === Position.Right) dx = Math.max(0, start.x + GAP_OFFSET - firstBend.x);
+        else if (sourcePosition === Position.Left)
+          dx = Math.min(0, start.x - GAP_OFFSET - firstBend.x);
+        else if (sourcePosition === Position.Bottom)
+          dy = Math.max(0, start.y + GAP_OFFSET - firstBend.y);
+        else if (sourcePosition === Position.Top)
+          dy = Math.min(0, start.y - GAP_OFFSET - firstBend.y);
+        shiftBends(0, 1, dx, dy);
+      }
+
+      // Re-snap: on a short route the two risers overlap, so a cross-axis shift
+      // can knock the opposite end off its handle axis.
+      snapFirstToSource();
+      snapLastToTarget();
 
       const points: XYPosition[] = [start, ...interior, end];
       edgePath = roundedPolylinePath(points);
@@ -255,6 +316,7 @@ export function useEdgePath({
         targetY,
         targetPosition,
         borderRadius: 16,
+        offset: GAP_OFFSET,
       });
     }
 

--- a/packages/apollo-react/src/canvas/hooks/useEdgePath.ts
+++ b/packages/apollo-react/src/canvas/hooks/useEdgePath.ts
@@ -1,4 +1,8 @@
-import { getSmoothStepPath, Position } from '@uipath/apollo-react/canvas/xyflow/react';
+import {
+  getSmoothStepPath,
+  Position,
+  type XYPosition,
+} from '@uipath/apollo-react/canvas/xyflow/react';
 import { useMemo } from 'react';
 import { GRID_SPACING } from '../constants';
 
@@ -19,6 +23,43 @@ const SOURCE_OFFSETS: Record<Position, { x: number; y: number }> = {
 // Helper function to snap a value to the grid
 const snapToGrid = (value: number): number => {
   return Math.round(value / GRID_SPACING) * GRID_SPACING;
+};
+
+const BEND_CORNER_RADIUS = GRID_SPACING;
+
+const distance = (a: XYPosition, b: XYPosition): number => Math.hypot(b.x - a.x, b.y - a.y);
+
+// A point `d` units from `from` along the direction toward `to`.
+const pointToward = (from: XYPosition, to: XYPosition, d: number): XYPosition => {
+  const len = distance(from, to);
+  if (len === 0) return { x: from.x, y: from.y };
+  const t = d / len;
+  return { x: from.x + (to.x - from.x) * t, y: from.y + (to.y - from.y) * t };
+};
+
+/**
+ * Build an SVG path through an ordered list of points, rounding each interior
+ * vertex with a quadratic curve.
+ */
+const roundedPolylinePath = (points: XYPosition[]): string => {
+  const first = points[0];
+  if (!first) return '';
+
+  let path = `M ${first.x} ${first.y}`;
+  for (let i = 1; i < points.length - 1; i++) {
+    const prev = points[i - 1];
+    const corner = points[i];
+    const next = points[i + 1];
+    if (!prev || !corner || !next) continue;
+    const radiusIn = Math.min(BEND_CORNER_RADIUS, distance(prev, corner) / 2);
+    const radiusOut = Math.min(BEND_CORNER_RADIUS, distance(corner, next) / 2);
+    const approach = pointToward(corner, prev, radiusIn);
+    const departure = pointToward(corner, next, radiusOut);
+    path += ` L ${approach.x} ${approach.y} Q ${corner.x} ${corner.y} ${departure.x} ${departure.y}`;
+  }
+  const last = points[points.length - 1];
+  if (last && points.length > 1) path += ` L ${last.x} ${last.y}`;
+  return path;
 };
 
 /**
@@ -73,6 +114,7 @@ export interface EdgePathParams {
   targetX: number;
   targetY: number;
   targetPosition: Position;
+  bendPoints?: XYPosition[];
 }
 
 export interface EdgePathState {
@@ -111,6 +153,7 @@ export function useEdgePath({
   targetX,
   targetY,
   targetPosition,
+  bendPoints,
 }: EdgePathParams): EdgePathState {
   // Memoize path calculation
   return useMemo(() => {
@@ -124,6 +167,8 @@ export function useEdgePath({
     let edgePath: string;
     let labelX: number;
     let labelY: number;
+
+    const hasBendPoints = !needsCustomPath && bendPoints != null && bendPoints.length > 0;
 
     if (needsCustomPath) {
       // Use larger height and right extension for success edges
@@ -143,6 +188,60 @@ export function useEdgePath({
       // Position label below the edge
       labelX = (sourceX + targetX) / 2;
       labelY = Math.max(sourceY, targetY) + loopHeight;
+    } else if (hasBendPoints) {
+      const start: XYPosition = {
+        x: sourceX + SOURCE_OFFSETS[sourcePosition].x,
+        y: sourceY + SOURCE_OFFSETS[sourcePosition].y,
+      };
+      const end: XYPosition = { x: targetX, y: targetY };
+
+      // Copy the bends — they're shared edge data and we mutate below (snap + shift).
+      const interior: XYPosition[] = bendPoints.map((p) => ({ x: p.x, y: p.y }));
+      const isSrcHorizontal = sourcePosition === Position.Left || sourcePosition === Position.Right;
+      const isTgtHorizontal = targetPosition === Position.Left || targetPosition === Position.Right;
+      const firstBend = interior[0];
+      const lastBend = interior[interior.length - 1];
+
+      // Snap the first/last bend onto the handle's perpendicular axis so the
+      // exit/entry segments stay orthogonal despite ELK's port vs handle offset.
+      if (firstBend) {
+        if (isSrcHorizontal) firstBend.y = start.y;
+        else firstBend.x = start.x;
+      }
+      if (lastBend) {
+        if (isTgtHorizontal) lastBend.y = end.y;
+        else lastBend.x = end.x;
+      }
+
+      // Keep the riser at least the source-offset past the handle in the exit
+      // direction; otherwise it lands on/behind the protruding handle and routes
+      // back into the node. Shift every bend by the shortfall to preserve shape.
+      if (firstBend) {
+        const exitGap = Math.abs(
+          isSrcHorizontal ? SOURCE_OFFSETS[sourcePosition].x : SOURCE_OFFSETS[sourcePosition].y
+        );
+        let dx = 0;
+        let dy = 0;
+        if (sourcePosition === Position.Right) dx = Math.max(0, sourceX + exitGap - firstBend.x);
+        else if (sourcePosition === Position.Left)
+          dx = Math.min(0, sourceX - exitGap - firstBend.x);
+        else if (sourcePosition === Position.Bottom)
+          dy = Math.max(0, sourceY + exitGap - firstBend.y);
+        else if (sourcePosition === Position.Top) dy = Math.min(0, sourceY - exitGap - firstBend.y);
+        if (dx !== 0 || dy !== 0) {
+          for (const p of interior) {
+            p.x += dx;
+            p.y += dy;
+          }
+        }
+      }
+
+      const points: XYPosition[] = [start, ...interior, end];
+      edgePath = roundedPolylinePath(points);
+
+      const mid = points[Math.floor(points.length / 2)] ?? end;
+      labelX = mid.x;
+      labelY = mid.y;
     } else {
       const { sourceOffsetX, sourceOffsetY } = {
         sourceOffsetX: sourceX + SOURCE_OFFSETS[sourcePosition].x,
@@ -176,5 +275,6 @@ export function useEdgePath({
     targetY,
     sourcePosition,
     targetPosition,
+    bendPoints,
   ]);
 }

--- a/packages/apollo-react/src/canvas/types.ts
+++ b/packages/apollo-react/src/canvas/types.ts
@@ -3,6 +3,7 @@ import type {
   Edge,
   Node,
   Viewport as ReactFlowViewport,
+  XYPosition,
 } from '@uipath/apollo-react/canvas/xyflow/react';
 import type { NodeProps } from '@uipath/apollo-react/canvas/xyflow/system';
 import type { IRawSpan } from '../types/TraceModels';
@@ -527,6 +528,12 @@ export type AgentFlowNodeDataUpdate<T extends AgentFlowCustomNode> = Partial<T['
 export type AgentFlowDefaultEdgeData = {
   label: string | null;
   isDimmed?: boolean;
+  /**
+   * Optional interior routing corners (in flow coordinates) produced by an
+   * auto-layout pass so the edge routes around nodes. Consumed by SequenceEdge
+   * via `useEdgePath`. Transient/derived — recompute on layout, do not persist.
+   */
+  bendPoints?: XYPosition[];
 };
 export type AgentFlowDefaultEdge = Edge<AgentFlowDefaultEdgeData, 'default'>;
 export type AgentFlowCustomEdge = AgentFlowDefaultEdge;


### PR DESCRIPTION
## Summary
Adds optional bend-point routing to `SequenceEdge`. When an edge carries `data.bendPoints` (interior corners in flow coordinates, produced by an auto-layout pass such as ELK), the edge routes through them instead of the default smooth-step path — so edges can avoid overlapping nodes.

## File Changes
- **`useEdgePath`**: new optional `bendPoints` param. The path is anchored on the live source/target handle positions and threaded through the interior bends with rounded corners. Two handle-alignment corrections keep it clean despite ELK routing from its *port* while React Flow renders the *handle*:
  1. perpendicular snap — first/last bend onto the handle's perpendicular axis (orthogonal exit/entry);
  2. parallel exit-gap — shifts the route so the riser sits a source-offset past the handle instead of on/behind it.
  Falls back to the existing smooth-step path when `bendPoints` is absent; loop/self edges ignore bends.
- **`SequenceEdge`**: forwards `data?.bendPoints` to `useEdgePath`.
- **`types.ts`**: documents `bendPoints` on `AgentFlowDefaultEdgeData` (transient/derived — recompute on layout, not persisted).
- **Storybook**: new `BendPoints` story (routed vs. straight comparison; clears bends on node drag-start so they follow the drag).



## Demo

https://github.com/user-attachments/assets/fa5ab8cc-6925-4237-8e00-a2bc8d9a8c87

## Notes
Purely additive — absent `bendPoints` ⇒ byte-for-byte the current smooth-step behavior, so no breaking change. `data.bendPoints` is consumed only; nothing is persisted.

## Testing
- 29 `useEdgePath` unit tests (routing through bends, perpendicular snap, exit-gap correction, smooth-step fallback, loop-edge ignore, recompute-on-change).
- Full `@uipath/apollo-react` suite (1664 tests) + `build` green.