### PR TITLE
fix(apollo-react): clip loop node matte to remove corner gaps

### DIFF
--- a/packages/apollo-react/src/canvas/components/LoopNode/LoopNode.tsx
+++ b/packages/apollo-react/src/canvas/components/LoopNode/LoopNode.tsx
@@ -392,6 +392,22 @@ function LoopNodeComponent(props: LoopNodeProps) {
       onMouseEnter={handleMouseEnter}
       onMouseLeave={handleMouseLeave}
     >
+      {/* Clip the surface-overlay matte to the card's inner edge so it never overshoots or
+          falls short at the corners. 19px = container rounded-[20px] - 1px border. */}
+      <div className="absolute inset-0 isolate flex flex-col overflow-hidden rounded-[19px]">
+        <Header
+          title={displayTitle}
+          icon={displayIcon}
+          loading={isLoading}
+          isParallel={isParallel}
+          label={label}
+          iterationPillState={iterationPillStateProp}
+          nodeWidth={containerWidth}
+          hasTopLeftAdornment={hasTopLeftAdornment}
+          hasTopRightAdornment={hasTopRightAdornment}
+        />
+        <BodyFrame isEmpty={showEmptyStateButton} isLoading={isLoading} />
+      </div>
       {ADORNMENT_SLOT_POSITIONS.map((slot) =>
         adornments?.[slot] ? (
           <BaseBadgeSlot key={slot} position={ADORNMENT_SLOT_SHAPES[slot]} shape="rectangle">
@@ -408,18 +424,6 @@ function LoopNodeComponent(props: LoopNodeProps) {
           onResizeEnd={handleResizeEnd}
         />
       ) : null}
-      <Header
-        title={displayTitle}
-        icon={displayIcon}
-        loading={isLoading}
-        isParallel={isParallel}
-        label={label}
-        iterationPillState={iterationPillStateProp}
-        nodeWidth={containerWidth}
-        hasTopLeftAdornment={hasTopLeftAdornment}
-        hasTopRightAdornment={hasTopRightAdornment}
-      />
-      <BodyFrame isEmpty={showEmptyStateButton} isLoading={isLoading} />
       {showEmptyStateButton ? (
         <div
           className={cn(
@@ -504,7 +508,7 @@ function Header({
   return (
     <div
       className={cn(
-        'flex shrink-0 cursor-grab items-center justify-between gap-2.5 rounded-t-[18px]',
+        'relative z-10 flex shrink-0 cursor-grab items-center justify-between gap-2.5 rounded-t-[18px]',
         '-mb-2.5 bg-surface-overlay px-3.5 pb-2.5 pt-2.5 text-foreground',
         'active:cursor-grabbing'
       )}
@@ -562,7 +566,9 @@ function BodyFrame({ isEmpty, isLoading }: { isEmpty?: boolean; isLoading?: bool
       data-empty={isEmpty ? 'true' : 'false'}
       className={cn(
         'relative m-2.5 flex flex-1 rounded-xl border-[1.5px] border-dashed border-border bg-transparent',
-        'shadow-[0_0_0_10px_var(--surface-overlay)]',
+        // Oversized spread on purpose: the parent rounded-[19px] clip layer (not this value)
+        // defines the matte's outer edge. Shrinking it back reintroduces the corner gaps.
+        'shadow-[0_0_0_200px_var(--surface-overlay)]',
         'pointer-events-none'
       )}
     >


### PR DESCRIPTION
## Before / After

Validation overlay: matte (surface-overlay) → **magenta**, canvas/any gap → **green**, card border → **gray**.

<img width="1184" height="580" alt="image" src="https://github.com/user-attachments/assets/4d946320-5717-4c9d-9c9d-e080b604a46e" />


<!-- drag comparison-bottom-corner.png here -->

**Body-frame top corner wedge under the header (Issue 1):**

<img width="1184" height="580" alt="image" src="https://github.com/user-attachments/assets/da2608cc-6c2e-4a2a-a96e-908c64b41b73" />


## Problem

The Loop node draws its surface-overlay "matte" (the solid frame around the dashed drop zone) with a `box-shadow` spread on the dashed frame. A box-shadow's corner radius is `frameRadius + spread`, which never matched the container's inner border radius (`rounded-[20px]` − 1px border = **19px**). So the dotted canvas showed through as:

1. **Gaps at the card's bottom corners** — the band's corner (radius `12 + 10 = 22`) is rounder than the card, so it falls short.
2. **A wedge at the body-frame's top corners**, just below the header, where the rounded band can't reach the side edge.

Radius-only tweaks can't fix both: the bottom needs a concentric radius while the top needs to be square — and squaring the dashed frame's top corners is itself a visible regression.

## Fix

Let a **clip define the matte's outer shape** instead of the box-shadow's geometry:

- Wrap `Header` + `BodyFrame` in an `absolute inset-0 isolate overflow-hidden rounded-[19px]` clip layer (an exact copy of the card's inner edge).
- Enlarge the matte's `box-shadow` spread `10px → 200px` so it overflows past the card edge everywhere; the clip trims it to the exact rounded shape.
- The shadow is outset, so the dashed frame's interior stays transparent → the drop zone still shows the canvas, and the **dashed frame keeps its original `rounded-xl`**.
- `Header` gets `relative z-10` so its content paints above the larger matte shadow.

Net: the matte hugs the card's rounded edge at **every** corner with **zero changes to the visible radii** (`rounded-t-[18px]`, `rounded-xl` unchanged).

> Note: a giant spread like `9999px` doesn't work — its corner radius clamps toward a circle and misses the rectangular corners. ~200px is the sweet spot.

## Validation (Playwright)

- **Pixel scan @4× DPR** across all four corners + the left edge through the wedge zone: every line reads `border → matte` with no canvas between. Clean.
- **High-contrast color overlay** (matte → magenta, canvas → green) at up to 30×: matte hugs the border everywhere; green only appears outside the card and inside the drop zone (both correct).
- **Adornments tested** — forced badges at all four corners render on top and unclipped (they're container children outside the clip layer); header adornment padding intact.
- **No regressions**: handles (Start/Continue/Break/Success), resize indicators, selection outline, child nodes/edges, and the nested-loops story all render correctly; `lint` passes. Diff is purely structural (16 insertions / 14 deletions).

## Test plan

- [ ] Storybook → `Apollo React / Canvas / Components / Nodes / LoopNode` → Default, and the nested/many-children stories
- [ ] Verify no canvas shows through at the card corners or under the header (zoom in)
- [ ] Verify the dashed drop zone corners are rounded
- [ ] Verify status/validation adornments still render at the corners