### PR TITLE
feat(apollo-react): add NodePropertyPanel editor stories

### DIFF
--- a/apps/storybook/package.json
+++ b/apps/storybook/package.json
@@ -38,7 +38,7 @@
     "storybook": "^10.4.1",
     "tailwindcss": "^4.1.17",
     "typescript": "^5.9.3",
-    "vite": "^8.0.0",
+    "vite": "^7.3.5",
     "vite-plugin-svgr": "^4.5.0"
   }
 }

--- a/apps/storybook/package.json
+++ b/apps/storybook/package.json
@@ -38,7 +38,7 @@
     "storybook": "^10.4.1",
     "tailwindcss": "^4.1.17",
     "typescript": "^5.9.3",
-    "vite": "^7.3.5",
+    "vite": "^8.0.0",
     "vite-plugin-svgr": "^4.5.0"
   }
 }

--- a/packages/apollo-react/biome.json
+++ b/packages/apollo-react/biome.json
@@ -76,7 +76,7 @@
   },
   "overrides": [
     {
-      "includes": ["**/*.stories.tsx"],
+      "includes": ["**/NodePropertyPanel.stories.tsx"],
       "linter": {
         "rules": {
           "a11y": {

--- a/packages/apollo-react/biome.json
+++ b/packages/apollo-react/biome.json
@@ -76,6 +76,16 @@
   },
   "overrides": [
     {
+      "includes": ["**/*.stories.tsx"],
+      "linter": {
+        "rules": {
+          "a11y": {
+            "noAutofocus": "off"
+          }
+        }
+      }
+    },
+    {
       "includes": ["src/canvas/**"],
       "linter": {
         "rules": {

--- a/packages/apollo-react/package.json
+++ b/packages/apollo-react/package.json
@@ -239,6 +239,7 @@
     "zustand": "^5.0.9"
   },
   "devDependencies": {
+    "@monaco-editor/react": "^4.7.0",
     "@lingui/cli": "^5.6.1",
     "@lingui/conf": "^5.6.1",
     "@lingui/format-json": "^5.6.1",

--- a/packages/apollo-react/package.json
+++ b/packages/apollo-react/package.json
@@ -239,12 +239,12 @@
     "zustand": "^5.0.9"
   },
   "devDependencies": {
-    "@monaco-editor/react": "^4.7.0",
     "@lingui/cli": "^5.6.1",
     "@lingui/conf": "^5.6.1",
     "@lingui/format-json": "^5.6.1",
     "@lingui/macro": "^5.6.1",
     "@lingui/swc-plugin": "^5.9.0",
+    "@monaco-editor/react": "^4.7.0",
     "@mui/private-theming": "^5.15.3",
     "@rsbuild/plugin-babel": "^1.0.6",
     "@rsbuild/plugin-react": "^1.4.1",

--- a/packages/apollo-react/src/canvas/components/NodePropertyPanel/ExpressionField.tsx
+++ b/packages/apollo-react/src/canvas/components/NodePropertyPanel/ExpressionField.tsx
@@ -1,0 +1,144 @@
+import { ChevronDown, Maximize2, Redo2, Sparkles, Undo2 } from 'lucide-react';
+
+export type ExpressionMode = 'expr' | 'json';
+
+export interface ExpressionFieldProps {
+  /** Display label shown above the editor. */
+  label?: string;
+  /** Current expression value. */
+  value?: string;
+  /** Editor mode — JavaScript expression or JSON template. Defaults to 'expr'. */
+  mode?: ExpressionMode;
+  /** Short description shown below the editor. */
+  description?: string;
+  /** Called when the expression value changes (Phase 2 — editing not yet wired). */
+  onChange?: (value: string) => void;
+  /** Called when the user switches between expr and json modes. */
+  onModeChange?: (mode: ExpressionMode) => void;
+}
+
+/**
+ * ExpressionField — syntax-highlighted expression editor with mode switcher.
+ *
+ * Phase 1: read-only display with Expr / JSON mode toggle, undo/redo chrome,
+ * AI assist button, and Insert variable affordance.
+ *
+ * Phase 2: live editing via Monaco/CodeMirror with variable binding ({x} pill),
+ * real-time validation, and IntelliSense.
+ */
+export function ExpressionField({
+  label,
+  value,
+  mode = 'expr',
+  description,
+  onModeChange,
+}: ExpressionFieldProps) {
+  const expression = value ?? '';
+  const activeMode = mode;
+
+  return (
+    <div className="flex flex-col gap-2">
+      {/* Label row */}
+      {label && (
+        <div className="flex items-center justify-between">
+          <span className="text-xs font-medium text-foreground-muted">{label}</span>
+          <div className="flex items-center gap-0.5">
+            <button
+              type="button"
+              title="AI assist"
+              aria-label="AI assist"
+              className="grid size-7 place-items-center rounded-lg text-foreground-subtle transition hover:bg-surface-overlay hover:text-foreground"
+            >
+              <Sparkles size={12} />
+            </button>
+            <button
+              type="button"
+              title="Insert variable"
+              aria-label="Insert variable"
+              className="flex h-7 items-center gap-1 rounded-lg px-2 text-[11px] text-foreground-subtle transition hover:bg-surface-overlay hover:text-foreground"
+            >
+              <span className="font-mono text-[10px]">{'{x}'}</span>
+              <span>Insert</span>
+              <ChevronDown size={9} />
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* Editor block */}
+      <div className="overflow-hidden rounded-xl border border-border-subtle bg-surface-raised">
+        {/* Block header */}
+        <div className="flex items-center justify-between border-b border-border-subtle bg-surface px-3 py-2">
+          <span className="font-mono text-xs text-foreground-muted">result</span>
+          <button
+            type="button"
+            title="Expand editor"
+            aria-label="Expand editor"
+            className="grid size-6 place-items-center rounded text-foreground-subtle transition hover:text-foreground"
+          >
+            <Maximize2 size={11} />
+          </button>
+        </div>
+
+        {/* Toolbar: undo / redo | mode switcher */}
+        <div className="flex items-center gap-1 border-b border-border-subtle bg-surface px-2.5 py-1.5">
+          <button
+            type="button"
+            title="Undo"
+            aria-label="Undo"
+            className="grid size-6 place-items-center rounded text-foreground-subtle transition hover:text-foreground"
+          >
+            <Undo2 size={12} />
+          </button>
+          <button
+            type="button"
+            title="Redo"
+            aria-label="Redo"
+            className="grid size-6 place-items-center rounded text-foreground-subtle transition hover:text-foreground"
+          >
+            <Redo2 size={12} />
+          </button>
+          <div className="mx-1 h-3 w-px shrink-0 bg-border-subtle" />
+          <button
+            type="button"
+            onClick={() => onModeChange?.('expr')}
+            className="rounded px-2 py-0.5 text-[11px] transition"
+            style={{
+              color: activeMode === 'expr' ? 'var(--foreground)' : 'var(--foreground-subtle)',
+              fontWeight: activeMode === 'expr' ? 600 : 400,
+            }}
+          >
+            expr
+          </button>
+          <button
+            type="button"
+            onClick={() => onModeChange?.('json')}
+            className="rounded px-2 py-0.5 text-[11px] transition"
+            style={{
+              color: activeMode === 'json' ? 'var(--foreground)' : 'var(--foreground-subtle)',
+              fontWeight: activeMode === 'json' ? 600 : 400,
+            }}
+          >
+            json
+          </button>
+        </div>
+
+        {/* Code display */}
+        <pre className="overflow-auto whitespace-pre-wrap bg-surface-raised p-3 text-xs font-mono leading-5 text-foreground">
+          {expression || '// Enter expression…'}
+        </pre>
+
+        {/* Footer */}
+        <div className="flex items-center justify-between border-t border-border-subtle bg-surface px-3 py-1.5">
+          <div className="flex items-center gap-1.5">
+            <span className="size-1.5 shrink-0 rounded-full bg-green-500" />
+            <span className="text-[10px] text-foreground-subtle">No errors</span>
+          </div>
+          <span className="text-[10px] text-foreground-subtle">Ln 1, Col 1</span>
+        </div>
+      </div>
+
+      {description && <p className="text-[11px] leading-4 text-foreground-subtle">{description}</p>}
+    </div>
+  );
+}

--- a/packages/apollo-react/src/canvas/components/NodePropertyPanel/ExpressionField.tsx
+++ b/packages/apollo-react/src/canvas/components/NodePropertyPanel/ExpressionField.tsx
@@ -16,13 +16,13 @@ export interface ExpressionFieldProps {
 }
 
 /**
- * ExpressionField — syntax-highlighted expression editor with mode switcher.
+ * ExpressionField — read-only expression display with mode switcher.
  *
- * Phase 1: read-only display with Expr / JSON mode toggle, undo/redo chrome,
+ * Phase 1: plain-text display with Expr / JSON mode toggle, undo/redo chrome,
  * AI assist button, and Insert variable affordance.
  *
- * Phase 2: live editing via Monaco/CodeMirror with variable binding ({x} pill),
- * real-time validation, and IntelliSense.
+ * Phase 2: live editing via Monaco/CodeMirror with syntax highlighting,
+ * variable binding ({x} pill), real-time validation, and IntelliSense.
  */
 export function ExpressionField({
   label,
@@ -131,7 +131,7 @@ export function ExpressionField({
         {/* Footer */}
         <div className="flex items-center justify-between border-t border-border-subtle bg-surface px-3 py-1.5">
           <div className="flex items-center gap-1.5">
-            <span className="size-1.5 shrink-0 rounded-full bg-green-500" />
+            <span className="size-1.5 shrink-0 rounded-full bg-[--success]" />
             <span className="text-[10px] text-foreground-subtle">No errors</span>
           </div>
           <span className="text-[10px] text-foreground-subtle">Ln 1, Col 1</span>

--- a/packages/apollo-react/src/canvas/components/NodePropertyPanel/ExpressionField.tsx
+++ b/packages/apollo-react/src/canvas/components/NodePropertyPanel/ExpressionField.tsx
@@ -136,7 +136,9 @@ export function ExpressionField({
         </div>
       </div>
 
-      {description && <p className="text-[11px] leading-4 text-foreground-subtle">{description}</p>}
+      {description && (
+        <span className="block text-[11px] leading-4 text-foreground-subtle">{description}</span>
+      )}
     </div>
   );
 }

--- a/packages/apollo-react/src/canvas/components/NodePropertyPanel/ExpressionField.tsx
+++ b/packages/apollo-react/src/canvas/components/NodePropertyPanel/ExpressionField.tsx
@@ -11,8 +11,6 @@ export interface ExpressionFieldProps {
   mode?: ExpressionMode;
   /** Short description shown below the editor. */
   description?: string;
-  /** Called when the expression value changes (Phase 2 — editing not yet wired). */
-  onChange?: (value: string) => void;
   /** Called when the user switches between expr and json modes. */
   onModeChange?: (mode: ExpressionMode) => void;
 }

--- a/packages/apollo-react/src/canvas/components/NodePropertyPanel/ExpressionField.tsx
+++ b/packages/apollo-react/src/canvas/components/NodePropertyPanel/ExpressionField.tsx
@@ -100,6 +100,7 @@ export function ExpressionField({
           <button
             type="button"
             onClick={() => onModeChange?.('expr')}
+            aria-pressed={activeMode === 'expr'}
             className="rounded px-2 py-0.5 text-[11px] transition"
             style={{
               color: activeMode === 'expr' ? 'var(--foreground)' : 'var(--foreground-subtle)',
@@ -111,6 +112,7 @@ export function ExpressionField({
           <button
             type="button"
             onClick={() => onModeChange?.('json')}
+            aria-pressed={activeMode === 'json'}
             className="rounded px-2 py-0.5 text-[11px] transition"
             style={{
               color: activeMode === 'json' ? 'var(--foreground)' : 'var(--foreground-subtle)',

--- a/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.stories.tsx
@@ -1,7 +1,17 @@
+import MonacoEditor from '@monaco-editor/react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import type { FormSchema } from '@uipath/apollo-wind';
-import { ChevronDown, Globe, Maximize2, Play, Redo2, Sparkles, Undo2, X } from 'lucide-react';
-import { useRef, useState } from 'react';
+import { cn, Switch, Tabs, TabsContent, TabsList, TabsTrigger } from '@uipath/apollo-wind';
+import {
+  apolloCoreDarkHCMonaco,
+  apolloCoreDarkMonaco,
+  apolloCoreLightHCMonaco,
+  apolloCoreLightMonaco,
+  apolloFutureDarkMonaco,
+  apolloFutureLightMonaco,
+} from '@uipath/apollo-wind/editor-themes';
+import { ChevronDown, CircleCheck, Code2, GitFork, Globe, GripVertical, Play, Plus, Sparkles, X } from 'lucide-react';
+import { useEffect, useRef, useState } from 'react';
 import type { ReactNode } from 'react';
 import { NodePropertyPanel } from './NodePropertyPanel';
 
@@ -30,30 +40,6 @@ const PanelFrame = ({
   </div>
 );
 
-const PanelTitleBar = ({ title }: { title: string }) => (
-  <div className="flex h-10 shrink-0 items-center justify-between border-b border-border-subtle bg-surface-raised px-2">
-    <span className="ml-2 text-sm font-semibold text-foreground">{title}</span>
-  </div>
-);
-
-const NodeIdentityRow = ({ name, type }: { name: string; type: string }) => (
-  <div className="flex shrink-0 items-center gap-3 border-b border-border-subtle bg-surface-raised px-6 py-4">
-    <div className="flex min-w-0 flex-1 flex-col">
-      <p className="truncate text-base font-semibold leading-5 tracking-[-0.4px] text-foreground">
-        {name}
-      </p>
-      <p className="mt-0.5 truncate text-sm leading-5 text-foreground-muted">{type}</p>
-    </div>
-    <button
-      type="button"
-      className="flex h-8 items-center gap-2 rounded-lg bg-brand px-4 text-sm font-semibold text-foreground-on-accent transition hover:bg-brand-hover"
-    >
-      <Play size={14} />
-      Run
-    </button>
-  </div>
-);
-
 function RunButton() {
   return (
     <button
@@ -65,6 +51,62 @@ function RunButton() {
     </button>
   );
 }
+
+function DebugButton() {
+  return (
+    <button
+      type="button"
+      className="flex h-8 items-center gap-2 rounded-lg bg-brand px-4 text-sm font-semibold text-foreground-on-accent transition hover:bg-brand-hover"
+    >
+      <Play size={14} />
+      Debug
+    </button>
+  );
+}
+
+// ── Monaco ──────────────────────────────────────────────────────────────────
+
+let _monacoThemesRegistered = false;
+
+// biome-ignore lint/suspicious/noExplicitAny: Monaco types not available at story level
+function registerMonacoThemes(monaco: any) {
+  if (_monacoThemesRegistered) return;
+  monaco.editor.defineTheme('apollo-future-dark', apolloFutureDarkMonaco);
+  monaco.editor.defineTheme('apollo-future-light', apolloFutureLightMonaco);
+  monaco.editor.defineTheme('apollo-core-dark', apolloCoreDarkMonaco);
+  monaco.editor.defineTheme('apollo-core-light', apolloCoreLightMonaco);
+  monaco.editor.defineTheme('apollo-core-dark-hc', apolloCoreDarkHCMonaco);
+  monaco.editor.defineTheme('apollo-core-light-hc', apolloCoreLightHCMonaco);
+  _monacoThemesRegistered = true;
+}
+
+const THEME_CLASS_MAP: Record<string, string> = {
+  'future-dark': 'apollo-future-dark',
+  'future-light': 'apollo-future-light',
+  'dark': 'apollo-core-dark',
+  'light': 'apollo-core-light',
+  'dark-hc': 'apollo-core-dark-hc',
+  'light-hc': 'apollo-core-light-hc',
+};
+
+function getMonacoThemeName(): string {
+  const classes = Array.from(document.body.classList);
+  const match = classes.find((c) => c in THEME_CLASS_MAP);
+  return match ? THEME_CLASS_MAP[match] : 'apollo-future-dark';
+}
+
+function useMonacoTheme(): string {
+  const [themeName, setThemeName] = useState(getMonacoThemeName);
+  useEffect(() => {
+    const observer = new MutationObserver(() => setThemeName(getMonacoThemeName()));
+    observer.observe(document.body, { attributes: true, attributeFilter: ['class'] });
+    return () => observer.disconnect();
+  }, []);
+  return themeName;
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+
 
 // ============================================================================
 // Shared FormSchema (steps = tabs; sections within each step hold the fields)
@@ -262,6 +304,12 @@ dockview) renders its own drag handle and close button.
 export default meta;
 type Story = StoryObj<typeof NodePropertyPanel>;
 
+// Matches the tab chrome TabbedStepForm uses inside MetadataForm.
+const TAB_LIST_CLASS =
+  'h-auto justify-start gap-0.5 overflow-x-auto rounded-lg bg-transparent p-0.5 text-muted-foreground [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden';
+const TAB_TRIGGER_CLASS =
+  'inline-flex h-6 shrink-0 items-center whitespace-nowrap rounded-md px-2.5 text-xs font-medium text-muted-foreground shadow-none transition-colors hover:text-foreground data-[state=active]:bg-surface-overlay data-[state=active]:text-foreground data-[state=active]:shadow-sm';
+
 // ============================================================================
 // Stories — NodePropertyPanel
 // ============================================================================
@@ -276,7 +324,7 @@ export const Default: Story = {
         nodeCategory="HTTP Request"
         action={<RunButton />}
         schema={httpRequestForm}
-        contentInset="0.75rem"
+        contentInset="0.875rem"
         onClose={() => {}}
         className="h-[640px]"
       />
@@ -292,6 +340,7 @@ export const EmbeddedNoTitleBar: Story = {
         nodeCategory="HTTP Request"
         action={<RunButton />}
         schema={httpRequestForm}
+        contentInset="0.875rem"
         className="h-[600px]"
       />
     </PanelFrame>
@@ -307,6 +356,7 @@ export const NoParametersTab: Story = {
         nodeCategory="Starts a flow run manually"
         action={<RunButton />}
         schema={manualTriggerForm}
+        contentInset="0.875rem"
         onClose={() => {}}
         className="h-[600px]"
       />
@@ -321,143 +371,146 @@ export const NoParametersTab: Story = {
 // ============================================================================
 
 function FullEditorStory() {
+  const monacoTheme = useMonacoTheme();
+  const [label, setLabel] = useState('Script');
+  const [category, setCategory] = useState('HTTP Request');
+  const [editingLabel, setEditingLabel] = useState(false);
+  const [editingCategory, setEditingCategory] = useState(false);
+  const labelRef = useRef<HTMLInputElement>(null);
+  const categoryRef = useRef<HTMLInputElement>(null);
+
   return (
     <CanvasBackground>
       <PanelFrame>
-        <PanelTitleBar title="Properties" />
-        <NodeIdentityRow name="Policy check" type="AI Agent" />
-        <div className="flex flex-col gap-6 overflow-auto bg-surface-raised px-6 pb-6 pt-4">
-          {/* Field: Path */}
-          <div className="flex flex-col gap-2">
-            <div className="flex items-center justify-between">
-              <span className="text-xs font-medium text-foreground-muted">Path</span>
-              <div className="flex items-center gap-0.5">
-                <button
-                  type="button"
-                  aria-label="AI assist"
-                  title="AI assist"
-                  className="grid size-7 place-items-center rounded-lg text-foreground-subtle transition hover:bg-surface-overlay hover:text-foreground"
-                >
-                  <Sparkles size={12} />
-                </button>
-                <button
-                  type="button"
-                  aria-label="Insert variable"
-                  title="Insert variable"
-                  className="flex h-7 items-center gap-1 rounded-lg px-2 text-[11px] text-foreground-subtle transition hover:bg-surface-overlay hover:text-foreground"
-                >
-                  <span className="font-mono text-[10px]">{'{x}'}</span>
-                  <span>Insert</span>
-                  <ChevronDown size={9} />
-                </button>
-              </div>
-            </div>
-            <div className="overflow-hidden rounded-xl border border-border-subtle bg-surface-raised">
-              <div className="flex items-center justify-between border-b border-border-subtle bg-surface px-3 py-2">
-                <span className="font-mono text-xs text-foreground-muted">result</span>
-                <button
-                  type="button"
-                  aria-label="Expand editor"
-                  title="Expand editor"
-                  className="grid size-6 place-items-center rounded text-foreground-subtle transition hover:text-foreground"
-                >
-                  <Maximize2 size={11} />
-                </button>
-              </div>
-              <div className="flex items-center gap-1 border-b border-border-subtle bg-surface px-2.5 py-1.5">
-                <button type="button" aria-label="Undo" title="Undo" className="grid size-6 place-items-center rounded text-foreground-subtle transition hover:text-foreground">
-                  <Undo2 size={12} />
-                </button>
-                <button type="button" aria-label="Redo" title="Redo" className="grid size-6 place-items-center rounded text-foreground-subtle transition hover:text-foreground">
-                  <Redo2 size={12} />
-                </button>
-                <div className="mx-1 h-3 w-px shrink-0 bg-border-subtle" />
-                <button type="button" className="rounded px-2 py-0.5 text-[11px] font-semibold text-foreground transition">
-                  expr
-                </button>
-                <button type="button" className="rounded px-2 py-0.5 text-[11px] text-foreground-subtle transition">
-                  json
-                </button>
-              </div>
-              <pre className="overflow-auto whitespace-pre-wrap bg-surface-raised p-3 text-xs font-mono leading-5 text-foreground">
-                {'items\n  .filter(x => x.active)\n  .map(x => x.value)'}
-              </pre>
-              <div className="flex items-center justify-between border-t border-border-subtle bg-surface px-3 py-1.5">
-                <div className="flex items-center gap-1.5">
-                  <span className="size-1.5 shrink-0 rounded-full bg-green-500" />
-                  <span className="text-[10px] text-foreground-subtle">No errors</span>
+        <NodePropertyPanel
+          panelTitle="Properties"
+          onClose={() => {}}
+          contentInset="0.875rem"
+          className="h-[560px]"
+        >
+          <div className="flex h-full flex-col">
+            {/* Inline-editable identity row */}
+            <div className="flex shrink-0 items-center justify-between gap-4 py-4 [padding-inline:var(--mf-content-inset,0.875rem)]">
+              <div className="flex min-w-0 flex-1 items-center gap-3.5">
+                <div className="grid size-11 shrink-0 place-items-center rounded-xl bg-surface-overlay text-foreground-subtle [&>svg]:size-5">
+                  <Code2 />
                 </div>
-                <span className="text-[10px] text-foreground-subtle">Ln 1, Col 1</span>
+                <div className="flex min-w-0 flex-1 flex-col justify-center">
+                  {editingLabel ? (
+                    <input
+                      ref={labelRef}
+                      value={label}
+                      onChange={(e) => setLabel(e.target.value)}
+                      onBlur={() => setEditingLabel(false)}
+                      onKeyDown={(e) => { if (e.key === 'Enter' || e.key === 'Escape') setEditingLabel(false); }}
+                      className="w-full rounded bg-surface-overlay px-1.5 py-0.5 text-base font-semibold leading-5 tracking-[-0.3px] text-foreground outline-none ring-1 ring-brand"
+                      autoFocus
+                    />
+                  ) : (
+                    <button
+                      type="button"
+                      onClick={() => { setEditingLabel(true); setTimeout(() => labelRef.current?.select(), 0); }}
+                      className="truncate rounded px-1.5 py-0.5 text-left text-base font-semibold leading-5 tracking-[-0.3px] text-foreground transition hover:bg-surface-overlay"
+                    >
+                      {label}
+                    </button>
+                  )}
+                  {editingCategory ? (
+                    <input
+                      ref={categoryRef}
+                      value={category}
+                      onChange={(e) => setCategory(e.target.value)}
+                      onBlur={() => setEditingCategory(false)}
+                      onKeyDown={(e) => { if (e.key === 'Enter' || e.key === 'Escape') setEditingCategory(false); }}
+                      className="w-full rounded bg-surface-overlay px-1.5 py-0.5 text-xs leading-4 text-foreground outline-none ring-1 ring-brand"
+                      autoFocus
+                    />
+                  ) : (
+                    <button
+                      type="button"
+                      onClick={() => { setEditingCategory(true); setTimeout(() => categoryRef.current?.select(), 0); }}
+                      className="truncate rounded px-1.5 py-0.5 text-left text-xs leading-4 text-foreground-muted transition hover:bg-surface-overlay"
+                    >
+                      {category}
+                    </button>
+                  )}
+                </div>
+              </div>
+              <div className="shrink-0">
+                <DebugButton />
               </div>
             </div>
-            <p className="text-[11px] leading-4 text-foreground-subtle">
-              Transform expression run against the node input data.
-            </p>
-          </div>
 
-          {/* Field: Output Mapping */}
-          <div className="flex flex-col gap-2">
-            <div className="flex items-center justify-between">
-              <span className="text-xs font-medium text-foreground-muted">Output Mapping</span>
-              <div className="flex items-center gap-0.5">
-                <button
-                  type="button"
-                  aria-label="AI assist"
-                  title="AI assist"
-                  className="grid size-7 place-items-center rounded-lg text-foreground-subtle transition hover:bg-surface-overlay hover:text-foreground"
-                >
-                  <Sparkles size={12} />
-                </button>
-                <button
-                  type="button"
-                  aria-label="Insert variable"
-                  title="Insert variable"
-                  className="flex h-7 items-center gap-1 rounded-lg px-2 text-[11px] text-foreground-subtle transition hover:bg-surface-overlay hover:text-foreground"
-                >
-                  <span className="font-mono text-[10px]">{'{x}'}</span>
-                  <span>Insert</span>
-                  <ChevronDown size={9} />
-                </button>
+            {/* Tabs + editor */}
+            <Tabs defaultValue="parameters" className="flex min-h-0 flex-1 flex-col">
+              <div className="shrink-0 pt-3 [padding-inline:var(--mf-content-inset,0.875rem)]">
+                <TabsList className={TAB_LIST_CLASS}>
+                  <TabsTrigger value="parameters" className={TAB_TRIGGER_CLASS}>Parameters</TabsTrigger>
+                  <TabsTrigger value="error-handling" className={TAB_TRIGGER_CLASS}>Error handling</TabsTrigger>
+                  <TabsTrigger value="advanced" className={TAB_TRIGGER_CLASS}>Advanced</TabsTrigger>
+                </TabsList>
               </div>
-            </div>
-            <div className="overflow-hidden rounded-xl border border-border-subtle bg-surface-raised">
-              <div className="flex items-center justify-between border-b border-border-subtle bg-surface px-3 py-2">
-                <span className="font-mono text-xs text-foreground-muted">object</span>
-                <button type="button" aria-label="Expand editor" title="Expand editor" className="grid size-6 place-items-center rounded text-foreground-subtle transition hover:text-foreground">
-                  <Maximize2 size={11} />
-                </button>
-              </div>
-              <div className="flex items-center gap-1 border-b border-border-subtle bg-surface px-2.5 py-1.5">
-                <button type="button" aria-label="Undo" title="Undo" className="grid size-6 place-items-center rounded text-foreground-subtle transition hover:text-foreground">
-                  <Undo2 size={12} />
-                </button>
-                <button type="button" aria-label="Redo" title="Redo" className="grid size-6 place-items-center rounded text-foreground-subtle transition hover:text-foreground">
-                  <Redo2 size={12} />
-                </button>
-                <div className="mx-1 h-3 w-px shrink-0 bg-border-subtle" />
-                <button type="button" className="rounded px-2 py-0.5 text-[11px] text-foreground-subtle transition">
-                  expr
-                </button>
-                <button type="button" className="rounded px-2 py-0.5 text-[11px] font-semibold text-foreground transition">
-                  json
-                </button>
-              </div>
-              <pre className="overflow-auto whitespace-pre-wrap bg-surface-raised p-3 text-xs font-mono leading-5 text-foreground">
-                {'{\n  "id": invoice.id,\n  "total": invoice.amount,\n  "approved": true\n}'}
-              </pre>
-              <div className="flex items-center justify-between border-t border-border-subtle bg-surface px-3 py-1.5">
-                <div className="flex items-center gap-1.5">
-                  <span className="size-1.5 shrink-0 rounded-full bg-green-500" />
-                  <span className="text-[10px] text-foreground-subtle">No errors</span>
+              <TabsContent value="parameters" className="mt-0 flex min-h-0 flex-1 flex-col">
+                <div className="flex shrink-0 items-center justify-between py-2 [padding-inline:var(--mf-content-inset,0.875rem)]">
+                  <span className="text-xs font-medium text-foreground-muted">Path</span>
+                  <div className="flex items-center gap-0.5">
+                    <button
+                      type="button"
+                      aria-label="AI assist"
+                      title="AI assist"
+                      className="grid size-7 place-items-center rounded-lg text-foreground-subtle transition hover:bg-surface-overlay hover:text-foreground"
+                    >
+                      <Sparkles size={12} />
+                    </button>
+                    <button
+                      type="button"
+                      aria-label="Insert variable"
+                      title="Insert variable"
+                      className="flex h-7 items-center gap-1 rounded-lg px-2 text-[11px] text-foreground-subtle transition hover:bg-surface-overlay hover:text-foreground"
+                    >
+                      <span className="font-mono text-[10px]">{'{x}'}</span>
+                      <span>Insert</span>
+                      <ChevronDown size={9} />
+                    </button>
+                  </div>
                 </div>
-                <span className="text-[10px] text-foreground-subtle">Ln 1, Col 1</span>
-              </div>
-            </div>
-            <p className="text-[11px] leading-4 text-foreground-subtle">
-              Maps the node output to the expected schema.
-            </p>
+                <div className="flex min-h-0 flex-1 flex-col pb-4 [padding-inline:var(--mf-content-inset,0.875rem)]">
+                  <div className="min-h-0 flex-1 overflow-hidden rounded-xl border border-border-subtle">
+                    <MonacoEditor
+                      height="100%"
+                      defaultLanguage="javascript"
+                      defaultValue={'// Script\nconst result = items\n  .filter(x => x.active)\n  .map(x => ({\n    id: x.id,\n    value: x.value,\n  }));\n\nreturn result;'}
+                      theme={monacoTheme}
+                      beforeMount={registerMonacoThemes}
+                      options={{
+                        fontSize: 13,
+                        lineHeight: 20,
+                        minimap: { enabled: false },
+                        scrollBeyondLastLine: false,
+                        wordWrap: 'on',
+                        fontFamily:
+                          'ui-monospace, SFMono-Regular, "SF Mono", Consolas, "Liberation Mono", Menlo, monospace',
+                        padding: { top: 6, bottom: 16 },
+                        lineNumbers: 'on',
+                        lineNumbersMinChars: 2,
+                        lineDecorationsWidth: 4,
+                        glyphMargin: false,
+                        folding: false,
+                        renderLineHighlight: 'line',
+                        hideCursorInOverviewRuler: true,
+                        overviewRulerBorder: false,
+                        scrollbar: { vertical: 'auto', horizontal: 'hidden', alwaysConsumeMouseWheel: false },
+                        automaticLayout: true,
+                      }}
+                    />
+                  </div>
+                </div>
+              </TabsContent>
+              <TabsContent value="error-handling" className="mt-0" />
+              <TabsContent value="advanced" className="mt-0" />
+            </Tabs>
           </div>
-        </div>
+        </NodePropertyPanel>
       </PanelFrame>
     </CanvasBackground>
   );
@@ -469,93 +522,296 @@ export const FullEditor: Story = {
 };
 
 // ============================================================================
-// Compact Editor
-// Collapsed by default. Shows label + value preview; expands inline on click.
+// Compact Editor — Switch/Case node with accordion case panels.
 // ============================================================================
 
+const COMPACT_EDITOR_OPTIONS = {
+  fontSize: 13,
+  lineHeight: 20,
+  minimap: { enabled: false },
+  scrollBeyondLastLine: false,
+  wordWrap: 'on',
+  fontFamily:
+    'ui-monospace, SFMono-Regular, "SF Mono", Consolas, "Liberation Mono", Menlo, monospace',
+  padding: { top: 6, bottom: 8 },
+  lineNumbers: 'on',
+  lineNumbersMinChars: 2,
+  lineDecorationsWidth: 4,
+  glyphMargin: false,
+  folding: false,
+  renderLineHighlight: 'line',
+  hideCursorInOverviewRuler: true,
+  overviewRulerBorder: false,
+  scrollbar: { vertical: 'auto', horizontal: 'hidden', alwaysConsumeMouseWheel: false },
+  automaticLayout: true,
+} as const;
+
+const INLINE_EDITOR_OPTIONS = {
+  fontSize: 13,
+  lineHeight: 20,
+  minimap: { enabled: false },
+  scrollBeyondLastLine: false,
+  wordWrap: 'off',
+  fontFamily:
+    'ui-monospace, SFMono-Regular, "SF Mono", Consolas, "Liberation Mono", Menlo, monospace',
+  padding: { top: 10, bottom: 10 },
+  lineNumbers: 'off',
+  lineNumbersMinChars: 0,
+  lineDecorationsWidth: 0,
+  glyphMargin: false,
+  folding: false,
+  renderLineHighlight: 'none',
+  hideCursorInOverviewRuler: true,
+  overviewRulerBorder: false,
+  overviewRulerLanes: 0,
+  scrollbar: { vertical: 'hidden', horizontal: 'hidden', alwaysConsumeMouseWheel: false },
+  automaticLayout: true,
+} as const;
+
+function CasePanel({
+  caseTitle,
+  onTitleChange,
+  onDelete,
+  monacoTheme,
+  defaultExpanded = false,
+  defaultValue = '',
+}: {
+  caseTitle: string;
+  onTitleChange: (title: string) => void;
+  onDelete: () => void;
+  monacoTheme: string;
+  defaultExpanded?: boolean;
+  defaultValue?: string;
+}) {
+  const [expanded, setExpanded] = useState(defaultExpanded);
+  const [editingTitle, setEditingTitle] = useState(false);
+  const titleRef = useRef<HTMLInputElement>(null);
+
+  return (
+    <div className="overflow-hidden rounded-xl border border-border-subtle">
+      {/* Card header */}
+      <div className="group flex items-center gap-2 px-3 py-2.5">
+        <div className="grid size-5 shrink-0 cursor-grab place-items-center text-foreground-subtle">
+          <GripVertical size={12} />
+        </div>
+        <button
+          type="button"
+          onClick={() => setExpanded((v) => !v)}
+          className="grid size-5 shrink-0 place-items-center rounded text-foreground-subtle transition hover:text-foreground"
+        >
+          <ChevronDown
+            size={12}
+            className={cn('transition-transform duration-150', !expanded && '-rotate-90')}
+          />
+        </button>
+        {editingTitle ? (
+          <input
+            ref={titleRef}
+            value={caseTitle}
+            onChange={(e) => onTitleChange(e.target.value)}
+            onBlur={() => setEditingTitle(false)}
+            onKeyDown={(e) => { if (e.key === 'Enter' || e.key === 'Escape') setEditingTitle(false); }}
+            className="flex-1 rounded bg-surface-overlay px-1 py-0.5 text-xs font-medium text-foreground outline-none ring-1 ring-brand"
+            autoFocus
+          />
+        ) : (
+          <button
+            type="button"
+            onClick={() => { setEditingTitle(true); setTimeout(() => titleRef.current?.select(), 0); }}
+            className="flex-1 truncate rounded px-1 py-0.5 text-left text-xs font-medium text-foreground transition hover:bg-surface-overlay"
+          >
+            {caseTitle}
+          </button>
+        )}
+        <button
+          type="button"
+          onClick={onDelete}
+          aria-label="Delete case"
+          title="Delete case"
+          className="grid size-5 shrink-0 place-items-center rounded text-foreground-subtle opacity-0 transition hover:text-foreground group-hover:opacity-100"
+        >
+          <X size={12} />
+        </button>
+      </div>
+
+      {expanded && (
+        <>
+          {/* Condition label + buttons */}
+          <div className="flex items-center justify-between border-t border-border-subtle px-3 py-2">
+            <span className="text-xs font-medium text-foreground-muted">Condition</span>
+            <div className="flex items-center gap-0.5">
+              <button
+                type="button"
+                aria-label="AI assist"
+                title="AI assist"
+                className="grid size-7 place-items-center rounded-lg text-foreground-subtle transition hover:bg-surface-overlay hover:text-foreground"
+              >
+                <Sparkles size={12} />
+              </button>
+              <button
+                type="button"
+                aria-label="Insert variable"
+                title="Insert variable"
+                className="flex h-7 items-center gap-1 rounded-lg px-2 text-[11px] text-foreground-subtle transition hover:bg-surface-overlay hover:text-foreground"
+              >
+                <span className="font-mono text-[10px]">{'{x}'}</span>
+                <span>Insert</span>
+                <ChevronDown size={9} />
+              </button>
+            </div>
+          </div>
+          <div className="px-3 pb-3">
+            <div className="overflow-hidden rounded-xl border border-border-subtle" style={{ height: '120px' }}>
+              <MonacoEditor
+                height="100%"
+                defaultLanguage="javascript"
+                defaultValue={defaultValue}
+                theme={monacoTheme}
+                beforeMount={registerMonacoThemes}
+                options={COMPACT_EDITOR_OPTIONS}
+              />
+            </div>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
 function CompactEditorStory() {
+  const monacoTheme = useMonacoTheme();
+  const [cases, setCases] = useState([{ id: 1, title: 'Case 1' }]);
+  const nextIdRef = useRef(2);
+  const [defaultBranch, setDefaultBranch] = useState(false);
+
+  const addCase = () => {
+    const id = nextIdRef.current++;
+    setCases((prev) => [...prev, { id, title: `Case ${id}` }]);
+  };
+  const deleteCase = (id: number) => setCases((prev) => prev.filter((c) => c.id !== id));
+  const updateCaseTitle = (id: number, title: string) =>
+    setCases((prev) => prev.map((c) => (c.id === id ? { ...c, title } : c)));
+  const [label, setLabel] = useState('Switch');
+  const [category, setCategory] = useState('Control');
+  const [editingLabel, setEditingLabel] = useState(false);
+  const [editingCategory, setEditingCategory] = useState(false);
+  const labelRef = useRef<HTMLInputElement>(null);
+  const categoryRef = useRef<HTMLInputElement>(null);
+
   return (
     <CanvasBackground>
       <PanelFrame>
-        <PanelTitleBar title="Properties" />
-        <NodeIdentityRow name="Policy check" type="AI Agent" />
-        <div className="flex flex-col overflow-auto bg-surface-raised pb-4 pt-2">
-          {/* Compact field row — collapsed */}
-          <div className="flex items-center gap-3 border-b border-border-subtle px-4 py-2.5">
-            <span className="w-24 shrink-0 text-xs text-foreground-muted">Path</span>
-            <div className="flex min-w-0 flex-1 items-center gap-2 overflow-hidden rounded-lg border border-border-subtle bg-surface px-2.5 py-1.5">
-              <span className="truncate font-mono text-xs text-foreground">
-                items.filter(x =&gt; x.active)
-              </span>
-            </div>
-            <button
-              type="button"
-              aria-label="AI assist"
-              title="AI assist"
-              className="grid size-6 shrink-0 place-items-center rounded text-foreground-subtle transition hover:text-foreground"
-            >
-              <Sparkles size={12} />
-            </button>
-          </div>
-
-          {/* Compact field row — expanded inline */}
-          <div className="border-b border-border-subtle px-4 py-2.5">
-            <div className="flex items-center gap-3 pb-2">
-              <span className="w-24 shrink-0 text-xs text-foreground-muted">Output Mapping</span>
-              <div className="flex min-w-0 flex-1 items-center justify-between gap-2">
-                <span className="truncate font-mono text-xs text-foreground-muted">
-                  expanded
-                </span>
-                <button
-                  type="button"
-                  aria-label="Close"
-                  title="Close"
-                  className="grid size-5 shrink-0 place-items-center rounded text-foreground-subtle transition hover:text-foreground"
-                >
-                  <X size={11} />
-                </button>
+        <NodePropertyPanel
+          panelTitle="Properties"
+          onClose={() => {}}
+          contentInset="0.875rem"
+          className="h-[640px]"
+        >
+          <div className="flex h-full flex-col">
+            {/* Inline-editable identity row */}
+            <div className="flex shrink-0 items-center justify-between gap-4 py-4 [padding-inline:var(--mf-content-inset,0.875rem)]">
+              <div className="flex min-w-0 flex-1 items-center gap-3.5">
+                <div className="grid size-11 shrink-0 place-items-center rounded-xl bg-surface-overlay text-foreground-subtle [&>svg]:size-5">
+                  <GitFork />
+                </div>
+                <div className="flex min-w-0 flex-1 flex-col justify-center">
+                  {editingLabel ? (
+                    <input
+                      ref={labelRef}
+                      value={label}
+                      onChange={(e) => setLabel(e.target.value)}
+                      onBlur={() => setEditingLabel(false)}
+                      onKeyDown={(e) => { if (e.key === 'Enter' || e.key === 'Escape') setEditingLabel(false); }}
+                      className="w-full rounded bg-surface-overlay px-1.5 py-0.5 text-base font-semibold leading-5 tracking-[-0.3px] text-foreground outline-none ring-1 ring-brand"
+                      autoFocus
+                    />
+                  ) : (
+                    <button
+                      type="button"
+                      onClick={() => { setEditingLabel(true); setTimeout(() => labelRef.current?.select(), 0); }}
+                      className="truncate rounded px-1.5 py-0.5 text-left text-base font-semibold leading-5 tracking-[-0.3px] text-foreground transition hover:bg-surface-overlay"
+                    >
+                      {label}
+                    </button>
+                  )}
+                  {editingCategory ? (
+                    <input
+                      ref={categoryRef}
+                      value={category}
+                      onChange={(e) => setCategory(e.target.value)}
+                      onBlur={() => setEditingCategory(false)}
+                      onKeyDown={(e) => { if (e.key === 'Enter' || e.key === 'Escape') setEditingCategory(false); }}
+                      className="w-full rounded bg-surface-overlay px-1.5 py-0.5 text-xs leading-4 text-foreground outline-none ring-1 ring-brand"
+                      autoFocus
+                    />
+                  ) : (
+                    <button
+                      type="button"
+                      onClick={() => { setEditingCategory(true); setTimeout(() => categoryRef.current?.select(), 0); }}
+                      className="truncate rounded px-1.5 py-0.5 text-left text-xs leading-4 text-foreground-muted transition hover:bg-surface-overlay"
+                    >
+                      {category}
+                    </button>
+                  )}
+                </div>
+              </div>
+              <div className="shrink-0">
+                <DebugButton />
               </div>
             </div>
-            <div className="overflow-hidden rounded-xl border border-border-subtle bg-surface-raised">
-              <div className="flex items-center gap-1 border-b border-border-subtle bg-surface px-2.5 py-1.5">
-                <button type="button" aria-label="Undo" title="Undo" className="grid size-6 place-items-center rounded text-foreground-subtle transition hover:text-foreground">
-                  <Undo2 size={12} />
-                </button>
-                <button type="button" aria-label="Redo" title="Redo" className="grid size-6 place-items-center rounded text-foreground-subtle transition hover:text-foreground">
-                  <Redo2 size={12} />
-                </button>
-                <div className="mx-1 h-3 w-px shrink-0 bg-border-subtle" />
-                <button type="button" className="rounded px-2 py-0.5 text-[11px] text-foreground-subtle transition">
-                  expr
-                </button>
-                <button type="button" className="rounded px-2 py-0.5 text-[11px] font-semibold text-foreground transition">
-                  json
-                </button>
-              </div>
-              <pre className="overflow-auto whitespace-pre-wrap bg-surface-raised p-3 text-xs font-mono leading-5 text-foreground">
-                {'{\n  "id": invoice.id,\n  "total": invoice.amount\n}'}
-              </pre>
-            </div>
-          </div>
 
-          {/* Another collapsed row */}
-          <div className="flex items-center gap-3 border-b border-border-subtle px-4 py-2.5">
-            <span className="w-24 shrink-0 text-xs text-foreground-muted">Condition</span>
-            <div className="flex min-w-0 flex-1 items-center gap-2 overflow-hidden rounded-lg border border-border-subtle bg-surface px-2.5 py-1.5">
-              <span className="truncate font-mono text-xs text-foreground-muted">
-                No expression
-              </span>
+          <Tabs defaultValue="parameters" className="flex min-h-0 flex-1 flex-col">
+            <div className="shrink-0 pt-3 [padding-inline:var(--mf-content-inset,0.875rem)]">
+              <TabsList className={TAB_LIST_CLASS}>
+                <TabsTrigger value="parameters" className={TAB_TRIGGER_CLASS}>Parameters</TabsTrigger>
+                <TabsTrigger value="error-handling" className={TAB_TRIGGER_CLASS}>Error handling</TabsTrigger>
+                <TabsTrigger value="advanced" className={TAB_TRIGGER_CLASS}>Advanced</TabsTrigger>
+              </TabsList>
             </div>
-            <button
-              type="button"
-              aria-label="AI assist"
-              title="AI assist"
-              className="grid size-6 shrink-0 place-items-center rounded text-foreground-subtle transition hover:text-foreground"
-            >
-              <Sparkles size={12} />
-            </button>
+
+            <TabsContent value="parameters" className="mt-0 min-h-0 flex-1 overflow-auto">
+              {/* Cases field label row */}
+              <div className="py-2 [padding-inline:var(--mf-content-inset,0.875rem)]">
+                <span className="text-sm font-medium text-foreground-muted">Cases</span>
+              </div>
+
+              {/* Case accordion panels — inset cards with gap */}
+              <div className="flex flex-col gap-2 pb-1 [padding-inline:var(--mf-content-inset,0.875rem)]">
+                {cases.map((c, i) => (
+                  <CasePanel
+                    key={c.id}
+                    caseTitle={c.title}
+                    onTitleChange={(title) => updateCaseTitle(c.id, title)}
+                    onDelete={() => deleteCase(c.id)}
+                    monacoTheme={monacoTheme}
+                    defaultExpanded={i === 0}
+                    defaultValue={i === 0 ? 'input.status === "active"' : ''}
+                  />
+                ))}
+              </div>
+
+              {/* Add case */}
+              <button
+                type="button"
+                onClick={addCase}
+                className="flex items-center gap-1.5 py-3 text-xs text-brand transition hover:text-brand-hover [padding-inline:var(--mf-content-inset,0.875rem)]"
+              >
+                <Plus size={12} />
+                Add case
+              </button>
+
+              {/* Default branch toggle */}
+              <div className="flex items-center gap-2 py-3 [padding-inline:var(--mf-content-inset,0.875rem)]">
+                <Switch size="sm" checked={defaultBranch} onCheckedChange={setDefaultBranch} />
+                <span className="text-xs text-foreground-muted">Default branch</span>
+              </div>
+            </TabsContent>
+
+            <TabsContent value="error-handling" className="mt-0" />
+            <TabsContent value="advanced" className="mt-0" />
+          </Tabs>
           </div>
-        </div>
+        </NodePropertyPanel>
       </PanelFrame>
     </CanvasBackground>
   );
@@ -568,79 +824,239 @@ export const CompactEditor: Story = {
 
 // ============================================================================
 // Input Editor
-// Single-line expression input for simple scalar values or conditions.
+// Inline expression inputs — one per case, no code editor panel.
 // ============================================================================
 
+function InlineCaseRow({
+  caseTitle,
+  onTitleChange,
+  onDelete,
+  monacoTheme,
+  defaultValue = '',
+}: {
+  caseTitle: string;
+  onTitleChange: (title: string) => void;
+  onDelete: () => void;
+  monacoTheme: string;
+  defaultValue?: string;
+}) {
+  const [editingTitle, setEditingTitle] = useState(false);
+  const titleRef = useRef<HTMLInputElement>(null);
+  const [value, setValue] = useState(defaultValue);
+  const [mode, setMode] = useState<'fixed' | 'expression'>('fixed');
+
+  return (
+    <div className="flex flex-col gap-1.5">
+      {/* Case title row with action buttons and delete on hover */}
+      <div className="group flex items-center">
+        {editingTitle ? (
+          <input
+            ref={titleRef}
+            value={caseTitle}
+            onChange={(e) => onTitleChange(e.target.value)}
+            onBlur={() => setEditingTitle(false)}
+            onKeyDown={(e) => { if (e.key === 'Enter' || e.key === 'Escape') setEditingTitle(false); }}
+            className="flex-1 rounded bg-surface-overlay px-1 py-0.5 text-xs font-medium text-foreground outline-none ring-1 ring-brand"
+            autoFocus
+          />
+        ) : (
+          <button
+            type="button"
+            onClick={() => { setEditingTitle(true); setTimeout(() => titleRef.current?.select(), 0); }}
+            className="flex-1 truncate rounded px-1 py-0.5 text-left text-xs font-medium text-foreground-muted transition hover:bg-surface-overlay hover:text-foreground"
+          >
+            {caseTitle}
+          </button>
+        )}
+        <div className="flex shrink-0 items-center gap-0.5">
+          <button
+            type="button"
+            onClick={onDelete}
+            aria-label="Delete case"
+            title="Delete case"
+            className="grid size-7 shrink-0 place-items-center rounded-lg text-foreground-subtle opacity-0 transition hover:bg-surface-overlay hover:text-foreground group-hover:opacity-100"
+          >
+            <X size={12} />
+          </button>
+          <button
+            type="button"
+            aria-label="AI assist"
+            title="AI assist"
+            className="grid size-7 place-items-center rounded-lg text-foreground-subtle transition hover:bg-surface-overlay hover:text-foreground"
+          >
+            <Sparkles size={12} />
+          </button>
+          <button
+            type="button"
+            aria-label="Insert variable"
+            title="Insert variable"
+            className="flex h-7 items-center gap-1 rounded-lg px-2 text-[11px] text-foreground-subtle transition hover:bg-surface-overlay hover:text-foreground"
+          >
+            <span className="font-mono text-[10px]">{'{x}'}</span>
+            <span>Insert</span>
+            <ChevronDown size={9} />
+          </button>
+        </div>
+      </div>
+      {/* Monaco editor — Code2 button overlays on the right to toggle mode */}
+      <div className="relative h-10 overflow-hidden rounded-xl border border-border-subtle">
+        <MonacoEditor
+          height="40px"
+          language={mode === 'expression' ? 'javascript' : 'plaintext'}
+          value={value}
+          onChange={(val) => setValue(val ?? '')}
+          theme={monacoTheme}
+          beforeMount={registerMonacoThemes}
+          options={INLINE_EDITOR_OPTIONS}
+        />
+        {value === '' && (
+          <div className="pointer-events-none absolute left-[6px] top-1/2 -translate-y-1/2 font-mono text-[13px] text-foreground-subtle">
+            {mode === 'fixed' ? 'Enter a value' : 'Enter an expression'}
+          </div>
+        )}
+        <button
+          type="button"
+          onClick={() => setMode((m) => (m === 'fixed' ? 'expression' : 'fixed'))}
+          title={mode === 'fixed' ? 'Switch to Expression' : 'Switch to Fixed'}
+          className={cn(
+            'absolute right-2 top-1/2 z-10 grid size-5 -translate-y-1/2 place-items-center rounded transition-colors',
+            mode === 'expression'
+              ? 'bg-surface-overlay text-foreground'
+              : 'text-foreground-subtle hover:text-foreground'
+          )}
+        >
+          <Code2 size={12} />
+        </button>
+      </div>
+    </div>
+  );
+}
+
 function InputEditorStory() {
+  const monacoTheme = useMonacoTheme();
+  const [cases, setCases] = useState([{ id: 1, title: 'Return value' }]);
+  const nextIdRef = useRef(2);
+  const [defaultBranch, setDefaultBranch] = useState(false);
+  const [label, setLabel] = useState('End');
+  const [category, setCategory] = useState('Control');
+  const [editingLabel, setEditingLabel] = useState(false);
+  const [editingCategory, setEditingCategory] = useState(false);
+  const labelRef = useRef<HTMLInputElement>(null);
+  const categoryRef = useRef<HTMLInputElement>(null);
+
+  const addCase = () => {
+    const id = nextIdRef.current++;
+    setCases((prev) => [...prev, { id, title: `Output variable ${id}` }]);
+  };
+  const deleteCase = (id: number) => setCases((prev) => prev.filter((c) => c.id !== id));
+  const updateCaseTitle = (id: number, title: string) =>
+    setCases((prev) => prev.map((c) => (c.id === id ? { ...c, title } : c)));
+
   return (
     <CanvasBackground>
       <PanelFrame>
-        <PanelTitleBar title="Properties" />
-        <NodeIdentityRow name="Policy check" type="AI Agent" />
-        <div className="flex flex-col gap-3 overflow-auto bg-surface-raised px-6 pb-6 pt-4">
-          {/* Inline expression input */}
-          <div className="flex flex-col gap-1.5">
-            <span className="text-xs font-medium text-foreground-muted">Condition</span>
-            <div className="flex items-center gap-1.5 overflow-hidden rounded-xl border border-border-subtle bg-surface px-3 py-2.5">
-              <span className="shrink-0 font-mono text-[10px] text-foreground-muted">fx</span>
-              <div className="mx-1 h-3 w-px shrink-0 bg-border-subtle" />
-              <span className="min-w-0 flex-1 truncate font-mono text-xs text-foreground">
-                input.status === &quot;active&quot;
-              </span>
-              <button
-                type="button"
-                aria-label="AI assist"
-                title="AI assist"
-                className="ml-1 grid size-6 shrink-0 place-items-center rounded text-foreground-subtle transition hover:text-foreground"
-              >
-                <Sparkles size={12} />
-              </button>
-            </div>
-          </div>
-
-          {/* Inline input — empty/placeholder state */}
-          <div className="flex flex-col gap-1.5">
-            <span className="text-xs font-medium text-foreground-muted">Retry limit</span>
-            <div className="flex items-center gap-1.5 overflow-hidden rounded-xl border border-border-subtle bg-surface px-3 py-2.5">
-              <span className="shrink-0 font-mono text-[10px] text-foreground-muted">fx</span>
-              <div className="mx-1 h-3 w-px shrink-0 bg-border-subtle" />
-              <span className="min-w-0 flex-1 truncate font-mono text-xs text-foreground-subtle">
-                Enter expression
-              </span>
-              <button
-                type="button"
-                aria-label="AI assist"
-                title="AI assist"
-                className="ml-1 grid size-6 shrink-0 place-items-center rounded text-foreground-subtle transition hover:text-foreground"
-              >
-                <Sparkles size={12} />
-              </button>
-            </div>
-          </div>
-
-          {/* Inline input — with variable pill */}
-          <div className="flex flex-col gap-1.5">
-            <span className="text-xs font-medium text-foreground-muted">Timeout (ms)</span>
-            <div className="flex items-center gap-1.5 overflow-hidden rounded-xl border border-border-subtle bg-surface px-3 py-2.5">
-              <span className="shrink-0 font-mono text-[10px] text-foreground-muted">fx</span>
-              <div className="mx-1 h-3 w-px shrink-0 bg-border-subtle" />
-              <div className="flex min-w-0 flex-1 items-center gap-1.5 overflow-hidden">
-                <span className="rounded-md bg-surface-overlay px-1.5 py-0.5 font-mono text-[10px] text-foreground">
-                  config.timeout
-                </span>
-                <span className="font-mono text-xs text-foreground">* 1000</span>
+        <NodePropertyPanel
+          panelTitle="Properties"
+          onClose={() => {}}
+          contentInset="0.875rem"
+          className="h-[640px]"
+        >
+          <div className="flex h-full flex-col">
+            {/* Inline-editable identity row */}
+            <div className="flex shrink-0 items-center justify-between gap-4 py-4 [padding-inline:var(--mf-content-inset,0.875rem)]">
+              <div className="flex min-w-0 flex-1 items-center gap-3.5">
+                <div className="grid size-11 shrink-0 place-items-center rounded-xl bg-surface-overlay text-foreground-subtle [&>svg]:size-5">
+                  <CircleCheck />
+                </div>
+                <div className="flex min-w-0 flex-1 flex-col justify-center">
+                  {editingLabel ? (
+                    <input
+                      ref={labelRef}
+                      value={label}
+                      onChange={(e) => setLabel(e.target.value)}
+                      onBlur={() => setEditingLabel(false)}
+                      onKeyDown={(e) => { if (e.key === 'Enter' || e.key === 'Escape') setEditingLabel(false); }}
+                      className="w-full rounded bg-surface-overlay px-1.5 py-0.5 text-base font-semibold leading-5 tracking-[-0.3px] text-foreground outline-none ring-1 ring-brand"
+                      autoFocus
+                    />
+                  ) : (
+                    <button
+                      type="button"
+                      onClick={() => { setEditingLabel(true); setTimeout(() => labelRef.current?.select(), 0); }}
+                      className="truncate rounded px-1.5 py-0.5 text-left text-base font-semibold leading-5 tracking-[-0.3px] text-foreground transition hover:bg-surface-overlay"
+                    >
+                      {label}
+                    </button>
+                  )}
+                  {editingCategory ? (
+                    <input
+                      ref={categoryRef}
+                      value={category}
+                      onChange={(e) => setCategory(e.target.value)}
+                      onBlur={() => setEditingCategory(false)}
+                      onKeyDown={(e) => { if (e.key === 'Enter' || e.key === 'Escape') setEditingCategory(false); }}
+                      className="w-full rounded bg-surface-overlay px-1.5 py-0.5 text-xs leading-4 text-foreground outline-none ring-1 ring-brand"
+                      autoFocus
+                    />
+                  ) : (
+                    <button
+                      type="button"
+                      onClick={() => { setEditingCategory(true); setTimeout(() => categoryRef.current?.select(), 0); }}
+                      className="truncate rounded px-1.5 py-0.5 text-left text-xs leading-4 text-foreground-muted transition hover:bg-surface-overlay"
+                    >
+                      {category}
+                    </button>
+                  )}
+                </div>
               </div>
-              <button
-                type="button"
-                aria-label="AI assist"
-                title="AI assist"
-                className="ml-1 grid size-6 shrink-0 place-items-center rounded text-foreground-subtle transition hover:text-foreground"
-              >
-                <Sparkles size={12} />
-              </button>
+              <div className="shrink-0">
+                <DebugButton />
+              </div>
             </div>
+
+            {/* Tabs */}
+            <Tabs defaultValue="parameters" className="flex min-h-0 flex-1 flex-col">
+              <div className="shrink-0 pt-3 [padding-inline:var(--mf-content-inset,0.875rem)]">
+                <TabsList className={TAB_LIST_CLASS}>
+                  <TabsTrigger value="parameters" className={TAB_TRIGGER_CLASS}>Parameters</TabsTrigger>
+                  <TabsTrigger value="error-handling" className={TAB_TRIGGER_CLASS}>Error handling</TabsTrigger>
+                  <TabsTrigger value="advanced" className={TAB_TRIGGER_CLASS}>Advanced</TabsTrigger>
+                </TabsList>
+              </div>
+              <TabsContent value="parameters" className="mt-0 min-h-0 flex-1 overflow-auto">
+                <div className="py-2 [padding-inline:var(--mf-content-inset,0.875rem)]">
+                  <span className="text-sm font-medium text-foreground-muted">Output messaging</span>
+                </div>
+                <div className="flex flex-col gap-3 pb-1 [padding-inline:var(--mf-content-inset,0.875rem)]">
+                  {cases.map((c) => (
+                    <InlineCaseRow
+                      key={c.id}
+                      caseTitle={c.title}
+                      onTitleChange={(title) => updateCaseTitle(c.id, title)}
+                      onDelete={() => deleteCase(c.id)}
+                      monacoTheme={monacoTheme}
+                      defaultValue=""
+                    />
+                  ))}
+                </div>
+                <button
+                  type="button"
+                  onClick={addCase}
+                  className="flex items-center gap-1.5 py-3 text-xs text-brand transition hover:text-brand-hover [padding-inline:var(--mf-content-inset,0.875rem)]"
+                >
+                  <Plus size={12} />
+                  Add output variable
+                </button>
+                <div className="flex items-center gap-2 py-3 [padding-inline:var(--mf-content-inset,0.875rem)]">
+                  <Switch size="sm" checked={defaultBranch} onCheckedChange={setDefaultBranch} />
+                  <span className="text-xs text-foreground-muted">Default branch</span>
+                </div>
+              </TabsContent>
+              <TabsContent value="error-handling" className="mt-0" />
+              <TabsContent value="advanced" className="mt-0" />
+            </Tabs>
           </div>
-        </div>
+        </NodePropertyPanel>
       </PanelFrame>
     </CanvasBackground>
   );
@@ -667,9 +1083,9 @@ function InlineEditingStory() {
   return (
     <CanvasBackground>
       <PanelFrame>
-        <PanelTitleBar title="Properties" />
+        <NodePropertyPanel panelTitle="Properties" onClose={() => {}} contentInset="0.875rem">
         {/* Node identity row — inline editable */}
-        <div className="flex shrink-0 items-center gap-3 border-b border-border-subtle bg-surface-raised px-6 py-4">
+        <div className="flex shrink-0 items-center gap-3 py-4 [padding-inline:var(--mf-content-inset,0.875rem)]">
           <div className="flex min-w-0 flex-1 flex-col gap-0.5">
             {editingName ? (
               <input
@@ -728,25 +1144,7 @@ function InlineEditingStory() {
             Run
           </button>
         </div>
-        {/* Fields */}
-        <div className="flex flex-col gap-4 overflow-auto bg-surface-raised px-6 pb-6 pt-4">
-          <div className="flex flex-col gap-1.5">
-            <span className="text-xs font-medium text-foreground-muted">Path</span>
-            <div className="rounded-xl border border-border-subtle bg-surface p-3">
-              <pre className="whitespace-pre-wrap font-mono text-xs leading-5 text-foreground">
-                {'items.filter(x => x.active).map(x => x.value)'}
-              </pre>
-            </div>
-          </div>
-          <div className="flex flex-col gap-1.5">
-            <span className="text-xs font-medium text-foreground-muted">Output Mapping</span>
-            <div className="rounded-xl border border-border-subtle bg-surface p-3">
-              <pre className="whitespace-pre-wrap font-mono text-xs leading-5 text-foreground">
-                {'{\n  "id": invoice.id,\n  "total": invoice.amount\n}'}
-              </pre>
-            </div>
-          </div>
-        </div>
+        </NodePropertyPanel>
       </PanelFrame>
     </CanvasBackground>
   );

--- a/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.stories.tsx
@@ -95,6 +95,7 @@ const THEME_CLASS_MAP: Record<string, string> = {
 };
 
 function getMonacoThemeName(): string {
+  if (typeof document === 'undefined') return 'apollo-future-dark';
   const classes = Array.from(document.body.classList);
   const match = classes.find((c) => c in THEME_CLASS_MAP);
   return match ? THEME_CLASS_MAP[match] : 'apollo-future-dark';

--- a/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import type { FormSchema } from '@uipath/apollo-wind';
-import { Globe, Play } from 'lucide-react';
+import { ChevronDown, Globe, Maximize2, Play, Redo2, Sparkles, Undo2, X } from 'lucide-react';
+import { useRef, useState } from 'react';
 import type { ReactNode } from 'react';
 import { NodePropertyPanel } from './NodePropertyPanel';
 
@@ -17,9 +18,39 @@ const CanvasBackground = ({ children }: { children: ReactNode }) => (
   </div>
 );
 
-const PanelFrame = ({ children }: { children: ReactNode }) => (
-  <div className="w-[380px] overflow-hidden rounded-2xl border border-border-subtle shadow-lg">
+const PanelFrame = ({
+  children,
+  width = 'w-[380px]',
+}: {
+  children: ReactNode;
+  width?: string;
+}) => (
+  <div className={`${width} overflow-hidden rounded-2xl border border-border-subtle shadow-lg`}>
     {children}
+  </div>
+);
+
+const PanelTitleBar = ({ title }: { title: string }) => (
+  <div className="flex h-10 shrink-0 items-center justify-between border-b border-border-subtle bg-surface-raised px-2">
+    <span className="ml-2 text-sm font-semibold text-foreground">{title}</span>
+  </div>
+);
+
+const NodeIdentityRow = ({ name, type }: { name: string; type: string }) => (
+  <div className="flex shrink-0 items-center gap-3 border-b border-border-subtle bg-surface-raised px-6 py-4">
+    <div className="flex min-w-0 flex-1 flex-col">
+      <p className="truncate text-base font-semibold leading-5 tracking-[-0.4px] text-foreground">
+        {name}
+      </p>
+      <p className="mt-0.5 truncate text-sm leading-5 text-foreground-muted">{type}</p>
+    </div>
+    <button
+      type="button"
+      className="flex h-8 items-center gap-2 rounded-lg bg-brand px-4 text-sm font-semibold text-foreground-on-accent transition hover:bg-brand-hover"
+    >
+      <Play size={14} />
+      Run
+    </button>
   </div>
 );
 
@@ -144,7 +175,6 @@ const httpRequestForm: FormSchema = {
   ],
 };
 
-// Manual trigger: no Parameters step, so that tab is omitted automatically.
 const manualTriggerForm: FormSchema = {
   id: 'manual-trigger',
   title: 'Manual trigger',
@@ -233,13 +263,9 @@ export default meta;
 type Story = StoryObj<typeof NodePropertyPanel>;
 
 // ============================================================================
-// Stories
+// Stories — NodePropertyPanel
 // ============================================================================
 
-/**
- * The full panel: title bar, node identity row with a Run action, and a
- * multi-step schema rendered as tabs.
- */
 export const Default: Story = {
   render: () => (
     <PanelFrame>
@@ -258,11 +284,6 @@ export const Default: Story = {
   ),
 };
 
-/**
- * Host-owned title bar: when dockview (or another panel system) renders the
- * draggable "Properties" header, omit `panelTitle` so the panel starts at the
- * node identity row.
- */
 export const EmbeddedNoTitleBar: Story = {
   render: () => (
     <PanelFrame>
@@ -277,10 +298,6 @@ export const EmbeddedNoTitleBar: Story = {
   ),
 };
 
-/**
- * A node with no parameters (Manual trigger). The Parameters tab is omitted
- * automatically because that step has no sections.
- */
 export const NoParametersTab: Story = {
   render: () => (
     <PanelFrame>
@@ -295,4 +312,447 @@ export const NoParametersTab: Story = {
       />
     </PanelFrame>
   ),
+};
+
+// ============================================================================
+// Stories — Expression Field (editor mockups)
+// Full-height panel with all expression editor chrome: toolbar, mode switcher,
+// undo/redo, AI assist, expand, and Insert variable affordance.
+// ============================================================================
+
+function FullEditorStory() {
+  return (
+    <CanvasBackground>
+      <PanelFrame>
+        <PanelTitleBar title="Properties" />
+        <NodeIdentityRow name="Policy check" type="AI Agent" />
+        <div className="flex flex-col gap-6 overflow-auto bg-surface-raised px-6 pb-6 pt-4">
+          {/* Field: Path */}
+          <div className="flex flex-col gap-2">
+            <div className="flex items-center justify-between">
+              <span className="text-xs font-medium text-foreground-muted">Path</span>
+              <div className="flex items-center gap-0.5">
+                <button
+                  type="button"
+                  aria-label="AI assist"
+                  title="AI assist"
+                  className="grid size-7 place-items-center rounded-lg text-foreground-subtle transition hover:bg-surface-overlay hover:text-foreground"
+                >
+                  <Sparkles size={12} />
+                </button>
+                <button
+                  type="button"
+                  aria-label="Insert variable"
+                  title="Insert variable"
+                  className="flex h-7 items-center gap-1 rounded-lg px-2 text-[11px] text-foreground-subtle transition hover:bg-surface-overlay hover:text-foreground"
+                >
+                  <span className="font-mono text-[10px]">{'{x}'}</span>
+                  <span>Insert</span>
+                  <ChevronDown size={9} />
+                </button>
+              </div>
+            </div>
+            <div className="overflow-hidden rounded-xl border border-border-subtle bg-surface-raised">
+              <div className="flex items-center justify-between border-b border-border-subtle bg-surface px-3 py-2">
+                <span className="font-mono text-xs text-foreground-muted">result</span>
+                <button
+                  type="button"
+                  aria-label="Expand editor"
+                  title="Expand editor"
+                  className="grid size-6 place-items-center rounded text-foreground-subtle transition hover:text-foreground"
+                >
+                  <Maximize2 size={11} />
+                </button>
+              </div>
+              <div className="flex items-center gap-1 border-b border-border-subtle bg-surface px-2.5 py-1.5">
+                <button type="button" aria-label="Undo" title="Undo" className="grid size-6 place-items-center rounded text-foreground-subtle transition hover:text-foreground">
+                  <Undo2 size={12} />
+                </button>
+                <button type="button" aria-label="Redo" title="Redo" className="grid size-6 place-items-center rounded text-foreground-subtle transition hover:text-foreground">
+                  <Redo2 size={12} />
+                </button>
+                <div className="mx-1 h-3 w-px shrink-0 bg-border-subtle" />
+                <button type="button" className="rounded px-2 py-0.5 text-[11px] font-semibold text-foreground transition">
+                  expr
+                </button>
+                <button type="button" className="rounded px-2 py-0.5 text-[11px] text-foreground-subtle transition">
+                  json
+                </button>
+              </div>
+              <pre className="overflow-auto whitespace-pre-wrap bg-surface-raised p-3 text-xs font-mono leading-5 text-foreground">
+                {'items\n  .filter(x => x.active)\n  .map(x => x.value)'}
+              </pre>
+              <div className="flex items-center justify-between border-t border-border-subtle bg-surface px-3 py-1.5">
+                <div className="flex items-center gap-1.5">
+                  <span className="size-1.5 shrink-0 rounded-full bg-green-500" />
+                  <span className="text-[10px] text-foreground-subtle">No errors</span>
+                </div>
+                <span className="text-[10px] text-foreground-subtle">Ln 1, Col 1</span>
+              </div>
+            </div>
+            <p className="text-[11px] leading-4 text-foreground-subtle">
+              Transform expression run against the node input data.
+            </p>
+          </div>
+
+          {/* Field: Output Mapping */}
+          <div className="flex flex-col gap-2">
+            <div className="flex items-center justify-between">
+              <span className="text-xs font-medium text-foreground-muted">Output Mapping</span>
+              <div className="flex items-center gap-0.5">
+                <button
+                  type="button"
+                  aria-label="AI assist"
+                  title="AI assist"
+                  className="grid size-7 place-items-center rounded-lg text-foreground-subtle transition hover:bg-surface-overlay hover:text-foreground"
+                >
+                  <Sparkles size={12} />
+                </button>
+                <button
+                  type="button"
+                  aria-label="Insert variable"
+                  title="Insert variable"
+                  className="flex h-7 items-center gap-1 rounded-lg px-2 text-[11px] text-foreground-subtle transition hover:bg-surface-overlay hover:text-foreground"
+                >
+                  <span className="font-mono text-[10px]">{'{x}'}</span>
+                  <span>Insert</span>
+                  <ChevronDown size={9} />
+                </button>
+              </div>
+            </div>
+            <div className="overflow-hidden rounded-xl border border-border-subtle bg-surface-raised">
+              <div className="flex items-center justify-between border-b border-border-subtle bg-surface px-3 py-2">
+                <span className="font-mono text-xs text-foreground-muted">object</span>
+                <button type="button" aria-label="Expand editor" title="Expand editor" className="grid size-6 place-items-center rounded text-foreground-subtle transition hover:text-foreground">
+                  <Maximize2 size={11} />
+                </button>
+              </div>
+              <div className="flex items-center gap-1 border-b border-border-subtle bg-surface px-2.5 py-1.5">
+                <button type="button" aria-label="Undo" title="Undo" className="grid size-6 place-items-center rounded text-foreground-subtle transition hover:text-foreground">
+                  <Undo2 size={12} />
+                </button>
+                <button type="button" aria-label="Redo" title="Redo" className="grid size-6 place-items-center rounded text-foreground-subtle transition hover:text-foreground">
+                  <Redo2 size={12} />
+                </button>
+                <div className="mx-1 h-3 w-px shrink-0 bg-border-subtle" />
+                <button type="button" className="rounded px-2 py-0.5 text-[11px] text-foreground-subtle transition">
+                  expr
+                </button>
+                <button type="button" className="rounded px-2 py-0.5 text-[11px] font-semibold text-foreground transition">
+                  json
+                </button>
+              </div>
+              <pre className="overflow-auto whitespace-pre-wrap bg-surface-raised p-3 text-xs font-mono leading-5 text-foreground">
+                {'{\n  "id": invoice.id,\n  "total": invoice.amount,\n  "approved": true\n}'}
+              </pre>
+              <div className="flex items-center justify-between border-t border-border-subtle bg-surface px-3 py-1.5">
+                <div className="flex items-center gap-1.5">
+                  <span className="size-1.5 shrink-0 rounded-full bg-green-500" />
+                  <span className="text-[10px] text-foreground-subtle">No errors</span>
+                </div>
+                <span className="text-[10px] text-foreground-subtle">Ln 1, Col 1</span>
+              </div>
+            </div>
+            <p className="text-[11px] leading-4 text-foreground-subtle">
+              Maps the node output to the expected schema.
+            </p>
+          </div>
+        </div>
+      </PanelFrame>
+    </CanvasBackground>
+  );
+}
+
+export const FullEditor: Story = {
+  name: 'Editor Full',
+  render: () => <FullEditorStory />,
+};
+
+// ============================================================================
+// Compact Editor
+// Collapsed by default. Shows label + value preview; expands inline on click.
+// ============================================================================
+
+function CompactEditorStory() {
+  return (
+    <CanvasBackground>
+      <PanelFrame>
+        <PanelTitleBar title="Properties" />
+        <NodeIdentityRow name="Policy check" type="AI Agent" />
+        <div className="flex flex-col overflow-auto bg-surface-raised pb-4 pt-2">
+          {/* Compact field row — collapsed */}
+          <div className="flex items-center gap-3 border-b border-border-subtle px-4 py-2.5">
+            <span className="w-24 shrink-0 text-xs text-foreground-muted">Path</span>
+            <div className="flex min-w-0 flex-1 items-center gap-2 overflow-hidden rounded-lg border border-border-subtle bg-surface px-2.5 py-1.5">
+              <span className="truncate font-mono text-xs text-foreground">
+                items.filter(x =&gt; x.active)
+              </span>
+            </div>
+            <button
+              type="button"
+              aria-label="AI assist"
+              title="AI assist"
+              className="grid size-6 shrink-0 place-items-center rounded text-foreground-subtle transition hover:text-foreground"
+            >
+              <Sparkles size={12} />
+            </button>
+          </div>
+
+          {/* Compact field row — expanded inline */}
+          <div className="border-b border-border-subtle px-4 py-2.5">
+            <div className="flex items-center gap-3 pb-2">
+              <span className="w-24 shrink-0 text-xs text-foreground-muted">Output Mapping</span>
+              <div className="flex min-w-0 flex-1 items-center justify-between gap-2">
+                <span className="truncate font-mono text-xs text-foreground-muted">
+                  expanded
+                </span>
+                <button
+                  type="button"
+                  aria-label="Close"
+                  title="Close"
+                  className="grid size-5 shrink-0 place-items-center rounded text-foreground-subtle transition hover:text-foreground"
+                >
+                  <X size={11} />
+                </button>
+              </div>
+            </div>
+            <div className="overflow-hidden rounded-xl border border-border-subtle bg-surface-raised">
+              <div className="flex items-center gap-1 border-b border-border-subtle bg-surface px-2.5 py-1.5">
+                <button type="button" aria-label="Undo" title="Undo" className="grid size-6 place-items-center rounded text-foreground-subtle transition hover:text-foreground">
+                  <Undo2 size={12} />
+                </button>
+                <button type="button" aria-label="Redo" title="Redo" className="grid size-6 place-items-center rounded text-foreground-subtle transition hover:text-foreground">
+                  <Redo2 size={12} />
+                </button>
+                <div className="mx-1 h-3 w-px shrink-0 bg-border-subtle" />
+                <button type="button" className="rounded px-2 py-0.5 text-[11px] text-foreground-subtle transition">
+                  expr
+                </button>
+                <button type="button" className="rounded px-2 py-0.5 text-[11px] font-semibold text-foreground transition">
+                  json
+                </button>
+              </div>
+              <pre className="overflow-auto whitespace-pre-wrap bg-surface-raised p-3 text-xs font-mono leading-5 text-foreground">
+                {'{\n  "id": invoice.id,\n  "total": invoice.amount\n}'}
+              </pre>
+            </div>
+          </div>
+
+          {/* Another collapsed row */}
+          <div className="flex items-center gap-3 border-b border-border-subtle px-4 py-2.5">
+            <span className="w-24 shrink-0 text-xs text-foreground-muted">Condition</span>
+            <div className="flex min-w-0 flex-1 items-center gap-2 overflow-hidden rounded-lg border border-border-subtle bg-surface px-2.5 py-1.5">
+              <span className="truncate font-mono text-xs text-foreground-muted">
+                No expression
+              </span>
+            </div>
+            <button
+              type="button"
+              aria-label="AI assist"
+              title="AI assist"
+              className="grid size-6 shrink-0 place-items-center rounded text-foreground-subtle transition hover:text-foreground"
+            >
+              <Sparkles size={12} />
+            </button>
+          </div>
+        </div>
+      </PanelFrame>
+    </CanvasBackground>
+  );
+}
+
+export const CompactEditor: Story = {
+  name: 'Editor Compact',
+  render: () => <CompactEditorStory />,
+};
+
+// ============================================================================
+// Input Editor
+// Single-line expression input for simple scalar values or conditions.
+// ============================================================================
+
+function InputEditorStory() {
+  return (
+    <CanvasBackground>
+      <PanelFrame>
+        <PanelTitleBar title="Properties" />
+        <NodeIdentityRow name="Policy check" type="AI Agent" />
+        <div className="flex flex-col gap-3 overflow-auto bg-surface-raised px-6 pb-6 pt-4">
+          {/* Inline expression input */}
+          <div className="flex flex-col gap-1.5">
+            <span className="text-xs font-medium text-foreground-muted">Condition</span>
+            <div className="flex items-center gap-1.5 overflow-hidden rounded-xl border border-border-subtle bg-surface px-3 py-2.5">
+              <span className="shrink-0 font-mono text-[10px] text-foreground-muted">fx</span>
+              <div className="mx-1 h-3 w-px shrink-0 bg-border-subtle" />
+              <span className="min-w-0 flex-1 truncate font-mono text-xs text-foreground">
+                input.status === &quot;active&quot;
+              </span>
+              <button
+                type="button"
+                aria-label="AI assist"
+                title="AI assist"
+                className="ml-1 grid size-6 shrink-0 place-items-center rounded text-foreground-subtle transition hover:text-foreground"
+              >
+                <Sparkles size={12} />
+              </button>
+            </div>
+          </div>
+
+          {/* Inline input — empty/placeholder state */}
+          <div className="flex flex-col gap-1.5">
+            <span className="text-xs font-medium text-foreground-muted">Retry limit</span>
+            <div className="flex items-center gap-1.5 overflow-hidden rounded-xl border border-border-subtle bg-surface px-3 py-2.5">
+              <span className="shrink-0 font-mono text-[10px] text-foreground-muted">fx</span>
+              <div className="mx-1 h-3 w-px shrink-0 bg-border-subtle" />
+              <span className="min-w-0 flex-1 truncate font-mono text-xs text-foreground-subtle">
+                Enter expression
+              </span>
+              <button
+                type="button"
+                aria-label="AI assist"
+                title="AI assist"
+                className="ml-1 grid size-6 shrink-0 place-items-center rounded text-foreground-subtle transition hover:text-foreground"
+              >
+                <Sparkles size={12} />
+              </button>
+            </div>
+          </div>
+
+          {/* Inline input — with variable pill */}
+          <div className="flex flex-col gap-1.5">
+            <span className="text-xs font-medium text-foreground-muted">Timeout (ms)</span>
+            <div className="flex items-center gap-1.5 overflow-hidden rounded-xl border border-border-subtle bg-surface px-3 py-2.5">
+              <span className="shrink-0 font-mono text-[10px] text-foreground-muted">fx</span>
+              <div className="mx-1 h-3 w-px shrink-0 bg-border-subtle" />
+              <div className="flex min-w-0 flex-1 items-center gap-1.5 overflow-hidden">
+                <span className="rounded-md bg-surface-overlay px-1.5 py-0.5 font-mono text-[10px] text-foreground">
+                  config.timeout
+                </span>
+                <span className="font-mono text-xs text-foreground">* 1000</span>
+              </div>
+              <button
+                type="button"
+                aria-label="AI assist"
+                title="AI assist"
+                className="ml-1 grid size-6 shrink-0 place-items-center rounded text-foreground-subtle transition hover:text-foreground"
+              >
+                <Sparkles size={12} />
+              </button>
+            </div>
+          </div>
+        </div>
+      </PanelFrame>
+    </CanvasBackground>
+  );
+}
+
+export const InputEditor: Story = {
+  name: 'Editor Inline',
+  render: () => <InputEditorStory />,
+};
+
+// ============================================================================
+// Inline Editing
+// Title and description in the node identity row are directly editable.
+// ============================================================================
+
+function InlineEditingStory() {
+  const [name, setName] = useState('Policy check');
+  const [type, setType] = useState('AI Agent');
+  const [editingName, setEditingName] = useState(false);
+  const [editingType, setEditingType] = useState(false);
+  const nameRef = useRef<HTMLInputElement>(null);
+  const typeRef = useRef<HTMLInputElement>(null);
+
+  return (
+    <CanvasBackground>
+      <PanelFrame>
+        <PanelTitleBar title="Properties" />
+        {/* Node identity row — inline editable */}
+        <div className="flex shrink-0 items-center gap-3 border-b border-border-subtle bg-surface-raised px-6 py-4">
+          <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+            {editingName ? (
+              <input
+                ref={nameRef}
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                onBlur={() => setEditingName(false)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' || e.key === 'Escape') setEditingName(false);
+                }}
+                className="w-full rounded bg-surface-overlay px-1.5 py-0.5 text-base font-semibold leading-5 tracking-[-0.4px] text-foreground outline-none ring-1 ring-brand"
+                autoFocus
+              />
+            ) : (
+              <button
+                type="button"
+                onClick={() => {
+                  setEditingName(true);
+                  setTimeout(() => nameRef.current?.select(), 0);
+                }}
+                className="truncate rounded px-1.5 py-0.5 text-left text-base font-semibold leading-5 tracking-[-0.4px] text-foreground transition hover:bg-surface-overlay"
+              >
+                {name}
+              </button>
+            )}
+            {editingType ? (
+              <input
+                ref={typeRef}
+                value={type}
+                onChange={(e) => setType(e.target.value)}
+                onBlur={() => setEditingType(false)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' || e.key === 'Escape') setEditingType(false);
+                }}
+                className="w-full rounded bg-surface-overlay px-1.5 py-0.5 text-sm leading-5 text-foreground outline-none ring-1 ring-brand"
+                autoFocus
+              />
+            ) : (
+              <button
+                type="button"
+                onClick={() => {
+                  setEditingType(true);
+                  setTimeout(() => typeRef.current?.select(), 0);
+                }}
+                className="truncate rounded px-1.5 py-0.5 text-left text-sm leading-5 text-foreground-muted transition hover:bg-surface-overlay"
+              >
+                {type}
+              </button>
+            )}
+          </div>
+          <button
+            type="button"
+            className="flex h-8 items-center gap-2 rounded-lg bg-brand px-4 text-sm font-semibold text-foreground-on-accent transition hover:bg-brand-hover"
+          >
+            <Play size={14} />
+            Run
+          </button>
+        </div>
+        {/* Fields */}
+        <div className="flex flex-col gap-4 overflow-auto bg-surface-raised px-6 pb-6 pt-4">
+          <div className="flex flex-col gap-1.5">
+            <span className="text-xs font-medium text-foreground-muted">Path</span>
+            <div className="rounded-xl border border-border-subtle bg-surface p-3">
+              <pre className="whitespace-pre-wrap font-mono text-xs leading-5 text-foreground">
+                {'items.filter(x => x.active).map(x => x.value)'}
+              </pre>
+            </div>
+          </div>
+          <div className="flex flex-col gap-1.5">
+            <span className="text-xs font-medium text-foreground-muted">Output Mapping</span>
+            <div className="rounded-xl border border-border-subtle bg-surface p-3">
+              <pre className="whitespace-pre-wrap font-mono text-xs leading-5 text-foreground">
+                {'{\n  "id": invoice.id,\n  "total": invoice.amount\n}'}
+              </pre>
+            </div>
+          </div>
+        </div>
+      </PanelFrame>
+    </CanvasBackground>
+  );
+}
+
+export const InlineEditing: Story = {
+  name: 'Inline Editing',
+  render: () => <InlineEditingStory />,
 };

--- a/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.stories.tsx
@@ -22,8 +22,8 @@ import {
   Sparkles,
   X,
 } from 'lucide-react';
-import { useEffect, useRef, useState } from 'react';
 import type { ReactNode } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { NodePropertyPanel } from './NodePropertyPanel';
 
 // ============================================================================
@@ -384,161 +384,159 @@ function FullEditorStory() {
   const categoryRef = useRef<HTMLInputElement>(null);
 
   return (
-    <CanvasBackground>
-      <PanelFrame>
-        <NodePropertyPanel
-          panelTitle="Properties"
-          onClose={() => {}}
-          contentInset="0.875rem"
-          className="h-[560px]"
-        >
-          <div className="flex h-full flex-col">
-            {/* Inline-editable identity row */}
-            <div className="flex shrink-0 items-center justify-between gap-4 py-4 [padding-inline:var(--mf-content-inset,0.875rem)]">
-              <div className="flex min-w-0 flex-1 items-center gap-3.5">
-                <div className="grid size-11 shrink-0 place-items-center rounded-xl bg-surface-overlay text-foreground-subtle [&>svg]:size-5">
-                  <Code2 />
-                </div>
-                <div className="flex min-w-0 flex-1 flex-col justify-center">
-                  {editingLabel ? (
-                    <input
-                      ref={labelRef}
-                      value={label}
-                      onChange={(e) => setLabel(e.target.value)}
-                      onBlur={() => setEditingLabel(false)}
-                      onKeyDown={(e) => {
-                        if (e.key === 'Enter' || e.key === 'Escape') setEditingLabel(false);
-                      }}
-                      className="w-full rounded bg-surface-overlay px-1.5 py-0.5 text-base font-semibold leading-5 tracking-[-0.3px] text-foreground outline-none ring-1 ring-brand"
-                      autoFocus
-                    />
-                  ) : (
-                    <button
-                      type="button"
-                      onClick={() => {
-                        setEditingLabel(true);
-                        setTimeout(() => labelRef.current?.select(), 0);
-                      }}
-                      className="truncate rounded px-1.5 py-0.5 text-left text-base font-semibold leading-5 tracking-[-0.3px] text-foreground transition hover:bg-surface-overlay"
-                    >
-                      {label}
-                    </button>
-                  )}
-                  {editingCategory ? (
-                    <input
-                      ref={categoryRef}
-                      value={category}
-                      onChange={(e) => setCategory(e.target.value)}
-                      onBlur={() => setEditingCategory(false)}
-                      onKeyDown={(e) => {
-                        if (e.key === 'Enter' || e.key === 'Escape') setEditingCategory(false);
-                      }}
-                      className="w-full rounded bg-surface-overlay px-1.5 py-0.5 text-xs leading-4 text-foreground outline-none ring-1 ring-brand"
-                      autoFocus
-                    />
-                  ) : (
-                    <button
-                      type="button"
-                      onClick={() => {
-                        setEditingCategory(true);
-                        setTimeout(() => categoryRef.current?.select(), 0);
-                      }}
-                      className="truncate rounded px-1.5 py-0.5 text-left text-xs leading-4 text-foreground-muted transition hover:bg-surface-overlay"
-                    >
-                      {category}
-                    </button>
-                  )}
-                </div>
+    <PanelFrame>
+      <NodePropertyPanel
+        panelTitle="Properties"
+        onClose={() => {}}
+        contentInset="0.875rem"
+        className="h-[560px]"
+      >
+        <div className="flex h-full flex-col">
+          {/* Inline-editable identity row */}
+          <div className="flex shrink-0 items-center justify-between gap-4 py-4 [padding-inline:var(--mf-content-inset,0.875rem)]">
+            <div className="flex min-w-0 flex-1 items-center gap-3.5">
+              <div className="grid size-11 shrink-0 place-items-center rounded-xl bg-surface-overlay text-foreground-subtle [&>svg]:size-5">
+                <Code2 />
               </div>
-              <div className="shrink-0">
-                <DebugButton />
+              <div className="flex min-w-0 flex-1 flex-col justify-center">
+                {editingLabel ? (
+                  <input
+                    ref={labelRef}
+                    value={label}
+                    onChange={(e) => setLabel(e.target.value)}
+                    onBlur={() => setEditingLabel(false)}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter' || e.key === 'Escape') setEditingLabel(false);
+                    }}
+                    className="w-full rounded bg-surface-overlay px-1.5 py-0.5 text-base font-semibold leading-5 tracking-[-0.3px] text-foreground outline-none ring-1 ring-brand"
+                    autoFocus
+                  />
+                ) : (
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setEditingLabel(true);
+                      setTimeout(() => labelRef.current?.select(), 0);
+                    }}
+                    className="truncate rounded px-1.5 py-0.5 text-left text-base font-semibold leading-5 tracking-[-0.3px] text-foreground transition hover:bg-surface-overlay"
+                  >
+                    {label}
+                  </button>
+                )}
+                {editingCategory ? (
+                  <input
+                    ref={categoryRef}
+                    value={category}
+                    onChange={(e) => setCategory(e.target.value)}
+                    onBlur={() => setEditingCategory(false)}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter' || e.key === 'Escape') setEditingCategory(false);
+                    }}
+                    className="w-full rounded bg-surface-overlay px-1.5 py-0.5 text-xs leading-4 text-foreground outline-none ring-1 ring-brand"
+                    autoFocus
+                  />
+                ) : (
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setEditingCategory(true);
+                      setTimeout(() => categoryRef.current?.select(), 0);
+                    }}
+                    className="truncate rounded px-1.5 py-0.5 text-left text-xs leading-4 text-foreground-muted transition hover:bg-surface-overlay"
+                  >
+                    {category}
+                  </button>
+                )}
               </div>
             </div>
-
-            {/* Tabs + editor */}
-            <Tabs defaultValue="parameters" className="flex min-h-0 flex-1 flex-col">
-              <div className="shrink-0 pt-3 [padding-inline:var(--mf-content-inset,0.875rem)]">
-                <TabsList className={TAB_LIST_CLASS}>
-                  <TabsTrigger value="parameters" className={TAB_TRIGGER_CLASS}>
-                    Parameters
-                  </TabsTrigger>
-                  <TabsTrigger value="error-handling" className={TAB_TRIGGER_CLASS}>
-                    Error handling
-                  </TabsTrigger>
-                  <TabsTrigger value="advanced" className={TAB_TRIGGER_CLASS}>
-                    Advanced
-                  </TabsTrigger>
-                </TabsList>
-              </div>
-              <TabsContent value="parameters" className="mt-0 flex min-h-0 flex-1 flex-col">
-                <div className="flex shrink-0 items-center justify-between py-2 [padding-inline:var(--mf-content-inset,0.875rem)]">
-                  <span className="text-xs font-medium text-foreground-muted">Path</span>
-                  <div className="flex items-center gap-0.5">
-                    <button
-                      type="button"
-                      aria-label="AI assist"
-                      title="AI assist"
-                      className="grid size-7 place-items-center rounded-lg text-foreground-subtle transition hover:bg-surface-overlay hover:text-foreground"
-                    >
-                      <Sparkles size={12} />
-                    </button>
-                    <button
-                      type="button"
-                      aria-label="Insert variable"
-                      title="Insert variable"
-                      className="flex h-7 items-center gap-1 rounded-lg px-2 text-[11px] text-foreground-subtle transition hover:bg-surface-overlay hover:text-foreground"
-                    >
-                      <span className="font-mono text-[10px]">{'{x}'}</span>
-                      <span>Insert</span>
-                      <ChevronDown size={9} />
-                    </button>
-                  </div>
-                </div>
-                <div className="flex min-h-0 flex-1 flex-col pb-4 [padding-inline:var(--mf-content-inset,0.875rem)]">
-                  <div className="min-h-0 flex-1 overflow-hidden rounded-xl border border-border-subtle">
-                    <MonacoEditor
-                      height="100%"
-                      defaultLanguage="javascript"
-                      defaultValue={
-                        '// Script\nconst result = items\n  .filter(x => x.active)\n  .map(x => ({\n    id: x.id,\n    value: x.value,\n  }));\n\nreturn result;'
-                      }
-                      theme={monacoTheme}
-                      beforeMount={registerMonacoThemes}
-                      options={{
-                        fontSize: 13,
-                        lineHeight: 20,
-                        minimap: { enabled: false },
-                        scrollBeyondLastLine: false,
-                        wordWrap: 'on',
-                        fontFamily:
-                          'ui-monospace, SFMono-Regular, "SF Mono", Consolas, "Liberation Mono", Menlo, monospace',
-                        padding: { top: 6, bottom: 16 },
-                        lineNumbers: 'on',
-                        lineNumbersMinChars: 2,
-                        lineDecorationsWidth: 4,
-                        glyphMargin: false,
-                        folding: false,
-                        renderLineHighlight: 'line',
-                        hideCursorInOverviewRuler: true,
-                        overviewRulerBorder: false,
-                        scrollbar: {
-                          vertical: 'auto',
-                          horizontal: 'hidden',
-                          alwaysConsumeMouseWheel: false,
-                        },
-                        automaticLayout: true,
-                      }}
-                    />
-                  </div>
-                </div>
-              </TabsContent>
-              <TabsContent value="error-handling" className="mt-0" />
-              <TabsContent value="advanced" className="mt-0" />
-            </Tabs>
+            <div className="shrink-0">
+              <DebugButton />
+            </div>
           </div>
-        </NodePropertyPanel>
-      </PanelFrame>
-    </CanvasBackground>
+
+          {/* Tabs + editor */}
+          <Tabs defaultValue="parameters" className="flex min-h-0 flex-1 flex-col">
+            <div className="shrink-0 pt-3 [padding-inline:var(--mf-content-inset,0.875rem)]">
+              <TabsList className={TAB_LIST_CLASS}>
+                <TabsTrigger value="parameters" className={TAB_TRIGGER_CLASS}>
+                  Parameters
+                </TabsTrigger>
+                <TabsTrigger value="error-handling" className={TAB_TRIGGER_CLASS}>
+                  Error handling
+                </TabsTrigger>
+                <TabsTrigger value="advanced" className={TAB_TRIGGER_CLASS}>
+                  Advanced
+                </TabsTrigger>
+              </TabsList>
+            </div>
+            <TabsContent value="parameters" className="mt-0 flex min-h-0 flex-1 flex-col">
+              <div className="flex shrink-0 items-center justify-between py-2 [padding-inline:var(--mf-content-inset,0.875rem)]">
+                <span className="text-xs font-medium text-foreground-muted">Path</span>
+                <div className="flex items-center gap-0.5">
+                  <button
+                    type="button"
+                    aria-label="AI assist"
+                    title="AI assist"
+                    className="grid size-7 place-items-center rounded-lg text-foreground-subtle transition hover:bg-surface-overlay hover:text-foreground"
+                  >
+                    <Sparkles size={12} />
+                  </button>
+                  <button
+                    type="button"
+                    aria-label="Insert variable"
+                    title="Insert variable"
+                    className="flex h-7 items-center gap-1 rounded-lg px-2 text-[11px] text-foreground-subtle transition hover:bg-surface-overlay hover:text-foreground"
+                  >
+                    <span className="font-mono text-[10px]">{'{x}'}</span>
+                    <span>Insert</span>
+                    <ChevronDown size={9} />
+                  </button>
+                </div>
+              </div>
+              <div className="flex min-h-0 flex-1 flex-col pb-4 [padding-inline:var(--mf-content-inset,0.875rem)]">
+                <div className="min-h-0 flex-1 overflow-hidden rounded-xl border border-border-subtle">
+                  <MonacoEditor
+                    height="100%"
+                    defaultLanguage="javascript"
+                    defaultValue={
+                      '// Script\nconst result = items\n  .filter(x => x.active)\n  .map(x => ({\n    id: x.id,\n    value: x.value,\n  }));\n\nreturn result;'
+                    }
+                    theme={monacoTheme}
+                    beforeMount={registerMonacoThemes}
+                    options={{
+                      fontSize: 13,
+                      lineHeight: 20,
+                      minimap: { enabled: false },
+                      scrollBeyondLastLine: false,
+                      wordWrap: 'on',
+                      fontFamily:
+                        'ui-monospace, SFMono-Regular, "SF Mono", Consolas, "Liberation Mono", Menlo, monospace',
+                      padding: { top: 6, bottom: 16 },
+                      lineNumbers: 'on',
+                      lineNumbersMinChars: 2,
+                      lineDecorationsWidth: 4,
+                      glyphMargin: false,
+                      folding: false,
+                      renderLineHighlight: 'line',
+                      hideCursorInOverviewRuler: true,
+                      overviewRulerBorder: false,
+                      scrollbar: {
+                        vertical: 'auto',
+                        horizontal: 'hidden',
+                        alwaysConsumeMouseWheel: false,
+                      },
+                      automaticLayout: true,
+                    }}
+                  />
+                </div>
+              </div>
+            </TabsContent>
+            <TabsContent value="error-handling" className="mt-0" />
+            <TabsContent value="advanced" className="mt-0" />
+          </Tabs>
+        </div>
+      </NodePropertyPanel>
+    </PanelFrame>
   );
 }
 
@@ -623,6 +621,7 @@ function CasePanel({
         <button
           type="button"
           onClick={() => setExpanded((v) => !v)}
+          aria-label={expanded ? 'Collapse case' : 'Expand case'}
           className="grid size-5 shrink-0 place-items-center rounded text-foreground-subtle transition hover:text-foreground"
         >
           <ChevronDown
@@ -733,137 +732,135 @@ function CompactEditorStory() {
   const categoryRef = useRef<HTMLInputElement>(null);
 
   return (
-    <CanvasBackground>
-      <PanelFrame>
-        <NodePropertyPanel
-          panelTitle="Properties"
-          onClose={() => {}}
-          contentInset="0.875rem"
-          className="h-[640px]"
-        >
-          <div className="flex h-full flex-col">
-            {/* Inline-editable identity row */}
-            <div className="flex shrink-0 items-center justify-between gap-4 py-4 [padding-inline:var(--mf-content-inset,0.875rem)]">
-              <div className="flex min-w-0 flex-1 items-center gap-3.5">
-                <div className="grid size-11 shrink-0 place-items-center rounded-xl bg-surface-overlay text-foreground-subtle [&>svg]:size-5">
-                  <GitFork />
-                </div>
-                <div className="flex min-w-0 flex-1 flex-col justify-center">
-                  {editingLabel ? (
-                    <input
-                      ref={labelRef}
-                      value={label}
-                      onChange={(e) => setLabel(e.target.value)}
-                      onBlur={() => setEditingLabel(false)}
-                      onKeyDown={(e) => {
-                        if (e.key === 'Enter' || e.key === 'Escape') setEditingLabel(false);
-                      }}
-                      className="w-full rounded bg-surface-overlay px-1.5 py-0.5 text-base font-semibold leading-5 tracking-[-0.3px] text-foreground outline-none ring-1 ring-brand"
-                      autoFocus
-                    />
-                  ) : (
-                    <button
-                      type="button"
-                      onClick={() => {
-                        setEditingLabel(true);
-                        setTimeout(() => labelRef.current?.select(), 0);
-                      }}
-                      className="truncate rounded px-1.5 py-0.5 text-left text-base font-semibold leading-5 tracking-[-0.3px] text-foreground transition hover:bg-surface-overlay"
-                    >
-                      {label}
-                    </button>
-                  )}
-                  {editingCategory ? (
-                    <input
-                      ref={categoryRef}
-                      value={category}
-                      onChange={(e) => setCategory(e.target.value)}
-                      onBlur={() => setEditingCategory(false)}
-                      onKeyDown={(e) => {
-                        if (e.key === 'Enter' || e.key === 'Escape') setEditingCategory(false);
-                      }}
-                      className="w-full rounded bg-surface-overlay px-1.5 py-0.5 text-xs leading-4 text-foreground outline-none ring-1 ring-brand"
-                      autoFocus
-                    />
-                  ) : (
-                    <button
-                      type="button"
-                      onClick={() => {
-                        setEditingCategory(true);
-                        setTimeout(() => categoryRef.current?.select(), 0);
-                      }}
-                      className="truncate rounded px-1.5 py-0.5 text-left text-xs leading-4 text-foreground-muted transition hover:bg-surface-overlay"
-                    >
-                      {category}
-                    </button>
-                  )}
-                </div>
+    <PanelFrame>
+      <NodePropertyPanel
+        panelTitle="Properties"
+        onClose={() => {}}
+        contentInset="0.875rem"
+        className="h-[640px]"
+      >
+        <div className="flex h-full flex-col">
+          {/* Inline-editable identity row */}
+          <div className="flex shrink-0 items-center justify-between gap-4 py-4 [padding-inline:var(--mf-content-inset,0.875rem)]">
+            <div className="flex min-w-0 flex-1 items-center gap-3.5">
+              <div className="grid size-11 shrink-0 place-items-center rounded-xl bg-surface-overlay text-foreground-subtle [&>svg]:size-5">
+                <GitFork />
               </div>
-              <div className="shrink-0">
-                <DebugButton />
+              <div className="flex min-w-0 flex-1 flex-col justify-center">
+                {editingLabel ? (
+                  <input
+                    ref={labelRef}
+                    value={label}
+                    onChange={(e) => setLabel(e.target.value)}
+                    onBlur={() => setEditingLabel(false)}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter' || e.key === 'Escape') setEditingLabel(false);
+                    }}
+                    className="w-full rounded bg-surface-overlay px-1.5 py-0.5 text-base font-semibold leading-5 tracking-[-0.3px] text-foreground outline-none ring-1 ring-brand"
+                    autoFocus
+                  />
+                ) : (
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setEditingLabel(true);
+                      setTimeout(() => labelRef.current?.select(), 0);
+                    }}
+                    className="truncate rounded px-1.5 py-0.5 text-left text-base font-semibold leading-5 tracking-[-0.3px] text-foreground transition hover:bg-surface-overlay"
+                  >
+                    {label}
+                  </button>
+                )}
+                {editingCategory ? (
+                  <input
+                    ref={categoryRef}
+                    value={category}
+                    onChange={(e) => setCategory(e.target.value)}
+                    onBlur={() => setEditingCategory(false)}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter' || e.key === 'Escape') setEditingCategory(false);
+                    }}
+                    className="w-full rounded bg-surface-overlay px-1.5 py-0.5 text-xs leading-4 text-foreground outline-none ring-1 ring-brand"
+                    autoFocus
+                  />
+                ) : (
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setEditingCategory(true);
+                      setTimeout(() => categoryRef.current?.select(), 0);
+                    }}
+                    className="truncate rounded px-1.5 py-0.5 text-left text-xs leading-4 text-foreground-muted transition hover:bg-surface-overlay"
+                  >
+                    {category}
+                  </button>
+                )}
               </div>
             </div>
+            <div className="shrink-0">
+              <DebugButton />
+            </div>
+          </div>
 
-            <Tabs defaultValue="parameters" className="flex min-h-0 flex-1 flex-col">
-              <div className="shrink-0 pt-3 [padding-inline:var(--mf-content-inset,0.875rem)]">
-                <TabsList className={TAB_LIST_CLASS}>
-                  <TabsTrigger value="parameters" className={TAB_TRIGGER_CLASS}>
-                    Parameters
-                  </TabsTrigger>
-                  <TabsTrigger value="error-handling" className={TAB_TRIGGER_CLASS}>
-                    Error handling
-                  </TabsTrigger>
-                  <TabsTrigger value="advanced" className={TAB_TRIGGER_CLASS}>
-                    Advanced
-                  </TabsTrigger>
-                </TabsList>
+          <Tabs defaultValue="parameters" className="flex min-h-0 flex-1 flex-col">
+            <div className="shrink-0 pt-3 [padding-inline:var(--mf-content-inset,0.875rem)]">
+              <TabsList className={TAB_LIST_CLASS}>
+                <TabsTrigger value="parameters" className={TAB_TRIGGER_CLASS}>
+                  Parameters
+                </TabsTrigger>
+                <TabsTrigger value="error-handling" className={TAB_TRIGGER_CLASS}>
+                  Error handling
+                </TabsTrigger>
+                <TabsTrigger value="advanced" className={TAB_TRIGGER_CLASS}>
+                  Advanced
+                </TabsTrigger>
+              </TabsList>
+            </div>
+
+            <TabsContent value="parameters" className="mt-0 min-h-0 flex-1 overflow-auto">
+              {/* Cases field label row */}
+              <div className="py-2 [padding-inline:var(--mf-content-inset,0.875rem)]">
+                <span className="text-sm font-medium text-foreground-muted">Cases</span>
               </div>
 
-              <TabsContent value="parameters" className="mt-0 min-h-0 flex-1 overflow-auto">
-                {/* Cases field label row */}
-                <div className="py-2 [padding-inline:var(--mf-content-inset,0.875rem)]">
-                  <span className="text-sm font-medium text-foreground-muted">Cases</span>
-                </div>
+              {/* Case accordion panels — inset cards with gap */}
+              <div className="flex flex-col gap-2 pb-1 [padding-inline:var(--mf-content-inset,0.875rem)]">
+                {cases.map((c, i) => (
+                  <CasePanel
+                    key={c.id}
+                    caseTitle={c.title}
+                    onTitleChange={(title) => updateCaseTitle(c.id, title)}
+                    onDelete={() => deleteCase(c.id)}
+                    monacoTheme={monacoTheme}
+                    defaultExpanded={i === 0}
+                    defaultValue={i === 0 ? 'input.status === "active"' : ''}
+                  />
+                ))}
+              </div>
 
-                {/* Case accordion panels — inset cards with gap */}
-                <div className="flex flex-col gap-2 pb-1 [padding-inline:var(--mf-content-inset,0.875rem)]">
-                  {cases.map((c, i) => (
-                    <CasePanel
-                      key={c.id}
-                      caseTitle={c.title}
-                      onTitleChange={(title) => updateCaseTitle(c.id, title)}
-                      onDelete={() => deleteCase(c.id)}
-                      monacoTheme={monacoTheme}
-                      defaultExpanded={i === 0}
-                      defaultValue={i === 0 ? 'input.status === "active"' : ''}
-                    />
-                  ))}
-                </div>
+              {/* Add case */}
+              <button
+                type="button"
+                onClick={addCase}
+                className="flex items-center gap-1.5 py-3 text-xs text-brand transition hover:text-brand-hover [padding-inline:var(--mf-content-inset,0.875rem)]"
+              >
+                <Plus size={12} />
+                Add case
+              </button>
 
-                {/* Add case */}
-                <button
-                  type="button"
-                  onClick={addCase}
-                  className="flex items-center gap-1.5 py-3 text-xs text-brand transition hover:text-brand-hover [padding-inline:var(--mf-content-inset,0.875rem)]"
-                >
-                  <Plus size={12} />
-                  Add case
-                </button>
+              {/* Default branch toggle */}
+              <div className="flex items-center gap-2 py-3 [padding-inline:var(--mf-content-inset,0.875rem)]">
+                <Switch size="sm" checked={defaultBranch} onCheckedChange={setDefaultBranch} />
+                <span className="text-xs text-foreground-muted">Default branch</span>
+              </div>
+            </TabsContent>
 
-                {/* Default branch toggle */}
-                <div className="flex items-center gap-2 py-3 [padding-inline:var(--mf-content-inset,0.875rem)]">
-                  <Switch size="sm" checked={defaultBranch} onCheckedChange={setDefaultBranch} />
-                  <span className="text-xs text-foreground-muted">Default branch</span>
-                </div>
-              </TabsContent>
-
-              <TabsContent value="error-handling" className="mt-0" />
-              <TabsContent value="advanced" className="mt-0" />
-            </Tabs>
-          </div>
-        </NodePropertyPanel>
-      </PanelFrame>
-    </CanvasBackground>
+            <TabsContent value="error-handling" className="mt-0" />
+            <TabsContent value="advanced" className="mt-0" />
+          </Tabs>
+        </div>
+      </NodePropertyPanel>
+    </PanelFrame>
   );
 }
 
@@ -973,6 +970,7 @@ function InlineCaseRow({
           type="button"
           onClick={() => setMode((m) => (m === 'fixed' ? 'expression' : 'fixed'))}
           title={mode === 'fixed' ? 'Switch to Expression' : 'Switch to Fixed'}
+          aria-label={mode === 'fixed' ? 'Switch to Expression' : 'Switch to Fixed'}
           className={cn(
             'absolute right-2 top-1/2 z-10 grid size-5 -translate-y-1/2 place-items-center rounded transition-colors',
             mode === 'expression'
@@ -1008,130 +1006,126 @@ function InputEditorStory() {
     setCases((prev) => prev.map((c) => (c.id === id ? { ...c, title } : c)));
 
   return (
-    <CanvasBackground>
-      <PanelFrame>
-        <NodePropertyPanel
-          panelTitle="Properties"
-          onClose={() => {}}
-          contentInset="0.875rem"
-          className="h-[640px]"
-        >
-          <div className="flex h-full flex-col">
-            {/* Inline-editable identity row */}
-            <div className="flex shrink-0 items-center justify-between gap-4 py-4 [padding-inline:var(--mf-content-inset,0.875rem)]">
-              <div className="flex min-w-0 flex-1 items-center gap-3.5">
-                <div className="grid size-11 shrink-0 place-items-center rounded-xl bg-surface-overlay text-foreground-subtle [&>svg]:size-5">
-                  <CircleCheck />
-                </div>
-                <div className="flex min-w-0 flex-1 flex-col justify-center">
-                  {editingLabel ? (
-                    <input
-                      ref={labelRef}
-                      value={label}
-                      onChange={(e) => setLabel(e.target.value)}
-                      onBlur={() => setEditingLabel(false)}
-                      onKeyDown={(e) => {
-                        if (e.key === 'Enter' || e.key === 'Escape') setEditingLabel(false);
-                      }}
-                      className="w-full rounded bg-surface-overlay px-1.5 py-0.5 text-base font-semibold leading-5 tracking-[-0.3px] text-foreground outline-none ring-1 ring-brand"
-                      autoFocus
-                    />
-                  ) : (
-                    <button
-                      type="button"
-                      onClick={() => {
-                        setEditingLabel(true);
-                        setTimeout(() => labelRef.current?.select(), 0);
-                      }}
-                      className="truncate rounded px-1.5 py-0.5 text-left text-base font-semibold leading-5 tracking-[-0.3px] text-foreground transition hover:bg-surface-overlay"
-                    >
-                      {label}
-                    </button>
-                  )}
-                  {editingCategory ? (
-                    <input
-                      ref={categoryRef}
-                      value={category}
-                      onChange={(e) => setCategory(e.target.value)}
-                      onBlur={() => setEditingCategory(false)}
-                      onKeyDown={(e) => {
-                        if (e.key === 'Enter' || e.key === 'Escape') setEditingCategory(false);
-                      }}
-                      className="w-full rounded bg-surface-overlay px-1.5 py-0.5 text-xs leading-4 text-foreground outline-none ring-1 ring-brand"
-                      autoFocus
-                    />
-                  ) : (
-                    <button
-                      type="button"
-                      onClick={() => {
-                        setEditingCategory(true);
-                        setTimeout(() => categoryRef.current?.select(), 0);
-                      }}
-                      className="truncate rounded px-1.5 py-0.5 text-left text-xs leading-4 text-foreground-muted transition hover:bg-surface-overlay"
-                    >
-                      {category}
-                    </button>
-                  )}
-                </div>
+    <PanelFrame>
+      <NodePropertyPanel
+        panelTitle="Properties"
+        onClose={() => {}}
+        contentInset="0.875rem"
+        className="h-[640px]"
+      >
+        <div className="flex h-full flex-col">
+          {/* Inline-editable identity row */}
+          <div className="flex shrink-0 items-center justify-between gap-4 py-4 [padding-inline:var(--mf-content-inset,0.875rem)]">
+            <div className="flex min-w-0 flex-1 items-center gap-3.5">
+              <div className="grid size-11 shrink-0 place-items-center rounded-xl bg-surface-overlay text-foreground-subtle [&>svg]:size-5">
+                <CircleCheck />
               </div>
-              <div className="shrink-0">
-                <DebugButton />
+              <div className="flex min-w-0 flex-1 flex-col justify-center">
+                {editingLabel ? (
+                  <input
+                    ref={labelRef}
+                    value={label}
+                    onChange={(e) => setLabel(e.target.value)}
+                    onBlur={() => setEditingLabel(false)}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter' || e.key === 'Escape') setEditingLabel(false);
+                    }}
+                    className="w-full rounded bg-surface-overlay px-1.5 py-0.5 text-base font-semibold leading-5 tracking-[-0.3px] text-foreground outline-none ring-1 ring-brand"
+                    autoFocus
+                  />
+                ) : (
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setEditingLabel(true);
+                      setTimeout(() => labelRef.current?.select(), 0);
+                    }}
+                    className="truncate rounded px-1.5 py-0.5 text-left text-base font-semibold leading-5 tracking-[-0.3px] text-foreground transition hover:bg-surface-overlay"
+                  >
+                    {label}
+                  </button>
+                )}
+                {editingCategory ? (
+                  <input
+                    ref={categoryRef}
+                    value={category}
+                    onChange={(e) => setCategory(e.target.value)}
+                    onBlur={() => setEditingCategory(false)}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter' || e.key === 'Escape') setEditingCategory(false);
+                    }}
+                    className="w-full rounded bg-surface-overlay px-1.5 py-0.5 text-xs leading-4 text-foreground outline-none ring-1 ring-brand"
+                    autoFocus
+                  />
+                ) : (
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setEditingCategory(true);
+                      setTimeout(() => categoryRef.current?.select(), 0);
+                    }}
+                    className="truncate rounded px-1.5 py-0.5 text-left text-xs leading-4 text-foreground-muted transition hover:bg-surface-overlay"
+                  >
+                    {category}
+                  </button>
+                )}
               </div>
             </div>
-
-            {/* Tabs */}
-            <Tabs defaultValue="parameters" className="flex min-h-0 flex-1 flex-col">
-              <div className="shrink-0 pt-3 [padding-inline:var(--mf-content-inset,0.875rem)]">
-                <TabsList className={TAB_LIST_CLASS}>
-                  <TabsTrigger value="parameters" className={TAB_TRIGGER_CLASS}>
-                    Parameters
-                  </TabsTrigger>
-                  <TabsTrigger value="error-handling" className={TAB_TRIGGER_CLASS}>
-                    Error handling
-                  </TabsTrigger>
-                  <TabsTrigger value="advanced" className={TAB_TRIGGER_CLASS}>
-                    Advanced
-                  </TabsTrigger>
-                </TabsList>
-              </div>
-              <TabsContent value="parameters" className="mt-0 min-h-0 flex-1 overflow-auto">
-                <div className="py-2 [padding-inline:var(--mf-content-inset,0.875rem)]">
-                  <span className="text-sm font-medium text-foreground-muted">
-                    Output messaging
-                  </span>
-                </div>
-                <div className="flex flex-col gap-3 pb-1 [padding-inline:var(--mf-content-inset,0.875rem)]">
-                  {cases.map((c) => (
-                    <InlineCaseRow
-                      key={c.id}
-                      caseTitle={c.title}
-                      onTitleChange={(title) => updateCaseTitle(c.id, title)}
-                      onDelete={() => deleteCase(c.id)}
-                      monacoTheme={monacoTheme}
-                      defaultValue=""
-                    />
-                  ))}
-                </div>
-                <button
-                  type="button"
-                  onClick={addCase}
-                  className="flex items-center gap-1.5 py-3 text-xs text-brand transition hover:text-brand-hover [padding-inline:var(--mf-content-inset,0.875rem)]"
-                >
-                  <Plus size={12} />
-                  Add output variable
-                </button>
-                <div className="flex items-center gap-2 py-3 [padding-inline:var(--mf-content-inset,0.875rem)]">
-                  <Switch size="sm" checked={defaultBranch} onCheckedChange={setDefaultBranch} />
-                  <span className="text-xs text-foreground-muted">Default branch</span>
-                </div>
-              </TabsContent>
-              <TabsContent value="error-handling" className="mt-0" />
-              <TabsContent value="advanced" className="mt-0" />
-            </Tabs>
+            <div className="shrink-0">
+              <DebugButton />
+            </div>
           </div>
-        </NodePropertyPanel>
-      </PanelFrame>
-    </CanvasBackground>
+
+          {/* Tabs */}
+          <Tabs defaultValue="parameters" className="flex min-h-0 flex-1 flex-col">
+            <div className="shrink-0 pt-3 [padding-inline:var(--mf-content-inset,0.875rem)]">
+              <TabsList className={TAB_LIST_CLASS}>
+                <TabsTrigger value="parameters" className={TAB_TRIGGER_CLASS}>
+                  Parameters
+                </TabsTrigger>
+                <TabsTrigger value="error-handling" className={TAB_TRIGGER_CLASS}>
+                  Error handling
+                </TabsTrigger>
+                <TabsTrigger value="advanced" className={TAB_TRIGGER_CLASS}>
+                  Advanced
+                </TabsTrigger>
+              </TabsList>
+            </div>
+            <TabsContent value="parameters" className="mt-0 min-h-0 flex-1 overflow-auto">
+              <div className="py-2 [padding-inline:var(--mf-content-inset,0.875rem)]">
+                <span className="text-sm font-medium text-foreground-muted">Output messaging</span>
+              </div>
+              <div className="flex flex-col gap-3 pb-1 [padding-inline:var(--mf-content-inset,0.875rem)]">
+                {cases.map((c) => (
+                  <InlineCaseRow
+                    key={c.id}
+                    caseTitle={c.title}
+                    onTitleChange={(title) => updateCaseTitle(c.id, title)}
+                    onDelete={() => deleteCase(c.id)}
+                    monacoTheme={monacoTheme}
+                    defaultValue=""
+                  />
+                ))}
+              </div>
+              <button
+                type="button"
+                onClick={addCase}
+                className="flex items-center gap-1.5 py-3 text-xs text-brand transition hover:text-brand-hover [padding-inline:var(--mf-content-inset,0.875rem)]"
+              >
+                <Plus size={12} />
+                Add output variable
+              </button>
+              <div className="flex items-center gap-2 py-3 [padding-inline:var(--mf-content-inset,0.875rem)]">
+                <Switch size="sm" checked={defaultBranch} onCheckedChange={setDefaultBranch} />
+                <span className="text-xs text-foreground-muted">Default branch</span>
+              </div>
+            </TabsContent>
+            <TabsContent value="error-handling" className="mt-0" />
+            <TabsContent value="advanced" className="mt-0" />
+          </Tabs>
+        </div>
+      </NodePropertyPanel>
+    </PanelFrame>
   );
 }
 
@@ -1154,72 +1148,70 @@ function InlineEditingStory() {
   const typeRef = useRef<HTMLInputElement>(null);
 
   return (
-    <CanvasBackground>
-      <PanelFrame>
-        <NodePropertyPanel panelTitle="Properties" onClose={() => {}} contentInset="0.875rem">
-          {/* Node identity row — inline editable */}
-          <div className="flex shrink-0 items-center gap-3 py-4 [padding-inline:var(--mf-content-inset,0.875rem)]">
-            <div className="flex min-w-0 flex-1 flex-col gap-0.5">
-              {editingName ? (
-                <input
-                  ref={nameRef}
-                  value={name}
-                  onChange={(e) => setName(e.target.value)}
-                  onBlur={() => setEditingName(false)}
-                  onKeyDown={(e) => {
-                    if (e.key === 'Enter' || e.key === 'Escape') setEditingName(false);
-                  }}
-                  className="w-full rounded bg-surface-overlay px-1.5 py-0.5 text-base font-semibold leading-5 tracking-[-0.4px] text-foreground outline-none ring-1 ring-brand"
-                  autoFocus
-                />
-              ) : (
-                <button
-                  type="button"
-                  onClick={() => {
-                    setEditingName(true);
-                    setTimeout(() => nameRef.current?.select(), 0);
-                  }}
-                  className="truncate rounded px-1.5 py-0.5 text-left text-base font-semibold leading-5 tracking-[-0.4px] text-foreground transition hover:bg-surface-overlay"
-                >
-                  {name}
-                </button>
-              )}
-              {editingType ? (
-                <input
-                  ref={typeRef}
-                  value={type}
-                  onChange={(e) => setType(e.target.value)}
-                  onBlur={() => setEditingType(false)}
-                  onKeyDown={(e) => {
-                    if (e.key === 'Enter' || e.key === 'Escape') setEditingType(false);
-                  }}
-                  className="w-full rounded bg-surface-overlay px-1.5 py-0.5 text-sm leading-5 text-foreground outline-none ring-1 ring-brand"
-                  autoFocus
-                />
-              ) : (
-                <button
-                  type="button"
-                  onClick={() => {
-                    setEditingType(true);
-                    setTimeout(() => typeRef.current?.select(), 0);
-                  }}
-                  className="truncate rounded px-1.5 py-0.5 text-left text-sm leading-5 text-foreground-muted transition hover:bg-surface-overlay"
-                >
-                  {type}
-                </button>
-              )}
-            </div>
-            <button
-              type="button"
-              className="flex h-8 items-center gap-2 rounded-lg bg-brand px-4 text-sm font-semibold text-foreground-on-accent transition hover:bg-brand-hover"
-            >
-              <Play size={14} />
-              Run
-            </button>
+    <PanelFrame>
+      <NodePropertyPanel panelTitle="Properties" onClose={() => {}} contentInset="0.875rem">
+        {/* Node identity row — inline editable */}
+        <div className="flex shrink-0 items-center gap-3 py-4 [padding-inline:var(--mf-content-inset,0.875rem)]">
+          <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+            {editingName ? (
+              <input
+                ref={nameRef}
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                onBlur={() => setEditingName(false)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' || e.key === 'Escape') setEditingName(false);
+                }}
+                className="w-full rounded bg-surface-overlay px-1.5 py-0.5 text-base font-semibold leading-5 tracking-[-0.4px] text-foreground outline-none ring-1 ring-brand"
+                autoFocus
+              />
+            ) : (
+              <button
+                type="button"
+                onClick={() => {
+                  setEditingName(true);
+                  setTimeout(() => nameRef.current?.select(), 0);
+                }}
+                className="truncate rounded px-1.5 py-0.5 text-left text-base font-semibold leading-5 tracking-[-0.4px] text-foreground transition hover:bg-surface-overlay"
+              >
+                {name}
+              </button>
+            )}
+            {editingType ? (
+              <input
+                ref={typeRef}
+                value={type}
+                onChange={(e) => setType(e.target.value)}
+                onBlur={() => setEditingType(false)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' || e.key === 'Escape') setEditingType(false);
+                }}
+                className="w-full rounded bg-surface-overlay px-1.5 py-0.5 text-sm leading-5 text-foreground outline-none ring-1 ring-brand"
+                autoFocus
+              />
+            ) : (
+              <button
+                type="button"
+                onClick={() => {
+                  setEditingType(true);
+                  setTimeout(() => typeRef.current?.select(), 0);
+                }}
+                className="truncate rounded px-1.5 py-0.5 text-left text-sm leading-5 text-foreground-muted transition hover:bg-surface-overlay"
+              >
+                {type}
+              </button>
+            )}
           </div>
-        </NodePropertyPanel>
-      </PanelFrame>
-    </CanvasBackground>
+          <button
+            type="button"
+            className="flex h-8 items-center gap-2 rounded-lg bg-brand px-4 text-sm font-semibold text-foreground-on-accent transition hover:bg-brand-hover"
+          >
+            <Play size={14} />
+            Run
+          </button>
+        </div>
+      </NodePropertyPanel>
+    </PanelFrame>
   );
 }
 

--- a/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.stories.tsx
@@ -875,6 +875,17 @@ export const CompactEditor: Story = {
 // Inline expression inputs — one per case, no code editor panel.
 // ============================================================================
 
+const INSERT_SNIPPETS = [
+  { label: 'Input data', code: 'context.input' },
+  { label: 'Item ID', code: 'item.id' },
+  { label: 'Item name', code: 'item.name' },
+  { label: 'Current index', code: 'index' },
+  { label: 'Timestamp', code: 'Date.now()' },
+  { label: 'True', code: 'true' },
+  { label: 'False', code: 'false' },
+  { label: 'Null', code: 'null' },
+];
+
 function InlineCaseRow({
   caseTitle,
   onTitleChange,
@@ -892,10 +903,29 @@ function InlineCaseRow({
   const titleRef = useRef<HTMLInputElement>(null);
   const [value, setValue] = useState(defaultValue);
   const [mode, setMode] = useState<'fixed' | 'expression'>('fixed');
+  const [insertOpen, setInsertOpen] = useState(false);
+  const [modePopoverOpen, setModePopoverOpen] = useState(false);
+  const insertRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!insertOpen) return;
+    const handler = (e: MouseEvent) => {
+      if (insertRef.current && !insertRef.current.contains(e.target as Node)) {
+        setInsertOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, [insertOpen]);
+
+  const insertSnippet = (code: string) => {
+    setValue((v) => (v ? `${v} ${code}` : code));
+    setInsertOpen(false);
+  };
 
   return (
     <div className="flex flex-col gap-1.5">
-      {/* Case title row with action buttons and delete on hover */}
+      {/* Case title row */}
       <div className="group flex items-center">
         {editingTitle ? (
           <input
@@ -939,48 +969,140 @@ function InlineCaseRow({
           >
             <Sparkles size={12} />
           </button>
-          <button
-            type="button"
-            aria-label="Insert variable"
-            title="Insert variable"
-            className="flex h-7 items-center gap-1 rounded-lg px-2 text-[11px] text-foreground-subtle transition hover:bg-surface-overlay hover:text-foreground"
-          >
-            <span className="font-mono text-[10px]">{'{x}'}</span>
-            <span>Insert</span>
-            <ChevronDown size={9} />
-          </button>
+          {/* Insert popover */}
+          <div ref={insertRef} className="relative">
+            <button
+              type="button"
+              aria-label="Insert snippet"
+              title="Insert snippet"
+              onClick={() => setInsertOpen((v) => !v)}
+              className={cn(
+                'flex h-7 items-center gap-1 rounded-lg px-2 text-[11px] transition',
+                insertOpen
+                  ? 'bg-surface-overlay text-foreground'
+                  : 'text-foreground-subtle hover:bg-surface-overlay hover:text-foreground'
+              )}
+            >
+              <span className="font-mono text-[10px]">{'{x}'}</span>
+              <span>Insert</span>
+              <ChevronDown size={9} />
+            </button>
+            {insertOpen && (
+              <div className="absolute right-0 top-full z-50 mt-1 min-w-[192px] overflow-hidden rounded-xl border border-border-subtle bg-surface-overlay py-1 shadow-lg">
+                {INSERT_SNIPPETS.map((s) => (
+                  <button
+                    key={s.code}
+                    type="button"
+                    onClick={() => insertSnippet(s.code)}
+                    className="flex w-full items-center justify-between gap-3 px-3 py-1.5 text-left hover:bg-surface-raised"
+                  >
+                    <span className="text-xs text-foreground">{s.label}</span>
+                    <span className="font-mono text-[10px] text-foreground-muted">{s.code}</span>
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
         </div>
       </div>
-      {/* Monaco editor — Code2 button overlays on the right to toggle mode */}
-      <div className="relative h-10 overflow-hidden rounded-xl border border-border-subtle">
-        <MonacoEditor
-          height="40px"
-          language={mode === 'expression' ? 'javascript' : 'plaintext'}
-          value={value}
-          onChange={(val) => setValue(val ?? '')}
-          theme={monacoTheme}
-          beforeMount={registerMonacoThemes}
-          options={INLINE_EDITOR_OPTIONS}
-        />
-        {value === '' && (
-          <div className="pointer-events-none absolute left-[6px] top-1/2 -translate-y-1/2 font-mono text-[13px] text-foreground-subtle">
-            {mode === 'fixed' ? 'Enter a value' : 'Enter an expression'}
+
+      {/* Monaco editor with mode toggle on the right.
+          Outer wrapper is NOT overflow-hidden so the popover can escape. */}
+      <div className="relative">
+        <div className="overflow-hidden rounded-xl border border-border-subtle">
+          <div className="relative h-10">
+            <MonacoEditor
+              height="40px"
+              language={mode === 'expression' ? 'javascript' : 'plaintext'}
+              value={value}
+              onChange={(val) => setValue(val ?? '')}
+              theme={monacoTheme}
+              beforeMount={registerMonacoThemes}
+              options={INLINE_EDITOR_OPTIONS}
+            />
+            {value === '' && (
+              <div className="pointer-events-none absolute left-[6px] top-1/2 -translate-y-1/2 font-mono text-[13px] text-foreground-subtle">
+                {mode === 'fixed' ? 'Enter a value' : 'Enter an expression'}
+              </div>
+            )}
           </div>
-        )}
-        <button
-          type="button"
-          onClick={() => setMode((m) => (m === 'fixed' ? 'expression' : 'fixed'))}
-          title={mode === 'fixed' ? 'Switch to Expression' : 'Switch to Fixed'}
-          aria-label={mode === 'fixed' ? 'Switch to Expression' : 'Switch to Fixed'}
-          className={cn(
-            'absolute right-2 top-1/2 z-10 grid size-5 -translate-y-1/2 place-items-center rounded transition-colors',
-            mode === 'expression'
-              ? 'bg-surface-overlay text-foreground'
-              : 'text-foreground-subtle hover:text-foreground'
-          )}
+        </div>
+        {/* Mode toggle — click to switch, hover to pick from popover */}
+        <div
+          className="absolute right-2 top-1/2 z-10 flex -translate-y-1/2 items-center gap-1.5"
+          onMouseEnter={() => setModePopoverOpen(true)}
+          onMouseLeave={() => setModePopoverOpen(false)}
         >
-          <Code2 size={12} />
-        </button>
+          <div className="h-3.5 w-px bg-border-subtle" />
+          <button
+            type="button"
+            onClick={() => setMode((m) => (m === 'fixed' ? 'expression' : 'fixed'))}
+            aria-label={
+              mode === 'fixed' ? 'Switch to Javascript expression' : 'Switch to Plain text'
+            }
+            className={cn(
+              'flex h-5 items-center rounded border px-1.5 text-[10px] font-medium transition',
+              mode === 'expression'
+                ? 'border-brand/30 bg-brand/10 text-brand'
+                : 'border-border-subtle bg-surface-overlay text-foreground-muted hover:border-border hover:text-foreground'
+            )}
+          >
+            {mode === 'fixed' ? 'PT' : 'JS'}
+          </button>
+          {modePopoverOpen && (
+            <div className="absolute right-0 top-full z-50 mt-2 w-56 overflow-hidden rounded-xl border border-border-subtle bg-surface-overlay shadow-lg">
+              <button
+                type="button"
+                onClick={() => {
+                  setMode('fixed');
+                  setModePopoverOpen(false);
+                }}
+                className={cn(
+                  'flex w-full flex-col gap-0.5 px-3 py-2.5 text-left transition hover:bg-surface-raised',
+                  mode === 'fixed' && 'bg-surface-raised'
+                )}
+              >
+                <div className="flex items-center gap-1.5">
+                  <span
+                    className={cn(
+                      'size-1.5 shrink-0 rounded-full',
+                      mode === 'fixed' ? 'bg-brand' : 'bg-border'
+                    )}
+                  />
+                  <span className="text-xs font-medium text-foreground">Plain text</span>
+                </div>
+                <span className="pl-3 text-[11px] leading-4 text-foreground-subtle">
+                  Enter static values like "hello" or 42
+                </span>
+              </button>
+              <div className="mx-3 h-px bg-border-subtle" />
+              <button
+                type="button"
+                onClick={() => {
+                  setMode('expression');
+                  setModePopoverOpen(false);
+                }}
+                className={cn(
+                  'flex w-full flex-col gap-0.5 px-3 py-2.5 text-left transition hover:bg-surface-raised',
+                  mode === 'expression' && 'bg-surface-raised'
+                )}
+              >
+                <div className="flex items-center gap-1.5">
+                  <span
+                    className={cn(
+                      'size-1.5 shrink-0 rounded-full',
+                      mode === 'expression' ? 'bg-brand' : 'bg-border'
+                    )}
+                  />
+                  <span className="text-xs font-medium text-foreground">Javascript expression</span>
+                </div>
+                <span className="pl-3 text-[11px] leading-4 text-foreground-subtle">
+                  Compute the return value dynamically with JS
+                </span>
+              </button>
+            </div>
+          )}
+        </div>
       </div>
     </div>
   );

--- a/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.stories.tsx
@@ -1,7 +1,20 @@
 import MonacoEditor from '@monaco-editor/react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import type { FormSchema } from '@uipath/apollo-wind';
-import { cn, Switch, Tabs, TabsContent, TabsList, TabsTrigger } from '@uipath/apollo-wind';
+import {
+  cn,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+  MetadataForm,
+  Switch,
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+} from '@uipath/apollo-wind';
 import {
   apolloCoreDarkHCMonaco,
   apolloCoreDarkMonaco,
@@ -20,9 +33,10 @@ import {
   Play,
   Plus,
   Sparkles,
+  Type,
   X,
 } from 'lucide-react';
-import type { ReactNode } from 'react';
+import type { CSSProperties, ReactNode } from 'react';
 import { useEffect, useRef, useState } from 'react';
 import { NodePropertyPanel } from './NodePropertyPanel';
 
@@ -53,6 +67,18 @@ function RunButton() {
     >
       <Play size={14} />
       Run
+    </button>
+  );
+}
+
+function RunButtonIconOnly() {
+  return (
+    <button
+      type="button"
+      aria-label="Run"
+      className="grid size-8 shrink-0 place-items-center rounded-lg bg-brand text-foreground-on-accent transition hover:bg-brand-hover"
+    >
+      <Play size={14} />
     </button>
   );
 }
@@ -582,7 +608,7 @@ const INLINE_EDITOR_OPTIONS = {
   padding: { top: 10, bottom: 10 },
   lineNumbers: 'off',
   lineNumbersMinChars: 0,
-  lineDecorationsWidth: 0,
+  lineDecorationsWidth: 14,
   glyphMargin: false,
   folding: false,
   renderLineHighlight: 'none',
@@ -904,7 +930,6 @@ function InlineCaseRow({
   const [value, setValue] = useState(defaultValue);
   const [mode, setMode] = useState<'fixed' | 'expression'>('fixed');
   const [insertOpen, setInsertOpen] = useState(false);
-  const [modePopoverOpen, setModePopoverOpen] = useState(false);
   const insertRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -1021,87 +1046,74 @@ function InlineCaseRow({
               options={INLINE_EDITOR_OPTIONS}
             />
             {value === '' && (
-              <div className="pointer-events-none absolute left-[6px] top-1/2 -translate-y-1/2 font-mono text-[13px] text-foreground-subtle">
+              <div className="pointer-events-none absolute left-[14px] top-1/2 -translate-y-1/2 font-mono text-[13px] text-foreground-subtle">
                 {mode === 'fixed' ? 'Enter a value' : 'Enter an expression'}
               </div>
             )}
           </div>
         </div>
-        {/* Mode toggle — click to switch, hover to pick from popover */}
-        <div
-          className="absolute right-2 top-1/2 z-10 flex -translate-y-1/2 items-center gap-1.5"
-          onMouseEnter={() => setModePopoverOpen(true)}
-          onMouseLeave={() => setModePopoverOpen(false)}
-        >
-          <div className="h-3.5 w-px bg-border-subtle" />
-          <button
-            type="button"
-            onClick={() => setMode((m) => (m === 'fixed' ? 'expression' : 'fixed'))}
-            aria-label={
-              mode === 'fixed' ? 'Switch to Javascript expression' : 'Switch to Plain text'
-            }
-            className={cn(
-              'flex h-5 items-center rounded border px-1.5 text-[10px] font-medium transition',
-              mode === 'expression'
-                ? 'border-brand/30 bg-brand/10 text-brand'
-                : 'border-border-subtle bg-surface-overlay text-foreground-muted hover:border-border hover:text-foreground'
-            )}
-          >
-            {mode === 'fixed' ? 'PT' : 'JS'}
-          </button>
-          {modePopoverOpen && (
-            <div className="absolute right-0 top-full z-50 mt-2 w-56 overflow-hidden rounded-xl border border-border-subtle bg-surface-overlay shadow-lg">
+        {/* Mode toggle — DropdownMenu picker */}
+        <div className="absolute right-2 top-1/2 z-10 flex -translate-y-1/2 items-center gap-1.5">
+          <div className="h-3.5 w-px bg-border" />
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
               <button
                 type="button"
-                onClick={() => {
-                  setMode('fixed');
-                  setModePopoverOpen(false);
-                }}
+                aria-label="Select expression mode"
                 className={cn(
-                  'flex w-full flex-col gap-0.5 px-3 py-2.5 text-left transition hover:bg-surface-raised',
+                  'flex h-6 items-center rounded border px-1.5 text-[10px] font-medium transition',
+                  mode === 'expression'
+                    ? 'border-brand/40 bg-brand/15 text-brand'
+                    : 'border-border bg-surface text-foreground-muted hover:text-foreground'
+                )}
+              >
+                {mode === 'fixed' ? 'PT' : 'JS'}
+              </button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" className="w-56 p-1">
+              <DropdownMenuItem
+                onClick={() => setMode('fixed')}
+                className={cn(
+                  'flex flex-col items-start gap-0.5 py-2.5 focus:bg-surface-overlay',
                   mode === 'fixed' && 'bg-surface-raised'
                 )}
               >
-                <div className="flex items-center gap-1.5">
-                  <span
-                    className={cn(
-                      'size-1.5 shrink-0 rounded-full',
-                      mode === 'fixed' ? 'bg-brand' : 'bg-border'
-                    )}
+                <div className="flex items-center gap-2">
+                  <Type
+                    size={13}
+                    className={cn('shrink-0', mode === 'fixed' ? 'text-brand' : 'text-foreground-muted')}
                   />
-                  <span className="text-xs font-medium text-foreground">Plain text</span>
+                  <span className={cn('text-xs font-medium', mode === 'fixed' ? 'text-brand' : 'text-foreground')}>
+                    Plain text
+                  </span>
                 </div>
-                <span className="pl-3 text-[11px] leading-4 text-foreground-subtle">
+                <span className="pl-[21px] text-[11px] leading-4 text-foreground-subtle">
                   Enter static values like "hello" or 42
                 </span>
-              </button>
-              <div className="mx-3 h-px bg-border-subtle" />
-              <button
-                type="button"
-                onClick={() => {
-                  setMode('expression');
-                  setModePopoverOpen(false);
-                }}
+              </DropdownMenuItem>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem
+                onClick={() => setMode('expression')}
                 className={cn(
-                  'flex w-full flex-col gap-0.5 px-3 py-2.5 text-left transition hover:bg-surface-raised',
+                  'flex flex-col items-start gap-0.5 py-2.5 focus:bg-surface-overlay',
                   mode === 'expression' && 'bg-surface-raised'
                 )}
               >
-                <div className="flex items-center gap-1.5">
-                  <span
-                    className={cn(
-                      'size-1.5 shrink-0 rounded-full',
-                      mode === 'expression' ? 'bg-brand' : 'bg-border'
-                    )}
+                <div className="flex items-center gap-2">
+                  <Code2
+                    size={13}
+                    className={cn('shrink-0', mode === 'expression' ? 'text-brand' : 'text-foreground-muted')}
                   />
-                  <span className="text-xs font-medium text-foreground">Javascript expression</span>
+                  <span className={cn('text-xs font-medium', mode === 'expression' ? 'text-brand' : 'text-foreground')}>
+                    Javascript expression
+                  </span>
                 </div>
-                <span className="pl-3 text-[11px] leading-4 text-foreground-subtle">
+                <span className="pl-[21px] text-[11px] leading-4 text-foreground-subtle">
                   Compute the return value dynamically with JS
                 </span>
-              </button>
-            </div>
-          )}
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
         </div>
       </div>
     </div>
@@ -1341,4 +1353,105 @@ function InlineEditingStory() {
 export const InlineEditing: Story = {
   name: 'Inline Editing',
   render: () => <InlineEditingStory />,
+};
+
+const SURFACE_REMAP = { '--surface-raised': 'var(--surface-overlay)' } as CSSProperties;
+
+function CompactResponsivePanelStory() {
+  const steps = httpRequestForm.steps ?? [];
+  const [activeStepId, setActiveStepId] = useState(steps[0]?.id ?? '');
+
+  const activeStep = steps.find((s) => s.id === activeStepId);
+
+  const flatSchema: FormSchema = {
+    id: httpRequestForm.id,
+    title: httpRequestForm.title,
+    mode: httpRequestForm.mode,
+    actions: [],
+    sections: activeStep?.sections ?? [],
+  };
+
+  return (
+    <NodePropertyPanel
+      panelTitle="Properties"
+      nodeLabel="Fetch invoice details"
+      nodeCategory="HTTP Request"
+      action={<RunButtonIconOnly />}
+      contentInset="0.875rem"
+      onClose={() => {}}
+      className="h-[480px]"
+    >
+      <div className="flex h-full flex-col" style={SURFACE_REMAP}>
+        <div className="shrink-0 border-b border-border-subtle px-[0.875rem] py-2">
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <button
+                type="button"
+                className="flex h-7 items-center gap-1.5 rounded-lg px-2 text-sm font-medium text-foreground transition hover:bg-surface-overlay"
+              >
+                <span>{activeStep?.title}</span>
+                <ChevronDown size={12} className="text-foreground-muted" />
+              </button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="start" className="w-44">
+              {steps.map((step) => (
+                <DropdownMenuItem
+                  key={step.id}
+                  onClick={() => setActiveStepId(step.id)}
+                  className={cn(
+                    'text-sm focus:bg-surface-overlay',
+                    step.id === activeStepId && 'bg-surface-raised font-medium'
+                  )}
+                >
+                  {step.title}
+                </DropdownMenuItem>
+              ))}
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
+        <div className="min-h-0 flex-1 overflow-y-auto [&_label]:text-foreground-muted">
+          <MetadataForm
+            schema={flatSchema}
+            className="flex flex-col gap-4 pb-6 pt-3 [padding-inline:0.875rem]"
+          />
+        </div>
+      </div>
+    </NodePropertyPanel>
+  );
+}
+
+export const Responsive: Story = {
+  name: 'Responsive',
+  render: () => (
+    <div className="flex items-start gap-[100px]">
+      <div className="flex flex-col gap-3">
+        <div className="flex flex-col gap-0.5">
+          <span className="text-xs font-medium text-foreground">Fixed Size</span>
+          <span className="text-xs text-foreground-muted">Example Spacious</span>
+        </div>
+        <PanelFrame>
+          <NodePropertyPanel
+            panelTitle="Properties"
+            nodeIcon={<Globe />}
+            nodeLabel="Fetch invoice details"
+            nodeCategory="HTTP Request"
+            action={<RunButton />}
+            schema={httpRequestForm}
+            contentInset="0.875rem"
+            onClose={() => {}}
+            className="h-[640px]"
+          />
+        </PanelFrame>
+      </div>
+      <div className="flex flex-col gap-3">
+        <div className="flex flex-col gap-0.5">
+          <span className="text-xs font-medium text-foreground">Fixed Size</span>
+          <span className="text-xs text-foreground-muted">Example Compact</span>
+        </div>
+        <PanelFrame width="w-[280px]">
+          <CompactResponsivePanelStory />
+        </PanelFrame>
+      </div>
+    </div>
+  ),
 };

--- a/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.stories.tsx
@@ -10,7 +10,18 @@ import {
   apolloFutureDarkMonaco,
   apolloFutureLightMonaco,
 } from '@uipath/apollo-wind/editor-themes';
-import { ChevronDown, CircleCheck, Code2, GitFork, Globe, GripVertical, Play, Plus, Sparkles, X } from 'lucide-react';
+import {
+  ChevronDown,
+  CircleCheck,
+  Code2,
+  GitFork,
+  Globe,
+  GripVertical,
+  Play,
+  Plus,
+  Sparkles,
+  X,
+} from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
 import type { ReactNode } from 'react';
 import { NodePropertyPanel } from './NodePropertyPanel';
@@ -28,13 +39,7 @@ const CanvasBackground = ({ children }: { children: ReactNode }) => (
   </div>
 );
 
-const PanelFrame = ({
-  children,
-  width = 'w-[380px]',
-}: {
-  children: ReactNode;
-  width?: string;
-}) => (
+const PanelFrame = ({ children, width = 'w-[380px]' }: { children: ReactNode; width?: string }) => (
   <div className={`${width} overflow-hidden rounded-2xl border border-border-subtle shadow-lg`}>
     {children}
   </div>
@@ -83,8 +88,8 @@ function registerMonacoThemes(monaco: any) {
 const THEME_CLASS_MAP: Record<string, string> = {
   'future-dark': 'apollo-future-dark',
   'future-light': 'apollo-future-light',
-  'dark': 'apollo-core-dark',
-  'light': 'apollo-core-light',
+  dark: 'apollo-core-dark',
+  light: 'apollo-core-light',
   'dark-hc': 'apollo-core-dark-hc',
   'light-hc': 'apollo-core-light-hc',
 };
@@ -106,7 +111,6 @@ function useMonacoTheme(): string {
 }
 
 // ────────────────────────────────────────────────────────────────────────────
-
 
 // ============================================================================
 // Shared FormSchema (steps = tabs; sections within each step hold the fields)
@@ -402,14 +406,19 @@ function FullEditorStory() {
                       value={label}
                       onChange={(e) => setLabel(e.target.value)}
                       onBlur={() => setEditingLabel(false)}
-                      onKeyDown={(e) => { if (e.key === 'Enter' || e.key === 'Escape') setEditingLabel(false); }}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter' || e.key === 'Escape') setEditingLabel(false);
+                      }}
                       className="w-full rounded bg-surface-overlay px-1.5 py-0.5 text-base font-semibold leading-5 tracking-[-0.3px] text-foreground outline-none ring-1 ring-brand"
                       autoFocus
                     />
                   ) : (
                     <button
                       type="button"
-                      onClick={() => { setEditingLabel(true); setTimeout(() => labelRef.current?.select(), 0); }}
+                      onClick={() => {
+                        setEditingLabel(true);
+                        setTimeout(() => labelRef.current?.select(), 0);
+                      }}
                       className="truncate rounded px-1.5 py-0.5 text-left text-base font-semibold leading-5 tracking-[-0.3px] text-foreground transition hover:bg-surface-overlay"
                     >
                       {label}
@@ -421,14 +430,19 @@ function FullEditorStory() {
                       value={category}
                       onChange={(e) => setCategory(e.target.value)}
                       onBlur={() => setEditingCategory(false)}
-                      onKeyDown={(e) => { if (e.key === 'Enter' || e.key === 'Escape') setEditingCategory(false); }}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter' || e.key === 'Escape') setEditingCategory(false);
+                      }}
                       className="w-full rounded bg-surface-overlay px-1.5 py-0.5 text-xs leading-4 text-foreground outline-none ring-1 ring-brand"
                       autoFocus
                     />
                   ) : (
                     <button
                       type="button"
-                      onClick={() => { setEditingCategory(true); setTimeout(() => categoryRef.current?.select(), 0); }}
+                      onClick={() => {
+                        setEditingCategory(true);
+                        setTimeout(() => categoryRef.current?.select(), 0);
+                      }}
                       className="truncate rounded px-1.5 py-0.5 text-left text-xs leading-4 text-foreground-muted transition hover:bg-surface-overlay"
                     >
                       {category}
@@ -445,9 +459,15 @@ function FullEditorStory() {
             <Tabs defaultValue="parameters" className="flex min-h-0 flex-1 flex-col">
               <div className="shrink-0 pt-3 [padding-inline:var(--mf-content-inset,0.875rem)]">
                 <TabsList className={TAB_LIST_CLASS}>
-                  <TabsTrigger value="parameters" className={TAB_TRIGGER_CLASS}>Parameters</TabsTrigger>
-                  <TabsTrigger value="error-handling" className={TAB_TRIGGER_CLASS}>Error handling</TabsTrigger>
-                  <TabsTrigger value="advanced" className={TAB_TRIGGER_CLASS}>Advanced</TabsTrigger>
+                  <TabsTrigger value="parameters" className={TAB_TRIGGER_CLASS}>
+                    Parameters
+                  </TabsTrigger>
+                  <TabsTrigger value="error-handling" className={TAB_TRIGGER_CLASS}>
+                    Error handling
+                  </TabsTrigger>
+                  <TabsTrigger value="advanced" className={TAB_TRIGGER_CLASS}>
+                    Advanced
+                  </TabsTrigger>
                 </TabsList>
               </div>
               <TabsContent value="parameters" className="mt-0 flex min-h-0 flex-1 flex-col">
@@ -479,7 +499,9 @@ function FullEditorStory() {
                     <MonacoEditor
                       height="100%"
                       defaultLanguage="javascript"
-                      defaultValue={'// Script\nconst result = items\n  .filter(x => x.active)\n  .map(x => ({\n    id: x.id,\n    value: x.value,\n  }));\n\nreturn result;'}
+                      defaultValue={
+                        '// Script\nconst result = items\n  .filter(x => x.active)\n  .map(x => ({\n    id: x.id,\n    value: x.value,\n  }));\n\nreturn result;'
+                      }
                       theme={monacoTheme}
                       beforeMount={registerMonacoThemes}
                       options={{
@@ -499,7 +521,11 @@ function FullEditorStory() {
                         renderLineHighlight: 'line',
                         hideCursorInOverviewRuler: true,
                         overviewRulerBorder: false,
-                        scrollbar: { vertical: 'auto', horizontal: 'hidden', alwaysConsumeMouseWheel: false },
+                        scrollbar: {
+                          vertical: 'auto',
+                          horizontal: 'hidden',
+                          alwaysConsumeMouseWheel: false,
+                        },
                         automaticLayout: true,
                       }}
                     />
@@ -610,14 +636,19 @@ function CasePanel({
             value={caseTitle}
             onChange={(e) => onTitleChange(e.target.value)}
             onBlur={() => setEditingTitle(false)}
-            onKeyDown={(e) => { if (e.key === 'Enter' || e.key === 'Escape') setEditingTitle(false); }}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' || e.key === 'Escape') setEditingTitle(false);
+            }}
             className="flex-1 rounded bg-surface-overlay px-1 py-0.5 text-xs font-medium text-foreground outline-none ring-1 ring-brand"
             autoFocus
           />
         ) : (
           <button
             type="button"
-            onClick={() => { setEditingTitle(true); setTimeout(() => titleRef.current?.select(), 0); }}
+            onClick={() => {
+              setEditingTitle(true);
+              setTimeout(() => titleRef.current?.select(), 0);
+            }}
             className="flex-1 truncate rounded px-1 py-0.5 text-left text-xs font-medium text-foreground transition hover:bg-surface-overlay"
           >
             {caseTitle}
@@ -661,7 +692,10 @@ function CasePanel({
             </div>
           </div>
           <div className="px-3 pb-3">
-            <div className="overflow-hidden rounded-xl border border-border-subtle" style={{ height: '120px' }}>
+            <div
+              className="overflow-hidden rounded-xl border border-border-subtle"
+              style={{ height: '120px' }}
+            >
               <MonacoEditor
                 height="100%"
                 defaultLanguage="javascript"
@@ -721,14 +755,19 @@ function CompactEditorStory() {
                       value={label}
                       onChange={(e) => setLabel(e.target.value)}
                       onBlur={() => setEditingLabel(false)}
-                      onKeyDown={(e) => { if (e.key === 'Enter' || e.key === 'Escape') setEditingLabel(false); }}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter' || e.key === 'Escape') setEditingLabel(false);
+                      }}
                       className="w-full rounded bg-surface-overlay px-1.5 py-0.5 text-base font-semibold leading-5 tracking-[-0.3px] text-foreground outline-none ring-1 ring-brand"
                       autoFocus
                     />
                   ) : (
                     <button
                       type="button"
-                      onClick={() => { setEditingLabel(true); setTimeout(() => labelRef.current?.select(), 0); }}
+                      onClick={() => {
+                        setEditingLabel(true);
+                        setTimeout(() => labelRef.current?.select(), 0);
+                      }}
                       className="truncate rounded px-1.5 py-0.5 text-left text-base font-semibold leading-5 tracking-[-0.3px] text-foreground transition hover:bg-surface-overlay"
                     >
                       {label}
@@ -740,14 +779,19 @@ function CompactEditorStory() {
                       value={category}
                       onChange={(e) => setCategory(e.target.value)}
                       onBlur={() => setEditingCategory(false)}
-                      onKeyDown={(e) => { if (e.key === 'Enter' || e.key === 'Escape') setEditingCategory(false); }}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter' || e.key === 'Escape') setEditingCategory(false);
+                      }}
                       className="w-full rounded bg-surface-overlay px-1.5 py-0.5 text-xs leading-4 text-foreground outline-none ring-1 ring-brand"
                       autoFocus
                     />
                   ) : (
                     <button
                       type="button"
-                      onClick={() => { setEditingCategory(true); setTimeout(() => categoryRef.current?.select(), 0); }}
+                      onClick={() => {
+                        setEditingCategory(true);
+                        setTimeout(() => categoryRef.current?.select(), 0);
+                      }}
                       className="truncate rounded px-1.5 py-0.5 text-left text-xs leading-4 text-foreground-muted transition hover:bg-surface-overlay"
                     >
                       {category}
@@ -760,56 +804,62 @@ function CompactEditorStory() {
               </div>
             </div>
 
-          <Tabs defaultValue="parameters" className="flex min-h-0 flex-1 flex-col">
-            <div className="shrink-0 pt-3 [padding-inline:var(--mf-content-inset,0.875rem)]">
-              <TabsList className={TAB_LIST_CLASS}>
-                <TabsTrigger value="parameters" className={TAB_TRIGGER_CLASS}>Parameters</TabsTrigger>
-                <TabsTrigger value="error-handling" className={TAB_TRIGGER_CLASS}>Error handling</TabsTrigger>
-                <TabsTrigger value="advanced" className={TAB_TRIGGER_CLASS}>Advanced</TabsTrigger>
-              </TabsList>
-            </div>
-
-            <TabsContent value="parameters" className="mt-0 min-h-0 flex-1 overflow-auto">
-              {/* Cases field label row */}
-              <div className="py-2 [padding-inline:var(--mf-content-inset,0.875rem)]">
-                <span className="text-sm font-medium text-foreground-muted">Cases</span>
+            <Tabs defaultValue="parameters" className="flex min-h-0 flex-1 flex-col">
+              <div className="shrink-0 pt-3 [padding-inline:var(--mf-content-inset,0.875rem)]">
+                <TabsList className={TAB_LIST_CLASS}>
+                  <TabsTrigger value="parameters" className={TAB_TRIGGER_CLASS}>
+                    Parameters
+                  </TabsTrigger>
+                  <TabsTrigger value="error-handling" className={TAB_TRIGGER_CLASS}>
+                    Error handling
+                  </TabsTrigger>
+                  <TabsTrigger value="advanced" className={TAB_TRIGGER_CLASS}>
+                    Advanced
+                  </TabsTrigger>
+                </TabsList>
               </div>
 
-              {/* Case accordion panels — inset cards with gap */}
-              <div className="flex flex-col gap-2 pb-1 [padding-inline:var(--mf-content-inset,0.875rem)]">
-                {cases.map((c, i) => (
-                  <CasePanel
-                    key={c.id}
-                    caseTitle={c.title}
-                    onTitleChange={(title) => updateCaseTitle(c.id, title)}
-                    onDelete={() => deleteCase(c.id)}
-                    monacoTheme={monacoTheme}
-                    defaultExpanded={i === 0}
-                    defaultValue={i === 0 ? 'input.status === "active"' : ''}
-                  />
-                ))}
-              </div>
+              <TabsContent value="parameters" className="mt-0 min-h-0 flex-1 overflow-auto">
+                {/* Cases field label row */}
+                <div className="py-2 [padding-inline:var(--mf-content-inset,0.875rem)]">
+                  <span className="text-sm font-medium text-foreground-muted">Cases</span>
+                </div>
 
-              {/* Add case */}
-              <button
-                type="button"
-                onClick={addCase}
-                className="flex items-center gap-1.5 py-3 text-xs text-brand transition hover:text-brand-hover [padding-inline:var(--mf-content-inset,0.875rem)]"
-              >
-                <Plus size={12} />
-                Add case
-              </button>
+                {/* Case accordion panels — inset cards with gap */}
+                <div className="flex flex-col gap-2 pb-1 [padding-inline:var(--mf-content-inset,0.875rem)]">
+                  {cases.map((c, i) => (
+                    <CasePanel
+                      key={c.id}
+                      caseTitle={c.title}
+                      onTitleChange={(title) => updateCaseTitle(c.id, title)}
+                      onDelete={() => deleteCase(c.id)}
+                      monacoTheme={monacoTheme}
+                      defaultExpanded={i === 0}
+                      defaultValue={i === 0 ? 'input.status === "active"' : ''}
+                    />
+                  ))}
+                </div>
 
-              {/* Default branch toggle */}
-              <div className="flex items-center gap-2 py-3 [padding-inline:var(--mf-content-inset,0.875rem)]">
-                <Switch size="sm" checked={defaultBranch} onCheckedChange={setDefaultBranch} />
-                <span className="text-xs text-foreground-muted">Default branch</span>
-              </div>
-            </TabsContent>
+                {/* Add case */}
+                <button
+                  type="button"
+                  onClick={addCase}
+                  className="flex items-center gap-1.5 py-3 text-xs text-brand transition hover:text-brand-hover [padding-inline:var(--mf-content-inset,0.875rem)]"
+                >
+                  <Plus size={12} />
+                  Add case
+                </button>
 
-            <TabsContent value="error-handling" className="mt-0" />
-            <TabsContent value="advanced" className="mt-0" />
-          </Tabs>
+                {/* Default branch toggle */}
+                <div className="flex items-center gap-2 py-3 [padding-inline:var(--mf-content-inset,0.875rem)]">
+                  <Switch size="sm" checked={defaultBranch} onCheckedChange={setDefaultBranch} />
+                  <span className="text-xs text-foreground-muted">Default branch</span>
+                </div>
+              </TabsContent>
+
+              <TabsContent value="error-handling" className="mt-0" />
+              <TabsContent value="advanced" className="mt-0" />
+            </Tabs>
           </div>
         </NodePropertyPanel>
       </PanelFrame>
@@ -855,14 +905,19 @@ function InlineCaseRow({
             value={caseTitle}
             onChange={(e) => onTitleChange(e.target.value)}
             onBlur={() => setEditingTitle(false)}
-            onKeyDown={(e) => { if (e.key === 'Enter' || e.key === 'Escape') setEditingTitle(false); }}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' || e.key === 'Escape') setEditingTitle(false);
+            }}
             className="flex-1 rounded bg-surface-overlay px-1 py-0.5 text-xs font-medium text-foreground outline-none ring-1 ring-brand"
             autoFocus
           />
         ) : (
           <button
             type="button"
-            onClick={() => { setEditingTitle(true); setTimeout(() => titleRef.current?.select(), 0); }}
+            onClick={() => {
+              setEditingTitle(true);
+              setTimeout(() => titleRef.current?.select(), 0);
+            }}
             className="flex-1 truncate rounded px-1 py-0.5 text-left text-xs font-medium text-foreground-muted transition hover:bg-surface-overlay hover:text-foreground"
           >
             {caseTitle}
@@ -975,14 +1030,19 @@ function InputEditorStory() {
                       value={label}
                       onChange={(e) => setLabel(e.target.value)}
                       onBlur={() => setEditingLabel(false)}
-                      onKeyDown={(e) => { if (e.key === 'Enter' || e.key === 'Escape') setEditingLabel(false); }}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter' || e.key === 'Escape') setEditingLabel(false);
+                      }}
                       className="w-full rounded bg-surface-overlay px-1.5 py-0.5 text-base font-semibold leading-5 tracking-[-0.3px] text-foreground outline-none ring-1 ring-brand"
                       autoFocus
                     />
                   ) : (
                     <button
                       type="button"
-                      onClick={() => { setEditingLabel(true); setTimeout(() => labelRef.current?.select(), 0); }}
+                      onClick={() => {
+                        setEditingLabel(true);
+                        setTimeout(() => labelRef.current?.select(), 0);
+                      }}
                       className="truncate rounded px-1.5 py-0.5 text-left text-base font-semibold leading-5 tracking-[-0.3px] text-foreground transition hover:bg-surface-overlay"
                     >
                       {label}
@@ -994,14 +1054,19 @@ function InputEditorStory() {
                       value={category}
                       onChange={(e) => setCategory(e.target.value)}
                       onBlur={() => setEditingCategory(false)}
-                      onKeyDown={(e) => { if (e.key === 'Enter' || e.key === 'Escape') setEditingCategory(false); }}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter' || e.key === 'Escape') setEditingCategory(false);
+                      }}
                       className="w-full rounded bg-surface-overlay px-1.5 py-0.5 text-xs leading-4 text-foreground outline-none ring-1 ring-brand"
                       autoFocus
                     />
                   ) : (
                     <button
                       type="button"
-                      onClick={() => { setEditingCategory(true); setTimeout(() => categoryRef.current?.select(), 0); }}
+                      onClick={() => {
+                        setEditingCategory(true);
+                        setTimeout(() => categoryRef.current?.select(), 0);
+                      }}
                       className="truncate rounded px-1.5 py-0.5 text-left text-xs leading-4 text-foreground-muted transition hover:bg-surface-overlay"
                     >
                       {category}
@@ -1018,14 +1083,22 @@ function InputEditorStory() {
             <Tabs defaultValue="parameters" className="flex min-h-0 flex-1 flex-col">
               <div className="shrink-0 pt-3 [padding-inline:var(--mf-content-inset,0.875rem)]">
                 <TabsList className={TAB_LIST_CLASS}>
-                  <TabsTrigger value="parameters" className={TAB_TRIGGER_CLASS}>Parameters</TabsTrigger>
-                  <TabsTrigger value="error-handling" className={TAB_TRIGGER_CLASS}>Error handling</TabsTrigger>
-                  <TabsTrigger value="advanced" className={TAB_TRIGGER_CLASS}>Advanced</TabsTrigger>
+                  <TabsTrigger value="parameters" className={TAB_TRIGGER_CLASS}>
+                    Parameters
+                  </TabsTrigger>
+                  <TabsTrigger value="error-handling" className={TAB_TRIGGER_CLASS}>
+                    Error handling
+                  </TabsTrigger>
+                  <TabsTrigger value="advanced" className={TAB_TRIGGER_CLASS}>
+                    Advanced
+                  </TabsTrigger>
                 </TabsList>
               </div>
               <TabsContent value="parameters" className="mt-0 min-h-0 flex-1 overflow-auto">
                 <div className="py-2 [padding-inline:var(--mf-content-inset,0.875rem)]">
-                  <span className="text-sm font-medium text-foreground-muted">Output messaging</span>
+                  <span className="text-sm font-medium text-foreground-muted">
+                    Output messaging
+                  </span>
                 </div>
                 <div className="flex flex-col gap-3 pb-1 [padding-inline:var(--mf-content-inset,0.875rem)]">
                   {cases.map((c) => (
@@ -1084,66 +1157,66 @@ function InlineEditingStory() {
     <CanvasBackground>
       <PanelFrame>
         <NodePropertyPanel panelTitle="Properties" onClose={() => {}} contentInset="0.875rem">
-        {/* Node identity row — inline editable */}
-        <div className="flex shrink-0 items-center gap-3 py-4 [padding-inline:var(--mf-content-inset,0.875rem)]">
-          <div className="flex min-w-0 flex-1 flex-col gap-0.5">
-            {editingName ? (
-              <input
-                ref={nameRef}
-                value={name}
-                onChange={(e) => setName(e.target.value)}
-                onBlur={() => setEditingName(false)}
-                onKeyDown={(e) => {
-                  if (e.key === 'Enter' || e.key === 'Escape') setEditingName(false);
-                }}
-                className="w-full rounded bg-surface-overlay px-1.5 py-0.5 text-base font-semibold leading-5 tracking-[-0.4px] text-foreground outline-none ring-1 ring-brand"
-                autoFocus
-              />
-            ) : (
-              <button
-                type="button"
-                onClick={() => {
-                  setEditingName(true);
-                  setTimeout(() => nameRef.current?.select(), 0);
-                }}
-                className="truncate rounded px-1.5 py-0.5 text-left text-base font-semibold leading-5 tracking-[-0.4px] text-foreground transition hover:bg-surface-overlay"
-              >
-                {name}
-              </button>
-            )}
-            {editingType ? (
-              <input
-                ref={typeRef}
-                value={type}
-                onChange={(e) => setType(e.target.value)}
-                onBlur={() => setEditingType(false)}
-                onKeyDown={(e) => {
-                  if (e.key === 'Enter' || e.key === 'Escape') setEditingType(false);
-                }}
-                className="w-full rounded bg-surface-overlay px-1.5 py-0.5 text-sm leading-5 text-foreground outline-none ring-1 ring-brand"
-                autoFocus
-              />
-            ) : (
-              <button
-                type="button"
-                onClick={() => {
-                  setEditingType(true);
-                  setTimeout(() => typeRef.current?.select(), 0);
-                }}
-                className="truncate rounded px-1.5 py-0.5 text-left text-sm leading-5 text-foreground-muted transition hover:bg-surface-overlay"
-              >
-                {type}
-              </button>
-            )}
+          {/* Node identity row — inline editable */}
+          <div className="flex shrink-0 items-center gap-3 py-4 [padding-inline:var(--mf-content-inset,0.875rem)]">
+            <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+              {editingName ? (
+                <input
+                  ref={nameRef}
+                  value={name}
+                  onChange={(e) => setName(e.target.value)}
+                  onBlur={() => setEditingName(false)}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter' || e.key === 'Escape') setEditingName(false);
+                  }}
+                  className="w-full rounded bg-surface-overlay px-1.5 py-0.5 text-base font-semibold leading-5 tracking-[-0.4px] text-foreground outline-none ring-1 ring-brand"
+                  autoFocus
+                />
+              ) : (
+                <button
+                  type="button"
+                  onClick={() => {
+                    setEditingName(true);
+                    setTimeout(() => nameRef.current?.select(), 0);
+                  }}
+                  className="truncate rounded px-1.5 py-0.5 text-left text-base font-semibold leading-5 tracking-[-0.4px] text-foreground transition hover:bg-surface-overlay"
+                >
+                  {name}
+                </button>
+              )}
+              {editingType ? (
+                <input
+                  ref={typeRef}
+                  value={type}
+                  onChange={(e) => setType(e.target.value)}
+                  onBlur={() => setEditingType(false)}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter' || e.key === 'Escape') setEditingType(false);
+                  }}
+                  className="w-full rounded bg-surface-overlay px-1.5 py-0.5 text-sm leading-5 text-foreground outline-none ring-1 ring-brand"
+                  autoFocus
+                />
+              ) : (
+                <button
+                  type="button"
+                  onClick={() => {
+                    setEditingType(true);
+                    setTimeout(() => typeRef.current?.select(), 0);
+                  }}
+                  className="truncate rounded px-1.5 py-0.5 text-left text-sm leading-5 text-foreground-muted transition hover:bg-surface-overlay"
+                >
+                  {type}
+                </button>
+              )}
+            </div>
+            <button
+              type="button"
+              className="flex h-8 items-center gap-2 rounded-lg bg-brand px-4 text-sm font-semibold text-foreground-on-accent transition hover:bg-brand-hover"
+            >
+              <Play size={14} />
+              Run
+            </button>
           </div>
-          <button
-            type="button"
-            className="flex h-8 items-center gap-2 rounded-lg bg-brand px-4 text-sm font-semibold text-foreground-on-accent transition hover:bg-brand-hover"
-          >
-            <Play size={14} />
-            Run
-          </button>
-        </div>
         </NodePropertyPanel>
       </PanelFrame>
     </CanvasBackground>

--- a/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.stories.tsx
@@ -1081,9 +1081,17 @@ function InlineCaseRow({
                 <div className="flex items-center gap-2">
                   <Type
                     size={13}
-                    className={cn('shrink-0', mode === 'fixed' ? 'text-brand' : 'text-foreground-muted')}
+                    className={cn(
+                      'shrink-0',
+                      mode === 'fixed' ? 'text-brand' : 'text-foreground-muted'
+                    )}
                   />
-                  <span className={cn('text-xs font-medium', mode === 'fixed' ? 'text-brand' : 'text-foreground')}>
+                  <span
+                    className={cn(
+                      'text-xs font-medium',
+                      mode === 'fixed' ? 'text-brand' : 'text-foreground'
+                    )}
+                  >
                     Plain text
                   </span>
                 </div>
@@ -1102,9 +1110,17 @@ function InlineCaseRow({
                 <div className="flex items-center gap-2">
                   <Code2
                     size={13}
-                    className={cn('shrink-0', mode === 'expression' ? 'text-brand' : 'text-foreground-muted')}
+                    className={cn(
+                      'shrink-0',
+                      mode === 'expression' ? 'text-brand' : 'text-foreground-muted'
+                    )}
                   />
-                  <span className={cn('text-xs font-medium', mode === 'expression' ? 'text-brand' : 'text-foreground')}>
+                  <span
+                    className={cn(
+                      'text-xs font-medium',
+                      mode === 'expression' ? 'text-brand' : 'text-foreground'
+                    )}
+                  >
                     Javascript expression
                   </span>
                 </div>
@@ -1387,7 +1403,7 @@ function CompactResponsivePanelStory() {
             <DropdownMenuTrigger asChild>
               <button
                 type="button"
-                className="flex h-7 items-center gap-1.5 rounded-lg px-2 text-sm font-medium text-foreground transition hover:bg-surface-overlay"
+                className="flex h-7 items-center gap-1.5 rounded-lg px-2 text-xs font-medium text-foreground transition hover:bg-surface-overlay"
               >
                 <span>{activeStep?.title}</span>
                 <ChevronDown size={12} className="text-foreground-muted" />
@@ -1423,7 +1439,7 @@ function CompactResponsivePanelStory() {
 export const Responsive: Story = {
   name: 'Responsive',
   render: () => (
-    <div className="flex items-start gap-[100px]">
+    <div className="flex items-start gap-[80px]">
       <div className="flex flex-col gap-3">
         <div className="flex flex-col gap-0.5">
           <span className="text-xs font-medium text-foreground">Fixed Size</span>

--- a/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.test.tsx
+++ b/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.test.tsx
@@ -67,4 +67,14 @@ describe('NodePropertyPanel', () => {
     render(<NodePropertyPanel schema={MULTI_STEP} />);
     expect(screen.queryByRole('button', { name: /submit/i })).not.toBeInTheDocument();
   });
+
+  it('renders children instead of the form when children are provided', () => {
+    render(
+      <NodePropertyPanel schema={MULTI_STEP}>
+        <div data-testid="custom-body">custom content</div>
+      </NodePropertyPanel>
+    );
+    expect(screen.getByTestId('custom-body')).toBeInTheDocument();
+    expect(screen.queryByRole('tab', { name: 'Parameters' })).not.toBeInTheDocument();
+  });
 });

--- a/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.tsx
+++ b/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.tsx
@@ -48,6 +48,7 @@ export function NodePropertyPanel({
   resetKey,
   className,
   contentInset = '1.5rem',
+  children,
 }: NodePropertyPanelProps) {
   const hasNodeHeader = !!(nodeLabel || nodeCategory || nodeIcon || action);
 
@@ -60,10 +61,13 @@ export function NodePropertyPanel({
   );
 
   return (
-    <div className={cn('flex min-h-0 flex-col bg-surface-raised', className)}>
+    <div
+      className={cn('flex min-h-0 flex-col bg-surface-raised', className)}
+      style={{ '--mf-content-inset': contentInset } as CSSProperties}
+    >
       {/* ── Title bar (optional; host panel system may own it) ── */}
       {panelTitle && (
-        <div className="flex h-10 shrink-0 items-center justify-between border-b border-border-subtle px-2">
+        <div className="flex h-10 shrink-0 items-center justify-between px-2">
           <div className="flex items-center gap-1">
             <div className="grid size-8 place-items-center text-foreground-subtle">
               <GripVertical size={14} />
@@ -86,8 +90,8 @@ export function NodePropertyPanel({
 
       {/* ── Node identity row ── */}
       {hasNodeHeader && (
-        <div className="flex shrink-0 items-center justify-between gap-4 border-b border-border-subtle px-6 py-4">
-          <div className="flex min-w-0 flex-1 items-center gap-3">
+        <div className="flex shrink-0 items-center justify-between gap-4 py-4 [padding-inline:var(--mf-content-inset,1.5rem)]">
+          <div className="flex min-w-0 flex-1 items-center gap-3.5">
             {nodeIcon && (
               <div className="grid size-11 shrink-0 place-items-center rounded-xl bg-surface-overlay text-foreground-subtle [&>svg]:size-5">
                 {nodeIcon}
@@ -97,12 +101,12 @@ export function NodePropertyPanel({
               {nodeLabel && (
                 // <span>, not <p>: host apps (e.g. Angular Material's `.mat-typography p`)
                 // inject a bottom margin on <p> that breaks the header alignment.
-                <span className="block truncate text-lg font-semibold leading-6 tracking-[-0.4px] text-foreground">
+                <span className="block truncate text-base font-semibold leading-5 tracking-[-0.3px] text-foreground">
                   {nodeLabel}
                 </span>
               )}
               {nodeCategory && (
-                <span className="block truncate text-sm leading-5 text-foreground-muted">
+                <span className="block truncate text-xs leading-4 text-foreground-muted">
                   {nodeCategory}
                 </span>
               )}
@@ -112,19 +116,16 @@ export function NodePropertyPanel({
         </div>
       )}
 
-      {/* ── Form ── */}
-      {!formSchema ? (
+      {/* ── Content (children) or Form ── */}
+      {children ? (
+        <div className="min-h-0 flex-1 overflow-auto">{children}</div>
+      ) : !formSchema ? (
         <div className="px-6 py-4 text-xs text-foreground-subtle">
           No form schema defined for this node.
         </div>
       ) : (
         <div className="min-h-0 flex-1 overflow-auto">
-          <div
-            style={{ ...SURFACE_REMAP, '--mf-content-inset': contentInset } as CSSProperties}
-            className="[&_label]:text-foreground-muted"
-          >
-            {/* Horizontal padding + the tab underline's full-bleed both derive from
-                `--mf-content-inset`, so they stay in lockstep. */}
+          <div style={SURFACE_REMAP} className="[&_label]:text-foreground-muted">
             <MetadataForm
               key={resetKey}
               schema={formSchema}

--- a/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.tsx
+++ b/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.tsx
@@ -118,9 +118,9 @@ export function NodePropertyPanel({
 
       {/* ── Content (children) or Form ── */}
       {children ? (
-        <div className="min-h-0 flex-1 overflow-auto">{children}</div>
+        <div className="min-h-0 flex-1 overflow-auto" style={SURFACE_REMAP}>{children}</div>
       ) : !formSchema ? (
-        <div className="px-6 py-4 text-xs text-foreground-subtle">
+        <div className="py-4 text-xs text-foreground-subtle [padding-inline:var(--mf-content-inset,1.5rem)]">
           No form schema defined for this node.
         </div>
       ) : (

--- a/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.tsx
+++ b/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.tsx
@@ -118,7 +118,9 @@ export function NodePropertyPanel({
 
       {/* ── Content (children) or Form ── */}
       {children ? (
-        <div className="min-h-0 flex-1 overflow-auto" style={SURFACE_REMAP}>{children}</div>
+        <div className="min-h-0 flex-1 overflow-auto" style={SURFACE_REMAP}>
+          {children}
+        </div>
       ) : !formSchema ? (
         <div className="py-4 text-xs text-foreground-subtle [padding-inline:var(--mf-content-inset,1.5rem)]">
           No form schema defined for this node.

--- a/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.types.ts
+++ b/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.types.ts
@@ -41,9 +41,9 @@ export interface NodePropertyPanelProps {
   resetKey?: string;
   className?: string;
   /**
-   * Horizontal inset (any CSS length) applied to the form content. It also drives
-   * the tab underline's full-bleed: the tab bar extends past this inset to the panel
-   * edges and re-insets its labels to line up with the fields. Default `1.5rem`.
+   * Horizontal inset (any CSS length) applied via `--mf-content-inset`. Aligns the
+   * form fields, identity row, and empty state to a consistent left/right edge.
+   * Default `1.5rem`.
    */
   contentInset?: string;
   /**

--- a/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.types.ts
+++ b/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.types.ts
@@ -49,8 +49,9 @@ export interface NodePropertyPanelProps {
   /**
    * Arbitrary content rendered in the panel body instead of a `MetadataForm`.
    * Use when the node's properties are not schema-driven (e.g. an expression
-   * editor, a preview pane, or a custom layout). When provided, `schema` is
-   * ignored and the children fill the scrollable content area.
+   * editor, a preview pane, or a custom layout). When provided, `schema`,
+   * `plugins`, `onSubmit`, `disabled`, and `resetKey` are all ignored.
+   * The children fill the scrollable content area.
    */
   children?: ReactNode;
 }

--- a/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.types.ts
+++ b/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.types.ts
@@ -46,4 +46,11 @@ export interface NodePropertyPanelProps {
    * edges and re-insets its labels to line up with the fields. Default `1.5rem`.
    */
   contentInset?: string;
+  /**
+   * Arbitrary content rendered in the panel body instead of a `MetadataForm`.
+   * Use when the node's properties are not schema-driven (e.g. an expression
+   * editor, a preview pane, or a custom layout). When provided, `schema` is
+   * ignored and the children fill the scrollable content area.
+   */
+  children?: ReactNode;
 }

--- a/packages/apollo-react/src/canvas/components/NodePropertyPanel/index.ts
+++ b/packages/apollo-react/src/canvas/components/NodePropertyPanel/index.ts
@@ -1,2 +1,4 @@
+export type { ExpressionFieldProps, ExpressionMode } from './ExpressionField';
+export { ExpressionField } from './ExpressionField';
 export { NodePropertyPanel } from './NodePropertyPanel';
 export type { NodePropertyPanelProps } from './NodePropertyPanel.types';

--- a/packages/apollo-wind/src/components/forms/metadata-form.tsx
+++ b/packages/apollo-wind/src/components/forms/metadata-form.tsx
@@ -387,20 +387,15 @@ function TabbedStepForm({
   return (
     <>
       <Tabs value={currentTab} onValueChange={setActiveTab} className="flex flex-col gap-4">
-        {/* Underline tabs (properties-panel style), overriding the primitive's
-          default segmented/pill look. Scoped here so the shared Tabs primitive
-          stays segmented for other consumers. */}
-        {/* Horizontal scroll when the tabs overflow a narrow panel (scrollbar hidden; tabs
-          stay on one line instead of clipping). The underline can optionally bleed past the
-          form's horizontal padding to the panel edges: a consumer sets `--mf-content-inset`
-          to its content inset and the list bleeds by that, re-insetting the labels. Default
-          0 keeps the underline at content width — correct for any padding. */}
-        <TabsList className="h-auto justify-start gap-4 overflow-x-auto rounded-none border-b border-border bg-transparent py-0 text-muted-foreground [-ms-overflow-style:none] [margin-inline:calc(var(--mf-content-inset,0px)*-1)] [padding-inline:var(--mf-content-inset,0px)] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+        {/* Segmented pill tabs (properties-panel style). Horizontal scroll when
+          tabs overflow a narrow panel; scrollbar is hidden so tabs stay on one
+          line without clipping. */}
+        <TabsList className="h-auto justify-start gap-0.5 overflow-x-auto rounded-lg bg-transparent p-0.5 text-muted-foreground [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
           {visibleSteps.map((step) => (
             <TabsTrigger
               key={step.id}
               value={step.id}
-              className="-mb-px shrink-0 whitespace-nowrap rounded-none border-b-2 border-transparent bg-transparent px-1 pb-2 pt-1 font-medium text-muted-foreground shadow-none transition-colors hover:text-foreground data-[state=active]:border-primary data-[state=active]:bg-transparent data-[state=active]:text-foreground data-[state=active]:shadow-none"
+              className="inline-flex h-6 shrink-0 items-center whitespace-nowrap rounded-md px-2.5 text-xs font-medium text-muted-foreground shadow-none transition-colors hover:text-foreground data-[state=active]:bg-surface-overlay data-[state=active]:text-foreground data-[state=active]:shadow-sm"
             >
               {step.title}
             </TabsTrigger>

--- a/packages/apollo-wind/src/editor-themes/monaco.ts
+++ b/packages/apollo-wind/src/editor-themes/monaco.ts
@@ -105,7 +105,7 @@ export const apolloFutureDarkMonaco = {
   inherit: false,
   rules: darkRules,
   colors: {
-    'editor.background': '#18181b', // zinc-900  surface-raised
+    'editor.background': '#27272a', // zinc-800  surface-overlay
     'editor.foreground': '#a1a1aa', // zinc-400  --code-rest
     'editorLineNumber.foreground': '#52525b', // zinc-600  comment level
     'editorLineNumber.activeForeground': '#a1a1aa', // zinc-400
@@ -149,7 +149,7 @@ export const apolloFutureLightMonaco = {
   inherit: false,
   rules: lightRules,
   colors: {
-    'editor.background': '#f4f4f5', // zinc-100  surface-raised
+    'editor.background': '#e4e4e7', // zinc-200  surface-overlay
     'editor.foreground': '#52525b', // zinc-600  --code-rest
     'editorLineNumber.foreground': '#a1a1aa', // zinc-400  comment level
     'editorLineNumber.activeForeground': '#71717a', // zinc-500

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -790,6 +790,9 @@ importers:
       '@lingui/swc-plugin':
         specifier: ^5.9.0
         version: 5.9.0(@lingui/core@5.9.5(@lingui/babel-plugin-lingui-macro@5.6.1(babel-plugin-macros@3.1.0)(typescript@5.9.3))(babel-plugin-macros@3.1.0))
+      '@monaco-editor/react':
+        specifier: ^4.7.0
+        version: 4.7.0(monaco-editor@0.55.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@mui/private-theming':
         specifier: ^5.15.3
         version: 5.17.1(@types/react@19.2.8)(react@19.2.3)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,10 +12,10 @@ overrides:
   postcss: ^8.5.14
   hono: ^4.12.25
   dompurify: '>=3.4.11'
-  undici: ^7.28.0
   js-yaml: '>=4.1.2'
   markdown-it: '>=14.1.2'
   '@babel/core': '>=7.29.1'
+  rolldown: 1.0.1
   esbuild: ^0.28.1
   ws@>=8.0.0 <9: ^8.21.0
   '@opentelemetry/core': ^2.8.0
@@ -3877,8 +3877,8 @@ packages:
   '@oxc-project/types@0.127.0':
     resolution: {integrity: sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==}
 
-  '@oxc-project/types@0.133.0':
-    resolution: {integrity: sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==}
+  '@oxc-project/types@0.130.0':
+    resolution: {integrity: sha512-ibD2usx9JRu7f5pu2tMKMI4cpA4NgXJQoYRP4pQ7Pxmn1l6k/53qWtQWZayhYy3X4QZkt90Ot+mJEaeXouio6Q==}
 
   '@oxc-resolver/binding-android-arm-eabi@11.20.0':
     resolution: {integrity: sha512-IjfWOXRgJFNdORDl+Uf1aibNgZY2guOD3zmOhx1BGVb/MIiqlFTdmjpQNplSN58lhWehnX4UNqC3QwpUo8pjJg==}
@@ -5003,97 +5003,97 @@ packages:
   '@remirror/core-constants@3.0.0':
     resolution: {integrity: sha512-42aWfPrimMfDKDi4YegyS7x+/0tlzaqwPQCULLanv3DMIlu96KTJR0fM5isWX2UViOqlGnX6YFgqWepcX+XMNg==}
 
-  '@rolldown/binding-android-arm64@1.0.3':
-    resolution: {integrity: sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==}
+  '@rolldown/binding-android-arm64@1.0.1':
+    resolution: {integrity: sha512-fJI3I0r3C3Oj/zdBCpaCmBRZYf07xpaq4yCfDDoSFm+beWNzbIl26puW8RraUdugoJw/95zerNOn6jasAhzSmg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
 
-  '@rolldown/binding-darwin-arm64@1.0.3':
-    resolution: {integrity: sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==}
+  '@rolldown/binding-darwin-arm64@1.0.1':
+    resolution: {integrity: sha512-cKnAhWEsV7TPcA/5EAteDp6KcJZBQ2G+BqE7zayMMi7kMvwRsbv7WT9aOnn0WNl4SKEIf43vjS31iUPu80nzXg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
 
-  '@rolldown/binding-darwin-x64@1.0.3':
-    resolution: {integrity: sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==}
+  '@rolldown/binding-darwin-x64@1.0.1':
+    resolution: {integrity: sha512-YKrVwQjIRBPo+5G/u03wGjbdy4q7pyzCe93DK9VJ7zkVmeg8LJ7GbgsiHWdR4xSoe4CAXRD7Bcjgbtr64bkXNg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
 
-  '@rolldown/binding-freebsd-x64@1.0.3':
-    resolution: {integrity: sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==}
+  '@rolldown/binding-freebsd-x64@1.0.1':
+    resolution: {integrity: sha512-z/oBsREo46SsFqBwYtFe0kpJeBijAT48O/WXLI4suiCLBkr03RTtTJMCzSdDd2znlh8VJizL09XVkQgk8IZonw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.3':
-    resolution: {integrity: sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==}
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.1':
+    resolution: {integrity: sha512-ik8q7GM11zxvYxFc2PeDcT6TBvhCQMaUxfph/M5l9sKuTs/Sjg3L+Byw0F7w0ZVLBZmx30P+gG0ECzzN+MFcmQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@rolldown/binding-linux-arm64-gnu@1.0.3':
-    resolution: {integrity: sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==}
+  '@rolldown/binding-linux-arm64-gnu@1.0.1':
+    resolution: {integrity: sha512-QoSx2EkyrrdZ6kcyE8stqZ62t0Yra8Fs5ia9lOxJrh6TMQJK7gQKmscdTHf7pOXKREKrVwOtJcQG3qVSfc866A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-arm64-musl@1.0.3':
-    resolution: {integrity: sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==}
+  '@rolldown/binding-linux-arm64-musl@1.0.1':
+    resolution: {integrity: sha512-uwNwFpwKeNiZawfAWBgg0VIztPTV3ihhh1vV334h9ivnNLorxnQMU6Fz8wG1Zb4Qh9LC1/MkcyT3YlDXG3Rsgg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@rolldown/binding-linux-ppc64-gnu@1.0.3':
-    resolution: {integrity: sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==}
+  '@rolldown/binding-linux-ppc64-gnu@1.0.1':
+    resolution: {integrity: sha512-zY1bul7OWr7DFBiJ++wofXvnr8B45ce3QsQUhKrIhXsygAh7bTkwyeM1bi1a2g5C/yC/N8TZyGDEoMfm/l9mpg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-s390x-gnu@1.0.3':
-    resolution: {integrity: sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==}
+  '@rolldown/binding-linux-s390x-gnu@1.0.1':
+    resolution: {integrity: sha512-0frlsT/f4Ft6I7SMESTKnF3cZsdicQn1dCMkF/jT9wDLE+gGoiQfv1nmT9e+s7s/fekvvy6tZM2jHvI2tkbJDQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-x64-gnu@1.0.3':
-    resolution: {integrity: sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==}
+  '@rolldown/binding-linux-x64-gnu@1.0.1':
+    resolution: {integrity: sha512-XABVmGp9Tg0WspTVvwduTc4fpqy6JnAUrSQe6OuyqD/03nI7r0O9OWUkMIwFrjKAIqolvqoA4ZrJppgwE0Gxmw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-x64-musl@1.0.3':
-    resolution: {integrity: sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==}
+  '@rolldown/binding-linux-x64-musl@1.0.1':
+    resolution: {integrity: sha512-bV4fzswuzVcKD90o/VM6QqKxnxlDq0g2BISDLNVmxrnhpv1DDbyPhCIjYfvzYLV+MvkKKnQt2Q6AO86SEBULUQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@rolldown/binding-openharmony-arm64@1.0.3':
-    resolution: {integrity: sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==}
+  '@rolldown/binding-openharmony-arm64@1.0.1':
+    resolution: {integrity: sha512-/Mh0Zhq3OP7fVs0kcQHZP6lZEthMGTaSf8UBQYSFEZDWGXXlEC+nJ6EqenaK2t4LBXMe3A+K/G2BVXXdtOr4PQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
 
-  '@rolldown/binding-wasm32-wasi@1.0.3':
-    resolution: {integrity: sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==}
+  '@rolldown/binding-wasm32-wasi@1.0.1':
+    resolution: {integrity: sha512-+1xc9X45l8ufsBAm6Gjvx2qDRIY9lTVt0cgWNcJ+1gdhXvkbxePA60yRTwSTuXL09CMhyJmjpV7E3NoyxbqFQQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [wasm32]
 
-  '@rolldown/binding-win32-arm64-msvc@1.0.3':
-    resolution: {integrity: sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==}
+  '@rolldown/binding-win32-arm64-msvc@1.0.1':
+    resolution: {integrity: sha512-1D+UqZdfnuR+Jy1GgMJwi85bD40H21uNmOPRWQhw4oRSuolZ/B5rixZ45DK2KXOTCvmVCecauWgEhbw8bI7tOw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
 
-  '@rolldown/binding-win32-x64-msvc@1.0.3':
-    resolution: {integrity: sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==}
+  '@rolldown/binding-win32-x64-msvc@1.0.1':
+    resolution: {integrity: sha512-INAycaWuhlOK3wk4mRHGsdgwYWmd9cChdPdE9bwWmy6rn9VqVNYNFGhOdXrofXUxwHIncSiPNb8tNm8knDVIeQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
@@ -11584,8 +11584,8 @@ packages:
   robust-predicates@3.0.2:
     resolution: {integrity: sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg==}
 
-  rolldown@1.0.3:
-    resolution: {integrity: sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==}
+  rolldown@1.0.1:
+    resolution: {integrity: sha512-X0KQHljNnEkWNqqiz9zJrGunh1B0HgOxLXvnFpCOcadzcy5qohZ3tqMEUg00vncoRovXuK3ZqCT9KnnKzoInFQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
@@ -12535,6 +12535,10 @@ packages:
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
 
+  undici@6.27.0:
+    resolution: {integrity: sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==}
+    engines: {node: '>=18.17'}
+
   undici@7.28.0:
     resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
     engines: {node: '>=20.18.1'}
@@ -13183,7 +13187,7 @@ snapshots:
   '@actions/http-client@4.0.0':
     dependencies:
       tunnel: 0.0.6
-      undici: 7.28.0
+      undici: 6.27.0
 
   '@actions/io@3.0.2': {}
 
@@ -15982,7 +15986,7 @@ snapshots:
 
   '@oxc-project/types@0.127.0': {}
 
-  '@oxc-project/types@0.133.0': {}
+  '@oxc-project/types@0.130.0': {}
 
   '@oxc-resolver/binding-android-arm-eabi@11.20.0':
     optional: true
@@ -17008,53 +17012,53 @@ snapshots:
 
   '@remirror/core-constants@3.0.0': {}
 
-  '@rolldown/binding-android-arm64@1.0.3':
+  '@rolldown/binding-android-arm64@1.0.1':
     optional: true
 
-  '@rolldown/binding-darwin-arm64@1.0.3':
+  '@rolldown/binding-darwin-arm64@1.0.1':
     optional: true
 
-  '@rolldown/binding-darwin-x64@1.0.3':
+  '@rolldown/binding-darwin-x64@1.0.1':
     optional: true
 
-  '@rolldown/binding-freebsd-x64@1.0.3':
+  '@rolldown/binding-freebsd-x64@1.0.1':
     optional: true
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.3':
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.1':
     optional: true
 
-  '@rolldown/binding-linux-arm64-gnu@1.0.3':
+  '@rolldown/binding-linux-arm64-gnu@1.0.1':
     optional: true
 
-  '@rolldown/binding-linux-arm64-musl@1.0.3':
+  '@rolldown/binding-linux-arm64-musl@1.0.1':
     optional: true
 
-  '@rolldown/binding-linux-ppc64-gnu@1.0.3':
+  '@rolldown/binding-linux-ppc64-gnu@1.0.1':
     optional: true
 
-  '@rolldown/binding-linux-s390x-gnu@1.0.3':
+  '@rolldown/binding-linux-s390x-gnu@1.0.1':
     optional: true
 
-  '@rolldown/binding-linux-x64-gnu@1.0.3':
+  '@rolldown/binding-linux-x64-gnu@1.0.1':
     optional: true
 
-  '@rolldown/binding-linux-x64-musl@1.0.3':
+  '@rolldown/binding-linux-x64-musl@1.0.1':
     optional: true
 
-  '@rolldown/binding-openharmony-arm64@1.0.3':
+  '@rolldown/binding-openharmony-arm64@1.0.1':
     optional: true
 
-  '@rolldown/binding-wasm32-wasi@1.0.3':
+  '@rolldown/binding-wasm32-wasi@1.0.1':
     dependencies:
       '@emnapi/core': 1.10.0
       '@emnapi/runtime': 1.10.0
       '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     optional: true
 
-  '@rolldown/binding-win32-arm64-msvc@1.0.3':
+  '@rolldown/binding-win32-arm64-msvc@1.0.1':
     optional: true
 
-  '@rolldown/binding-win32-x64-msvc@1.0.3':
+  '@rolldown/binding-win32-x64-msvc@1.0.1':
     optional: true
 
   '@rolldown/pluginutils@1.0.0-rc.3': {}
@@ -24561,26 +24565,26 @@ snapshots:
 
   robust-predicates@3.0.2: {}
 
-  rolldown@1.0.3:
+  rolldown@1.0.1:
     dependencies:
-      '@oxc-project/types': 0.133.0
+      '@oxc-project/types': 0.130.0
       '@rolldown/pluginutils': 1.0.1
     optionalDependencies:
-      '@rolldown/binding-android-arm64': 1.0.3
-      '@rolldown/binding-darwin-arm64': 1.0.3
-      '@rolldown/binding-darwin-x64': 1.0.3
-      '@rolldown/binding-freebsd-x64': 1.0.3
-      '@rolldown/binding-linux-arm-gnueabihf': 1.0.3
-      '@rolldown/binding-linux-arm64-gnu': 1.0.3
-      '@rolldown/binding-linux-arm64-musl': 1.0.3
-      '@rolldown/binding-linux-ppc64-gnu': 1.0.3
-      '@rolldown/binding-linux-s390x-gnu': 1.0.3
-      '@rolldown/binding-linux-x64-gnu': 1.0.3
-      '@rolldown/binding-linux-x64-musl': 1.0.3
-      '@rolldown/binding-openharmony-arm64': 1.0.3
-      '@rolldown/binding-wasm32-wasi': 1.0.3
-      '@rolldown/binding-win32-arm64-msvc': 1.0.3
-      '@rolldown/binding-win32-x64-msvc': 1.0.3
+      '@rolldown/binding-android-arm64': 1.0.1
+      '@rolldown/binding-darwin-arm64': 1.0.1
+      '@rolldown/binding-darwin-x64': 1.0.1
+      '@rolldown/binding-freebsd-x64': 1.0.1
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.1
+      '@rolldown/binding-linux-arm64-gnu': 1.0.1
+      '@rolldown/binding-linux-arm64-musl': 1.0.1
+      '@rolldown/binding-linux-ppc64-gnu': 1.0.1
+      '@rolldown/binding-linux-s390x-gnu': 1.0.1
+      '@rolldown/binding-linux-x64-gnu': 1.0.1
+      '@rolldown/binding-linux-x64-musl': 1.0.1
+      '@rolldown/binding-openharmony-arm64': 1.0.1
+      '@rolldown/binding-wasm32-wasi': 1.0.1
+      '@rolldown/binding-win32-arm64-msvc': 1.0.1
+      '@rolldown/binding-win32-x64-msvc': 1.0.1
 
   rope-sequence@1.3.4: {}
 
@@ -25753,6 +25757,8 @@ snapshots:
 
   undici-types@7.16.0: {}
 
+  undici@6.27.0: {}
+
   undici@7.28.0: {}
 
   unicode-canonical-property-names-ecmascript@2.0.1: {}
@@ -26018,7 +26024,7 @@ snapshots:
       lightningcss: 1.32.0
       picomatch: 4.0.4
       postcss: 8.5.15
-      rolldown: 1.0.3
+      rolldown: 1.0.1
       tinyglobby: 0.2.17
     optionalDependencies:
       '@types/node': 24.10.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,7 +11,8 @@ overrides:
   picomatch: '>=4.0.4'
   postcss: ^8.5.14
   hono: ^4.12.25
-  dompurify: '>=3.4.9'
+  dompurify: '>=3.4.11'
+  undici: '>=7.28.0'
   js-yaml: '>=4.1.2'
   markdown-it: '>=14.1.2'
   '@babel/core': '>=7.29.1'
@@ -130,10 +131,10 @@ importers:
         version: 0.4.6(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       nextra:
         specifier: ^4.6.1
-        version: 4.6.1(next@16.2.6(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
+        version: 4.6.1(next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
       nextra-theme-docs:
         specifier: ^4.6.1
-        version: 4.6.1(@types/react@19.2.8)(next@16.2.6(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(nextra@4.6.1(next@16.2.6(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(use-sync-external-store@1.6.0(react@19.2.3))
+        version: 4.6.1(@types/react@19.2.8)(next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(nextra@4.6.1(next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(use-sync-external-store@1.6.0(react@19.2.3))
       postcss:
         specifier: ^8.5.14
         version: 8.5.15
@@ -332,10 +333,10 @@ importers:
         version: 0.4.6(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       nextra:
         specifier: ^4.6.1
-        version: 4.6.1(next@16.2.6(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
+        version: 4.6.1(next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
       nextra-theme-docs:
         specifier: ^4.6.1
-        version: 4.6.1(@types/react@19.2.8)(next@16.2.6(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(nextra@4.6.1(next@16.2.6(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(use-sync-external-store@1.6.0(react@19.2.3))
+        version: 4.6.1(@types/react@19.2.8)(next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(nextra@4.6.1(next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(use-sync-external-store@1.6.0(react@19.2.3))
       pkce-challenge:
         specifier: ^6.0.0
         version: 6.0.0
@@ -7794,8 +7795,8 @@ packages:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
     engines: {node: '>= 4'}
 
-  dompurify@3.4.10:
-    resolution: {integrity: sha512-0xzNv0e7oYC6yyuOGZIABPM4qtg3QxLFniDNPP4ZP90wR8Yq3zgwpRbrNiT4N3IKqDbbYFEJLV+JWEs19aZ//w==}
+  dompurify@3.4.11:
+    resolution: {integrity: sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==}
 
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
@@ -12534,13 +12535,9 @@ packages:
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
 
-  undici@6.24.1:
-    resolution: {integrity: sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA==}
-    engines: {node: '>=18.17'}
-
-  undici@7.25.0:
-    resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
-    engines: {node: '>=20.18.1'}
+  undici@8.5.0:
+    resolution: {integrity: sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg==}
+    engines: {node: '>=22.19.0'}
 
   unicode-canonical-property-names-ecmascript@2.0.1:
     resolution: {integrity: sha512-dA8WbNeb2a6oQzAQ55YlT5vQAWGV9WXOsi3SskE3bcCdM0P4SDd+24zS/OCacdRq5BkdsRj9q3Pg6YyQoxIGqg==}
@@ -13186,7 +13183,7 @@ snapshots:
   '@actions/http-client@4.0.0':
     dependencies:
       tunnel: 0.0.6
-      undici: 6.24.1
+      undici: 8.5.0
 
   '@actions/io@3.0.2': {}
 
@@ -17311,7 +17308,7 @@ snapshots:
       p-filter: 4.1.0
       semantic-release: 25.0.3(typescript@5.9.3)
       tinyglobby: 0.2.15
-      undici: 7.25.0
+      undici: 8.5.0
       url-join: 5.0.0
     transitivePeerDependencies:
       - supports-color
@@ -17334,7 +17331,7 @@ snapshots:
       p-filter: 4.1.0
       semantic-release: 25.0.3(typescript@5.9.3)
       tinyglobby: 0.2.17
-      undici: 7.25.0
+      undici: 8.5.0
       url-join: 5.0.0
     transitivePeerDependencies:
       - supports-color
@@ -19998,7 +19995,7 @@ snapshots:
     dependencies:
       domelementtype: 2.3.0
 
-  dompurify@3.4.10:
+  dompurify@3.4.11:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -22449,7 +22446,7 @@ snapshots:
       d3-sankey: 0.12.3
       dagre-d3-es: 7.0.14
       dayjs: 1.11.20
-      dompurify: 3.4.10
+      dompurify: 3.4.11
       es-toolkit: 1.46.1
       katex: 0.16.45
       khroma: 2.1.0
@@ -22796,7 +22793,7 @@ snapshots:
 
   monaco-editor@0.55.1:
     dependencies:
-      dompurify: 3.4.10
+      dompurify: 3.4.11
       marked: 14.0.0
 
   moo@0.5.3: {}
@@ -22908,13 +22905,13 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
-  nextra-theme-docs@4.6.1(@types/react@19.2.8)(next@16.2.6(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(nextra@4.6.1(next@16.2.6(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(use-sync-external-store@1.6.0(react@19.2.3)):
+  nextra-theme-docs@4.6.1(@types/react@19.2.8)(next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(nextra@4.6.1(next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(use-sync-external-store@1.6.0(react@19.2.3)):
     dependencies:
       '@headlessui/react': 2.2.9(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       clsx: 2.1.1
       next: 16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       next-themes: 0.4.6(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      nextra: 4.6.1(next@16.2.6(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
+      nextra: 4.6.1(next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
       react: 19.2.3
       react-compiler-runtime: 19.1.0-rc.3(react@19.2.3)
       react-dom: 19.2.3(react@19.2.3)
@@ -22926,7 +22923,7 @@ snapshots:
       - immer
       - use-sync-external-store
 
-  nextra@4.6.1(next@16.2.6(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3):
+  nextra@4.6.1(next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3):
     dependencies:
       '@formatjs/intl-localematcher': 0.6.2
       '@headlessui/react': 2.2.9(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -25756,9 +25753,7 @@ snapshots:
 
   undici-types@7.16.0: {}
 
-  undici@6.24.1: {}
-
-  undici@7.25.0: {}
+  undici@8.5.0: {}
 
   unicode-canonical-property-names-ecmascript@2.0.1: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,7 +12,7 @@ overrides:
   postcss: ^8.5.14
   hono: ^4.12.25
   dompurify: '>=3.4.11'
-  undici: '>=7.28.0'
+  undici: ^7.28.0
   js-yaml: '>=4.1.2'
   markdown-it: '>=14.1.2'
   '@babel/core': '>=7.29.1'
@@ -12535,9 +12535,9 @@ packages:
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
 
-  undici@8.5.0:
-    resolution: {integrity: sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg==}
-    engines: {node: '>=22.19.0'}
+  undici@7.28.0:
+    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
+    engines: {node: '>=20.18.1'}
 
   unicode-canonical-property-names-ecmascript@2.0.1:
     resolution: {integrity: sha512-dA8WbNeb2a6oQzAQ55YlT5vQAWGV9WXOsi3SskE3bcCdM0P4SDd+24zS/OCacdRq5BkdsRj9q3Pg6YyQoxIGqg==}
@@ -13183,7 +13183,7 @@ snapshots:
   '@actions/http-client@4.0.0':
     dependencies:
       tunnel: 0.0.6
-      undici: 8.5.0
+      undici: 7.28.0
 
   '@actions/io@3.0.2': {}
 
@@ -17308,7 +17308,7 @@ snapshots:
       p-filter: 4.1.0
       semantic-release: 25.0.3(typescript@5.9.3)
       tinyglobby: 0.2.15
-      undici: 8.5.0
+      undici: 7.28.0
       url-join: 5.0.0
     transitivePeerDependencies:
       - supports-color
@@ -17331,7 +17331,7 @@ snapshots:
       p-filter: 4.1.0
       semantic-release: 25.0.3(typescript@5.9.3)
       tinyglobby: 0.2.17
-      undici: 8.5.0
+      undici: 7.28.0
       url-join: 5.0.0
     transitivePeerDependencies:
       - supports-color
@@ -25753,7 +25753,7 @@ snapshots:
 
   undici-types@7.16.0: {}
 
-  undici@8.5.0: {}
+  undici@7.28.0: {}
 
   unicode-canonical-property-names-ecmascript@2.0.1: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,11 +11,10 @@ overrides:
   picomatch: '>=4.0.4'
   postcss: ^8.5.14
   hono: ^4.12.25
-  dompurify: '>=3.4.11'
+  dompurify: '>=3.4.9'
   js-yaml: '>=4.1.2'
   markdown-it: '>=14.1.2'
   '@babel/core': '>=7.29.1'
-  rolldown: 1.0.1
   esbuild: ^0.28.1
   ws@>=8.0.0 <9: ^8.21.0
   '@opentelemetry/core': ^2.8.0
@@ -131,10 +130,10 @@ importers:
         version: 0.4.6(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       nextra:
         specifier: ^4.6.1
-        version: 4.6.1(next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
+        version: 4.6.1(next@16.2.6(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
       nextra-theme-docs:
         specifier: ^4.6.1
-        version: 4.6.1(@types/react@19.2.8)(next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(nextra@4.6.1(next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(use-sync-external-store@1.6.0(react@19.2.3))
+        version: 4.6.1(@types/react@19.2.8)(next@16.2.6(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(nextra@4.6.1(next@16.2.6(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(use-sync-external-store@1.6.0(react@19.2.3))
       postcss:
         specifier: ^8.5.14
         version: 8.5.15
@@ -333,10 +332,10 @@ importers:
         version: 0.4.6(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       nextra:
         specifier: ^4.6.1
-        version: 4.6.1(next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
+        version: 4.6.1(next@16.2.6(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
       nextra-theme-docs:
         specifier: ^4.6.1
-        version: 4.6.1(@types/react@19.2.8)(next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(nextra@4.6.1(next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(use-sync-external-store@1.6.0(react@19.2.3))
+        version: 4.6.1(@types/react@19.2.8)(next@16.2.6(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(nextra@4.6.1(next@16.2.6(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(use-sync-external-store@1.6.0(react@19.2.3))
       pkce-challenge:
         specifier: ^6.0.0
         version: 6.0.0
@@ -482,7 +481,7 @@ importers:
         version: 10.4.2(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.8)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
       '@storybook/addon-docs':
         specifier: ^10.4.1
-        version: 10.4.2(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(esbuild@0.28.1)(rollup@4.61.1)(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.8)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@7.3.5(@types/node@24.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.43.1)(tsx@4.22.4)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.28.1))
+        version: 10.4.2(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(esbuild@0.28.1)(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.8)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@8.0.16(@types/node@24.10.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.43.1)(tsx@4.22.4)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.28.1))
       '@storybook/addon-links':
         specifier: ^10.4.1
         version: 10.4.2(@types/react@19.2.8)(react@19.2.3)(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.8)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
@@ -497,10 +496,10 @@ importers:
         version: 10.4.2(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.8)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.9.3)
       '@storybook/react-vite':
         specifier: ^10.4.1
-        version: 10.4.2(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(esbuild@0.28.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.61.1)(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.8)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.9.3)(vite@7.3.5(@types/node@24.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.43.1)(tsx@4.22.4)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.28.1))
+        version: 10.4.2(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(esbuild@0.28.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.8)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.9.3)(vite@8.0.16(@types/node@24.10.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.43.1)(tsx@4.22.4)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.28.1))
       '@tailwindcss/vite':
         specifier: ^4.2.2
-        version: 4.2.2(vite@7.3.5(@types/node@24.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.43.1)(tsx@4.22.4)(yaml@2.8.3))
+        version: 4.2.2(vite@8.0.16(@types/node@24.10.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.43.1)(tsx@4.22.4)(yaml@2.8.3))
       '@types/react':
         specifier: ^19.2.6
         version: 19.2.8
@@ -509,10 +508,10 @@ importers:
         version: 19.2.3(@types/react@19.2.8)
       '@vitejs/plugin-react':
         specifier: ^5.2.0
-        version: 5.2.0(vite@7.3.5(@types/node@24.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.43.1)(tsx@4.22.4)(yaml@2.8.3))
+        version: 5.2.0(vite@8.0.16(@types/node@24.10.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.43.1)(tsx@4.22.4)(yaml@2.8.3))
       react-scan:
         specifier: ^0.5.3
-        version: 0.5.3(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.61.1)
+        version: 0.5.3(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       storybook:
         specifier: ^10.4.1
         version: 10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.8)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -523,11 +522,11 @@ importers:
         specifier: ^5.9.3
         version: 5.9.3
       vite:
-        specifier: ^7.3.5
-        version: 7.3.5(@types/node@24.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.43.1)(tsx@4.22.4)(yaml@2.8.3)
+        specifier: ^8.0.0
+        version: 8.0.16(@types/node@24.10.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.43.1)(tsx@4.22.4)(yaml@2.8.3)
       vite-plugin-svgr:
         specifier: ^4.5.0
-        version: 4.5.0(rollup@4.61.1)(typescript@5.9.3)(vite@7.3.5(@types/node@24.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.43.1)(tsx@4.22.4)(yaml@2.8.3))
+        version: 4.5.0(typescript@5.9.3)(vite@8.0.16(@types/node@24.10.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.43.1)(tsx@4.22.4)(yaml@2.8.3))
 
   packages/apollo-core:
     devDependencies:
@@ -810,7 +809,7 @@ importers:
         version: 10.4.2(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.8)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.9.3)
       '@storybook/react-vite':
         specifier: ^10.4.1
-        version: 10.4.2(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(esbuild@0.28.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.61.1)(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.8)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.9.3)(vite@8.0.16(@types/node@24.10.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.43.1)(tsx@4.22.4)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.28.1))
+        version: 10.4.2(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(esbuild@0.28.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.8)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.9.3)(vite@8.0.16(@types/node@24.10.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.43.1)(tsx@4.22.4)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.28.1))
       '@svgr/webpack':
         specifier: ^8.1.0
         version: 8.1.0(typescript@5.9.3)
@@ -1111,7 +1110,7 @@ importers:
         version: 10.4.2(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.8)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
       '@storybook/addon-docs':
         specifier: ^10.4.1
-        version: 10.4.2(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(esbuild@0.28.1)(rollup@4.61.1)(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.8)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@8.0.16(@types/node@24.10.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.43.1)(tsx@4.22.4)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.28.1))
+        version: 10.4.2(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(esbuild@0.28.1)(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.8)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@8.0.16(@types/node@24.10.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.43.1)(tsx@4.22.4)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.28.1))
       '@storybook/addon-links':
         specifier: ^10.4.1
         version: 10.4.2(@types/react@19.2.8)(react@19.2.3)(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.8)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
@@ -1120,7 +1119,7 @@ importers:
         version: 0.2.3(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.8)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.9.3)
       '@storybook/react-vite':
         specifier: ^10.4.1
-        version: 10.4.2(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(esbuild@0.28.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.61.1)(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.8)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.9.3)(vite@8.0.16(@types/node@24.10.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.43.1)(tsx@4.22.4)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.28.1))
+        version: 10.4.2(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(esbuild@0.28.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.8)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.9.3)(vite@8.0.16(@types/node@24.10.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.43.1)(tsx@4.22.4)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.28.1))
       '@tailwindcss/cli':
         specifier: ^4.1.17
         version: 4.1.17
@@ -1183,7 +1182,7 @@ importers:
         version: 19.2.3(react@19.2.3)
       react-scan:
         specifier: ^0.5.3
-        version: 0.5.3(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.61.1)
+        version: 0.5.3(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       semantic-release:
         specifier: ^25.0.3
         version: 25.0.3(typescript@5.9.3)
@@ -3877,8 +3876,8 @@ packages:
   '@oxc-project/types@0.127.0':
     resolution: {integrity: sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==}
 
-  '@oxc-project/types@0.130.0':
-    resolution: {integrity: sha512-ibD2usx9JRu7f5pu2tMKMI4cpA4NgXJQoYRP4pQ7Pxmn1l6k/53qWtQWZayhYy3X4QZkt90Ot+mJEaeXouio6Q==}
+  '@oxc-project/types@0.133.0':
+    resolution: {integrity: sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==}
 
   '@oxc-resolver/binding-android-arm-eabi@11.20.0':
     resolution: {integrity: sha512-IjfWOXRgJFNdORDl+Uf1aibNgZY2guOD3zmOhx1BGVb/MIiqlFTdmjpQNplSN58lhWehnX4UNqC3QwpUo8pjJg==}
@@ -5003,97 +5002,97 @@ packages:
   '@remirror/core-constants@3.0.0':
     resolution: {integrity: sha512-42aWfPrimMfDKDi4YegyS7x+/0tlzaqwPQCULLanv3DMIlu96KTJR0fM5isWX2UViOqlGnX6YFgqWepcX+XMNg==}
 
-  '@rolldown/binding-android-arm64@1.0.1':
-    resolution: {integrity: sha512-fJI3I0r3C3Oj/zdBCpaCmBRZYf07xpaq4yCfDDoSFm+beWNzbIl26puW8RraUdugoJw/95zerNOn6jasAhzSmg==}
+  '@rolldown/binding-android-arm64@1.0.3':
+    resolution: {integrity: sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
 
-  '@rolldown/binding-darwin-arm64@1.0.1':
-    resolution: {integrity: sha512-cKnAhWEsV7TPcA/5EAteDp6KcJZBQ2G+BqE7zayMMi7kMvwRsbv7WT9aOnn0WNl4SKEIf43vjS31iUPu80nzXg==}
+  '@rolldown/binding-darwin-arm64@1.0.3':
+    resolution: {integrity: sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
 
-  '@rolldown/binding-darwin-x64@1.0.1':
-    resolution: {integrity: sha512-YKrVwQjIRBPo+5G/u03wGjbdy4q7pyzCe93DK9VJ7zkVmeg8LJ7GbgsiHWdR4xSoe4CAXRD7Bcjgbtr64bkXNg==}
+  '@rolldown/binding-darwin-x64@1.0.3':
+    resolution: {integrity: sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
 
-  '@rolldown/binding-freebsd-x64@1.0.1':
-    resolution: {integrity: sha512-z/oBsREo46SsFqBwYtFe0kpJeBijAT48O/WXLI4suiCLBkr03RTtTJMCzSdDd2znlh8VJizL09XVkQgk8IZonw==}
+  '@rolldown/binding-freebsd-x64@1.0.3':
+    resolution: {integrity: sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.1':
-    resolution: {integrity: sha512-ik8q7GM11zxvYxFc2PeDcT6TBvhCQMaUxfph/M5l9sKuTs/Sjg3L+Byw0F7w0ZVLBZmx30P+gG0ECzzN+MFcmQ==}
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.3':
+    resolution: {integrity: sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@rolldown/binding-linux-arm64-gnu@1.0.1':
-    resolution: {integrity: sha512-QoSx2EkyrrdZ6kcyE8stqZ62t0Yra8Fs5ia9lOxJrh6TMQJK7gQKmscdTHf7pOXKREKrVwOtJcQG3qVSfc866A==}
+  '@rolldown/binding-linux-arm64-gnu@1.0.3':
+    resolution: {integrity: sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-arm64-musl@1.0.1':
-    resolution: {integrity: sha512-uwNwFpwKeNiZawfAWBgg0VIztPTV3ihhh1vV334h9ivnNLorxnQMU6Fz8wG1Zb4Qh9LC1/MkcyT3YlDXG3Rsgg==}
+  '@rolldown/binding-linux-arm64-musl@1.0.3':
+    resolution: {integrity: sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@rolldown/binding-linux-ppc64-gnu@1.0.1':
-    resolution: {integrity: sha512-zY1bul7OWr7DFBiJ++wofXvnr8B45ce3QsQUhKrIhXsygAh7bTkwyeM1bi1a2g5C/yC/N8TZyGDEoMfm/l9mpg==}
+  '@rolldown/binding-linux-ppc64-gnu@1.0.3':
+    resolution: {integrity: sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-s390x-gnu@1.0.1':
-    resolution: {integrity: sha512-0frlsT/f4Ft6I7SMESTKnF3cZsdicQn1dCMkF/jT9wDLE+gGoiQfv1nmT9e+s7s/fekvvy6tZM2jHvI2tkbJDQ==}
+  '@rolldown/binding-linux-s390x-gnu@1.0.3':
+    resolution: {integrity: sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-x64-gnu@1.0.1':
-    resolution: {integrity: sha512-XABVmGp9Tg0WspTVvwduTc4fpqy6JnAUrSQe6OuyqD/03nI7r0O9OWUkMIwFrjKAIqolvqoA4ZrJppgwE0Gxmw==}
+  '@rolldown/binding-linux-x64-gnu@1.0.3':
+    resolution: {integrity: sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-x64-musl@1.0.1':
-    resolution: {integrity: sha512-bV4fzswuzVcKD90o/VM6QqKxnxlDq0g2BISDLNVmxrnhpv1DDbyPhCIjYfvzYLV+MvkKKnQt2Q6AO86SEBULUQ==}
+  '@rolldown/binding-linux-x64-musl@1.0.3':
+    resolution: {integrity: sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@rolldown/binding-openharmony-arm64@1.0.1':
-    resolution: {integrity: sha512-/Mh0Zhq3OP7fVs0kcQHZP6lZEthMGTaSf8UBQYSFEZDWGXXlEC+nJ6EqenaK2t4LBXMe3A+K/G2BVXXdtOr4PQ==}
+  '@rolldown/binding-openharmony-arm64@1.0.3':
+    resolution: {integrity: sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
 
-  '@rolldown/binding-wasm32-wasi@1.0.1':
-    resolution: {integrity: sha512-+1xc9X45l8ufsBAm6Gjvx2qDRIY9lTVt0cgWNcJ+1gdhXvkbxePA60yRTwSTuXL09CMhyJmjpV7E3NoyxbqFQQ==}
+  '@rolldown/binding-wasm32-wasi@1.0.3':
+    resolution: {integrity: sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [wasm32]
 
-  '@rolldown/binding-win32-arm64-msvc@1.0.1':
-    resolution: {integrity: sha512-1D+UqZdfnuR+Jy1GgMJwi85bD40H21uNmOPRWQhw4oRSuolZ/B5rixZ45DK2KXOTCvmVCecauWgEhbw8bI7tOw==}
+  '@rolldown/binding-win32-arm64-msvc@1.0.3':
+    resolution: {integrity: sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
 
-  '@rolldown/binding-win32-x64-msvc@1.0.1':
-    resolution: {integrity: sha512-INAycaWuhlOK3wk4mRHGsdgwYWmd9cChdPdE9bwWmy6rn9VqVNYNFGhOdXrofXUxwHIncSiPNb8tNm8knDVIeQ==}
+  '@rolldown/binding-win32-x64-msvc@1.0.3':
+    resolution: {integrity: sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
@@ -5112,144 +5111,6 @@ packages:
     peerDependenciesMeta:
       rollup:
         optional: true
-
-  '@rollup/rollup-android-arm-eabi@4.61.1':
-    resolution: {integrity: sha512-JnBB8MdXj45cajvTuO5FmPlvFVJRQgvrz1uSEl3NwqFnReAPGwb8EanbGi4z2nRaqLzjJSv5/JmycoTKlRZxHA==}
-    cpu: [arm]
-    os: [android]
-
-  '@rollup/rollup-android-arm64@4.61.1':
-    resolution: {integrity: sha512-Jx2g7iSjw4AOT0HDPHM9RV3GNjRXwybWtSFZiZAYUTjUwjVrYIwq3kBf+LnhqJlzXFAqTAh2F7IGI+O568exPw==}
-    cpu: [arm64]
-    os: [android]
-
-  '@rollup/rollup-darwin-arm64@4.61.1':
-    resolution: {integrity: sha512-0F1L/Z3Eqv8mT2n3dCpeO8GcTvHvVqkP5/t6DMsn0KzhYVcg+s7Ncl5DS8qjKYEeio6Az0Gt6nyBORay5qIlCA==}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@rollup/rollup-darwin-x64@4.61.1':
-    resolution: {integrity: sha512-qLttcH871ujY4YcVfUSShhOw+CsoTatYz8gRbHO7Bb92QH059/P0y5do1KMs41fY0BpD2x4AJH/gID0zFiqVKQ==}
-    cpu: [x64]
-    os: [darwin]
-
-  '@rollup/rollup-freebsd-arm64@4.61.1':
-    resolution: {integrity: sha512-fUI4RapGE0Oh3mb8mgfvC1O2nU1RpDZUKnDQm3xB1Ipg7C2wTs5Kstz7G2uWK99a8S2yTMq8/P4uycwNa0nJyw==}
-    cpu: [arm64]
-    os: [freebsd]
-
-  '@rollup/rollup-freebsd-x64@4.61.1':
-    resolution: {integrity: sha512-H5YrdvJaDtI/U9/emrD4b++xkvp3y/JvOe4rizHbxvkyMfRS/CiRYdji+Pl8D0brEaNFWUh1drQxgAGIl6Xudw==}
-    cpu: [x64]
-    os: [freebsd]
-
-  '@rollup/rollup-linux-arm-gnueabihf@4.61.1':
-    resolution: {integrity: sha512-Q8CBCCQtDFrYtXoeUXSrnFXKOnyUhx6bz+SkL6A0E7V8kAiCJ5pamq1WtbfpVGhR5TSpXY6ak3avmDc5fHTyJA==}
-    cpu: [arm]
-    os: [linux]
-    libc: [glibc]
-
-  '@rollup/rollup-linux-arm-musleabihf@4.61.1':
-    resolution: {integrity: sha512-nwnhk1581l0FBVellGcVCAT0Oi06onEA3WB53sf01VO3I0UPBkMH9sXONYME2K0ovXcNayJfNtHfm6mpJElatQ==}
-    cpu: [arm]
-    os: [linux]
-    libc: [musl]
-
-  '@rollup/rollup-linux-arm64-gnu@4.61.1':
-    resolution: {integrity: sha512-x5Xr49hwt3hdW75UOZm3395YwwzPyauktslv29KpWL/T+vVAzoT3azLcTWv0eMciBNrx+DYjH4paehHoLpPvpg==}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-
-  '@rollup/rollup-linux-arm64-musl@4.61.1':
-    resolution: {integrity: sha512-unMS3H73DpaoPyyEVPjGKleM/s0mkmsauTENpw4INQY8y4+IuLNjkueQ5QCtC0D3N38Y38yhAU8OoZ20S2Tm6w==}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
-
-  '@rollup/rollup-linux-loong64-gnu@4.61.1':
-    resolution: {integrity: sha512-zNZzGRnAhwjFEYmvphJRV5XaQGjs62cCmeYYHUT//NbvEnHauw+I85nGG+SiVg5ld4GX8D1IbKIX+ozITQnhMQ==}
-    cpu: [loong64]
-    os: [linux]
-    libc: [glibc]
-
-  '@rollup/rollup-linux-loong64-musl@4.61.1':
-    resolution: {integrity: sha512-LdpWGL8X209B2SIvWjqlc8VZgM6PKfontSerGepuldQmHYrAOtnMCXeJkxXGbC+PPZVOuu5czJo7fNV6aeW8rQ==}
-    cpu: [loong64]
-    os: [linux]
-    libc: [musl]
-
-  '@rollup/rollup-linux-ppc64-gnu@4.61.1':
-    resolution: {integrity: sha512-EC5kTtNaNGOmbMGqar8dvJy6y/hg99GAwjfBz++pxZhQATXGcRjd6c5en5wcbru0vkRmiMGsQKdMJOOf6sza4g==}
-    cpu: [ppc64]
-    os: [linux]
-    libc: [glibc]
-
-  '@rollup/rollup-linux-ppc64-musl@4.61.1':
-    resolution: {integrity: sha512-8hiwp6D4acEcNK78I4rP0/XtS1sknWIAMJBPdR4l6zUtyTm5KiTDr5bXmWt4foY7nAN7AThDHgkLIEZOWKbzWw==}
-    cpu: [ppc64]
-    os: [linux]
-    libc: [musl]
-
-  '@rollup/rollup-linux-riscv64-gnu@4.61.1':
-    resolution: {integrity: sha512-10dh/h/BqA7DuMPWSxkR8uks18FRwnwOEqr5zOTEl+NOwP/OMzKX8OFR/Of9xxDA7D5qef1Nzar5WDD2kCCr1g==}
-    cpu: [riscv64]
-    os: [linux]
-    libc: [glibc]
-
-  '@rollup/rollup-linux-riscv64-musl@4.61.1':
-    resolution: {integrity: sha512-YKJ5lg35DP17gcAOggnihe+APw9HLyj1Xn7gsmGumBJAUDa6NGXNixJzmkWLhcK9TOuuyQjdamzvJefkO7qHZQ==}
-    cpu: [riscv64]
-    os: [linux]
-    libc: [musl]
-
-  '@rollup/rollup-linux-s390x-gnu@4.61.1':
-    resolution: {integrity: sha512-Mlil5G2Jj6a7B3LWGctg+XPL9vdXYuzCtNXfxOQ0nPjc2m6ueUktocPGH9bnAM0bNRKb/bAWTujUU7IJQdQA+g==}
-    cpu: [s390x]
-    os: [linux]
-    libc: [glibc]
-
-  '@rollup/rollup-linux-x64-gnu@4.61.1':
-    resolution: {integrity: sha512-bVWIOIk6pV01p4CdUbPP7CJ/434z+OooYjDuFcR+44N35YvKUC66G8MGnvcWx5mWKW3g61J+t74l3Kj15Kwn2Q==}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
-
-  '@rollup/rollup-linux-x64-musl@4.61.1':
-    resolution: {integrity: sha512-qy5pBvZbqNFheBz61R1rzsezjm0J7O2oNGoWtGoY89SZYLUfxAJTBAqDChqAIdB4rCiIbi9nF7yZ83GnNiLwSw==}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
-
-  '@rollup/rollup-openbsd-x64@4.61.1':
-    resolution: {integrity: sha512-E83TXjI4zm0+5f2qO+UOudaCYIhYwpJ5jq6YCZNIZ+6CbfhKrkAGezeiASBL9ElxAxFsRS9ZhESv8mfnj6TKeg==}
-    cpu: [x64]
-    os: [openbsd]
-
-  '@rollup/rollup-openharmony-arm64@4.61.1':
-    resolution: {integrity: sha512-fbWnKqVkjrJN38vNe3ahkbk6iejS/3b0Nt7EEtPpE6RBacZcGXNKbzfHN3GUUlXOPghUg0j6XUGrtjX9z1sIvA==}
-    cpu: [arm64]
-    os: [openharmony]
-
-  '@rollup/rollup-win32-arm64-msvc@4.61.1':
-    resolution: {integrity: sha512-ArMl38iVAbk0New1ogihQNY6iphLi4ZaRsa037gUzv5yeKPY8TD3Dmy4x2RNC1VztU/uqm+G+/RwFrSka3Oy2g==}
-    cpu: [arm64]
-    os: [win32]
-
-  '@rollup/rollup-win32-ia32-msvc@4.61.1':
-    resolution: {integrity: sha512-0mYtjHS9ucAbcATycCNK9IGBk/cCe/ma7EmSLGZdsxnOA8cjRIyU04wDpVAD9NiOfLUR9KTxdiO53uOkherqjQ==}
-    cpu: [ia32]
-    os: [win32]
-
-  '@rollup/rollup-win32-x64-gnu@4.61.1':
-    resolution: {integrity: sha512-gK1iCEPfpoSG9wfBihXxvBMi8ZfcWffYkEsC/Eih+iFENTaewvNcrEQ69lIOWYO5pePHKLHHO7nq5AILGO/HQQ==}
-    cpu: [x64]
-    os: [win32]
-
-  '@rollup/rollup-win32-x64-msvc@4.61.1':
-    resolution: {integrity: sha512-X+zaP2x+j4RXGfbp/seSoRHWnPxzApilDszisZxbYH5C/jTxFhCtDNdPGZb9lJyYPs24wGxruPF7Y+sIXt9Gzw==}
-    cpu: [x64]
-    os: [win32]
 
   '@rsbuild/core@1.6.7':
     resolution: {integrity: sha512-V0INbMrT/LwyhzKmvpupe2oSvPFWaivz7sdriFRp381BJvD0d2pYcq9iRW91bxgMRX78MgTzFYAu868hMAzoSw==}
@@ -7933,8 +7794,8 @@ packages:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
     engines: {node: '>= 4'}
 
-  dompurify@3.4.11:
-    resolution: {integrity: sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==}
+  dompurify@3.4.10:
+    resolution: {integrity: sha512-0xzNv0e7oYC6yyuOGZIABPM4qtg3QxLFniDNPP4ZP90wR8Yq3zgwpRbrNiT4N3IKqDbbYFEJLV+JWEs19aZ//w==}
 
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
@@ -11722,14 +11583,9 @@ packages:
   robust-predicates@3.0.2:
     resolution: {integrity: sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg==}
 
-  rolldown@1.0.1:
-    resolution: {integrity: sha512-X0KQHljNnEkWNqqiz9zJrGunh1B0HgOxLXvnFpCOcadzcy5qohZ3tqMEUg00vncoRovXuK3ZqCT9KnnKzoInFQ==}
+  rolldown@1.0.3:
+    resolution: {integrity: sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==}
     engines: {node: ^20.19.0 || >=22.12.0}
-    hasBin: true
-
-  rollup@4.61.1:
-    resolution: {integrity: sha512-I4KW6iuRpuu2uHBLraZ1wNZe0DP7lnRha+VJ9tNaYVaVgKhW0aI3h4RYnoRPeql0flHm/Co55b7snEDcOfOJrA==}
-    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
   rope-sequence@1.3.4:
@@ -12678,12 +12534,12 @@ packages:
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
 
-  undici@6.27.0:
-    resolution: {integrity: sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==}
+  undici@6.24.1:
+    resolution: {integrity: sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA==}
     engines: {node: '>=18.17'}
 
-  undici@7.28.0:
-    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
+  undici@7.25.0:
+    resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
     engines: {node: '>=20.18.1'}
 
   unicode-canonical-property-names-ecmascript@2.0.1:
@@ -12905,46 +12761,6 @@ packages:
       vite: '*'
     peerDependenciesMeta:
       vite:
-        optional: true
-
-  vite@7.3.5:
-    resolution: {integrity: sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    hasBin: true
-    peerDependencies:
-      '@types/node': ^20.19.0 || >=22.12.0
-      jiti: '>=1.21.0'
-      less: ^4.0.0
-      lightningcss: ^1.21.0
-      sass: ^1.70.0
-      sass-embedded: ^1.70.0
-      stylus: '>=0.54.8'
-      sugarss: ^5.0.0
-      terser: ^5.16.0
-      tsx: ^4.8.1
-      yaml: ^2.4.2
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      jiti:
-        optional: true
-      less:
-        optional: true
-      lightningcss:
-        optional: true
-      sass:
-        optional: true
-      sass-embedded:
-        optional: true
-      stylus:
-        optional: true
-      sugarss:
-        optional: true
-      terser:
-        optional: true
-      tsx:
-        optional: true
-      yaml:
         optional: true
 
   vite@8.0.16:
@@ -13370,7 +13186,7 @@ snapshots:
   '@actions/http-client@4.0.0':
     dependencies:
       tunnel: 0.0.6
-      undici: 6.27.0
+      undici: 6.24.1
 
   '@actions/io@3.0.2': {}
 
@@ -15216,14 +15032,6 @@ snapshots:
       '@types/yargs': 17.0.35
       chalk: 4.1.2
 
-  '@joshwooding/vite-plugin-react-docgen-typescript@0.7.0(typescript@5.9.3)(vite@7.3.5(@types/node@24.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.43.1)(tsx@4.22.4)(yaml@2.8.3))':
-    dependencies:
-      glob: 13.0.6
-      react-docgen-typescript: 2.4.0(typescript@5.9.3)
-      vite: 7.3.5(@types/node@24.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.43.1)(tsx@4.22.4)(yaml@2.8.3)
-    optionalDependencies:
-      typescript: 5.9.3
-
   '@joshwooding/vite-plugin-react-docgen-typescript@0.7.0(typescript@5.9.3)(vite@8.0.16(@types/node@24.10.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.43.1)(tsx@4.22.4)(yaml@2.8.3))':
     dependencies:
       glob: 13.0.6
@@ -16177,7 +15985,7 @@ snapshots:
 
   '@oxc-project/types@0.127.0': {}
 
-  '@oxc-project/types@0.130.0': {}
+  '@oxc-project/types@0.133.0': {}
 
   '@oxc-resolver/binding-android-arm-eabi@11.20.0':
     optional: true
@@ -17203,141 +17011,64 @@ snapshots:
 
   '@remirror/core-constants@3.0.0': {}
 
-  '@rolldown/binding-android-arm64@1.0.1':
+  '@rolldown/binding-android-arm64@1.0.3':
     optional: true
 
-  '@rolldown/binding-darwin-arm64@1.0.1':
+  '@rolldown/binding-darwin-arm64@1.0.3':
     optional: true
 
-  '@rolldown/binding-darwin-x64@1.0.1':
+  '@rolldown/binding-darwin-x64@1.0.3':
     optional: true
 
-  '@rolldown/binding-freebsd-x64@1.0.1':
+  '@rolldown/binding-freebsd-x64@1.0.3':
     optional: true
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.1':
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.3':
     optional: true
 
-  '@rolldown/binding-linux-arm64-gnu@1.0.1':
+  '@rolldown/binding-linux-arm64-gnu@1.0.3':
     optional: true
 
-  '@rolldown/binding-linux-arm64-musl@1.0.1':
+  '@rolldown/binding-linux-arm64-musl@1.0.3':
     optional: true
 
-  '@rolldown/binding-linux-ppc64-gnu@1.0.1':
+  '@rolldown/binding-linux-ppc64-gnu@1.0.3':
     optional: true
 
-  '@rolldown/binding-linux-s390x-gnu@1.0.1':
+  '@rolldown/binding-linux-s390x-gnu@1.0.3':
     optional: true
 
-  '@rolldown/binding-linux-x64-gnu@1.0.1':
+  '@rolldown/binding-linux-x64-gnu@1.0.3':
     optional: true
 
-  '@rolldown/binding-linux-x64-musl@1.0.1':
+  '@rolldown/binding-linux-x64-musl@1.0.3':
     optional: true
 
-  '@rolldown/binding-openharmony-arm64@1.0.1':
+  '@rolldown/binding-openharmony-arm64@1.0.3':
     optional: true
 
-  '@rolldown/binding-wasm32-wasi@1.0.1':
+  '@rolldown/binding-wasm32-wasi@1.0.3':
     dependencies:
       '@emnapi/core': 1.10.0
       '@emnapi/runtime': 1.10.0
       '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     optional: true
 
-  '@rolldown/binding-win32-arm64-msvc@1.0.1':
+  '@rolldown/binding-win32-arm64-msvc@1.0.3':
     optional: true
 
-  '@rolldown/binding-win32-x64-msvc@1.0.1':
+  '@rolldown/binding-win32-x64-msvc@1.0.3':
     optional: true
 
   '@rolldown/pluginutils@1.0.0-rc.3': {}
 
   '@rolldown/pluginutils@1.0.1': {}
 
-  '@rollup/pluginutils@5.3.0(rollup@4.61.1)':
+  '@rollup/pluginutils@5.3.0':
     dependencies:
       '@types/estree': 1.0.9
       estree-walker: 2.0.2
       picomatch: 4.0.4
-    optionalDependencies:
-      rollup: 4.61.1
-
-  '@rollup/rollup-android-arm-eabi@4.61.1':
-    optional: true
-
-  '@rollup/rollup-android-arm64@4.61.1':
-    optional: true
-
-  '@rollup/rollup-darwin-arm64@4.61.1':
-    optional: true
-
-  '@rollup/rollup-darwin-x64@4.61.1':
-    optional: true
-
-  '@rollup/rollup-freebsd-arm64@4.61.1':
-    optional: true
-
-  '@rollup/rollup-freebsd-x64@4.61.1':
-    optional: true
-
-  '@rollup/rollup-linux-arm-gnueabihf@4.61.1':
-    optional: true
-
-  '@rollup/rollup-linux-arm-musleabihf@4.61.1':
-    optional: true
-
-  '@rollup/rollup-linux-arm64-gnu@4.61.1':
-    optional: true
-
-  '@rollup/rollup-linux-arm64-musl@4.61.1':
-    optional: true
-
-  '@rollup/rollup-linux-loong64-gnu@4.61.1':
-    optional: true
-
-  '@rollup/rollup-linux-loong64-musl@4.61.1':
-    optional: true
-
-  '@rollup/rollup-linux-ppc64-gnu@4.61.1':
-    optional: true
-
-  '@rollup/rollup-linux-ppc64-musl@4.61.1':
-    optional: true
-
-  '@rollup/rollup-linux-riscv64-gnu@4.61.1':
-    optional: true
-
-  '@rollup/rollup-linux-riscv64-musl@4.61.1':
-    optional: true
-
-  '@rollup/rollup-linux-s390x-gnu@4.61.1':
-    optional: true
-
-  '@rollup/rollup-linux-x64-gnu@4.61.1':
-    optional: true
-
-  '@rollup/rollup-linux-x64-musl@4.61.1':
-    optional: true
-
-  '@rollup/rollup-openbsd-x64@4.61.1':
-    optional: true
-
-  '@rollup/rollup-openharmony-arm64@4.61.1':
-    optional: true
-
-  '@rollup/rollup-win32-arm64-msvc@4.61.1':
-    optional: true
-
-  '@rollup/rollup-win32-ia32-msvc@4.61.1':
-    optional: true
-
-  '@rollup/rollup-win32-x64-gnu@4.61.1':
-    optional: true
-
-  '@rollup/rollup-win32-x64-msvc@4.61.1':
-    optional: true
 
   '@rsbuild/core@1.6.7':
     dependencies:
@@ -17580,7 +17311,7 @@ snapshots:
       p-filter: 4.1.0
       semantic-release: 25.0.3(typescript@5.9.3)
       tinyglobby: 0.2.15
-      undici: 7.28.0
+      undici: 7.25.0
       url-join: 5.0.0
     transitivePeerDependencies:
       - supports-color
@@ -17602,8 +17333,8 @@ snapshots:
       mime: 4.1.0
       p-filter: 4.1.0
       semantic-release: 25.0.3(typescript@5.9.3)
-      tinyglobby: 0.2.15
-      undici: 7.28.0
+      tinyglobby: 0.2.17
+      undici: 7.25.0
       url-join: 5.0.0
     transitivePeerDependencies:
       - supports-color
@@ -17707,29 +17438,10 @@ snapshots:
       axe-core: 4.11.0
       storybook: 10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.8)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
 
-  '@storybook/addon-docs@10.4.2(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(esbuild@0.28.1)(rollup@4.61.1)(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.8)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@7.3.5(@types/node@24.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.43.1)(tsx@4.22.4)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.28.1))':
+  '@storybook/addon-docs@10.4.2(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(esbuild@0.28.1)(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.8)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@8.0.16(@types/node@24.10.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.43.1)(tsx@4.22.4)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.28.1))':
     dependencies:
       '@mdx-js/react': 3.1.1(@types/react@19.2.8)(react@19.2.3)
-      '@storybook/csf-plugin': 10.4.2(esbuild@0.28.1)(rollup@4.61.1)(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.8)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@7.3.5(@types/node@24.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.43.1)(tsx@4.22.4)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.28.1))
-      '@storybook/icons': 2.0.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@storybook/react-dom-shim': 10.4.2(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.8)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
-      storybook: 10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.8)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      ts-dedent: 2.2.0
-    optionalDependencies:
-      '@types/react': 19.2.8
-    transitivePeerDependencies:
-      - '@types/react-dom'
-      - esbuild
-      - rollup
-      - vite
-      - webpack
-
-  '@storybook/addon-docs@10.4.2(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(esbuild@0.28.1)(rollup@4.61.1)(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.8)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@8.0.16(@types/node@24.10.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.43.1)(tsx@4.22.4)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.28.1))':
-    dependencies:
-      '@mdx-js/react': 3.1.1(@types/react@19.2.8)(react@19.2.3)
-      '@storybook/csf-plugin': 10.4.2(esbuild@0.28.1)(rollup@4.61.1)(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.8)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@8.0.16(@types/node@24.10.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.43.1)(tsx@4.22.4)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.28.1))
+      '@storybook/csf-plugin': 10.4.2(esbuild@0.28.1)(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.8)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@8.0.16(@types/node@24.10.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.43.1)(tsx@4.22.4)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.28.1))
       '@storybook/icons': 2.0.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@storybook/react-dom-shim': 10.4.2(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.8)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
       react: 19.2.3
@@ -17766,20 +17478,9 @@ snapshots:
       - '@tmcp/auth'
       - typescript
 
-  '@storybook/builder-vite@10.4.2(esbuild@0.28.1)(rollup@4.61.1)(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.8)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@7.3.5(@types/node@24.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.43.1)(tsx@4.22.4)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.28.1))':
+  '@storybook/builder-vite@10.4.2(esbuild@0.28.1)(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.8)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@8.0.16(@types/node@24.10.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.43.1)(tsx@4.22.4)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.28.1))':
     dependencies:
-      '@storybook/csf-plugin': 10.4.2(esbuild@0.28.1)(rollup@4.61.1)(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.8)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@7.3.5(@types/node@24.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.43.1)(tsx@4.22.4)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.28.1))
-      storybook: 10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.8)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      ts-dedent: 2.2.0
-      vite: 7.3.5(@types/node@24.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.43.1)(tsx@4.22.4)(yaml@2.8.3)
-    transitivePeerDependencies:
-      - esbuild
-      - rollup
-      - webpack
-
-  '@storybook/builder-vite@10.4.2(esbuild@0.28.1)(rollup@4.61.1)(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.8)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@8.0.16(@types/node@24.10.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.43.1)(tsx@4.22.4)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.28.1))':
-    dependencies:
-      '@storybook/csf-plugin': 10.4.2(esbuild@0.28.1)(rollup@4.61.1)(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.8)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@8.0.16(@types/node@24.10.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.43.1)(tsx@4.22.4)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.28.1))
+      '@storybook/csf-plugin': 10.4.2(esbuild@0.28.1)(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.8)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@8.0.16(@types/node@24.10.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.43.1)(tsx@4.22.4)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.28.1))
       storybook: 10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.8)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       ts-dedent: 2.2.0
       vite: 8.0.16(@types/node@24.10.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.43.1)(tsx@4.22.4)(yaml@2.8.3)
@@ -17788,23 +17489,12 @@ snapshots:
       - rollup
       - webpack
 
-  '@storybook/csf-plugin@10.4.2(esbuild@0.28.1)(rollup@4.61.1)(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.8)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@7.3.5(@types/node@24.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.43.1)(tsx@4.22.4)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.28.1))':
+  '@storybook/csf-plugin@10.4.2(esbuild@0.28.1)(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.8)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@8.0.16(@types/node@24.10.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.43.1)(tsx@4.22.4)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.28.1))':
     dependencies:
       storybook: 10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.8)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       unplugin: 2.3.10
     optionalDependencies:
       esbuild: 0.28.1
-      rollup: 4.61.1
-      vite: 7.3.5(@types/node@24.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.43.1)(tsx@4.22.4)(yaml@2.8.3)
-      webpack: 5.105.4(esbuild@0.28.1)
-
-  '@storybook/csf-plugin@10.4.2(esbuild@0.28.1)(rollup@4.61.1)(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.8)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@8.0.16(@types/node@24.10.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.43.1)(tsx@4.22.4)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.28.1))':
-    dependencies:
-      storybook: 10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.8)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      unplugin: 2.3.10
-    optionalDependencies:
-      esbuild: 0.28.1
-      rollup: 4.61.1
       vite: 8.0.16(@types/node@24.10.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.43.1)(tsx@4.22.4)(yaml@2.8.3)
       webpack: 5.105.4(esbuild@0.28.1)
 
@@ -17839,35 +17529,11 @@ snapshots:
       '@types/react': 19.2.8
       '@types/react-dom': 19.2.3(@types/react@19.2.8)
 
-  '@storybook/react-vite@10.4.2(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(esbuild@0.28.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.61.1)(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.8)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.9.3)(vite@7.3.5(@types/node@24.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.43.1)(tsx@4.22.4)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.28.1))':
-    dependencies:
-      '@joshwooding/vite-plugin-react-docgen-typescript': 0.7.0(typescript@5.9.3)(vite@7.3.5(@types/node@24.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.43.1)(tsx@4.22.4)(yaml@2.8.3))
-      '@rollup/pluginutils': 5.3.0(rollup@4.61.1)
-      '@storybook/builder-vite': 10.4.2(esbuild@0.28.1)(rollup@4.61.1)(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.8)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@7.3.5(@types/node@24.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.43.1)(tsx@4.22.4)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.28.1))
-      '@storybook/react': 10.4.2(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.8)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.9.3)
-      empathic: 2.0.0
-      magic-string: 0.30.21
-      react: 19.2.3
-      react-docgen: 8.0.2
-      react-dom: 19.2.3(react@19.2.3)
-      resolve: 1.22.11
-      storybook: 10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.8)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      tsconfig-paths: 4.2.0
-      vite: 7.3.5(@types/node@24.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.43.1)(tsx@4.22.4)(yaml@2.8.3)
-    transitivePeerDependencies:
-      - '@types/react'
-      - '@types/react-dom'
-      - esbuild
-      - rollup
-      - supports-color
-      - typescript
-      - webpack
-
-  '@storybook/react-vite@10.4.2(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(esbuild@0.28.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.61.1)(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.8)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.9.3)(vite@8.0.16(@types/node@24.10.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.43.1)(tsx@4.22.4)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.28.1))':
+  '@storybook/react-vite@10.4.2(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(esbuild@0.28.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.8)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.9.3)(vite@8.0.16(@types/node@24.10.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.43.1)(tsx@4.22.4)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.28.1))':
     dependencies:
       '@joshwooding/vite-plugin-react-docgen-typescript': 0.7.0(typescript@5.9.3)(vite@8.0.16(@types/node@24.10.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.43.1)(tsx@4.22.4)(yaml@2.8.3))
-      '@rollup/pluginutils': 5.3.0(rollup@4.61.1)
-      '@storybook/builder-vite': 10.4.2(esbuild@0.28.1)(rollup@4.61.1)(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.8)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@8.0.16(@types/node@24.10.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.43.1)(tsx@4.22.4)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.28.1))
+      '@rollup/pluginutils': 5.3.0
+      '@storybook/builder-vite': 10.4.2(esbuild@0.28.1)(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.8)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@8.0.16(@types/node@24.10.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.43.1)(tsx@4.22.4)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.28.1))
       '@storybook/react': 10.4.2(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.8)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.9.3)
       empathic: 2.0.0
       magic-string: 0.30.21
@@ -18211,12 +17877,12 @@ snapshots:
       postcss: 8.5.15
       tailwindcss: 4.3.0
 
-  '@tailwindcss/vite@4.2.2(vite@7.3.5(@types/node@24.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.43.1)(tsx@4.22.4)(yaml@2.8.3))':
+  '@tailwindcss/vite@4.2.2(vite@8.0.16(@types/node@24.10.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.43.1)(tsx@4.22.4)(yaml@2.8.3))':
     dependencies:
       '@tailwindcss/node': 4.2.2
       '@tailwindcss/oxide': 4.2.2
       tailwindcss: 4.2.2
-      vite: 7.3.5(@types/node@24.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.43.1)(tsx@4.22.4)(yaml@2.8.3)
+      vite: 8.0.16(@types/node@24.10.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.43.1)(tsx@4.22.4)(yaml@2.8.3)
 
   '@tanstack/ai-client@0.8.0':
     dependencies:
@@ -18849,18 +18515,6 @@ snapshots:
     optionalDependencies:
       next: 16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react: 19.2.3
-
-  '@vitejs/plugin-react@5.2.0(vite@7.3.5(@types/node@24.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.43.1)(tsx@4.22.4)(yaml@2.8.3))':
-    dependencies:
-      '@babel/core': 7.29.7
-      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.7)
-      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.29.7)
-      '@rolldown/pluginutils': 1.0.0-rc.3
-      '@types/babel__core': 7.20.5
-      react-refresh: 0.18.0
-      vite: 7.3.5(@types/node@24.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.43.1)(tsx@4.22.4)(yaml@2.8.3)
-    transitivePeerDependencies:
-      - supports-color
 
   '@vitejs/plugin-react@5.2.0(vite@8.0.16(@types/node@24.10.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.43.1)(tsx@4.22.4)(yaml@2.8.3))':
     dependencies:
@@ -20344,7 +19998,7 @@ snapshots:
     dependencies:
       domelementtype: 2.3.0
 
-  dompurify@3.4.11:
+  dompurify@3.4.10:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -22795,7 +22449,7 @@ snapshots:
       d3-sankey: 0.12.3
       dagre-d3-es: 7.0.14
       dayjs: 1.11.20
-      dompurify: 3.4.11
+      dompurify: 3.4.10
       es-toolkit: 1.46.1
       katex: 0.16.45
       khroma: 2.1.0
@@ -23142,7 +22796,7 @@ snapshots:
 
   monaco-editor@0.55.1:
     dependencies:
-      dompurify: 3.4.11
+      dompurify: 3.4.10
       marked: 14.0.0
 
   moo@0.5.3: {}
@@ -23254,13 +22908,13 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
-  nextra-theme-docs@4.6.1(@types/react@19.2.8)(next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(nextra@4.6.1(next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(use-sync-external-store@1.6.0(react@19.2.3)):
+  nextra-theme-docs@4.6.1(@types/react@19.2.8)(next@16.2.6(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(nextra@4.6.1(next@16.2.6(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(use-sync-external-store@1.6.0(react@19.2.3)):
     dependencies:
       '@headlessui/react': 2.2.9(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       clsx: 2.1.1
       next: 16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       next-themes: 0.4.6(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      nextra: 4.6.1(next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
+      nextra: 4.6.1(next@16.2.6(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
       react: 19.2.3
       react-compiler-runtime: 19.1.0-rc.3(react@19.2.3)
       react-dom: 19.2.3(react@19.2.3)
@@ -23272,7 +22926,7 @@ snapshots:
       - immer
       - use-sync-external-store
 
-  nextra@4.6.1(next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3):
+  nextra@4.6.1(next@16.2.6(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3):
     dependencies:
       '@formatjs/intl-localematcher': 0.6.2
       '@headlessui/react': 2.2.9(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -24439,13 +24093,13 @@ snapshots:
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
 
-  react-scan@0.5.3(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.61.1):
+  react-scan@0.5.3(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
       '@babel/core': 7.29.7
       '@babel/generator': 7.28.5
       '@babel/types': 7.29.0
       '@preact/signals': 1.3.3(preact@10.28.2)
-      '@rollup/pluginutils': 5.3.0(rollup@4.61.1)
+      '@rollup/pluginutils': 5.3.0
       '@types/node': 20.19.27
       bippy: 0.5.32(@types/react@19.2.8)(react@19.2.3)
       commander: 14.0.2
@@ -24910,57 +24564,26 @@ snapshots:
 
   robust-predicates@3.0.2: {}
 
-  rolldown@1.0.1:
+  rolldown@1.0.3:
     dependencies:
-      '@oxc-project/types': 0.130.0
+      '@oxc-project/types': 0.133.0
       '@rolldown/pluginutils': 1.0.1
     optionalDependencies:
-      '@rolldown/binding-android-arm64': 1.0.1
-      '@rolldown/binding-darwin-arm64': 1.0.1
-      '@rolldown/binding-darwin-x64': 1.0.1
-      '@rolldown/binding-freebsd-x64': 1.0.1
-      '@rolldown/binding-linux-arm-gnueabihf': 1.0.1
-      '@rolldown/binding-linux-arm64-gnu': 1.0.1
-      '@rolldown/binding-linux-arm64-musl': 1.0.1
-      '@rolldown/binding-linux-ppc64-gnu': 1.0.1
-      '@rolldown/binding-linux-s390x-gnu': 1.0.1
-      '@rolldown/binding-linux-x64-gnu': 1.0.1
-      '@rolldown/binding-linux-x64-musl': 1.0.1
-      '@rolldown/binding-openharmony-arm64': 1.0.1
-      '@rolldown/binding-wasm32-wasi': 1.0.1
-      '@rolldown/binding-win32-arm64-msvc': 1.0.1
-      '@rolldown/binding-win32-x64-msvc': 1.0.1
-
-  rollup@4.61.1:
-    dependencies:
-      '@types/estree': 1.0.9
-    optionalDependencies:
-      '@rollup/rollup-android-arm-eabi': 4.61.1
-      '@rollup/rollup-android-arm64': 4.61.1
-      '@rollup/rollup-darwin-arm64': 4.61.1
-      '@rollup/rollup-darwin-x64': 4.61.1
-      '@rollup/rollup-freebsd-arm64': 4.61.1
-      '@rollup/rollup-freebsd-x64': 4.61.1
-      '@rollup/rollup-linux-arm-gnueabihf': 4.61.1
-      '@rollup/rollup-linux-arm-musleabihf': 4.61.1
-      '@rollup/rollup-linux-arm64-gnu': 4.61.1
-      '@rollup/rollup-linux-arm64-musl': 4.61.1
-      '@rollup/rollup-linux-loong64-gnu': 4.61.1
-      '@rollup/rollup-linux-loong64-musl': 4.61.1
-      '@rollup/rollup-linux-ppc64-gnu': 4.61.1
-      '@rollup/rollup-linux-ppc64-musl': 4.61.1
-      '@rollup/rollup-linux-riscv64-gnu': 4.61.1
-      '@rollup/rollup-linux-riscv64-musl': 4.61.1
-      '@rollup/rollup-linux-s390x-gnu': 4.61.1
-      '@rollup/rollup-linux-x64-gnu': 4.61.1
-      '@rollup/rollup-linux-x64-musl': 4.61.1
-      '@rollup/rollup-openbsd-x64': 4.61.1
-      '@rollup/rollup-openharmony-arm64': 4.61.1
-      '@rollup/rollup-win32-arm64-msvc': 4.61.1
-      '@rollup/rollup-win32-ia32-msvc': 4.61.1
-      '@rollup/rollup-win32-x64-gnu': 4.61.1
-      '@rollup/rollup-win32-x64-msvc': 4.61.1
-      fsevents: 2.3.3
+      '@rolldown/binding-android-arm64': 1.0.3
+      '@rolldown/binding-darwin-arm64': 1.0.3
+      '@rolldown/binding-darwin-x64': 1.0.3
+      '@rolldown/binding-freebsd-x64': 1.0.3
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.3
+      '@rolldown/binding-linux-arm64-gnu': 1.0.3
+      '@rolldown/binding-linux-arm64-musl': 1.0.3
+      '@rolldown/binding-linux-ppc64-gnu': 1.0.3
+      '@rolldown/binding-linux-s390x-gnu': 1.0.3
+      '@rolldown/binding-linux-x64-gnu': 1.0.3
+      '@rolldown/binding-linux-x64-musl': 1.0.3
+      '@rolldown/binding-openharmony-arm64': 1.0.3
+      '@rolldown/binding-wasm32-wasi': 1.0.3
+      '@rolldown/binding-win32-arm64-msvc': 1.0.3
+      '@rolldown/binding-win32-x64-msvc': 1.0.3
 
   rope-sequence@1.3.4: {}
 
@@ -26133,9 +25756,9 @@ snapshots:
 
   undici-types@7.16.0: {}
 
-  undici@6.27.0: {}
+  undici@6.24.1: {}
 
-  undici@7.28.0: {}
+  undici@7.25.0: {}
 
   unicode-canonical-property-names-ecmascript@2.0.1: {}
 
@@ -26373,12 +25996,12 @@ snapshots:
       d3-time: 3.1.0
       d3-timer: 3.0.1
 
-  vite-plugin-svgr@4.5.0(rollup@4.61.1)(typescript@5.9.3)(vite@7.3.5(@types/node@24.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.43.1)(tsx@4.22.4)(yaml@2.8.3)):
+  vite-plugin-svgr@4.5.0(typescript@5.9.3)(vite@8.0.16(@types/node@24.10.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.43.1)(tsx@4.22.4)(yaml@2.8.3)):
     dependencies:
-      '@rollup/pluginutils': 5.3.0(rollup@4.61.1)
+      '@rollup/pluginutils': 5.3.0
       '@svgr/core': 8.1.0(typescript@5.9.3)
       '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0(typescript@5.9.3))
-      vite: 7.3.5(@types/node@24.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.43.1)(tsx@4.22.4)(yaml@2.8.3)
+      vite: 8.0.16(@types/node@24.10.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.43.1)(tsx@4.22.4)(yaml@2.8.3)
     transitivePeerDependencies:
       - rollup
       - supports-color
@@ -26395,29 +26018,12 @@ snapshots:
       - supports-color
       - typescript
 
-  vite@7.3.5(@types/node@24.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.43.1)(tsx@4.22.4)(yaml@2.8.3):
-    dependencies:
-      esbuild: 0.28.1
-      fdir: 6.5.0(picomatch@4.0.4)
-      picomatch: 4.0.4
-      postcss: 8.5.15
-      rollup: 4.61.1
-      tinyglobby: 0.2.17
-    optionalDependencies:
-      '@types/node': 24.10.1
-      fsevents: 2.3.3
-      jiti: 2.7.0
-      lightningcss: 1.32.0
-      terser: 5.43.1
-      tsx: 4.22.4
-      yaml: 2.8.3
-
   vite@8.0.16(@types/node@24.10.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.43.1)(tsx@4.22.4)(yaml@2.8.3):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
       postcss: 8.5.15
-      rolldown: 1.0.1
+      rolldown: 1.0.3
       tinyglobby: 0.2.17
     optionalDependencies:
       '@types/node': 24.10.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -482,7 +482,7 @@ importers:
         version: 10.4.2(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.8)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
       '@storybook/addon-docs':
         specifier: ^10.4.1
-        version: 10.4.2(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(esbuild@0.28.1)(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.8)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@8.0.16(@types/node@24.10.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.43.1)(tsx@4.22.4)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.28.1))
+        version: 10.4.2(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(esbuild@0.28.1)(rollup@4.61.1)(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.8)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@7.3.5(@types/node@24.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.43.1)(tsx@4.22.4)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.28.1))
       '@storybook/addon-links':
         specifier: ^10.4.1
         version: 10.4.2(@types/react@19.2.8)(react@19.2.3)(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.8)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
@@ -497,10 +497,10 @@ importers:
         version: 10.4.2(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.8)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.9.3)
       '@storybook/react-vite':
         specifier: ^10.4.1
-        version: 10.4.2(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(esbuild@0.28.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.8)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.9.3)(vite@8.0.16(@types/node@24.10.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.43.1)(tsx@4.22.4)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.28.1))
+        version: 10.4.2(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(esbuild@0.28.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.61.1)(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.8)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.9.3)(vite@7.3.5(@types/node@24.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.43.1)(tsx@4.22.4)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.28.1))
       '@tailwindcss/vite':
         specifier: ^4.2.2
-        version: 4.2.2(vite@8.0.16(@types/node@24.10.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.43.1)(tsx@4.22.4)(yaml@2.8.3))
+        version: 4.2.2(vite@7.3.5(@types/node@24.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.43.1)(tsx@4.22.4)(yaml@2.8.3))
       '@types/react':
         specifier: ^19.2.6
         version: 19.2.8
@@ -509,10 +509,10 @@ importers:
         version: 19.2.3(@types/react@19.2.8)
       '@vitejs/plugin-react':
         specifier: ^5.2.0
-        version: 5.2.0(vite@8.0.16(@types/node@24.10.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.43.1)(tsx@4.22.4)(yaml@2.8.3))
+        version: 5.2.0(vite@7.3.5(@types/node@24.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.43.1)(tsx@4.22.4)(yaml@2.8.3))
       react-scan:
         specifier: ^0.5.3
-        version: 0.5.3(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 0.5.3(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.61.1)
       storybook:
         specifier: ^10.4.1
         version: 10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.8)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -523,11 +523,11 @@ importers:
         specifier: ^5.9.3
         version: 5.9.3
       vite:
-        specifier: ^8.0.0
-        version: 8.0.16(@types/node@24.10.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.43.1)(tsx@4.22.4)(yaml@2.8.3)
+        specifier: ^7.3.5
+        version: 7.3.5(@types/node@24.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.43.1)(tsx@4.22.4)(yaml@2.8.3)
       vite-plugin-svgr:
         specifier: ^4.5.0
-        version: 4.5.0(typescript@5.9.3)(vite@8.0.16(@types/node@24.10.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.43.1)(tsx@4.22.4)(yaml@2.8.3))
+        version: 4.5.0(rollup@4.61.1)(typescript@5.9.3)(vite@7.3.5(@types/node@24.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.43.1)(tsx@4.22.4)(yaml@2.8.3))
 
   packages/apollo-core:
     devDependencies:
@@ -807,7 +807,7 @@ importers:
         version: 10.4.2(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.8)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.9.3)
       '@storybook/react-vite':
         specifier: ^10.4.1
-        version: 10.4.2(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(esbuild@0.28.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.8)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.9.3)(vite@8.0.16(@types/node@24.10.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.43.1)(tsx@4.22.4)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.28.1))
+        version: 10.4.2(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(esbuild@0.28.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.61.1)(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.8)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.9.3)(vite@8.0.16(@types/node@24.10.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.43.1)(tsx@4.22.4)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.28.1))
       '@svgr/webpack':
         specifier: ^8.1.0
         version: 8.1.0(typescript@5.9.3)
@@ -1108,7 +1108,7 @@ importers:
         version: 10.4.2(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.8)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
       '@storybook/addon-docs':
         specifier: ^10.4.1
-        version: 10.4.2(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(esbuild@0.28.1)(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.8)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@8.0.16(@types/node@24.10.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.43.1)(tsx@4.22.4)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.28.1))
+        version: 10.4.2(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(esbuild@0.28.1)(rollup@4.61.1)(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.8)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@8.0.16(@types/node@24.10.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.43.1)(tsx@4.22.4)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.28.1))
       '@storybook/addon-links':
         specifier: ^10.4.1
         version: 10.4.2(@types/react@19.2.8)(react@19.2.3)(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.8)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
@@ -1117,7 +1117,7 @@ importers:
         version: 0.2.3(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.8)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.9.3)
       '@storybook/react-vite':
         specifier: ^10.4.1
-        version: 10.4.2(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(esbuild@0.28.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.8)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.9.3)(vite@8.0.16(@types/node@24.10.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.43.1)(tsx@4.22.4)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.28.1))
+        version: 10.4.2(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(esbuild@0.28.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.61.1)(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.8)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.9.3)(vite@8.0.16(@types/node@24.10.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.43.1)(tsx@4.22.4)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.28.1))
       '@tailwindcss/cli':
         specifier: ^4.1.17
         version: 4.1.17
@@ -1180,7 +1180,7 @@ importers:
         version: 19.2.3(react@19.2.3)
       react-scan:
         specifier: ^0.5.3
-        version: 0.5.3(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 0.5.3(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.61.1)
       semantic-release:
         specifier: ^25.0.3
         version: 25.0.3(typescript@5.9.3)
@@ -5109,6 +5109,144 @@ packages:
     peerDependenciesMeta:
       rollup:
         optional: true
+
+  '@rollup/rollup-android-arm-eabi@4.61.1':
+    resolution: {integrity: sha512-JnBB8MdXj45cajvTuO5FmPlvFVJRQgvrz1uSEl3NwqFnReAPGwb8EanbGi4z2nRaqLzjJSv5/JmycoTKlRZxHA==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.61.1':
+    resolution: {integrity: sha512-Jx2g7iSjw4AOT0HDPHM9RV3GNjRXwybWtSFZiZAYUTjUwjVrYIwq3kBf+LnhqJlzXFAqTAh2F7IGI+O568exPw==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.61.1':
+    resolution: {integrity: sha512-0F1L/Z3Eqv8mT2n3dCpeO8GcTvHvVqkP5/t6DMsn0KzhYVcg+s7Ncl5DS8qjKYEeio6Az0Gt6nyBORay5qIlCA==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.61.1':
+    resolution: {integrity: sha512-qLttcH871ujY4YcVfUSShhOw+CsoTatYz8gRbHO7Bb92QH059/P0y5do1KMs41fY0BpD2x4AJH/gID0zFiqVKQ==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.61.1':
+    resolution: {integrity: sha512-fUI4RapGE0Oh3mb8mgfvC1O2nU1RpDZUKnDQm3xB1Ipg7C2wTs5Kstz7G2uWK99a8S2yTMq8/P4uycwNa0nJyw==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.61.1':
+    resolution: {integrity: sha512-H5YrdvJaDtI/U9/emrD4b++xkvp3y/JvOe4rizHbxvkyMfRS/CiRYdji+Pl8D0brEaNFWUh1drQxgAGIl6Xudw==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.61.1':
+    resolution: {integrity: sha512-Q8CBCCQtDFrYtXoeUXSrnFXKOnyUhx6bz+SkL6A0E7V8kAiCJ5pamq1WtbfpVGhR5TSpXY6ak3avmDc5fHTyJA==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.61.1':
+    resolution: {integrity: sha512-nwnhk1581l0FBVellGcVCAT0Oi06onEA3WB53sf01VO3I0UPBkMH9sXONYME2K0ovXcNayJfNtHfm6mpJElatQ==}
+    cpu: [arm]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-arm64-gnu@4.61.1':
+    resolution: {integrity: sha512-x5Xr49hwt3hdW75UOZm3395YwwzPyauktslv29KpWL/T+vVAzoT3azLcTWv0eMciBNrx+DYjH4paehHoLpPvpg==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm64-musl@4.61.1':
+    resolution: {integrity: sha512-unMS3H73DpaoPyyEVPjGKleM/s0mkmsauTENpw4INQY8y4+IuLNjkueQ5QCtC0D3N38Y38yhAU8OoZ20S2Tm6w==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-loong64-gnu@4.61.1':
+    resolution: {integrity: sha512-zNZzGRnAhwjFEYmvphJRV5XaQGjs62cCmeYYHUT//NbvEnHauw+I85nGG+SiVg5ld4GX8D1IbKIX+ozITQnhMQ==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-loong64-musl@4.61.1':
+    resolution: {integrity: sha512-LdpWGL8X209B2SIvWjqlc8VZgM6PKfontSerGepuldQmHYrAOtnMCXeJkxXGbC+PPZVOuu5czJo7fNV6aeW8rQ==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.61.1':
+    resolution: {integrity: sha512-EC5kTtNaNGOmbMGqar8dvJy6y/hg99GAwjfBz++pxZhQATXGcRjd6c5en5wcbru0vkRmiMGsQKdMJOOf6sza4g==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-ppc64-musl@4.61.1':
+    resolution: {integrity: sha512-8hiwp6D4acEcNK78I4rP0/XtS1sknWIAMJBPdR4l6zUtyTm5KiTDr5bXmWt4foY7nAN7AThDHgkLIEZOWKbzWw==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.61.1':
+    resolution: {integrity: sha512-10dh/h/BqA7DuMPWSxkR8uks18FRwnwOEqr5zOTEl+NOwP/OMzKX8OFR/Of9xxDA7D5qef1Nzar5WDD2kCCr1g==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-riscv64-musl@4.61.1':
+    resolution: {integrity: sha512-YKJ5lg35DP17gcAOggnihe+APw9HLyj1Xn7gsmGumBJAUDa6NGXNixJzmkWLhcK9TOuuyQjdamzvJefkO7qHZQ==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-s390x-gnu@4.61.1':
+    resolution: {integrity: sha512-Mlil5G2Jj6a7B3LWGctg+XPL9vdXYuzCtNXfxOQ0nPjc2m6ueUktocPGH9bnAM0bNRKb/bAWTujUU7IJQdQA+g==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-gnu@4.61.1':
+    resolution: {integrity: sha512-bVWIOIk6pV01p4CdUbPP7CJ/434z+OooYjDuFcR+44N35YvKUC66G8MGnvcWx5mWKW3g61J+t74l3Kj15Kwn2Q==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-musl@4.61.1':
+    resolution: {integrity: sha512-qy5pBvZbqNFheBz61R1rzsezjm0J7O2oNGoWtGoY89SZYLUfxAJTBAqDChqAIdB4rCiIbi9nF7yZ83GnNiLwSw==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-openbsd-x64@4.61.1':
+    resolution: {integrity: sha512-E83TXjI4zm0+5f2qO+UOudaCYIhYwpJ5jq6YCZNIZ+6CbfhKrkAGezeiASBL9ElxAxFsRS9ZhESv8mfnj6TKeg==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.61.1':
+    resolution: {integrity: sha512-fbWnKqVkjrJN38vNe3ahkbk6iejS/3b0Nt7EEtPpE6RBacZcGXNKbzfHN3GUUlXOPghUg0j6XUGrtjX9z1sIvA==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.61.1':
+    resolution: {integrity: sha512-ArMl38iVAbk0New1ogihQNY6iphLi4ZaRsa037gUzv5yeKPY8TD3Dmy4x2RNC1VztU/uqm+G+/RwFrSka3Oy2g==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.61.1':
+    resolution: {integrity: sha512-0mYtjHS9ucAbcATycCNK9IGBk/cCe/ma7EmSLGZdsxnOA8cjRIyU04wDpVAD9NiOfLUR9KTxdiO53uOkherqjQ==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.61.1':
+    resolution: {integrity: sha512-gK1iCEPfpoSG9wfBihXxvBMi8ZfcWffYkEsC/Eih+iFENTaewvNcrEQ69lIOWYO5pePHKLHHO7nq5AILGO/HQQ==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.61.1':
+    resolution: {integrity: sha512-X+zaP2x+j4RXGfbp/seSoRHWnPxzApilDszisZxbYH5C/jTxFhCtDNdPGZb9lJyYPs24wGxruPF7Y+sIXt9Gzw==}
+    cpu: [x64]
+    os: [win32]
 
   '@rsbuild/core@1.6.7':
     resolution: {integrity: sha512-V0INbMrT/LwyhzKmvpupe2oSvPFWaivz7sdriFRp381BJvD0d2pYcq9iRW91bxgMRX78MgTzFYAu868hMAzoSw==}
@@ -11586,6 +11724,11 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
+  rollup@4.61.1:
+    resolution: {integrity: sha512-I4KW6iuRpuu2uHBLraZ1wNZe0DP7lnRha+VJ9tNaYVaVgKhW0aI3h4RYnoRPeql0flHm/Co55b7snEDcOfOJrA==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
   rope-sequence@1.3.4:
     resolution: {integrity: sha512-UT5EDe2cu2E/6O4igUr5PSFs23nvvukicWHx6GnOPlHAiiYbzNuCRQCuiUdHJQcqKalLKlrYJnjY0ySGsXNQXQ==}
 
@@ -12759,6 +12902,46 @@ packages:
       vite: '*'
     peerDependenciesMeta:
       vite:
+        optional: true
+
+  vite@7.3.5:
+    resolution: {integrity: sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      lightningcss: ^1.21.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
         optional: true
 
   vite@8.0.16:
@@ -15030,6 +15213,14 @@ snapshots:
       '@types/yargs': 17.0.35
       chalk: 4.1.2
 
+  '@joshwooding/vite-plugin-react-docgen-typescript@0.7.0(typescript@5.9.3)(vite@7.3.5(@types/node@24.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.43.1)(tsx@4.22.4)(yaml@2.8.3))':
+    dependencies:
+      glob: 13.0.6
+      react-docgen-typescript: 2.4.0(typescript@5.9.3)
+      vite: 7.3.5(@types/node@24.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.43.1)(tsx@4.22.4)(yaml@2.8.3)
+    optionalDependencies:
+      typescript: 5.9.3
+
   '@joshwooding/vite-plugin-react-docgen-typescript@0.7.0(typescript@5.9.3)(vite@8.0.16(@types/node@24.10.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.43.1)(tsx@4.22.4)(yaml@2.8.3))':
     dependencies:
       glob: 13.0.6
@@ -17062,11 +17253,88 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.1': {}
 
-  '@rollup/pluginutils@5.3.0':
+  '@rollup/pluginutils@5.3.0(rollup@4.61.1)':
     dependencies:
       '@types/estree': 1.0.9
       estree-walker: 2.0.2
       picomatch: 4.0.4
+    optionalDependencies:
+      rollup: 4.61.1
+
+  '@rollup/rollup-android-arm-eabi@4.61.1':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.61.1':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.61.1':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.61.1':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.61.1':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.61.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.61.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.61.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.61.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.61.1':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.61.1':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.61.1':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.61.1':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.61.1':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.61.1':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.61.1':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.61.1':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.61.1':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.61.1':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.61.1':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.61.1':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.61.1':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.61.1':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.61.1':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.61.1':
+    optional: true
 
   '@rsbuild/core@1.6.7':
     dependencies:
@@ -17436,10 +17704,29 @@ snapshots:
       axe-core: 4.11.0
       storybook: 10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.8)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
 
-  '@storybook/addon-docs@10.4.2(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(esbuild@0.28.1)(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.8)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@8.0.16(@types/node@24.10.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.43.1)(tsx@4.22.4)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.28.1))':
+  '@storybook/addon-docs@10.4.2(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(esbuild@0.28.1)(rollup@4.61.1)(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.8)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@7.3.5(@types/node@24.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.43.1)(tsx@4.22.4)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.28.1))':
     dependencies:
       '@mdx-js/react': 3.1.1(@types/react@19.2.8)(react@19.2.3)
-      '@storybook/csf-plugin': 10.4.2(esbuild@0.28.1)(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.8)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@8.0.16(@types/node@24.10.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.43.1)(tsx@4.22.4)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.28.1))
+      '@storybook/csf-plugin': 10.4.2(esbuild@0.28.1)(rollup@4.61.1)(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.8)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@7.3.5(@types/node@24.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.43.1)(tsx@4.22.4)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.28.1))
+      '@storybook/icons': 2.0.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@storybook/react-dom-shim': 10.4.2(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.8)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+      storybook: 10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.8)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      ts-dedent: 2.2.0
+    optionalDependencies:
+      '@types/react': 19.2.8
+    transitivePeerDependencies:
+      - '@types/react-dom'
+      - esbuild
+      - rollup
+      - vite
+      - webpack
+
+  '@storybook/addon-docs@10.4.2(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(esbuild@0.28.1)(rollup@4.61.1)(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.8)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@8.0.16(@types/node@24.10.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.43.1)(tsx@4.22.4)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.28.1))':
+    dependencies:
+      '@mdx-js/react': 3.1.1(@types/react@19.2.8)(react@19.2.3)
+      '@storybook/csf-plugin': 10.4.2(esbuild@0.28.1)(rollup@4.61.1)(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.8)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@8.0.16(@types/node@24.10.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.43.1)(tsx@4.22.4)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.28.1))
       '@storybook/icons': 2.0.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@storybook/react-dom-shim': 10.4.2(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.8)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
       react: 19.2.3
@@ -17476,9 +17763,20 @@ snapshots:
       - '@tmcp/auth'
       - typescript
 
-  '@storybook/builder-vite@10.4.2(esbuild@0.28.1)(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.8)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@8.0.16(@types/node@24.10.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.43.1)(tsx@4.22.4)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.28.1))':
+  '@storybook/builder-vite@10.4.2(esbuild@0.28.1)(rollup@4.61.1)(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.8)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@7.3.5(@types/node@24.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.43.1)(tsx@4.22.4)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.28.1))':
     dependencies:
-      '@storybook/csf-plugin': 10.4.2(esbuild@0.28.1)(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.8)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@8.0.16(@types/node@24.10.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.43.1)(tsx@4.22.4)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.28.1))
+      '@storybook/csf-plugin': 10.4.2(esbuild@0.28.1)(rollup@4.61.1)(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.8)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@7.3.5(@types/node@24.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.43.1)(tsx@4.22.4)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.28.1))
+      storybook: 10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.8)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      ts-dedent: 2.2.0
+      vite: 7.3.5(@types/node@24.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.43.1)(tsx@4.22.4)(yaml@2.8.3)
+    transitivePeerDependencies:
+      - esbuild
+      - rollup
+      - webpack
+
+  '@storybook/builder-vite@10.4.2(esbuild@0.28.1)(rollup@4.61.1)(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.8)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@8.0.16(@types/node@24.10.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.43.1)(tsx@4.22.4)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.28.1))':
+    dependencies:
+      '@storybook/csf-plugin': 10.4.2(esbuild@0.28.1)(rollup@4.61.1)(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.8)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@8.0.16(@types/node@24.10.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.43.1)(tsx@4.22.4)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.28.1))
       storybook: 10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.8)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       ts-dedent: 2.2.0
       vite: 8.0.16(@types/node@24.10.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.43.1)(tsx@4.22.4)(yaml@2.8.3)
@@ -17487,12 +17785,23 @@ snapshots:
       - rollup
       - webpack
 
-  '@storybook/csf-plugin@10.4.2(esbuild@0.28.1)(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.8)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@8.0.16(@types/node@24.10.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.43.1)(tsx@4.22.4)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.28.1))':
+  '@storybook/csf-plugin@10.4.2(esbuild@0.28.1)(rollup@4.61.1)(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.8)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@7.3.5(@types/node@24.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.43.1)(tsx@4.22.4)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.28.1))':
     dependencies:
       storybook: 10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.8)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       unplugin: 2.3.10
     optionalDependencies:
       esbuild: 0.28.1
+      rollup: 4.61.1
+      vite: 7.3.5(@types/node@24.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.43.1)(tsx@4.22.4)(yaml@2.8.3)
+      webpack: 5.105.4(esbuild@0.28.1)
+
+  '@storybook/csf-plugin@10.4.2(esbuild@0.28.1)(rollup@4.61.1)(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.8)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@8.0.16(@types/node@24.10.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.43.1)(tsx@4.22.4)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.28.1))':
+    dependencies:
+      storybook: 10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.8)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      unplugin: 2.3.10
+    optionalDependencies:
+      esbuild: 0.28.1
+      rollup: 4.61.1
       vite: 8.0.16(@types/node@24.10.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.43.1)(tsx@4.22.4)(yaml@2.8.3)
       webpack: 5.105.4(esbuild@0.28.1)
 
@@ -17527,11 +17836,35 @@ snapshots:
       '@types/react': 19.2.8
       '@types/react-dom': 19.2.3(@types/react@19.2.8)
 
-  '@storybook/react-vite@10.4.2(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(esbuild@0.28.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.8)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.9.3)(vite@8.0.16(@types/node@24.10.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.43.1)(tsx@4.22.4)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.28.1))':
+  '@storybook/react-vite@10.4.2(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(esbuild@0.28.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.61.1)(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.8)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.9.3)(vite@7.3.5(@types/node@24.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.43.1)(tsx@4.22.4)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.28.1))':
+    dependencies:
+      '@joshwooding/vite-plugin-react-docgen-typescript': 0.7.0(typescript@5.9.3)(vite@7.3.5(@types/node@24.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.43.1)(tsx@4.22.4)(yaml@2.8.3))
+      '@rollup/pluginutils': 5.3.0(rollup@4.61.1)
+      '@storybook/builder-vite': 10.4.2(esbuild@0.28.1)(rollup@4.61.1)(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.8)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@7.3.5(@types/node@24.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.43.1)(tsx@4.22.4)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.28.1))
+      '@storybook/react': 10.4.2(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.8)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.9.3)
+      empathic: 2.0.0
+      magic-string: 0.30.21
+      react: 19.2.3
+      react-docgen: 8.0.2
+      react-dom: 19.2.3(react@19.2.3)
+      resolve: 1.22.11
+      storybook: 10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.8)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      tsconfig-paths: 4.2.0
+      vite: 7.3.5(@types/node@24.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.43.1)(tsx@4.22.4)(yaml@2.8.3)
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+      - esbuild
+      - rollup
+      - supports-color
+      - typescript
+      - webpack
+
+  '@storybook/react-vite@10.4.2(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(esbuild@0.28.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.61.1)(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.8)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.9.3)(vite@8.0.16(@types/node@24.10.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.43.1)(tsx@4.22.4)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.28.1))':
     dependencies:
       '@joshwooding/vite-plugin-react-docgen-typescript': 0.7.0(typescript@5.9.3)(vite@8.0.16(@types/node@24.10.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.43.1)(tsx@4.22.4)(yaml@2.8.3))
-      '@rollup/pluginutils': 5.3.0
-      '@storybook/builder-vite': 10.4.2(esbuild@0.28.1)(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.8)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@8.0.16(@types/node@24.10.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.43.1)(tsx@4.22.4)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.28.1))
+      '@rollup/pluginutils': 5.3.0(rollup@4.61.1)
+      '@storybook/builder-vite': 10.4.2(esbuild@0.28.1)(rollup@4.61.1)(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.8)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@8.0.16(@types/node@24.10.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.43.1)(tsx@4.22.4)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.28.1))
       '@storybook/react': 10.4.2(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.8)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.9.3)
       empathic: 2.0.0
       magic-string: 0.30.21
@@ -17875,12 +18208,12 @@ snapshots:
       postcss: 8.5.15
       tailwindcss: 4.3.0
 
-  '@tailwindcss/vite@4.2.2(vite@8.0.16(@types/node@24.10.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.43.1)(tsx@4.22.4)(yaml@2.8.3))':
+  '@tailwindcss/vite@4.2.2(vite@7.3.5(@types/node@24.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.43.1)(tsx@4.22.4)(yaml@2.8.3))':
     dependencies:
       '@tailwindcss/node': 4.2.2
       '@tailwindcss/oxide': 4.2.2
       tailwindcss: 4.2.2
-      vite: 8.0.16(@types/node@24.10.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.43.1)(tsx@4.22.4)(yaml@2.8.3)
+      vite: 7.3.5(@types/node@24.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.43.1)(tsx@4.22.4)(yaml@2.8.3)
 
   '@tanstack/ai-client@0.8.0':
     dependencies:
@@ -18513,6 +18846,18 @@ snapshots:
     optionalDependencies:
       next: 16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react: 19.2.3
+
+  '@vitejs/plugin-react@5.2.0(vite@7.3.5(@types/node@24.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.43.1)(tsx@4.22.4)(yaml@2.8.3))':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.29.7)
+      '@rolldown/pluginutils': 1.0.0-rc.3
+      '@types/babel__core': 7.20.5
+      react-refresh: 0.18.0
+      vite: 7.3.5(@types/node@24.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.43.1)(tsx@4.22.4)(yaml@2.8.3)
+    transitivePeerDependencies:
+      - supports-color
 
   '@vitejs/plugin-react@5.2.0(vite@8.0.16(@types/node@24.10.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.43.1)(tsx@4.22.4)(yaml@2.8.3))':
     dependencies:
@@ -24091,13 +24436,13 @@ snapshots:
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
 
-  react-scan@0.5.3(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+  react-scan@0.5.3(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.61.1):
     dependencies:
       '@babel/core': 7.29.7
       '@babel/generator': 7.28.5
       '@babel/types': 7.29.0
       '@preact/signals': 1.3.3(preact@10.28.2)
-      '@rollup/pluginutils': 5.3.0
+      '@rollup/pluginutils': 5.3.0(rollup@4.61.1)
       '@types/node': 20.19.27
       bippy: 0.5.32(@types/react@19.2.8)(react@19.2.3)
       commander: 14.0.2
@@ -24582,6 +24927,37 @@ snapshots:
       '@rolldown/binding-wasm32-wasi': 1.0.1
       '@rolldown/binding-win32-arm64-msvc': 1.0.1
       '@rolldown/binding-win32-x64-msvc': 1.0.1
+
+  rollup@4.61.1:
+    dependencies:
+      '@types/estree': 1.0.9
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.61.1
+      '@rollup/rollup-android-arm64': 4.61.1
+      '@rollup/rollup-darwin-arm64': 4.61.1
+      '@rollup/rollup-darwin-x64': 4.61.1
+      '@rollup/rollup-freebsd-arm64': 4.61.1
+      '@rollup/rollup-freebsd-x64': 4.61.1
+      '@rollup/rollup-linux-arm-gnueabihf': 4.61.1
+      '@rollup/rollup-linux-arm-musleabihf': 4.61.1
+      '@rollup/rollup-linux-arm64-gnu': 4.61.1
+      '@rollup/rollup-linux-arm64-musl': 4.61.1
+      '@rollup/rollup-linux-loong64-gnu': 4.61.1
+      '@rollup/rollup-linux-loong64-musl': 4.61.1
+      '@rollup/rollup-linux-ppc64-gnu': 4.61.1
+      '@rollup/rollup-linux-ppc64-musl': 4.61.1
+      '@rollup/rollup-linux-riscv64-gnu': 4.61.1
+      '@rollup/rollup-linux-riscv64-musl': 4.61.1
+      '@rollup/rollup-linux-s390x-gnu': 4.61.1
+      '@rollup/rollup-linux-x64-gnu': 4.61.1
+      '@rollup/rollup-linux-x64-musl': 4.61.1
+      '@rollup/rollup-openbsd-x64': 4.61.1
+      '@rollup/rollup-openharmony-arm64': 4.61.1
+      '@rollup/rollup-win32-arm64-msvc': 4.61.1
+      '@rollup/rollup-win32-ia32-msvc': 4.61.1
+      '@rollup/rollup-win32-x64-gnu': 4.61.1
+      '@rollup/rollup-win32-x64-msvc': 4.61.1
+      fsevents: 2.3.3
 
   rope-sequence@1.3.4: {}
 
@@ -25994,12 +26370,12 @@ snapshots:
       d3-time: 3.1.0
       d3-timer: 3.0.1
 
-  vite-plugin-svgr@4.5.0(typescript@5.9.3)(vite@8.0.16(@types/node@24.10.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.43.1)(tsx@4.22.4)(yaml@2.8.3)):
+  vite-plugin-svgr@4.5.0(rollup@4.61.1)(typescript@5.9.3)(vite@7.3.5(@types/node@24.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.43.1)(tsx@4.22.4)(yaml@2.8.3)):
     dependencies:
-      '@rollup/pluginutils': 5.3.0
+      '@rollup/pluginutils': 5.3.0(rollup@4.61.1)
       '@svgr/core': 8.1.0(typescript@5.9.3)
       '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0(typescript@5.9.3))
-      vite: 8.0.16(@types/node@24.10.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.43.1)(tsx@4.22.4)(yaml@2.8.3)
+      vite: 7.3.5(@types/node@24.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.43.1)(tsx@4.22.4)(yaml@2.8.3)
     transitivePeerDependencies:
       - rollup
       - supports-color
@@ -26015,6 +26391,23 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
       - typescript
+
+  vite@7.3.5(@types/node@24.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.43.1)(tsx@4.22.4)(yaml@2.8.3):
+    dependencies:
+      esbuild: 0.28.1
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+      postcss: 8.5.15
+      rollup: 4.61.1
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      '@types/node': 24.10.1
+      fsevents: 2.3.3
+      jiti: 2.7.0
+      lightningcss: 1.32.0
+      terser: 5.43.1
+      tsx: 4.22.4
+      yaml: 2.8.3
 
   vite@8.0.16(@types/node@24.10.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.43.1)(tsx@4.22.4)(yaml@2.8.3):
     dependencies:


### PR DESCRIPTION
## Summary

Adds canvas **NodePropertyPanel** editor stories to Storybook, demonstrating interactive property panels for workflow nodes. Also introduces a Responsive story exploring compact panel patterns.

### Stories added

- **Editor Full** — full-height panel with Monaco code editor, expandable CasePanel rows, and inline-editable node title/category
- **Editor Compact** — compact variant with accordion CasePanels, inline title editing, delete-on-hover for cases, default branch toggle
- **Editor Inline** — End/Control node panel with per-row Monaco fields, Insert snippet popover, and PT/JS mode toggle via accessible \`DropdownMenu\`
- **Responsive** — side-by-side comparison of spacious (380×640) and compact (280×480) panel sizes, demonstrating responsive adaptations: hidden node icon, icon-only run button, and dropdown tab navigation replacing the standard tab strip

### Component changes

- \`NodePropertyPanel.tsx\` — \`children\` prop added for custom layouts; border separators removed from title bar and identity row; \`contentInset\` drives the CSS custom property on root
- \`NodePropertyPanel.types.ts\` — added \`children\` and \`contentInset\` props with updated JSDoc
- \`ExpressionField.tsx\` — description changed from \`<p>\` to \`<span class="block">\` to prevent Angular Material typography margin injection
- \`monaco.ts\` — fixed \`apolloFutureDarkMonaco\` / \`apolloFutureLightMonaco\` editor backgrounds to match \`surface-overlay\`
- \`metadata-form.tsx\` — \`TabbedStepForm\` tab style updated from underline to compact pill tabs

### Editor Inline details

- Monaco inline editor with \`lineDecorationsWidth: 14\` to align cursor with placeholder text
- Insert snippet popover (click-triggered, flat variable list)
- PT/JS mode toggle replaced hover popover with a Radix \`DropdownMenu\` from \`apollo-wind\` for proper keyboard nav, escape-to-close, and hover states
- SSR guard on \`getMonacoThemeName()\` to prevent autodocs crash

### Responsive story details

- \`RunButtonIconOnly\` — icon-only variant of the run button for compact layouts
- \`CompactResponsivePanelStory\` — manages active step state, renders a \`DropdownMenu\` tab selector, and passes a flat single-step \`FormSchema\` to \`MetadataForm\` to avoid rendering an internal tab bar

### Dependencies

- \`@monaco-editor/react ^4.7.0\` added as devDependency to \`apollo-react\` (story files only, not shipped in the package bundle)

### Security

- Resolved \`dompurify\` (GHSA-cmwh-pvxp-8882) and \`undici\` (GHSA-vmh5-mc38-953g, GHSA-pr7r-676h-xcf6) via \`pnpm-workspace.yaml\` overrides

<img width="1527" height="1221" alt="Screenshot 2026-06-23 at 10 38 50 AM" src="https://github.com/user-attachments/assets/311521e1-4473-4a5a-a6ec-0ec8029eaa15" />
<img width="1527" height="1221" alt="Screenshot 2026-06-23 at 10 38 58 AM" src="https://github.com/user-attachments/assets/64291841-97c8-4713-b548-f1a5b3985a78" />
<img width="1527" height="1221" alt="Screenshot 2026-06-23 at 10 39 02 AM" src="https://github.com/user-attachments/assets/744af452-f9a6-4480-bf3b-80cb294a5681" />
<img width="1527" height="1221" alt="Screenshot 2026-06-23 at 10 39 12 AM" src="https://github.com/user-attachments/assets/2d93c86c-d57b-45dc-923b-3656eeb8a0f0" />
<img width="1527" height="1221" alt="Screenshot 2026-06-23 at 10 39 09 AM" src="https://github.com/user-attachments/assets/fdf98ed3-876a-4336-9259-19d00b1164e7" />
