### PR TITLE
fix(apollo-react, apollo-wind): bump react-syntax-highlighter to ^16.1.1 (ESM fix)

### DIFF
--- a/packages/apollo-react/package.json
+++ b/packages/apollo-react/package.json
@@ -225,7 +225,7 @@
     "react-dropzone": "^14.3.8",
     "react-focus-lock": "^2.13.7",
     "react-markdown": "^10.1.0",
-    "react-syntax-highlighter": "^16.1.0",
+    "react-syntax-highlighter": "^16.1.1",
     "react-window": "^2.2.1",
     "rehype-katex": "^7.0.1",
     "remark-breaks": "^4.0.0",

--- a/packages/apollo-wind/package.json
+++ b/packages/apollo-wind/package.json
@@ -120,7 +120,7 @@
     "react-hook-form": "^7.66.1",
     "react-live": "^4.1.8",
     "react-resizable-panels": "^4.7.3",
-    "react-syntax-highlighter": "^16.1.0",
+    "react-syntax-highlighter": "^16.1.1",
     "recharts": "2.15.4",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.4.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -730,7 +730,7 @@ importers:
         specifier: ^10.1.0
         version: 10.1.0(@types/react@19.2.8)(react@19.2.3)
       react-syntax-highlighter:
-        specifier: ^16.1.0
+        specifier: ^16.1.1
         version: 16.1.1(react@19.2.3)
       react-window:
         specifier: ^2.2.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1046,7 +1046,7 @@ importers:
         specifier: ^4.7.3
         version: 4.7.3(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react-syntax-highlighter:
-        specifier: ^16.1.0
+        specifier: ^16.1.1
         version: 16.1.1(react@19.2.3)
       recharts:
         specifier: 2.15.4


### PR DESCRIPTION
## Summary
- Bumps `react-syntax-highlighter` from `^16.1.0` to `^16.1.1` in apollo-react
- `16.1.0` has broken ESM exports (extensionless imports in `dist/esm/`) that fail under Node v24's strict ESM resolution
    - `16.1.1` adds `.js` extensions to all ESM imports: https://github.com/react-syntax-highlighter/react-syntax-highlighter/pull/627
- `apollo-react`'s `ap-chat/code` component imports from `react-syntax-highlighter/dist/esm/styles/prism`, triggering the issue in consumers (e.g. traceview-ui)

## Before
**"Cannot find module" errors in testing**
<img width="1321" height="726" alt="image" src="https://github.com/user-attachments/assets/450930f9-cb1b-4537-84dd-781890f723de" />

## After
**Successful test coverage run**
<img width="1323" height="799" alt="image" src="https://github.com/user-attachments/assets/70980c0a-0cf0-4eaa-8198-0eb206049938" />


## Test plan
- [x] Verify apollo-react builds cleanly
- [x] Verify consumers (traceview-ui) can drop the `react-syntax-highlighter` override after this ships