### PR TITLE
feat(apollo-react): expose canvas handle positioning utility

### DIFF
--- a/packages/apollo-react/src/canvas/components/ButtonHandle/ButtonHandle.tsx
+++ b/packages/apollo-react/src/canvas/components/ButtonHandle/ButtonHandle.tsx
@@ -3,12 +3,13 @@ import { memo, useCallback, useMemo, useRef, useState } from 'react';
 import type { HandleConfigurationSpecificPosition } from '../../schema/node-definition/handle';
 import { canvasEventBus } from '../../utils/CanvasEventBus';
 import { cx } from '../../utils/CssUtil';
+import { calculateGridAlignedHandlePositions } from '../../utils/handle-positioning';
 import {
   getHandleActionPortal,
   getInwardHandleLayout,
   type InwardHandleLayout,
 } from './ButtonHandleLayoutUtils';
-import { calculateGridAlignedHandlePositions, pixelToPercent } from './ButtonHandleStyleUtils';
+import { pixelToPercent } from './ButtonHandleStyleUtils';
 import { HandleButton, HandleHoverBridge } from './HandleButton';
 import { HandleLabel } from './HandleLabel';
 import { HandleNotch, type HandleType } from './HandleNotch';

--- a/packages/apollo-react/src/canvas/components/ButtonHandle/ButtonHandleStyleUtils.test.ts
+++ b/packages/apollo-react/src/canvas/components/ButtonHandle/ButtonHandleStyleUtils.test.ts
@@ -1,12 +1,10 @@
 import { Position } from '@uipath/apollo-react/canvas/xyflow/react';
 import {
   bottomPositionForHandle,
-  calculateGridAlignedHandlePositions,
   heightForHandleWithPosition,
   leftPositionForHandle,
   pixelToPercent,
   rightPositionForHandle,
-  snapToGrid,
   topPositionForHandle,
   transformForHandle,
   widthForHandleWithPosition,
@@ -848,106 +846,6 @@ describe('ButtonHandleStyleUtils', () => {
         customPositionAndOffsets: { left: 10, width: 100 },
       });
       expect(transform).toBe('translate(0%, -50%)');
-    });
-  });
-
-  describe('snapToGrid', () => {
-    it('should snap a value to the nearest grid multiple (default grid size 16)', () => {
-      expect(snapToGrid(0)).toBe(0);
-      expect(snapToGrid(8)).toBe(16); // 8/16 = 0.5, rounds to 1 * 16 = 16
-      expect(snapToGrid(7)).toBe(0); // 7/16 = 0.4375, rounds to 0
-      expect(snapToGrid(16)).toBe(16);
-      expect(snapToGrid(24)).toBe(32); // 24/16 = 1.5, rounds to 2 * 16 = 32
-      expect(snapToGrid(25)).toBe(32); // 25/16 = 1.5625, rounds to 2 * 16 = 32
-      expect(snapToGrid(48)).toBe(48);
-    });
-
-    it('should snap using custom grid size', () => {
-      expect(snapToGrid(5, 10)).toBe(10); // 5/10 = 0.5, rounds to 1 * 10 = 10
-      expect(snapToGrid(4, 10)).toBe(0); // 4/10 = 0.4, rounds to 0
-      expect(snapToGrid(15, 10)).toBe(20); // 15/10 = 1.5, rounds to 2 * 10 = 20
-    });
-  });
-
-  describe('calculateGridAlignedHandlePositions', () => {
-    it('should return empty array for 0 handles', () => {
-      expect(calculateGridAlignedHandlePositions(96, 0)).toEqual([]);
-    });
-
-    it('should return center grid position for 1 handle', () => {
-      expect(calculateGridAlignedHandlePositions(96, 1)).toEqual([48]);
-    });
-
-    it('should snap single handle to grid when nodeSize is not grid-aligned', () => {
-      // 312px node: ideal center 156 is off-grid by 4. Snap → 160.
-      expect(calculateGridAlignedHandlePositions(312, 1)).toEqual([160]);
-    });
-
-    it('should snap single handle to grid when nodeSize is odd', () => {
-      // 321px: half is 160.5. Snap → 160.
-      expect(calculateGridAlignedHandlePositions(321, 1)).toEqual([160]);
-    });
-
-    it('should calculate equidistant positions for 2 handles', () => {
-      // 2 handles, gridSize=8: ideal=96/3=32, rounded=32, span=32, start=(96-32)/2=32
-      // Positions: 32, 64
-      expect(calculateGridAlignedHandlePositions(96, 2)).toEqual([32, 64]);
-    });
-
-    it('should calculate equidistant positions for 3 handles', () => {
-      // 3 handles, gridSize=16: ideal=96/4=24, rounded=32, span=64, start=(96-64)/2=16
-      // Positions: 16, 48, 80
-      expect(calculateGridAlignedHandlePositions(96, 3)).toEqual([16, 48, 80]);
-    });
-
-    it('should calculate equidistant positions for 4 handles', () => {
-      // 4 handles, gridSize=16: ideal=96/5=19.2, rounded=16, start=24.
-      // Spacing is already at gridSize so parity fix cannot bump down further.
-      // In practice BaseNode auto-grows so 4 handles never fit in 96px.
-      expect(calculateGridAlignedHandlePositions(96, 4)).toEqual([24, 40, 56, 72]);
-    });
-
-    it('should work with larger node sizes', () => {
-      // 160px, 3 handles, gridSize=16: ideal=40, rounded=48, span=96, start=32
-      // Positions: 32, 80, 128
-      expect(calculateGridAlignedHandlePositions(160, 3)).toEqual([32, 80, 128]);
-    });
-
-    it('should fix parity when fewer handles share a taller node', () => {
-      // 160px node (driven by 3 handles on the other side), 2 handles on this side.
-      // ideal=53.33, rounded=48, start=56 (off-grid).
-      // Parity fix bumps spacing down to 32: span=32, start=64.
-      // Positions: 64, 96 — both on 16px grid, handles stay inward
-      expect(calculateGridAlignedHandlePositions(160, 2)).toEqual([64, 96]);
-    });
-
-    it('should use custom grid size', () => {
-      // 100px, 2 handles, gridSize=10: ideal=33.33, rounded=30, start=35 (off-grid).
-      // Parity fix bumps spacing down to 20: span=20, start=40.
-      // Positions: 40, 60 (symmetric around 50)
-      expect(calculateGridAlignedHandlePositions(100, 2, 10)).toEqual([40, 60]);
-    });
-
-    it('should calculate equidistant positions for 5 handles', () => {
-      // 5 handles, gridSize=8: ideal=96/6=16, rounded=16, span=64, start=16
-      // Positions: 16, 32, 48, 64, 80
-      expect(calculateGridAlignedHandlePositions(96, 5)).toEqual([16, 32, 48, 64, 80]);
-    });
-
-    it('should distribute even handle counts symmetrically', () => {
-      // 80px, 6 handles, gridSize=16: ideal=80/7≈11.43, rounded=16, span=80, start=0.
-      // Positions: 0, 16, 32, 48, 64, 80. Midpoint = (0+80)/2 = 40 = nodeSize/2 ✓
-      const positions = calculateGridAlignedHandlePositions(80, 6);
-      expect(positions).toEqual([0, 16, 32, 48, 64, 80]);
-      expect((positions[0] + positions[positions.length - 1]) / 2).toBe(40);
-    });
-
-    it('should not stack handles when ideal spacing is below half a grid step', () => {
-      // 32px, 8 handles, gridSize=8: ideal=32/9≈3.56, rounded=0 → clamped to gridSize=8.
-      // Regression: previously every handle landed on the same pixel.
-      const positions = calculateGridAlignedHandlePositions(32, 8);
-      const unique = new Set(positions);
-      expect(unique.size).toBe(positions.length);
     });
   });
 

--- a/packages/apollo-react/src/canvas/components/ButtonHandle/ButtonHandleStyleUtils.ts
+++ b/packages/apollo-react/src/canvas/components/ButtonHandle/ButtonHandleStyleUtils.ts
@@ -1,5 +1,4 @@
 import { Position } from '@uipath/apollo-react/canvas/xyflow/react';
-import { GRID_SPACING } from '../../constants';
 import type { HandleConfigurationSpecificPosition } from '../../schema/node-definition/handle';
 
 /**
@@ -18,84 +17,6 @@ const isVerticalEdge = (position: Position): boolean =>
 // The cross-axis remains fixed so labels/buttons align to a stable anchor.
 export const HANDLE_CROSS_AXIS_SIZE_PX = 24;
 export const HANDLE_EDGE_COVERAGE_RATIO = 0.5;
-
-/**
- * Snaps a value to the nearest grid multiple
- * @param value - The value to snap
- * @param gridSize - The grid size (defaults to GRID_SPACING)
- * @returns The value snapped to the nearest grid multiple
- */
-export const snapToGrid = (value: number, gridSize: number = GRID_SPACING): number => {
-  return Math.round(value / gridSize) * gridSize;
-};
-
-/**
- * Calculates handle positions that are equidistant, symmetric around the node
- * center, and use a grid-aligned spacing.
- *
- * Symmetry note: positions are placed outward from the node's true center
- * rather than snapped individually. Per-position snapping with `Math.round`
- * (round-half-up) systematically biases the entire row in one direction when
- * `startPosition` lands on a half-grid value — most visibly with even handle
- * counts and odd-multiple spacings. Computing from the center keeps handles
- * mirrored across `nodeSize / 2` even if every position ends up half a grid
- * unit off (still pixel-aligned at the gridSize granularity used here).
- *
- * @param nodeSize - The size of the node in the relevant dimension (width for Top/Bottom handles, height for Left/Right handles)
- * @param numHandles - Number of handles to position
- * @param gridSize - The grid size for spacing
- * @returns Array of pixel positions for each handle, symmetric around the node center
- */
-export const calculateGridAlignedHandlePositions = (
-  nodeSize: number,
-  numHandles: number,
-  gridSize: number = GRID_SPACING
-): number[] => {
-  if (numHandles === 0) return [];
-  if (nodeSize <= 0) return [];
-  if (numHandles === 1) {
-    // Snap to grid so a single handle stays aligned when `nodeSize` is odd or
-    // off-grid (e.g. a 312px container would otherwise place its handle at 156).
-    return [snapToGrid(nodeSize / 2, gridSize)];
-  }
-
-  const idealSpacing = nodeSize / (numHandles + 1);
-
-  // Grid alignment is only meaningful when the node itself sits on the grid.
-  // When nodeSize isn't a grid multiple, snapping spacing can't produce
-  // grid-aligned positions, so just return ideal equidistant positions.
-  if (nodeSize % gridSize !== 0) {
-    const positions: number[] = [];
-    for (let i = 0; i < numHandles; i++) {
-      positions.push(idealSpacing * (i + 1));
-    }
-    return positions;
-  }
-
-  // Round to the nearest grid multiple, with a lower bound of one grid step so
-  // handles don't all stack at the center when `idealSpacing < gridSize / 2`.
-  const roundedSpacing = Math.round(idealSpacing / gridSize) * gridSize;
-  let gridAlignedSpacing = Math.max(gridSize, roundedSpacing);
-
-  // Distribute symmetrically around the node center.
-  let totalSpan = (numHandles - 1) * gridAlignedSpacing;
-  let startPosition = (nodeSize - totalSpan) / 2;
-
-  // Since nodeSize is a grid multiple, startPosition is either on-grid or
-  // exactly half a grid step off. Bump spacing down one grid step to fix parity.
-  if (startPosition % gridSize !== 0 && gridAlignedSpacing > gridSize) {
-    gridAlignedSpacing -= gridSize;
-    totalSpan = (numHandles - 1) * gridAlignedSpacing;
-    startPosition = (nodeSize - totalSpan) / 2;
-  }
-
-  const positions: number[] = [];
-  for (let i = 0; i < numHandles; i++) {
-    positions.push(startPosition + i * gridAlignedSpacing);
-  }
-
-  return positions;
-};
 
 /**
  * Converts a grid-aligned pixel position to a percentage of the node size

--- a/packages/apollo-react/src/canvas/components/ButtonHandle/SmartHandle.tsx
+++ b/packages/apollo-react/src/canvas/components/ButtonHandle/SmartHandle.tsx
@@ -20,8 +20,9 @@ import {
 } from 'react';
 import { canvasEventBus } from '../../utils/CanvasEventBus';
 import { cx } from '../../utils/CssUtil';
+import { calculateGridAlignedHandlePositions } from '../../utils/handle-positioning';
 import type { HandleActionEvent } from './ButtonHandle';
-import { calculateGridAlignedHandlePositions, pixelToPercent } from './ButtonHandleStyleUtils';
+import { pixelToPercent } from './ButtonHandleStyleUtils';
 import { HandleButton } from './HandleButton';
 import { HandleLabel } from './HandleLabel';
 import { HandleNotch } from './HandleNotch';

--- a/packages/apollo-react/src/canvas/utils/handle-positioning.test.ts
+++ b/packages/apollo-react/src/canvas/utils/handle-positioning.test.ts
@@ -1,0 +1,85 @@
+import { calculateGridAlignedHandlePositions } from './handle-positioning';
+
+describe('handle-positioning', () => {
+  describe('calculateGridAlignedHandlePositions', () => {
+    it('should return empty array for 0 handles', () => {
+      expect(calculateGridAlignedHandlePositions(96, 0)).toEqual([]);
+    });
+
+    it('should return center grid position for 1 handle', () => {
+      expect(calculateGridAlignedHandlePositions(96, 1)).toEqual([48]);
+    });
+
+    it('should snap single handle to grid when nodeSize is not grid-aligned', () => {
+      // 312px node: ideal center 156 is off-grid by 4. Snap → 160.
+      expect(calculateGridAlignedHandlePositions(312, 1)).toEqual([160]);
+    });
+
+    it('should snap single handle to grid when nodeSize is odd', () => {
+      // 321px: half is 160.5. Snap → 160.
+      expect(calculateGridAlignedHandlePositions(321, 1)).toEqual([160]);
+    });
+
+    it('should calculate equidistant positions for 2 handles', () => {
+      // 2 handles, gridSize=8: ideal=96/3=32, rounded=32, span=32, start=(96-32)/2=32
+      // Positions: 32, 64
+      expect(calculateGridAlignedHandlePositions(96, 2, 8)).toEqual([32, 64]);
+    });
+
+    it('should calculate equidistant positions for 3 handles', () => {
+      // 3 handles, gridSize=16: ideal=96/4=24, rounded=32, span=64, start=(96-64)/2=16
+      // Positions: 16, 48, 80
+      expect(calculateGridAlignedHandlePositions(96, 3)).toEqual([16, 48, 80]);
+    });
+
+    it('should calculate equidistant positions for 4 handles', () => {
+      // 4 handles, gridSize=16: ideal=96/5=19.2, rounded=16, start=24.
+      // Spacing is already at gridSize so parity fix cannot bump down further.
+      // In practice BaseNode auto-grows so 4 handles never fit in 96px.
+      expect(calculateGridAlignedHandlePositions(96, 4)).toEqual([24, 40, 56, 72]);
+    });
+
+    it('should work with larger node sizes', () => {
+      // 160px, 3 handles, gridSize=16: ideal=40, rounded=48, span=96, start=32
+      // Positions: 32, 80, 128
+      expect(calculateGridAlignedHandlePositions(160, 3)).toEqual([32, 80, 128]);
+    });
+
+    it('should fix parity when fewer handles share a taller node', () => {
+      // 160px node (driven by 3 handles on the other side), 2 handles on this side.
+      // ideal=53.33, rounded=48, start=56 (off-grid).
+      // Parity fix bumps spacing down to 32: span=32, start=64.
+      // Positions: 64, 96 — both on 16px grid, handles stay inward
+      expect(calculateGridAlignedHandlePositions(160, 2)).toEqual([64, 96]);
+    });
+
+    it('should use custom grid size', () => {
+      // 100px, 2 handles, gridSize=10: ideal=33.33, rounded=30, start=35 (off-grid).
+      // Parity fix bumps spacing down to 20: span=20, start=40.
+      // Positions: 40, 60 (symmetric around 50)
+      expect(calculateGridAlignedHandlePositions(100, 2, 10)).toEqual([40, 60]);
+    });
+
+    it('should calculate equidistant positions for 5 handles', () => {
+      // 5 handles, gridSize=8: ideal=96/6=16, rounded=16, span=64, start=16
+      // Positions: 16, 32, 48, 64, 80
+      expect(calculateGridAlignedHandlePositions(96, 5, 8)).toEqual([16, 32, 48, 64, 80]);
+    });
+
+    it('should distribute even handle counts symmetrically', () => {
+      // 80px, 6 handles, gridSize=16: ideal=80/7≈11.43, rounded=16, span=80, start=0.
+      // Positions: 0, 16, 32, 48, 64, 80. Midpoint = (0+80)/2 = 40 = nodeSize/2 ✓
+      const positions = calculateGridAlignedHandlePositions(80, 6);
+      expect(positions).toEqual([0, 16, 32, 48, 64, 80]);
+      expect((positions[0]! + positions[positions.length - 1]!) / 2).toBe(40);
+    });
+
+    it('should not stack handles when ideal spacing is below half a grid step', () => {
+      // 32px, 8 handles, gridSize=8: ideal=32/9≈3.56, rounded=0 → clamped to gridSize=8.
+      // Regression: previously every handle landed on the same pixel.
+      const positions = calculateGridAlignedHandlePositions(32, 8, 8);
+      const unique = new Set(positions);
+      expect(unique.size).toBe(positions.length);
+    });
+  });
+});

--- a/packages/apollo-react/src/canvas/utils/handle-positioning.ts
+++ b/packages/apollo-react/src/canvas/utils/handle-positioning.ts
@@ -1,0 +1,73 @@
+import { GRID_SPACING } from '../constants';
+
+const snapToGrid = (value: number, gridSize: number = GRID_SPACING): number => {
+  return Math.round(value / gridSize) * gridSize;
+};
+
+/**
+ * Calculates handle positions that are equidistant, symmetric around the node
+ * center, and use a grid-aligned spacing.
+ *
+ * Symmetry note: positions are placed outward from the node's true center
+ * rather than snapped individually. Per-position snapping with `Math.round`
+ * (round-half-up) systematically biases the entire row in one direction when
+ * `startPosition` lands on a half-grid value, most visibly with even handle
+ * counts and odd-multiple spacings. Computing from the center keeps handles
+ * mirrored across `nodeSize / 2` even if every position ends up half a grid
+ * unit off (still pixel-aligned at the gridSize granularity used here).
+ *
+ * @param nodeSize - The size of the node in the relevant dimension (width for Top/Bottom handles, height for Left/Right handles).
+ * @param numHandles - Number of handles to position.
+ * @param gridSize - The grid size for spacing.
+ * @returns Array of pixel positions for each handle, symmetric around the node center.
+ */
+export const calculateGridAlignedHandlePositions = (
+  nodeSize: number,
+  numHandles: number,
+  gridSize: number = GRID_SPACING
+): number[] => {
+  if (numHandles === 0) return [];
+  if (nodeSize <= 0) return [];
+  if (numHandles === 1) {
+    // Snap to grid so a single handle stays aligned when `nodeSize` is odd or
+    // off-grid (e.g. a 312px container would otherwise place its handle at 156).
+    return [snapToGrid(nodeSize / 2, gridSize)];
+  }
+
+  const idealSpacing = nodeSize / (numHandles + 1);
+
+  // Grid alignment is only meaningful when the node itself sits on the grid.
+  // When nodeSize isn't a grid multiple, snapping spacing can't produce
+  // grid-aligned positions, so just return ideal equidistant positions.
+  if (nodeSize % gridSize !== 0) {
+    const positions: number[] = [];
+    for (let i = 0; i < numHandles; i++) {
+      positions.push(idealSpacing * (i + 1));
+    }
+    return positions;
+  }
+
+  // Round to the nearest grid multiple, with a lower bound of one grid step so
+  // handles don't all stack at the center when `idealSpacing < gridSize / 2`.
+  const roundedSpacing = Math.round(idealSpacing / gridSize) * gridSize;
+  let gridAlignedSpacing = Math.max(gridSize, roundedSpacing);
+
+  // Distribute symmetrically around the node center.
+  let totalSpan = (numHandles - 1) * gridAlignedSpacing;
+  let startPosition = (nodeSize - totalSpan) / 2;
+
+  // Since nodeSize is a grid multiple, startPosition is either on-grid or
+  // exactly half a grid step off. Bump spacing down one grid step to fix parity.
+  if (startPosition % gridSize !== 0 && gridAlignedSpacing > gridSize) {
+    gridAlignedSpacing -= gridSize;
+    totalSpan = (numHandles - 1) * gridAlignedSpacing;
+    startPosition = (nodeSize - totalSpan) / 2;
+  }
+
+  const positions: number[] = [];
+  for (let i = 0; i < numHandles; i++) {
+    positions.push(startPosition + i * gridAlignedSpacing);
+  }
+
+  return positions;
+};

--- a/packages/apollo-react/src/canvas/utils/index.ts
+++ b/packages/apollo-react/src/canvas/utils/index.ts
@@ -11,6 +11,7 @@ export * from './createPreviewGraph';
 export * from './createPreviewNode';
 export * from './export-canvas';
 export * from './GroupModificationUtils';
+export * from './handle-positioning';
 export * from './icon-registry';
 export * from './manifest-resolver';
 export * from './NodeUtils';


### PR DESCRIPTION
## Summary

- Moved the existing `calculateGridAlignedHandlePositions` logic from `ButtonHandleStyleUtils` into `src/canvas/utils/handle-positioning.ts` so it can be shared with consumers.
- This is a 1:1 move of the existing handle positioning algorithm and its behavior tests, not a rewrite.
- Re-exported `calculateGridAlignedHandlePositions` from the public canvas utils barrel, making it available from `@uipath/apollo-react/canvas/utils` and the root canvas barrel.
- Kept the small snap helper internal to `handle-positioning.ts`; `NodeUtils.snapToGrid` is not changed.
- Updated `ButtonHandle` and `SmartHandle` to use the moved helper for rendering.

## Why

Downstream canvas layout/tidy code needs to align with Apollo's actual rendered side-handle slots without duplicating the placement math.

## Validation

- `pnpm --dir packages/apollo-react exec vitest --run src/canvas/components/ButtonHandle src/canvas/utils/handle-positioning.test.ts`
- `pnpm --dir packages/apollo-react exec tsc --noEmit --pretty false --project tsconfig.json`
- `pnpm --dir packages/apollo-react exec biome check src/canvas/components/ButtonHandle/ButtonHandle.tsx src/canvas/components/ButtonHandle/SmartHandle.tsx src/canvas/components/ButtonHandle/ButtonHandleStyleUtils.ts src/canvas/components/ButtonHandle/ButtonHandleStyleUtils.test.ts src/canvas/utils/index.ts src/canvas/utils/handle-positioning.ts src/canvas/utils/handle-positioning.test.ts`
