### PR TITLE
docs(apollo-vertex): note docs page is MDX

### DIFF
--- a/apps/apollo-vertex/README.md
+++ b/apps/apollo-vertex/README.md
@@ -55,6 +55,6 @@ npx shadcn@latest add http://localhost:3000/r/button.json
 
 1.  Create the component file in `registry/<component>/<component>.tsx`.
 2.  Add the component definition to `registry.json`.
-3.  Create a documentation page in `app/components/<component>/page.mdx`.
+3.  Create a documentation page in `app/components/<component>/page.mdx` (MDX).
 4.  Run `pnpm registry:build` to update the registry artifacts.
 


### PR DESCRIPTION
## Description

Tiny doc fix: clarifies that the component documentation page in the **Adding a New Component** steps is an MDX file.

> Note: minimal PR opened to exercise an automation that reacts to requested reviewers (teams + individuals).