### PR TITLE
docs(apollo-vertex): clarify registry.json entry fields

### DIFF
--- a/apps/apollo-vertex/README.md
+++ b/apps/apollo-vertex/README.md
@@ -56,5 +56,5 @@ npx shadcn@latest add http://localhost:3000/r/button.json
 1.  Create the component file in `registry/<component>/<component>.tsx`.
 2.  Add the component definition (name, files, dependencies) to `registry.json`.
 3.  Create a documentation page in `app/components/<component>/page.mdx`.
-4.  Run `pnpm registry:build` to update the registry artifacts.
+4.  Run `pnpm registry:build` to regenerate the registry artifacts under `public/r/`.
 

--- a/apps/apollo-vertex/README.md
+++ b/apps/apollo-vertex/README.md
@@ -54,7 +54,7 @@ npx shadcn@latest add http://localhost:3000/r/button.json
 ## Adding a New Component
 
 1.  Create the component file in `registry/<component>/<component>.tsx`.
-2.  Add the component definition to `registry.json`.
+2.  Add the component definition (name, files, dependencies) to `registry.json`.
 3.  Create a documentation page in `app/components/<component>/page.mdx`.
 4.  Run `pnpm registry:build` to update the registry artifacts.
 


### PR DESCRIPTION
## Description

Tiny doc fix: clarifies which fields go into the `registry.json` entry (name, files, dependencies) in the **Adding a New Component** steps.

> Note: minimal PR opened to exercise an automation that reacts to requested reviewers (teams + individuals).