### PR TITLE
fix(apollo-react): show node label fallback tooltips

### DIFF
--- a/packages/apollo-react/src/canvas/components/BaseNode/BaseNode.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/BaseNode/BaseNode.stories.tsx
@@ -8,7 +8,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 import { Column } from '@uipath/apollo-react/canvas/layouts';
 import type { Node } from '@uipath/apollo-react/canvas/xyflow/react';
 import { Panel } from '@uipath/apollo-react/canvas/xyflow/react';
-import { Button, Input, Label, Slider, Switch, cn } from '@uipath/apollo-wind';
+import { Button, cn, Input, Label, Slider, Switch } from '@uipath/apollo-wind';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { NodeRegistryProvider } from '../../core';
 import type { CategoryManifest, NodeManifest } from '../../schema';
@@ -22,12 +22,12 @@ import {
 } from '../../storybook-utils';
 import { DefaultCanvasTranslations } from '../../types';
 import type { ValidationErrorSeverity } from '../../types/validation';
+import { CanvasIcon } from '../../utils/icon-registry';
 import { BaseCanvas } from '../BaseCanvas';
 import { CanvasPositionControls } from '../CanvasPositionControls';
 import { NodeInspector } from '../NodeInspector';
-import { CanvasIcon } from '../../utils/icon-registry';
-import { BaseNodeOverrideConfigProvider } from './BaseNodeConfigContext';
 import type { BaseNodeData } from './BaseNode.types';
+import { BaseNodeOverrideConfigProvider } from './BaseNodeConfigContext';
 
 // ============================================================================
 // Meta Configuration
@@ -1150,6 +1150,79 @@ function SizesStory() {
   );
 }
 
+function LabelTooltipsStory() {
+  const initialNodes = useMemo<Node<BaseNodeData>[]>(
+    () => [
+      createNode({
+        id: 'label-tooltip-circle',
+        type: 'uipath.manual-trigger',
+        position: { x: 160, y: 180 },
+        data: {
+          nodeType: 'uipath.manual-trigger',
+          version: '1.0.0',
+          display: {
+            label:
+              'Customer Intake Trigger With a Very Long Header That Should Clamp Across Multiple Lines and Continue Far Beyond the Visible Node Label Area for Tooltip Testing',
+            subLabel:
+              'Fallback sublabel tooltip uses this full trigger description when labelTooltip is absent. This deliberately verbose description keeps going long enough to exceed the circular node sublabel clamp, so hover can reveal the complete text for a customer intake process with multiple upstream systems, exception routing, validation notes, and operational metadata.',
+            shape: 'circle',
+          },
+        },
+      }),
+      createNode({
+        id: 'label-tooltip-square',
+        type: 'uipath.blank-node',
+        position: { x: 440, y: 180 },
+        data: {
+          nodeType: 'uipath.blank-node',
+          version: '1.0.0',
+          display: {
+            label:
+              'Quarterly Revenue Reconciliation Approval With Exception Handling Manual Review Regional Overrides Audit Controls and a Name That Intentionally Keeps Going',
+            subLabel:
+              'Hover this sublabel to verify it becomes the tooltip content without an override. The copy is intentionally extended with enough operational detail to overflow the square node sublabel clamp during visual review, including invoice matching, revenue variance notes, controller approval status, and downstream posting requirements.',
+            shape: 'square',
+          },
+        },
+      }),
+      {
+        ...createNode({
+          id: 'label-tooltip-rectangle',
+          type: 'uipath.agent',
+          position: { x: 720, y: 180 },
+          data: {
+            nodeType: 'uipath.agent',
+            version: '1.0.0',
+            display: {
+              label:
+                'Operations Agent With Long Header Text That Exceeds the Available Rectangle Width by a Wide Margin for Tooltip Testing',
+              subLabel:
+                'This rectangle sublabel is intentionally long so the smart tooltip can expose the full text after the two-line clamp, including monitoring context, escalation policy, queue ownership, and remediation notes.',
+              shape: 'rectangle',
+            },
+          },
+        }),
+        width: 184,
+        height: 64,
+      },
+    ],
+    []
+  );
+  const { canvasProps } = useCanvasStory({ initialNodes });
+
+  return (
+    <BaseCanvas {...canvasProps} mode="design">
+      <Panel position="bottom-right">
+        <CanvasPositionControls translations={DefaultCanvasTranslations} />
+      </Panel>
+      <StoryInfoPanel
+        title="Label Tooltips"
+        description="Hover the truncated node labels and sublabels. No labelTooltip override is provided, so each tooltip should use the corresponding label or sublabel text."
+      />
+    </BaseCanvas>
+  );
+}
+
 /**
  * Story-only manifest with `repeat` expressions and templated labels so the
  * DynamicHandles story can demonstrate manifest-level dynamic handle features.
@@ -1482,6 +1555,11 @@ export const ExecutionStates: Story = {
 export const Sizes: Story = {
   name: 'Sizes',
   render: () => <SizesStory />,
+};
+
+export const LabelTooltips: Story = {
+  name: 'Label Tooltips',
+  render: () => <LabelTooltipsStory />,
 };
 
 export const Handles: Story = {

--- a/packages/apollo-react/src/canvas/components/BaseNode/NodeLabel.integration.test.tsx
+++ b/packages/apollo-react/src/canvas/components/BaseNode/NodeLabel.integration.test.tsx
@@ -1,0 +1,115 @@
+import { act, renderHook } from '@testing-library/react';
+import { createRef } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { useTruncationDetection } from '../../../material/components/ap-tooltip/useTruncationDetection';
+import { render, screen } from '../../utils/testing';
+import { CanvasTooltip } from '../CanvasTooltip';
+import { NodeLabel } from './NodeLabel';
+
+// Exercises the real (un-mocked) CanvasTooltip: ref composition, TooltipTrigger
+// asChild wiring, and the truncation detection reading the actual label element.
+// Radix does not portal its content in happy-dom, so the popup itself is covered
+// by Storybook rather than asserted here.
+
+// happy-dom does not evaluate the Tailwind line-clamp styles, so report a clamp
+// for the element and drive scroll/client height to decide whether it overflows.
+function mockLineClamp(element: HTMLElement, { overflowing }: { overflowing: boolean }) {
+  const originalGetComputedStyle = window.getComputedStyle;
+  vi.spyOn(window, 'getComputedStyle').mockImplementation((target) => {
+    const style = originalGetComputedStyle.call(window, target);
+    if (target !== element) {
+      return style;
+    }
+
+    return new Proxy(style, {
+      get(proxyTarget, prop, receiver) {
+        if (prop === 'getPropertyValue') {
+          return (property: string) =>
+            property === '-webkit-line-clamp' ? '3' : proxyTarget.getPropertyValue(property);
+        }
+        return Reflect.get(proxyTarget, prop, receiver);
+      },
+    });
+  });
+
+  Object.defineProperties(element, {
+    clientHeight: { configurable: true, value: 36 },
+    scrollHeight: { configurable: true, value: overflowing ? 72 : 36 },
+  });
+}
+
+describe('NodeLabel tooltip integration (real CanvasTooltip)', () => {
+  const detachedElements: HTMLElement[] = [];
+
+  // Standalone elements aren't owned by Testing Library's render root, so remove
+  // them explicitly to avoid leaking DOM state into later tests.
+  function appendDetached() {
+    const element = document.createElement('div');
+    document.body.appendChild(element);
+    detachedElements.push(element);
+    return element;
+  }
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    while (detachedElements.length) {
+      detachedElements.pop()?.remove();
+    }
+  });
+
+  describe('real CanvasTooltip wiring', () => {
+    it('renders the label as the tooltip trigger with no wrapper element (asChild)', () => {
+      render(<NodeLabel label="Long node label" subLabel="" selected />);
+
+      const label = screen.getByTestId('node-label');
+      const container = label.parentElement;
+
+      // asChild means the label element itself is the trigger: CanvasTooltip
+      // must not inject an extra wrapper into the text container.
+      expect(container?.children).toHaveLength(1);
+      expect(container?.firstElementChild).toBe(label);
+    });
+
+    it('composes the trigger ref onto the actual rendered element', () => {
+      const ref = createRef<HTMLDivElement>();
+
+      render(
+        <CanvasTooltip content="Full label" smartTooltip>
+          <div ref={ref} data-testid="trigger">
+            Long label text
+          </div>
+        </CanvasTooltip>
+      );
+
+      // Smart truncation inspects the real label node, so CanvasTooltip must
+      // forward the consumer ref to the element it actually renders.
+      expect(ref.current).toBe(screen.getByTestId('trigger'));
+    });
+  });
+
+  describe('smart truncation reads the actual label element', () => {
+    it('reports truncated when line-clamped content overflows', () => {
+      const element = appendDetached();
+      mockLineClamp(element, { overflowing: true });
+
+      const { result } = renderHook(() => useTruncationDetection({ current: element }));
+      act(() => {
+        result.current.check();
+      });
+
+      expect(result.current.isTruncated).toBe(true);
+    });
+
+    it('reports not truncated when line-clamped content fits', () => {
+      const element = appendDetached();
+      mockLineClamp(element, { overflowing: false });
+
+      const { result } = renderHook(() => useTruncationDetection({ current: element }));
+      act(() => {
+        result.current.check();
+      });
+
+      expect(result.current.isTruncated).toBe(false);
+    });
+  });
+});

--- a/packages/apollo-react/src/canvas/components/BaseNode/NodeLabel.test.tsx
+++ b/packages/apollo-react/src/canvas/components/BaseNode/NodeLabel.test.tsx
@@ -1,6 +1,31 @@
+import type { HTMLAttributes, ReactNode } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { render, screen, type UserEvent, userEvent } from '../../utils/testing';
 import { NodeLabel, type NodeLabelProps } from './NodeLabel';
+
+vi.mock('../CanvasTooltip', async () => {
+  const React = await import('react');
+
+  return {
+    CanvasTooltip: ({ content, children }: { content: ReactNode; children: ReactNode }) => {
+      const trigger = React.isValidElement(children)
+        ? React.cloneElement(children, {
+            'data-tooltip-trigger': typeof content === 'string' ? content : 'true',
+            onMouseEnter: () => undefined,
+          } as HTMLAttributes<HTMLElement>)
+        : children;
+
+      return (
+        <div
+          data-testid="canvas-tooltip"
+          data-tooltip-content={typeof content === 'string' ? content : undefined}
+        >
+          {trigger}
+        </div>
+      );
+    },
+  };
+});
 
 describe('NodeLabel', () => {
   const defaultProps: NodeLabelProps = {
@@ -45,6 +70,38 @@ describe('NodeLabel', () => {
 
       expect(screen.getByText('Test Node')).toBeInTheDocument();
       expect(screen.getByText('Adornment')).toBeInTheDocument();
+    });
+  });
+
+  describe('Tooltips', () => {
+    it('should use label and subLabel as tooltip content when labelTooltip is not provided', () => {
+      render(<NodeLabel {...defaultProps} />);
+
+      const tooltips = screen.getAllByTestId('canvas-tooltip');
+
+      expect(tooltips).toHaveLength(2);
+      expect(tooltips[0]).toHaveAttribute('data-tooltip-content', 'Test Node');
+      expect(tooltips[1]).toHaveAttribute('data-tooltip-content', 'Test Description');
+    });
+
+    it('should use labelTooltip for both label and subLabel when provided', () => {
+      render(<NodeLabel {...defaultProps} labelTooltip="Custom tooltip" />);
+
+      const tooltips = screen.getAllByTestId('canvas-tooltip');
+
+      expect(tooltips).toHaveLength(2);
+      expect(tooltips[0]).toHaveAttribute('data-tooltip-content', 'Custom tooltip');
+      expect(tooltips[1]).toHaveAttribute('data-tooltip-content', 'Custom tooltip');
+    });
+
+    it('should pass tooltip trigger props to label and subLabel elements', () => {
+      render(<NodeLabel {...defaultProps} />);
+
+      expect(screen.getByTestId('node-label')).toHaveAttribute('data-tooltip-trigger', 'Test Node');
+      expect(screen.getByTestId('node-sublabel')).toHaveAttribute(
+        'data-tooltip-trigger',
+        'Test Description'
+      );
     });
   });
 

--- a/packages/apollo-react/src/canvas/components/BaseNode/NodeLabel.tsx
+++ b/packages/apollo-react/src/canvas/components/BaseNode/NodeLabel.tsx
@@ -37,78 +37,100 @@ export const BaseTextContainer = ({
 
 interface ConditionalTooltipProps {
   content?: string;
+  placement?: 'top' | 'bottom';
   children: React.ReactNode;
 }
 
-const ConditionalTooltip = ({ content, children }: ConditionalTooltipProps) => {
+const ConditionalTooltip = ({ content, placement = 'top', children }: ConditionalTooltipProps) => {
   if (!content) {
     return children;
   }
 
   return (
-    <CanvasTooltip delay placement="top" content={content} smartTooltip>
+    <CanvasTooltip delay placement={placement} content={content} smartTooltip>
       {children}
     </CanvasTooltip>
   );
 };
 
-interface HeaderProps {
+interface HeaderProps extends React.HTMLAttributes<HTMLDivElement> {
   shape?: NodeShape;
   backgroundColor?: string;
   onDoubleClick?: (e: React.MouseEvent) => void;
-  children: React.ReactNode;
   'data-testid'?: string;
 }
 
-const Header = ({
-  shape,
-  backgroundColor,
-  onDoubleClick,
-  children,
-  'data-testid': dataTestId,
-}: HeaderProps) => (
-  // biome-ignore lint/a11y/noStaticElementInteractions: double-click-to-edit is the existing UX
-  <div
-    data-testid={dataTestId}
-    onDoubleClick={onDoubleClick}
-    className={cx(
-      'text-center text-sm leading-[18px] font-semibold text-foreground overflow-hidden',
-      backgroundColor && 'px-1.5 py-0.5 rounded-sm',
-      shape === 'rectangle'
-        ? 'w-full text-left whitespace-nowrap text-ellipsis'
-        : 'wrap-break-word line-clamp-3'
-    )}
-    style={backgroundColor ? { backgroundColor } : undefined}
-  >
-    {children}
-  </div>
+const Header = forwardRef<HTMLDivElement, HeaderProps>(
+  (
+    {
+      shape,
+      backgroundColor,
+      onDoubleClick,
+      children,
+      className,
+      style,
+      'data-testid': dataTestId,
+      ...triggerProps
+    },
+    ref
+  ) => (
+    <div
+      {...triggerProps}
+      ref={ref}
+      data-testid={dataTestId}
+      onDoubleClick={onDoubleClick}
+      className={cx(
+        'text-center text-sm leading-[18px] font-semibold text-foreground overflow-hidden',
+        backgroundColor && 'px-1.5 py-0.5 rounded-sm',
+        shape === 'rectangle'
+          ? 'w-full text-left whitespace-nowrap text-ellipsis'
+          : 'wrap-break-word line-clamp-3',
+        className
+      )}
+      style={{ ...style, ...(backgroundColor ? { backgroundColor } : undefined) }}
+    >
+      {children}
+    </div>
+  )
 );
+Header.displayName = 'Header';
 
-interface SubHeaderProps {
+interface SubHeaderProps extends React.HTMLAttributes<HTMLDivElement> {
   shape?: NodeShape;
   onDoubleClick?: (e: React.MouseEvent) => void;
-  children: React.ReactNode;
   'data-testid'?: string;
 }
 
-const SubHeader = ({
-  shape,
-  onDoubleClick,
-  children,
-  'data-testid': dataTestId,
-}: SubHeaderProps) => (
-  // biome-ignore lint/a11y/noStaticElementInteractions: double-click-to-edit is the existing UX
-  <div
-    data-testid={dataTestId}
-    onDoubleClick={onDoubleClick}
-    className={cx(
-      'text-center text-xs leading-[18px] text-foreground-muted wrap-break-word overflow-hidden',
-      shape === 'rectangle' ? 'w-full text-left line-clamp-2' : 'line-clamp-5'
-    )}
-  >
-    {children}
-  </div>
+const SubHeader = forwardRef<HTMLDivElement, SubHeaderProps>(
+  (
+    {
+      shape,
+      onDoubleClick,
+      children,
+      className,
+      style,
+      'data-testid': dataTestId,
+      ...triggerProps
+    },
+    ref
+  ) => (
+    <div
+      {...triggerProps}
+      ref={ref}
+      data-testid={dataTestId}
+      onDoubleClick={onDoubleClick}
+      className={cx(
+        'text-center text-xs leading-[18px] text-foreground-muted wrap-break-word overflow-hidden',
+        shape === 'rectangle' ? 'w-full text-left line-clamp-2' : 'line-clamp-5',
+        className
+      )}
+      style={style}
+    >
+      {children}
+    </div>
+  )
 );
+SubHeader.displayName = 'SubHeader';
 
 interface EditableLabelProps {
   shape?: NodeShape;
@@ -307,6 +329,14 @@ const NodeLabelInternal = ({
     );
   }
 
+  const headerTooltipContent = labelTooltip ?? label;
+  const subHeaderTooltipContent = labelTooltip ?? subLabel;
+
+  // Rectangle nodes render the label inside the node body, so a top-placed
+  // tooltip sits above the node. Other shapes render the label below the node,
+  // where a top-placed tooltip would overlap the node itself, so place it below.
+  const tooltipPlacement = shape === 'rectangle' ? 'top' : 'bottom';
+
   return (
     <BaseTextContainer hasBottomHandles={hasBottomHandles} shape={shape}>
       {isEditing ? (
@@ -338,25 +368,29 @@ const NodeLabelInternal = ({
           />
         </>
       ) : (
-        <ConditionalTooltip content={labelTooltip}>
-          <Header
-            shape={shape}
-            backgroundColor={labelBackgroundColor}
-            onDoubleClick={readonly ? undefined : handleDoubleClick(labelInputRef)}
-            data-testid="node-label"
-          >
-            {label}
-          </Header>
-          {subLabel && (
-            <SubHeader
+        <>
+          <ConditionalTooltip content={headerTooltipContent} placement={tooltipPlacement}>
+            <Header
               shape={shape}
-              onDoubleClick={readonly ? undefined : handleDoubleClick(subLabelInputRef)}
-              data-testid="node-sublabel"
+              backgroundColor={labelBackgroundColor}
+              onDoubleClick={readonly ? undefined : handleDoubleClick(labelInputRef)}
+              data-testid="node-label"
             >
-              {subLabel}
-            </SubHeader>
+              {label}
+            </Header>
+          </ConditionalTooltip>
+          {subLabel && (
+            <ConditionalTooltip content={subHeaderTooltipContent} placement={tooltipPlacement}>
+              <SubHeader
+                shape={shape}
+                onDoubleClick={readonly ? undefined : handleDoubleClick(subLabelInputRef)}
+                data-testid="node-sublabel"
+              >
+                {subLabel}
+              </SubHeader>
+            </ConditionalTooltip>
           )}
-        </ConditionalTooltip>
+        </>
       )}
       {centerAdornment}
     </BaseTextContainer>

--- a/packages/apollo-react/src/material/components/ap-tooltip/ApTooltip.test.tsx
+++ b/packages/apollo-react/src/material/components/ap-tooltip/ApTooltip.test.tsx
@@ -197,6 +197,53 @@ describe('ApTooltip', () => {
     expect(container).toBeInTheDocument();
   });
 
+  it('shows smartTooltip for line-clamped multiline overflow', async () => {
+    const originalGetComputedStyle = window.getComputedStyle;
+
+    render(
+      <ApTooltip content="Full label text" smartTooltip>
+        <div data-testid="clamped-label" style={{ overflow: 'hidden' }}>
+          Long label text that wraps across more than two lines
+        </div>
+      </ApTooltip>
+    );
+
+    const label = screen.getByTestId('clamped-label');
+    const getComputedStyleSpy = vi
+      .spyOn(window, 'getComputedStyle')
+      .mockImplementation((element) => {
+        const style = originalGetComputedStyle.call(window, element);
+        if (element !== label) {
+          return style;
+        }
+
+        return new Proxy(style, {
+          get(target, prop, receiver) {
+            if (prop === 'getPropertyValue') {
+              return (property: string) =>
+                property === '-webkit-line-clamp' ? '2' : target.getPropertyValue(property);
+            }
+            return Reflect.get(target, prop, receiver);
+          },
+        });
+      });
+
+    Object.defineProperties(label, {
+      clientHeight: { configurable: true, value: 36 },
+      scrollHeight: { configurable: true, value: 72 },
+    });
+
+    try {
+      await userEvent.hover(label);
+
+      await waitFor(() => {
+        expect(screen.getByText('Full label text')).toBeInTheDocument();
+      });
+    } finally {
+      getComputedStyleSpy.mockRestore();
+    }
+  });
+
   /**
    * Re-rendering behavior tests
    *

--- a/packages/apollo-react/src/material/components/ap-tooltip/useTruncationDetection.ts
+++ b/packages/apollo-react/src/material/components/ap-tooltip/useTruncationDetection.ts
@@ -2,6 +2,38 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 
 const TOOLTIP_TARGET_ELEMENT = 'tooltip-target-element';
 
+function getLineClamp(computedStyle: CSSStyleDeclaration) {
+  return (
+    computedStyle.getPropertyValue('-webkit-line-clamp') ||
+    (computedStyle as CSSStyleDeclaration & { WebkitLineClamp?: string }).WebkitLineClamp
+  );
+}
+
+function hasLineClamp(computedStyle: CSSStyleDeclaration) {
+  const lineClamp = getLineClamp(computedStyle);
+  return Boolean(lineClamp && lineClamp !== 'none');
+}
+
+function isTruncationStyleCandidate(element: HTMLElement) {
+  const computedStyle = window.getComputedStyle(element);
+  return computedStyle.textOverflow === 'ellipsis' || hasLineClamp(computedStyle);
+}
+
+function findTruncationStyleCandidate(element: Element | null) {
+  if (!(element instanceof HTMLElement)) {
+    return undefined;
+  }
+
+  if (isTruncationStyleCandidate(element)) {
+    return element;
+  }
+
+  return Array.from(element.children).find(
+    (child): child is HTMLElement =>
+      child instanceof HTMLElement && isTruncationStyleCandidate(child)
+  );
+}
+
 export function useTruncationDetection(elementRef: React.RefObject<HTMLElement | null>): {
   isTruncated: boolean;
   check: () => void;
@@ -36,12 +68,12 @@ export function useTruncationDetection(elementRef: React.RefObject<HTMLElement |
         if (rootNode instanceof ShadowRoot) {
           const hostElement = rootNode.host;
           const slottedElement =
-            (hostElement.querySelector('div[data-slot-name="children"]') as HTMLElement) ||
-            (Array.from(hostElement.children).find(
-              (child) =>
-                child instanceof HTMLElement &&
-                window.getComputedStyle(child).textOverflow === 'ellipsis'
-            ) as HTMLElement | undefined);
+            findTruncationStyleCandidate(
+              hostElement.querySelector('div[data-slot-name="children"]')
+            ) ||
+            (Array.from(hostElement.children)
+              .map((child) => findTruncationStyleCandidate(child))
+              .find(Boolean) as HTMLElement | undefined);
           if (slottedElement instanceof HTMLElement) {
             targetElement = slottedElement;
           }
@@ -49,10 +81,17 @@ export function useTruncationDetection(elementRef: React.RefObject<HTMLElement |
       }
     }
     const computedStyle = window.getComputedStyle(targetElement);
+    const isLineClamped = hasLineClamp(computedStyle);
     const hasEllipsis = computedStyle.textOverflow === 'ellipsis';
     const hasOverflowHidden =
       computedStyle.overflow === 'hidden' || computedStyle.overflowX === 'hidden';
     const hasWhiteSpaceNowrap = computedStyle.whiteSpace === 'nowrap';
+
+    if (isLineClamped) {
+      setIsTruncated(targetElement.scrollHeight > targetElement.clientHeight);
+      return;
+    }
+
     if (!hasEllipsis || !hasOverflowHidden || !hasWhiteSpaceNowrap) {
       setIsTruncated(false);
       return;


### PR DESCRIPTION
## Summary

- Wrap node label header and subheader text in independent conditional tooltips.
- Use the visible label/subLabel as fallback tooltip content when no `labelTooltip` override is provided.
- Preserve tooltip trigger props and refs on the underlying label DOM nodes so hover and smart truncation checks work.
- Extend smart tooltip truncation detection to recognize line-clamped multiline overflow.
- Add a BaseNode Storybook story with deliberately long labels and sublabels for visual verification.

## Demo


https://github.com/user-attachments/assets/4a34b36b-395a-48ba-9788-6bf7816b5fe0



## Validation

- `pnpm --filter @uipath/apollo-react exec vitest --run src/canvas/components/BaseNode/NodeLabel.test.tsx src/material/components/ap-tooltip/ApTooltip.test.tsx`
- `pnpm exec biome check src/canvas/components/BaseNode/NodeLabel.tsx src/canvas/components/BaseNode/NodeLabel.test.tsx src/canvas/components/BaseNode/BaseNode.stories.tsx src/material/components/ap-tooltip/useTruncationDetection.ts src/material/components/ap-tooltip/ApTooltip.test.tsx`
