### PR TITLE
fix(apollo-react): adjust node toolbar offsets [MST-10329]

### DIFF
--- a/packages/apollo-react/src/canvas/components/BaseNode/BaseNode.test.tsx
+++ b/packages/apollo-react/src/canvas/components/BaseNode/BaseNode.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import type { Node, NodeProps } from '@uipath/apollo-react/canvas/xyflow/react';
 import { Position } from '@uipath/apollo-react/canvas/xyflow/react';
 import { describe, expect, it, vi } from 'vitest';
@@ -16,6 +16,10 @@ const {
   mockManifest,
   mockUseButtonHandles,
   mockOverrideConfig,
+  mockMode,
+  mockMultipleNodesSelected,
+  mockIsConnecting,
+  mockNodeToolbar,
 } = vi.hoisted(() => ({
   mockUpdateNode: vi.fn(),
   mockHandleConfigs: { current: undefined as HandleGroupManifest[] | undefined },
@@ -28,12 +32,17 @@ const {
   // biome-ignore lint/suspicious/noExplicitAny: hook receives a broad typed options object
   mockUseButtonHandles: vi.fn() as any,
   mockOverrideConfig: { current: {} as Record<string, unknown> },
+  mockMode: { current: 'design' as string },
+  mockMultipleNodesSelected: { current: false },
+  mockIsConnecting: { current: false },
+  // biome-ignore lint/suspicious/noExplicitAny: captures the toolbar props for assertions
+  mockNodeToolbar: vi.fn() as any,
 }));
 
 // xyflow is globally mocked in canvas-mocks.ts; extend with test-specific overrides.
 vi.mock('@uipath/apollo-react/canvas/xyflow/react', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@uipath/apollo-react/canvas/xyflow/react')>()),
-  useStore: () => false,
+  useStore: () => mockIsConnecting.current,
   useUpdateNodeInternals: () => vi.fn(),
   useReactFlow: () => ({ updateNodeData: vi.fn(), updateNode: mockUpdateNode }),
 }));
@@ -50,11 +59,17 @@ vi.mock('../../core', () => ({
 }));
 
 vi.mock('../BaseCanvas/BaseCanvasModeProvider', () => ({
-  useBaseCanvasMode: () => ({ mode: 'design' }),
+  useBaseCanvasMode: () => ({ mode: mockMode.current }),
 }));
 vi.mock('../BaseCanvas/ConnectedHandlesContext', () => ({ useConnectedHandles: () => new Set() }));
 vi.mock('../BaseCanvas/SelectionStateContext', () => ({
-  useSelectionState: () => ({ multipleNodesSelected: false }),
+  useSelectionState: () => ({ multipleNodesSelected: mockMultipleNodesSelected.current }),
+}));
+vi.mock('../Toolbar', () => ({
+  NodeToolbar: (props: Record<string, unknown>) => {
+    mockNodeToolbar(props);
+    return null;
+  },
 }));
 vi.mock('../BaseCanvas/CanvasThemeContext', () => ({
   useCanvasTheme: () => ({ isDarkMode: false }),
@@ -140,9 +155,13 @@ describe('BaseNode', () => {
   afterEach(() => {
     mockUpdateNode.mockClear();
     mockUseButtonHandles.mockClear();
+    mockNodeToolbar.mockClear();
     mockHandleConfigs.current = undefined;
     mockManifest.current = { ...DEFAULT_MANIFEST };
     mockOverrideConfig.current = {};
+    mockMode.current = 'design';
+    mockMultipleNodesSelected.current = false;
+    mockIsConnecting.current = false;
   });
 
   describe('Height computation', () => {
@@ -334,6 +353,177 @@ describe('BaseNode', () => {
 
       expect(onHandleMouseEnter).toHaveBeenCalledWith(payload);
       expect(onHandleMouseLeave).toHaveBeenCalledWith(payload);
+    });
+  });
+
+  describe('Toolbar offset', () => {
+    type Handle = HandleGroupManifest['handles'][number];
+
+    const TOP_TOOLBAR = {
+      actions: [{ id: 'edit', icon: 'edit', label: 'Edit', onAction: vi.fn() }],
+      position: 'top',
+    };
+
+    const buttonHandle: Handle = {
+      id: 'src',
+      type: 'source',
+      handleType: 'output',
+      showButton: true,
+    };
+    const labelHandle: Handle = {
+      id: 'art',
+      type: 'source',
+      handleType: 'artifact',
+      label: 'Memory',
+      showButton: false,
+    };
+    const labelHandleButtonOmitted: Handle = {
+      id: 'art',
+      type: 'source',
+      handleType: 'artifact',
+      label: 'Memory',
+      showButton: false,
+    };
+    const buttonAndLabelHandle: Handle = {
+      id: 'src-labeled',
+      type: 'source',
+      handleType: 'output',
+      label: 'Output',
+      showButton: true,
+    };
+
+    const topHandles = (...handles: Handle[]): HandleGroupManifest[] => [
+      { position: Position.Top, handles },
+    ];
+
+    const renderNode = (overrides: Partial<NodeProps<Node<BaseNodeData>>> = {}) => {
+      mockOverrideConfig.current = { toolbarConfig: TOP_TOOLBAR };
+      return render(<BaseNode {...defaultProps} {...overrides} />);
+    };
+
+    // The latest `offsetToolbar` value handed to NodeToolbar.
+    const offset = () => mockNodeToolbar.mock.calls.at(-1)?.[0]?.offsetToolbar;
+
+    it('does not offset when no handle is configured at the toolbar side', () => {
+      mockHandleConfigs.current = [];
+      renderNode({ selected: true });
+      expect(offset()).toBe(false);
+    });
+
+    it('does not offset when the handle is on a different side than the toolbar', () => {
+      mockHandleConfigs.current = [{ position: Position.Bottom, handles: [buttonHandle] }];
+      renderNode({ selected: true });
+      expect(offset()).toBe(false);
+    });
+
+    it("offsets for 'button' when a selected node shows a source add button", () => {
+      mockHandleConfigs.current = topHandles(buttonHandle);
+      renderNode({ selected: true });
+      expect(offset()).toBe('button');
+    });
+
+    it('does not offset for a button in readonly mode (button is not rendered)', () => {
+      mockMode.current = 'readonly';
+      mockHandleConfigs.current = topHandles(buttonHandle);
+      renderNode({ selected: true });
+      expect(offset()).toBe(false);
+    });
+
+    it("offsets for 'label' when a labeled handle has no visible button", () => {
+      mockHandleConfigs.current = topHandles(labelHandle);
+      renderNode({ selected: true });
+      expect(offset()).toBe('label');
+    });
+
+    it("offsets for 'label' when a labeled handle has omitted button in smart handles mode", () => {
+      mockHandleConfigs.current = topHandles(labelHandleButtonOmitted);
+      renderNode({ selected: true, data: { useSmartHandles: true } });
+      expect(offset()).toBe('label');
+    });
+
+    it("offsets for 'label' on a labeled handle even in readonly mode", () => {
+      mockMode.current = 'readonly';
+      mockHandleConfigs.current = topHandles(labelHandle);
+      renderNode({ selected: true });
+      expect(offset()).toBe('label');
+    });
+
+    it("prefers 'button' over 'label' when both are shown", () => {
+      mockHandleConfigs.current = topHandles(buttonAndLabelHandle);
+      renderNode({ selected: true });
+      expect(offset()).toBe('button');
+    });
+
+    it("falls back to 'label' when the button is hidden but the label shows", () => {
+      mockMode.current = 'readonly';
+      mockHandleConfigs.current = topHandles(buttonAndLabelHandle);
+      renderNode({ selected: true });
+      expect(offset()).toBe('label');
+    });
+
+    it('does not offset while multiple nodes are selected', () => {
+      mockMultipleNodesSelected.current = true;
+      mockHandleConfigs.current = topHandles(labelHandle);
+      renderNode({ selected: true });
+      expect(offset()).toBe(false);
+    });
+
+    it('ignores a handle group that is not visible', () => {
+      mockHandleConfigs.current = [
+        { position: Position.Top, visible: false, handles: [labelHandle] },
+      ];
+      renderNode({ selected: true });
+      expect(offset()).toBe(false);
+    });
+
+    it('ignores an individually hidden handle', () => {
+      mockHandleConfigs.current = topHandles({ ...labelHandle, visible: false });
+      renderNode({ selected: true });
+      expect(offset()).toBe(false);
+    });
+
+    it('offsets a ButtonHandle add button on hover alone (not selected)', () => {
+      mockHandleConfigs.current = topHandles(buttonHandle);
+      const { container } = renderNode({ selected: false });
+      expect(offset()).toBe(false);
+      fireEvent.mouseEnter(container.firstChild as Element);
+      expect(offset()).toBe('button');
+    });
+
+    it('requires selection — not just hover — for a SmartHandle add button', () => {
+      mockHandleConfigs.current = topHandles(buttonHandle);
+      const { container } = renderNode({ selected: false, data: { useSmartHandles: true } });
+      fireEvent.mouseEnter(container.firstChild as Element);
+      expect(offset()).toBe(false);
+    });
+
+    it('does not apply the button offset while a connection is in progress', () => {
+      // ButtonHandle add buttons are hidden during connect; the offset must match.
+      mockIsConnecting.current = true;
+      mockHandleConfigs.current = topHandles(buttonHandle);
+      renderNode({ selected: true });
+      expect(offset()).toBe(false);
+    });
+
+    it('falls back to the label offset while connecting when the handle is labeled', () => {
+      mockIsConnecting.current = true;
+      mockHandleConfigs.current = topHandles(buttonAndLabelHandle);
+      renderNode({ selected: true });
+      expect(offset()).toBe('label');
+    });
+
+    it('honors a custom shouldShowAddButtonFn (parity with useButtonHandles)', () => {
+      // AgentNode-style predicate shows the add button whenever selected — even in
+      // readonly, where the default predicate would not. The offset must follow it.
+      mockMode.current = 'readonly';
+      mockOverrideConfig.current = {
+        toolbarConfig: TOP_TOOLBAR,
+        shouldShowAddButtonFn: (o: { showAddButton: boolean; selected: boolean }) =>
+          o.showAddButton || o.selected,
+      };
+      mockHandleConfigs.current = topHandles(buttonHandle);
+      render(<BaseNode {...defaultProps} selected={true} />);
+      expect(offset()).toBe('button');
     });
   });
 });

--- a/packages/apollo-react/src/canvas/components/BaseNode/BaseNode.tsx
+++ b/packages/apollo-react/src/canvas/components/BaseNode/BaseNode.tsx
@@ -401,19 +401,6 @@ const BaseNodeComponent = (props: NodeProps<Node<BaseNodeData>>) => {
     [isConnecting, selected, isHovered, dragging]
   );
 
-  const toolbarPosition = toolbarConfig?.position ?? (toolbarConfig ? Position.Top : undefined);
-
-  // True when handle buttons at the toolbar's position would collide with it.
-  const hasHandleButtonsAtToolbar = useMemo(() => {
-    if (!toolbarPosition || !handleConfigurations?.length) return false;
-    return handleConfigurations.some(
-      (config) =>
-        config.position === toolbarPosition &&
-        config.visible !== false &&
-        config.handles.some((h) => h.type === 'source' && h.showButton !== false)
-    );
-  }, [toolbarPosition, handleConfigurations]);
-
   const hasVisibleBottomHandles = useMemo(() => {
     if (
       !handleConfigurations ||
@@ -479,6 +466,69 @@ const BaseNodeComponent = (props: NodeProps<Node<BaseNodeData>>) => {
 
   // Check if smart handles are enabled via node data
   const useSmartHandles = data?.useSmartHandles ?? false;
+  const toolbarPosition = toolbarConfig?.position ?? (toolbarConfig ? Position.Top : undefined);
+
+  // Handle affordances *configured* at the toolbar's side that it would overlap.
+  // `button` = a source add button; `label` = a handle label (any handle type).
+  // Whether each is actually rendered is gated by `offsetToolbar` below, since
+  // buttons and labels appear under different conditions.
+  const toolbarSideHandleAffordances = useMemo(() => {
+    let hasButton = false;
+    let hasLabel = false;
+    if (!toolbarPosition || !handleConfigurations?.length) {
+      return { hasButton, hasLabel };
+    }
+    for (const config of handleConfigurations) {
+      if (config.position !== toolbarPosition || config.visible === false) continue;
+      for (const handle of config.handles) {
+        if (handle.visible === false) continue;
+        const showButton = useSmartHandles ? handle.showButton : handle.showButton !== false;
+        if (handle.type === 'source' && showButton) hasButton = true;
+        if (handle.label) hasLabel = true;
+      }
+    }
+    return { hasButton, hasLabel };
+  }, [toolbarPosition, handleConfigurations]);
+
+  // Offset the toolbar to clear whichever handle affordance is actually rendered
+  // at its side — not merely configured. A shown add button stacks button + label
+  // and needs the larger offset; a label alone needs only a small one.
+  const offsetToolbar = useMemo<'button' | 'label' | false>(() => {
+    if (multipleNodesSelected) return false;
+    const { hasButton, hasLabel } = toolbarSideHandleAffordances;
+
+    // Mirror the gating that actually renders an add button (see `useButtonHandles`
+    // / `smartHandleElements`), so the larger 'button' offset only applies when one
+    // is really on screen — not while connecting/dragging or under a custom predicate.
+    const isAddButtonShown = () => {
+      // SmartHandle add buttons require selection (and ignore connect/drag state).
+      if (useSmartHandles) {
+        return mode === 'design' && !!selected;
+      }
+      const showAddButton = mode === 'design' && !isConnecting && !dragging;
+      if (shouldShowAddButtonFn) {
+        return shouldShowAddButtonFn({ showAddButton, selected: !!selected });
+      }
+      return showAddButton && (!!selected || isHovered);
+    };
+
+    if (hasButton && isAddButtonShown()) return 'button';
+    // Labels render whenever their handle is visible — on hover or selection, in
+    // any mode (including readonly) — which is exactly when the toolbar is shown,
+    // so a configured label always coincides with it.
+    if (hasLabel) return 'label';
+    return false;
+  }, [
+    toolbarSideHandleAffordances,
+    mode,
+    multipleNodesSelected,
+    useSmartHandles,
+    selected,
+    isHovered,
+    isConnecting,
+    dragging,
+    shouldShowAddButtonFn,
+  ]);
 
   // Generate ButtonHandle elements (default behavior)
   // Hide add buttons when multiple nodes are selected to avoid visual clutter
@@ -666,7 +716,7 @@ const BaseNodeComponent = (props: NodeProps<Node<BaseNodeData>>) => {
           config={toolbarConfig}
           expanded={selected || isHovered}
           hidden={dragging || multipleNodesSelected}
-          offsetToolbar={hasHandleButtonsAtToolbar}
+          offsetToolbar={offsetToolbar}
         />
       )}
       {handleElements}

--- a/packages/apollo-react/src/canvas/components/Toolbar/NodeToolbar/NodeToolbar.test.tsx
+++ b/packages/apollo-react/src/canvas/components/Toolbar/NodeToolbar/NodeToolbar.test.tsx
@@ -436,4 +436,48 @@ describe('NodeToolbar', () => {
       expect(screen.getByTestId('custom-overflow-icon')).toBeInTheDocument();
     });
   });
+
+  describe('Offset and hover bridge', () => {
+    const bridge = () => screen.queryByTestId('node-toolbar-hover-bridge');
+    const positioner = () => screen.getByRole('toolbar').parentElement;
+
+    it('renders the hover bridge and no offset when offsetToolbar is unset', () => {
+      render(<NodeToolbar {...defaultProps} />);
+
+      expect(bridge()).toBeInTheDocument();
+      expect(positioner()?.style.getPropertyValue('--toolbar-offset')).toBe('');
+    });
+
+    it('renders the hover bridge and a smaller offset for a label collision', () => {
+      render(<NodeToolbar {...defaultProps} offsetToolbar="label" />);
+
+      const offset = Number.parseInt(
+        positioner()?.style.getPropertyValue('--toolbar-offset') ?? '',
+        10
+      );
+      expect(bridge()).toBeInTheDocument();
+      expect(offset).toBeGreaterThan(0);
+      expect(offset).toBeLessThan(48); // smaller than the button offset
+    });
+
+    it('skips the hover bridge and applies the larger offset for a button collision', () => {
+      render(<NodeToolbar {...defaultProps} offsetToolbar="button" />);
+
+      expect(bridge()).not.toBeInTheDocument();
+      expect(positioner()?.style.getPropertyValue('--toolbar-offset')).toBe('48px');
+    });
+
+    it('treats offsetToolbar={true} as a back-compat alias for "button"', () => {
+      render(<NodeToolbar {...defaultProps} offsetToolbar={true} />);
+
+      expect(bridge()).not.toBeInTheDocument();
+      expect(positioner()?.style.getPropertyValue('--toolbar-offset')).toBe('48px');
+    });
+
+    it('does not render the hover bridge when the toolbar is hidden', () => {
+      render(<NodeToolbar {...defaultProps} expanded={false} />);
+
+      expect(bridge()).not.toBeInTheDocument();
+    });
+  });
 });

--- a/packages/apollo-react/src/canvas/components/Toolbar/NodeToolbar/NodeToolbar.tsx
+++ b/packages/apollo-react/src/canvas/components/Toolbar/NodeToolbar/NodeToolbar.tsx
@@ -22,13 +22,30 @@ const POSITIONER_POSITION_CLASS: Record<'top' | 'bottom' | 'left' | 'right', str
   right: 'right-[calc(-52px-var(--toolbar-offset,0px))] top-0 bottom-0 flex-col',
 };
 
-/** Extra displacement (px) applied when `offsetToolbar` is true. */
-const TOOLBAR_OFFSET = 48; // Clears the button handle + label + gaps
+/** Extra displacement (px) applied to clear a colliding handle affordance. */
+const TOOLBAR_OFFSET: Record<'button' | 'label', number> = {
+  button: 48, // Clears the add button + its label + gaps
+  label: 24, // 1.5rem — clears a label-only handle
+};
 
 const POSITIONER_ALIGN_CLASS: Record<'start' | 'center' | 'end', string> = {
   start: 'justify-start',
   center: 'justify-center',
   end: 'justify-end',
+};
+
+// Invisible hover bridge that fills the gap between the node and the toolbar.
+// Without it, moving the pointer across that empty gap fires the node's
+// `mouseleave` and dismisses the toolbar. Each side anchors to the node-facing
+// edge of the positioner and spans the base 12px gap plus the current offset,
+// so it still reaches the node when the toolbar is pushed out for a label.
+// Skipped only for the `'button'` offset — a source add button (and, for the
+// ButtonHandle path, its own `HandleHoverBridge`) already occupies that side.
+const POSITIONER_BRIDGE_CLASS: Record<'top' | 'bottom' | 'left' | 'right', string> = {
+  top: 'top-full left-0 right-0 h-[calc(12px+var(--toolbar-offset,0px))]',
+  bottom: 'bottom-full left-0 right-0 h-[calc(12px+var(--toolbar-offset,0px))]',
+  left: 'left-full top-0 bottom-0 w-[calc(12px+var(--toolbar-offset,0px))]',
+  right: 'right-full top-0 bottom-0 w-[calc(12px+var(--toolbar-offset,0px))]',
 };
 
 const CONTAINER_BASE_CLASS =
@@ -85,6 +102,10 @@ const NodeToolbarComponent = ({
   const position = config.position || 'top';
   const align = config.align || 'center';
 
+  // Normalize the offset prop: `true` is a back-compat alias for 'button'.
+  const offsetMode: 'button' | 'label' | undefined =
+    offsetToolbar === true ? 'button' : offsetToolbar || undefined;
+
   const positionerClassName = useMemo(
     () =>
       cn(POSITIONER_BASE_CLASS, POSITIONER_POSITION_CLASS[position], POSITIONER_ALIGN_CLASS[align]),
@@ -108,9 +129,9 @@ const NodeToolbarComponent = ({
   );
 
   const offsetStyle = useMemo(() => {
-    if (!offsetToolbar) return undefined;
-    return { '--toolbar-offset': `${TOOLBAR_OFFSET}px` } as React.CSSProperties;
-  }, [offsetToolbar]);
+    if (!offsetMode) return undefined;
+    return { '--toolbar-offset': `${TOOLBAR_OFFSET[offsetMode]}px` } as React.CSSProperties;
+  }, [offsetMode]);
 
   const toolbarAnimationVariants = useMemo(() => {
     const offsetAxis = position === 'top' || position === 'bottom' ? 'y' : 'x';
@@ -137,6 +158,16 @@ const NodeToolbarComponent = ({
     <AnimatePresence>
       {displayState !== 'hidden' && (
         <div className={positionerClassName} style={offsetStyle}>
+          {offsetMode !== 'button' && (
+            <div
+              aria-hidden
+              data-testid="node-toolbar-hover-bridge"
+              className={cn(
+                'absolute pointer-events-auto cursor-default',
+                POSITIONER_BRIDGE_CLASS[position]
+              )}
+            />
+          )}
           <motion.div
             layout="position"
             className={containerClassName}

--- a/packages/apollo-react/src/canvas/components/Toolbar/NodeToolbar/NodeToolbar.types.ts
+++ b/packages/apollo-react/src/canvas/components/Toolbar/NodeToolbar/NodeToolbar.types.ts
@@ -14,8 +14,13 @@ export interface NodeToolbarProps {
   expanded: boolean;
   /** When true, forcefully hides all toolbar actions including pinned items */
   hidden?: boolean;
-  /** When true, push the toolbar further from the node to clear handle buttons. */
-  offsetToolbar?: boolean;
+  /**
+   * Push the toolbar further from the node to clear a colliding handle affordance.
+   * `'button'` clears a source add button (larger offset); `'label'` clears a
+   * label-only handle (smaller offset). Omit/`false` for no offset.
+   * `true` is accepted as a back-compat alias for `'button'`.
+   */
+  offsetToolbar?: boolean | 'button' | 'label';
   /** Render the toolbar in the node overlay layer instead of inside the node wrapper. */
   portalToNodeOverlay?: boolean;
 }


### PR DESCRIPTION
Addresses two issues with the node toolbar UX.

1. The gap between the main node body and the toolbar did not capture mouse events, so we would lose the hover state and dismiss the toolbar.
    - This PR adds a hover bridge to the toolbar so that the events are captured and propagated to the node parent so the hover state is not lost.
3. The gap between the main node body and toolbar was extended/offset when we have buttons colliding on the same side of the node. But we did not account for when the buttons might be hidden because of canvas mode. So the gap was too large in these scenarios.
    - This PR adds a two-step check for the offset. 1) that there is any configuration and 2) that the configuration will be applied. This covers both buttons and lone labels.


https://github.com/user-attachments/assets/d4c61bbd-0189-4e84-9ce1-5526c9b129df

<img width="557" height="274" alt="Screenshot 2026-06-08 at 4 56 33 PM" src="https://github.com/user-attachments/assets/753063e9-cacb-400b-8538-216825bc97bb" />
