### PR TITLE
docs(apollo-vertex): add intro to Adding a New Component

### DIFF
--- a/apps/apollo-vertex/README.md
+++ b/apps/apollo-vertex/README.md
@@ -53,6 +53,8 @@ npx shadcn@latest add http://localhost:3000/r/button.json
 
 ## Adding a New Component
 
+To add a new component to the registry, follow these steps:
+
 1.  Create the component file in `registry/<component>/<component>.tsx`.
 2.  Add the component definition to `registry.json`.
 3.  Create a documentation page in `app/components/<component>/page.mdx`.


### PR DESCRIPTION
## Description

Tiny doc fix: adds a short intro line before the numbered steps in the **Adding a New Component** section of the apollo-vertex README.

> Note: minimal PR opened to exercise an automation that reacts to requested reviewers (teams + individuals).

🤖 Generated with [Claude Code](https://claude.com/claude-code)