### PR TITLE
feat(apollo-react): add onStatusClick to StageNode header status icon

### DIFF
--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.stories.tsx
@@ -227,6 +227,9 @@ export const Default: Story = {
         width: 304,
         data: {
           onReplaceTaskFromToolbox: () => {},
+          onStatusClick: () => {
+            window.alert('Status icon clicked - this would navigate to the validation issue');
+          },
           stageDetails: {
             label: 'Validation - Failed',
             isReadOnly: true,
@@ -255,6 +258,9 @@ export const Default: Story = {
         position: { x: 1104, y: 96 },
         width: 304,
         data: {
+          onStatusClick: () => {
+            window.alert('Status icon clicked - this would navigate to the validation issue');
+          },
           stageDetails: {
             label: 'Review - Warning',
             isReadOnly: true,

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.test.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.test.tsx
@@ -915,6 +915,43 @@ describe('StageNode - SLA Indicator', () => {
   });
 });
 
+describe('StageNode - Status Icon', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const warningExecution = {
+    stageStatus: { status: 'Warning' as const, label: 'This stage has validation warnings.' },
+    taskStatus: {},
+  };
+
+  it('does not render the status icon when status is undefined', () => {
+    renderStageNode({ execution: { stageStatus: {}, taskStatus: {} } });
+
+    expect(screen.queryByTestId('stage-status-stage-1')).not.toBeInTheDocument();
+  });
+
+  it('invokes onStatusClick without propagating to onStageClick', async () => {
+    const onStatusClick = vi.fn();
+    const onStageClick = vi.fn();
+    renderStageNode({ execution: warningExecution, onStatusClick, onStageClick });
+
+    await userEvent.click(screen.getByTestId('stage-status-stage-1'));
+
+    expect(onStatusClick).toHaveBeenCalledTimes(1);
+    expect(onStageClick).not.toHaveBeenCalled();
+  });
+
+  it('propagates the click to onStageClick when onStatusClick is not provided', async () => {
+    const onStageClick = vi.fn();
+    renderStageNode({ execution: warningExecution, onStageClick });
+
+    await userEvent.click(screen.getByTestId('stage-status-stage-1'));
+
+    expect(onStageClick).toHaveBeenCalledTimes(1);
+  });
+});
+
 describe('StageNode - Header Chips', () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.types.ts
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.types.ts
@@ -82,6 +82,7 @@ export interface StageNodeBaseProps {
   };
   menuItems?: NodeMenuItem[];
   onStageClick?: () => void;
+  onStatusClick?: () => void;
   onTaskAdd?: () => void;
   onAddTaskFromToolbox?: (taskItem: ListItem) => void;
   onTaskToolboxSearch?: ToolboxSearchHandler;

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNodeHeader.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNodeHeader.tsx
@@ -132,6 +132,7 @@ const StageNodeHeaderInner = ({
     id,
     stageDetails,
     execution,
+    onStatusClick,
     onTaskAdd,
     onAddTaskFromToolbox,
     onStageTitleChange,
@@ -164,7 +165,21 @@ const StageNodeHeaderInner = ({
         <Row gap={Spacing.SpacingMicro} align="start" py={Padding.PadS}>
           {status && (
             <CanvasTooltip content={statusTooltip} placement="top">
-              <Button variant="ghost" size="icon" className="h-6 w-6" aria-label={statusTooltip}>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-6 w-6"
+                aria-label={statusTooltip}
+                data-testid={`stage-status-${id}`}
+                onClick={
+                  onStatusClick
+                    ? (e) => {
+                        e.stopPropagation();
+                        onStatusClick();
+                      }
+                    : undefined
+                }
+              >
                 {status === 'NotExecuted' ? (
                   <CanvasIcon
                     icon="hourglass"


### PR DESCRIPTION
## Summary

Adds an optional `onStatusClick` callback to `StageNode` so consumers can make the header execution/validation status icon clickable. Today the icon is a button with a tooltip but no click API, so clicks fall through to generic stage selection. Maestro's Case Manager needs it to navigate from a stage's warning/error icon to the offending validation issue in the properties panel.

Part 1 of [MST-10929] — part 2 (wiring the navigation in PO.Frontend) follows after this is released. Should not close the ticket.

## Demo

<img width="1682" height="650" alt="image" src="https://github.com/user-attachments/assets/dab86f3c-50d2-44a4-9980-b729425e0b33" />

## Changes

- `StageNode.types.ts` — new optional `onStatusClick?: () => void` on `StageNodeBaseProps`
- `StageNodeHeader.tsx` — status icon button invokes `onStatusClick` with `stopPropagation` (same pattern as the add-task button and header chips); adds `data-testid="stage-status-<id>"`; behavior unchanged when the prop is omitted
- `StageNode.test.tsx` — 3 new tests: no icon without status, click invokes callback without reaching `onStageClick`, click propagates to `onStageClick` when the prop is omitted
- `StageNode.stories.tsx` — Default story's Failed/Warning stages wire `onStatusClick` to an alert for manual verification

## Testing

- [x] `vitest run StageNode.test.tsx` — 65 passed
- [x] Manual testing in Storybook (Default story)
- [x] Unit tests added/updated
- [x] Type-safe (no `as any` / type suppressions added)

[MST-10929]: https://uipath.atlassian.net/browse/MST-10929
