### PR TITLE
docs(repo): add storybook:dev to development commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ pnpm dev              # Watch mode for all packages
 pnpm build            # Build all packages
 pnpm lint             # Lint all packages
 pnpm test             # Run tests
+pnpm storybook:dev    # Run Storybook
 ```
 
 ### Component Guidelines


### PR DESCRIPTION
## Description

Tiny doc fix: the **Development Commands** list in the root README omitted `pnpm storybook:dev`, even though the Quick Start section above uses it. Added it for consistency.

> Note: minimal PR opened to exercise a CI/automation workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)