### PR TITLE
chore(storybook): update IA + docs background

### DIFF
--- a/apps/storybook/.storybook/DocsContainer.tsx
+++ b/apps/storybook/.storybook/DocsContainer.tsx
@@ -1,0 +1,67 @@
+import { DocsContainer, type DocsContainerProps } from '@storybook/addon-docs/blocks';
+// biome-ignore lint/correctness/noUnusedImports: needed for JSX
+import React, { type PropsWithChildren, useEffect, useState } from 'react';
+import { GLOBALS_UPDATED, SET_GLOBALS } from 'storybook/internal/core-events';
+import { themes } from 'storybook/theming';
+import { ALL_THEMES, DEFAULT_THEME, type ThemeMode } from './themes';
+
+const DARK_THEMES: ThemeMode[] = ['dark', 'dark-hc', 'future-dark', 'vertex', 'canvas'];
+
+/**
+ * Read the current `theme` global off the preview channel. Docs pages have no
+ * story context, so the channel's last globals event is the source of truth.
+ */
+function themeFromChannel(channel: DocsContainerProps['context']['channel']): ThemeMode {
+  const updated = channel.last(GLOBALS_UPDATED)?.[0]?.globals?.theme;
+  const initial = channel.last(SET_GLOBALS)?.[0]?.globals?.theme;
+  const theme = updated ?? initial ?? DEFAULT_THEME;
+  return (ALL_THEMES as string[]).includes(theme) ? (theme as ThemeMode) : DEFAULT_THEME;
+}
+
+/**
+ * Theme-aware docs container.
+ *
+ * Addon-docs paints the docs page background from its own Storybook theme,
+ * which is static by default — so docs pages stayed light regardless of the
+ * Apollo theme selected in the toolbar. This wrapper follows the `theme`
+ * global and:
+ * - passes a matching dark/light docs theme to `DocsContainer`, and
+ * - applies the Apollo theme class to <body> (MDX-only pages render no story,
+ *   so the preview decorator that normally does this never runs there).
+ */
+export const ApolloDocsContainer = ({
+  children,
+  context,
+}: PropsWithChildren<DocsContainerProps>) => {
+  const [theme, setTheme] = useState<ThemeMode>(() => themeFromChannel(context.channel));
+
+  useEffect(() => {
+    const onGlobalsUpdated = ({ globals }: { globals: { theme?: string } }) => {
+      if (globals.theme && (ALL_THEMES as string[]).includes(globals.theme)) {
+        setTheme(globals.theme as ThemeMode);
+      }
+    };
+    context.channel.on(GLOBALS_UPDATED, onGlobalsUpdated);
+    return () => {
+      context.channel.off(GLOBALS_UPDATED, onGlobalsUpdated);
+    };
+  }, [context.channel]);
+
+  // Same body-class contract as the preview decorator (see preview.tsx).
+  useEffect(() => {
+    const body = document.body;
+    body.classList.remove(...ALL_THEMES);
+    body.classList.add(theme);
+    return () => {
+      body.classList.remove(...ALL_THEMES);
+    };
+  }, [theme]);
+
+  const docsTheme = DARK_THEMES.includes(theme) ? themes.dark : themes.light;
+
+  return (
+    <DocsContainer context={context} theme={docsTheme}>
+      {children}
+    </DocsContainer>
+  );
+};

--- a/apps/storybook/.storybook/main.ts
+++ b/apps/storybook/.storybook/main.ts
@@ -36,24 +36,24 @@ if (isDev) {
 const config: StorybookConfig = {
   stories: [
     {
+      directory: '../src',
+      files: '**/*.stories.@(tsx|ts|jsx|js|mdx)',
+      titlePrefix: 'Apollo Core',
+    },
+    {
       directory: '../../../packages/apollo-wind/src',
       files: '**/*.stories.@(tsx|ts|jsx|js|mdx)',
-      titlePrefix: 'Wind',
+      titlePrefix: 'Apollo Wind',
     },
     {
       directory: '../../../packages/apollo-react/src/canvas',
       files: '**/*.stories.@(tsx|ts|jsx|js|mdx)',
-      titlePrefix: 'Canvas',
+      titlePrefix: 'Apollo React/Canvas',
     },
     {
       directory: '../../../packages/apollo-react/src/material',
       files: '**/*.stories.@(tsx|ts|jsx|js|mdx)',
-      titlePrefix: 'Material (Maintenance Only)',
-    },
-    {
-      directory: '../src',
-      files: '**/*.stories.@(tsx|ts|jsx|js|mdx)',
-      titlePrefix: 'Core',
+      titlePrefix: 'Apollo React/Material (Maintenance Only)',
     },
   ],
   addons: [
@@ -96,6 +96,15 @@ const config: StorybookConfig = {
       #storybook-root > * {
         width: 100%;
         height: 100%;
+      }
+      /* Docs pages: paint surfaces from Apollo semantic tokens (driven by the
+         theme class on <body>, see .storybook/DocsContainer.tsx). The docs
+         theme object can't hold var()/oklch values (storybook theming derives
+         colors via polished), so the background is tokenized here instead. */
+      #storybook-docs .sbdocs-wrapper,
+      #storybook-docs .sbdocs-preview,
+      #storybook-docs .docs-story {
+        background: var(--color-background);
       }
     </style>
   `,

--- a/apps/storybook/.storybook/preview.tsx
+++ b/apps/storybook/.storybook/preview.tsx
@@ -12,6 +12,7 @@ import {
 } from '@uipath/apollo-react/material/theme';
 // biome-ignore lint/correctness/noUnusedImports: needed
 import React, { useEffect } from 'react';
+import { ApolloDocsContainer } from './DocsContainer';
 import { GlobalStyles } from './GlobalStyles';
 import { ALL_THEMES, clampThemeForMaterial, DEFAULT_THEME, type ThemeMode } from './themes';
 
@@ -110,6 +111,9 @@ const preview: Preview = {
   },
   parameters: {
     backgrounds: { disable: true },
+    docs: {
+      container: ApolloDocsContainer,
+    },
     controls: {
       matchers: {
         color: /(background|color)$/i,
@@ -122,7 +126,7 @@ const preview: Preview = {
     options: {
       storySort: {
         order: [
-          'Wind',
+          'Apollo Wind',
           [
             'Introduction',
             'Theme',
@@ -164,35 +168,39 @@ const preview: Preview = {
             'Experiments',
             '*',
           ],
-          'Canvas',
+          'Apollo React',
           [
-            'Introduction',
-            'Theme',
-            'Components',
+            'Canvas',
             [
-              'All Components',
-              'Canvas',
-              'Controls',
-              'Edges',
-              'Layout',
-              'Nodes',
-              'Panels',
-              'Primitives',
+              'Introduction',
+              'Theme',
+              'Components',
+              [
+                'All Components',
+                'Canvas',
+                'Controls',
+                'Edges',
+                'Layout',
+                'Nodes',
+                'Panels',
+                'Primitives',
+                '*',
+              ],
+              'Templates',
+              [
+                'Canvas Blank',
+                'Canvas with Panels',
+                'Canvas Agent Flow',
+                'Canvas Agent Flow Coded',
+                '*',
+              ],
               '*',
             ],
-            'Templates',
-            [
-              'Canvas Blank',
-              'Canvas with Panels',
-              'Canvas Agent Flow',
-              'Canvas Agent Flow Coded',
-              '*',
-            ],
+            'Material (Maintenance Only)',
+            ['Introduction', 'Components', ['All Components', '*'], '*'],
             '*',
           ],
-          'Material (Maintenance Only)',
-          ['Introduction', 'Components', ['All Components', '*'], '*'],
-          'Core',
+          'Apollo Core',
           [
             'Introduction',
             'Colors',


### PR DESCRIPTION
Small change to organize storybook more correlated to the packages:
Apollo Wind
Apollo React / Canvas
Apollo React / Material
Apollo Core

Fix background color on docs pages.