### PR TITLE
fix(apollo-react): match escalation tool names case-insensitively in agent canvas

### DIFF
--- a/packages/apollo-react/src/canvas/components/AgentCanvas/nodes/ResourceNode.tsx
+++ b/packages/apollo-react/src/canvas/components/AgentCanvas/nodes/ResourceNode.tsx
@@ -355,7 +355,7 @@ export const ResourceNode = memo(
 
     const breakpointAdornment = useMemo((): React.ReactNode => {
       if (!hasBreakpoint) return undefined;
-      return <CanvasIcon icon="circle" size={14} color="#cc3d45" />;
+      return <CanvasIcon icon="circle" size={14} color="#cc3d45" fill="#cc3d45" />;
     }, [hasBreakpoint]);
 
     const statusAdornment = useMemo((): React.ReactNode => {

--- a/packages/apollo-react/src/canvas/utils/icon-registry.tsx
+++ b/packages/apollo-react/src/canvas/utils/icon-registry.tsx
@@ -10,7 +10,12 @@ import { icons } from 'lucide-react';
 import { type JSX, memo, useMemo } from 'react';
 import * as Icons from '../icons';
 
-export type IconComponent = (props: { w?: number; h?: number; color?: string }) => JSX.Element;
+export type IconComponent = (props: {
+  w?: number;
+  h?: number;
+  color?: string;
+  fill?: string;
+}) => JSX.Element;
 
 /**
  * Registry of available icons (UIPath icons only)
@@ -94,11 +99,13 @@ export function getIcon(iconId?: string): IconComponent {
   const LucideIcon = (
     icons as Record<
       string,
-      React.ComponentType<{ width?: number; height?: number; color?: string }>
+      React.ComponentType<{ width?: number; height?: number; color?: string; fill?: string }>
     >
   )[pascalCaseId];
   if (LucideIcon) {
-    return ({ w, h, color }) => <LucideIcon width={w ?? 24} height={h ?? 24} color={color} />;
+    return ({ w, h, color, fill }) => (
+      <LucideIcon width={w ?? 24} height={h ?? 24} color={color} {...(fill?.length && { fill })} />
+    );
   }
 
   // Fallback to box icon
@@ -110,16 +117,22 @@ export interface CanvasIconProps {
   icon?: string;
   size?: number;
   color?: string;
+  fill?: string;
 }
 
 /**
  * Memoized component for rendering icons from the registry.
  * Use this instead of getIcon() to avoid creating components during render.
  */
-export const CanvasIcon = memo(function CanvasIcon({ icon, size = 16, color }: CanvasIconProps) {
+export const CanvasIcon = memo(function CanvasIcon({
+  icon,
+  size = 16,
+  color,
+  fill,
+}: CanvasIconProps) {
   const Icon = useMemo(() => (icon ? getIcon(icon) : null), [icon]);
   if (!Icon) return null;
-  return <Icon w={size} h={size} color={color} />;
+  return <Icon w={size} h={size} color={color} fill={fill} />;
 });
 
 /** @deprecated Use `CanvasIcon` instead. */

--- a/packages/apollo-react/src/canvas/utils/props-helpers.test.ts
+++ b/packages/apollo-react/src/canvas/utils/props-helpers.test.ts
@@ -365,6 +365,25 @@ describe('props-helpers', () => {
       expect((escalationNode?.data as any).hasSuccess).toBe(true);
     });
 
+    it('matches escalation status case-insensitively (span preserves resource-name casing)', () => {
+      // Backend emits `escalate_Test_Escalation` (case preserved); normalizeToolName lowercases.
+      const spans = [
+        {
+          Attributes: JSON.stringify({ toolName: 'escalate_Test_Escalation' }),
+          Status: 0, // RUNNING status
+        } as any,
+      ];
+
+      const propsWithSpans = { ...mockAgentFlowProps, spans };
+      const { nodes } = computeNodesAndEdges(propsWithSpans);
+
+      const escalationNode = nodes.find(
+        (node) => node.type === 'resource' && node.data.type === 'escalation'
+      );
+
+      expect((escalationNode?.data as any).hasRunning).toBe(true);
+    });
+
     it('handles context tool name normalization', () => {
       const spans = [
         {
@@ -381,6 +400,40 @@ describe('props-helpers', () => {
       );
 
       expect((contextNode?.data as any).hasSuccess).toBe(true);
+    });
+
+    it('skips spans with malformed Attributes without throwing, still detecting valid spans', () => {
+      const spans = [
+        { Attributes: '{ this is not valid json', Status: 0 } as any,
+        { Attributes: JSON.stringify({ toolName: 'Test_Tool' }), Status: 1 } as any,
+      ];
+
+      const propsWithSpans = { ...mockAgentFlowProps, spans };
+      let nodes;
+      expect(() => {
+        nodes = computeNodesAndEdges(propsWithSpans).nodes;
+      }).not.toThrow();
+
+      const toolNode = nodes!.find(
+        (node: any) => node.type === 'resource' && node.data.type === 'tool'
+      );
+      expect((toolNode?.data as any).hasSuccess).toBe(true);
+    });
+
+    it('treats an in-flight span with missing Status as RUNNING', () => {
+      const spans = [
+        {
+          // Status omitted entirely (span streamed before Status populated)
+          Attributes: JSON.stringify({ toolName: 'Test_Tool' }),
+        } as any,
+      ];
+
+      const propsWithSpans = { ...mockAgentFlowProps, spans };
+      const { nodes } = computeNodesAndEdges(propsWithSpans);
+
+      const toolNode = nodes.find((node) => node.type === 'resource' && node.data.type === 'tool');
+      expect((toolNode?.data as any).hasRunning).toBe(true);
+      expect((toolNode?.data as any).hasSuccess).toBe(false);
     });
   });
 });

--- a/packages/apollo-react/src/canvas/utils/props-helpers.ts
+++ b/packages/apollo-react/src/canvas/utils/props-helpers.ts
@@ -24,6 +24,22 @@ const SPAN_STATUS = {
 export const NODE_ID_DELIMITER = '=>';
 export const EDGE_ID_DELIMITER = '::';
 
+// Streaming/partial spans can carry malformed JSON; an unguarded throw here would
+// abort node-status computation for the whole render and drop highlighting intermittently.
+const parseSpanAttributes = (span: IRawSpan): Record<string, unknown> | null => {
+  if (!span.Attributes) return null;
+  try {
+    return JSON.parse(span.Attributes);
+  } catch {
+    return null;
+  }
+};
+
+// An in-flight span may arrive before its Status is populated; treat a missing/non-numeric
+// Status as RUNNING so the node still glows while executing.
+const spanStatus = (span: IRawSpan): number =>
+  Number.isFinite(span.Status) ? span.Status : SPAN_STATUS.RUNNING;
+
 const getResourceNodeId = (resource: AgentFlowResource): string => {
   return resource.id;
 };
@@ -49,7 +65,7 @@ const hasResourceStatus = (
   targetStatus: number
 ): boolean => {
   for (const span of spans) {
-    const attributes = span.Attributes ? JSON.parse(span.Attributes) : null;
+    const attributes = parseSpanAttributes(span);
     if (!attributes) continue;
 
     // Check for tool/context/escalation/mcp status
@@ -62,7 +78,13 @@ const hasResourceStatus = (
     ) {
       const normalizedToolName = normalizeToolName(resource);
 
-      if (attributes.toolName === normalizedToolName && span.Status === targetStatus) {
+      // Case-insensitive: escalation tool names preserve the resource-name casing in the span
+      // (e.g. `escalate_Escalation_1`) while normalizeToolName lowercases it.
+      if (
+        typeof attributes.toolName === 'string' &&
+        attributes.toolName.toLowerCase() === normalizedToolName.toLowerCase() &&
+        spanStatus(span) === targetStatus
+      ) {
         return true;
       }
     }
@@ -96,11 +118,11 @@ const hasModelStatus = (
   targetStatus: number
 ): boolean => {
   for (const span of spans) {
-    const attributes = span.Attributes ? JSON.parse(span.Attributes) : null;
+    const attributes = parseSpanAttributes(span);
     if (!attributes) continue;
 
     // Check for model status
-    if (attributes.type === 'completion' && span.Status === targetStatus) {
+    if (attributes.type === 'completion' && spanStatus(span) === targetStatus) {
       return true;
     }
   }
@@ -129,12 +151,12 @@ export const hasModelSuccess = (model: AgentFlowModel, spans: IRawSpan[]): boole
 // Helper function to check if an agent has a running status
 export const hasAgentRunning = (spans: IRawSpan[]): boolean => {
   for (const span of spans) {
-    const attributes = span.Attributes ? JSON.parse(span.Attributes) : null;
+    const attributes = parseSpanAttributes(span);
     if (!attributes) continue;
 
     // Check for agent run status
     if (attributes.type === 'agentRun') {
-      const isRunning = span.Status === SPAN_STATUS.RUNNING;
+      const isRunning = spanStatus(span) === SPAN_STATUS.RUNNING;
       return isRunning;
     }
   }


### PR DESCRIPTION
Two related Agent Canvas (`@uipath/apollo-react`) bug fixes surfaced while bumping apollo-react v3 → v4, plus a small type cleanup.

## 1. Escalation nodes/edges not highlighting during execution

On the agent execution view, an escalation node never glowed blue/green and the canvas didn't focus it, even though the run was clearly escalating.

**Root cause:** escalation toolCall spans preserve the resource-name casing (e.g. `escalate_Escalation_1`), but `normalizeToolName` lowercases it (`escalate_escalation_1`). The `toolName` equality in `hasResourceStatus` therefore never matched mixed-case escalations, so the node got no running/success status — and since the edge color is derived from the connected node's status, the path stayed grey. It looked "intermittent" because lowercase-named escalations matched fine while mixed-case ones (the default `Escalation_1`) never did. Regular tools were unaffected (their normalization doesn't lowercase).

**Fix:** compare tool names case-insensitively (lowercase both sides).

## 2. Span parsing hardening

`hasResourceStatus` / `hasModelStatus` / `hasAgentRunning` called `JSON.parse` unguarded and compared `span.Status` strictly. During live streaming a malformed/partial span could throw (aborting node-status computation for the whole render) or arrive before `Status` was populated.

**Fix:** `parseSpanAttributes` guards `JSON.parse` (skips bad spans instead of throwing), and a missing/non-numeric `Status` is treated as `RUNNING` so in-progress highlighting stays stable while spans stream in.

## 3. Breakpoint icon rendered as a hollow circle

After the canvas icon migration, the breakpoint adornment used Lucide's `circle`, which is stroke-only (`fill="none"`), so it showed as a hollow outline instead of the expected solid dot.

**Fix:** forward a `fill` prop through `CanvasIcon` → `getIcon` to the underlying icon, and set it on the breakpoint dot so it renders a solid red circle.

## Tests
Added regression tests in `props-helpers.test.ts` for mixed-case escalation spans, malformed-JSON attributes, and missing-`Status` handling.

## Files
- `canvas/utils/props-helpers.ts` — case-insensitive tool-name match + guarded parsing + default RUNNING status
- `canvas/utils/icon-registry.tsx` — `CanvasIcon`/`getIcon` now forward a `fill` prop
- `canvas/components/AgentCanvas/nodes/ResourceNode.tsx` — filled breakpoint dot
- `canvas/utils/props-helpers.test.ts` — regression tests
