### PR TITLE
fix(apollo-react): improve canvas overlay performance [MST-11141]

### DIFF
--- a/packages/apollo-react/src/canvas/components/BaseNode/BaseNode.tsx
+++ b/packages/apollo-react/src/canvas/components/BaseNode/BaseNode.tsx
@@ -710,11 +710,12 @@ const BaseNodeComponent = (props: NodeProps<Node<BaseNodeData>>) => {
           <div className="basis-full pt-0.5 min-w-0 overflow-hidden">{displayFooter}</div>
         )}
       </BaseContainer>
-      {toolbarConfig && !dragging && !multipleNodesSelected && (
+      {toolbarConfig && (
         <NodeToolbar
           nodeId={id}
           config={toolbarConfig}
           expanded={selected || isHovered}
+          hidden={dragging || multipleNodesSelected}
           offsetToolbar={offsetToolbar}
         />
       )}

--- a/packages/apollo-react/src/canvas/components/BaseNode/BaseNode.tsx
+++ b/packages/apollo-react/src/canvas/components/BaseNode/BaseNode.tsx
@@ -710,12 +710,11 @@ const BaseNodeComponent = (props: NodeProps<Node<BaseNodeData>>) => {
           <div className="basis-full pt-0.5 min-w-0 overflow-hidden">{displayFooter}</div>
         )}
       </BaseContainer>
-      {toolbarConfig && (
+      {toolbarConfig && !dragging && !multipleNodesSelected && (
         <NodeToolbar
           nodeId={id}
           config={toolbarConfig}
           expanded={selected || isHovered}
-          hidden={dragging || multipleNodesSelected}
           offsetToolbar={offsetToolbar}
         />
       )}

--- a/packages/apollo-react/src/canvas/components/ButtonHandle/HandleButton.tsx
+++ b/packages/apollo-react/src/canvas/components/ButtonHandle/HandleButton.tsx
@@ -155,7 +155,13 @@ export const HandleButton = memo(
       </div>
     );
 
+    const shouldRenderPortal = Boolean(visible || (label && labelVisible));
+
     if (portal) {
+      if (!shouldRenderPortal) {
+        return null;
+      }
+
       const { nodeId, ...anchor } = portal;
 
       return (

--- a/packages/apollo-react/src/canvas/components/Edges/shared/hooks/useExecutionEdge.ts
+++ b/packages/apollo-react/src/canvas/components/Edges/shared/hooks/useExecutionEdge.ts
@@ -1,6 +1,10 @@
 import { type ReactNode, useMemo } from 'react';
 import { useEdgeExecutionState, useElementValidationStatus } from '../../../../hooks';
-import type { ElementStatus, NodeExecutionStateWithDebug } from '../../../../types/execution';
+import {
+  type ElementStatus,
+  ElementStatusValues,
+  type NodeExecutionStateWithDebug,
+} from '../../../../types/execution';
 import type { ValidationErrorSeverity } from '../../../../types/validation';
 import { edgeTargetStatusToEdgeColor, getStatusAnimation } from '../../EdgeUtils';
 
@@ -39,7 +43,15 @@ export function useExecutionEdge(args: UseExecutionEdgeArgs): ExecutionEdge {
 
   const status = enabled ? resolveStatus(executionState, validation) : undefined;
   const statusColor = status ? edgeTargetStatusToEdgeColor[status] : undefined;
-  const animation = useMemo(() => getStatusAnimation(status, edgePath), [status, edgePath]);
+  // Non-animating edges should not recompute animation output on geometry-only updates.
+  const animationPath = status === ElementStatusValues.InProgress ? edgePath : undefined;
+  const animation = useMemo(() => {
+    if (animationPath == null) {
+      return null;
+    }
+
+    return getStatusAnimation(status, animationPath);
+  }, [status, animationPath]);
 
   return { statusColor, animation };
 }

--- a/packages/apollo-react/src/canvas/components/LoopNode/LoopNode.tsx
+++ b/packages/apollo-react/src/canvas/components/LoopNode/LoopNode.tsx
@@ -430,11 +430,12 @@ function LoopNodeComponent(props: LoopNodeProps) {
           <EmptyState label={addNodeToLoopLabel} onAddFirstChild={handleEmptyClick} />
         </div>
       ) : null}
-      {toolbarConfig && !dragging && !multipleNodesSelected && (
+      {toolbarConfig && (
         <NodeToolbar
           nodeId={id}
           config={toolbarConfig}
           expanded={selected || isHovered}
+          hidden={dragging || multipleNodesSelected}
           portalToNodeOverlay
         />
       )}

--- a/packages/apollo-react/src/canvas/components/LoopNode/LoopNode.tsx
+++ b/packages/apollo-react/src/canvas/components/LoopNode/LoopNode.tsx
@@ -112,7 +112,7 @@ function resolveInteractionState(
 function useHasChildNodes(id: string, enabled: boolean): boolean {
   return useStore(
     useCallback(
-      (state: ReactFlowState) => !enabled || state.nodes.some((node) => node.parentId === id),
+      (state: ReactFlowState) => !enabled || (state.parentLookup.get(id)?.size ?? 0) > 0,
       [id, enabled]
     )
   );
@@ -430,12 +430,11 @@ function LoopNodeComponent(props: LoopNodeProps) {
           <EmptyState label={addNodeToLoopLabel} onAddFirstChild={handleEmptyClick} />
         </div>
       ) : null}
-      {toolbarConfig && (
+      {toolbarConfig && !dragging && !multipleNodesSelected && (
         <NodeToolbar
           nodeId={id}
           config={toolbarConfig}
           expanded={selected || isHovered}
-          hidden={dragging || multipleNodesSelected}
           portalToNodeOverlay
         />
       )}

--- a/packages/apollo-react/src/canvas/components/LoopNode/LoopNode.tsx
+++ b/packages/apollo-react/src/canvas/components/LoopNode/LoopNode.tsx
@@ -555,7 +555,13 @@ function EmptyState({ label, onAddFirstChild }: { label: string; onAddFirstChild
   );
 }
 
-function BodyFrame({ isEmpty, isLoading }: { isEmpty?: boolean; isLoading?: boolean }) {
+const BodyFrame = memo(function BodyFrame({
+  isEmpty,
+  isLoading,
+}: {
+  isEmpty?: boolean;
+  isLoading?: boolean;
+}) {
   return (
     <div
       data-testid="loop-body-frame"
@@ -571,9 +577,9 @@ function BodyFrame({ isEmpty, isLoading }: { isEmpty?: boolean; isLoading?: bool
       ) : null}
     </div>
   );
-}
+});
 
-function ResizeControls({
+const ResizeControls = memo(function ResizeControls({
   minimums = DEFAULT_RESIZE_MINIMUMS,
   onResize,
   onResizeStart,
@@ -605,9 +611,13 @@ function ResizeControls({
       ))}
     </>
   );
-}
+});
 
-function ResizeCornerIndicators({ visible }: { visible: boolean }) {
+const ResizeCornerIndicators = memo(function ResizeCornerIndicators({
+  visible,
+}: {
+  visible: boolean;
+}) {
   return (
     <>
       {RESIZE_CONTROLS.map(({ position, indicatorClassName }) => (
@@ -624,7 +634,7 @@ function ResizeCornerIndicators({ visible }: { visible: boolean }) {
       ))}
     </>
   );
-}
+});
 
 type SharedHandleGroupProps = {
   nodeId: string;

--- a/packages/apollo-react/src/canvas/components/NodeViewportOverlay.tsx
+++ b/packages/apollo-react/src/canvas/components/NodeViewportOverlay.tsx
@@ -1,5 +1,11 @@
-import { useInternalNode, ViewportPortal } from '@uipath/apollo-react/canvas/xyflow/react';
+import {
+  type ReactFlowState,
+  useStore,
+  ViewportPortal,
+} from '@uipath/apollo-react/canvas/xyflow/react';
 import type { CSSProperties, ReactNode } from 'react';
+import { useCallback } from 'react';
+import { shallow } from 'zustand/shallow';
 
 // React Flow adds 1000 to selected node z-index and styles its connection line at 1001.
 // Node viewport overlays sit just above those library layers.
@@ -25,13 +31,38 @@ export type NodeViewportOverlayProps = {
   children: ReactNode;
 };
 
-export function NodeViewportOverlay({ nodeId, anchor, layer, children }: NodeViewportOverlayProps) {
-  const internalNode = useInternalNode(nodeId);
-  const positionAbsolute = internalNode?.internals.positionAbsolute;
-  const width = anchor?.width ?? internalNode?.measured?.width ?? internalNode?.width;
-  const height = anchor?.height ?? internalNode?.measured?.height ?? internalNode?.height;
+type NodeViewportOverlayGeometry = {
+  x: number | undefined;
+  y: number | undefined;
+  width: number | undefined;
+  height: number | undefined;
+};
 
-  if (!positionAbsolute || width == null || height == null) {
+export function NodeViewportOverlay({ nodeId, anchor, layer, children }: NodeViewportOverlayProps) {
+  const geometry = useStore(
+    useCallback(
+      (state: ReactFlowState): NodeViewportOverlayGeometry => {
+        const internalNode = state.nodeLookup.get(nodeId);
+        const positionAbsolute = internalNode?.internals.positionAbsolute;
+
+        return {
+          x: positionAbsolute?.x,
+          y: positionAbsolute?.y,
+          width: anchor?.width ?? internalNode?.measured?.width ?? internalNode?.width,
+          height: anchor?.height ?? internalNode?.measured?.height ?? internalNode?.height,
+        };
+      },
+      [anchor?.height, anchor?.width, nodeId]
+    ),
+    shallow
+  );
+
+  if (
+    geometry.x == null ||
+    geometry.y == null ||
+    geometry.width == null ||
+    geometry.height == null
+  ) {
     return children;
   }
 
@@ -41,10 +72,10 @@ export function NodeViewportOverlay({ nodeId, anchor, layer, children }: NodeVie
         className="absolute pointer-events-none"
         style={{
           position: 'absolute',
-          left: positionAbsolute.x + (anchor?.left ?? 0),
-          top: positionAbsolute.y + (anchor?.top ?? 0),
-          width,
-          height,
+          left: geometry.x + (anchor?.left ?? 0),
+          top: geometry.y + (anchor?.top ?? 0),
+          width: geometry.width,
+          height: geometry.height,
           transform: anchor?.transform,
           zIndex: layer ? NODE_VIEWPORT_OVERLAY_Z_INDEX[layer] : undefined,
         }}

--- a/packages/apollo-react/src/canvas/components/StickyNoteNode/StickyNoteNode.tsx
+++ b/packages/apollo-react/src/canvas/components/StickyNoteNode/StickyNoteNode.tsx
@@ -11,6 +11,8 @@ import remarkBreaks from 'remark-breaks';
 import remarkGfm from 'remark-gfm';
 import { useSafeLingui } from '../../../i18n';
 import { GRID_SPACING } from '../../constants';
+import { areNodePropsEqualIgnoringPosition } from '../../utils/nodePropsEqual';
+import { useSelectionState } from '../BaseCanvas/SelectionStateContext';
 import { NodeViewportOverlay } from '../NodeViewportOverlay';
 import type { ToolbarAction } from '../Toolbar';
 import { NodeToolbar } from '../Toolbar';
@@ -71,6 +73,7 @@ const StickyNoteNodeComponent = ({
 }: StickyNoteNodeProps) => {
   const { _ } = useSafeLingui();
   const { updateNodeData, deleteElements } = useReactFlow();
+  const { multipleNodesSelected } = useSelectionState();
   const [isEditing, setIsEditing] = useState(!readOnly && (data.autoFocus ?? false));
   const [isResizing, setIsResizing] = useState(false);
   const [isColorPickerOpen, setIsColorPickerOpen] = useState(false);
@@ -108,10 +111,10 @@ const StickyNoteNodeComponent = ({
   }, [isEditing, data.autoFocus, id, updateNodeData, readOnly]);
 
   useEffect(() => {
-    if (!selected || isResizing) {
+    if (!selected || dragging || isResizing || multipleNodesSelected) {
       setIsColorPickerOpen(false);
     }
-  }, [selected, isResizing]);
+  }, [selected, dragging, isResizing, multipleNodesSelected]);
 
   useEffect(() => {
     if (readOnly) {
@@ -341,6 +344,9 @@ const StickyNoteNodeComponent = ({
     };
   }, [_, handleEditClick, handleToggleColorPicker, color, handleDelete]);
 
+  const shouldRenderToolbarOverlay =
+    !readOnly && selected && !dragging && !isResizing && !multipleNodesSelected;
+
   return (
     <>
       <Global styles={stickyNoteGlobalStyles} />
@@ -453,10 +459,10 @@ const StickyNoteNodeComponent = ({
           )}
         </StickyNoteContainer>
 
-        {!readOnly && selected && !dragging && !isResizing && (
+        {shouldRenderToolbarOverlay && (
           <NodeToolbar nodeId={id} config={toolbarConfig} expanded={true} portalToNodeOverlay />
         )}
-        {!readOnly && selected && !dragging && !isResizing && (
+        {shouldRenderToolbarOverlay && (
           <NodeViewportOverlay nodeId={id} layer="nodeToolbar">
             <AnimatePresence>
               {isColorPickerOpen && (
@@ -506,4 +512,4 @@ const StickyNoteNodeComponent = ({
   );
 };
 
-export const StickyNoteNode = memo(StickyNoteNodeComponent);
+export const StickyNoteNode = memo(StickyNoteNodeComponent, areNodePropsEqualIgnoringPosition);

--- a/packages/apollo-react/src/canvas/components/Toolbar/NodeToolbar/NodeToolbar.tsx
+++ b/packages/apollo-react/src/canvas/components/Toolbar/NodeToolbar/NodeToolbar.tsx
@@ -154,6 +154,10 @@ const NodeToolbarComponent = ({
     return null;
   }
 
+  if (portalToNodeOverlay && displayState === 'hidden') {
+    return null;
+  }
+
   const toolbarContent = (
     <AnimatePresence>
       {displayState !== 'hidden' && (

--- a/packages/apollo-react/src/canvas/storybook-utils/components/StoryInfoPanel.tsx
+++ b/packages/apollo-react/src/canvas/storybook-utils/components/StoryInfoPanel.tsx
@@ -1,7 +1,7 @@
 import { Column, Row } from '@uipath/apollo-react/canvas/layouts';
 import { Panel } from '@uipath/apollo-react/canvas/xyflow/react';
 import { Button } from '@uipath/apollo-wind';
-import { useState } from 'react';
+import { memo, useState } from 'react';
 import { CanvasIcon } from '../../utils/icon-registry';
 
 export interface StoryInfoPanelProps {
@@ -19,7 +19,7 @@ export interface StoryInfoPanelProps {
   position?: 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right';
 }
 
-export function StoryInfoPanel({
+export const StoryInfoPanel = memo(function StoryInfoPanel({
   title,
   description,
   children,
@@ -77,4 +77,4 @@ export function StoryInfoPanel({
       </Column>
     </Panel>
   );
-}
+});

--- a/packages/apollo-react/src/canvas/storybook-utils/manifests/node-definitions.ts
+++ b/packages/apollo-react/src/canvas/storybook-utils/manifests/node-definitions.ts
@@ -265,7 +265,6 @@ export const allNodeManifests: NodeManifest[] = [
         handles: [
           {
             id: 'success',
-            label: 'Success',
             type: 'source',
             handleType: 'output',
           },

--- a/packages/apollo-react/src/canvas/utils/index.ts
+++ b/packages/apollo-react/src/canvas/utils/index.ts
@@ -14,6 +14,7 @@ export * from './GroupModificationUtils';
 export * from './handle-positioning';
 export * from './icon-registry';
 export * from './manifest-resolver';
+export * from './nodePropsEqual';
 export * from './NodeUtils';
 export * from './props-helpers';
 export * from './resource-operations';


### PR DESCRIPTION
## Summary

This PR reduces unnecessary React/render work in the canvas overlay and loop-container paths during high-frequency interactions like dragging, resizing, multi-selecting, and geometry-only updates. The main target is avoidable component work around viewport portals, hidden overlays, loop chrome, sticky notes, and edge animation output.

## What is optimized

- **Node viewport overlays subscribe only to geometry.** `NodeViewportOverlay` now reads just `x`, `y`, `width`, and `height` from the React Flow store with a selector and `shallow` equality. That avoids re-rendering overlay portals when unrelated internal node fields change.
- **Hidden portal content stops mounting.** `HandleButton` skips the viewport portal when neither the add button nor its label is visible. `NodeToolbar` also returns `null` for hidden toolbar instances that are rendered through the node overlay portal, so hidden toolbars do not keep portal wrappers and animation structure alive.
- **Loop success handle labels are removed.** The loop `success` handle still exists for edge connectivity, but it no longer renders the visible `Success` label. This removes a portalized connected-handle label that was showing up during nested-loop drag profiling.
- **Loop shell chrome can bail out during drag.** `BodyFrame`, `ResizeControls`, and `ResizeCornerIndicators` are memoized so static loop chrome does not rerender just because the loop shell rerenders. Resize hit targets remain mounted, so unselected loops can still be resized by hovering the resize controls.
- **Storybook-only static chrome can bail out.** `StoryInfoPanel` is memoized so the story description panel does not rerender during canvas drag profiling.
- **Sticky notes skip position-only churn.** `StickyNoteNode` now uses the position-insensitive node props comparator, so moving nodes does not force sticky note markdown, edit state, resize handles, toolbar config, and color picker UI to re-render unnecessarily.
- **Sticky note overlays render only when actionable.** The sticky note toolbar and color picker overlay now share a single visibility guard and close during drag, resize, and multi-select states. That keeps overlay work out of interaction states where the controls are not usable.
- **Execution edge animations recompute only for in-progress edges.** `useExecutionEdge` still applies status colors for all execution and validation states, but only calls `getStatusAnimation` when the edge status is `InProgress`. Completed, failed, and validation-colored edges no longer rebuild animation output on path-only geometry updates.
- **Loop child detection uses React Flow lookup state.** Loop nodes now check `parentLookup` instead of scanning `state.nodes` to determine whether a loop has children, making that check a map lookup rather than a full node-list scan.
- **The shared node comparator is exported.** `nodePropsEqual` is exported from canvas utils so other canvas nodes can reuse the same position-insensitive memoization path.

## Demo

- This PR primarily reduces avoidable re-renders from `NodeViewportOverlay` / viewport portal.
- We still see expected re-renders from React Flow internals like `NodeWrapper` and `EdgeWrapper`.
- `CanvasEdge`, `SequenceEdge`, `EdgePath`, and `EdgeArrow` still rerender when edge positions change because the SVG geometry has to move with the nodes.

Before vs After

https://github.com/user-attachments/assets/f200508f-4bc9-4582-8811-414cabc03988

https://github.com/user-attachments/assets/a89781f9-fe23-42c2-9f0c-71e05d3a581f

## Expected impact

- Less React work while dragging, selecting, resizing, and moving around larger canvases.
- Fewer hidden portal trees in the viewport overlay layer.
- Less nested-loop drag churn from static loop chrome and connected handle labels.
- Less animation recomputation for status-colored edges when only edge geometry changes.
- Lower sticky note render cost during position updates and multi-node interactions.
- Better scaling for loop-heavy canvases when checking child-node presence.

## Validation

- `pnpm --filter @uipath/apollo-react exec vitest run src/canvas/utils/nodePropsEqual.test.tsx`
- `pnpm --filter @uipath/apollo-react exec vitest run src/canvas/components/LoopNode/LoopNode.test.tsx`
- `pnpm --filter @uipath/apollo-react exec tsc --noEmit --project tsconfig.json`
