### PR TITLE
fix(apollo-react): correct NodePropertyTrigger popover alignment and gap

### DIFF
--- a/packages/apollo-react/src/canvas/controls/NodePropertyTrigger/NodePropertyTrigger.tsx
+++ b/packages/apollo-react/src/canvas/controls/NodePropertyTrigger/NodePropertyTrigger.tsx
@@ -509,7 +509,14 @@ export function NodePropertyTrigger({
             <DropdownMenuContent
               data-node-property-trigger-menu
               align="end"
-              sideOffset={8}
+              // sideOffset + alignOffset compensate for the pill's p-1 (4px) wrapper padding.
+              // The DropdownMenuTrigger is the sliders button, whose bottom is 4px above the
+              // pill's bottom edge and whose right edge is 4px inside the pill's right edge.
+              // sideOffset={12}: 12 - 4 = 8px gap from pill bottom  ✓
+              // alignOffset={-4}: for align="end" negative shifts content RIGHT →
+              //   content right = sliders button right + 4 = pill right  ✓
+              sideOffset={12}
+              alignOffset={-4}
               className="w-56 rounded-xl border-border-subtle bg-surface-raised p-0 shadow-[0_4px_16px_rgba(0,0,0,0.12)]"
             >
               {children ?? defaultSections}


### PR DESCRIPTION
## Summary

Fixes two visual alignment issues with the `NodePropertyTrigger` popover that were not carried over when the component was rebuilt:

- **Right alignment**: the popover was offset 4px to the left of the pill's right edge. Added `alignOffset={-4}` — for Radix `align="end"`, negative values shift toward END (right in LTR), compensating for the 4px `p-1` padding on the pill wrapper.
- **Gap from pill**: the previous `sideOffset={8}` measured from the **sliders button** bottom, not the pill bottom. Since the button sits 4px above the pill's bottom edge (`p-1` padding), the effective gap was only 4px. Changed to `sideOffset={12}` so the gap from the pill's bottom to the popover top is exactly 8px.

### Root cause

`DropdownMenuTrigger` wraps the sliders `<button>` element, not the outer pill `<div>`. Radix measures `sideOffset` and `alignOffset` from the trigger element's bounding box — so both offsets must account for the pill's 4px wrapper padding.

## Visual

| Before | After |
|--------|-------|
| Popover 4px left of pill right edge, 4px gap | Popover flush with pill right edge, 8px gap |

## Test plan

- [ ] Open **Default** story — click sliders button, confirm popover right edge aligns with pill right edge and has 8px gap below pill
- [ ] Open **States** story — confirm open state matches same alignment
- [ ] Open **WithPresets** and **Composed** stories — confirm consistent alignment across all variants

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<img width="729" height="528" alt="alignment" src="https://github.com/user-attachments/assets/6b0ee0b4-fd94-4c0f-9227-a2099f263de0" />
