### PR TITLE
feat(apollo-react): unified CanvasEdge with waypoint editing and pluggable routing

### DIFF
--- a/packages/apollo-react/src/canvas/components/Edges/CanvasEdge.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/Edges/CanvasEdge.stories.tsx
@@ -1,0 +1,731 @@
+/**
+ * CanvasEdge Stories
+ *
+ * The unified canvas edge — visual styling renders unconditionally,
+ * and behaviors (waypoint editing, future execution/toolbar) opt in via
+ * `enable*` flags on the edge data.
+ */
+import type { Meta, StoryObj } from '@storybook/react';
+import type { Edge, Node } from '@uipath/apollo-react/canvas/xyflow/react';
+import { Position } from '@uipath/apollo-react/canvas/xyflow/react';
+import { useCallback, useMemo, useState } from 'react';
+import {
+  createNode as createMockNode,
+  StoryInfoPanel,
+  useCanvasStory,
+  withCanvasProviders,
+} from '../../storybook-utils';
+import { ElementStatusValues } from '../../types/execution';
+import { BaseCanvas } from '../BaseCanvas';
+import { CanvasEdge } from './CanvasEdge';
+import type { EdgeRouter, RoutedEdge, RouteRequest } from './shared/routing';
+import { useGraphRouter } from './shared/routing';
+import type { CanvasEdgeData, Waypoint } from './shared/types';
+import { generateWaypointId, waypointsEqual } from './shared/waypoints';
+
+const meta: Meta = {
+  title: 'Components/Edges/CanvasEdge',
+  parameters: { layout: 'fullscreen' },
+  decorators: [withCanvasProviders()],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const edgeTypes = { 'canvas-edge': CanvasEdge };
+
+interface NodeConfig {
+  id: string;
+  label: string;
+  x: number;
+  y: number;
+  sourcePositions?: Position[];
+  targetPositions?: Position[];
+}
+
+/** Thin sugar over the shared mock factory: positions → handleConfigurations. */
+function createNode(config: NodeConfig): Node {
+  const { id, label, x, y, sourcePositions = [], targetPositions = [] } = config;
+  return createMockNode({
+    id,
+    type: 'uipath.blank-node',
+    position: { x, y },
+    display: { label },
+    handleConfigurations: [
+      ...sourcePositions.map((position) => ({
+        position,
+        handles: [
+          { id: `out-${position}`, type: 'source' as const, handleType: 'output' as const },
+        ],
+      })),
+      ...targetPositions.map((position) => ({
+        position,
+        handles: [{ id: `in-${position}`, type: 'target' as const, handleType: 'input' as const }],
+      })),
+    ],
+  });
+}
+
+/**
+ * Interactive demo. Editable edges set `enableEditing: true`. Hover an edge
+ * to surface segment drag handles, double-click a segment to add a waypoint,
+ * drag waypoints to move them, double-click a waypoint to remove it.
+ */
+function InteractiveStory() {
+  const initialNodes = useMemo(
+    () => [
+      createNode({ id: 'a1', label: 'A1', x: 100, y: 100, sourcePositions: [Position.Right] }),
+      createNode({ id: 'b1', label: 'B1', x: 400, y: 100, targetPositions: [Position.Left] }),
+
+      createNode({ id: 'a2', label: 'A2', x: 100, y: 200, sourcePositions: [Position.Right] }),
+      createNode({ id: 'b2', label: 'B2', x: 400, y: 300, targetPositions: [Position.Left] }),
+
+      createNode({ id: 'c1', label: 'C1', x: 100, y: 450, sourcePositions: [Position.Right] }),
+      createNode({ id: 'd1', label: 'D1', x: 400, y: 550, targetPositions: [Position.Left] }),
+
+      createNode({ id: 'e1', label: 'Solid', x: 550, y: 100, sourcePositions: [Position.Right] }),
+      createNode({ id: 'f1', label: 'Target', x: 850, y: 100, targetPositions: [Position.Left] }),
+
+      createNode({ id: 'e2', label: 'Dashed', x: 550, y: 200, sourcePositions: [Position.Right] }),
+      createNode({ id: 'f2', label: 'Target', x: 850, y: 200, targetPositions: [Position.Left] }),
+
+      createNode({ id: 'e3', label: 'Invalid', x: 550, y: 300, sourcePositions: [Position.Right] }),
+      createNode({ id: 'f3', label: 'Target', x: 850, y: 300, targetPositions: [Position.Left] }),
+
+      createNode({
+        id: 'e4',
+        label: 'No Arrow',
+        x: 550,
+        y: 400,
+        sourcePositions: [Position.Right],
+      }),
+      createNode({ id: 'f4', label: 'Target', x: 850, y: 400, targetPositions: [Position.Left] }),
+    ],
+    []
+  );
+
+  const presetWaypoints: Waypoint[] = [
+    { id: 'wp-1', x: 300, y: 498 },
+    { id: 'wp-2', x: 300, y: 598 },
+  ];
+
+  const initialEdges: Edge<CanvasEdgeData>[] = useMemo(
+    () => [
+      {
+        id: 'e1',
+        source: 'a1',
+        target: 'b1',
+        sourceHandle: `out-${Position.Right}`,
+        targetHandle: `in-${Position.Left}`,
+        type: 'canvas-edge',
+        data: { enableEditing: true },
+      },
+      {
+        id: 'e2',
+        source: 'a2',
+        target: 'b2',
+        sourceHandle: `out-${Position.Right}`,
+        targetHandle: `in-${Position.Left}`,
+        type: 'canvas-edge',
+        data: { enableEditing: true },
+      },
+      {
+        id: 'e3',
+        source: 'c1',
+        target: 'd1',
+        sourceHandle: `out-${Position.Right}`,
+        targetHandle: `in-${Position.Left}`,
+        type: 'canvas-edge',
+        data: { enableEditing: true, waypoints: presetWaypoints },
+      },
+      {
+        id: 'e4',
+        source: 'e1',
+        target: 'f1',
+        sourceHandle: `out-${Position.Right}`,
+        targetHandle: `in-${Position.Left}`,
+        type: 'canvas-edge',
+        data: { enableEditing: true, strokeStyle: 'solid' },
+      },
+      {
+        id: 'e5',
+        source: 'e2',
+        target: 'f2',
+        sourceHandle: `out-${Position.Right}`,
+        targetHandle: `in-${Position.Left}`,
+        type: 'canvas-edge',
+        data: { enableEditing: true, strokeStyle: 'dashed' },
+      },
+      {
+        id: 'e6',
+        source: 'e3',
+        target: 'f3',
+        sourceHandle: `out-${Position.Right}`,
+        targetHandle: `in-${Position.Left}`,
+        type: 'canvas-edge',
+        data: { enableEditing: true, isInvalid: true },
+      },
+      {
+        id: 'e7',
+        source: 'e4',
+        target: 'f4',
+        sourceHandle: `out-${Position.Right}`,
+        targetHandle: `in-${Position.Left}`,
+        type: 'canvas-edge',
+        data: { enableEditing: true, hideArrowHead: true },
+      },
+    ],
+    []
+  );
+
+  const { canvasProps } = useCanvasStory({ initialNodes, initialEdges });
+
+  return <BaseCanvas {...canvasProps} edgeTypes={edgeTypes} mode="design" />;
+}
+
+export const Default: Story = {
+  render: () => <InteractiveStory />,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Single edge type with composed behaviors. Edges with `enableEditing: true` expose waypoint editing; visual variants (solid/dashed/invalid/no-arrow) render the same way regardless of editing state.',
+      },
+    },
+  },
+};
+
+/**
+ * Same edges with editing turned OFF. Visual rendering is identical;
+ * waypoint handles and segment drag affordances are absent.
+ */
+function ReadOnlyStory() {
+  const initialNodes = useMemo(
+    () => [
+      createNode({ id: 'a1', label: 'A1', x: 100, y: 100, sourcePositions: [Position.Right] }),
+      createNode({ id: 'b1', label: 'B1', x: 400, y: 100, targetPositions: [Position.Left] }),
+      createNode({ id: 'c1', label: 'C1', x: 100, y: 250, sourcePositions: [Position.Right] }),
+      createNode({ id: 'd1', label: 'D1', x: 400, y: 350, targetPositions: [Position.Left] }),
+    ],
+    []
+  );
+
+  const presetWaypoints: Waypoint[] = [
+    { id: 'wp-1', x: 250, y: 298 },
+    { id: 'wp-2', x: 250, y: 398 },
+  ];
+
+  const initialEdges: Edge<CanvasEdgeData>[] = useMemo(
+    () => [
+      {
+        id: 'e1',
+        source: 'a1',
+        target: 'b1',
+        sourceHandle: `out-${Position.Right}`,
+        targetHandle: `in-${Position.Left}`,
+        type: 'canvas-edge',
+        data: {},
+      },
+      {
+        id: 'e2',
+        source: 'c1',
+        target: 'd1',
+        sourceHandle: `out-${Position.Right}`,
+        targetHandle: `in-${Position.Left}`,
+        type: 'canvas-edge',
+        data: { waypoints: presetWaypoints },
+      },
+    ],
+    []
+  );
+
+  const { canvasProps } = useCanvasStory({ initialNodes, initialEdges });
+  return <BaseCanvas {...canvasProps} edgeTypes={edgeTypes} mode="design" />;
+}
+
+export const NonEditable: Story = {
+  render: () => <ReadOnlyStory />,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Edges without `enableEditing` render the same path but expose no editing affordances.',
+      },
+    },
+  },
+};
+
+/**
+ * Handle routing + execution + toolbar — the workflow use case. This is what
+ * `SequenceEdge` ships as a preset, expressed directly with CanvasEdge flags.
+ */
+function HandleRoutingStory() {
+  const initialNodes = useMemo(
+    () => [
+      createNode({ id: 'a1', label: 'Start', x: 100, y: 100, sourcePositions: [Position.Right] }),
+      createNode({
+        id: 'b1',
+        label: 'Step',
+        x: 400,
+        y: 100,
+        sourcePositions: [Position.Right],
+        targetPositions: [Position.Left],
+      }),
+      createNode({ id: 'c1', label: 'End', x: 700, y: 100, targetPositions: [Position.Left] }),
+    ],
+    []
+  );
+
+  const initialEdges: Edge<CanvasEdgeData>[] = useMemo(
+    () => [
+      {
+        id: 'e1',
+        source: 'a1',
+        target: 'b1',
+        sourceHandle: `out-${Position.Right}`,
+        targetHandle: `in-${Position.Left}`,
+        type: 'canvas-edge',
+        data: { routing: 'handle', enableExecution: true, enableToolbar: true, label: 'Run' },
+      },
+      {
+        id: 'e2',
+        source: 'b1',
+        target: 'c1',
+        sourceHandle: `out-${Position.Right}`,
+        targetHandle: `in-${Position.Left}`,
+        type: 'canvas-edge',
+        data: { routing: 'handle', enableExecution: true, enableToolbar: true },
+      },
+    ],
+    []
+  );
+
+  const { canvasProps } = useCanvasStory({ initialNodes, initialEdges });
+  return <BaseCanvas {...canvasProps} edgeTypes={edgeTypes} mode="design" />;
+}
+
+export const HandleRouting: Story = {
+  render: () => <HandleRoutingStory />,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'CanvasEdge with `routing: "handle"`, `enableExecution: true`, `enableToolbar: true`. This is the workflow preset that `SequenceEdge` wraps.',
+      },
+    },
+  },
+};
+
+/**
+ * The full composition: waypoint editing + add-node toolbar on the same edge.
+ * Hover an edge to see both affordances at once — segment drag handles and
+ * waypoint dots from the editor, plus the add-node "+" button from the
+ * toolbar that follows the cursor along the path.
+ */
+function EditingPlusToolbarStory() {
+  const initialNodes = useMemo(
+    () => [
+      createNode({ id: 'a1', label: 'A1', x: 100, y: 100, sourcePositions: [Position.Right] }),
+      createNode({ id: 'b1', label: 'B1', x: 500, y: 100, targetPositions: [Position.Left] }),
+
+      createNode({ id: 'a2', label: 'A2', x: 100, y: 280, sourcePositions: [Position.Right] }),
+      createNode({ id: 'b2', label: 'B2', x: 500, y: 380, targetPositions: [Position.Left] }),
+
+      createNode({ id: 'a3', label: 'A3', x: 100, y: 520, sourcePositions: [Position.Right] }),
+      createNode({ id: 'b3', label: 'B3', x: 500, y: 620, targetPositions: [Position.Left] }),
+    ],
+    []
+  );
+
+  const presetWaypointsA: Waypoint[] = [
+    { id: 'wp-a-1', x: 300, y: 328 },
+    { id: 'wp-a-2', x: 300, y: 428 },
+  ];
+  const presetWaypointsB: Waypoint[] = [
+    { id: 'wp-b-1', x: 250, y: 568 },
+    { id: 'wp-b-2', x: 350, y: 568 },
+    { id: 'wp-b-3', x: 350, y: 668 },
+  ];
+
+  const initialEdges: Edge<CanvasEdgeData>[] = useMemo(
+    () => [
+      // Auto-routed, editing + toolbar both enabled
+      {
+        id: 'e1',
+        source: 'a1',
+        target: 'b1',
+        sourceHandle: `out-${Position.Right}`,
+        targetHandle: `in-${Position.Left}`,
+        type: 'canvas-edge',
+        data: { enableEditing: true, enableToolbar: true, label: 'Edit + Toolbar' },
+      },
+      // With existing waypoints — drag segments OR use toolbar to add a node
+      {
+        id: 'e2',
+        source: 'a2',
+        target: 'b2',
+        sourceHandle: `out-${Position.Right}`,
+        targetHandle: `in-${Position.Left}`,
+        type: 'canvas-edge',
+        data: {
+          enableEditing: true,
+          enableToolbar: true,
+          waypoints: presetWaypointsA,
+        },
+      },
+      // Multi-segment path — full composition
+      {
+        id: 'e3',
+        source: 'a3',
+        target: 'b3',
+        sourceHandle: `out-${Position.Right}`,
+        targetHandle: `in-${Position.Left}`,
+        type: 'canvas-edge',
+        data: {
+          enableEditing: true,
+          enableToolbar: true,
+          enableExecution: true,
+          waypoints: presetWaypointsB,
+          label: 'All three',
+        },
+      },
+    ],
+    []
+  );
+
+  const { canvasProps } = useCanvasStory({ initialNodes, initialEdges });
+  return <BaseCanvas {...canvasProps} edgeTypes={edgeTypes} mode="design" />;
+}
+
+/**
+ * Controlled mode — `onWaypointsChange` lets the consumer intercept every
+ * waypoint update. The consumer still has to push the new value back into
+ * React Flow's edge state (same pattern as React's controlled `<input>`)
+ * — the callback alone doesn't move the line. This story records each
+ * change in a history stack and supports undo.
+ */
+function ControlledStory() {
+  const initialNodes = useMemo(
+    () => [
+      createNode({ id: 'a1', label: 'A', x: 100, y: 200, sourcePositions: [Position.Right] }),
+      createNode({ id: 'b1', label: 'B', x: 600, y: 300, targetPositions: [Position.Left] }),
+    ],
+    []
+  );
+
+  const initialWaypoints: Waypoint[] = useMemo(
+    () => [
+      { id: 'wp-1', x: 350, y: 248 },
+      { id: 'wp-2', x: 350, y: 348 },
+    ],
+    []
+  );
+
+  // History seeded with the initial state so undo is a no-op until the first
+  // change; `history.length - 1` reads as "user-driven changes so far".
+  const [history, setHistory] = useState<Waypoint[][]>([initialWaypoints]);
+
+  const initialEdges: Edge<CanvasEdgeData>[] = useMemo(
+    () => [
+      {
+        id: 'e1',
+        source: 'a1',
+        target: 'b1',
+        sourceHandle: `out-${Position.Right}`,
+        targetHandle: `in-${Position.Left}`,
+        type: 'canvas-edge',
+        data: { enableEditing: true, waypoints: initialWaypoints },
+      },
+    ],
+    [initialWaypoints]
+  );
+
+  const { canvasProps, edges, setEdges } = useCanvasStory({ initialNodes, initialEdges });
+
+  const handleChange = useCallback(
+    (next: Waypoint[]) => {
+      setHistory((h) => (waypointsEqual(h.at(-1) ?? [], next) ? h : [...h, next]));
+      setEdges((eds) =>
+        eds.map((edge) =>
+          edge.id === 'e1' ? { ...edge, data: { ...edge.data, waypoints: next } } : edge
+        )
+      );
+    },
+    [setEdges]
+  );
+
+  // The callback lives on `data` because React Flow only forwards `data` to
+  // custom edge components — there's no `onChange` prop slot. Re-injecting
+  // each render keeps the closure pointing at fresh state.
+  const edgesWithCallback = useMemo(
+    () =>
+      edges.map((edge) =>
+        edge.id === 'e1'
+          ? { ...edge, data: { ...edge.data, onWaypointsChange: handleChange } }
+          : edge
+      ),
+    [edges, handleChange]
+  );
+
+  const undo = useCallback(() => {
+    setHistory((h) => {
+      if (h.length <= 1) return h;
+      const next = h.slice(0, -1);
+      const prev = next.at(-1) ?? [];
+      setEdges((eds) =>
+        eds.map((edge) =>
+          edge.id === 'e1' ? { ...edge, data: { ...edge.data, waypoints: prev } } : edge
+        )
+      );
+      return next;
+    });
+  }, [setEdges]);
+
+  const currentWaypoints = history.at(-1) ?? [];
+
+  return (
+    <>
+      <BaseCanvas {...canvasProps} edges={edgesWithCallback} edgeTypes={edgeTypes} mode="design" />
+      <StoryInfoPanel title="Controlled waypoints" description={`${history.length - 1} change(s)`}>
+        <button
+          type="button"
+          onClick={undo}
+          disabled={history.length <= 1}
+          style={{ marginTop: 8, marginBottom: 8 }}
+        >
+          Undo
+        </button>
+        <pre
+          style={{
+            margin: 0,
+            fontSize: 11,
+            fontFamily: 'monospace',
+            whiteSpace: 'pre-wrap',
+            color: 'var(--canvas-foreground)',
+          }}
+        >
+          {JSON.stringify(currentWaypoints, null, 2)}
+        </pre>
+      </StoryInfoPanel>
+    </>
+  );
+}
+
+export const Controlled: Story = {
+  render: () => <ControlledStory />,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "`onWaypointsChange` lets the consumer intercept every waypoint update before it lands in React Flow state. **The callback alone does NOT move the edge** — the consumer must call `setEdges` themselves with the new value, mirroring React's controlled-input pattern. This story records each change in a history stack and demonstrates undo.",
+      },
+    },
+  },
+};
+
+export const EditingPlusToolbar: Story = {
+  render: () => <EditingPlusToolbarStory />,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Waypoint editing AND add-node toolbar on the same edge. Hover to surface both affordances — drag segments/waypoints to reshape the path, or use the add-node button to insert a node along it. The third edge layers execution status on top, demonstrating full behavior composition.',
+      },
+    },
+  },
+};
+
+/**
+ * Distinctive "shelf" router — every edge takes a 90° detour through a
+ * horizontal highway at y=600. The shape is intentionally not what the
+ * built-in auto-router would produce, so it's visually obvious that the
+ * pluggable router is in effect.
+ *
+ * Drag a segment on a routed edge: the routed waypoints materialize into
+ * `data.waypoints` and the edge becomes manual — user intent overrides the
+ * router from that point on.
+ */
+const shelfRouter: EdgeRouter = {
+  route(req: RouteRequest): RoutedEdge[] {
+    const HIGHWAY_Y = 600;
+    return req.edges.map((edge) => ({
+      edgeId: edge.edgeId,
+      waypoints: [
+        { id: generateWaypointId(), x: edge.source.x + 32, y: edge.source.y },
+        { id: generateWaypointId(), x: edge.source.x + 32, y: HIGHWAY_Y },
+        { id: generateWaypointId(), x: edge.target.x - 32, y: HIGHWAY_Y },
+        { id: generateWaypointId(), x: edge.target.x - 32, y: edge.target.y },
+      ],
+    }));
+  },
+};
+
+function PluggableRouterStory() {
+  const initialNodes = useMemo(
+    () => [
+      createNode({ id: 'a1', label: 'A1', x: 100, y: 100, sourcePositions: [Position.Right] }),
+      createNode({ id: 'b1', label: 'B1', x: 600, y: 100, targetPositions: [Position.Left] }),
+
+      createNode({ id: 'a2', label: 'A2', x: 100, y: 250, sourcePositions: [Position.Right] }),
+      createNode({ id: 'b2', label: 'B2', x: 600, y: 250, targetPositions: [Position.Left] }),
+
+      createNode({ id: 'a3', label: 'A3', x: 100, y: 400, sourcePositions: [Position.Right] }),
+      createNode({ id: 'b3', label: 'B3', x: 600, y: 400, targetPositions: [Position.Left] }),
+    ],
+    []
+  );
+
+  const initialEdges: Edge<CanvasEdgeData>[] = useMemo(
+    () => [
+      {
+        id: 'e1',
+        source: 'a1',
+        target: 'b1',
+        sourceHandle: `out-${Position.Right}`,
+        targetHandle: `in-${Position.Left}`,
+        type: 'canvas-edge',
+        // routing: 'waypoint' is the explicit opt-in useGraphRouter requires —
+        // undeclared edges are never router-fed (or polluted with routedWaypoints)
+        data: { routing: 'waypoint', enableEditing: true },
+      },
+      {
+        id: 'e2',
+        source: 'a2',
+        target: 'b2',
+        sourceHandle: `out-${Position.Right}`,
+        targetHandle: `in-${Position.Left}`,
+        type: 'canvas-edge',
+        data: { routing: 'waypoint', enableEditing: true },
+      },
+      {
+        id: 'e3',
+        source: 'a3',
+        target: 'b3',
+        sourceHandle: `out-${Position.Right}`,
+        targetHandle: `in-${Position.Left}`,
+        type: 'canvas-edge',
+        data: { routing: 'waypoint', enableEditing: true },
+      },
+    ],
+    []
+  );
+
+  const { canvasProps } = useCanvasStory({ initialNodes, initialEdges });
+  useGraphRouter(shelfRouter);
+
+  return (
+    <>
+      <BaseCanvas {...canvasProps} edgeTypes={edgeTypes} mode="design" />
+      <StoryInfoPanel
+        title="Pluggable router"
+        description="A custom EdgeRouter routes every edge through y=600. Drag a segment to override — that edge becomes manual."
+      />
+    </>
+  );
+}
+
+export const PluggableRouter: Story = {
+  render: () => <PluggableRouterStory />,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Demonstrates the `EdgeRouter` contract. The story wires up `useGraphRouter(shelfRouter)`, a custom router that forces every edge through a distinctive y=600 horizontal highway. Drag any segment to override — manual waypoints take priority over routed output, so the user can always escape the router.',
+      },
+    },
+  },
+};
+
+/** One row per execution status worth distinguishing visually. `None` and
+ * `Terminated`/`UserCancelled` reuse colors already shown, so they're omitted. */
+const EXECUTION_STATES = [
+  ElementStatusValues.InProgress,
+  ElementStatusValues.Completed,
+  ElementStatusValues.Failed,
+  ElementStatusValues.Paused,
+  ElementStatusValues.ActionNeeded,
+  ElementStatusValues.Cancelled,
+  ElementStatusValues.Warning,
+  ElementStatusValues.NotExecuted,
+] as const;
+
+/**
+ * Execution states on CanvasEdge. `enableExecution: true` subscribes the edge
+ * to execution + validation status, which drives the stroke color and — for
+ * `InProgress` — a dot animating along the path. The storybook providers
+ * resolve status from the edge id (`edge-<Status>`), standing in for a host
+ * app supplying real state through `ExecutionStatusContext`.
+ */
+function ExecutionStatesStory() {
+  // One Start → Step → End chain per status, mirroring the HandleRouting
+  // story's layout. The middle node carries the status — both in its label
+  // and in its own execution state (the storybook provider reads it from id
+  // segment [1], `mid-<Status>`), so node and edges show one coherent state.
+  const initialNodes = useMemo(
+    () =>
+      EXECUTION_STATES.flatMap((status, i) => {
+        const y = 100 + i * 160;
+        return [
+          createNode({
+            id: `src${i}`,
+            label: 'Start',
+            x: 100,
+            y,
+            sourcePositions: [Position.Right],
+          }),
+          createNode({
+            id: `mid-${status}`,
+            label: status,
+            x: 400,
+            y,
+            sourcePositions: [Position.Right],
+            targetPositions: [Position.Left],
+          }),
+          createNode({ id: `tgt${i}`, label: 'End', x: 700, y, targetPositions: [Position.Left] }),
+        ];
+      }),
+    []
+  );
+
+  // The storybook execution provider reads the status from id segment [1]
+  // (`edge-<Status>-…`), so both edges in a row resolve to the same state.
+  const initialEdges: Edge<CanvasEdgeData>[] = useMemo(
+    () =>
+      EXECUTION_STATES.flatMap((status, i) => [
+        {
+          id: `edge-${status}-in`,
+          source: `src${i}`,
+          target: `mid-${status}`,
+          sourceHandle: `out-${Position.Right}`,
+          targetHandle: `in-${Position.Left}`,
+          type: 'canvas-edge',
+          data: { enableExecution: true, enableEditing: true },
+        },
+        {
+          id: `edge-${status}-out`,
+          source: `mid-${status}`,
+          target: `tgt${i}`,
+          sourceHandle: `out-${Position.Right}`,
+          targetHandle: `in-${Position.Left}`,
+          type: 'canvas-edge',
+          data: { enableExecution: true, enableEditing: true },
+        },
+      ]),
+    []
+  );
+
+  const { canvasProps } = useCanvasStory({ initialNodes, initialEdges });
+  return <BaseCanvas {...canvasProps} edgeTypes={edgeTypes} mode="design" />;
+}
+
+export const ExecutionStates: Story = {
+  render: () => <ExecutionStatesStory />,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Each Start → Step → End chain shows one execution state: the middle node carries the status (its label and its own node execution state), and both edges set `enableExecution: true`, coloring their stroke to match and animating a traveling dot while `InProgress`. Edges also set `enableEditing: true` to show the behaviors compose — hover an edge to drag segments or double-click to add waypoints. Status is mocked from element ids (`edge-<Status>-…`, `mid-<Status>`); host apps provide it via `ExecutionStatusContext`. Selection and hover intentionally override status colors (see `resolveEdgeColor` priority). The same flags work with `routing: 'handle'` — that combination is the `SequenceEdge` preset shown in HandleRouting.",
+      },
+    },
+  },
+};

--- a/packages/apollo-react/src/canvas/components/Edges/CanvasEdge.tsx
+++ b/packages/apollo-react/src/canvas/components/Edges/CanvasEdge.tsx
@@ -1,0 +1,226 @@
+import { Position } from '@uipath/apollo-react/canvas/xyflow/react';
+import { memo, useCallback, useRef, useState } from 'react';
+import { isPreviewEdge } from '../../utils/createPreviewNode';
+import { useBaseCanvasMode } from '../BaseCanvas/BaseCanvasModeProvider';
+import { EdgeToolbar, useEdgeToolbarState } from '../Toolbar';
+import { areEdgePropsEqual } from './shared/areEdgePropsEqual';
+import { EMPTY_WAYPOINTS } from './shared/constants';
+import { isSegmentInteractable, isSegmentPerpendicular } from './shared/geometry';
+import {
+  useEdgeGeometry,
+  useExecutionEdge,
+  useNodeDragRebalance,
+  useWaypointEditor,
+} from './shared/hooks';
+import {
+  EdgeArrow,
+  EdgeLabel,
+  EdgePath,
+  SegmentDragHandle,
+  WaypointHandle,
+} from './shared/primitives';
+import { resolveEdgeColor } from './shared/resolveEdgeColor';
+import type { CanvasEdgeProps } from './shared/types';
+
+/**
+ * Single edge component for Apollo Canvas. Behaviors are toggled via flags
+ * on `data`:
+ *
+ * - `routing: 'waypoint' | 'handle'` (default `'waypoint'`)
+ * - `enableEditing`   — drag/insert/remove waypoints (waypoint routing only)
+ * - `enableExecution` — subscribe to execution + validation status
+ * - `enableToolbar`   — render add-node toolbar
+ */
+export const CanvasEdge = memo(function CanvasEdge({
+  id,
+  selected,
+  animated,
+  source,
+  target,
+  sourceX,
+  sourceY,
+  sourcePosition = Position.Right,
+  targetX,
+  targetY,
+  targetPosition = Position.Left,
+  sourceHandleId,
+  targetHandleId,
+  style,
+  data,
+}: CanvasEdgeProps) {
+  const isReadOnly = useBaseCanvasMode().mode === 'readonly';
+  const [isHovered, setIsHovered] = useState(false);
+  const onMouseEnter = useCallback(() => setIsHovered(true), []);
+  const onMouseLeave = useCallback(() => setIsHovered(false), []);
+  const pathRef = useRef<SVGPathElement | null>(null);
+
+  const routing = data?.routing ?? 'waypoint';
+  const storedWaypoints = data?.waypoints ?? EMPTY_WAYPOINTS;
+  const strokeStyle = data?.strokeStyle ?? 'solid';
+  const hideArrowHead = !!data?.hideArrowHead;
+  const label = data?.label;
+
+  const editingEnabled = !!data?.enableEditing && routing === 'waypoint' && !isReadOnly;
+
+  // While a connected node is dragged, the waypoints follow it (and persist on
+  // release); otherwise these are the stored waypoints unchanged.
+  const waypoints = useNodeDragRebalance({
+    edgeId: id,
+    source,
+    target,
+    sourceX,
+    sourceY,
+    sourcePosition,
+    targetX,
+    targetY,
+    targetPosition,
+    waypoints: storedWaypoints,
+    enabled: editingEnabled,
+    onChange: data?.onWaypointsChange,
+  });
+
+  const routedWaypoints = data?.routedWaypoints ?? EMPTY_WAYPOINTS;
+  const effectiveWaypoints = waypoints.length > 0 ? waypoints : routedWaypoints;
+  const executionEnabled = !!data?.enableExecution;
+  const toolbarEnabled = !!data?.enableToolbar && !isReadOnly;
+
+  const previewEdge = isPreviewEdge({ id, source, target });
+
+  const geometry = useEdgeGeometry({
+    routing,
+    sourceNodeId: source,
+    targetNodeId: target,
+    sourceHandleId,
+    targetHandleId,
+    sourceX,
+    sourceY,
+    sourcePosition,
+    targetX,
+    targetY,
+    targetPosition,
+    waypoints: effectiveWaypoints,
+    enableSegments: editingEnabled,
+    hideArrowHead,
+  });
+
+  const editor = useWaypointEditor({
+    edgeId: id,
+    waypoints,
+    pathPoints: geometry.pathPoints,
+    enabled: editingEnabled,
+    onChange: data?.onWaypointsChange,
+  });
+
+  const execution = useExecutionEdge({
+    edgeId: id,
+    target,
+    edgePath: geometry.edgePath,
+    enabled: executionEnabled,
+  });
+
+  const isDiffRemoved = data?.isDiffRemoved ?? false;
+
+  const color = resolveEdgeColor({
+    selected,
+    isHovered,
+    isInvalid: data?.isInvalid ?? false,
+    isDiffAdded: data?.isDiffAdded ?? false,
+    isDiffRemoved,
+    previewEdge,
+    statusColor: execution.statusColor,
+  });
+
+  const toolbar = useEdgeToolbarState({
+    edgeId: id,
+    pathElementRef: pathRef,
+    isHovered: toolbarEnabled && isHovered,
+    source,
+    target,
+    sourceHandleId,
+    targetHandleId,
+    sourcePosition,
+    targetPosition,
+  });
+
+  const showEditingChrome = editingEnabled && (isHovered || selected || editor.isDragging);
+  const opacity = (style?.opacity as number | undefined) ?? 1;
+
+  return (
+    <>
+      <g
+        onMouseEnter={onMouseEnter}
+        onMouseLeave={onMouseLeave}
+        onMouseMove={toolbarEnabled ? toolbar.handleMouseMoveOnPath : undefined}
+      >
+        <EdgePath
+          id={id}
+          d={geometry.edgePath}
+          color={color}
+          selected={selected}
+          animated={animated}
+          strokeStyle={previewEdge || isDiffRemoved ? 'dashed' : strokeStyle}
+          isReadOnly={isReadOnly}
+          style={style}
+          opacity={opacity}
+          pathRef={pathRef}
+        />
+
+        {showEditingChrome &&
+          geometry.segments.map((segment, index) => {
+            if (!isSegmentInteractable(segment) || !isSegmentPerpendicular(segment)) return null;
+            return (
+              <SegmentDragHandle
+                key={segment.id}
+                segment={segment}
+                segmentIndex={index}
+                handlers={editor.segmentHandlers}
+              />
+            );
+          })}
+
+        {editingEnabled &&
+          waypoints.map((waypoint, index) => (
+            <WaypointHandle
+              key={waypoint.id}
+              waypoint={waypoint}
+              index={index}
+              forceVisible={showEditingChrome}
+              handlers={editor.waypointHandlers}
+            />
+          ))}
+
+        {!hideArrowHead && (
+          <EdgeArrow
+            target={{ x: targetX, y: targetY }}
+            angle={geometry.arrow.angle}
+            offset={geometry.arrow.offset}
+            color={color}
+            opacity={opacity}
+          />
+        )}
+
+        {execution.animation}
+
+        {typeof label === 'string' && label.length > 0 && (
+          <EdgeLabel
+            x={geometry.labelPoint.x}
+            y={geometry.labelPoint.y}
+            text={label}
+            selected={selected}
+          />
+        )}
+      </g>
+
+      {toolbarEnabled && toolbar.showToolbar && toolbar.toolbarPositioning && (
+        <EdgeToolbar
+          edgeId={id}
+          visible={toolbar.showToolbar}
+          positioning={toolbar.toolbarPositioning}
+          config={toolbar.config}
+          onMouseEnter={onMouseEnter}
+          onMouseLeave={onMouseLeave}
+        />
+      )}
+    </>
+  );
+}, areEdgePropsEqual);

--- a/packages/apollo-react/src/canvas/components/Edges/SequenceEdge.test.tsx
+++ b/packages/apollo-react/src/canvas/components/Edges/SequenceEdge.test.tsx
@@ -1,0 +1,72 @@
+import { render } from '@testing-library/react';
+import { Position } from '@uipath/apollo-react/canvas/xyflow/react';
+import { describe, expect, it, vi } from 'vitest';
+import { SequenceEdge } from './SequenceEdge';
+import type { CanvasEdgeData, CanvasEdgeProps } from './shared/types';
+
+// Capture what the preset passes down instead of rendering the full edge —
+// the wrapper's only job is flag translation.
+const { capturedProps } = vi.hoisted(() => ({
+  capturedProps: { current: undefined as CanvasEdgeProps | undefined },
+}));
+
+vi.mock('./CanvasEdge', () => ({
+  CanvasEdge: (props: CanvasEdgeProps) => {
+    capturedProps.current = props;
+    return null;
+  },
+}));
+
+const baseProps = {
+  id: 'e1',
+  source: 'a',
+  target: 'b',
+  sourcePosition: Position.Right,
+  targetPosition: Position.Left,
+  sourceX: 0,
+  sourceY: 0,
+  targetX: 100,
+  targetY: 0,
+} as unknown as CanvasEdgeProps;
+
+function renderPreset(data?: Record<string, unknown>): CanvasEdgeData {
+  capturedProps.current = undefined;
+  render(<SequenceEdge {...baseProps} data={data as CanvasEdgeData} />);
+  expect(capturedProps.current).toBeDefined();
+  return capturedProps.current?.data as CanvasEdgeData;
+}
+
+describe('SequenceEdge preset translation', () => {
+  it('defaults to handle routing with execution and toolbar enabled', () => {
+    const data = renderPreset();
+    expect(data.routing).toBe('handle');
+    expect(data.enableExecution).toBe(true);
+    expect(data.enableToolbar).toBe(true);
+  });
+
+  it('translates the legacy hideToolbar flag to enableToolbar: false and strips it', () => {
+    const data = renderPreset({ hideToolbar: true });
+    expect(data.enableToolbar).toBe(false);
+    expect('hideToolbar' in data).toBe(false);
+  });
+
+  it('keeps the toolbar enabled when hideToolbar is absent or false', () => {
+    expect(renderPreset({ hideToolbar: false }).enableToolbar).toBe(true);
+    expect(renderPreset({}).enableToolbar).toBe(true);
+  });
+
+  it('lets consumer data override the preset defaults', () => {
+    const data = renderPreset({ enableExecution: false, label: 'Run' });
+    expect(data.enableExecution).toBe(false);
+    expect(data.label).toBe('Run');
+    expect(data.routing).toBe('handle');
+  });
+
+  it('passes the remaining edge props through untouched', () => {
+    const data = renderPreset({ isDiffRemoved: true, hideArrowHead: true });
+    expect(data.isDiffRemoved).toBe(true);
+    expect(data.hideArrowHead).toBe(true);
+    expect(capturedProps.current?.id).toBe('e1');
+    expect(capturedProps.current?.source).toBe('a');
+  });
+});

--- a/packages/apollo-react/src/canvas/components/Edges/SequenceEdge.tsx
+++ b/packages/apollo-react/src/canvas/components/Edges/SequenceEdge.tsx
@@ -1,264 +1,30 @@
-import { type EdgeProps, Position } from '@uipath/apollo-react/canvas/xyflow/react';
-import { memo, useRef, useState } from 'react';
-import { useEdgeExecutionState, useEdgePath, useElementValidationStatus } from '../../hooks';
-import type { NodeExecutionStateWithDebug } from '../../types/execution';
-import { isPreviewEdge } from '../../utils/createPreviewNode';
-import { useBaseCanvasMode } from '../BaseCanvas/BaseCanvasModeProvider';
-import { EdgeToolbar, useEdgeToolbarState } from '../Toolbar';
-import { edgeTargetStatusToEdgeColor, getStatusAnimation } from './EdgeUtils';
+import { memo, useMemo } from 'react';
+import { CanvasEdge } from './CanvasEdge';
+import { areEdgePropsEqual } from './shared/areEdgePropsEqual';
+import type { CanvasEdgeData, CanvasEdgeProps } from './shared/types';
 
-const ARROW_SIZE = 10;
-
-// Arrow angle based on which side of the TARGET node the edge connects to
-// The arrow should point INTO the target node
-// Angle 0 = pointing right, PI/2 = pointing down, PI = pointing left, -PI/2 = pointing up
-const ANGLE_MAP: Record<Position, number> = {
-  [Position.Left]: 0, // Edge enters left side, arrow points right
-  [Position.Right]: Math.PI, // Edge enters right side, arrow points left
-  [Position.Top]: Math.PI / 2, // Edge enters top, arrow points down
-  [Position.Bottom]: -Math.PI / 2, // Edge enters bottom, arrow points up
+/** Legacy SequenceEdge data contract, translated to `CanvasEdgeData` below. */
+type LegacySequenceEdgeData = CanvasEdgeData & {
+  /** @deprecated Use `enableToolbar: false` instead. */
+  hideToolbar?: boolean;
 };
 
-// Offset to position start/arrow slightly away from the node edge
-const ARROW_OFFSETS: Record<Position, { x: number; y: number }> = {
-  [Position.Left]: { x: 8, y: 0 },
-  [Position.Right]: { x: -8, y: 0 },
-  [Position.Top]: { x: 0, y: 8 },
-  [Position.Bottom]: { x: 0, y: -8 },
-};
+/**
+ * Workflow edge preset — `CanvasEdge` with `routing: 'handle'`, execution and
+ * toolbar enabled by default. Consumer-supplied `data` overrides any default.
+ * Prefer `CanvasEdge` directly for new code; kept for backward compatibility
+ * with existing `type: 'sequence'` registrations.
+ */
+export const SequenceEdge = memo(function SequenceEdge(props: CanvasEdgeProps) {
+  const data = useMemo<CanvasEdgeData>(() => {
+    const { hideToolbar, ...rest } = (props.data ?? {}) as LegacySequenceEdgeData;
+    return {
+      routing: 'handle',
+      enableExecution: true,
+      enableToolbar: hideToolbar !== true,
+      ...rest,
+    };
+  }, [props.data]);
 
-// Custom comparison to prevent re-renders during pan/zoom
-// Coordinates can have tiny floating point differences that don't affect visual output
-function areEdgePropsEqual(prevProps: EdgeProps, nextProps: EdgeProps): boolean {
-  // Always re-render if these change
-  if (prevProps.id !== nextProps.id) return false;
-  if (prevProps.selected !== nextProps.selected) return false;
-  if (prevProps.animated !== nextProps.animated) return false;
-  if (prevProps.source !== nextProps.source) return false;
-  if (prevProps.target !== nextProps.target) return false;
-  if (prevProps.sourcePosition !== nextProps.sourcePosition) return false;
-  if (prevProps.targetPosition !== nextProps.targetPosition) return false;
-  if (prevProps.data !== nextProps.data) return false;
-  if (prevProps.style !== nextProps.style) return false;
-
-  // For coordinates, only re-render if change is > 0.5px (avoids floating point noise)
-  const threshold = 0.5;
-  if (Math.abs(prevProps.sourceX - nextProps.sourceX) > threshold) return false;
-  if (Math.abs(prevProps.sourceY - nextProps.sourceY) > threshold) return false;
-  if (Math.abs(prevProps.targetX - nextProps.targetX) > threshold) return false;
-  if (Math.abs(prevProps.targetY - nextProps.targetY) > threshold) return false;
-
-  return true;
-}
-
-export const SequenceEdge = memo(function SequenceEdge({
-  id,
-  selected,
-  animated,
-  source,
-  sourceX,
-  sourceY,
-  sourcePosition,
-  sourceHandleId,
-  target,
-  targetX,
-  targetY,
-  targetPosition,
-  targetHandleId,
-  style,
-  data,
-}: EdgeProps) {
-  const [isHovered, setIsHovered] = useState(false);
-  const pathElementRef = useRef<SVGPathElement | null>(null);
-
-  const { mode } = useBaseCanvasMode();
-  const isReadOnly = mode === 'readonly';
-  const previewEdge = isPreviewEdge({ id, source, target });
-
-  const executionStatus = useEdgeExecutionState(id, target);
-  const { validationStatus } = useElementValidationStatus(id) ?? { validationStatus: undefined };
-
-  // Use provided status or fall back to hook values
-  const status = executionStatus
-    ? ((executionStatus as NodeExecutionStateWithDebug)?.status ?? executionStatus)
-    : validationStatus;
-
-  // Check if this edge has diff styling applied
-  const isDiffAdded = data?.isDiffAdded === true;
-  const isDiffRemoved = data?.isDiffRemoved === true;
-
-  const hideArrowHead = data?.hideArrowHead === true;
-  const hideToolbar = data?.hideToolbar === true;
-
-  const angle = ANGLE_MAP[targetPosition];
-  const { x: offsetX, y: offsetY } = ARROW_OFFSETS[targetPosition];
-
-  // When the arrow head is hidden, inset the target point so the line stops at
-  // the same visual distance from the target node as the source side — the
-  // arrow polygon normally fills this gap.
-  const { edgePath, labelX, labelY } = useEdgePath({
-    sourceNodeId: source,
-    targetNodeId: target,
-    sourceHandleId,
-    targetHandleId,
-    sourceX,
-    sourceY,
-    sourcePosition,
-    targetX: hideArrowHead ? targetX + offsetX : targetX,
-    targetY: hideArrowHead ? targetY + offsetY : targetY,
-    targetPosition,
-  });
-
-  // Edge toolbar state
-  const {
-    showToolbar,
-    toolbarPositioning,
-    config: toolbarConfig,
-    handleMouseMoveOnPath,
-  } = useEdgeToolbarState({
-    edgeId: id,
-    pathElementRef,
-    isHovered,
-    sourceHandleId,
-    targetHandleId,
-    sourcePosition,
-    targetPosition,
-    source,
-    target,
-  });
-
-  const getEdgeColor = () => {
-    // Diff styling takes priority
-    if (isDiffAdded) return 'var(--canvas-success-icon)';
-    if (isDiffRemoved) return 'var(--canvas-error-icon)';
-
-    if (previewEdge) return 'var(--canvas-primary)';
-    if (selected) return 'var(--canvas-primary)';
-    if (isHovered) return 'var(--canvas-primary-hover)';
-    if (status) return edgeTargetStatusToEdgeColor[status] ?? 'var(--canvas-border)';
-    return 'var(--canvas-border)';
-  };
-
-  const edgeColor = getEdgeColor();
-
-  return (
-    <>
-      <g
-        onMouseEnter={() => setIsHovered(true)}
-        onMouseLeave={() => setIsHovered(false)}
-        onMouseMove={handleMouseMoveOnPath}
-      >
-        {/* Invisible interaction layer for easier selection */}
-        <path
-          className="react-flow__edge-interaction"
-          d={edgePath}
-          fill="none"
-          stroke="transparent"
-          strokeWidth={20}
-          style={{ pointerEvents: 'stroke', cursor: isReadOnly ? 'default' : 'pointer' }}
-        />
-
-        {/* Outline for selected state */}
-        {selected && (
-          <path
-            className="react-flow__edge-outline"
-            d={edgePath}
-            fill="none"
-            stroke="var(--canvas-primary)"
-            strokeWidth={10}
-            opacity={0.3}
-            style={{
-              pointerEvents: 'none',
-              transition: 'opacity 0.2s ease',
-            }}
-          />
-        )}
-
-        {/* Visual edge path */}
-        <path
-          id={id}
-          className="react-flow__edge-path"
-          d={edgePath}
-          strokeWidth={style?.strokeWidth || 2}
-          style={{
-            stroke: edgeColor,
-            strokeDasharray: animated
-              ? undefined
-              : isDiffRemoved
-                ? style?.strokeDasharray || '5,5'
-                : previewEdge
-                  ? '5,5'
-                  : '0',
-            opacity: style?.opacity !== undefined ? style.opacity : 1,
-            transition: 'stroke 0.2s ease, opacity 0.2s ease',
-          }}
-          ref={pathElementRef}
-        />
-
-        {/* Arrow head - filled triangle */}
-        {!hideArrowHead && (
-          <polygon
-            points={`
-              ${targetX},${targetY}
-              ${targetX - ARROW_SIZE * Math.cos(angle - Math.PI / 6)},${targetY - ARROW_SIZE * Math.sin(angle - Math.PI / 6)}
-              ${targetX - ARROW_SIZE * Math.cos(angle + Math.PI / 6)},${targetY - ARROW_SIZE * Math.sin(angle + Math.PI / 6)}
-            `}
-            fill={edgeColor}
-            style={{
-              pointerEvents: 'none',
-              opacity: style?.opacity !== undefined ? style.opacity : 1,
-              transition: 'fill 0.2s ease, opacity 0.2s ease',
-              transform: `translate(${offsetX}px, ${offsetY}px)`,
-            }}
-          />
-        )}
-
-        {getStatusAnimation(status, edgePath)}
-
-        {/* Edge label from data */}
-        {typeof data?.label === 'string' && data.label.length > 0 && (
-          <foreignObject
-            x={labelX}
-            y={labelY}
-            width={1}
-            height={1}
-            overflow="visible"
-            style={{ pointerEvents: 'none' }}
-          >
-            <div
-              className="react-flow__edge-label nodrag nopan"
-              style={{
-                position: 'absolute',
-                transform: 'translate(-50%, -50%)',
-                whiteSpace: 'nowrap',
-                pointerEvents: 'none',
-                color: 'var(--canvas-foreground)',
-                background: 'var(--canvas-background)',
-                padding: '4px 8px',
-                borderRadius: '4px',
-                fontSize: '12px',
-                fontWeight: 500,
-                border: `1px solid ${selected ? 'var(--canvas-primary)' : 'var(--canvas-border)'}`,
-                boxShadow: '0 1px 3px 0 rgba(0, 0, 0, 0.1)',
-              }}
-            >
-              {data.label}
-            </div>
-          </foreignObject>
-        )}
-      </g>
-
-      {/* Edge toolbar for adding nodes */}
-      {!hideToolbar && showToolbar && toolbarPositioning && (
-        <EdgeToolbar
-          edgeId={id}
-          visible={showToolbar}
-          positioning={toolbarPositioning}
-          config={toolbarConfig}
-          onMouseEnter={() => setIsHovered(true)}
-          onMouseLeave={() => setIsHovered(false)}
-        />
-      )}
-    </>
-  );
+  return <CanvasEdge {...props} data={data} />;
 }, areEdgePropsEqual);

--- a/packages/apollo-react/src/canvas/components/Edges/index.ts
+++ b/packages/apollo-react/src/canvas/components/Edges/index.ts
@@ -1,1 +1,25 @@
+export { CanvasEdge } from './CanvasEdge';
 export * from './SequenceEdge';
+export type {
+  EdgeRouter,
+  RouteAnchor,
+  RoutedEdge,
+  RouteEdgeRequest,
+  RouteNodeRequest,
+  RouteRequest,
+} from './shared/routing';
+export {
+  defaultEdgeRouter,
+  defaultIsRoutable,
+  useGraphRouter,
+} from './shared/routing';
+export type {
+  CanvasEdgeData,
+  CanvasEdgeProps,
+  EdgeRouting,
+  EdgeStrokeStyle,
+  Point,
+  Segment,
+  SegmentOrientation,
+  Waypoint,
+} from './shared/types';

--- a/packages/apollo-react/src/canvas/components/Edges/shared/areEdgePropsEqual.test.ts
+++ b/packages/apollo-react/src/canvas/components/Edges/shared/areEdgePropsEqual.test.ts
@@ -1,0 +1,60 @@
+import type { EdgeProps } from '@uipath/apollo-react/canvas/xyflow/react';
+import { Position } from '@uipath/apollo-react/canvas/xyflow/react';
+import { describe, expect, it } from 'vitest';
+import { areEdgePropsEqual } from './areEdgePropsEqual';
+
+const baseProps = {
+  id: 'e1',
+  selected: false,
+  animated: false,
+  source: 'a',
+  target: 'b',
+  sourceHandleId: 'out',
+  targetHandleId: 'in',
+  sourcePosition: Position.Right,
+  targetPosition: Position.Left,
+  sourceX: 100,
+  sourceY: 100,
+  targetX: 400,
+  targetY: 100,
+  data: { enableExecution: true },
+  style: { strokeWidth: 2 },
+} as unknown as EdgeProps;
+
+function withChanges(changes: Partial<Record<keyof EdgeProps, unknown>>): EdgeProps {
+  return { ...baseProps, ...changes } as EdgeProps;
+}
+
+describe('areEdgePropsEqual', () => {
+  it('treats identical props as equal', () => {
+    expect(areEdgePropsEqual(baseProps, withChanges({}))).toBe(true);
+  });
+
+  it('suppresses sub-pixel coordinate jitter (≤ 0.5px)', () => {
+    expect(
+      areEdgePropsEqual(
+        baseProps,
+        withChanges({ sourceX: 100.4, sourceY: 99.6, targetX: 400.3, targetY: 100.2 })
+      )
+    ).toBe(true);
+  });
+
+  it('re-renders when a coordinate moves more than the threshold', () => {
+    expect(areEdgePropsEqual(baseProps, withChanges({ targetX: 401 }))).toBe(false);
+  });
+
+  it.each([
+    ['selected', true],
+    ['animated', true],
+    ['source', 'other'],
+    ['target', 'other'],
+    ['sourceHandleId', 'other'],
+    ['targetHandleId', 'other'],
+    ['sourcePosition', Position.Bottom],
+    ['targetPosition', Position.Top],
+    ['data', { enableExecution: true }], // new identity, same shape
+    ['style', { strokeWidth: 2 }], // new identity, same shape
+  ] as const)('re-renders when %s changes', (key, value) => {
+    expect(areEdgePropsEqual(baseProps, withChanges({ [key]: value }))).toBe(false);
+  });
+});

--- a/packages/apollo-react/src/canvas/components/Edges/shared/areEdgePropsEqual.ts
+++ b/packages/apollo-react/src/canvas/components/Edges/shared/areEdgePropsEqual.ts
@@ -1,0 +1,24 @@
+import type { EdgeProps } from '@uipath/apollo-react/canvas/xyflow/react';
+
+/** Suppresses re-renders from sub-pixel coordinate jitter during pan/zoom. */
+export function areEdgePropsEqual(prev: EdgeProps, next: EdgeProps): boolean {
+  if (prev.id !== next.id) return false;
+  if (prev.selected !== next.selected) return false;
+  if (prev.animated !== next.animated) return false;
+  if (prev.source !== next.source) return false;
+  if (prev.target !== next.target) return false;
+  if (prev.sourceHandleId !== next.sourceHandleId) return false;
+  if (prev.targetHandleId !== next.targetHandleId) return false;
+  if (prev.sourcePosition !== next.sourcePosition) return false;
+  if (prev.targetPosition !== next.targetPosition) return false;
+  if (prev.data !== next.data) return false;
+  if (prev.style !== next.style) return false;
+
+  const threshold = 0.5;
+  if (Math.abs(prev.sourceX - next.sourceX) > threshold) return false;
+  if (Math.abs(prev.sourceY - next.sourceY) > threshold) return false;
+  if (Math.abs(prev.targetX - next.targetX) > threshold) return false;
+  if (Math.abs(prev.targetY - next.targetY) > threshold) return false;
+
+  return true;
+}

--- a/packages/apollo-react/src/canvas/components/Edges/shared/constants.ts
+++ b/packages/apollo-react/src/canvas/components/Edges/shared/constants.ts
@@ -1,0 +1,90 @@
+import { Position } from '@uipath/apollo-react/canvas/xyflow/react';
+import { GRID_SPACING } from '../../../constants';
+import type { Point, Waypoint } from './types';
+
+/** Stable empty array for `?? EMPTY_WAYPOINTS` fallbacks — an inline `[]`
+ * would change identity every render and defeat geometry memoization. */
+export const EMPTY_WAYPOINTS: Waypoint[] = [];
+
+export const EDGE_CONSTANTS = {
+  /** Border radius for smooth corners on rounded paths */
+  BORDER_RADIUS: GRID_SPACING,
+  /** Arrow head size for directional edges */
+  ARROW_SIZE: 10,
+  /** Half-angle (radians) of each arrow head wing relative to the tangent. */
+  ARROW_HALF_ANGLE: Math.PI / 6,
+  /** Default stroke width */
+  STROKE_WIDTH: 2,
+  /** Stroke width when selected */
+  SELECTED_STROKE_WIDTH: 3,
+  /** Width of the invisible interaction layer used for hit testing */
+  INTERACTION_STROKE_WIDTH: 20,
+  /** Stroke width of the soft outline drawn behind the visible path when selected. */
+  SELECTED_OUTLINE_STROKE_WIDTH: 10,
+  /** Opacity of the soft outline drawn behind the visible path when selected. */
+  SELECTED_OUTLINE_OPACITY: 0.3,
+  /** Minimum segment length required to allow segment drag */
+  MIN_SEGMENT_LENGTH: 32,
+  /**
+   * Tolerance (px) under which coordinates are treated as equal by the
+   * dedupe/collinearity checks in geometry.ts. Load-bearing for the
+   * consolidation fixed-point loop.
+   */
+  COLLINEAR_TOLERANCE: 1,
+  /** Distance the arrow sits inset from the target node edge */
+  ARROW_OFFSET: 8,
+  /**
+   * Minimum distance the path travels perpendicular to a node face before it
+   * is allowed to turn. Keeps the connector from folding back across the node
+   * when the adjacent waypoint sits behind the exit direction.
+   */
+  STUB_OFFSET: GRID_SPACING * 2,
+} as const;
+
+/** CSS transition shared by the visible edge path and the arrow head. */
+export const EDGE_PATH_TRANSITION = 'stroke 0.2s ease, opacity 0.2s ease';
+
+/** SVG `stroke-dasharray` values used by the visible path layer. */
+export const EDGE_DASHARRAY = {
+  solid: '0',
+  dashed: '5,5',
+} as const;
+
+/**
+ * Color tokens used by canvas edges. Values reference CSS variables defined
+ * in canvas/styles/variables.css.
+ */
+export const EDGE_COLORS = {
+  default: 'var(--canvas-border)',
+  hover: 'var(--canvas-primary-hover)',
+  selected: 'var(--canvas-primary)',
+  invalid: 'var(--canvas-error-icon)',
+  diffAdded: 'var(--canvas-success-icon)',
+  diffRemoved: 'var(--canvas-error-icon)',
+} as const;
+
+/**
+ * Arrow angle based on which side of the TARGET node the edge connects to.
+ * The arrow points INTO the target node.
+ * Angle 0 = right, PI/2 = down, PI = left, -PI/2 = up.
+ */
+export const ARROW_ANGLE_MAP: Record<Position, number> = {
+  [Position.Left]: 0,
+  [Position.Right]: Math.PI,
+  [Position.Top]: Math.PI / 2,
+  [Position.Bottom]: -Math.PI / 2,
+};
+
+/**
+ * Inset offset applied to either endpoint of the path. Used for the source
+ * (path origin) and the target (arrow tip) so both ends sit inside the node
+ * fill — the visible line then meets the node edge cleanly with no gap.
+ * Also consumed by `useEdgePath`, so waypoint- and handle-routed edges share
+ * one inset definition.
+ */
+export const ARROW_OFFSETS: Record<Position, Point> = {
+  [Position.Left]: { x: EDGE_CONSTANTS.ARROW_OFFSET, y: 0 },
+  [Position.Right]: { x: -EDGE_CONSTANTS.ARROW_OFFSET, y: 0 },
+  [Position.Top]: { x: 0, y: EDGE_CONSTANTS.ARROW_OFFSET },
+  [Position.Bottom]: { x: 0, y: -EDGE_CONSTANTS.ARROW_OFFSET },
+};

--- a/packages/apollo-react/src/canvas/components/Edges/shared/geometry.test.ts
+++ b/packages/apollo-react/src/canvas/components/Edges/shared/geometry.test.ts
@@ -1,0 +1,266 @@
+import { Position } from '@uipath/apollo-react/canvas/xyflow/react';
+import { describe, expect, it } from 'vitest';
+import { ARROW_OFFSETS, EDGE_CONSTANTS } from './constants';
+import {
+  buildPathVertices,
+  consolidateWaypoints,
+  createRoundedPath,
+  extractSegments,
+  getPathArcMidpoint,
+  getSegmentOrientation,
+  isSegmentPerpendicular,
+  routeAnchorToPoint,
+  snapPointToGrid,
+} from './geometry';
+import type { PathVertex, Point, Waypoint } from './types';
+
+const wp = (id: string, x: number, y: number): Waypoint => ({ id, x, y });
+const vertex = (x: number, y: number, waypointIndex = -1): PathVertex => ({ x, y, waypointIndex });
+
+/** Every consecutive pair of points is axis-aligned (horizontal or vertical). */
+function isOrthogonal(points: Point[]): boolean {
+  for (let i = 0; i < points.length - 1; i++) {
+    const a = points[i]!;
+    const b = points[i + 1]!;
+    if (Math.abs(a.x - b.x) >= 1 && Math.abs(a.y - b.y) >= 1) return false;
+  }
+  return true;
+}
+
+describe('routeAnchorToPoint', () => {
+  it('returns no elbow when the point is already aligned with the exit axis', () => {
+    // Right face, point straight ahead on the same row.
+    expect(routeAnchorToPoint({ x: 0, y: 0 }, Position.Right, { x: 100, y: 0 })).toEqual([]);
+  });
+
+  it('returns a single elbow when the point is ahead of the face but off-axis', () => {
+    // Right face: travel along x to the point, then turn — elbow shares anchor y.
+    expect(routeAnchorToPoint({ x: 0, y: 0 }, Position.Right, { x: 100, y: 50 })).toEqual([
+      { x: 100, y: 0 },
+    ]);
+  });
+
+  it('hooks around with two elbows when the point is behind the face', () => {
+    // Right face, point to the left (behind): leave by STUB_OFFSET, then cross over.
+    const stub = EDGE_CONSTANTS.STUB_OFFSET;
+    expect(routeAnchorToPoint({ x: 0, y: 0 }, Position.Right, { x: -100, y: 50 })).toEqual([
+      { x: stub, y: 0 },
+      { x: stub, y: 50 },
+    ]);
+  });
+
+  it('handles a vertical (bottom) face the same way on the other axis', () => {
+    // Bottom face, point ahead (below) and off-axis → single elbow sharing anchor x.
+    expect(routeAnchorToPoint({ x: 0, y: 0 }, Position.Bottom, { x: 50, y: 100 })).toEqual([
+      { x: 0, y: 100 },
+    ]);
+  });
+
+  it('hooks for a vertical face when the point is behind', () => {
+    const stub = EDGE_CONSTANTS.STUB_OFFSET;
+    // Bottom face (exits downward), point above (behind).
+    expect(routeAnchorToPoint({ x: 0, y: 0 }, Position.Bottom, { x: 50, y: -100 })).toEqual([
+      { x: 0, y: stub },
+      { x: 50, y: stub },
+    ]);
+  });
+});
+
+describe('consolidateWaypoints', () => {
+  it('removes a midpoint collinear with its neighbours, keeping the corners', () => {
+    // {50,0} lies on the straight run between {0,0} and {100,0}. Endpoints are
+    // offset perpendicularly so the leading/trailing trims do not fire.
+    const result = consolidateWaypoints(
+      [
+        { x: 0, y: 0 },
+        { x: 50, y: 0 },
+        { x: 100, y: 0 },
+      ],
+      { x: 0, y: -50 },
+      { x: 100, y: -50 }
+    );
+    expect(result).toEqual([
+      { x: 0, y: 0 },
+      { x: 100, y: 0 },
+    ]);
+  });
+
+  it('collapses a fully-straight run to nothing', () => {
+    const result = consolidateWaypoints(
+      [
+        { x: 0, y: 0 },
+        { x: 50, y: 0 },
+        { x: 100, y: 0 },
+      ],
+      { x: -50, y: 0 },
+      { x: 150, y: 0 }
+    );
+    expect(result).toEqual([]);
+  });
+
+  it('dedupes coincident points', () => {
+    const result = consolidateWaypoints(
+      [
+        { x: 50, y: 50 },
+        { x: 50, y: 50 },
+      ],
+      { x: 0, y: 50 },
+      { x: 50, y: 100 }
+    );
+    expect(result).toHaveLength(1);
+  });
+
+  it('never drops a protected point, even when collinear', () => {
+    const protectedPoint = { x: 50, y: 0 };
+    const result = consolidateWaypoints(
+      [{ x: 0, y: 0 }, protectedPoint, { x: 100, y: 0 }],
+      { x: -50, y: 0 },
+      { x: 150, y: 0 },
+      (p) => p === protectedPoint
+    );
+    expect(result).toEqual([protectedPoint]);
+  });
+
+  it('preserves object identity of surviving points', () => {
+    const keep = { x: 50, y: 50 };
+    const result = consolidateWaypoints([keep], { x: 0, y: 0 }, { x: 100, y: 100 });
+    expect(result[0]).toBe(keep);
+  });
+});
+
+describe('buildPathVertices', () => {
+  it('auto-routes with no manual waypoints and tags every vertex as derived', () => {
+    const result = buildPathVertices(0, 0, Position.Right, 200, 0, Position.Left, []);
+    expect(result.length).toBeGreaterThanOrEqual(2);
+    expect(result.every((v) => v.waypointIndex === -1)).toBe(true);
+    expect(isOrthogonal(result)).toBe(true);
+  });
+
+  it('always draws through a single off-line waypoint (regression)', () => {
+    const result = buildPathVertices(0, 0, Position.Right, 200, 0, Position.Left, [
+      wp('a', 100, 50),
+    ]);
+    const drawn = result.find((v) => v.waypointIndex === 0);
+    expect(drawn).toBeDefined();
+    expect(drawn).toMatchObject({ x: 100, y: 50 });
+  });
+
+  it('keeps the source and target anchors as the path endpoints (regression)', () => {
+    // Two vertically-aligned waypoints between A (top-left) and B (bottom-right).
+    // The path must remain anchored to both nodes — consolidation must not trim
+    // the anchors.
+    const result = buildPathVertices(0, 0, Position.Right, 200, 200, Position.Left, [
+      wp('wp-1', 100, 50),
+      wp('wp-2', 100, 150),
+    ]);
+
+    const src = ARROW_OFFSETS[Position.Right];
+    const tgt = ARROW_OFFSETS[Position.Left];
+    expect(result[0]).toMatchObject({ x: src.x, y: src.y, waypointIndex: -1 });
+    expect(result.at(-1)).toMatchObject({ x: 200 + tgt.x, y: 200 + tgt.y, waypointIndex: -1 });
+
+    // Both waypoints are drawn through, and the whole path stays orthogonal.
+    expect(
+      result
+        .map((v) => v.waypointIndex)
+        .filter((i) => i >= 0)
+        .sort()
+    ).toEqual([0, 1]);
+    expect(isOrthogonal(result)).toBe(true);
+  });
+
+  it('keeps the whole path orthogonal between two non-aligned waypoints (no diagonals)', () => {
+    const result = buildPathVertices(0, 0, Position.Right, 300, 0, Position.Left, [
+      wp('a', 80, 40),
+      wp('b', 200, 120),
+    ]);
+    expect(isOrthogonal(result)).toBe(true);
+  });
+
+  it('tags each user waypoint with its stored index exactly once', () => {
+    const result = buildPathVertices(0, 0, Position.Right, 300, 100, Position.Left, [
+      wp('a', 80, 40),
+      wp('b', 200, 120),
+    ]);
+    const indices = result.map((v) => v.waypointIndex).filter((i) => i >= 0);
+    expect(indices.sort()).toEqual([0, 1]);
+  });
+});
+
+describe('extractSegments', () => {
+  it('maps segment indices against the interior vertices even when stubs are present', () => {
+    // start, stub, waypoint(0), stub, end — one user waypoint flanked by stubs.
+    const vertices: PathVertex[] = [
+      vertex(0, 0), // start anchor
+      vertex(50, 0), // derived stub
+      vertex(50, 50, 0), // user waypoint 0
+      vertex(50, 100), // derived stub
+      vertex(0, 100), // end anchor
+    ];
+    const segments = extractSegments(vertices);
+    expect(segments).toHaveLength(4);
+    // First segment starts at the source anchor.
+    expect(segments[0]!.waypointIndexBefore).toBe(-1);
+    // Last segment ends at the target anchor — index === interior count (3).
+    expect(segments.at(-1)!.waypointIndexAfter).toBe(3);
+    // Indices are contiguous against the interior list, not the stored waypoints.
+    expect(segments.map((s) => s.waypointIndexBefore)).toEqual([-1, 0, 1, 2]);
+  });
+});
+
+describe('segment helpers', () => {
+  it('classifies orientation by dominant axis', () => {
+    expect(getSegmentOrientation({ x: 0, y: 0 }, { x: 100, y: 10 })).toBe('horizontal');
+    expect(getSegmentOrientation({ x: 0, y: 0 }, { x: 10, y: 100 })).toBe('vertical');
+  });
+
+  it('treats only axis-aligned segments as perpendicular', () => {
+    expect(isSegmentPerpendicular({ start: { x: 0, y: 0 }, end: { x: 100, y: 0 } })).toBe(true);
+    expect(isSegmentPerpendicular({ start: { x: 0, y: 0 }, end: { x: 100, y: 100 } })).toBe(false);
+  });
+});
+
+describe('getPathArcMidpoint', () => {
+  it('returns the point at half the total arc length', () => {
+    // L-shape: 100 across then 100 down → midpoint is the corner.
+    const mid = getPathArcMidpoint([
+      { x: 0, y: 0 },
+      { x: 100, y: 0 },
+      { x: 100, y: 100 },
+    ]);
+    expect(mid).toEqual({ x: 100, y: 0 });
+  });
+
+  it('is safe for degenerate input', () => {
+    expect(getPathArcMidpoint([])).toEqual({ x: 0, y: 0 });
+    expect(getPathArcMidpoint([{ x: 5, y: 7 }])).toEqual({ x: 5, y: 7 });
+  });
+});
+
+describe('createRoundedPath', () => {
+  it('emits a straight line for two points', () => {
+    expect(
+      createRoundedPath([
+        { x: 0, y: 0 },
+        { x: 100, y: 0 },
+      ])
+    ).toBe('M 0 0 L 100 0');
+  });
+
+  it('rounds interior corners with a quadratic curve', () => {
+    const d = createRoundedPath([
+      { x: 0, y: 0 },
+      { x: 100, y: 0 },
+      { x: 100, y: 100 },
+    ]);
+    expect(d.startsWith('M 0 0')).toBe(true);
+    expect(d).toContain('Q');
+  });
+});
+
+describe('snapPointToGrid', () => {
+  it('snaps both axes to the grid', () => {
+    // GRID_SPACING = 16 → nearest multiple of 16.
+    expect(snapPointToGrid({ x: 17, y: 7 })).toEqual({ x: 16, y: 0 });
+  });
+});

--- a/packages/apollo-react/src/canvas/components/Edges/shared/geometry.ts
+++ b/packages/apollo-react/src/canvas/components/Edges/shared/geometry.ts
@@ -1,0 +1,488 @@
+import type { Position } from '@uipath/apollo-react/canvas/xyflow/react';
+import { snapToGrid } from '../../../utils/NodeUtils';
+import { ARROW_OFFSETS, EDGE_CONSTANTS } from './constants';
+import type { PathVertex, Point, Segment, SegmentOrientation, Waypoint } from './types';
+
+const { BORDER_RADIUS, MIN_SEGMENT_LENGTH, COLLINEAR_TOLERANCE: TOL } = EDGE_CONSTANTS;
+
+export function snapPointToGrid(point: Point): Point {
+  return { x: snapToGrid(point.x), y: snapToGrid(point.y) };
+}
+
+function getDirection(position: Position): { dx: number; dy: number } {
+  switch (position) {
+    case 'left':
+      return { dx: -1, dy: 0 };
+    case 'right':
+      return { dx: 1, dy: 0 };
+    case 'top':
+      return { dx: 0, dy: -1 };
+    case 'bottom':
+      return { dx: 0, dy: 1 };
+    default:
+      return { dx: 1, dy: 0 };
+  }
+}
+
+/** True when a node face exits horizontally (left/right), i.e. the connecting
+ * segment runs along x. */
+export function isHorizontalPosition(position: Position): boolean {
+  return getDirection(position).dx !== 0;
+}
+
+/**
+ * Auto-route a path between source and target with orthogonal segments
+ * when no manual waypoints are provided.
+ */
+export function calculateAutoWaypoints(
+  sourceX: number,
+  sourceY: number,
+  sourcePosition: Position,
+  targetX: number,
+  targetY: number,
+  targetPosition: Position
+): Point[] {
+  const sourceOffset = ARROW_OFFSETS[sourcePosition];
+  const targetOffset = ARROW_OFFSETS[targetPosition];
+
+  const startX = sourceX + sourceOffset.x;
+  const startY = sourceY + sourceOffset.y;
+  const endX = targetX + targetOffset.x;
+  const endY = targetY + targetOffset.y;
+
+  const isSourceHorizontal = isHorizontalPosition(sourcePosition);
+  const isTargetHorizontal = isHorizontalPosition(targetPosition);
+
+  const waypoints: Point[] = [];
+
+  if (isSourceHorizontal && isTargetHorizontal) {
+    const midX = snapToGrid((startX + endX) / 2);
+    if (Math.abs(startY - endY) > MIN_SEGMENT_LENGTH / 2) {
+      waypoints.push({ x: midX, y: startY });
+      waypoints.push({ x: midX, y: endY });
+    }
+  } else if (!isSourceHorizontal && !isTargetHorizontal) {
+    const midY = snapToGrid((startY + endY) / 2);
+    if (Math.abs(startX - endX) > MIN_SEGMENT_LENGTH / 2) {
+      waypoints.push({ x: startX, y: midY });
+      waypoints.push({ x: endX, y: midY });
+    }
+  } else if (isSourceHorizontal && !isTargetHorizontal) {
+    waypoints.push({ x: endX, y: startY });
+  } else {
+    waypoints.push({ x: startX, y: endY });
+  }
+
+  return waypoints;
+}
+
+/**
+ * Orthogonal connector joining a node anchor to its adjacent waypoint. Keeps
+ * every segment axis-aligned so the stub never collapses into a diagonal line
+ * once a node is dragged away from its (fixed) waypoints.
+ *
+ * The path must leave (or enter) a node perpendicular to the face it attaches
+ * to. Two shapes, picked by where the point sits relative to the exit face:
+ *
+ * - **Point ahead** of the face → a single elbow gives a clean L (travel along
+ *   the face axis to the point's coordinate, then turn).
+ * - **Point behind** the face → a single elbow would fold the path straight
+ *   back across the node. Instead, leave the face by a fixed {@link
+ *   EDGE_CONSTANTS.STUB_OFFSET}, cross over to the point's far axis, then
+ *   approach — a hook that clears the node.
+ *
+ * Returns `[]` when the anchor and point are already aligned (no elbow needed).
+ * Degenerate elbows (coincident with the anchor, the point, or each other) are
+ * dropped so no zero-length segments reach {@link createRoundedPath}.
+ *
+ * Remaining limitation: a point directly behind the face at the same cross-axis
+ * (a true head-on reversal) still routes back over the node — clearing the
+ * node's full bounding box needs node dimensions (a real router).
+ */
+export function routeAnchorToPoint(anchor: Point, anchorPosition: Position, point: Point): Point[] {
+  const dir = getDirection(anchorPosition);
+  const isHorizontal = dir.dx !== 0;
+
+  // Signed distance from anchor to point along the exit direction. Negative
+  // means the point sits behind the node face.
+  const forward = isHorizontal ? (point.x - anchor.x) * dir.dx : (point.y - anchor.y) * dir.dy;
+
+  let elbows: Point[];
+  if (forward >= 0) {
+    elbows = isHorizontal ? [{ x: point.x, y: anchor.y }] : [{ x: anchor.x, y: point.y }];
+  } else {
+    const { STUB_OFFSET } = EDGE_CONSTANTS;
+    elbows = isHorizontal
+      ? [
+          { x: anchor.x + dir.dx * STUB_OFFSET, y: anchor.y },
+          { x: anchor.x + dir.dx * STUB_OFFSET, y: point.y },
+        ]
+      : [
+          { x: anchor.x, y: anchor.y + dir.dy * STUB_OFFSET },
+          { x: point.x, y: anchor.y + dir.dy * STUB_OFFSET },
+        ];
+  }
+
+  // Drop elbows coincident with the previous point or the destination — they
+  // collapse into a straight join and would create zero-length segments.
+  const result: Point[] = [];
+  let prev = anchor;
+  for (const elbow of elbows) {
+    const samePrev = Math.abs(elbow.x - prev.x) < TOL && Math.abs(elbow.y - prev.y) < TOL;
+    const samePoint = Math.abs(elbow.x - point.x) < TOL && Math.abs(elbow.y - point.y) < TOL;
+    if (samePrev || samePoint) continue;
+    result.push(elbow);
+    prev = elbow;
+  }
+  return result;
+}
+
+/**
+ * Orthogonal connector between two interior points (waypoint→waypoint). Returns
+ * a single elbow when the points aren't already axis-aligned, or `[]` when they
+ * are. The elbow leaves `from` perpendicular to how the path arrived there
+ * (`incoming`) so the route doesn't immediately double back — producing a clean
+ * staircase rather than a diagonal between non-aligned waypoints.
+ */
+function connectorElbow(from: Point, to: Point, incoming: SegmentOrientation | null): Point | null {
+  const alignedX = Math.abs(from.x - to.x) < TOL;
+  const alignedY = Math.abs(from.y - to.y) < TOL;
+  if (alignedX || alignedY) return null;
+  // Arrived horizontally → leave vertically (elbow shares from.x); otherwise
+  // leave horizontally (elbow shares from.y).
+  return incoming === 'horizontal' ? { x: from.x, y: to.y } : { x: to.x, y: from.y };
+}
+
+/**
+ * Build the ordered, provenance-tagged vertices of the path:
+ * `[start, …, end]`. Falls back to auto-routing when no manual waypoints are
+ * provided. When manual waypoints exist:
+ *
+ * - orthogonal stubs are derived between each anchor and its adjacent waypoint
+ *   (see {@link routeAnchorToPoint}),
+ * - consecutive waypoints are joined orthogonally (see {@link connectorElbow}),
+ * - the whole thing is consolidated so redundant derived elbows collapse —
+ *   user waypoints are protected, so the line is always drawn through them.
+ *
+ * Every vertex carries a `waypointIndex` (the stored waypoint it represents, or
+ * `-1` for anchors/derived elbows) so the editor can map segments back to the
+ * stored waypoints. Stubs and elbows are render-only — stored waypoints are
+ * untouched.
+ */
+export function buildPathVertices(
+  sourceX: number,
+  sourceY: number,
+  sourcePosition: Position,
+  targetX: number,
+  targetY: number,
+  targetPosition: Position,
+  waypoints: Waypoint[] = []
+): PathVertex[] {
+  const sourceOffset = ARROW_OFFSETS[sourcePosition];
+  const targetOffset = ARROW_OFFSETS[targetPosition];
+
+  const start: Point = { x: sourceX + sourceOffset.x, y: sourceY + sourceOffset.y };
+  const end: Point = { x: targetX + targetOffset.x, y: targetY + targetOffset.y };
+
+  const derived = (p: Point): PathVertex => ({ x: p.x, y: p.y, waypointIndex: -1 });
+
+  if (waypoints.length === 0) {
+    const autoWaypoints = calculateAutoWaypoints(
+      sourceX,
+      sourceY,
+      sourcePosition,
+      targetX,
+      targetY,
+      targetPosition
+    );
+    return [start, ...autoWaypoints, end].map(derived);
+  }
+
+  const startVertex = derived(start);
+  const endVertex = derived(end);
+
+  // `path` carries the start anchor only as orientation context for the
+  // interior-elbow heuristic; it is sliced off before consolidation. The
+  // anchors must never be fed to `consolidateWaypoints` — they are trivially
+  // collinear with the path endpoints (they *are* the endpoints) and would be
+  // trimmed, detaching the edge from its nodes.
+  const path: PathVertex[] = [startVertex];
+
+  // Source stub: anchor face → first waypoint.
+  for (const elbow of routeAnchorToPoint(start, sourcePosition, waypoints[0]!)) {
+    path.push(derived(elbow));
+  }
+  path.push({ x: waypoints[0]!.x, y: waypoints[0]!.y, waypointIndex: 0 });
+
+  // Interior links: orthogonalize between consecutive waypoints.
+  for (let i = 1; i < waypoints.length; i++) {
+    const from = path[path.length - 1]!;
+    const incoming = path.length >= 2 ? getSegmentOrientation(path[path.length - 2]!, from) : null;
+    const elbow = connectorElbow(from, waypoints[i]!, incoming);
+    if (elbow) path.push(derived(elbow));
+    path.push({ x: waypoints[i]!.x, y: waypoints[i]!.y, waypointIndex: i });
+  }
+
+  // Target stub: last waypoint → anchor face (reverse of the anchor-outward order).
+  const targetStub = routeAnchorToPoint(end, targetPosition, waypoints[waypoints.length - 1]!);
+  for (let j = targetStub.length - 1; j >= 0; j--) {
+    path.push(derived(targetStub[j]!));
+  }
+
+  // Consolidate the interior only (everything between the anchors), then wrap
+  // it back in the untouched anchors.
+  const interior = consolidateWaypoints(path.slice(1), start, end, (v) => v.waypointIndex >= 0);
+  return [startVertex, ...interior, endVertex];
+}
+
+/**
+ * Collapse a path's interior points to its minimal orthogonal form: drop
+ * duplicates, remove points that are collinear with their neighbours, and trim
+ * leading/trailing points that are collinear with the path endpoints. Iterates
+ * to a fixed point so cascading removals settle.
+ *
+ * `isProtected` marks points that must never be dropped — user waypoints, so
+ * the line is always drawn through them. Only the derived stub elbows around
+ * them are cleaned. Defaults to protecting nothing (pure geometric collapse).
+ *
+ * Generic over `Point` so it preserves the concrete element type (and object
+ * identity of surviving points — callers rely on this to detect no-op
+ * changes). Lives here, not in `waypoints.ts`, so the render-path
+ * `buildPathVertices` can reuse it without an import cycle.
+ */
+export function consolidateWaypoints<T extends Point>(
+  points: T[],
+  pathStart: Point,
+  pathEnd: Point,
+  isProtected: (point: T) => boolean = () => false
+): T[] {
+  let current = points;
+  let changed = true;
+
+  while (changed && current.length > 0) {
+    changed = false;
+    const before = current.length;
+
+    if (current.length > 1) {
+      const deduped: T[] = [current[0]!];
+      for (let i = 1; i < current.length; i++) {
+        const prev = deduped[deduped.length - 1]!;
+        const curr = current[i]!;
+        if (Math.abs(curr.x - prev.x) > TOL || Math.abs(curr.y - prev.y) > TOL) {
+          deduped.push(curr);
+        } else if (isProtected(curr) && !isProtected(prev)) {
+          // Coincident points collapse to one; keep the protected waypoint
+          // rather than the derived stub.
+          deduped[deduped.length - 1] = curr;
+        }
+      }
+      current = deduped;
+    }
+
+    if (current.length > 2) {
+      const result: T[] = [current[0]!];
+      for (let i = 1; i < current.length - 1; i++) {
+        const prev = result[result.length - 1]!;
+        const curr = current[i]!;
+        const next = current[i + 1]!;
+        const horizontalLine = Math.abs(prev.y - curr.y) <= TOL && Math.abs(curr.y - next.y) <= TOL;
+        const verticalLine = Math.abs(prev.x - curr.x) <= TOL && Math.abs(curr.x - next.x) <= TOL;
+        if ((!horizontalLine && !verticalLine) || isProtected(curr)) result.push(curr);
+      }
+      result.push(current[current.length - 1]!);
+      current = result;
+    }
+
+    if (current.length >= 2) {
+      const first = current[0]!;
+      const second = current[1]!;
+      const collinearH =
+        Math.abs(pathStart.y - first.y) <= TOL && Math.abs(first.y - second.y) <= TOL;
+      const collinearV =
+        Math.abs(pathStart.x - first.x) <= TOL && Math.abs(first.x - second.x) <= TOL;
+      if ((collinearH || collinearV) && !isProtected(first)) current = current.slice(1);
+    }
+
+    if (current.length >= 2) {
+      const last = current[current.length - 1]!;
+      const secondLast = current[current.length - 2]!;
+      const collinearH =
+        Math.abs(secondLast.y - last.y) <= TOL && Math.abs(last.y - pathEnd.y) <= TOL;
+      const collinearV =
+        Math.abs(secondLast.x - last.x) <= TOL && Math.abs(last.x - pathEnd.x) <= TOL;
+      if ((collinearH || collinearV) && !isProtected(last)) current = current.slice(0, -1);
+    }
+
+    if (current.length === 1) {
+      const wp = current[0]!;
+      const collinearH = Math.abs(pathStart.y - wp.y) <= TOL && Math.abs(wp.y - pathEnd.y) <= TOL;
+      const collinearV = Math.abs(pathStart.x - wp.x) <= TOL && Math.abs(wp.x - pathEnd.x) <= TOL;
+      if ((collinearH || collinearV) && !isProtected(wp)) current = [];
+    }
+
+    if (current.length >= 2) {
+      const cleaned: T[] = [];
+      for (let i = 0; i < current.length; i++) {
+        const curr = current[i]!;
+        const prev = cleaned[cleaned.length - 1];
+        const next = current[i + 1];
+        if (!isProtected(curr)) {
+          if (prev && Math.abs(curr.x - prev.x) <= TOL && Math.abs(curr.y - prev.y) <= TOL)
+            continue;
+          if (next && Math.abs(curr.x - next.x) <= TOL && Math.abs(curr.y - next.y) <= TOL)
+            continue;
+        }
+        cleaned.push(curr);
+      }
+      current = cleaned;
+    }
+
+    changed = current.length !== before;
+  }
+
+  return current;
+}
+
+export function getSegmentOrientation(start: Point, end: Point): SegmentOrientation {
+  return Math.abs(end.x - start.x) > Math.abs(end.y - start.y) ? 'horizontal' : 'vertical';
+}
+
+/**
+ * True only when the segment is aligned on one axis (within tolerance).
+ */
+export function isSegmentPerpendicular(segment: { start: Point; end: Point }): boolean {
+  const dx = Math.abs(segment.end.x - segment.start.x);
+  const dy = Math.abs(segment.end.y - segment.start.y);
+  return dx < TOL || dy < TOL;
+}
+
+/**
+ * Derive per-segment metadata from the path vertices. `waypointIndexBefore/
+ * After` are indices into the *interior* vertex list (= the materialized
+ * waypoint list the editor builds on grab), with `-1` meaning the source anchor
+ * and the interior count meaning the target anchor. Indexing against the
+ * interior count — not the stored waypoint count — keeps the mapping correct
+ * even when derived stubs/elbows are present.
+ */
+export function extractSegments(pathPoints: PathVertex[]): Segment[] {
+  const segments: Segment[] = [];
+  const interiorCount = Math.max(0, pathPoints.length - 2);
+  for (let i = 0; i < pathPoints.length - 1; i++) {
+    const start = pathPoints[i]!;
+    const end = pathPoints[i + 1]!;
+    segments.push({
+      id: `seg-${i}`,
+      start: { x: start.x, y: start.y },
+      end: { x: end.x, y: end.y },
+      orientation: getSegmentOrientation(start, end),
+      waypointIndexBefore: i - 1,
+      waypointIndexAfter: i < interiorCount ? i : interiorCount,
+    });
+  }
+  return segments;
+}
+
+/**
+ * Build an SVG path string. Each interior point becomes a quadratic curve
+ * with radius clamped to half the shorter adjoining segment.
+ */
+export function createRoundedPath(points: Point[], borderRadius: number = BORDER_RADIUS): string {
+  if (points.length < 2) return '';
+
+  const firstPoint = points[0]!;
+  const path: string[] = [`M ${firstPoint.x} ${firstPoint.y}`];
+
+  if (points.length === 2) {
+    const secondPoint = points[1]!;
+    path.push(`L ${secondPoint.x} ${secondPoint.y}`);
+    return path.join(' ');
+  }
+
+  for (let i = 1; i < points.length - 1; i++) {
+    const prev = points[i - 1]!;
+    const curr = points[i]!;
+    const next = points[i + 1]!;
+
+    const v1 = { x: curr.x - prev.x, y: curr.y - prev.y };
+    const v2 = { x: next.x - curr.x, y: next.y - curr.y };
+    const len1 = Math.sqrt(v1.x * v1.x + v1.y * v1.y);
+    const len2 = Math.sqrt(v2.x * v2.x + v2.y * v2.y);
+
+    const radius = Math.min(borderRadius, Math.min(len1, len2) / 2);
+
+    if (radius < 1) {
+      path.push(`L ${curr.x} ${curr.y}`);
+      continue;
+    }
+
+    const n1 = { x: v1.x / len1, y: v1.y / len1 };
+    const n2 = { x: v2.x / len2, y: v2.y / len2 };
+    const cornerStart = { x: curr.x - n1.x * radius, y: curr.y - n1.y * radius };
+    const cornerEnd = { x: curr.x + n2.x * radius, y: curr.y + n2.y * radius };
+
+    path.push(`L ${cornerStart.x} ${cornerStart.y}`);
+    path.push(`Q ${curr.x} ${curr.y} ${cornerEnd.x} ${cornerEnd.y}`);
+  }
+
+  const lastPoint = points[points.length - 1]!;
+  path.push(`L ${lastPoint.x} ${lastPoint.y}`);
+  return path.join(' ');
+}
+
+export function getSegmentMidpoint(segment: Segment): Point {
+  return {
+    x: (segment.start.x + segment.end.x) / 2,
+    y: (segment.start.y + segment.end.y) / 2,
+  };
+}
+
+export function getSegmentLength(segment: Segment): number {
+  const dx = segment.end.x - segment.start.x;
+  const dy = segment.end.y - segment.start.y;
+  return Math.sqrt(dx * dx + dy * dy);
+}
+
+export function isSegmentInteractable(segment: Segment): boolean {
+  return getSegmentLength(segment) >= MIN_SEGMENT_LENGTH;
+}
+
+/**
+ * Point at half the total arc length of an orthogonal path. Used for label
+ * placement so the label sits on a straight stretch rather than at a corner
+ * waypoint. Linearly interpolates within the segment containing the midpoint.
+ */
+export function getPathArcMidpoint(points: Point[]): Point {
+  if (points.length === 0) return { x: 0, y: 0 };
+  if (points.length === 1) return { x: points[0]!.x, y: points[0]!.y };
+
+  const lengths: number[] = [];
+  let total = 0;
+  for (let i = 0; i < points.length - 1; i++) {
+    const dx = points[i + 1]!.x - points[i]!.x;
+    const dy = points[i + 1]!.y - points[i]!.y;
+    const len = Math.sqrt(dx * dx + dy * dy);
+    lengths.push(len);
+    total += len;
+  }
+
+  if (total === 0) return { x: points[0]!.x, y: points[0]!.y };
+
+  const target = total / 2;
+  let acc = 0;
+  for (let i = 0; i < lengths.length; i++) {
+    const segLen = lengths[i]!;
+    if (acc + segLen >= target) {
+      const t = (target - acc) / segLen;
+      const start = points[i]!;
+      const end = points[i + 1]!;
+      return {
+        x: start.x + t * (end.x - start.x),
+        y: start.y + t * (end.y - start.y),
+      };
+    }
+    acc += segLen;
+  }
+
+  const last = points[points.length - 1]!;
+  return { x: last.x, y: last.y };
+}

--- a/packages/apollo-react/src/canvas/components/Edges/shared/hooks/index.ts
+++ b/packages/apollo-react/src/canvas/components/Edges/shared/hooks/index.ts
@@ -1,0 +1,4 @@
+export { useEdgeGeometry } from './useEdgeGeometry';
+export { useExecutionEdge } from './useExecutionEdge';
+export { useNodeDragRebalance } from './useNodeDragRebalance';
+export { useWaypointEditor } from './useWaypointEditor';

--- a/packages/apollo-react/src/canvas/components/Edges/shared/hooks/useEdgeGeometry.ts
+++ b/packages/apollo-react/src/canvas/components/Edges/shared/hooks/useEdgeGeometry.ts
@@ -1,0 +1,155 @@
+import type { Position } from '@uipath/apollo-react/canvas/xyflow/react';
+import { useMemo } from 'react';
+import { useEdgePath } from '../../../../hooks';
+import { ARROW_ANGLE_MAP, ARROW_OFFSETS, EDGE_CONSTANTS } from '../constants';
+import {
+  buildPathVertices,
+  createRoundedPath,
+  extractSegments,
+  getPathArcMidpoint,
+} from '../geometry';
+import type { EdgeRouting, PathVertex, Point, Segment, Waypoint } from '../types';
+
+const EMPTY_VERTICES: PathVertex[] = [];
+const EMPTY_SEGMENTS: Segment[] = [];
+
+export type UseEdgeGeometryArgs = {
+  routing: EdgeRouting;
+  /** Source node id — used by handle routing for loop detection. */
+  sourceNodeId: string;
+  /** Target node id — used by handle routing for loop detection. */
+  targetNodeId: string;
+  sourceHandleId?: string | null;
+  targetHandleId?: string | null;
+  sourceX: number;
+  sourceY: number;
+  sourcePosition: Position;
+  targetX: number;
+  targetY: number;
+  targetPosition: Position;
+  /** Manual waypoints — only used in `waypoint` routing. */
+  waypoints: Waypoint[];
+  /**
+   * When false, `segments` is always empty and segment extraction is skipped.
+   * Segments are only consumed by the editing chrome, so consumers with
+   * editing disabled avoid the per-render allocation. Defaults to true.
+   */
+  enableSegments?: boolean;
+  /**
+   * When true, target endpoint is inset by `ARROW_OFFSETS[targetPosition]`
+   * so the line stops at the same visual distance from the target as the
+   * arrow polygon would have filled.
+   */
+  hideArrowHead?: boolean;
+};
+
+export type EdgeGeometry = {
+  /** SVG path `d` attribute. */
+  edgePath: string;
+  /** Ordered, provenance-tagged vertices of the path. Empty for handle routing. */
+  pathPoints: PathVertex[];
+  /** Per-segment metadata for hit-testing and editing. Empty for handle routing. */
+  segments: Segment[];
+  /** Position recommended for centered labels along the path. */
+  labelPoint: Point;
+  /** Arrow geometry (independent of routing strategy). */
+  arrow: {
+    angle: number;
+    offset: Point;
+  };
+};
+
+/**
+ * Compute edge geometry for the active routing strategy. The waypoint pipeline
+ * (vertices → segments → rounded path) runs only for `waypoint` routing;
+ * handle-routed edges skip it entirely. The handle strategy (`useEdgePath`) is
+ * a memoized hook that must be called unconditionally (rules of hooks), so for
+ * waypoint routing it is fed constant inputs — its memo never invalidates and
+ * no smooth-step path is recomputed on coordinate changes.
+ */
+export function useEdgeGeometry(args: UseEdgeGeometryArgs): EdgeGeometry {
+  const {
+    routing,
+    sourceNodeId,
+    targetNodeId,
+    sourceHandleId,
+    targetHandleId,
+    sourceX,
+    sourceY,
+    sourcePosition,
+    targetX,
+    targetY,
+    targetPosition,
+    waypoints,
+    enableSegments = true,
+    hideArrowHead = false,
+  } = args;
+
+  const arrowOffset = ARROW_OFFSETS[targetPosition];
+  const isWaypoint = routing === 'waypoint';
+  const isHandle = routing === 'handle';
+
+  const pathPoints = useMemo(
+    () =>
+      isWaypoint
+        ? buildPathVertices(
+            sourceX,
+            sourceY,
+            sourcePosition,
+            targetX,
+            targetY,
+            targetPosition,
+            waypoints
+          )
+        : EMPTY_VERTICES,
+    [isWaypoint, sourceX, sourceY, sourcePosition, targetX, targetY, targetPosition, waypoints]
+  );
+
+  const segments = useMemo(
+    () => (enableSegments ? extractSegments(pathPoints) : EMPTY_SEGMENTS),
+    [enableSegments, pathPoints]
+  );
+
+  const waypointPath = useMemo(
+    () => createRoundedPath(pathPoints, EDGE_CONSTANTS.BORDER_RADIUS),
+    [pathPoints]
+  );
+
+  const handle = useEdgePath({
+    sourceNodeId: isHandle ? sourceNodeId : '',
+    targetNodeId: isHandle ? targetNodeId : '',
+    sourceHandleId: isHandle ? sourceHandleId : null,
+    targetHandleId: isHandle ? targetHandleId : null,
+    sourceX: isHandle ? sourceX : 0,
+    sourceY: isHandle ? sourceY : 0,
+    sourcePosition,
+    targetX: isHandle ? (hideArrowHead ? targetX + arrowOffset.x : targetX) : 0,
+    targetY: isHandle ? (hideArrowHead ? targetY + arrowOffset.y : targetY) : 0,
+    targetPosition,
+  });
+
+  const labelPoint = useMemo(
+    () => (isHandle ? { x: handle.labelX, y: handle.labelY } : getPathArcMidpoint(pathPoints)),
+    [isHandle, handle.labelX, handle.labelY, pathPoints]
+  );
+
+  const arrow = { angle: ARROW_ANGLE_MAP[targetPosition], offset: arrowOffset };
+
+  if (isHandle) {
+    return {
+      edgePath: handle.edgePath,
+      pathPoints: EMPTY_VERTICES,
+      segments: EMPTY_SEGMENTS,
+      labelPoint,
+      arrow,
+    };
+  }
+
+  return {
+    edgePath: waypointPath,
+    pathPoints,
+    segments,
+    labelPoint,
+    arrow,
+  };
+}

--- a/packages/apollo-react/src/canvas/components/Edges/shared/hooks/useEdgeWaypointWriter.ts
+++ b/packages/apollo-react/src/canvas/components/Edges/shared/hooks/useEdgeWaypointWriter.ts
@@ -1,0 +1,46 @@
+import { useReactFlow } from '@uipath/apollo-react/canvas/xyflow/react';
+import { useCallback, useEffect, useRef } from 'react';
+import type { Waypoint } from '../types';
+import { waypointsEqual } from '../waypoints';
+
+/**
+ * Returns a stable callback that persists an edge's waypoints. In controlled
+ * mode (an `onChange` is supplied) it calls that instead of touching React Flow
+ * state — the consumer owns persistence. Otherwise it writes straight into the
+ * edge's `data.waypoints`, skipping the update when nothing changed.
+ *
+ * Shared by the waypoint editor and the node-drag rebalancer so both commit the
+ * same way.
+ */
+export function useEdgeWaypointWriter(
+  edgeId: string,
+  onChange?: (next: Waypoint[]) => void
+): (next: Waypoint[]) => void {
+  const { setEdges } = useReactFlow();
+  const onChangeRef = useRef(onChange);
+  useEffect(() => {
+    onChangeRef.current = onChange;
+  });
+
+  return useCallback(
+    (next: Waypoint[]) => {
+      const consumer = onChangeRef.current;
+      if (consumer) {
+        consumer(next);
+        return;
+      }
+      setEdges((edges) => {
+        let changed = false;
+        const updated = edges.map((edge) => {
+          if (edge.id !== edgeId) return edge;
+          const current = (edge.data as { waypoints?: Waypoint[] } | undefined)?.waypoints ?? [];
+          if (waypointsEqual(current, next)) return edge;
+          changed = true;
+          return { ...edge, data: { ...edge.data, waypoints: next } };
+        });
+        return changed ? updated : edges;
+      });
+    },
+    [edgeId, setEdges]
+  );
+}

--- a/packages/apollo-react/src/canvas/components/Edges/shared/hooks/useExecutionEdge.ts
+++ b/packages/apollo-react/src/canvas/components/Edges/shared/hooks/useExecutionEdge.ts
@@ -1,0 +1,45 @@
+import { type ReactNode, useMemo } from 'react';
+import { useEdgeExecutionState, useElementValidationStatus } from '../../../../hooks';
+import type { ElementStatus, NodeExecutionStateWithDebug } from '../../../../types/execution';
+import type { ValidationErrorSeverity } from '../../../../types/validation';
+import { edgeTargetStatusToEdgeColor, getStatusAnimation } from '../../EdgeUtils';
+
+export type UseExecutionEdgeArgs = {
+  edgeId: string;
+  target: string;
+  /** SVG path along which the in-progress dot animates. */
+  edgePath: string;
+  /** When false the underlying hooks still subscribe (rules of hooks) but their output is ignored. */
+  enabled: boolean;
+};
+
+export type ExecutionEdge = {
+  statusColor: string | undefined;
+  animation: ReactNode;
+};
+
+function resolveStatus(
+  executionState: ReturnType<typeof useEdgeExecutionState>,
+  validation: ReturnType<typeof useElementValidationStatus>
+): ElementStatus | ValidationErrorSeverity | undefined {
+  if (executionState) {
+    return ((executionState as NodeExecutionStateWithDebug)?.status ?? executionState) as
+      | ElementStatus
+      | ValidationErrorSeverity
+      | undefined;
+  }
+  return validation?.validationStatus;
+}
+
+export function useExecutionEdge(args: UseExecutionEdgeArgs): ExecutionEdge {
+  const { edgeId, target, edgePath, enabled } = args;
+
+  const executionState = useEdgeExecutionState(edgeId, target);
+  const validation = useElementValidationStatus(edgeId);
+
+  const status = enabled ? resolveStatus(executionState, validation) : undefined;
+  const statusColor = status ? edgeTargetStatusToEdgeColor[status] : undefined;
+  const animation = useMemo(() => getStatusAnimation(status, edgePath), [status, edgePath]);
+
+  return { statusColor, animation };
+}

--- a/packages/apollo-react/src/canvas/components/Edges/shared/hooks/useNodeDragRebalance.ts
+++ b/packages/apollo-react/src/canvas/components/Edges/shared/hooks/useNodeDragRebalance.ts
@@ -1,0 +1,113 @@
+import {
+  type Position,
+  type ReactFlowState,
+  useStore,
+} from '@uipath/apollo-react/canvas/xyflow/react';
+import { useLayoutEffect, useRef } from 'react';
+import type { Point, Waypoint } from '../types';
+import { rebalanceWaypoints, waypointsEqual } from '../waypoints';
+import { useEdgeWaypointWriter } from './useEdgeWaypointWriter';
+
+export type UseNodeDragRebalanceArgs = {
+  edgeId: string;
+  source: string;
+  target: string;
+  /** Current source/target handle coordinates (as passed to the geometry). */
+  sourceX: number;
+  sourceY: number;
+  sourcePosition: Position;
+  targetX: number;
+  targetY: number;
+  targetPosition: Position;
+  waypoints: Waypoint[];
+  /** When false the stored waypoints are returned unchanged (no rebalancing). */
+  enabled: boolean;
+  onChange?: (next: Waypoint[]) => void;
+};
+
+/**
+ * Makes an edge's waypoints follow a node drag. While either endpoint node is
+ * being dragged, the stored waypoints are remapped (see {@link
+ * rebalanceWaypoints}) relative to the anchor box captured at drag start, so
+ * the bends track the moving node instead of being left behind. The remapped
+ * positions are returned for rendering and persisted once the drag ends.
+ *
+ * Returns the waypoints to render/route with: rebalanced during a drag, the
+ * stored ones otherwise.
+ */
+export function useNodeDragRebalance(args: UseNodeDragRebalanceArgs): Waypoint[] {
+  const {
+    edgeId,
+    source,
+    target,
+    sourceX,
+    sourceY,
+    sourcePosition,
+    targetX,
+    targetY,
+    targetPosition,
+    waypoints,
+    enabled,
+    onChange,
+  } = args;
+
+  // `enabled` first so disabled edges pay one boolean test per store update
+  // instead of two Map lookups.
+  const dragging = useStore(
+    (state: ReactFlowState) =>
+      enabled &&
+      !!(state.nodeLookup.get(source)?.dragging || state.nodeLookup.get(target)?.dragging)
+  );
+
+  const write = useEdgeWaypointWriter(edgeId, onChange);
+
+  // Pre-drag baseline: refreshed every non-dragging render, frozen during a
+  // drag so the remap always maps from the original positions (mapping from the
+  // continuously-updated stored waypoints would compound and drift).
+  const baselineRef = useRef<{ s: Point; t: Point; waypoints: Waypoint[] }>({
+    s: { x: sourceX, y: sourceY },
+    t: { x: targetX, y: targetY },
+    waypoints,
+  });
+  // Latest rebalanced result, captured so it can be persisted on drag end.
+  const lastRebalancedRef = useRef<Waypoint[] | null>(null);
+  const prevDraggingRef = useRef(false);
+
+  const active = enabled && dragging && waypoints.length > 0;
+
+  if (!dragging) {
+    baselineRef.current = {
+      s: { x: sourceX, y: sourceY },
+      t: { x: targetX, y: targetY },
+      waypoints,
+    };
+  }
+
+  let display = waypoints;
+  if (active) {
+    const { s, t, waypoints: w0 } = baselineRef.current;
+    display = rebalanceWaypoints(
+      w0,
+      { position: sourcePosition, from: s, to: { x: sourceX, y: sourceY } },
+      { position: targetPosition, from: t, to: { x: targetX, y: targetY } }
+    );
+    lastRebalancedRef.current = display;
+  }
+
+  // Persist the final rebalanced positions when the drag ends, in a layout
+  // effect so the write lands before paint and the line never flashes back to
+  // the stale positions.
+  useLayoutEffect(() => {
+    const wasDragging = prevDraggingRef.current;
+    prevDraggingRef.current = dragging;
+    if (!wasDragging || dragging) return;
+
+    const final = lastRebalancedRef.current;
+    lastRebalancedRef.current = null;
+    if (enabled && final && !waypointsEqual(waypoints, final)) {
+      write(final);
+    }
+  });
+
+  return display;
+}

--- a/packages/apollo-react/src/canvas/components/Edges/shared/hooks/useWaypointEditor.ts
+++ b/packages/apollo-react/src/canvas/components/Edges/shared/hooks/useWaypointEditor.ts
@@ -1,0 +1,219 @@
+import { useReactFlow } from '@uipath/apollo-react/canvas/xyflow/react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { snapPointToGrid } from '../geometry';
+import type { PathVertex, Point, Segment, Waypoint } from '../types';
+import {
+  insertWaypoint,
+  materializePathWaypoints,
+  moveSegmentByDelta,
+  moveWaypoint,
+  removeWaypoint,
+  waypointsEqual,
+} from '../waypoints';
+import { useEdgeWaypointWriter } from './useEdgeWaypointWriter';
+
+type DragState =
+  | { type: 'none' }
+  | { type: 'waypoint'; waypointIndex: number; initialWaypoints: Waypoint[] }
+  | {
+      type: 'segment';
+      segment: Segment;
+      initialWaypoints: Waypoint[];
+      initialPathPoints: Point[];
+    };
+
+export type UseWaypointEditorArgs = {
+  edgeId: string;
+  waypoints: Waypoint[];
+  pathPoints: PathVertex[];
+  /**
+   * When false the editor returns inert handlers, registers no listeners,
+   * and reports `isDragging: false`. The hook still runs (rules of hooks)
+   * but does no work.
+   */
+  enabled: boolean;
+  /**
+   * When provided, the editor calls this instead of writing to React Flow
+   * state. The consumer owns persistence (controlled mode).
+   */
+  onChange?: (next: Waypoint[]) => void;
+};
+
+export type WaypointHandlers = {
+  onMouseDown: (index: number, e: React.MouseEvent) => void;
+  onDoubleClick: (index: number) => void;
+};
+
+export type SegmentHandlers = {
+  onMouseDown: (segment: Segment, e: React.MouseEvent) => void;
+  onDoubleClick: (segmentIndex: number, e: React.MouseEvent) => void;
+};
+
+export type WaypointEditor = {
+  isDragging: boolean;
+  /** Stable handlers for the SVG group rendering each waypoint. */
+  waypointHandlers: WaypointHandlers;
+  /** Stable handlers for each segment's interaction line. */
+  segmentHandlers: SegmentHandlers;
+};
+
+/**
+ * Owns drag state, window listeners, and waypoint mutation for a single edge.
+ *
+ * Mouse positions are converted to flow coordinates via the viewport so
+ * dragging feels 1:1 in canvas coordinates regardless of pan/zoom. Mutations
+ * are throttled via requestAnimationFrame to coalesce rapid mousemove events.
+ *
+ * The full derived path is materialized into concrete waypoints once at
+ * segment-drag start so subsequent move ticks reuse stable waypoint IDs and
+ * the segment indices line up with the stored list.
+ */
+export function useWaypointEditor(args: UseWaypointEditorArgs): WaypointEditor {
+  const { edgeId, waypoints, pathPoints, enabled, onChange } = args;
+  const { screenToFlowPosition } = useReactFlow();
+  const writeWaypoints = useEdgeWaypointWriter(edgeId, onChange);
+
+  const [dragState, setDragState] = useState<DragState>({ type: 'none' });
+  const dragStartRef = useRef<Point | null>(null);
+  const rafRef = useRef<number | null>(null);
+
+  // Refs track the latest waypoints/pathPoints so the callbacks below stay
+  // stable across renders. This keeps the mousemove effect from tearing down
+  // listeners every drag tick and ensures the no-op dedupe compares against the
+  // most recent waypoints.
+  const waypointsRef = useRef(waypoints);
+  const pathPointsRef = useRef(pathPoints);
+  useEffect(() => {
+    waypointsRef.current = waypoints;
+    pathPointsRef.current = pathPoints;
+  });
+
+  const updateWaypoints = useCallback(
+    (next: Waypoint[]) => {
+      if (waypointsEqual(waypointsRef.current, next)) return;
+      writeWaypoints(next);
+    },
+    [writeWaypoints]
+  );
+
+  useEffect(() => {
+    if (!enabled || dragState.type === 'none') return;
+
+    const handleMouseMove = (e: MouseEvent) => {
+      if (!dragStartRef.current) return;
+      if (rafRef.current !== null) cancelAnimationFrame(rafRef.current);
+
+      rafRef.current = requestAnimationFrame(() => {
+        // Unsnapped conversion: moveWaypoint/moveSegmentByDelta snap the
+        // resulting positions themselves; snapping the deltas here would
+        // double-quantize the drag.
+        const start = screenToFlowPosition(dragStartRef.current!, { snapToGrid: false });
+        const current = screenToFlowPosition({ x: e.clientX, y: e.clientY }, { snapToGrid: false });
+        const delta: Point = { x: current.x - start.x, y: current.y - start.y };
+
+        if (dragState.type === 'waypoint') {
+          const initial = dragState.initialWaypoints[dragState.waypointIndex];
+          if (!initial) return;
+          updateWaypoints(
+            moveWaypoint(dragState.initialWaypoints, dragState.waypointIndex, {
+              x: initial.x + delta.x,
+              y: initial.y + delta.y,
+            })
+          );
+        } else if (dragState.type === 'segment') {
+          updateWaypoints(
+            moveSegmentByDelta(
+              dragState.initialWaypoints,
+              dragState.segment,
+              delta,
+              dragState.initialPathPoints
+            )
+          );
+        }
+      });
+    };
+
+    const handleMouseUp = () => {
+      if (rafRef.current !== null) {
+        cancelAnimationFrame(rafRef.current);
+        rafRef.current = null;
+      }
+      setDragState({ type: 'none' });
+      dragStartRef.current = null;
+    };
+
+    window.addEventListener('mousemove', handleMouseMove);
+    window.addEventListener('mouseup', handleMouseUp);
+    return () => {
+      window.removeEventListener('mousemove', handleMouseMove);
+      window.removeEventListener('mouseup', handleMouseUp);
+      if (rafRef.current !== null) cancelAnimationFrame(rafRef.current);
+    };
+  }, [enabled, dragState, updateWaypoints, screenToFlowPosition]);
+
+  const waypointHandlers = useMemo<WaypointHandlers>(
+    () => ({
+      onMouseDown: (index: number, e: React.MouseEvent) => {
+        if (!enabled) return;
+        e.stopPropagation();
+        e.preventDefault();
+        dragStartRef.current = { x: e.clientX, y: e.clientY };
+        setDragState({
+          type: 'waypoint',
+          waypointIndex: index,
+          initialWaypoints: [...waypointsRef.current],
+        });
+      },
+      onDoubleClick: (index: number) => {
+        if (!enabled) return;
+        updateWaypoints(removeWaypoint(waypointsRef.current, index));
+      },
+    }),
+    [enabled, updateWaypoints]
+  );
+
+  const segmentHandlers = useMemo<SegmentHandlers>(
+    () => ({
+      onMouseDown: (segment: Segment, e: React.MouseEvent) => {
+        if (!enabled) return;
+        e.stopPropagation();
+        e.preventDefault();
+        dragStartRef.current = { x: e.clientX, y: e.clientY };
+
+        // Materialize the full derived path so segment math runs on a clean
+        // 1:1 waypoint list; the grabbed segment's indices already match it.
+        const materialized = materializePathWaypoints(pathPointsRef.current, waypointsRef.current);
+
+        setDragState({
+          type: 'segment',
+          segment,
+          initialWaypoints: materialized,
+          initialPathPoints: [...pathPointsRef.current],
+        });
+      },
+      onDoubleClick: (segmentIndex: number, e: React.MouseEvent) => {
+        if (!enabled) return;
+        // Keep React Flow's edge-level double-click handlers (selection,
+        // onEdgeDoubleClick) out of waypoint insertion. Canvas double-click
+        // zoom is suppressed separately via `nopan` on the handle element.
+        e.stopPropagation();
+        e.preventDefault();
+        // Convert screen coords to canvas/flow coords so the new waypoint
+        // lands at the cursor regardless of pan/zoom.
+        const flowPoint = screenToFlowPosition({ x: e.clientX, y: e.clientY });
+        const snapped = snapPointToGrid(flowPoint);
+        updateWaypoints(
+          insertWaypoint(pathPointsRef.current, waypointsRef.current, segmentIndex, snapped)
+        );
+      },
+    }),
+    [enabled, screenToFlowPosition, updateWaypoints]
+  );
+
+  const isDragging = enabled && dragState.type !== 'none';
+
+  return useMemo(
+    () => ({ isDragging, waypointHandlers, segmentHandlers }),
+    [isDragging, waypointHandlers, segmentHandlers]
+  );
+}

--- a/packages/apollo-react/src/canvas/components/Edges/shared/primitives/EdgeArrow.test.tsx
+++ b/packages/apollo-react/src/canvas/components/Edges/shared/primitives/EdgeArrow.test.tsx
@@ -1,0 +1,49 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { EdgeArrow } from './EdgeArrow';
+
+function renderArrow(props: Partial<React.ComponentProps<typeof EdgeArrow>> = {}) {
+  const { container } = render(
+    <svg>
+      <EdgeArrow
+        target={{ x: 100, y: 50 }}
+        angle={0}
+        offset={{ x: 8, y: 0 }}
+        color="var(--canvas-border)"
+        {...props}
+      />
+    </svg>
+  );
+  return container.querySelector('polygon') as SVGPolygonElement;
+}
+
+/** Locks the arrow-head geometry the legacy SequenceEdge rendered inline. */
+describe('EdgeArrow', () => {
+  it('places the tip at the target point and insets via the offset transform', () => {
+    const polygon = renderArrow();
+    // first point of the triangle is the tip
+    expect(polygon.getAttribute('points')?.startsWith('100,50 ')).toBe(true);
+    expect(polygon.style.transform).toBe('translate(8px, 0px)');
+    expect(polygon.style.pointerEvents).toBe('none');
+  });
+
+  it('fills with the resolved edge color at the given opacity', () => {
+    const polygon = renderArrow({ color: 'var(--canvas-error-icon)', opacity: 0.5 });
+    expect(polygon.getAttribute('fill')).toBe('var(--canvas-error-icon)');
+    expect(polygon.style.opacity).toBe('0.5');
+  });
+
+  it('rotates the wings with the entry angle', () => {
+    // angle 0 (entering the target's left face) puts both wings left of the tip
+    const horizontal = renderArrow({ angle: 0 }).getAttribute('points')!;
+    const [, leftWing, rightWing] = horizontal.split(' ');
+    expect(Number.parseFloat(leftWing!.split(',')[0]!)).toBeLessThan(100);
+    expect(Number.parseFloat(rightWing!.split(',')[0]!)).toBeLessThan(100);
+
+    // angle PI/2 (entering the top face) puts both wings above the tip
+    const vertical = renderArrow({ angle: Math.PI / 2 }).getAttribute('points')!;
+    const [, upLeft, upRight] = vertical.split(' ');
+    expect(Number.parseFloat(upLeft!.split(',')[1]!)).toBeLessThan(50);
+    expect(Number.parseFloat(upRight!.split(',')[1]!)).toBeLessThan(50);
+  });
+});

--- a/packages/apollo-react/src/canvas/components/Edges/shared/primitives/EdgeArrow.tsx
+++ b/packages/apollo-react/src/canvas/components/Edges/shared/primitives/EdgeArrow.tsx
@@ -1,0 +1,38 @@
+import { EDGE_CONSTANTS } from '../constants';
+import type { Point } from '../types';
+
+const { ARROW_SIZE, ARROW_HALF_ANGLE } = EDGE_CONSTANTS;
+const ARROW_TRANSITION = 'fill 0.2s ease, opacity 0.2s ease';
+
+export type EdgeArrowProps = {
+  /** Tip of the arrow — the target node anchor point. */
+  target: Point;
+  /** Angle pointing INTO the target (radians). */
+  angle: number;
+  /** Inset offset translating the arrow away from the node edge. */
+  offset: Point;
+  color: string;
+  opacity?: number;
+};
+
+export function EdgeArrow({ target, angle, offset, color, opacity = 1 }: EdgeArrowProps) {
+  const tipX = target.x;
+  const tipY = target.y;
+  const leftX = tipX - ARROW_SIZE * Math.cos(angle - ARROW_HALF_ANGLE);
+  const leftY = tipY - ARROW_SIZE * Math.sin(angle - ARROW_HALF_ANGLE);
+  const rightX = tipX - ARROW_SIZE * Math.cos(angle + ARROW_HALF_ANGLE);
+  const rightY = tipY - ARROW_SIZE * Math.sin(angle + ARROW_HALF_ANGLE);
+
+  return (
+    <polygon
+      points={`${tipX},${tipY} ${leftX},${leftY} ${rightX},${rightY}`}
+      fill={color}
+      style={{
+        pointerEvents: 'none',
+        opacity,
+        transition: ARROW_TRANSITION,
+        transform: `translate(${offset.x}px, ${offset.y}px)`,
+      }}
+    />
+  );
+}

--- a/packages/apollo-react/src/canvas/components/Edges/shared/primitives/EdgeLabel.test.tsx
+++ b/packages/apollo-react/src/canvas/components/Edges/shared/primitives/EdgeLabel.test.tsx
@@ -1,0 +1,37 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { EdgeLabel } from './EdgeLabel';
+
+function renderLabel(props: Partial<React.ComponentProps<typeof EdgeLabel>> = {}) {
+  const { container } = render(
+    <svg>
+      <EdgeLabel x={150} y={50} text="Run" {...props} />
+    </svg>
+  );
+  return {
+    foreignObject: container.querySelector('foreignObject'),
+    label: container.querySelector('.react-flow__edge-label') as HTMLDivElement,
+  };
+}
+
+/** Locks the label markup the legacy SequenceEdge rendered inline. */
+describe('EdgeLabel', () => {
+  it('renders the text centered on the given point, opted out of pan/drag', () => {
+    const { foreignObject, label } = renderLabel();
+    expect(label.textContent).toBe('Run');
+    expect(foreignObject?.getAttribute('x')).toBe('150');
+    expect(foreignObject?.getAttribute('y')).toBe('50');
+    expect(label.className).toContain('nodrag');
+    expect(label.className).toContain('nopan');
+    expect(label.style.transform).toBe('translate(-50%, -50%)');
+    expect(label.style.pointerEvents).toBe('none');
+  });
+
+  it('uses the primary border when selected and the default border otherwise', () => {
+    // assert on the raw attribute — happy-dom's border shorthand drops var() colors
+    expect(renderLabel().label.getAttribute('style')).toContain('var(--canvas-border)');
+    expect(renderLabel({ selected: true }).label.getAttribute('style')).toContain(
+      'var(--canvas-primary)'
+    );
+  });
+});

--- a/packages/apollo-react/src/canvas/components/Edges/shared/primitives/EdgeLabel.tsx
+++ b/packages/apollo-react/src/canvas/components/Edges/shared/primitives/EdgeLabel.tsx
@@ -1,0 +1,39 @@
+export type EdgeLabelProps = {
+  x: number;
+  y: number;
+  text: string;
+  selected?: boolean;
+};
+
+export function EdgeLabel({ x, y, text, selected }: EdgeLabelProps) {
+  return (
+    <foreignObject
+      x={x}
+      y={y}
+      width={1}
+      height={1}
+      overflow="visible"
+      style={{ pointerEvents: 'none' }}
+    >
+      <div
+        className="react-flow__edge-label nodrag nopan"
+        style={{
+          position: 'absolute',
+          transform: 'translate(-50%, -50%)',
+          whiteSpace: 'nowrap',
+          pointerEvents: 'none',
+          color: 'var(--canvas-foreground)',
+          background: 'var(--canvas-background)',
+          padding: '4px 8px',
+          borderRadius: '4px',
+          fontSize: '12px',
+          fontWeight: 500,
+          border: `1px solid ${selected ? 'var(--canvas-primary)' : 'var(--canvas-border)'}`,
+          boxShadow: '0 1px 3px 0 rgba(0, 0, 0, 0.1)',
+        }}
+      >
+        {text}
+      </div>
+    </foreignObject>
+  );
+}

--- a/packages/apollo-react/src/canvas/components/Edges/shared/primitives/EdgePath.test.tsx
+++ b/packages/apollo-react/src/canvas/components/Edges/shared/primitives/EdgePath.test.tsx
@@ -1,0 +1,66 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { EdgePath } from './EdgePath';
+
+const D = 'M 0 0 L 100 0';
+
+function renderPath(props: Partial<React.ComponentProps<typeof EdgePath>> = {}) {
+  const { container } = render(
+    <svg>
+      <EdgePath d={D} color="var(--canvas-border)" {...props} />
+    </svg>
+  );
+  return {
+    visible: container.querySelector('.react-flow__edge-path') as SVGPathElement,
+    interaction: container.querySelector('.react-flow__edge-interaction') as SVGPathElement,
+    outline: container.querySelector('.react-flow__edge-outline') as SVGPathElement | null,
+  };
+}
+
+/**
+ * Locks the visual contract the legacy SequenceEdge path stack implemented
+ * inline. Values are asserted as literals on purpose: retuning a shared
+ * constant changes this published contract and should fail here, not slide
+ * through silently.
+ */
+describe('EdgePath', () => {
+  it('renders solid by default and dashed for strokeStyle="dashed"', () => {
+    expect(renderPath().visible.style.strokeDasharray).toBe('0');
+    expect(renderPath({ strokeStyle: 'dashed' }).visible.style.strokeDasharray).toBe('5,5');
+  });
+
+  it('sets no dasharray when animated, so React Flow dash animation applies', () => {
+    expect(renderPath({ animated: true }).visible.style.strokeDasharray).toBe('');
+    // animated wins even when a dashed strokeStyle is requested
+    expect(
+      renderPath({ animated: true, strokeStyle: 'dashed' }).visible.style.strokeDasharray
+    ).toBe('');
+  });
+
+  it('uses 2px stroke by default, 3px when selected, and style.strokeWidth when provided', () => {
+    expect(renderPath().visible.getAttribute('stroke-width')).toBe('2');
+    expect(renderPath({ selected: true }).visible.getAttribute('stroke-width')).toBe('3');
+    expect(
+      renderPath({ selected: true, style: { strokeWidth: 5 } }).visible.getAttribute('stroke-width')
+    ).toBe('5');
+  });
+
+  it('renders the selection outline layer only when selected', () => {
+    expect(renderPath().outline).toBeNull();
+    const { outline } = renderPath({ selected: true });
+    expect(outline).not.toBeNull();
+    expect(outline?.getAttribute('stroke')).toBe('var(--canvas-primary)');
+  });
+
+  it('applies opacity to the visible path and keeps the 20px interaction layer', () => {
+    const { visible, interaction } = renderPath({ opacity: 0.5 });
+    expect(visible.style.opacity).toBe('0.5');
+    expect(interaction.getAttribute('stroke-width')).toBe('20');
+    expect(interaction.getAttribute('stroke')).toBe('transparent');
+  });
+
+  it('uses a default cursor in readonly mode and pointer otherwise', () => {
+    expect(renderPath().interaction.style.cursor).toBe('pointer');
+    expect(renderPath({ isReadOnly: true }).interaction.style.cursor).toBe('default');
+  });
+});

--- a/packages/apollo-react/src/canvas/components/Edges/shared/primitives/EdgePath.tsx
+++ b/packages/apollo-react/src/canvas/components/Edges/shared/primitives/EdgePath.tsx
@@ -1,0 +1,101 @@
+import type { CSSProperties } from 'react';
+import { EDGE_COLORS, EDGE_CONSTANTS, EDGE_DASHARRAY, EDGE_PATH_TRANSITION } from '../constants';
+import type { EdgeStrokeStyle } from '../types';
+
+const {
+  INTERACTION_STROKE_WIDTH,
+  STROKE_WIDTH,
+  SELECTED_STROKE_WIDTH,
+  SELECTED_OUTLINE_STROKE_WIDTH,
+  SELECTED_OUTLINE_OPACITY,
+} = EDGE_CONSTANTS;
+
+export type EdgePathProps = {
+  /** SVG path `d` attribute. */
+  d: string;
+  /** Resolved stroke color (CSS var or color string). */
+  color: string;
+  selected?: boolean;
+  /**
+   * React Flow's `animated` edge flag. When true, no `strokeDasharray` is set
+   * so React Flow's animated-edge CSS (dashdraw on `.react-flow__edge-path`)
+   * takes effect instead of being overridden.
+   */
+  animated?: boolean;
+  strokeStyle?: EdgeStrokeStyle;
+  isReadOnly?: boolean;
+  /** Optional ref for the visible path element. */
+  pathRef?: React.Ref<SVGPathElement>;
+  /** Edge id (becomes the visible path element id, useful for animateMotion). */
+  id?: string;
+  style?: CSSProperties;
+  /** Resolved opacity for the visible path. */
+  opacity?: number;
+};
+
+/**
+ * Three-layer SVG path stack used by every canvas edge:
+ *   1. Invisible thick stroke for hit testing
+ *   2. Wide soft outline when selected
+ *   3. The visible path itself
+ */
+export function EdgePath(props: EdgePathProps) {
+  const {
+    d,
+    color,
+    selected,
+    animated,
+    strokeStyle,
+    isReadOnly,
+    pathRef,
+    id,
+    style,
+    opacity = 1,
+  } = props;
+
+  const dasharray = animated
+    ? undefined
+    : strokeStyle === 'dashed'
+      ? EDGE_DASHARRAY.dashed
+      : EDGE_DASHARRAY.solid;
+  const strokeWidth =
+    (style?.strokeWidth as number | undefined) ?? (selected ? SELECTED_STROKE_WIDTH : STROKE_WIDTH);
+
+  return (
+    <>
+      <path
+        className="react-flow__edge-interaction"
+        d={d}
+        fill="none"
+        stroke="transparent"
+        strokeWidth={INTERACTION_STROKE_WIDTH}
+        style={{ pointerEvents: 'stroke', cursor: isReadOnly ? 'default' : 'pointer' }}
+      />
+      {selected && (
+        <path
+          className="react-flow__edge-outline"
+          d={d}
+          fill="none"
+          stroke={EDGE_COLORS.selected}
+          strokeWidth={SELECTED_OUTLINE_STROKE_WIDTH}
+          opacity={SELECTED_OUTLINE_OPACITY}
+          style={{ pointerEvents: 'none', transition: 'opacity 0.2s ease' }}
+        />
+      )}
+      <path
+        id={id}
+        ref={pathRef}
+        className="react-flow__edge-path"
+        d={d}
+        fill="none"
+        strokeWidth={strokeWidth}
+        style={{
+          stroke: color,
+          strokeDasharray: dasharray,
+          opacity,
+          transition: EDGE_PATH_TRANSITION,
+        }}
+      />
+    </>
+  );
+}

--- a/packages/apollo-react/src/canvas/components/Edges/shared/primitives/SegmentDragHandle.tsx
+++ b/packages/apollo-react/src/canvas/components/Edges/shared/primitives/SegmentDragHandle.tsx
@@ -1,0 +1,89 @@
+import { memo, useState } from 'react';
+import { EDGE_COLORS, EDGE_CONSTANTS } from '../constants';
+import { getSegmentMidpoint } from '../geometry';
+import type { SegmentHandlers } from '../hooks/useWaypointEditor';
+import type { Segment, SegmentOrientation } from '../types';
+
+const { INTERACTION_STROKE_WIDTH } = EDGE_CONSTANTS;
+
+const SEGMENT_CURSOR: Record<SegmentOrientation, string> = {
+  horizontal: 'ns-resize',
+  vertical: 'ew-resize',
+};
+
+const HANDLE_RECT: Record<
+  SegmentOrientation,
+  { x: number; y: number; width: number; height: number }
+> = {
+  horizontal: { x: -12, y: -5, width: 24, height: 10 },
+  vertical: { x: -5, y: -12, width: 10, height: 24 },
+};
+
+export type SegmentDragHandleProps = {
+  segment: Segment;
+  /** Index of the segment in the extracted list, passed back to `handlers`. */
+  segmentIndex: number;
+  handlers: SegmentHandlers;
+};
+
+export const SegmentDragHandle = memo(function SegmentDragHandle({
+  segment,
+  segmentIndex,
+  handlers,
+}: SegmentDragHandleProps) {
+  const [isHovered, setIsHovered] = useState(false);
+  const midpoint = getSegmentMidpoint(segment);
+  const cursor = SEGMENT_CURSOR[segment.orientation];
+  const rect = HANDLE_RECT[segment.orientation];
+
+  return (
+    <>
+      {/* `nopan` opts out of React Flow's d3-zoom gestures (notably double-
+          click zoom) at the filter level — a React-level stopPropagation fires
+          too late because d3 listens below React's delegation root. */}
+      <line
+        className="nopan"
+        x1={segment.start.x}
+        y1={segment.start.y}
+        x2={segment.end.x}
+        y2={segment.end.y}
+        stroke="transparent"
+        strokeWidth={INTERACTION_STROKE_WIDTH}
+        style={{ cursor, pointerEvents: 'stroke' }}
+        onMouseEnter={() => setIsHovered(true)}
+        onMouseLeave={() => setIsHovered(false)}
+        onMouseDown={(e) => handlers.onMouseDown(segment, e)}
+        onDoubleClick={(e) => handlers.onDoubleClick(segmentIndex, e)}
+      />
+      {isHovered && (
+        <>
+          <line
+            x1={segment.start.x}
+            y1={segment.start.y}
+            x2={segment.end.x}
+            y2={segment.end.y}
+            stroke={EDGE_COLORS.selected}
+            strokeWidth={4}
+            opacity={0.4}
+            style={{ pointerEvents: 'none' }}
+          />
+          <g
+            transform={`translate(${midpoint.x}, ${midpoint.y})`}
+            style={{ pointerEvents: 'none' }}
+          >
+            <rect
+              x={rect.x}
+              y={rect.y}
+              width={rect.width}
+              height={rect.height}
+              rx={5}
+              fill={EDGE_COLORS.selected}
+              stroke="white"
+              strokeWidth={2}
+            />
+          </g>
+        </>
+      )}
+    </>
+  );
+});

--- a/packages/apollo-react/src/canvas/components/Edges/shared/primitives/WaypointHandle.tsx
+++ b/packages/apollo-react/src/canvas/components/Edges/shared/primitives/WaypointHandle.tsx
@@ -1,0 +1,53 @@
+import { memo, useState } from 'react';
+import { EDGE_COLORS } from '../constants';
+import type { WaypointHandlers } from '../hooks/useWaypointEditor';
+import type { Waypoint } from '../types';
+
+export type WaypointHandleProps = {
+  waypoint: Waypoint;
+  /** Index of the waypoint in the stored list, passed back to `handlers`. */
+  index: number;
+  /** Force the visible dot regardless of hover (edge hovered/selected/dragging). */
+  forceVisible: boolean;
+  handlers: WaypointHandlers;
+};
+
+export const WaypointHandle = memo(function WaypointHandle({
+  waypoint,
+  index,
+  forceVisible,
+  handlers,
+}: WaypointHandleProps) {
+  const [isHovered, setIsHovered] = useState(false);
+  const visible = forceVisible || isHovered;
+
+  return (
+    // `nopan` opts out of React Flow's d3-zoom gestures (notably double-click
+    // zoom) at the filter level — a React-level stopPropagation fires too late
+    // because d3 listens below React's delegation root.
+    <g
+      className="nopan"
+      transform={`translate(${waypoint.x}, ${waypoint.y})`}
+      onMouseEnter={() => setIsHovered(true)}
+      onMouseLeave={() => setIsHovered(false)}
+      onMouseDown={(e) => handlers.onMouseDown(index, e)}
+      onDoubleClick={(e) => {
+        e.stopPropagation();
+        e.preventDefault();
+        handlers.onDoubleClick(index);
+      }}
+      style={{ cursor: 'move' }}
+    >
+      <circle r={16} fill="transparent" style={{ pointerEvents: 'all' }} />
+      {visible && (
+        <circle
+          r={6}
+          fill={EDGE_COLORS.selected}
+          stroke="white"
+          strokeWidth={2}
+          style={{ pointerEvents: 'none' }}
+        />
+      )}
+    </g>
+  );
+});

--- a/packages/apollo-react/src/canvas/components/Edges/shared/primitives/index.ts
+++ b/packages/apollo-react/src/canvas/components/Edges/shared/primitives/index.ts
@@ -1,0 +1,10 @@
+export type { EdgeArrowProps } from './EdgeArrow';
+export { EdgeArrow } from './EdgeArrow';
+export type { EdgeLabelProps } from './EdgeLabel';
+export { EdgeLabel } from './EdgeLabel';
+export type { EdgePathProps } from './EdgePath';
+export { EdgePath } from './EdgePath';
+export type { SegmentDragHandleProps } from './SegmentDragHandle';
+export { SegmentDragHandle } from './SegmentDragHandle';
+export type { WaypointHandleProps } from './WaypointHandle';
+export { WaypointHandle } from './WaypointHandle';

--- a/packages/apollo-react/src/canvas/components/Edges/shared/resolveEdgeColor.test.ts
+++ b/packages/apollo-react/src/canvas/components/Edges/shared/resolveEdgeColor.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import { EDGE_COLORS } from './constants';
+import { resolveEdgeColor } from './resolveEdgeColor';
+
+const STATUS = 'var(--canvas-info-icon)';
+
+/**
+ * Locks the color priority the legacy SequenceEdge implemented inline:
+ * diff > invalid > preview/selected > hover > status > default.
+ */
+describe('resolveEdgeColor', () => {
+  it('returns the default border color with no state', () => {
+    expect(resolveEdgeColor({})).toBe(EDGE_COLORS.default);
+  });
+
+  it('diffAdded wins over everything', () => {
+    expect(
+      resolveEdgeColor({
+        isDiffAdded: true,
+        isDiffRemoved: true,
+        isInvalid: true,
+        previewEdge: true,
+        selected: true,
+        isHovered: true,
+        statusColor: STATUS,
+      })
+    ).toBe(EDGE_COLORS.diffAdded);
+  });
+
+  it('diffRemoved wins over invalid/selection/hover/status', () => {
+    expect(
+      resolveEdgeColor({
+        isDiffRemoved: true,
+        isInvalid: true,
+        previewEdge: true,
+        selected: true,
+        isHovered: true,
+        statusColor: STATUS,
+      })
+    ).toBe(EDGE_COLORS.diffRemoved);
+  });
+
+  it('invalid wins over selection/hover/status', () => {
+    expect(
+      resolveEdgeColor({ isInvalid: true, selected: true, isHovered: true, statusColor: STATUS })
+    ).toBe(EDGE_COLORS.invalid);
+  });
+
+  it('preview and selected resolve to the primary color over hover and status', () => {
+    expect(resolveEdgeColor({ previewEdge: true, isHovered: true, statusColor: STATUS })).toBe(
+      EDGE_COLORS.selected
+    );
+    expect(resolveEdgeColor({ selected: true, isHovered: true, statusColor: STATUS })).toBe(
+      EDGE_COLORS.selected
+    );
+  });
+
+  it('hover wins over status', () => {
+    expect(resolveEdgeColor({ isHovered: true, statusColor: STATUS })).toBe(EDGE_COLORS.hover);
+  });
+
+  it('status color applies when nothing overrides it', () => {
+    expect(resolveEdgeColor({ statusColor: STATUS })).toBe(STATUS);
+  });
+});

--- a/packages/apollo-react/src/canvas/components/Edges/shared/resolveEdgeColor.ts
+++ b/packages/apollo-react/src/canvas/components/Edges/shared/resolveEdgeColor.ts
@@ -1,0 +1,27 @@
+import { EDGE_COLORS } from './constants';
+
+export type EdgeColorState = {
+  selected?: boolean;
+  isHovered?: boolean;
+  isInvalid?: boolean;
+  isDiffAdded?: boolean;
+  isDiffRemoved?: boolean;
+  /** True when the edge represents a transient connection preview. */
+  previewEdge?: boolean;
+  /** Optional execution status color override (already resolved to a CSS var). */
+  statusColor?: string;
+};
+
+/** Priority: diff > invalid > preview/selected > hover > status > default. */
+export function resolveEdgeColor(state: EdgeColorState): string {
+  const { selected, isHovered, isInvalid, isDiffAdded, isDiffRemoved, previewEdge, statusColor } =
+    state;
+
+  if (isDiffAdded) return EDGE_COLORS.diffAdded;
+  if (isDiffRemoved) return EDGE_COLORS.diffRemoved;
+  if (isInvalid) return EDGE_COLORS.invalid;
+  if (previewEdge || selected) return EDGE_COLORS.selected;
+  if (isHovered) return EDGE_COLORS.hover;
+  if (statusColor) return statusColor;
+  return EDGE_COLORS.default;
+}

--- a/packages/apollo-react/src/canvas/components/Edges/shared/routing/defaultEdgeRouter.ts
+++ b/packages/apollo-react/src/canvas/components/Edges/shared/routing/defaultEdgeRouter.ts
@@ -1,0 +1,32 @@
+import { calculateAutoWaypoints } from '../geometry';
+import type { EdgeRouter, RoutedEdge, RouteRequest } from './types';
+
+/**
+ * Per-edge naive router — independent orthogonal routing for each edge with
+ * no obstacle awareness. Equivalent to CanvasEdge's built-in fallback when no
+ * waypoints exist. Useful as a baseline implementation, a starting point for
+ * custom routers, or to satisfy the EdgeRouter contract without external deps.
+ *
+ * IDs are deterministic (`${edgeId}-r${i}`), so repeated calls with identical
+ * positions produce value-equal waypoints (fresh objects each call) — which
+ * keeps the `waypointsPositionallyEqual` write-guard stable and makes test
+ * assertions predictable.
+ */
+export const defaultEdgeRouter: EdgeRouter = {
+  route(req: RouteRequest): RoutedEdge[] {
+    return req.edges.map((edge) => {
+      const points = calculateAutoWaypoints(
+        edge.source.x,
+        edge.source.y,
+        edge.source.position,
+        edge.target.x,
+        edge.target.y,
+        edge.target.position
+      );
+      return {
+        edgeId: edge.edgeId,
+        waypoints: points.map((p, i) => ({ id: `${edge.edgeId}-r${i}`, x: p.x, y: p.y })),
+      };
+    });
+  },
+};

--- a/packages/apollo-react/src/canvas/components/Edges/shared/routing/index.ts
+++ b/packages/apollo-react/src/canvas/components/Edges/shared/routing/index.ts
@@ -1,0 +1,10 @@
+export { defaultEdgeRouter } from './defaultEdgeRouter';
+export type {
+  EdgeRouter,
+  RouteAnchor,
+  RoutedEdge,
+  RouteEdgeRequest,
+  RouteNodeRequest,
+  RouteRequest,
+} from './types';
+export { defaultIsRoutable, useGraphRouter } from './useGraphRouter';

--- a/packages/apollo-react/src/canvas/components/Edges/shared/routing/types.ts
+++ b/packages/apollo-react/src/canvas/components/Edges/shared/routing/types.ts
@@ -1,0 +1,48 @@
+import type { Position } from '@uipath/apollo-react/canvas/xyflow/react';
+import type { Waypoint } from '../types';
+
+/** Per-edge anchor point. Coordinates are absolute canvas coords. */
+export type RouteAnchor = {
+  nodeId: string;
+  handleId?: string | null;
+  x: number;
+  y: number;
+  position: Position;
+};
+
+/** A single edge as seen by the router. */
+export type RouteEdgeRequest = {
+  edgeId: string;
+  source: RouteAnchor;
+  target: RouteAnchor;
+};
+
+/** A node as seen by the router. Width/height let routers do obstacle avoidance. */
+export type RouteNodeRequest = {
+  id: string;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+};
+
+export type RouteRequest = {
+  edges: RouteEdgeRequest[];
+  nodes: RouteNodeRequest[];
+};
+
+export type RoutedEdge = {
+  edgeId: string;
+  /** Intermediate waypoints (excluding source/target endpoints). */
+  waypoints: Waypoint[];
+};
+
+/**
+ * Pluggable router contract. Per-edge routers ignore `req.nodes`; obstacle-aware
+ * routers (ELK, dagre, custom) consume the full graph. Implementations may be
+ * synchronous (return RoutedEdge[] directly) or asynchronous (return a Promise,
+ * for routers running in a worker).
+ */
+export interface EdgeRouter {
+  route(req: RouteRequest): RoutedEdge[] | Promise<RoutedEdge[]>;
+}

--- a/packages/apollo-react/src/canvas/components/Edges/shared/routing/useGraphRouter.test.tsx
+++ b/packages/apollo-react/src/canvas/components/Edges/shared/routing/useGraphRouter.test.tsx
@@ -1,0 +1,144 @@
+import { render, waitFor } from '@testing-library/react';
+import {
+  type Edge,
+  type Node,
+  ReactFlowProvider,
+  useEdges,
+} from '@uipath/apollo-react/canvas/xyflow/react';
+import { describe, expect, it, vi } from 'vitest';
+
+// The global canvas test setup stubs React Flow out entirely; this hook is
+// store-orchestration logic, so it needs the real provider/store/subscription.
+vi.unmock('@uipath/apollo-react/canvas/xyflow/react');
+
+import type { CanvasEdgeData } from '../types';
+import type { EdgeRouter, RouteRequest } from './types';
+import { useGraphRouter } from './useGraphRouter';
+
+const nodes: Node[] = [
+  { id: 'a', position: { x: 0, y: 0 }, width: 100, height: 40, data: {} },
+  { id: 'b', position: { x: 300, y: 0 }, width: 100, height: 40, data: {} },
+];
+
+function makeEdge(id: string, data: CanvasEdgeData = {}): Edge {
+  return { id, source: 'a', target: 'b', data };
+}
+
+/** An edge that opted into graph routing (`routing: 'waypoint'` declared). */
+function makeRoutableEdge(id: string, data: CanvasEdgeData = {}): Edge {
+  return makeEdge(id, { routing: 'waypoint', ...data });
+}
+
+/** Routes every requested edge through one fixed bend, recording requests. */
+function makeRecordingRouter() {
+  const requests: RouteRequest[] = [];
+  const router: EdgeRouter = {
+    route(request) {
+      requests.push(request);
+      return request.edges.map((edge) => ({
+        edgeId: edge.edgeId,
+        waypoints: [{ id: `${edge.edgeId}-r0`, x: 200, y: 100 }],
+      }));
+    },
+  };
+  return { router, requests };
+}
+
+function Probe({ router, latestEdges }: { router: EdgeRouter; latestEdges: { current: Edge[] } }) {
+  useGraphRouter(router);
+  latestEdges.current = useEdges();
+  return null;
+}
+
+function renderRouter(initialEdges: Edge[], router: EdgeRouter) {
+  const latestEdges = { current: initialEdges };
+  render(
+    // defaultNodes/defaultEdges (not initial*) make the store own the elements,
+    // so the hook's setEdges writes land instead of no-opping as "controlled".
+    <ReactFlowProvider defaultNodes={nodes} defaultEdges={initialEdges}>
+      <Probe router={router} latestEdges={latestEdges} />
+    </ReactFlowProvider>
+  );
+  return latestEdges;
+}
+
+describe('useGraphRouter', () => {
+  it('routes only opted-in edges — handle, manual-waypoint, and undeclared edges are excluded', async () => {
+    const { router, requests } = makeRecordingRouter();
+    renderRouter(
+      [
+        makeRoutableEdge('routable'),
+        makeEdge('preset', { routing: 'handle' }),
+        makeRoutableEdge('manual', { waypoints: [{ id: 'w1', x: 150, y: 50 }] }),
+        // SequenceEdge at the store level: its preset applies routing: 'handle'
+        // at render time only, so store data carries no routing field. Routing
+        // is opt-in precisely so edges like this are never touched.
+        makeEdge('sequenceLike', { enableExecution: true }),
+      ],
+      router
+    );
+
+    await waitFor(() => expect(requests.length).toBeGreaterThan(0));
+    expect(requests[0]!.edges.map((edge) => edge.edgeId)).toEqual(['routable']);
+  });
+
+  it('writes routedWaypoints to routable edges without touching other edge data', async () => {
+    const { router } = makeRecordingRouter();
+    const latest = renderRouter(
+      [makeRoutableEdge('routable'), makeEdge('sequenceLike', { enableExecution: true })],
+      router
+    );
+
+    await waitFor(() => {
+      const routed = latest.current.find((edge) => edge.id === 'routable');
+      expect((routed?.data as CanvasEdgeData).routedWaypoints).toEqual([
+        { id: 'routable-r0', x: 200, y: 100 },
+      ]);
+    });
+    const sequenceLike = latest.current.find((edge) => edge.id === 'sequenceLike');
+    expect('routedWaypoints' in (sequenceLike?.data as CanvasEdgeData)).toBe(false);
+  });
+
+  it('removes stale routedWaypoints when an edge has been taken over manually', async () => {
+    const { router } = makeRecordingRouter();
+    const latest = renderRouter(
+      [
+        makeRoutableEdge('takenOver', {
+          waypoints: [{ id: 'w1', x: 150, y: 50 }],
+          routedWaypoints: [{ id: 'stale', x: 1, y: 2 }],
+        }),
+      ],
+      router
+    );
+
+    await waitFor(() => {
+      const edge = latest.current.find((e) => e.id === 'takenOver');
+      expect('routedWaypoints' in (edge?.data as CanvasEdgeData)).toBe(false);
+    });
+    // the manual waypoints themselves are untouched
+    const edge = latest.current.find((e) => e.id === 'takenOver');
+    expect((edge?.data as CanvasEdgeData).waypoints).toEqual([{ id: 'w1', x: 150, y: 50 }]);
+  });
+
+  it('does not re-run the router in response to its own routedWaypoints write', async () => {
+    const { router, requests } = makeRecordingRouter();
+    const latest = renderRouter([makeRoutableEdge('routable')], router);
+
+    await waitFor(() => {
+      const edge = latest.current.find((e) => e.id === 'routable');
+      expect((edge?.data as CanvasEdgeData).routedWaypoints).toBeDefined();
+    });
+    expect(requests.length).toBe(1);
+  });
+
+  it('never invokes the router when no edge is routable and nothing is stale', async () => {
+    const { router, requests } = makeRecordingRouter();
+    const latest = renderRouter(
+      [makeEdge('p1', { routing: 'handle' }), makeEdge('p2', { enableExecution: true })],
+      router
+    );
+
+    await waitFor(() => expect(latest.current.length).toBe(2));
+    expect(requests.length).toBe(0);
+  });
+});

--- a/packages/apollo-react/src/canvas/components/Edges/shared/routing/useGraphRouter.ts
+++ b/packages/apollo-react/src/canvas/components/Edges/shared/routing/useGraphRouter.ts
@@ -1,0 +1,231 @@
+import {
+  type Edge,
+  type Node,
+  Position,
+  type ReactFlowState,
+  useReactFlow,
+  useStore,
+} from '@uipath/apollo-react/canvas/xyflow/react';
+import { useCallback, useEffect } from 'react';
+import { getNodeDimensions } from '../../../../utils/container';
+import type { CanvasEdgeData } from '../types';
+import { waypointsPositionallyEqual } from '../waypoints';
+import type {
+  EdgeRouter,
+  RoutedEdge,
+  RouteEdgeRequest,
+  RouteNodeRequest,
+  RouteRequest,
+} from './types';
+
+/**
+ * An edge is router-controlled only while it explicitly declares
+ * `routing: 'waypoint'` in its data and the user hasn't taken over with
+ * manual waypoints. Routing is opt-in by design: presets that apply their
+ * routing mode at render time (SequenceEdge sets `routing: 'handle'` in the
+ * component, not in store data) and custom/legacy edge types are
+ * indistinguishable from waypoint edges at the store level, so anything that
+ * doesn't declare itself is left untouched rather than silently polluted
+ * with router output. Note this is stricter than rendering: CanvasEdge
+ * *renders* waypoint routing when `routing` is unset, but is only
+ * router-fed when it declares it.
+ *
+ * The manual-waypoints clause is load-bearing: it is what makes the router
+ * yield to `useWaypointEditor` (which materializes routed points into
+ * `data.waypoints` on the first segment drag) and what arms the stale
+ * `routedWaypoints` cleanup. Custom predicates should compose with it rather
+ * than replace it: `(edge) => defaultIsRoutable(edge) && isMyEdge(edge)`.
+ */
+export function defaultIsRoutable(edge: Edge): boolean {
+  const data = edge.data as CanvasEdgeData | undefined;
+  return data?.routing === 'waypoint' && !data.waypoints?.length;
+}
+
+/**
+ * Subscribes to graph changes, runs the supplied router, and writes the
+ * results back to each edge's `data.routedWaypoints`. Manual `data.waypoints`
+ * always take priority over routed output (CanvasEdge picks manual first).
+ *
+ * Only routable edges are included in requests and written to: by default
+ * those declaring `routing: 'waypoint'` without manual waypoints (see
+ * {@link defaultIsRoutable}; overridable for graphs with their own
+ * discriminator). When an edge leaves router control — the user materialized
+ * manual waypoints, or the predicate changed — its stale `routedWaypoints`
+ * key is removed so render-only routing metadata never leaks into
+ * persistence or undo state.
+ *
+ * The subscription is a fingerprint of the routing-relevant store state (node
+ * geometry, edge connectivity, routability), so selection changes and the
+ * hook's own `routedWaypoints` writes do not re-run the router. Position
+ * changes still re-route at frame rate during a drag. The cleanup flag drops
+ * stale RESULTS, but does NOT abort the router's in-flight work. For
+ * expensive routers (e.g. ELK in a worker), gate routing on `onNodeDragStop`
+ * or wrap the router in a debouncer; otherwise the worker burns CPU on every
+ * superseded request.
+ *
+ * Both `router` and `isRoutable` must be referentially stable (module
+ * constants or memoized) — new identities re-run routing every render.
+ *
+ * Handle positions are approximated as the right edge of the source node
+ * and the left edge of the target node. Routers needing precise handle
+ * locations can introspect React Flow's handle bounds directly.
+ */
+export function useGraphRouter(
+  router: EdgeRouter,
+  isRoutable: (edge: Edge) => boolean = defaultIsRoutable
+): void {
+  const { getNodes, getEdges, setEdges } = useReactFlow();
+  const signature = useStore(
+    useCallback((state: ReactFlowState) => routeSignature(state, isRoutable), [isRoutable])
+  );
+
+  useEffect(() => {
+    // `signature` is the dependency that drives this effect; the store is read
+    // imperatively so the effect doesn't also re-run on unrelated store churn.
+    if (!signature) return;
+
+    let cancelled = false;
+
+    const apply = (routes: RoutedEdge[]) => {
+      if (cancelled) return;
+      const byId = new Map(routes.map((r) => [r.edgeId, r]));
+      setEdges((current) => {
+        // Copy-on-write: drag frames usually reconcile to no change, so only
+        // clone the array once an edge actually differs.
+        let next: Edge[] | null = null;
+        for (let i = 0; i < current.length; i++) {
+          const edge = current[i]!;
+          const reconciled = reconcileEdge(edge, byId, isRoutable);
+          if (reconciled !== edge) {
+            next ??= [...current];
+            next[i] = reconciled;
+          }
+        }
+        return next ?? current;
+      });
+    };
+
+    const edges = getEdges();
+    if (!edges.some(isRoutable)) {
+      // Nothing to route. Reconcile only if some edge still carries stale
+      // router output (it just became manual); otherwise skip the store
+      // dispatch entirely — this is the steady state for handle-routed
+      // graphs, hit on every drag frame.
+      const hasStale = edges.some(
+        (edge) => (edge.data as CanvasEdgeData | undefined)?.routedWaypoints !== undefined
+      );
+      if (hasStale) apply([]);
+      return;
+    }
+
+    const request = buildRequest(getNodes(), edges, isRoutable);
+    if (request.edges.length === 0) {
+      // Routable edges exist but none could be resolved (dangling endpoints).
+      apply([]);
+      return;
+    }
+
+    const result = router.route(request);
+
+    if (result instanceof Promise) {
+      result.then(apply).catch((err) => {
+        if (cancelled) return;
+        console.error('[useGraphRouter] router.route() rejected:', err);
+      });
+    } else {
+      apply(result);
+    }
+
+    return () => {
+      cancelled = true;
+    };
+  }, [signature, router, isRoutable, getNodes, getEdges, setEdges]);
+}
+
+/**
+ * One edge's reconcile step: strip stale router output from edges that left
+ * router control, write fresh routed waypoints when positions changed, and
+ * return the same reference when nothing needs to happen.
+ */
+function reconcileEdge(
+  edge: Edge,
+  routesById: Map<string, RoutedEdge>,
+  isRoutable: (edge: Edge) => boolean
+): Edge {
+  const data = edge.data as CanvasEdgeData | undefined;
+
+  if (!isRoutable(edge)) {
+    if (data?.routedWaypoints === undefined) return edge;
+    // The edge left router control — drop the render-only cache so it can't
+    // be persisted alongside the user's manual waypoints.
+    const { routedWaypoints: _removed, ...rest } = data;
+    return { ...edge, data: rest };
+  }
+
+  const route = routesById.get(edge.id);
+  if (!route) return edge;
+  const prev = data?.routedWaypoints ?? [];
+  // Position-only compare: arbitrary consumer routers may generate fresh ids
+  // each call, so id-aware equality would always miss and the
+  // write→re-render→write cycle would never terminate.
+  if (waypointsPositionallyEqual(prev, route.waypoints)) return edge;
+  return { ...edge, data: { ...edge.data, routedWaypoints: route.waypoints } };
+}
+
+/**
+ * Fingerprint of everything `buildRequest` reads. Excludes selection state and
+ * edge `data` — except each edge's routability, so the transition to/from
+ * manual waypoints triggers a reconcile (routing or cleanup) — and notably
+ * excludes `routedWaypoints`, so the router's own output never re-triggers it.
+ */
+function routeSignature(state: ReactFlowState, isRoutable: (edge: Edge) => boolean): string {
+  let sig = '';
+  for (const node of state.nodes) {
+    const { width, height } = getNodeDimensions(node);
+    sig += `${node.id}:${node.position.x},${node.position.y},${width},${height}|`;
+  }
+  for (const edge of state.edges) {
+    sig += `${edge.id}:${edge.source}/${edge.sourceHandle ?? ''}>${edge.target}/${edge.targetHandle ?? ''}:${isRoutable(edge) ? 'r' : 'm'}|`;
+  }
+  return sig;
+}
+
+function buildRequest(
+  nodes: Node[],
+  edges: Edge[],
+  isRoutable: (edge: Edge) => boolean
+): RouteRequest {
+  const routeNodes: RouteNodeRequest[] = nodes.map((n) => {
+    const { width, height } = getNodeDimensions(n);
+    return { id: n.id, x: n.position.x, y: n.position.y, width, height };
+  });
+  const nodeMap = new Map(routeNodes.map((n) => [n.id, n]));
+
+  const routeEdges: RouteEdgeRequest[] = [];
+  for (const edge of edges) {
+    if (!isRoutable(edge)) continue;
+    const source = nodeMap.get(edge.source);
+    const target = nodeMap.get(edge.target);
+    if (!source || !target) continue;
+
+    routeEdges.push({
+      edgeId: edge.id,
+      source: {
+        nodeId: edge.source,
+        handleId: edge.sourceHandle ?? null,
+        x: source.x + source.width,
+        y: source.y + source.height / 2,
+        position: Position.Right,
+      },
+      target: {
+        nodeId: edge.target,
+        handleId: edge.targetHandle ?? null,
+        x: target.x,
+        y: target.y + target.height / 2,
+        position: Position.Left,
+      },
+    });
+  }
+
+  return { nodes: routeNodes, edges: routeEdges };
+}

--- a/packages/apollo-react/src/canvas/components/Edges/shared/types.ts
+++ b/packages/apollo-react/src/canvas/components/Edges/shared/types.ts
@@ -1,0 +1,96 @@
+import type { Edge, EdgeProps, XYPosition } from '@uipath/apollo-react/canvas/xyflow/react';
+
+export type Point = XYPosition;
+
+export type Waypoint = Point & {
+  id: string;
+};
+
+/**
+ * A point on the rendered path, tagged with provenance. `waypointIndex` is the
+ * index of the stored waypoint this vertex represents, or `-1` for the source/
+ * target anchors and for derived elbows (stub corners, interior orthogonal
+ * joints). Lets the editor map a rendered segment back to the stored waypoints.
+ */
+export type PathVertex = Point & {
+  waypointIndex: number;
+};
+
+export type SegmentOrientation = 'horizontal' | 'vertical';
+
+export type Segment = {
+  id: string;
+  start: Point;
+  end: Point;
+  orientation: SegmentOrientation;
+  /** Index of the waypoint before this segment (-1 for source) */
+  waypointIndexBefore: number;
+  /** Index of the waypoint after this segment (waypoints.length for target) */
+  waypointIndexAfter: number;
+};
+
+export type EdgeStrokeStyle = 'solid' | 'dashed';
+
+/**
+ * Edge routing strategy.
+ *
+ * - `waypoint` — orthogonal segments with optional draggable waypoints.
+ * - `handle`   — smooth-step path resolved from handle positions, including
+ *                support for self-loops and `loopBack` target handles.
+ *
+ * Rendering defaults to `waypoint` when unset, but graph routers
+ * (`useGraphRouter`) only feed edges that declare `'waypoint'` explicitly —
+ * undeclared edges are never written to.
+ */
+export type EdgeRouting = 'waypoint' | 'handle';
+
+/**
+ * Single data shape for the unified canvas edge.
+ *
+ * Visual fields render unconditionally. Behavior fields (`enable*`) gate the
+ * downstream effects of each hook (event listeners, callbacks, animations).
+ * Underlying store subscriptions still run — turning a flag off avoids
+ * listener installs and renders driven by the hook's outputs, not the
+ * subscription itself.
+ */
+export type CanvasEdgeData = {
+  // Visual
+  strokeStyle?: EdgeStrokeStyle;
+  hideArrowHead?: boolean;
+  label?: string | null;
+
+  // Visual state flags
+  isInvalid?: boolean;
+  isDiffAdded?: boolean;
+  isDiffRemoved?: boolean;
+
+  // Routing strategy. Defaults to 'waypoint'.
+  routing?: EdgeRouting;
+
+  // Behavior enablement
+  enableEditing?: boolean;
+  enableExecution?: boolean;
+  enableToolbar?: boolean;
+
+  // Data the editing behavior operates on
+  waypoints?: Waypoint[];
+
+  /**
+   * Pre-computed waypoints from a graph router (see `EdgeRouter`). Used as
+   * the path geometry when no manual `waypoints` are present. Manual edits
+   * always take priority — the moment the user drags a routed segment, the
+   * routed points materialize into `waypoints` and the edge becomes manual.
+   */
+  routedWaypoints?: Waypoint[];
+
+  /**
+   * Controlled-mutation callback. When present, the editor calls this instead
+   * of writing to React Flow state — the consumer is responsible for
+   * persisting the new waypoints (e.g., to enable undo/redo, debouncing,
+   * server sync, or validation rejection). When absent, the editor mutates
+   * `setEdges` directly (uncontrolled mode).
+   */
+  onWaypointsChange?: (next: Waypoint[]) => void;
+};
+
+export type CanvasEdgeProps = EdgeProps<Edge<CanvasEdgeData>>;

--- a/packages/apollo-react/src/canvas/components/Edges/shared/waypoints.test.ts
+++ b/packages/apollo-react/src/canvas/components/Edges/shared/waypoints.test.ts
@@ -1,0 +1,206 @@
+import { Position } from '@uipath/apollo-react/canvas/xyflow/react';
+import { describe, expect, it } from 'vitest';
+import type { PathVertex, Point, Segment, Waypoint } from './types';
+import {
+  insertWaypoint,
+  materializePathWaypoints,
+  moveSegmentByDelta,
+  moveWaypoint,
+  type RebalanceEndpoint,
+  rebalanceWaypoints,
+  removeWaypoint,
+  waypointsEqual,
+  waypointsPositionallyEqual,
+} from './waypoints';
+
+const wp = (id: string, x: number, y: number): Waypoint => ({ id, x, y });
+const vertex = (x: number, y: number, waypointIndex = -1): PathVertex => ({ x, y, waypointIndex });
+
+// start, stub, user waypoint(0), stub, end — one waypoint flanked by derived stubs.
+const VERTICES_WITH_STUBS: PathVertex[] = [
+  vertex(0, 0),
+  vertex(50, 0),
+  vertex(50, 50, 0),
+  vertex(50, 100),
+  vertex(0, 100),
+];
+
+describe('materializePathWaypoints', () => {
+  it('promotes every interior vertex to a waypoint, minting ids for derived points', () => {
+    const result = materializePathWaypoints(VERTICES_WITH_STUBS, [wp('kept', 50, 50)]);
+    // 3 interior vertices (two stubs + the waypoint) become 3 waypoints.
+    expect(result).toHaveLength(3);
+    expect(result.map((p) => ({ x: p.x, y: p.y }))).toEqual([
+      { x: 50, y: 0 },
+      { x: 50, y: 50 },
+      { x: 50, y: 100 },
+    ]);
+  });
+
+  it('preserves the id (and object) of real waypoints', () => {
+    const stored = wp('kept', 50, 50);
+    const result = materializePathWaypoints(VERTICES_WITH_STUBS, [stored]);
+    expect(result[1]).toBe(stored);
+    // Derived points get fresh generated ids.
+    expect(result[0]!.id).not.toBe('kept');
+    expect(result[0]!.id).toMatch(/^wp-/);
+  });
+});
+
+describe('insertWaypoint', () => {
+  it('materializes the path and splices the new waypoint into the segment', () => {
+    const result = insertWaypoint(VERTICES_WITH_STUBS, [wp('kept', 50, 50)], 1, { x: 60, y: 60 });
+    // 3 materialized + 1 inserted.
+    expect(result).toHaveLength(4);
+    // New waypoint lands at segment index 1, grid-snapped (GRID_SPACING = 16).
+    expect(result[1]).toMatchObject({ x: 64, y: 64 });
+    expect(result[1]!.id).toMatch(/^wp-/);
+  });
+});
+
+describe('moveWaypoint', () => {
+  it('moves only the targeted waypoint and snaps it to the grid', () => {
+    const result = moveWaypoint([wp('a', 0, 0), wp('b', 100, 100)], 1, { x: 137, y: 7 });
+    expect(result[0]).toEqual(wp('a', 0, 0));
+    expect(result[1]).toMatchObject({ id: 'b', x: 144, y: 0 });
+  });
+});
+
+describe('removeWaypoint', () => {
+  it('drops the waypoint at the given index', () => {
+    const result = removeWaypoint([wp('a', 0, 0), wp('b', 1, 1), wp('c', 2, 2)], 1);
+    expect(result.map((w) => w.id)).toEqual(['a', 'c']);
+  });
+});
+
+describe('waypointsEqual / waypointsPositionallyEqual', () => {
+  it('id-aware equality distinguishes different ids at the same position', () => {
+    expect(waypointsEqual([wp('a', 0, 0)], [wp('a', 0, 0)])).toBe(true);
+    expect(waypointsEqual([wp('a', 0, 0)], [wp('b', 0, 0)])).toBe(false);
+  });
+
+  it('position-only equality ignores ids', () => {
+    expect(waypointsPositionallyEqual([wp('a', 0, 0)], [wp('b', 0, 0)])).toBe(true);
+    expect(waypointsPositionallyEqual([wp('a', 0, 0)], [wp('a', 0, 1)])).toBe(false);
+  });
+});
+
+describe('rebalanceWaypoints', () => {
+  const fixedSource = (p: Point): RebalanceEndpoint => ({
+    position: Position.Right,
+    from: p,
+    to: p,
+  });
+  const fixedTarget = (p: Point): RebalanceEndpoint => ({
+    position: Position.Left,
+    from: p,
+    to: p,
+  });
+
+  it('moves only the adjacent waypoint, on the cross-axis, when the target moves (B2-above-A2)', () => {
+    const result = rebalanceWaypoints(
+      [wp('wp-1', 300, 328), wp('wp-2', 300, 428)],
+      fixedSource({ x: 196, y: 328 }),
+      // target (Left face → cross-axis is y) dragged up from y=428 to y=148.
+      { position: Position.Left, from: { x: 500, y: 428 }, to: { x: 500, y: 148 } }
+    );
+    // wp-1 (adjacent to the still source) untouched; wp-2 tracks target on y,
+    // x fixed.
+    expect(result).toEqual([
+      { id: 'wp-1', x: 300, y: 328 },
+      { id: 'wp-2', x: 300, y: 148 },
+    ]);
+  });
+
+  it('leaves interior waypoints untouched', () => {
+    const result = rebalanceWaypoints(
+      [wp('a', 300, 328), wp('b', 300, 428), wp('c', 400, 428)],
+      // source (Right face) dragged up 78px; target unchanged.
+      { position: Position.Right, from: { x: 196, y: 328 }, to: { x: 196, y: 250 } },
+      fixedTarget({ x: 500, y: 428 })
+    );
+    // Only the first waypoint shifts on y; b and c are byte-identical.
+    expect(result[0]).toEqual({ id: 'a', x: 300, y: 250 });
+    expect(result[1]).toEqual({ id: 'b', x: 300, y: 428 });
+    expect(result[2]).toEqual({ id: 'c', x: 400, y: 428 });
+  });
+
+  it('shifts on x for a vertical (top/bottom) face', () => {
+    const result = rebalanceWaypoints(
+      [wp('a', 100, 300)],
+      // source bottom face → cross-axis is x; moved +60 on x.
+      { position: Position.Bottom, from: { x: 100, y: 100 }, to: { x: 160, y: 100 } },
+      fixedTarget({ x: 100, y: 600 })
+    );
+    expect(result[0]).toEqual({ id: 'a', x: 160, y: 300 });
+  });
+
+  it('is a no-op when neither node moves', () => {
+    const result = rebalanceWaypoints(
+      [wp('a', 300, 250)],
+      fixedSource({ x: 100, y: 100 }),
+      fixedTarget({ x: 500, y: 400 })
+    );
+    expect(result).toEqual([{ id: 'a', x: 300, y: 250 }]);
+  });
+
+  it('translates the whole route when both endpoints move by the same delta (group move)', () => {
+    const result = rebalanceWaypoints(
+      [wp('a', 300, 328), wp('b', 350, 428)],
+      { position: Position.Right, from: { x: 196, y: 328 }, to: { x: 256, y: 378 } },
+      { position: Position.Left, from: { x: 500, y: 428 }, to: { x: 560, y: 478 } }
+    );
+    // Same (+60,+50) delta on both ends → every waypoint translates, interior
+    // bends included, preserving the shape exactly.
+    expect(result).toEqual([
+      { id: 'a', x: 360, y: 378 },
+      { id: 'b', x: 410, y: 478 },
+    ]);
+  });
+
+  it('translates a lone waypoint once on a group move (no double-apply)', () => {
+    const result = rebalanceWaypoints(
+      [wp('a', 300, 250)],
+      { position: Position.Right, from: { x: 100, y: 100 }, to: { x: 140, y: 140 } },
+      { position: Position.Left, from: { x: 500, y: 400 }, to: { x: 540, y: 440 } }
+    );
+    // +40 on each axis applied once — not 2x on y.
+    expect(result).toEqual([{ id: 'a', x: 340, y: 290 }]);
+  });
+
+  it('leaves a lone waypoint fixed when both endpoints move differently (conflict)', () => {
+    const result = rebalanceWaypoints(
+      [wp('a', 300, 250)],
+      { position: Position.Right, from: { x: 100, y: 100 }, to: { x: 100, y: 150 } },
+      { position: Position.Left, from: { x: 500, y: 400 }, to: { x: 500, y: 370 } }
+    );
+    // Conflicting cross-axis deltas (+50 vs -30) → keep central intent, don't
+    // double-shift; derived terminal elbows absorb the difference.
+    expect(result).toEqual([{ id: 'a', x: 300, y: 250 }]);
+  });
+});
+
+describe('moveSegmentByDelta', () => {
+  it('translates a middle segment by moving both its endpoint waypoints', () => {
+    // Path: source → w0 → w1 → w2 → target, all materialized.
+    const waypoints = [wp('w0', 50, 0), wp('w1', 50, 100), wp('w2', 150, 100)];
+    // Segment between w0 and w1 (vertical) — indices into the interior list.
+    const segment: Segment = {
+      id: 'seg-2',
+      start: { x: 50, y: 0 },
+      end: { x: 50, y: 100 },
+      orientation: 'vertical',
+      waypointIndexBefore: 0,
+      waypointIndexAfter: 1,
+    };
+    const pathPoints = [{ x: 0, y: 0 }, ...waypoints, { x: 200, y: 100 }];
+    const result = moveSegmentByDelta(waypoints, segment, { x: 16, y: 0 }, pathPoints);
+
+    // A vertical segment moves along x; both endpoints shift to the snapped x
+    // (50 + 16 = 66 → snapped to the nearest grid line, 64).
+    const w0 = result.find((w) => w.id === 'w0');
+    const w1 = result.find((w) => w.id === 'w1');
+    expect(w0?.x).toBe(64);
+    expect(w1?.x).toBe(64);
+  });
+});

--- a/packages/apollo-react/src/canvas/components/Edges/shared/waypoints.ts
+++ b/packages/apollo-react/src/canvas/components/Edges/shared/waypoints.ts
@@ -1,0 +1,272 @@
+import type { Position } from '@uipath/apollo-react/canvas/xyflow/react';
+import { snapToGrid } from '../../../utils/NodeUtils';
+import { EDGE_CONSTANTS } from './constants';
+import { consolidateWaypoints, isHorizontalPosition, snapPointToGrid } from './geometry';
+import type { PathVertex, Point, Segment, Waypoint } from './types';
+
+/**
+ * Promote the path's interior vertices (waypoints + derived stub/elbow points)
+ * to a concrete waypoint list, preserving the ids of real waypoints and
+ * minting fresh ids for derived points. Called when the user grabs a segment
+ * so segment math operates on a clean 1:1 path — and the derived elbows the
+ * user is now editing become real, draggable waypoints. The result is index-
+ * aligned with the segment indices from {@link extractSegments}.
+ */
+export function materializePathWaypoints(vertices: PathVertex[], stored: Waypoint[]): Waypoint[] {
+  return vertices.slice(1, -1).map((vertex) => {
+    const existing = vertex.waypointIndex >= 0 ? stored[vertex.waypointIndex] : undefined;
+    return existing ?? { id: generateWaypointId(), x: vertex.x, y: vertex.y };
+  });
+}
+
+export function generateWaypointId(): string {
+  return `wp-${crypto.randomUUID()}`;
+}
+
+/**
+ * True when two waypoint arrays describe the same path (id + position). Used
+ * by the editor to short-circuit no-op drag ticks where snap-rounding produced
+ * the same coordinates.
+ */
+export function waypointsEqual(a: Waypoint[], b: Waypoint[]): boolean {
+  if (a === b) return true;
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    const wa = a[i]!;
+    const wb = b[i]!;
+    if (wa.x !== wb.x || wa.y !== wb.y || wa.id !== wb.id) return false;
+  }
+  return true;
+}
+
+/**
+ * Position-only equality. Routers generate fresh ids on every call, so the
+ * graph-router orchestration uses this to break the write→re-render→write
+ * feedback loop when computed positions haven't actually changed.
+ */
+export function waypointsPositionallyEqual(a: Waypoint[], b: Waypoint[]): boolean {
+  if (a === b) return true;
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    if (a[i]!.x !== b[i]!.x || a[i]!.y !== b[i]!.y) return false;
+  }
+  return true;
+}
+
+/**
+ * Insert a waypoint into the segment at `segmentIndex`. The path's interior
+ * vertices (including derived stubs/elbows) are first materialized into a
+ * concrete waypoint list, then the new waypoint is spliced into that segment —
+ * so insertion lands at the right spot regardless of derived points, and the
+ * surrounding stubs become real waypoints alongside it.
+ */
+export function insertWaypoint(
+  vertices: PathVertex[],
+  stored: Waypoint[],
+  segmentIndex: number,
+  position: Point
+): Waypoint[] {
+  const newWaypoint: Waypoint = {
+    id: generateWaypointId(),
+    ...snapPointToGrid(position),
+  };
+
+  const materialized = materializePathWaypoints(vertices, stored);
+  materialized.splice(Math.max(0, segmentIndex), 0, newWaypoint);
+  return materialized;
+}
+
+export function removeWaypoint(waypoints: Waypoint[], index: number): Waypoint[] {
+  return waypoints.filter((_, i) => i !== index);
+}
+
+/** An edge endpoint for rebalancing: which face it attaches to, plus the anchor
+ * position at drag start (`from`) and now (`to`). */
+export type RebalanceEndpoint = {
+  position: Position;
+  from: Point;
+  to: Point;
+};
+
+/** Movement below this (px) on both axes is treated as "did not move". */
+const REBALANCE_EPSILON = 0.5;
+
+/**
+ * Reposition waypoints to follow a node drag (see ALGORITHM.md §9). Three cases:
+ *
+ * - **Group move** — both endpoints moved by ~the same delta → translate the
+ *   whole route by it, preserving the shape exactly (§9.7).
+ * - **Single waypoint** — it is both first and last, so apply only the endpoint
+ *   that actually moved; if both moved differently it is left as the user's
+ *   central intent (derived terminal elbows absorb the difference) rather than
+ *   double-shifted (§9.9).
+ * - **Otherwise** — the first waypoint tracks the source and the last tracks the
+ *   target, each on the axis perpendicular to that node's face (the cross-axis);
+ *   interior waypoints stay fixed (§9.3/§9.5/§9.8).
+ *
+ * Shifts are by the node's cross-axis delta, so any intentional offset between a
+ * waypoint and its node is preserved. Ids are preserved.
+ */
+export function rebalanceWaypoints(
+  waypoints: Waypoint[],
+  source: RebalanceEndpoint,
+  target: RebalanceEndpoint
+): Waypoint[] {
+  if (waypoints.length === 0) return waypoints;
+
+  const sourceDelta = delta(source);
+  const targetDelta = delta(target);
+
+  // Group move: both endpoints moved together → translate the whole route.
+  if (isMoved(sourceDelta) && deltasEqual(sourceDelta, targetDelta)) {
+    return waypoints.map((w) => ({ id: w.id, x: w.x + sourceDelta.x, y: w.y + sourceDelta.y }));
+  }
+
+  const next = waypoints.map((w) => ({ ...w }));
+
+  if (next.length === 1) {
+    // A lone waypoint is adjacent to both ends. Apply only the endpoint that
+    // moved; if both moved (differently — group move is handled above) leave it
+    // alone so it isn't double-shifted.
+    const sourceMoved = isMoved(sourceDelta);
+    const targetMoved = isMoved(targetDelta);
+    if (sourceMoved && !targetMoved) shiftAdjacentWaypoint(next[0]!, source);
+    else if (targetMoved && !sourceMoved) shiftAdjacentWaypoint(next[0]!, target);
+    return next;
+  }
+
+  shiftAdjacentWaypoint(next[0]!, source);
+  shiftAdjacentWaypoint(next[next.length - 1]!, target);
+  return next;
+}
+
+function delta(endpoint: RebalanceEndpoint): Point {
+  return { x: endpoint.to.x - endpoint.from.x, y: endpoint.to.y - endpoint.from.y };
+}
+
+function isMoved(d: Point): boolean {
+  return Math.abs(d.x) >= REBALANCE_EPSILON || Math.abs(d.y) >= REBALANCE_EPSILON;
+}
+
+function deltasEqual(a: Point, b: Point): boolean {
+  return Math.abs(a.x - b.x) < REBALANCE_EPSILON && Math.abs(a.y - b.y) < REBALANCE_EPSILON;
+}
+
+/** Shift a waypoint by the endpoint's delta on the cross-axis only (the axis
+ * perpendicular to the node's face). */
+function shiftAdjacentWaypoint(waypoint: Waypoint, endpoint: RebalanceEndpoint): void {
+  if (isHorizontalPosition(endpoint.position)) {
+    waypoint.y += endpoint.to.y - endpoint.from.y;
+  } else {
+    waypoint.x += endpoint.to.x - endpoint.from.x;
+  }
+}
+
+export function moveWaypoint(waypoints: Waypoint[], index: number, newPosition: Point): Waypoint[] {
+  const snapped = snapPointToGrid(newPosition);
+  return waypoints.map((wp, i) => (i === index ? { ...wp, ...snapped } : wp));
+}
+
+/**
+ * Translate a segment along its perpendicular axis by `delta`. When the
+ * segment is anchored to source or target, two stub waypoints are inserted
+ * to preserve the smooth-step shape.
+ *
+ * `initialWaypoints` and `initialSegment` should already be materialized via
+ * {@link materializePathWaypoints} at drag start to avoid ID churn during drag.
+ */
+export function moveSegmentByDelta(
+  initialWaypoints: Waypoint[],
+  initialSegment: Segment,
+  delta: Point,
+  initialPathPoints: Point[]
+): Waypoint[] {
+  const moveAxis = initialSegment.orientation === 'horizontal' ? 'y' : 'x';
+  const moveValue = moveAxis === 'y' ? delta.y : delta.x;
+
+  const working: Waypoint[] = initialWaypoints.map((wp) => ({ ...wp }));
+
+  const isConnectedToSource = initialSegment.waypointIndexBefore < 0;
+  const isConnectedToTarget = initialSegment.waypointIndexAfter >= working.length;
+
+  let insertedAtStart = false;
+  const stubOffset = EDGE_CONSTANTS.STUB_OFFSET;
+  const orientation = initialSegment.orientation;
+
+  const segmentStart = initialSegment.start;
+  const segmentEnd = initialSegment.end;
+  const pathSource = initialPathPoints[0]!;
+  const pathTarget = initialPathPoints[initialPathPoints.length - 1]!;
+
+  const movedCoordinate =
+    orientation === 'horizontal'
+      ? snapToGrid(segmentStart.y + moveValue)
+      : snapToGrid(segmentStart.x + moveValue);
+
+  if (isConnectedToSource) {
+    const stubCoord = snapToGrid(
+      (orientation === 'horizontal' ? segmentStart.x : segmentStart.y) + stubOffset
+    );
+    const [anchorStub, movedStub] = makeStubPair(
+      segmentStart,
+      orientation,
+      stubCoord,
+      movedCoordinate
+    );
+    working.unshift(anchorStub, movedStub);
+    insertedAtStart = true;
+  }
+
+  if (isConnectedToTarget) {
+    const stubCoord = snapToGrid(
+      (orientation === 'horizontal' ? segmentEnd.x : segmentEnd.y) - stubOffset
+    );
+    const [anchorStub, movedStub] = makeStubPair(
+      segmentEnd,
+      orientation,
+      stubCoord,
+      movedCoordinate
+    );
+    working.push(movedStub, anchorStub);
+  }
+
+  const indexOffset = insertedAtStart ? 2 : 0;
+
+  if (!isConnectedToSource && initialSegment.waypointIndexBefore >= 0) {
+    const idx = initialSegment.waypointIndexBefore + indexOffset;
+    const wp = working[idx];
+    if (wp) wp[moveAxis] = movedCoordinate;
+  }
+
+  if (!isConnectedToTarget && initialSegment.waypointIndexAfter < initialWaypoints.length) {
+    const idx = initialSegment.waypointIndexAfter + indexOffset;
+    const wp = working[idx];
+    if (wp) wp[moveAxis] = movedCoordinate;
+  }
+
+  return consolidateWaypoints(working, pathSource, pathTarget);
+}
+
+/**
+ * Two stub waypoints preserving the smooth-step shape where a dragged segment
+ * meets a node anchor: one on the segment's original line at `stubCoord` (the
+ * along-axis coordinate next to the anchor), one shifted to `movedCoordinate`
+ * on the perpendicular axis.
+ */
+function makeStubPair(
+  anchor: Point,
+  orientation: Segment['orientation'],
+  stubCoord: number,
+  movedCoordinate: number
+): [Waypoint, Waypoint] {
+  if (orientation === 'horizontal') {
+    return [
+      { id: generateWaypointId(), x: stubCoord, y: anchor.y },
+      { id: generateWaypointId(), x: stubCoord, y: movedCoordinate },
+    ];
+  }
+  return [
+    { id: generateWaypointId(), x: anchor.x, y: stubCoord },
+    { id: generateWaypointId(), x: movedCoordinate, y: stubCoord },
+  ];
+}

--- a/packages/apollo-react/src/canvas/components/Flow.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/Flow.stories.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import type { Edge, Node, NodeProps } from '@uipath/apollo-react/canvas/xyflow/react';
+import type { Edge, EdgeTypes, Node, NodeProps } from '@uipath/apollo-react/canvas/xyflow/react';
 import { Handle, Panel, Position, useReactFlow } from '@uipath/apollo-react/canvas/xyflow/react';
 import { Download, Plus, StickyNote } from 'lucide-react';
 import { type FC, memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
@@ -18,6 +18,8 @@ import { showPreviewGraph } from '../utils/createPreviewGraph';
 import { AddNodeManager, AddNodePanel } from './AddNodePanel';
 import { BaseCanvas } from './BaseCanvas';
 import type { BaseNodeData } from './BaseNode/BaseNode.types';
+import type { CanvasEdgeProps } from './Edges';
+import { CanvasEdge } from './Edges';
 import { FloatingCanvasPanel } from './FloatingCanvasPanel';
 import { StickyNoteNode } from './StickyNoteNode';
 import type { StickyNoteData } from './StickyNoteNode/StickyNoteNode.types';
@@ -29,6 +31,7 @@ import type { ListItem } from './Toolbox';
 
 interface FlowStoryArgs {
   useSmartHandles: boolean;
+  useCanvasEdge: boolean;
 }
 
 const meta: Meta<FlowStoryArgs> = {
@@ -46,9 +49,18 @@ const meta: Meta<FlowStoryArgs> = {
         defaultValue: { summary: 'false' },
       },
     },
+    useCanvasEdge: {
+      control: 'boolean',
+      description:
+        'Render edges with the new orthogonal CanvasEdge (draggable waypoints) instead of SequenceEdge',
+      table: {
+        defaultValue: { summary: 'false' },
+      },
+    },
   },
   args: {
     useSmartHandles: false,
+    useCanvasEdge: false,
   },
 };
 
@@ -164,7 +176,16 @@ const additionalNodeTypes = {
   stickyNote: StickyNoteNode,
 };
 
-function DefaultStory({ useSmartHandles }: FlowStoryArgs) {
+// Preset wrapper following the SequenceEdge pattern: editing defaults ON for
+// edges of this type (per-edge `data.enableEditing` still wins, matching how
+// presets layer defaults), so no per-edge store state needs to be patched and
+// newly connected edges pick it up automatically.
+function EditableCanvasEdge(props: CanvasEdgeProps) {
+  const data = useMemo(() => ({ enableEditing: true, ...props.data }), [props.data]);
+  return <CanvasEdge {...props} data={data} />;
+}
+
+function DefaultStory({ useSmartHandles, useCanvasEdge }: FlowStoryArgs) {
   const initialNodes = useMemo(() => createInitialNodes(useSmartHandles), [useSmartHandles]);
   const initialEdges = useMemo(() => createInitialEdges(), []);
   const [stickyNoteCounter, setStickyNoteCounter] = useState(0);
@@ -185,6 +206,17 @@ function DefaultStory({ useSmartHandles }: FlowStoryArgs) {
     initialEdges,
     additionalNodeTypes,
   });
+
+  // Swap the `default` edge renderer for the new CanvasEdge (with editing
+  // enabled via the preset wrapper) when toggled. Edges carry no explicit
+  // `type`, so they resolve to `edgeTypes.default`.
+  const edgeTypes = useMemo<EdgeTypes>(
+    () =>
+      useCanvasEdge
+        ? { ...canvasProps.edgeTypes, default: EditableCanvasEdge }
+        : canvasProps.edgeTypes,
+    [useCanvasEdge, canvasProps.edgeTypes]
+  );
 
   // Update nodes when useSmartHandles changes
   const handleSmartHandlesToggle = useCallback(() => {
@@ -336,6 +368,7 @@ function DefaultStory({ useSmartHandles }: FlowStoryArgs) {
   return (
     <BaseCanvas
       {...canvasProps}
+      edgeTypes={edgeTypes}
       deleteKeyCode={DELETE_KEY_CODES}
       mode="design"
       selectionOnDrag

--- a/packages/apollo-react/src/canvas/hooks/useEdgePath.ts
+++ b/packages/apollo-react/src/canvas/hooks/useEdgePath.ts
@@ -1,6 +1,8 @@
-import { getSmoothStepPath, Position } from '@uipath/apollo-react/canvas/xyflow/react';
+import { getSmoothStepPath, type Position } from '@uipath/apollo-react/canvas/xyflow/react';
 import { useMemo } from 'react';
+import { ARROW_OFFSETS, EDGE_CONSTANTS } from '../components/Edges/shared/constants';
 import { GRID_SPACING } from '../constants';
+import { snapToGrid } from '../utils/NodeUtils';
 
 // Constants
 const LOOP_HEIGHT = GRID_SPACING * 6;
@@ -9,17 +11,8 @@ const LOOP_RIGHT_EXTENSION = GRID_SPACING * 3;
 const LOOP_SUCCESS_RIGHT_EXTENSION = GRID_SPACING * 4;
 const LOOP_LEFT_EXTENSION = GRID_SPACING * 2;
 const LOOP_CORNER_RADIUS = GRID_SPACING;
-const SOURCE_OFFSETS: Record<Position, { x: number; y: number }> = {
-  [Position.Left]: { x: 8, y: 0 },
-  [Position.Right]: { x: -8, y: 0 },
-  [Position.Top]: { x: 0, y: 8 },
-  [Position.Bottom]: { x: 0, y: -8 },
-};
-
-// Helper function to snap a value to the grid
-const snapToGrid = (value: number): number => {
-  return Math.round(value / GRID_SPACING) * GRID_SPACING;
-};
+// Endpoint inset shared with waypoint-routed edges (Edges/shared/constants).
+const SOURCE_OFFSETS = ARROW_OFFSETS;
 
 /**
  * Helper function to create a custom loop path that goes below the node
@@ -155,7 +148,7 @@ export function useEdgePath({
         targetX,
         targetY,
         targetPosition,
-        borderRadius: 16,
+        borderRadius: EDGE_CONSTANTS.BORDER_RADIUS,
       });
     }
 


### PR DESCRIPTION
## Summary

Introduces **`CanvasEdge`** — a single canvas edge component whose behaviors compose via flags on `data` — and refactors **`SequenceEdge`** into a thin, backward-compatible preset on top of it (`routing: 'handle'`, execution + toolbar enabled, legacy `hideToolbar` translated).

### What's new

- **Waypoint routing** (default): orthogonal segments with rounded corners, hover-revealed segment drag handles, double-click to insert/remove waypoints, grid snapping, and waypoint rebalancing while a connected node is dragged. Controlled mode via `onWaypointsChange` for undo/redo or server-side persistence.
- **Shared edge layer**: `EdgePath` / `EdgeArrow` / `EdgeLabel` / handle primitives, geometry + waypoint math (unit-tested), color resolution, and memo comparator extracted from the old SequenceEdge monolith.
- **Pluggable routing**: an `EdgeRouter` contract + `useGraphRouter` orchestration hook. Subscribes via a geometry/connectivity fingerprint, so selection changes and the router's own writes don't re-trigger routing; manual waypoints always take priority over routed output.
- **`animated` support** carried through from main (no `strokeDasharray` override so React Flow's dashdraw CSS applies).
- **Stories**: editing, non-editable, handle routing (the SequenceEdge preset), controlled mode, pluggable router, and execution states (Start → Step → End chains where node + edges share one mocked status, with editing enabled to show behaviors compose).

https://github.com/user-attachments/assets/3b2393e2-75ab-46a7-9362-5ec4f58d9475


### Backward compatibility (SequenceEdge consumers)

API- and behavior-compatible: same props/`data` contract (incl. `hideToolbar`), same path geometry (incl. self-loop/`loopBack`), same execution colors/animations, same toolbar conditions, perf-neutral. Two deliberate visual deltas for reviewers to confirm:

1. **Selected edges render 3px stroke** (was 2px) when no explicit `style.strokeWidth` is set.
2. **`style.strokeDasharray` is no longer honored on diff-removed edges** — they always use the standard `5,5` dash.

Both will show up in visual regression baselines; flag if either should be reverted instead.

## Test plan

- [x] `vitest` canvas suite: 75 files / 1487 tests passing (includes new geometry + waypoint tests)
- [x] `tsc --noEmit` and Biome clean
- [ ] Visual regression run to consciously accept the two deltas above
- [ ] Manual pass over the new Storybook stories (Components/Edges/CanvasEdge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)