### PR TITLE
feat(apollo-react): add Optional and Ends case status badges to StageNode header

### DIFF
--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.stories.tsx
@@ -2701,8 +2701,6 @@ export const WithStatusBadges: Story = {
         data: {
           stageDetails: {
             label: 'Intake',
-            isOptional: true,
-            optionalTooltip: 'Not required for case completion',
             tasks: [
               [{ id: 't1', label: 'Prepare closing docs', icon: <DocumentIcon /> }],
               [{ id: 't2', label: 'eSign envelope', icon: <ProcessIcon /> }],
@@ -2720,6 +2718,10 @@ export const WithStatusBadges: Story = {
                 tooltip: 'Exit rules',
                 onClick: () => window.alert('Open exit rules panel'),
               },
+              {
+                type: StageHeaderChipType.Optional,
+                tooltip: 'Not required for case completion',
+              },
             ],
           },
           execution: { stageStatus: { slaText: 'SLA: 3 days' } },
@@ -2736,8 +2738,6 @@ export const WithStatusBadges: Story = {
         data: {
           stageDetails: {
             label: 'Rejected',
-            endsCase: true,
-            endsCaseTooltip: 'Entering this stage ends the case',
             tasks: [
               [{ id: 't3', label: 'Summarize rejection', icon: <DocumentIcon /> }],
               [{ id: 't4', label: 'Send customer letter', icon: <ProcessIcon /> }],
@@ -2748,6 +2748,10 @@ export const WithStatusBadges: Story = {
                 count: 1,
                 tooltip: 'Entry rules',
                 onClick: () => window.alert('Open entry rules panel'),
+              },
+              {
+                type: StageHeaderChipType.EndsCase,
+                tooltip: 'Entering this stage ends the case',
               },
             ],
           },
@@ -2764,10 +2768,6 @@ export const WithStatusBadges: Story = {
         data: {
           stageDetails: {
             label: 'Optional + terminal',
-            isOptional: true,
-            endsCase: true,
-            optionalLabel: 'Optional',
-            endsCaseLabel: 'Ends case',
             tasks: [[{ id: 't5', label: 'Final compliance audit', icon: <DocumentIcon /> }]],
             headerChips: [
               {
@@ -2781,6 +2781,8 @@ export const WithStatusBadges: Story = {
                 tooltip: 'Stage completion',
                 onClick: () => window.alert('Open stage completion panel'),
               },
+              { type: StageHeaderChipType.Optional, label: 'Optional' },
+              { type: StageHeaderChipType.EndsCase, label: 'Ends case' },
             ],
           },
           execution: { stageStatus: { slaText: 'SLA: 1 day remaining', slaIcon: 'warning' } },

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.stories.tsx
@@ -2687,3 +2687,107 @@ export const WithRulesTags: Story = {
     ],
   },
 };
+
+export const WithStatusBadges: Story = {
+  name: 'With Status Badges (Optional / Ends Case)',
+  parameters: {
+    nodes: [
+      // Optional stage — subtle, non-interactive "Optional" badge alongside SLA + chips.
+      {
+        id: '1',
+        type: 'stage',
+        position: { x: 48, y: 96 },
+        width: 304,
+        data: {
+          stageDetails: {
+            label: 'Intake',
+            isOptional: true,
+            optionalTooltip: 'Not required for case completion',
+            tasks: [
+              [{ id: 't1', label: 'Prepare closing docs', icon: <DocumentIcon /> }],
+              [{ id: 't2', label: 'eSign envelope', icon: <ProcessIcon /> }],
+            ],
+            headerChips: [
+              {
+                type: StageHeaderChipType.Entry,
+                count: 1,
+                tooltip: 'Entry rules',
+                onClick: () => window.alert('Open entry rules panel'),
+              },
+              {
+                type: StageHeaderChipType.Exit,
+                count: 1,
+                tooltip: 'Exit rules',
+                onClick: () => window.alert('Open exit rules panel'),
+              },
+            ],
+          },
+          execution: { stageStatus: { slaText: 'SLA: 3 days' } },
+          onTaskClick: (taskId: string) => window.alert(`Task clicked: ${taskId}`),
+          onTaskAdd: () => window.alert('Add task'),
+        },
+      },
+      // Terminal stage — filled danger "Ends case" badge.
+      {
+        id: '2',
+        type: 'stage',
+        position: { x: 400, y: 96 },
+        width: 304,
+        data: {
+          stageDetails: {
+            label: 'Rejected',
+            endsCase: true,
+            endsCaseTooltip: 'Entering this stage ends the case',
+            tasks: [
+              [{ id: 't3', label: 'Summarize rejection', icon: <DocumentIcon /> }],
+              [{ id: 't4', label: 'Send customer letter', icon: <ProcessIcon /> }],
+            ],
+            headerChips: [
+              {
+                type: StageHeaderChipType.Entry,
+                count: 1,
+                tooltip: 'Entry rules',
+                onClick: () => window.alert('Open entry rules panel'),
+              },
+            ],
+          },
+          onTaskClick: (taskId: string) => window.alert(`Task clicked: ${taskId}`),
+          onTaskAdd: () => window.alert('Add task'),
+        },
+      },
+      // Both badges + SLA + chips coexisting, plus consumer-supplied labels.
+      {
+        id: '3',
+        type: 'stage',
+        position: { x: 752, y: 96 },
+        width: 304,
+        data: {
+          stageDetails: {
+            label: 'Optional + terminal',
+            isOptional: true,
+            endsCase: true,
+            optionalLabel: 'Optional',
+            endsCaseLabel: 'Ends case',
+            tasks: [[{ id: 't5', label: 'Final compliance audit', icon: <DocumentIcon /> }]],
+            headerChips: [
+              {
+                type: StageHeaderChipType.Entry,
+                count: 2,
+                tooltip: 'Entry rules',
+                onClick: () => window.alert('Open entry rules panel'),
+              },
+              {
+                type: StageHeaderChipType.Completion,
+                tooltip: 'Stage completion',
+                onClick: () => window.alert('Open stage completion panel'),
+              },
+            ],
+          },
+          execution: { stageStatus: { slaText: 'SLA: 1 day remaining', slaIcon: 'warning' } },
+          onTaskClick: (taskId: string) => window.alert(`Task clicked: ${taskId}`),
+          onTaskAdd: () => window.alert('Add task'),
+        },
+      },
+    ],
+  },
+};

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.stories.tsx
@@ -2721,6 +2721,7 @@ export const WithStatusBadges: Story = {
               {
                 type: StageHeaderChipType.Optional,
                 tooltip: 'Not required for case completion',
+                onClick: () => window.alert('Open "Required for case completion" setting'),
               },
             ],
           },
@@ -2752,6 +2753,7 @@ export const WithStatusBadges: Story = {
               {
                 type: StageHeaderChipType.EndsCase,
                 tooltip: 'Entering this stage ends the case',
+                onClick: () => window.alert('Open terminal-stage setting'),
               },
             ],
           },
@@ -2781,8 +2783,16 @@ export const WithStatusBadges: Story = {
                 tooltip: 'Stage completion',
                 onClick: () => window.alert('Open stage completion panel'),
               },
-              { type: StageHeaderChipType.Optional, label: 'Optional' },
-              { type: StageHeaderChipType.EndsCase, label: 'Ends case' },
+              {
+                type: StageHeaderChipType.Optional,
+                label: 'Optional',
+                onClick: () => window.alert('Open "Required for case completion" setting'),
+              },
+              {
+                type: StageHeaderChipType.EndsCase,
+                label: 'Ends case',
+                onClick: () => window.alert('Open terminal-stage setting'),
+              },
             ],
           },
           execution: { stageStatus: { slaText: 'SLA: 1 day remaining', slaIcon: 'warning' } },

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.stories.tsx
@@ -2692,7 +2692,7 @@ export const WithStatusBadges: Story = {
   name: 'With Status Badges (Optional / Ends Case)',
   parameters: {
     nodes: [
-      // Optional stage — subtle, non-interactive "Optional" badge alongside SLA + chips.
+      // Optional stage — subtle "Optional" badge (clickable) alongside SLA + chips.
       {
         id: '1',
         type: 'stage',

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.styles.ts
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.styles.ts
@@ -255,7 +255,7 @@ export const StageChip = styled.button`
   justify-content: center;
   gap: ${Padding.PadS};
   box-sizing: border-box;
-  height: 24px;
+  height: ${Spacing.SpacingL};
   padding: 0 ${Spacing.SpacingXs};
   border-radius: 10px;
   border: 1px solid var(--canvas-border-de-emp);

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.styles.ts
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.styles.ts
@@ -78,7 +78,7 @@ export const StageHeader = styled.div<{ isException?: boolean }>`
 `;
 
 export const StageContent = styled.div`
-  padding: 15px ${STAGE_CONTENT_PADDING_X}px ${Spacing.SpacingBase} ${STAGE_CONTENT_PADDING_X}px;
+  padding: 15px ${STAGE_CONTENT_PADDING_X}px ${Spacing.SpacingS} ${STAGE_CONTENT_PADDING_X}px;
   border-radius: 0 0 ${Spacing.SpacingBase} ${Spacing.SpacingBase};
   overflow: hidden;
   flex: 1;
@@ -254,7 +254,9 @@ export const StageChip = styled.button`
   align-items: center;
   justify-content: center;
   gap: ${Padding.PadS};
-  padding: ${Padding.PadXs} ${Spacing.SpacingXs};
+  box-sizing: border-box;
+  height: 24px;
+  padding: 0 ${Spacing.SpacingXs};
   border-radius: 10px;
   border: 1px solid var(--canvas-border-de-emp);
   background: transparent;

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.test.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.test.tsx
@@ -1018,7 +1018,9 @@ describe('StageNode - Status Badges', () => {
   const optionalBadge = () => screen.queryByTestId('stage-optional-badge-stage-1');
   const endsCaseBadge = () => screen.queryByTestId('stage-ends-case-badge-stage-1');
 
-  const withChips = (chips: { type: StageHeaderChipType; label?: string; tooltip?: string }[]) => ({
+  const withChips = (
+    chips: { type: StageHeaderChipType; label?: string; tooltip?: string; onClick?: () => void }[]
+  ) => ({
     stageDetails: { ...defaultProps.stageDetails, headerChips: chips },
   });
 
@@ -1068,22 +1070,18 @@ describe('StageNode - Status Badges', () => {
     expect(optionalBadge()).toHaveTextContent('Optional');
   });
 
-  it('is not rendered as an interactive button', () => {
+  it('renders the badge as an interactive button', () => {
     renderStageNode(withChips([{ type: StageHeaderChipType.Optional }]));
-    expect(
-      screen.queryByRole('button', { name: StageHeaderChipType.Optional })
-    ).not.toBeInTheDocument();
+    expect(optionalBadge()?.tagName).toBe('BUTTON');
   });
 
-  it('makes the badge keyboard-focusable only when a tooltip is provided', () => {
-    renderStageNode(
-      withChips([
-        { type: StageHeaderChipType.Optional, tooltip: 'Not required for case completion' },
-        { type: StageHeaderChipType.EndsCase },
-      ])
-    );
-    expect(optionalBadge()).toHaveAttribute('tabindex', '0');
-    expect(endsCaseBadge()).not.toHaveAttribute('tabindex');
+  it('calls the chip onClick when the badge is clicked', async () => {
+    const user = userEvent.setup();
+    const onClick = vi.fn();
+    renderStageNode(withChips([{ type: StageHeaderChipType.EndsCase, onClick }]));
+
+    await user.click(endsCaseBadge() as HTMLElement);
+    expect(onClick).toHaveBeenCalledTimes(1);
   });
 
   it('renders status badges alongside SLA text and interactive chips', () => {

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.test.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.test.tsx
@@ -1070,9 +1070,14 @@ describe('StageNode - Status Badges', () => {
     expect(optionalBadge()).toHaveTextContent('Optional');
   });
 
-  it('renders the badge as an interactive button', () => {
-    renderStageNode(withChips([{ type: StageHeaderChipType.Optional }]));
+  it('renders an interactive button when an onClick is provided', () => {
+    renderStageNode(withChips([{ type: StageHeaderChipType.Optional, onClick: vi.fn() }]));
     expect(optionalBadge()?.tagName).toBe('BUTTON');
+  });
+
+  it('renders a non-interactive span when no onClick is provided', () => {
+    renderStageNode(withChips([{ type: StageHeaderChipType.Optional }]));
+    expect(optionalBadge()?.tagName).toBe('SPAN');
   });
 
   it('calls the chip onClick when the badge is clicked', async () => {

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.test.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.test.tsx
@@ -1018,63 +1018,83 @@ describe('StageNode - Status Badges', () => {
   const optionalBadge = () => screen.queryByTestId('stage-optional-badge-stage-1');
   const endsCaseBadge = () => screen.queryByTestId('stage-ends-case-badge-stage-1');
 
+  const withChips = (chips: { type: StageHeaderChipType; label?: string; tooltip?: string }[]) => ({
+    stageDetails: { ...defaultProps.stageDetails, headerChips: chips },
+  });
+
   it('does not render status badges by default', () => {
     renderStageNode();
     expect(optionalBadge()).not.toBeInTheDocument();
     expect(endsCaseBadge()).not.toBeInTheDocument();
   });
 
-  it('renders the Optional badge with the default label when isOptional is true', () => {
-    renderStageNode({ stageDetails: { ...defaultProps.stageDetails, isOptional: true } });
+  it('renders the Optional badge with the default label', () => {
+    renderStageNode(withChips([{ type: StageHeaderChipType.Optional }]));
     const badge = optionalBadge();
     expect(badge).toBeInTheDocument();
     expect(badge).toHaveTextContent('Optional');
     expect(endsCaseBadge()).not.toBeInTheDocument();
   });
 
-  it('renders the Ends case badge with the default label when endsCase is true', () => {
-    renderStageNode({ stageDetails: { ...defaultProps.stageDetails, endsCase: true } });
+  it('renders the Ends case badge with the default label', () => {
+    renderStageNode(withChips([{ type: StageHeaderChipType.EndsCase }]));
     const badge = endsCaseBadge();
     expect(badge).toBeInTheDocument();
     expect(badge).toHaveTextContent('Ends case');
     expect(optionalBadge()).not.toBeInTheDocument();
   });
 
-  it('renders both badges when both flags are set', () => {
-    renderStageNode({
-      stageDetails: { ...defaultProps.stageDetails, isOptional: true, endsCase: true },
-    });
+  it('renders both status badges when both chips are present', () => {
+    renderStageNode(
+      withChips([{ type: StageHeaderChipType.Optional }, { type: StageHeaderChipType.EndsCase }])
+    );
     expect(optionalBadge()).toBeInTheDocument();
     expect(endsCaseBadge()).toBeInTheDocument();
   });
 
-  it('uses consumer-supplied labels when provided', () => {
-    renderStageNode({
-      stageDetails: {
-        ...defaultProps.stageDetails,
-        isOptional: true,
-        endsCase: true,
-        optionalLabel: 'Opcional',
-        endsCaseLabel: 'Finaliza caso',
-      },
-    });
+  it('uses consumer-supplied chip labels when provided', () => {
+    renderStageNode(
+      withChips([
+        { type: StageHeaderChipType.Optional, label: 'Opcional' },
+        { type: StageHeaderChipType.EndsCase, label: 'Finaliza caso' },
+      ])
+    );
     expect(optionalBadge()).toHaveTextContent('Opcional');
     expect(endsCaseBadge()).toHaveTextContent('Finaliza caso');
   });
 
-  it('renders the status row even when there is no SLA text or header chips', () => {
-    renderStageNode({ stageDetails: { ...defaultProps.stageDetails, isOptional: true } });
-    expect(optionalBadge()).toBeInTheDocument();
-    expect(screen.queryByTestId('stage-sla-stage-1')).not.toBeInTheDocument();
+  it('falls back to the default label when an empty label is supplied', () => {
+    renderStageNode(withChips([{ type: StageHeaderChipType.Optional, label: '' }]));
+    expect(optionalBadge()).toHaveTextContent('Optional');
   });
 
-  it('renders status badges alongside SLA text and header chips', () => {
+  it('is not rendered as an interactive button', () => {
+    renderStageNode(withChips([{ type: StageHeaderChipType.Optional }]));
+    expect(
+      screen.queryByRole('button', { name: StageHeaderChipType.Optional })
+    ).not.toBeInTheDocument();
+  });
+
+  it('makes the badge keyboard-focusable only when a tooltip is provided', () => {
+    renderStageNode(
+      withChips([
+        { type: StageHeaderChipType.Optional, tooltip: 'Not required for case completion' },
+        { type: StageHeaderChipType.EndsCase },
+      ])
+    );
+    expect(optionalBadge()).toHaveAttribute('tabindex', '0');
+    expect(endsCaseBadge()).not.toHaveAttribute('tabindex');
+  });
+
+  it('renders status badges alongside SLA text and interactive chips', () => {
     renderStageNode({
       stageDetails: {
         ...defaultProps.stageDetails,
-        isOptional: true,
-        endsCase: true,
-        headerChips: [{ type: StageHeaderChipType.Entry }],
+        headerChips: [
+          { type: StageHeaderChipType.Entry },
+          { type: StageHeaderChipType.Optional },
+          { type: StageHeaderChipType.EndsCase },
+        ],
       },
       execution: {
         stageStatus: { slaText: 'SLA: 3 days' },
@@ -1085,19 +1105,6 @@ describe('StageNode - Status Badges', () => {
     expect(screen.getByRole('button', { name: StageHeaderChipType.Entry })).toBeInTheDocument();
     expect(optionalBadge()).toBeInTheDocument();
     expect(endsCaseBadge()).toBeInTheDocument();
-  });
-
-  it('renders the badge when an optionalTooltip is provided', () => {
-    renderStageNode({
-      stageDetails: {
-        ...defaultProps.stageDetails,
-        isOptional: true,
-        optionalTooltip: 'Not required for case completion',
-      },
-    });
-
-    expect(optionalBadge()).toBeInTheDocument();
-    expect(optionalBadge()).toHaveTextContent('Optional');
   });
 });
 

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.test.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.test.tsx
@@ -1010,6 +1010,97 @@ describe('StageNode - Header Chips', () => {
   });
 });
 
+describe('StageNode - Status Badges', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const optionalBadge = () => screen.queryByTestId('stage-optional-badge-stage-1');
+  const endsCaseBadge = () => screen.queryByTestId('stage-ends-case-badge-stage-1');
+
+  it('does not render status badges by default', () => {
+    renderStageNode();
+    expect(optionalBadge()).not.toBeInTheDocument();
+    expect(endsCaseBadge()).not.toBeInTheDocument();
+  });
+
+  it('renders the Optional badge with the default label when isOptional is true', () => {
+    renderStageNode({ stageDetails: { ...defaultProps.stageDetails, isOptional: true } });
+    const badge = optionalBadge();
+    expect(badge).toBeInTheDocument();
+    expect(badge).toHaveTextContent('Optional');
+    expect(endsCaseBadge()).not.toBeInTheDocument();
+  });
+
+  it('renders the Ends case badge with the default label when endsCase is true', () => {
+    renderStageNode({ stageDetails: { ...defaultProps.stageDetails, endsCase: true } });
+    const badge = endsCaseBadge();
+    expect(badge).toBeInTheDocument();
+    expect(badge).toHaveTextContent('Ends case');
+    expect(optionalBadge()).not.toBeInTheDocument();
+  });
+
+  it('renders both badges when both flags are set', () => {
+    renderStageNode({
+      stageDetails: { ...defaultProps.stageDetails, isOptional: true, endsCase: true },
+    });
+    expect(optionalBadge()).toBeInTheDocument();
+    expect(endsCaseBadge()).toBeInTheDocument();
+  });
+
+  it('uses consumer-supplied labels when provided', () => {
+    renderStageNode({
+      stageDetails: {
+        ...defaultProps.stageDetails,
+        isOptional: true,
+        endsCase: true,
+        optionalLabel: 'Opcional',
+        endsCaseLabel: 'Finaliza caso',
+      },
+    });
+    expect(optionalBadge()).toHaveTextContent('Opcional');
+    expect(endsCaseBadge()).toHaveTextContent('Finaliza caso');
+  });
+
+  it('renders the status row even when there is no SLA text or header chips', () => {
+    renderStageNode({ stageDetails: { ...defaultProps.stageDetails, isOptional: true } });
+    expect(optionalBadge()).toBeInTheDocument();
+    expect(screen.queryByTestId('stage-sla-stage-1')).not.toBeInTheDocument();
+  });
+
+  it('renders status badges alongside SLA text and header chips', () => {
+    renderStageNode({
+      stageDetails: {
+        ...defaultProps.stageDetails,
+        isOptional: true,
+        endsCase: true,
+        headerChips: [{ type: StageHeaderChipType.Entry }],
+      },
+      execution: {
+        stageStatus: { slaText: 'SLA: 3 days' },
+        taskStatus: {},
+      },
+    });
+    expect(screen.getByTestId('stage-sla-stage-1')).toHaveTextContent('SLA: 3 days');
+    expect(screen.getByRole('button', { name: StageHeaderChipType.Entry })).toBeInTheDocument();
+    expect(optionalBadge()).toBeInTheDocument();
+    expect(endsCaseBadge()).toBeInTheDocument();
+  });
+
+  it('renders the badge when an optionalTooltip is provided', () => {
+    renderStageNode({
+      stageDetails: {
+        ...defaultProps.stageDetails,
+        isOptional: true,
+        optionalTooltip: 'Not required for case completion',
+      },
+    });
+
+    expect(optionalBadge()).toBeInTheDocument();
+    expect(optionalBadge()).toHaveTextContent('Optional');
+  });
+});
+
 describe('StageNode - Add Task Button', () => {
   it('disables the add task button when loadingTaskIds is non-empty', () => {
     renderStageNode({

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.types.ts
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.types.ts
@@ -41,11 +41,14 @@ export enum StageHeaderChipType {
   Exit = 'exit',
   Completion = 'completion',
   ReturnToOrigin = 'returnToOrigin',
+  Optional = 'optional',
+  EndsCase = 'endsCase',
 }
 
 export interface StageHeaderChip {
   type: StageHeaderChipType;
   count?: number;
+  label?: string;
   tooltip?: React.ReactNode;
   onClick?: () => void;
 }
@@ -65,12 +68,6 @@ export interface StageNodeBaseProps {
     tasks: StageTaskItem[][];
     selectedTaskId?: string;
     headerChips?: StageHeaderChip[];
-    isOptional?: boolean;
-    optionalLabel?: string;
-    optionalTooltip?: React.ReactNode;
-    endsCase?: boolean;
-    endsCaseLabel?: string;
-    endsCaseTooltip?: React.ReactNode;
   };
   taskOptions?: ListItem[];
   execution?: {

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.types.ts
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.types.ts
@@ -65,6 +65,12 @@ export interface StageNodeBaseProps {
     tasks: StageTaskItem[][];
     selectedTaskId?: string;
     headerChips?: StageHeaderChip[];
+    isOptional?: boolean;
+    optionalLabel?: string;
+    optionalTooltip?: React.ReactNode;
+    endsCase?: boolean;
+    endsCaseLabel?: string;
+    endsCaseTooltip?: React.ReactNode;
   };
   taskOptions?: ListItem[];
   execution?: {

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNodeHeader.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNodeHeader.tsx
@@ -33,7 +33,7 @@ const CHIP_ICONS: Partial<Record<StageHeaderChipType, React.ReactElement>> = {
   [StageHeaderChipType.ReturnToOrigin]: <ReturnToOriginIcon w={Icon.IconXs} h={Icon.IconXs} />,
 };
 
-/** Header-chip types that render as non-interactive status pills instead of the interactive {@link StageChip}. */
+/** Header-chip types that render as filled status pills (Optional / Ends case) instead of the icon-based {@link StageChip}. */
 const STATUS_BADGE_CONFIG: Partial<
   Record<
     StageHeaderChipType,
@@ -41,37 +41,43 @@ const STATUS_BADGE_CONFIG: Partial<
   >
 > = {
   [StageHeaderChipType.Optional]: {
-    className: 'bg-background-secondary text-foreground-muted',
+    className: 'bg-background-secondary text-foreground-muted hover:bg-background-secondary/80',
     testId: 'optional',
     labelKey: 'optionalBadge',
   },
   [StageHeaderChipType.EndsCase]: {
-    className: 'bg-error-icon text-foreground-inverse',
+    className: 'bg-error-icon text-foreground-inverse hover:bg-error-icon/80',
     testId: 'ends-case',
     labelKey: 'endsCaseBadge',
   },
 };
 
-/** Non-interactive status pill (no count/click); focusable only when a tooltip is supplied so it's reachable via keyboard. */
+/** Filled status pill (e.g. "Optional", "Ends case"). Interactive — clicking navigates the consumer to the related control. */
 const StageStatusBadge = ({
   label,
   tooltip,
   className,
   testId,
+  onClick,
 }: {
   label: string;
   tooltip?: React.ReactNode;
   className: string;
   testId: string;
+  onClick?: () => void;
 }) => {
   const badge = (
-    <span
+    <button
+      type="button"
       data-testid={testId}
-      tabIndex={tooltip ? 0 : undefined}
-      className={`inline-flex h-6 items-center justify-center whitespace-nowrap rounded-[10px] border border-transparent px-2 text-xs font-normal ${className}`}
+      onClick={(e) => {
+        e.stopPropagation();
+        onClick?.();
+      }}
+      className={`inline-flex h-6 cursor-pointer items-center justify-center whitespace-nowrap rounded-[10px] border border-transparent px-2 text-xs font-normal transition-colors focus-visible:outline-2 focus-visible:outline-offset-2 ${className}`}
     >
       {label}
-    </span>
+    </button>
   );
 
   if (tooltip) {
@@ -190,6 +196,7 @@ const StageNodeHeaderInner = ({
                       className={statusBadge.className}
                       label={chip.label || labels[statusBadge.labelKey]}
                       tooltip={chip.tooltip}
+                      onClick={chip.onClick}
                     />
                   );
                 }

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNodeHeader.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNodeHeader.tsx
@@ -26,58 +26,81 @@ const SLA_ICON_CONFIG: Record<StageSlaIcon, { icon: string; iconColor: string }>
   },
 };
 
-const CHIP_ICONS: Partial<Record<StageHeaderChipType, React.ReactElement>> = {
+const CHIP_ICONS: Record<StageHeaderChipType, React.ReactElement | null> = {
   [StageHeaderChipType.Entry]: <EntryConditionIcon w={Icon.IconXs} h={Icon.IconXs} />,
   [StageHeaderChipType.Exit]: <ExitConditionIcon w={Icon.IconXs} h={Icon.IconXs} />,
   [StageHeaderChipType.Completion]: <ChecklistIcon size={16} />,
   [StageHeaderChipType.ReturnToOrigin]: <ReturnToOriginIcon w={Icon.IconXs} h={Icon.IconXs} />,
+  // Render as status pills (see STATUS_BADGE_CONFIG), never via CHIP_ICONS — listed for exhaustiveness.
+  [StageHeaderChipType.Optional]: null,
+  [StageHeaderChipType.EndsCase]: null,
 };
 
 /** Header-chip types that render as filled status pills (Optional / Ends case) instead of the icon-based {@link StageChip}. */
 const STATUS_BADGE_CONFIG: Partial<
   Record<
     StageHeaderChipType,
-    { className: string; testId: string; labelKey: 'optionalBadge' | 'endsCaseBadge' }
+    {
+      className: string;
+      hoverClassName: string;
+      testId: string;
+      labelKey: 'optionalBadge' | 'endsCaseBadge';
+    }
   >
 > = {
   [StageHeaderChipType.Optional]: {
-    className: 'bg-background-secondary text-foreground-muted hover:bg-background-secondary/80',
+    className: 'bg-background-secondary text-foreground-muted',
+    hoverClassName: 'hover:bg-background-secondary/80',
     testId: 'optional',
     labelKey: 'optionalBadge',
   },
   [StageHeaderChipType.EndsCase]: {
-    className: 'bg-error-icon text-foreground-inverse hover:bg-error-icon/80',
+    className: 'bg-error-icon text-foreground-inverse',
+    hoverClassName: 'hover:bg-error-icon/80',
     testId: 'ends-case',
     labelKey: 'endsCaseBadge',
   },
 };
 
-/** Filled status pill (e.g. "Optional", "Ends case"). Interactive — clicking navigates the consumer to the related control. */
+const STATUS_BADGE_BASE_CLASS =
+  'inline-flex h-6 items-center justify-center whitespace-nowrap rounded-[10px] border border-transparent px-2 text-xs font-normal';
+
+/**
+ * Filled status pill (e.g. "Optional", "Ends case"). Interactive when an `onClick` is supplied —
+ * it then renders a focusable button with hover that navigates the consumer to the related control;
+ * otherwise it renders a plain, non-interactive label.
+ */
 const StageStatusBadge = ({
   label,
   tooltip,
   className,
+  hoverClassName,
   testId,
   onClick,
 }: {
   label: string;
   tooltip?: React.ReactNode;
   className: string;
+  hoverClassName: string;
   testId: string;
   onClick?: () => void;
 }) => {
-  const badge = (
+  const badge = onClick ? (
     <button
       type="button"
       data-testid={testId}
       onClick={(e) => {
         e.stopPropagation();
-        onClick?.();
+        onClick();
       }}
-      className={`inline-flex h-6 cursor-pointer items-center justify-center whitespace-nowrap rounded-[10px] border border-transparent px-2 text-xs font-normal transition-colors focus-visible:outline-2 focus-visible:outline-offset-2 ${className}`}
+      className={`${STATUS_BADGE_BASE_CLASS} ${className} ${hoverClassName} cursor-pointer transition-colors focus-visible:outline-2 focus-visible:outline-offset-2`}
     >
       {label}
     </button>
+  ) : (
+    <span data-testid={testId} className={`${STATUS_BADGE_BASE_CLASS} ${className}`}>
+      {label}
+    </span>
   );
 
   if (tooltip) {
@@ -194,6 +217,7 @@ const StageNodeHeaderInner = ({
                       key={chip.type}
                       testId={`stage-${statusBadge.testId}-badge-${id}`}
                       className={statusBadge.className}
+                      hoverClassName={statusBadge.hoverClassName}
                       label={chip.label || labels[statusBadge.labelKey]}
                       tooltip={chip.tooltip}
                       onClick={chip.onClick}

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNodeHeader.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNodeHeader.tsx
@@ -26,18 +26,33 @@ const SLA_ICON_CONFIG: Record<StageSlaIcon, { icon: string; iconColor: string }>
   },
 };
 
-const CHIP_ICONS: Record<StageHeaderChipType, React.ReactElement> = {
+const CHIP_ICONS: Partial<Record<StageHeaderChipType, React.ReactElement>> = {
   [StageHeaderChipType.Entry]: <EntryConditionIcon w={Icon.IconXs} h={Icon.IconXs} />,
   [StageHeaderChipType.Exit]: <ExitConditionIcon w={Icon.IconXs} h={Icon.IconXs} />,
   [StageHeaderChipType.Completion]: <ChecklistIcon size={16} />,
   [StageHeaderChipType.ReturnToOrigin]: <ReturnToOriginIcon w={Icon.IconXs} h={Icon.IconXs} />,
 };
 
-/**
- * Non-interactive status pill rendered in the stage header (e.g. "Optional",
- * "Ends case"). Unlike {@link StageChip} these have no count and no click
- * behavior — they are pure status indicators driven by `stageDetails` flags.
- */
+/** Header-chip types that render as non-interactive status pills instead of the interactive {@link StageChip}. */
+const STATUS_BADGE_CONFIG: Partial<
+  Record<
+    StageHeaderChipType,
+    { className: string; testId: string; labelKey: 'optionalBadge' | 'endsCaseBadge' }
+  >
+> = {
+  [StageHeaderChipType.Optional]: {
+    className: 'bg-background-secondary text-foreground-muted',
+    testId: 'optional',
+    labelKey: 'optionalBadge',
+  },
+  [StageHeaderChipType.EndsCase]: {
+    className: 'bg-error-icon text-foreground-inverse',
+    testId: 'ends-case',
+    labelKey: 'endsCaseBadge',
+  },
+};
+
+/** Non-interactive status pill (no count/click); focusable only when a tooltip is supplied so it's reachable via keyboard. */
 const StageStatusBadge = ({
   label,
   tooltip,
@@ -52,7 +67,8 @@ const StageStatusBadge = ({
   const badge = (
     <span
       data-testid={testId}
-      className={`inline-flex h-5 items-center whitespace-nowrap rounded-full px-2 text-xs font-normal leading-5 ${className}`}
+      tabIndex={tooltip ? 0 : undefined}
+      className={`inline-flex h-6 items-center justify-center whitespace-nowrap rounded-[10px] border border-transparent px-2 text-xs font-normal ${className}`}
     >
       {label}
     </span>
@@ -104,14 +120,6 @@ const StageNodeHeaderInner = ({
   const statusFallbackName = status ? getStatusName(status) : '';
   const statusTooltip = statusLabel || statusFallbackName;
 
-  const isOptional = !!stageDetails.isOptional;
-  const endsCase = !!stageDetails.endsCase;
-  const optionalLabel = stageDetails.optionalLabel ?? labels.optionalBadge;
-  const endsCaseLabel = stageDetails.endsCaseLabel ?? labels.endsCaseBadge;
-  const hasHeaderChips = !!stageDetails.headerChips && stageDetails.headerChips.length > 0;
-  const hasStatusBadges = isOptional || endsCase;
-  const showStatusRow = !!slaText || hasHeaderChips || hasStatusBadges;
-
   return (
     <StageHeader isException={isException} data-testid={`stage-header-${id}`}>
       <div className="flex items-start justify-between gap-1">
@@ -156,8 +164,8 @@ const StageNodeHeaderInner = ({
           )}
         </Row>
       </div>
-      {showStatusRow && (
-        <div className="mt-1 flex flex-wrap items-center justify-between gap-2">
+      {(slaText || (stageDetails.headerChips && stageDetails.headerChips.length > 0)) && (
+        <div className="flex min-h-8 flex-wrap items-center justify-between gap-x-2 gap-y-2">
           {slaText && (
             <span
               className="inline-flex items-center gap-1 text-xs text-foreground-muted"
@@ -170,9 +178,22 @@ const StageNodeHeaderInner = ({
               {slaText}
             </span>
           )}
-          {(hasHeaderChips || hasStatusBadges) && (
-            <div className="flex flex-wrap items-center gap-1">
-              {stageDetails.headerChips?.map((chip) => {
+          {stageDetails.headerChips && stageDetails.headerChips.length > 0 && (
+            <div className="flex flex-wrap items-center gap-x-1 gap-y-2">
+              {stageDetails.headerChips.map((chip) => {
+                const statusBadge = STATUS_BADGE_CONFIG[chip.type];
+                if (statusBadge) {
+                  return (
+                    <StageStatusBadge
+                      key={chip.type}
+                      testId={`stage-${statusBadge.testId}-badge-${id}`}
+                      className={statusBadge.className}
+                      label={chip.label || labels[statusBadge.labelKey]}
+                      tooltip={chip.tooltip}
+                    />
+                  );
+                }
+
                 const button = (
                   <StageChip
                     key={chip.type}
@@ -196,27 +217,15 @@ const StageNodeHeaderInner = ({
                 }
                 return button;
               })}
-              {isOptional && (
-                <StageStatusBadge
-                  testId={`stage-optional-badge-${id}`}
-                  className="bg-background-secondary text-foreground-muted"
-                  label={optionalLabel}
-                  tooltip={stageDetails.optionalTooltip}
-                />
-              )}
-              {endsCase && (
-                <StageStatusBadge
-                  testId={`stage-ends-case-badge-${id}`}
-                  className="bg-error-icon text-foreground-inverse"
-                  label={endsCaseLabel}
-                  tooltip={stageDetails.endsCaseTooltip}
-                />
-              )}
             </div>
           )}
         </div>
       )}
-      {stageDuration && <span className="mt-1 text-xs text-foreground-muted">{stageDuration}</span>}
+      {stageDuration && (
+        <span className="flex min-h-8 items-center text-xs text-foreground-muted">
+          {stageDuration}
+        </span>
+      )}
     </StageHeader>
   );
 };

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNodeHeader.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNodeHeader.tsx
@@ -33,6 +33,41 @@ const CHIP_ICONS: Record<StageHeaderChipType, React.ReactElement> = {
   [StageHeaderChipType.ReturnToOrigin]: <ReturnToOriginIcon w={Icon.IconXs} h={Icon.IconXs} />,
 };
 
+/**
+ * Non-interactive status pill rendered in the stage header (e.g. "Optional",
+ * "Ends case"). Unlike {@link StageChip} these have no count and no click
+ * behavior — they are pure status indicators driven by `stageDetails` flags.
+ */
+const StageStatusBadge = ({
+  label,
+  tooltip,
+  className,
+  testId,
+}: {
+  label: string;
+  tooltip?: React.ReactNode;
+  className: string;
+  testId: string;
+}) => {
+  const badge = (
+    <span
+      data-testid={testId}
+      className={`inline-flex h-5 items-center whitespace-nowrap rounded-full px-2 text-xs font-normal leading-5 ${className}`}
+    >
+      {label}
+    </span>
+  );
+
+  if (tooltip) {
+    return (
+      <CanvasTooltip placement="bottom" content={tooltip}>
+        {badge}
+      </CanvasTooltip>
+    );
+  }
+  return badge;
+};
+
 const StageNodeHeaderInner = ({
   props,
   isReadOnly,
@@ -68,6 +103,14 @@ const StageNodeHeaderInner = ({
   const slaIndicator = slaIcon ? SLA_ICON_CONFIG[slaIcon] : undefined;
   const statusFallbackName = status ? getStatusName(status) : '';
   const statusTooltip = statusLabel || statusFallbackName;
+
+  const isOptional = !!stageDetails.isOptional;
+  const endsCase = !!stageDetails.endsCase;
+  const optionalLabel = stageDetails.optionalLabel ?? labels.optionalBadge;
+  const endsCaseLabel = stageDetails.endsCaseLabel ?? labels.endsCaseBadge;
+  const hasHeaderChips = !!stageDetails.headerChips && stageDetails.headerChips.length > 0;
+  const hasStatusBadges = isOptional || endsCase;
+  const showStatusRow = !!slaText || hasHeaderChips || hasStatusBadges;
 
   return (
     <StageHeader isException={isException} data-testid={`stage-header-${id}`}>
@@ -113,7 +156,7 @@ const StageNodeHeaderInner = ({
           )}
         </Row>
       </div>
-      {(slaText || (stageDetails.headerChips && stageDetails.headerChips.length > 0)) && (
+      {showStatusRow && (
         <div className="mt-1 flex flex-wrap items-center justify-between gap-2">
           {slaText && (
             <span
@@ -127,9 +170,9 @@ const StageNodeHeaderInner = ({
               {slaText}
             </span>
           )}
-          {stageDetails.headerChips && stageDetails.headerChips.length > 0 && (
+          {(hasHeaderChips || hasStatusBadges) && (
             <div className="flex flex-wrap items-center gap-1">
-              {stageDetails.headerChips.map((chip) => {
+              {stageDetails.headerChips?.map((chip) => {
                 const button = (
                   <StageChip
                     key={chip.type}
@@ -153,6 +196,22 @@ const StageNodeHeaderInner = ({
                 }
                 return button;
               })}
+              {isOptional && (
+                <StageStatusBadge
+                  testId={`stage-optional-badge-${id}`}
+                  className="bg-background-secondary text-foreground-muted"
+                  label={optionalLabel}
+                  tooltip={stageDetails.optionalTooltip}
+                />
+              )}
+              {endsCase && (
+                <StageStatusBadge
+                  testId={`stage-ends-case-badge-${id}`}
+                  className="bg-error-icon text-foreground-inverse"
+                  label={endsCaseLabel}
+                  tooltip={stageDetails.endsCaseTooltip}
+                />
+              )}
             </div>
           )}
         </div>

--- a/packages/apollo-react/src/canvas/components/StageNode/useStageNodeLabels.ts
+++ b/packages/apollo-react/src/canvas/components/StageNode/useStageNodeLabels.ts
@@ -13,6 +13,8 @@ export interface StageNodeLabels {
   sequentialTasks: string;
   parallel: string;
   untitledStage: string;
+  optionalBadge: string;
+  endsCaseBadge: string;
   contextMenu: StageContextMenuLabels;
 }
 
@@ -34,6 +36,8 @@ export function useStageNodeLabels(): StageNodeLabels {
       sequentialTasks: _({ id: 'stage-node.sequential-tasks', message: 'Sequential tasks' }),
       parallel: _({ id: 'stage-node.parallel', message: 'Parallel' }),
       untitledStage: _({ id: 'stage-node.untitled-stage', message: 'Untitled stage' }),
+      optionalBadge: _({ id: 'stage-node.optional-badge', message: 'Optional' }),
+      endsCaseBadge: _({ id: 'stage-node.ends-case-badge', message: 'Ends case' }),
       contextMenu: {
         moveUp: _({ id: 'stage-node.move-up', message: 'Move up' }),
         moveDown: _({ id: 'stage-node.move-down', message: 'Move down' }),


### PR DESCRIPTION
## Summary

Adds two non-interactive status badges — **Optional** and **Ends case** — to the `StageNode` canvas header in `@uipath/apollo-react`. They are pure status indicators (no count, no click) driven by new optional `stageDetails` flags, complementing the existing interactive header chips and SLA text. This is **part 1 of a 2-part feature**; part 2 (the domain logic that computes `isOptional` / `endsCase` and supplies localized copy) lands separately in **PO.Frontend**. Relates to **MST-10799**.

## Demo

<img width="2190" height="678" alt="image" src="https://github.com/user-attachments/assets/948c9c3a-2c25-448a-a66a-73c19e812031" />

## Changes

- **`StageNode.types.ts`** — added optional, backward-compatible fields to `stageDetails`: `isOptional`, `endsCase`, plus consumer-supplied `optionalLabel` / `optionalTooltip` / `endsCaseLabel` / `endsCaseTooltip` (all default to off/undefined).
- **`StageNodeHeader.tsx`** — new local `StageStatusBadge` (non-interactive `<span>` pill, optional `CanvasTooltip`); renders the badges in the header status row alongside SLA + `headerChips`. The status row now also shows when only badges are present.
- **`useStageNodeLabels.ts`** — localized default labels (`optionalBadge` → "Optional", `endsCaseBadge` → "Ends case") used as fallback when the consumer doesn't supply copy, so PO.Frontend retains i18n ownership.
- Design tokens: Optional = `bg-background-secondary` + `text-foreground-muted`; Ends case = `bg-error-icon` + `text-foreground-inverse` (theme-aware contrast across light/dark/HC).
- **Tests** — new "Status Badges" suite (default-off, default + consumer labels, both badges, coexistence with SLA/chips, tooltip wiring).
- **Stories** — new `WithStatusBadges` story mirroring the Figma frames (Optional / terminal / combined stages).

## Flow

```mermaid
flowchart TD
    A[stageDetails] -->|isOptional / endsCase| B[StageNodeHeader]
    A -->|optionalLabel / endsCaseLabel| B
    H[useStageNodeLabels] -->|localized fallback| B
    B --> C{flag set?}
    C -->|isOptional| D[StageStatusBadge: Optional]
    C -->|endsCase| E[StageStatusBadge: Ends case]
    D --> F[header status row]
    E --> F
```

## Testing

- [x] `pnpm lint` passes (JS + deps)
- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes (apollo-react: 1703 tests)
- [ ] `pnpm test:visual` — no `test:visual` task in apollo-react locally; runs in CI
- [x] Manual testing / Storybook checked (`WithStatusBadges` story)
- [x] Type-safe (no `as any` / type suppressions added)


# Padding Updates

Stage cards weren't bottom-aligning to the canvas 16px grid. Verified this is not introduced here — for any stage without the new badges, the rendered DOM is byte-identical to main.
Root cause: StageNode is content-sized, and its header chrome was built from non-grid pieces (22px chips, the mt-1 status-row margin, the duration line, etc.), so card heights weren't 16px multiples.
Swept every node type: StageNode was the only offender. BaseNode/LoopNode/GroupNode/BlankCanvasNode/TriggerNode/StickyNote are all already grid-aligned by construction (explicit GRID_SPACING multiples or snap-to-grid on resize).
Fix: made every StageNode vertical segment a 16px multiple

Status row and duration line → 32px (min-h-8) grid-clean rows.
Chips/badges → 24px so each wrapped chip-row is a clean 32px pitch (24 + 8px gap); wrapped lines keep an 8px gap instead of touching.
Tasks already step 48px (3×16); trimmed content bottom padding to land totals on the grid.
Result: card heights are now always multiples of 16 (e.g. 128 / 160 / 208 / 256), so bottoms sit on the dot grid in every config — empty, SLA-only, chips, wrapped, and execution/duration cards.

## Demo 2

<img width="2322" height="710" alt="image" src="https://github.com/user-attachments/assets/71ec9ad2-46ef-4d1e-9454-3f5b4a268bd3" />

<img width="2300" height="686" alt="image" src="https://github.com/user-attachments/assets/f1343119-2472-4613-9569-a75cadecfc86" />

<img width="2072" height="892" alt="image" src="https://github.com/user-attachments/assets/5e475f51-5cff-4afa-808c-97b894a1ecfe" />

<img width="1630" height="766" alt="image" src="https://github.com/user-attachments/assets/7a0af1e9-e1c9-4a4d-a40a-16186289cc23" />

I checked all stage nodes but there are a few ^