### PR TITLE
docs(apollo-vertex): note committing generated registry files

### DIFF
--- a/apps/apollo-vertex/README.md
+++ b/apps/apollo-vertex/README.md
@@ -57,4 +57,5 @@ npx shadcn@latest add http://localhost:3000/r/button.json
 2.  Add the component definition to `registry.json`.
 3.  Create a documentation page in `app/components/<component>/page.mdx`.
 4.  Run `pnpm registry:build` to update the registry artifacts.
+5.  Commit the generated files under `public/r/`.
 


### PR DESCRIPTION
## Description

Tiny doc fix: adds a step to the **Adding a New Component** list reminding contributors to commit the generated registry files under `public/r/`.

> Note: minimal PR opened to exercise an automation that reacts to requested reviewers (teams + individuals).

🤖 Generated with [Claude Code](https://claude.com/claude-code)