### PR TITLE
fix(apollo-react): keep node toolbar usable on disabled nodes and fix dark-mode prompt preview

### DIFF
--- a/packages/apollo-react/src/canvas/components/AgentCanvas/nodes/AgentNode.styles.ts
+++ b/packages/apollo-react/src/canvas/components/AgentCanvas/nodes/AgentNode.styles.ts
@@ -103,7 +103,8 @@ export const SettingsPromptBox = styled.div<{ isEmpty?: boolean }>`
   color: ${({ isEmpty }) =>
     isEmpty ? 'var(--canvas-foreground-de-emp)' : 'var(--canvas-foreground)'};
   font-style: ${({ isEmpty }) => (isEmpty ? 'italic' : 'normal')};
-  background: var(--canvas-background-secondary);
+  background: var(--canvas-background-hover);
+  border: 1px solid var(--canvas-border-de-emp);
   border-radius: 6px;
   padding: 8px 10px;
   max-height: 80px;

--- a/packages/apollo-react/src/canvas/components/BaseNode/BaseNode.tsx
+++ b/packages/apollo-react/src/canvas/components/BaseNode/BaseNode.tsx
@@ -659,16 +659,16 @@ const BaseNodeComponent = (props: NodeProps<Node<BaseNodeData>>) => {
         {displayFooter && (
           <div className="basis-full pt-0.5 min-w-0 overflow-hidden">{displayFooter}</div>
         )}
-        {toolbarConfig && (
-          <NodeToolbar
-            nodeId={id}
-            config={toolbarConfig}
-            expanded={selected || isHovered}
-            hidden={dragging || multipleNodesSelected}
-            offsetToolbar={hasHandleButtonsAtToolbar}
-          />
-        )}
       </BaseContainer>
+      {toolbarConfig && (
+        <NodeToolbar
+          nodeId={id}
+          config={toolbarConfig}
+          expanded={selected || isHovered}
+          hidden={dragging || multipleNodesSelected}
+          offsetToolbar={hasHandleButtonsAtToolbar}
+        />
+      )}
       {handleElements}
       {executionStatus === 'ActionNeeded' &&
         (() => {


### PR DESCRIPTION
Two Agent Canvas (`@uipath/apollo-react`) fixes.

## 1. Disabled tool's toolbar is no longer usable (can't re-enable)

When a tool node is disabled via the toolbar's "Disable" action, its toolbar became dimmed and showed a not-allowed cursor, so it couldn't be clicked to re-enable the node.

**Root cause:** `NodeToolbar` was rendered as a DOM child of `BaseContainer`, which gets `opacity-50 cursor-not-allowed` in the disabled interaction state. That styling (and the opacity stacking context) cascaded to the toolbar — the one control that can re-enable the node.

**Fix:** render `NodeToolbar` as a **sibling** of `BaseContainer` (the same way `handleElements` are already rendered). Its absolute positioning origin is unchanged (the outer `relative` wrapper shrink-wraps `BaseContainer`), so it stays in place but is no longer affected by the disabled node's dimming/cursor.

## 2. Agent node prompt preview box invisible in dark mode

In the read-only Agent Settings preview, the System/User prompt boxes had no visible background in dark mode (visible as light-grey boxes in light mode — see screenshots).

**Root cause:** the box used `--canvas-background-secondary`, which resolves to the **same value as `--canvas-background-raised`** (the `FloatingCanvasPanel` popover surface) in dark mode (`#273139`), so it blended into the surface. In light mode the two differ (`#f4f5f7` vs `#ffffff`), which is why it only showed there.

**Fix:** the box now uses a translucent overlay background (`--canvas-background-hover`) plus a `--canvas-border-de-emp` border, so it stays distinct from the raised surface in both themes.

## Files
- `canvas/components/BaseNode/BaseNode.tsx` — toolbar rendered as a sibling of `BaseContainer`
- `canvas/components/AgentCanvas/nodes/AgentNode.styles.ts` — prompt box background/border

## Testing
- `BaseNode`, `NodeToolbar`, `AgentNode` unit tests pass (58); biome lint/format and `tsc` clean.
- Note: the toolbar change is in shared `BaseNode`, so it affects every node type's toolbar — worth a quick visual check that toolbar positioning is unchanged across node types.

https://github.com/user-attachments/assets/8aecee93-4a6c-4bb9-bfa7-e0de67d0a64b