### PR TITLE
fix(apollo-wind): use surface-overlay for future field backgrounds

### DIFF
--- a/packages/apollo-wind/src/components/ui/combobox.tsx
+++ b/packages/apollo-wind/src/components/ui/combobox.tsx
@@ -53,7 +53,7 @@ export function Combobox({
           aria-expanded={open}
           aria-label={selectedItem ? selectedItem.label : placeholder}
           className={cn(
-            'w-[280px] justify-between future:rounded-xl future:border-0 future:bg-surface-raised future:hover:bg-surface-overlay future:font-normal future:text-muted-foreground',
+            'w-[280px] justify-between future:rounded-xl future:border-0 future:bg-surface-overlay future:hover:bg-surface-hover future:font-normal future:text-muted-foreground',
             className
           )}
           disabled={disabled}

--- a/packages/apollo-wind/src/components/ui/input.tsx
+++ b/packages/apollo-wind/src/components/ui/input.tsx
@@ -12,7 +12,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
           // Base styles (all themes)
           'flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-base transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
           // Future Dark / Future Light overrides
-          'future:h-10 future:rounded-xl future:border-0 future:bg-surface-raised future:py-2 future:text-sm future:placeholder:text-foreground-muted future:placeholder:font-normal future:focus-visible:ring-offset-2 future:focus-visible:ring-offset-background',
+          'future:h-10 future:rounded-xl future:border-0 future:bg-surface-overlay future:py-2 future:text-sm future:placeholder:text-foreground-muted future:placeholder:font-normal future:focus-visible:ring-offset-2 future:focus-visible:ring-offset-background',
           className
         )}
         ref={ref}

--- a/packages/apollo-wind/src/components/ui/multi-select.tsx
+++ b/packages/apollo-wind/src/components/ui/multi-select.tsx
@@ -74,7 +74,7 @@ const MultiSelect = React.forwardRef<HTMLDivElement, MultiSelectProps>(
               aria-expanded={open}
               aria-label={selected.length > 0 ? `${selected.length} items selected` : placeholder}
               className={cn(
-                'w-full justify-between future:rounded-xl future:border-0 future:bg-surface-raised future:hover:bg-surface-overlay future:font-normal future:text-muted-foreground',
+                'w-full justify-between future:rounded-xl future:border-0 future:bg-surface-overlay future:hover:bg-surface-hover future:font-normal future:text-muted-foreground',
                 selected.length > 0 ? 'h-auto min-h-10' : 'h-10'
               )}
               disabled={disabled}
@@ -89,7 +89,7 @@ const MultiSelect = React.forwardRef<HTMLDivElement, MultiSelectProps>(
                       <Badge
                         key={value}
                         variant="secondary"
-                        className="mr-1"
+                        className="mr-1 future:bg-surface-raised future:hover:bg-surface-raised"
                         onClick={(e) => {
                           e.stopPropagation();
                           handleUnselect(value);

--- a/packages/apollo-wind/src/components/ui/select.tsx
+++ b/packages/apollo-wind/src/components/ui/select.tsx
@@ -17,7 +17,7 @@ const SelectTrigger = React.forwardRef<
   <SelectPrimitive.Trigger
     ref={ref}
     className={cn(
-      'flex h-9 w-full cursor-pointer items-center justify-between rounded-md border border-input bg-transparent px-3 py-1 text-base transition-colors data-[placeholder]:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 md:text-sm [&>span]:line-clamp-1 future:h-10 future:rounded-xl future:border-0 future:bg-surface-raised future:hover:bg-surface-overlay future:px-4 future:gap-4 future:font-normal future:text-muted-foreground',
+      'flex h-9 w-full cursor-pointer items-center justify-between rounded-md border border-input bg-transparent px-3 py-1 text-base transition-colors data-[placeholder]:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 md:text-sm [&>span]:line-clamp-1 future:h-10 future:rounded-xl future:border-0 future:bg-surface-overlay future:hover:bg-surface-hover future:px-4 future:gap-4 future:font-normal future:text-muted-foreground',
       className
     )}
     {...props}

--- a/packages/apollo-wind/src/components/ui/textarea.tsx
+++ b/packages/apollo-wind/src/components/ui/textarea.tsx
@@ -12,7 +12,7 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
           // Base styles (all themes)
           'flex min-h-[80px] w-full rounded-md border border-input bg-transparent px-3 py-2 text-base transition-colors placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
           // Future Dark / Future Light overrides
-          'future:rounded-xl future:border-0 future:bg-surface-raised future:text-sm future:placeholder:text-foreground-muted future:placeholder:font-normal future:focus-visible:ring-offset-2 future:focus-visible:ring-offset-background',
+          'future:rounded-xl future:border-0 future:bg-surface-overlay future:text-sm future:placeholder:text-foreground-muted future:placeholder:font-normal future:focus-visible:ring-offset-2 future:focus-visible:ring-offset-background',
           className
         )}
         ref={ref}


### PR DESCRIPTION
## What

Aligns the resting background of **Future-theme form fields** with the flow prototype, which renders its parameter fields on `surface-overlay` (the prototype's `--color-input-bg` resolves to `--surface-overlay` in both `future-dark` and `future-light`). apollo-wind's fields were on `surface-raised`, one step darker — producing the visible mismatch.

## Changes (`future:` variant only)

| Component | Resting bg | Hover bg |
|---|---|---|
| `input.tsx` | `surface-raised` → `surface-overlay` | — |
| `textarea.tsx` | `surface-raised` → `surface-overlay` | — |
| `select.tsx` | `surface-raised` → `surface-overlay` | `surface-overlay` → `surface-hover` |
| `combobox.tsx` | `surface-raised` → `surface-overlay` | `surface-overlay` → `surface-hover` |
| `multi-select.tsx` | `surface-raised` → `surface-overlay` | `surface-overlay` → `surface-hover` |

For the trigger fields, hover bumps to `surface-hover` so the hover affordance stays one step above the new resting color (matching the prototype, whose select focus goes to `surface-hover`).

### Multi-select chip contrast

The multi-select renders selected items as `<Badge variant="secondary">`, which maps to `--secondary` → `surface-overlay` in the future themes. Once the trigger moved to `surface-overlay`, the chips had zero contrast against it (and `surface-hover` then collided with the trigger's hover state). The chips now use `future:bg-surface-raised` (resting + hover), the one surface token that contrasts against **both** trigger states in both themes:

- **Dark:** chip `#18181b` on field `#27272a` (rest) / `#3f3f46` (hover) — a darker recessed pill.
- **Light:** chip `#f4f4f5` on field `#e4e4e7` / `#d4d4d8` — a lighter raised pill.

## Scope / not touched

- Changes are confined to the `future:` variant — classic / canvas / vertex themes are unaffected.
- `pagination.tsx` (active page chip) and `file-upload.tsx` (dropzone) also use `future:bg-surface-raised` but are not form fields, so they're left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)