### PR TITLE
fix(storybook): redirect legacy wind- story paths to apollo-wind-

### DIFF
--- a/apps/storybook/.storybook/main.ts
+++ b/apps/storybook/.storybook/main.ts
@@ -116,6 +116,19 @@ const config: StorybookConfig = {
         width: auto;
       }
     </style>
+    <script>
+      // Rewrite legacy story paths that used the old "Wind" titlePrefix (pre-IA rename).
+      // Storybook stores the last-viewed story in the URL (?path=) so returning users
+      // who bookmarked or cached a "wind-*" path land here with an invalid story ID.
+      (function () {
+        var params = new URLSearchParams(window.location.search);
+        var path = params.get('path');
+        if (path && path.indexOf('/story/wind-') === 0) {
+          params.set('path', path.replace('/story/wind-', '/story/apollo-wind-'));
+          window.location.replace('?' + params.toString());
+        }
+      })();
+    </script>
   `,
   previewBody: isDev
     ? (body) =>


### PR DESCRIPTION
## Summary

- Adds a small inline script to `managerHead` in `main.ts` that intercepts `?path=/story/wind-*` URLs on load and rewrites them to the current `?path=/story/apollo-wind-*` equivalent
- Fixes the broken first-visit experience on https://apollo-design.vercel.app/ for returning users who have the old story path cached/bookmarked

## Root cause

The Storybook `titlePrefix` for `apollo-wind` was renamed from `'Wind'` → `'Apollo Wind'` in the IA update (`c3fcf17e`). This changed all story IDs (e.g. `wind-introduction-getting-started--default` → `apollo-wind-introduction-getting-started--default`). Returning users whose browser has the old `?path=` URL in history or as a bookmark land on a "Couldn't find story" error page.

## How the fix works

The redirect script runs synchronously in the manager `<head>` before Storybook initialises, so there's no flash of the error state — the URL is rewritten and the page reloads transparently.

## Test plan

- [ ] Visit `https://apollo-design.vercel.app/?path=/story/wind-introduction-getting-started--default` after deploy — should redirect cleanly to the `apollo-wind-*` equivalent
- [ ] Visit `https://apollo-design.vercel.app/` with no path — should land on the default Introduction story with no error

🤖 Generated with [Claude Code](https://claude.com/claude-code)