### PR TITLE
feat(storybook): add system-wide introduction landing page and unify getting started docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,9 +4,9 @@
 
 ### No em dashes in Storybook documentation content
 
-**Never use ` — ` (em dash with spaces) in any Storybook story copy** — this includes description text, callouts, step labels, tooltips, and any other user-facing content in `.stories.tsx` files.
+**Never use ` — ` (em dash with spaces) in any Storybook story copy.** This includes description text, callouts, step labels, tooltips, and any other user-facing content in `.stories.tsx` files.
 
-- Use a period and a new sentence instead: `"...ownership model. Source is copied..."`)
+- Use a period and a new sentence instead: `"...ownership model. Source is copied..."`
 - Use a colon for lists or clarifications: `"Prerequisites: Node 18+, Tailwind v4"`
 - Use a comma for light joining: `"...templates, all consistent with..."`
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,18 @@
 
 ## Rules
 
+### No em dashes in Storybook documentation content
+
+**Never use ` — ` (em dash with spaces) in any Storybook story copy** — this includes description text, callouts, step labels, tooltips, and any other user-facing content in `.stories.tsx` files.
+
+- Use a period and a new sentence instead: `"...ownership model. Source is copied..."`)
+- Use a colon for lists or clarifications: `"Prerequisites: Node 18+, Tailwind v4"`
+- Use a comma for light joining: `"...templates, all consistent with..."`
+
+This applies to all packages: `apollo-wind`, `apollo-react`, `apollo-core`, and the root `apps/storybook` introduction pages.
+
+---
+
 ### Default to verified docs, not memory.
 
 When working with frameworks or UI libraries (e.g., Tailwind, Shadcn, Storybook, etc.) — **never rely on memory or training data**.

--- a/apps/storybook/.storybook/main.ts
+++ b/apps/storybook/.storybook/main.ts
@@ -36,7 +36,11 @@ if (isDev) {
 const config: StorybookConfig = {
   stories: [
     {
-      directory: '../src',
+      directory: '../src/introduction',
+      files: '**/*.stories.@(tsx|ts|jsx|js|mdx)',
+    },
+    {
+      directory: '../src/core',
       files: '**/*.stories.@(tsx|ts|jsx|js|mdx)',
       titlePrefix: 'Apollo Core',
     },

--- a/apps/storybook/.storybook/preview.tsx
+++ b/apps/storybook/.storybook/preview.tsx
@@ -126,6 +126,7 @@ const preview: Preview = {
     options: {
       storySort: {
         order: [
+          'Introduction',
           'Apollo Wind',
           [
             'Introduction',
@@ -204,14 +205,18 @@ const preview: Preview = {
           'Apollo Core',
           [
             'Introduction',
-            'Colors',
-            'Typography',
-            'Spacing',
-            'Borders',
-            'Shadows',
-            'Icons',
-            'Screens',
-            'CSS Variables',
+            'Theme',
+            [
+              'Colors',
+              'Typography',
+              'Spacing',
+              'Borders',
+              'Shadows',
+              'Icons',
+              'Screens',
+              'CSS Variables',
+              '*',
+            ],
             '*',
           ],
         ],

--- a/apps/storybook/src/core/borders.stories.tsx
+++ b/apps/storybook/src/core/borders.stories.tsx
@@ -12,7 +12,7 @@ import {
 } from './shared';
 
 const meta = {
-  title: 'Borders',
+  title: 'Theme/Borders',
   tags: ['autodocs'],
   parameters: {
     layout: 'fullscreen',

--- a/apps/storybook/src/core/colors.stories.tsx
+++ b/apps/storybook/src/core/colors.stories.tsx
@@ -11,7 +11,7 @@ import {
 } from './shared';
 
 const meta = {
-  title: 'Colors',
+  title: 'Theme/Colors',
   tags: ['autodocs'],
   parameters: {
     layout: 'fullscreen',

--- a/apps/storybook/src/core/css-variables.stories.tsx
+++ b/apps/storybook/src/core/css-variables.stories.tsx
@@ -3,7 +3,7 @@ import { useEffect, useState } from 'react';
 import { PageContainer, SearchInput } from './shared';
 
 const meta = {
-  title: 'CSS Variables',
+  title: 'Theme/CSS Variables',
   tags: ['autodocs'],
   parameters: {
     layout: 'fullscreen',

--- a/apps/storybook/src/core/icons.stories.tsx
+++ b/apps/storybook/src/core/icons.stories.tsx
@@ -15,7 +15,7 @@ import {
 } from './shared';
 
 const meta = {
-  title: 'Icons',
+  title: 'Theme/Icons',
   tags: ['autodocs'],
   parameters: {
     layout: 'fullscreen',

--- a/apps/storybook/src/core/introduction.stories.tsx
+++ b/apps/storybook/src/core/introduction.stories.tsx
@@ -43,9 +43,13 @@ function CodeBlock({ children, label }: { children: string; label?: string }) {
   const [copied, setCopied] = React.useState(false);
 
   const handleCopy = () => {
-    navigator.clipboard.writeText(children);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
+    navigator.clipboard
+      .writeText(children)
+      .then(() => {
+        setCopied(true);
+        setTimeout(() => setCopied(false), 2000);
+      })
+      .catch(() => {});
   };
 
   return (

--- a/apps/storybook/src/core/introduction.stories.tsx
+++ b/apps/storybook/src/core/introduction.stories.tsx
@@ -168,10 +168,17 @@ function OverviewTab() {
           {[
             {
               title: 'Design Tokens',
-              description: 'Colors, spacing, typography, radius, shadows — the full Apollo token set as JS constants and CSS variables.',
+              description:
+                'Colors, spacing, typography, radius, shadows — the full Apollo token set as JS constants and CSS variables.',
               example: (
                 <div className="flex gap-1.5">
-                  {['bg-primary', 'bg-blue-500', 'bg-emerald-500', 'bg-amber-500', 'bg-rose-500'].map((c) => (
+                  {[
+                    'bg-primary',
+                    'bg-blue-500',
+                    'bg-emerald-500',
+                    'bg-amber-500',
+                    'bg-rose-500',
+                  ].map((c) => (
                     <div key={c} className={`h-6 w-6 rounded-full ${c}`} />
                   ))}
                 </div>
@@ -179,16 +186,29 @@ function OverviewTab() {
             },
             {
               title: 'Icons',
-              description: '1000+ SVG icons from the Apollo icon set, importable as React components or raw SVG.',
+              description:
+                '1000+ SVG icons from the Apollo icon set, importable as React components or raw SVG.',
               example: (
-                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" className="h-6 w-6 text-foreground" aria-hidden="true">
-                  <path strokeLinecap="round" strokeLinejoin="round" d="M13.5 16.875h3.375m0 0h3.375m-3.375 0V13.5m0 3.375v3.375M3 4.5v4.25A2.25 2.25 0 0 0 5.25 11h4.5A2.25 2.25 0 0 0 12 8.75V4.5A2.25 2.25 0 0 0 9.75 2.25h-4.5A2.25 2.25 0 0 0 3 4.5Zm0 10.5v.75A2.25 2.25 0 0 0 5.25 18h4.5A2.25 2.25 0 0 0 12 15.75v-.75A2.25 2.25 0 0 0 9.75 12.75h-4.5A2.25 2.25 0 0 0 3 15Zm9-10.5v.75a2.25 2.25 0 0 0 2.25 2.25h.75" />
+                <svg
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="1.5"
+                  className="h-6 w-6 text-foreground"
+                  aria-hidden="true"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="M13.5 16.875h3.375m0 0h3.375m-3.375 0V13.5m0 3.375v3.375M3 4.5v4.25A2.25 2.25 0 0 0 5.25 11h4.5A2.25 2.25 0 0 0 12 8.75V4.5A2.25 2.25 0 0 0 9.75 2.25h-4.5A2.25 2.25 0 0 0 3 4.5Zm0 10.5v.75A2.25 2.25 0 0 0 5.25 18h4.5A2.25 2.25 0 0 0 12 15.75v-.75A2.25 2.25 0 0 0 9.75 12.75h-4.5A2.25 2.25 0 0 0 3 15Zm9-10.5v.75a2.25 2.25 0 0 0 2.25 2.25h.75"
+                  />
                 </svg>
               ),
             },
             {
               title: 'Fonts',
-              description: 'Inter and JetBrains Mono font face declarations, self-hosted and ready to import.',
+              description:
+                'Inter and JetBrains Mono font face declarations, self-hosted and ready to import.',
               example: (
                 <div className="flex flex-col gap-0.5">
                   <span className="text-base font-semibold leading-none text-foreground">Aa</span>
@@ -198,7 +218,8 @@ function OverviewTab() {
             },
             {
               title: 'CSS Custom Properties',
-              description: 'All tokens as CSS variables, resolved by the active theme class on the root element.',
+              description:
+                'All tokens as CSS variables, resolved by the active theme class on the root element.',
               example: (
                 <code className="text-xs text-muted-foreground">
                   <span className="text-blue-400">--color-primary</span>
@@ -274,7 +295,10 @@ function QuickStartTab() {
 @import "@uipath/apollo-core/tokens/css/theme-variables.css";
 @import "@uipath/apollo-core/fonts/font.css";`}
               </CodeBlock>
-              <p>This loads all Apollo design tokens as CSS custom properties and registers the font faces.</p>
+              <p>
+                This loads all Apollo design tokens as CSS custom properties and registers the font
+                faces.
+              </p>
             </StepItem>
 
             <StepItem step={3} title="Apply a theme class">
@@ -295,7 +319,9 @@ function QuickStartTab() {
           <Divider />
 
           <div>
-            <h3 className="mb-3 text-lg font-semibold text-foreground">Using tokens in JavaScript</h3>
+            <h3 className="mb-3 text-lg font-semibold text-foreground">
+              Using tokens in JavaScript
+            </h3>
             <SectionDescription>
               Import typed token constants directly from the package for use in JS/TS code.
             </SectionDescription>
@@ -312,7 +338,9 @@ const style = {
           <Divider />
 
           <div>
-            <h3 className="mb-3 text-lg font-semibold text-foreground">Using CSS custom properties</h3>
+            <h3 className="mb-3 text-lg font-semibold text-foreground">
+              Using CSS custom properties
+            </h3>
             <SectionDescription>
               All tokens are also available as CSS variables, resolved by the active theme class on{' '}
               <InlineCode>{'<body>'}</InlineCode>.
@@ -365,8 +393,8 @@ body.dark  { /* dark token values  */ }
             <StepItem step={4} title="Start Storybook">
               <CodeBlock label="terminal">{'pnpm storybook:dev'}</CodeBlock>
               <p>
-                Opens Apollo Storybook at <InlineCode>http://localhost:6007</InlineCode>. Changes
-                to source files hot-reload automatically.
+                Opens Apollo Storybook at <InlineCode>http://localhost:6007</InlineCode>. Changes to
+                source files hot-reload automatically.
               </p>
             </StepItem>
           </div>
@@ -395,9 +423,11 @@ function TokensTab() {
           storyPath="/story/apollo-core-theme-colors--page"
           example={
             <div className="flex gap-1.5">
-              {['bg-primary', 'bg-blue-500', 'bg-emerald-500', 'bg-amber-500', 'bg-rose-500'].map((c) => (
-                <div key={c} className={`h-6 w-6 rounded-full ${c}`} />
-              ))}
+              {['bg-primary', 'bg-blue-500', 'bg-emerald-500', 'bg-amber-500', 'bg-rose-500'].map(
+                (c) => (
+                  <div key={c} className={`h-6 w-6 rounded-full ${c}`} />
+                )
+              )}
             </div>
           }
         />
@@ -419,7 +449,11 @@ function TokensTab() {
           example={
             <div className="flex items-end gap-1">
               {[2, 3, 4, 6, 8].map((s) => (
-                <div key={s} className="rounded-sm bg-primary/40" style={{ width: s * 4, height: s * 4 }} />
+                <div
+                  key={s}
+                  className="rounded-sm bg-primary/40"
+                  style={{ width: s * 4, height: s * 4 }}
+                />
               ))}
             </div>
           }
@@ -429,8 +463,19 @@ function TokensTab() {
           description="SVG icon library with 1000+ icons from the Apollo icon set."
           storyPath="/story/apollo-core-theme-icons--page"
           example={
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" className="h-6 w-6 text-foreground" aria-hidden="true">
-              <path strokeLinecap="round" strokeLinejoin="round" d="M13.5 16.875h3.375m0 0h3.375m-3.375 0V13.5m0 3.375v3.375M3 4.5v4.25A2.25 2.25 0 0 0 5.25 11h4.5A2.25 2.25 0 0 0 12 8.75V4.5A2.25 2.25 0 0 0 9.75 2.25h-4.5A2.25 2.25 0 0 0 3 4.5Zm0 10.5v.75A2.25 2.25 0 0 0 5.25 18h4.5A2.25 2.25 0 0 0 12 15.75v-.75A2.25 2.25 0 0 0 9.75 12.75h-4.5A2.25 2.25 0 0 0 3 15Zm9-10.5v.75a2.25 2.25 0 0 0 2.25 2.25h.75" />
+            <svg
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="1.5"
+              className="h-6 w-6 text-foreground"
+              aria-hidden="true"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M13.5 16.875h3.375m0 0h3.375m-3.375 0V13.5m0 3.375v3.375M3 4.5v4.25A2.25 2.25 0 0 0 5.25 11h4.5A2.25 2.25 0 0 0 12 8.75V4.5A2.25 2.25 0 0 0 9.75 2.25h-4.5A2.25 2.25 0 0 0 3 4.5Zm0 10.5v.75A2.25 2.25 0 0 0 5.25 18h4.5A2.25 2.25 0 0 0 12 15.75v-.75A2.25 2.25 0 0 0 9.75 12.75h-4.5A2.25 2.25 0 0 0 3 15Zm9-10.5v.75a2.25 2.25 0 0 0 2.25 2.25h.75"
+              />
             </svg>
           }
         />
@@ -476,7 +521,11 @@ function TokensTab() {
           example={
             <div className="flex items-end gap-1.5">
               {['xs', 'sm', 'md', 'lg'].map((s, i) => (
-                <div key={s} className="rounded-sm bg-primary/30" style={{ width: 18 + i * 8, height: 18 + i * 4 }} />
+                <div
+                  key={s}
+                  className="rounded-sm bg-primary/30"
+                  style={{ width: 18 + i * 8, height: 18 + i * 4 }}
+                />
               ))}
             </div>
           }

--- a/apps/storybook/src/core/introduction.stories.tsx
+++ b/apps/storybook/src/core/introduction.stories.tsx
@@ -169,7 +169,7 @@ function OverviewTab() {
             {
               title: 'Design Tokens',
               description:
-                'Colors, spacing, typography, radius, shadows — the full Apollo token set as JS constants and CSS variables.',
+                'Colors, spacing, typography, radius, shadows: the full Apollo token set as JS constants and CSS variables.',
               example: (
                 <div className="flex gap-1.5">
                   {[
@@ -368,6 +368,15 @@ body.dark  { /* dark token values  */ }
               This path is for contributors and team members who want to browse or modify Apollo
               Core source files and run Storybook on their machine.
             </p>
+            <ul className="mt-2 list-disc pl-4 space-y-1">
+              <li>
+                <strong>Node.js 22 or later</strong> is required. Check your version with{' '}
+                <InlineCode>node --version</InlineCode>.
+              </li>
+              <li>
+                <strong>pnpm 11.1.3</strong> is the required package manager for this repo.
+              </li>
+            </ul>
           </InfoCallout>
 
           <div className="space-y-6">
@@ -378,10 +387,10 @@ body.dark  { /* dark token values  */ }
             </StepItem>
 
             <StepItem step={2} title="Install dependencies">
-              <CodeBlock label="terminal">{'npm install -g pnpm\npnpm install'}</CodeBlock>
+              <CodeBlock label="terminal">{'npm install -g pnpm@11.1.3\npnpm install'}</CodeBlock>
               <p>
-                This project uses <InlineCode>pnpm</InlineCode> workspaces. Install it globally if
-                you don't have it yet.
+                This project uses <InlineCode>pnpm</InlineCode> workspaces. Install the pinned
+                version globally if you don't have it yet.
               </p>
             </StepItem>
 
@@ -420,7 +429,7 @@ function TokensTab() {
         <TokenCard
           title="Colors"
           description="Semantic color tokens for text, backgrounds, borders, and brand palettes."
-          storyPath="/story/apollo-core-theme-colors--page"
+          storyPath="/story/apollo-core-theme-colors--all"
           example={
             <div className="flex gap-1.5">
               {['bg-primary', 'bg-blue-500', 'bg-emerald-500', 'bg-amber-500', 'bg-rose-500'].map(
@@ -434,7 +443,7 @@ function TokensTab() {
         <TokenCard
           title="Typography"
           description="Font families, sizes, weights, and line heights for consistent type."
-          storyPath="/story/apollo-core-theme-typography--page"
+          storyPath="/story/apollo-core-theme-typography--all"
           example={
             <div className="flex flex-col gap-0.5">
               <span className="text-base font-semibold leading-none text-foreground">Aa</span>
@@ -445,7 +454,7 @@ function TokensTab() {
         <TokenCard
           title="Spacing"
           description="A consistent spacing scale from xs to 4xl used across all components."
-          storyPath="/story/apollo-core-theme-spacing--page"
+          storyPath="/story/apollo-core-theme-spacing--all"
           example={
             <div className="flex items-end gap-1">
               {[2, 3, 4, 6, 8].map((s) => (
@@ -461,7 +470,7 @@ function TokensTab() {
         <TokenCard
           title="Icons"
           description="SVG icon library with 1000+ icons from the Apollo icon set."
-          storyPath="/story/apollo-core-theme-icons--page"
+          storyPath="/story/apollo-core-theme-icons--all"
           example={
             <svg
               viewBox="0 0 24 24"
@@ -482,7 +491,7 @@ function TokensTab() {
         <TokenCard
           title="Shadows"
           description="Elevation shadow tokens for cards, modals, and layered surfaces."
-          storyPath="/story/apollo-core-theme-shadows--page"
+          storyPath="/story/apollo-core-theme-shadows--all"
           example={
             <div className="flex gap-3">
               {['shadow-sm', 'shadow-md', 'shadow-lg'].map((s) => (
@@ -494,7 +503,7 @@ function TokensTab() {
         <TokenCard
           title="Borders"
           description="Border radius and width tokens for consistent component shapes."
-          storyPath="/story/apollo-core-theme-borders--page"
+          storyPath="/story/apollo-core-theme-borders--all"
           example={
             <div className="flex gap-3">
               {['rounded-sm', 'rounded-md', 'rounded-xl', 'rounded-full'].map((r) => (
@@ -506,7 +515,7 @@ function TokensTab() {
         <TokenCard
           title="CSS Variables"
           description="All tokens as CSS custom properties for use in any framework or plain CSS."
-          storyPath="/story/apollo-core-theme-css-variables--page"
+          storyPath="/story/apollo-core-theme-css-variables--all"
           example={
             <code className="text-xs text-muted-foreground">
               <span className="text-blue-400">--color-primary</span>
@@ -517,7 +526,7 @@ function TokensTab() {
         <TokenCard
           title="Screens"
           description="Responsive breakpoint tokens matching Tailwind's screen scale."
-          storyPath="/story/apollo-core-theme-screens--page"
+          storyPath="/story/apollo-core-theme-screens--all"
           example={
             <div className="flex items-end gap-1.5">
               {['xs', 'sm', 'md', 'lg'].map((s, i) => (

--- a/apps/storybook/src/core/introduction.stories.tsx
+++ b/apps/storybook/src/core/introduction.stories.tsx
@@ -132,7 +132,7 @@ function TokenCard({
       </div>
       <a
         href={`/?path=${storyPath}`}
-        target="_parent"
+        target="_top"
         className="mt-auto inline-flex items-center justify-center rounded-lg border border-border bg-background px-4 py-2 text-xs font-medium text-foreground transition-colors hover:bg-muted no-underline"
       >
         View tokens →

--- a/apps/storybook/src/core/introduction.stories.tsx
+++ b/apps/storybook/src/core/introduction.stories.tsx
@@ -1,0 +1,541 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import * as React from 'react';
+
+const meta = {
+  title: 'Introduction/Getting Started',
+  parameters: {
+    layout: 'fullscreen',
+  },
+} satisfies Meta;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// ============================================================================
+// Primitives
+// ============================================================================
+
+function cn(...classes: (string | undefined | false)[]) {
+  return classes.filter(Boolean).join(' ');
+}
+
+function Divider() {
+  return <div className="my-10 h-px bg-border" />;
+}
+
+function InlineCode({ children }: { children: React.ReactNode }) {
+  return (
+    <code className="rounded bg-muted px-1.5 py-0.5 font-mono text-sm font-medium text-foreground">
+      {children}
+    </code>
+  );
+}
+
+function InfoCallout({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="rounded-lg border border-border bg-muted/50 p-4 text-sm leading-6 text-muted-foreground">
+      {children}
+    </div>
+  );
+}
+
+function CodeBlock({ children, label }: { children: string; label?: string }) {
+  const [copied, setCopied] = React.useState(false);
+
+  const handleCopy = () => {
+    navigator.clipboard.writeText(children);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  return (
+    <div className="relative overflow-hidden rounded-lg border border-border bg-muted/50">
+      {label && (
+        <div className="flex items-center justify-between border-b border-border px-4 py-2">
+          <span className="text-xs font-medium text-muted-foreground">{label}</span>
+          <button
+            type="button"
+            onClick={handleCopy}
+            className="cursor-pointer rounded px-2 py-1 text-xs font-medium text-muted-foreground transition-colors hover:text-foreground"
+          >
+            {copied ? 'Copied!' : 'Copy'}
+          </button>
+        </div>
+      )}
+      {!label && (
+        <button
+          type="button"
+          onClick={handleCopy}
+          className="absolute top-2 right-2 cursor-pointer rounded px-2 py-1 text-xs font-medium text-muted-foreground transition-colors hover:text-foreground"
+        >
+          {copied ? 'Copied!' : 'Copy'}
+        </button>
+      )}
+      <pre className="overflow-x-auto p-4 text-sm leading-6 text-foreground">
+        <code>{children}</code>
+      </pre>
+    </div>
+  );
+}
+
+function SectionDescription({ children }: { children: React.ReactNode }) {
+  return <p className="mb-6 text-base leading-7 text-muted-foreground">{children}</p>;
+}
+
+function StepItem({
+  step,
+  title,
+  children,
+}: {
+  step: number;
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="flex gap-4">
+      <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-primary text-sm font-semibold text-primary-foreground">
+        {step}
+      </div>
+      <div className="flex-1 pt-0.5">
+        <h4 className="mb-2 text-base font-semibold text-foreground">{title}</h4>
+        <div className="space-y-3 text-sm leading-6 text-muted-foreground">{children}</div>
+      </div>
+    </div>
+  );
+}
+
+// ============================================================================
+// Token category card
+// ============================================================================
+
+function TokenCard({
+  title,
+  description,
+  storyPath,
+  example,
+}: {
+  title: string;
+  description: string;
+  storyPath: string;
+  example: React.ReactNode;
+}) {
+  return (
+    <div className="flex flex-col gap-3 rounded-xl border border-border bg-card p-5">
+      <div className="flex h-10 items-center">{example}</div>
+      <div>
+        <p className="text-sm font-semibold text-foreground">{title}</p>
+        <p className="mt-0.5 text-xs leading-5 text-muted-foreground">{description}</p>
+      </div>
+      <a
+        href={`/?path=${storyPath}`}
+        target="_parent"
+        className="mt-auto inline-flex items-center justify-center rounded-lg border border-border bg-background px-4 py-2 text-xs font-medium text-foreground transition-colors hover:bg-muted no-underline"
+      >
+        View tokens →
+      </a>
+    </div>
+  );
+}
+
+// ============================================================================
+// Tab: Overview
+// ============================================================================
+
+function OverviewTab() {
+  return (
+    <div className="space-y-6">
+      <SectionDescription>
+        Apollo Core is the framework-agnostic foundation of the Apollo design system. It provides
+        design tokens, icons, fonts, and CSS custom properties consumed by both{' '}
+        <InlineCode>apollo-wind</InlineCode> and <InlineCode>apollo-react</InlineCode>.
+      </SectionDescription>
+
+      <InfoCallout>
+        <p className="mb-1 font-medium text-foreground">Most projects do not need this directly</p>
+        <p>
+          Install Apollo Core directly only if you need tokens, icons, or fonts without a component
+          library. If you are starting a new React app, start with{' '}
+          <InlineCode>apollo-wind</InlineCode> or <InlineCode>apollo-react</InlineCode> instead.
+          Both already include core as a dependency.
+        </p>
+      </InfoCallout>
+
+      <Divider />
+
+      <div>
+        <h3 className="mb-4 text-lg font-semibold text-foreground">What's included</h3>
+        <div className="grid gap-4 sm:grid-cols-2">
+          {[
+            {
+              title: 'Design Tokens',
+              description: 'Colors, spacing, typography, radius, shadows — the full Apollo token set as JS constants and CSS variables.',
+              example: (
+                <div className="flex gap-1.5">
+                  {['bg-primary', 'bg-blue-500', 'bg-emerald-500', 'bg-amber-500', 'bg-rose-500'].map((c) => (
+                    <div key={c} className={`h-6 w-6 rounded-full ${c}`} />
+                  ))}
+                </div>
+              ),
+            },
+            {
+              title: 'Icons',
+              description: '1000+ SVG icons from the Apollo icon set, importable as React components or raw SVG.',
+              example: (
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" className="h-6 w-6 text-foreground" aria-hidden="true">
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M13.5 16.875h3.375m0 0h3.375m-3.375 0V13.5m0 3.375v3.375M3 4.5v4.25A2.25 2.25 0 0 0 5.25 11h4.5A2.25 2.25 0 0 0 12 8.75V4.5A2.25 2.25 0 0 0 9.75 2.25h-4.5A2.25 2.25 0 0 0 3 4.5Zm0 10.5v.75A2.25 2.25 0 0 0 5.25 18h4.5A2.25 2.25 0 0 0 12 15.75v-.75A2.25 2.25 0 0 0 9.75 12.75h-4.5A2.25 2.25 0 0 0 3 15Zm9-10.5v.75a2.25 2.25 0 0 0 2.25 2.25h.75" />
+                </svg>
+              ),
+            },
+            {
+              title: 'Fonts',
+              description: 'Inter and JetBrains Mono font face declarations, self-hosted and ready to import.',
+              example: (
+                <div className="flex flex-col gap-0.5">
+                  <span className="text-base font-semibold leading-none text-foreground">Aa</span>
+                  <span className="text-xs text-muted-foreground">Inter / JetBrains Mono</span>
+                </div>
+              ),
+            },
+            {
+              title: 'CSS Custom Properties',
+              description: 'All tokens as CSS variables, resolved by the active theme class on the root element.',
+              example: (
+                <code className="text-xs text-muted-foreground">
+                  <span className="text-blue-400">--color-primary</span>
+                  <span className="text-foreground">: oklch(...);</span>
+                </code>
+              ),
+            },
+          ].map(({ title, description, example }) => (
+            <div key={title} className="rounded-xl border border-border bg-card p-5">
+              <div className="mb-3 flex h-8 items-center">{example}</div>
+              <h4 className="mb-1 text-sm font-semibold text-foreground">{title}</h4>
+              <p className="text-xs leading-5 text-muted-foreground">{description}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ============================================================================
+// Tab: Quick Start
+// ============================================================================
+
+const quickStartPaths = ['Add to existing project', 'Run locally'] as const;
+type QuickStartPath = (typeof quickStartPaths)[number];
+
+function QuickStartTab() {
+  const [path, setPath] = React.useState<QuickStartPath>('Add to existing project');
+
+  return (
+    <div className="space-y-8">
+      {/* Path switcher */}
+      <div className="rounded-xl border border-border bg-card p-5">
+        <p className="mb-1 text-sm font-semibold text-foreground">What are you trying to do?</p>
+        <p className="mb-4 text-xs text-muted-foreground">
+          Choose the path that matches your goal. The steps below will update accordingly.
+        </p>
+        <div className="flex flex-col gap-2 sm:flex-row">
+          {quickStartPaths.map((p) => (
+            <button
+              key={p}
+              type="button"
+              onClick={() => setPath(p)}
+              className={cn(
+                'flex-1 cursor-pointer rounded-lg border px-4 py-3 text-left text-sm transition-colors',
+                path === p
+                  ? 'border-primary bg-primary/10 font-medium text-foreground'
+                  : 'border-border bg-background text-muted-foreground hover:text-foreground'
+              )}
+            >
+              <span className="block font-medium text-foreground">{p}</span>
+              <span className="mt-0.5 block text-xs text-muted-foreground">
+                {p === 'Add to existing project'
+                  ? 'Install Apollo Core as a dependency in your own app'
+                  : 'Clone the apollo-ui repo and run Storybook locally'}
+              </span>
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {path === 'Add to existing project' && (
+        <>
+          <div className="space-y-6">
+            <StepItem step={1} title="Install the package">
+              <CodeBlock label="terminal">{'npm install @uipath/apollo-core'}</CodeBlock>
+            </StepItem>
+
+            <StepItem step={2} title="Import CSS variables">
+              <CodeBlock label="global CSS or app entry">
+                {`@import "@uipath/apollo-core/tokens/css/variables.css";
+@import "@uipath/apollo-core/tokens/css/theme-variables.css";
+@import "@uipath/apollo-core/fonts/font.css";`}
+              </CodeBlock>
+              <p>This loads all Apollo design tokens as CSS custom properties and registers the font faces.</p>
+            </StepItem>
+
+            <StepItem step={3} title="Apply a theme class">
+              <CodeBlock label="HTML or root element">
+                {`<!-- Light theme -->
+<body class="light">
+
+<!-- Dark theme -->
+<body class="dark">`}
+              </CodeBlock>
+              <p>
+                The theme class on <InlineCode>{'<body>'}</InlineCode> resolves all semantic token
+                values. Switch class to change the active theme.
+              </p>
+            </StepItem>
+          </div>
+
+          <Divider />
+
+          <div>
+            <h3 className="mb-3 text-lg font-semibold text-foreground">Using tokens in JavaScript</h3>
+            <SectionDescription>
+              Import typed token constants directly from the package for use in JS/TS code.
+            </SectionDescription>
+            <CodeBlock label="Token imports">{`import { ColorPrimary500, SpacingMd, FontSizeSm } from '@uipath/apollo-core';
+
+// Use in inline styles or style objects
+const style = {
+  color: ColorPrimary500,
+  padding: SpacingMd,
+  fontSize: FontSizeSm,
+};`}</CodeBlock>
+          </div>
+
+          <Divider />
+
+          <div>
+            <h3 className="mb-3 text-lg font-semibold text-foreground">Using CSS custom properties</h3>
+            <SectionDescription>
+              All tokens are also available as CSS variables, resolved by the active theme class on{' '}
+              <InlineCode>{'<body>'}</InlineCode>.
+            </SectionDescription>
+            <CodeBlock label="CSS usage">{`/* Apply theme class to body */
+body.light { /* light token values */ }
+body.dark  { /* dark token values  */ }
+
+/* Then use vars anywhere in your CSS */
+.my-component {
+  background: var(--color-background);
+  color: var(--color-foreground);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+}`}</CodeBlock>
+          </div>
+        </>
+      )}
+
+      {path === 'Run locally' && (
+        <>
+          <InfoCallout>
+            <p className="mb-1 font-medium text-foreground">Before you begin</p>
+            <p>
+              This path is for contributors and team members who want to browse or modify Apollo
+              Core source files and run Storybook on their machine.
+            </p>
+          </InfoCallout>
+
+          <div className="space-y-6">
+            <StepItem step={1} title="Clone the repository">
+              <CodeBlock label="terminal">
+                {'git clone https://github.com/UiPath/apollo-ui.git\ncd apollo-ui'}
+              </CodeBlock>
+            </StepItem>
+
+            <StepItem step={2} title="Install dependencies">
+              <CodeBlock label="terminal">{'npm install -g pnpm\npnpm install'}</CodeBlock>
+              <p>
+                This project uses <InlineCode>pnpm</InlineCode> workspaces. Install it globally if
+                you don't have it yet.
+              </p>
+            </StepItem>
+
+            <StepItem step={3} title="Build all packages">
+              <CodeBlock label="terminal">{'pnpm build'}</CodeBlock>
+              <p>Compiles apollo-core, apollo-wind, and apollo-react before Storybook starts.</p>
+            </StepItem>
+
+            <StepItem step={4} title="Start Storybook">
+              <CodeBlock label="terminal">{'pnpm storybook:dev'}</CodeBlock>
+              <p>
+                Opens Apollo Storybook at <InlineCode>http://localhost:6007</InlineCode>. Changes
+                to source files hot-reload automatically.
+              </p>
+            </StepItem>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+// ============================================================================
+// Tab: Tokens
+// ============================================================================
+
+function TokensTab() {
+  return (
+    <div className="space-y-6">
+      <SectionDescription>
+        All token categories available in Apollo Core. Click any card to explore the full set with
+        live values and copy-ready references.
+      </SectionDescription>
+
+      <div className="grid gap-4 sm:grid-cols-2">
+        <TokenCard
+          title="Colors"
+          description="Semantic color tokens for text, backgrounds, borders, and brand palettes."
+          storyPath="/story/apollo-core-theme-colors--page"
+          example={
+            <div className="flex gap-1.5">
+              {['bg-primary', 'bg-blue-500', 'bg-emerald-500', 'bg-amber-500', 'bg-rose-500'].map((c) => (
+                <div key={c} className={`h-6 w-6 rounded-full ${c}`} />
+              ))}
+            </div>
+          }
+        />
+        <TokenCard
+          title="Typography"
+          description="Font families, sizes, weights, and line heights for consistent type."
+          storyPath="/story/apollo-core-theme-typography--page"
+          example={
+            <div className="flex flex-col gap-0.5">
+              <span className="text-base font-semibold leading-none text-foreground">Aa</span>
+              <span className="text-xs text-muted-foreground">Inter / JetBrains Mono</span>
+            </div>
+          }
+        />
+        <TokenCard
+          title="Spacing"
+          description="A consistent spacing scale from xs to 4xl used across all components."
+          storyPath="/story/apollo-core-theme-spacing--page"
+          example={
+            <div className="flex items-end gap-1">
+              {[2, 3, 4, 6, 8].map((s) => (
+                <div key={s} className="rounded-sm bg-primary/40" style={{ width: s * 4, height: s * 4 }} />
+              ))}
+            </div>
+          }
+        />
+        <TokenCard
+          title="Icons"
+          description="SVG icon library with 1000+ icons from the Apollo icon set."
+          storyPath="/story/apollo-core-theme-icons--page"
+          example={
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" className="h-6 w-6 text-foreground" aria-hidden="true">
+              <path strokeLinecap="round" strokeLinejoin="round" d="M13.5 16.875h3.375m0 0h3.375m-3.375 0V13.5m0 3.375v3.375M3 4.5v4.25A2.25 2.25 0 0 0 5.25 11h4.5A2.25 2.25 0 0 0 12 8.75V4.5A2.25 2.25 0 0 0 9.75 2.25h-4.5A2.25 2.25 0 0 0 3 4.5Zm0 10.5v.75A2.25 2.25 0 0 0 5.25 18h4.5A2.25 2.25 0 0 0 12 15.75v-.75A2.25 2.25 0 0 0 9.75 12.75h-4.5A2.25 2.25 0 0 0 3 15Zm9-10.5v.75a2.25 2.25 0 0 0 2.25 2.25h.75" />
+            </svg>
+          }
+        />
+        <TokenCard
+          title="Shadows"
+          description="Elevation shadow tokens for cards, modals, and layered surfaces."
+          storyPath="/story/apollo-core-theme-shadows--page"
+          example={
+            <div className="flex gap-3">
+              {['shadow-sm', 'shadow-md', 'shadow-lg'].map((s) => (
+                <div key={s} className={`h-6 w-6 rounded bg-card ${s}`} />
+              ))}
+            </div>
+          }
+        />
+        <TokenCard
+          title="Borders"
+          description="Border radius and width tokens for consistent component shapes."
+          storyPath="/story/apollo-core-theme-borders--page"
+          example={
+            <div className="flex gap-3">
+              {['rounded-sm', 'rounded-md', 'rounded-xl', 'rounded-full'].map((r) => (
+                <div key={r} className={`h-6 w-6 border border-border ${r}`} />
+              ))}
+            </div>
+          }
+        />
+        <TokenCard
+          title="CSS Variables"
+          description="All tokens as CSS custom properties for use in any framework or plain CSS."
+          storyPath="/story/apollo-core-theme-css-variables--page"
+          example={
+            <code className="text-xs text-muted-foreground">
+              <span className="text-blue-400">--color-primary</span>
+              <span className="text-foreground">: oklch(...);</span>
+            </code>
+          }
+        />
+        <TokenCard
+          title="Screens"
+          description="Responsive breakpoint tokens matching Tailwind's screen scale."
+          storyPath="/story/apollo-core-theme-screens--page"
+          example={
+            <div className="flex items-end gap-1.5">
+              {['xs', 'sm', 'md', 'lg'].map((s, i) => (
+                <div key={s} className="rounded-sm bg-primary/30" style={{ width: 18 + i * 8, height: 18 + i * 4 }} />
+              ))}
+            </div>
+          }
+        />
+      </div>
+    </div>
+  );
+}
+
+// ============================================================================
+// Page
+// ============================================================================
+
+const tabs = ['Overview', 'Quick Start', 'Tokens'] as const;
+type TabId = (typeof tabs)[number];
+
+function CoreIntroductionPage() {
+  const [activeTab, setActiveTab] = React.useState<TabId>('Overview');
+
+  return (
+    <div className="min-h-screen w-full bg-background text-foreground">
+      <div className="mx-auto max-w-3xl space-y-2 p-8">
+        {/* Header */}
+        <h1 className="text-[2rem] font-bold tracking-tight text-foreground">Apollo Core</h1>
+        <p className="text-base leading-7 text-muted-foreground">
+          The framework-agnostic foundation of the Apollo design system. Design tokens, icons,
+          fonts, and CSS custom properties.
+        </p>
+
+        {/* Tabs */}
+        <div className="flex gap-1 border-b border-border pb-0 pt-6">
+          {tabs.map((tab) => (
+            <button
+              type="button"
+              key={tab}
+              className={cn(
+                'cursor-pointer px-4 pb-3 text-sm font-medium transition-colors',
+                activeTab === tab
+                  ? 'border-b-2 border-primary text-foreground'
+                  : 'text-muted-foreground hover:text-foreground'
+              )}
+              onClick={() => setActiveTab(tab)}
+            >
+              {tab}
+            </button>
+          ))}
+        </div>
+
+        {/* Tab content */}
+        <div className="pt-6">
+          {activeTab === 'Overview' && <OverviewTab />}
+          {activeTab === 'Quick Start' && <QuickStartTab />}
+          {activeTab === 'Tokens' && <TokensTab />}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export const Default: Story = {
+  render: () => <CoreIntroductionPage />,
+};

--- a/apps/storybook/src/core/screens.stories.tsx
+++ b/apps/storybook/src/core/screens.stories.tsx
@@ -3,7 +3,7 @@ import { ScreenSizes } from '@uipath/apollo-react/core';
 import { PageContainer, PageDescription, PageTitle, PRIMARY_GRADIENT, SHADOW_SM } from './shared';
 
 const meta = {
-  title: 'Screens',
+  title: 'Theme/Screens',
   tags: ['autodocs'],
   parameters: {
     layout: 'fullscreen',

--- a/apps/storybook/src/core/shadows.stories.tsx
+++ b/apps/storybook/src/core/shadows.stories.tsx
@@ -3,7 +3,7 @@ import { Shadow } from '@uipath/apollo-react/core';
 import { BRAND_GRADIENT, PageContainer, PageDescription, PageTitle } from './shared';
 
 const meta = {
-  title: 'Shadows',
+  title: 'Theme/Shadows',
   tags: ['autodocs'],
   parameters: {
     layout: 'fullscreen',

--- a/apps/storybook/src/core/spacing.stories.tsx
+++ b/apps/storybook/src/core/spacing.stories.tsx
@@ -13,7 +13,7 @@ import {
 } from './shared';
 
 const meta = {
-  title: 'Spacing',
+  title: 'Theme/Spacing',
   tags: ['autodocs'],
   parameters: {
     layout: 'fullscreen',

--- a/apps/storybook/src/core/typography.stories.tsx
+++ b/apps/storybook/src/core/typography.stories.tsx
@@ -11,7 +11,7 @@ import {
 } from './shared';
 
 const meta = {
-  title: 'Typography',
+  title: 'Theme/Typography',
   tags: ['autodocs'],
   parameters: {
     layout: 'fullscreen',

--- a/apps/storybook/src/introduction/introduction.stories.tsx
+++ b/apps/storybook/src/introduction/introduction.stories.tsx
@@ -1,0 +1,235 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import * as React from 'react';
+
+const meta = {
+  title: 'Introduction',
+  parameters: {
+    layout: 'fullscreen',
+  },
+} satisfies Meta;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// ============================================================================
+// Primitives
+// ============================================================================
+
+function Divider() {
+  return <div className="my-10 h-px bg-border" />;
+}
+
+function InlineCode({ children }: { children: React.ReactNode }) {
+  return (
+    <code className="rounded bg-muted px-1.5 py-0.5 font-mono text-sm font-medium text-foreground">
+      {children}
+    </code>
+  );
+}
+
+function Tag({ children }: { children: React.ReactNode }) {
+  return (
+    <span className="inline-flex items-center rounded-full border border-border bg-muted px-2.5 py-0.5 text-xs font-medium text-muted-foreground">
+      {children}
+    </span>
+  );
+}
+
+function SectionHeading({ children }: { children: React.ReactNode }) {
+  return <h2 className="mb-2 text-xl font-semibold tracking-tight text-foreground">{children}</h2>;
+}
+
+function SectionDescription({ children }: { children: React.ReactNode }) {
+  return <p className="mb-6 text-base leading-7 text-muted-foreground">{children}</p>;
+}
+
+// ============================================================================
+// Package card
+// ============================================================================
+
+function PackageCard({
+  name,
+  packageName,
+  description,
+  tags,
+  storyPath,
+  accent,
+}: {
+  name: string;
+  packageName: string;
+  description: string;
+  tags: string[];
+  storyPath: string;
+  accent: string;
+}) {
+  return (
+    <div className="flex flex-col gap-4 rounded-xl border border-border bg-card p-6">
+      <div className="flex flex-col gap-2">
+        <div className={`inline-block h-1.5 w-8 rounded-full ${accent}`} />
+        <h3 className="text-base font-semibold text-foreground">{name}</h3>
+        <InlineCode>{packageName}</InlineCode>
+        <a
+          href={`/?path=${storyPath}`}
+          target="_parent"
+          className="self-start rounded-lg border border-border bg-background px-4 py-2 text-xs font-medium text-foreground transition-colors hover:bg-muted no-underline"
+        >
+          Explore docs →
+        </a>
+      </div>
+      <p className="text-sm leading-6 text-muted-foreground">{description}</p>
+      <div className="flex flex-wrap gap-1.5">
+        {tags.map((tag) => (
+          <Tag key={tag}>{tag}</Tag>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// ============================================================================
+// Decision row
+// ============================================================================
+
+function DecisionRow({
+  scenario,
+  recommendation,
+  pkg,
+}: {
+  scenario: string;
+  recommendation: string;
+  pkg: string;
+}) {
+  return (
+    <div className="flex items-start gap-4 rounded-lg border border-border bg-card p-4">
+      <div className="flex-1">
+        <p className="text-sm font-medium text-foreground">{scenario}</p>
+        <p className="mt-0.5 text-xs text-muted-foreground">{recommendation}</p>
+      </div>
+      <InlineCode>{pkg}</InlineCode>
+    </div>
+  );
+}
+
+// ============================================================================
+// Story
+// ============================================================================
+
+function IntroductionPage() {
+  return (
+    <div className="min-h-screen bg-background">
+      <div className="mx-auto max-w-4xl px-8 py-16">
+        {/* Hero */}
+        <div className="mb-16">
+          <div className="mb-4 flex items-center gap-2">
+            <Tag>Open Source</Tag>
+            <Tag>UiPath</Tag>
+          </div>
+          <h1 className="mb-4 text-4xl font-bold tracking-tight text-foreground">
+            Apollo Design System
+          </h1>
+          <p className="max-w-2xl text-lg leading-8 text-muted-foreground">
+            The UiPath open-source design system. Shared tokens, React components, and Tailwind
+            utilities for building consistent product experiences across web apps and canvas editors.
+          </p>
+        </div>
+
+        {/* Repository */}
+        <div className="mb-10 flex items-center justify-between rounded-xl border border-border bg-card px-6 py-5">
+          <div>
+            <p className="text-sm font-semibold text-foreground">UiPath/apollo-ui</p>
+            <p className="text-xs text-muted-foreground">
+              Open source on GitHub. Contributions welcome.
+            </p>
+          </div>
+          <a
+            href="https://github.com/UiPath/apollo-ui"
+            target="_blank"
+            rel="noreferrer"
+            className="rounded-lg border border-border bg-background px-4 py-2 text-xs font-medium text-foreground transition-colors hover:bg-muted no-underline"
+          >
+            View on GitHub →
+          </a>
+        </div>
+
+        <Divider />
+
+        {/* Packages */}
+        <div className="mb-12">
+          <SectionHeading>Three packages, one system</SectionHeading>
+          <SectionDescription>
+            Apollo is split into focused packages. Pick the one that matches your use case, or
+            combine them.
+          </SectionDescription>
+          <div className="grid gap-4 sm:grid-cols-3">
+            <PackageCard
+              name="Apollo Wind"
+              packageName="@uipath/apollo-wind"
+              description="Tailwind CSS components built on shadcn/ui and Radix primitives. The recommended starting point for new React applications."
+              tags={['Tailwind CSS', 'shadcn/ui', 'New apps']}
+              storyPath="/story/apollo-wind-introduction-getting-started--default"
+              accent="bg-violet-500"
+            />
+            <PackageCard
+              name="Apollo React"
+              packageName="@uipath/apollo-react"
+              description="Canvas components for workflow and node-based editors built on React Flow, plus a Material UI theme for existing apps."
+              tags={['React Flow', 'Canvas', 'Material UI']}
+              storyPath="/story/apollo-react-canvas-introduction-getting-started--default"
+              accent="bg-blue-500"
+            />
+            <PackageCard
+              name="Apollo Core"
+              packageName="@uipath/apollo-core"
+              description="Framework-agnostic design tokens: colors, typography, spacing, icons, and CSS custom properties. The foundation everything else is built on."
+              tags={['Tokens', 'CSS vars', 'Any framework']}
+              storyPath="/story/apollo-core-introduction-getting-started--default"
+              accent="bg-emerald-500"
+            />
+          </div>
+        </div>
+
+        <Divider />
+
+        {/* Which package */}
+        <div className="mb-12">
+          <SectionHeading>Which package do I need?</SectionHeading>
+          <SectionDescription>
+            Not sure where to start? Match your situation to the right package.
+          </SectionDescription>
+          <div className="flex flex-col gap-2">
+            <DecisionRow
+              scenario="Building a new React app or component library"
+              recommendation="Start here. Modern components, dark mode, and accessibility out of the box."
+              pkg="apollo-wind"
+            />
+            <DecisionRow
+              scenario="Building a workflow canvas, node editor, or diagram tool"
+              recommendation="Canvas components built on React Flow with drag, resize, and property panels"
+              pkg="apollo-react/canvas"
+            />
+            <DecisionRow
+              scenario="Theming an existing Material UI app"
+              recommendation="Drop-in MUI theme overrides that apply Apollo tokens to your existing components"
+              pkg="apollo-react/material"
+            />
+            <DecisionRow
+              scenario="Using a non-React framework (Vue, Web Components, vanilla CSS)"
+              recommendation="Import CSS custom properties and icon assets with no framework dependency."
+              pkg="apollo-core"
+            />
+            <DecisionRow
+              scenario="Adding Apollo tokens to a custom design tool or token pipeline"
+              recommendation="Raw JSON and SCSS token exports for Style Dictionary, Figma Tokens, and similar"
+              pkg="apollo-core"
+            />
+          </div>
+        </div>
+
+      </div>
+    </div>
+  );
+}
+
+export const Overview: Story = {
+  render: () => <IntroductionPage />,
+};

--- a/apps/storybook/src/introduction/introduction.stories.tsx
+++ b/apps/storybook/src/introduction/introduction.stories.tsx
@@ -70,7 +70,7 @@ function PackageCard({
         <InlineCode>{packageName}</InlineCode>
         <a
           href={`/?path=${storyPath}`}
-          target="_parent"
+          target="_top"
           className="self-start rounded-lg border border-border bg-background px-4 py-2 text-xs font-medium text-foreground transition-colors hover:bg-muted no-underline"
         >
           Explore docs →
@@ -127,7 +127,7 @@ function IntroductionPage() {
           <h1 className="mb-4 text-4xl font-bold tracking-tight text-foreground">
             Apollo Design System
           </h1>
-          <p className="max-w-2xl text-lg leading-8 text-muted-foreground">
+          <p className="text-lg leading-8 text-muted-foreground">
             The UiPath open-source design system. Shared tokens, React components, and Tailwind
             utilities for building consistent product experiences across web apps and canvas
             editors.
@@ -145,7 +145,7 @@ function IntroductionPage() {
           <a
             href="https://github.com/UiPath/apollo-ui"
             target="_blank"
-            rel="noreferrer"
+            rel="noopener noreferrer"
             className="rounded-lg border border-border bg-background px-4 py-2 text-xs font-medium text-foreground transition-colors hover:bg-muted no-underline"
           >
             View on GitHub →

--- a/apps/storybook/src/introduction/introduction.stories.tsx
+++ b/apps/storybook/src/introduction/introduction.stories.tsx
@@ -129,7 +129,8 @@ function IntroductionPage() {
           </h1>
           <p className="max-w-2xl text-lg leading-8 text-muted-foreground">
             The UiPath open-source design system. Shared tokens, React components, and Tailwind
-            utilities for building consistent product experiences across web apps and canvas editors.
+            utilities for building consistent product experiences across web apps and canvas
+            editors.
           </p>
         </div>
 
@@ -224,7 +225,6 @@ function IntroductionPage() {
             />
           </div>
         </div>
-
       </div>
     </div>
   );

--- a/packages/apollo-react/src/canvas/stories/GettingStarted.stories.tsx
+++ b/packages/apollo-react/src/canvas/stories/GettingStarted.stories.tsx
@@ -114,7 +114,7 @@ function OverviewTab() {
       <SectionDescription>
         Apollo Canvas is a React-based visual workflow editor built on top of ReactFlow. It provides
         a complete set of nodes, edges, controls, and panels designed for building process
-        automation UIs — consistent with the Apollo design system.
+        automation UIs, consistent with the Apollo design system.
       </SectionDescription>
 
       <InfoCallout>
@@ -157,7 +157,7 @@ function OverviewTab() {
             {
               title: 'Controls',
               description:
-                'Interactive UI overlaid on the canvas — toolbar, zoom, node picker, and handles.',
+                'Interactive UI overlaid on the canvas: toolbar, zoom, node picker, and handles.',
               components: ['CanvasModeToolbar', 'CanvasZoomControls', 'Toolbox', 'AddNodePanel'],
             },
             {
@@ -207,7 +207,7 @@ function OverviewTab() {
             <tbody>
               {[
                 ['design', 'Build and edit the workflow graph', 'Yes'],
-                ['debug', 'Step through execution with live node status', 'No — locked during run'],
+                ['debug', 'Step through execution with live node status', 'No, locked during run'],
                 ['evaluate', 'Review and assess workflow quality', 'No'],
               ].map(([mode, purpose, editable]) => (
                 <tr key={mode} className="border-b border-border last:border-0 hover:bg-muted/20">
@@ -231,7 +231,7 @@ function OverviewTab() {
           {[
             {
               title: 'Nodes are data-driven',
-              body: 'Node appearance is controlled entirely by data passed via nodeTypes and the node data object — never by direct DOM manipulation.',
+              body: 'Node appearance is controlled entirely by data passed via nodeTypes and the node data object. Never use direct DOM manipulation.',
             },
             {
               title: 'Status is contextual',
@@ -261,30 +261,65 @@ function OverviewTab() {
 // Tab: Quick Start
 // ============================================================================
 
+const quickStartPaths = ['Add to existing project', 'Run locally'] as const;
+type QuickStartPath = (typeof quickStartPaths)[number];
+
 function QuickStartTab() {
+  const [path, setPath] = React.useState<QuickStartPath>('Add to existing project');
+
   return (
     <div className="space-y-8">
-      <SectionDescription>
-        Get a canvas with nodes, edges, and toolbar controls running in under 5 minutes.
-      </SectionDescription>
-
-      <StepItem step={1} title="Install the package">
-        <CodeBlock label="terminal">{'pnpm add @uipath/apollo-react'}</CodeBlock>
-        <p>
-          The canvas is included in the main package — no separate install needed for ReactFlow.
+      {/* Path switcher */}
+      <div className="rounded-xl border border-border bg-card p-5">
+        <p className="mb-1 text-sm font-semibold text-foreground">What are you trying to do?</p>
+        <p className="mb-4 text-xs text-muted-foreground">
+          Choose the path that matches your goal — the steps below will update accordingly.
         </p>
-      </StepItem>
+        <div className="flex flex-col gap-2 sm:flex-row">
+          {quickStartPaths.map((p) => (
+            <button
+              key={p}
+              type="button"
+              onClick={() => setPath(p)}
+              className={cn(
+                'flex-1 cursor-pointer rounded-lg border px-4 py-3 text-left text-sm transition-colors',
+                path === p
+                  ? 'border-primary bg-primary/10 font-medium text-foreground'
+                  : 'border-border bg-background text-muted-foreground hover:text-foreground'
+              )}
+            >
+              <span className="block font-medium text-foreground">{p}</span>
+              <span className="mt-0.5 block text-xs text-muted-foreground">
+                {p === 'Add to existing project'
+                  ? 'Install Apollo Canvas as a dependency in your own app'
+                  : 'Clone the apollo-ui repo and run Storybook locally'}
+              </span>
+            </button>
+          ))}
+        </div>
+      </div>
 
-      <StepItem step={2} title="Import the CSS theme">
-        <CodeBlock label="main.tsx or _app.tsx">
-          {"import '@uipath/apollo-react/core/theme.css';"}
-        </CodeBlock>
-        <p>This loads the Apollo design tokens as CSS custom properties.</p>
-      </StepItem>
+      {path === 'Add to existing project' && (
+        <>
+          <div className="space-y-6">
+            <StepItem step={1} title="Install the package">
+              <CodeBlock label="terminal">{'pnpm add @uipath/apollo-react'}</CodeBlock>
+              <p>
+                The canvas is included in the main package. No separate install needed for
+                ReactFlow.
+              </p>
+            </StepItem>
 
-      <StepItem step={3} title="Render a canvas">
-        <CodeBlock label="MyCanvas.tsx">
-          {`import { useState, useCallback } from 'react';
+            <StepItem step={2} title="Import the CSS theme">
+              <CodeBlock label="main.tsx or _app.tsx">
+                {"import '@uipath/apollo-react/core/theme.css';"}
+              </CodeBlock>
+              <p>This loads the Apollo design tokens as CSS custom properties.</p>
+            </StepItem>
+
+            <StepItem step={3} title="Render a canvas">
+              <CodeBlock label="MyCanvas.tsx">
+                {`import { useState, useCallback } from 'react';
 import {
   type Node, type Edge,
   type NodeChange, type EdgeChange, type Connection,
@@ -336,38 +371,39 @@ export function MyCanvas() {
     </div>
   );
 }`}
-        </CodeBlock>
-      </StepItem>
+              </CodeBlock>
+            </StepItem>
+          </div>
 
-      <Divider />
+          <Divider />
 
-      <div>
-        <h3 className="mb-3 text-lg font-semibold text-foreground">Import Paths</h3>
-        <SectionDescription>
-          Canvas exports are namespaced under the <InlineCode>/canvas</InlineCode> subpath.
-        </SectionDescription>
-        <div className="space-y-3">
-          <CodeBlock label="Canvas components">
-            {`import { BaseCanvas, CanvasModeToolbar, CanvasZoomControls } from '@uipath/apollo-react/canvas';`}
-          </CodeBlock>
-          <CodeBlock label="ReactFlow re-exports (nodes, edges, hooks)">
-            {`import { useReactFlow, Panel, Handle } from '@uipath/apollo-react/canvas/xyflow/react';`}
-          </CodeBlock>
-          <CodeBlock label="Canvas hooks">
-            {`import { useCanvasEvents, useExportCanvas, useElementsOverlap } from '@uipath/apollo-react/canvas';`}
-          </CodeBlock>
-        </div>
-      </div>
+          <div>
+            <h3 className="mb-3 text-lg font-semibold text-foreground">Import Paths</h3>
+            <SectionDescription>
+              Canvas exports are namespaced under the <InlineCode>/canvas</InlineCode> subpath.
+            </SectionDescription>
+            <div className="space-y-3">
+              <CodeBlock label="Canvas components">
+                {`import { BaseCanvas, CanvasModeToolbar, CanvasZoomControls } from '@uipath/apollo-react/canvas';`}
+              </CodeBlock>
+              <CodeBlock label="ReactFlow re-exports (nodes, edges, hooks)">
+                {`import { useReactFlow, Panel, Handle } from '@uipath/apollo-react/canvas/xyflow/react';`}
+              </CodeBlock>
+              <CodeBlock label="Canvas hooks">
+                {`import { useCanvasEvents, useExportCanvas, useElementsOverlap } from '@uipath/apollo-react/canvas';`}
+              </CodeBlock>
+            </div>
+          </div>
 
-      <Divider />
+          <Divider />
 
-      <div>
-        <h3 className="mb-3 text-lg font-semibold text-foreground">Writing Stories</h3>
-        <SectionDescription>
-          Use the built-in storybook utilities to reduce boilerplate in canvas stories.
-        </SectionDescription>
-        <CodeBlock label="MyNode.stories.tsx">
-          {`import { withCanvasProviders, useCanvasStory } from '../storybook-utils';
+          <div>
+            <h3 className="mb-3 text-lg font-semibold text-foreground">Writing Stories</h3>
+            <SectionDescription>
+              Use the built-in storybook utilities to reduce boilerplate in canvas stories.
+            </SectionDescription>
+            <CodeBlock label="MyNode.stories.tsx">
+              {`import { withCanvasProviders, useCanvasStory } from '../storybook-utils';
 import { BaseCanvas } from '../BaseCanvas';
 
 const meta = {
@@ -386,16 +422,62 @@ function MyStory() {
 }
 
 export const Default = { render: () => <MyStory /> };`}
-        </CodeBlock>
-        <div className="mt-3">
+            </CodeBlock>
+            <div className="mt-3">
+              <InfoCallout>
+                <span className="font-medium text-foreground">withCanvasProviders</span> wraps the
+                story in ReactFlowProvider, ExecutionStatusContext, and ValidationStatusContext.{' '}
+                <span className="font-medium text-foreground">useCanvasStory</span> manages
+                node/edge state and returns a ready-to-spread{' '}
+                <InlineCode>canvasProps</InlineCode> object.
+              </InfoCallout>
+            </div>
+          </div>
+        </>
+      )}
+
+      {path === 'Run locally' && (
+        <>
           <InfoCallout>
-            <span className="font-medium text-foreground">withCanvasProviders</span> wraps the story
-            in ReactFlowProvider, ExecutionStatusContext, and ValidationStatusContext.{' '}
-            <span className="font-medium text-foreground">useCanvasStory</span> manages node/edge
-            state and returns a ready-to-spread <InlineCode>canvasProps</InlineCode> object.
+            <p className="mb-1 font-medium text-foreground">Before you begin</p>
+            <p>
+              This path is for contributors and team members who want to browse or modify Apollo
+              Canvas source files and run Storybook on their machine.
+            </p>
           </InfoCallout>
-        </div>
-      </div>
+
+          <div className="space-y-6">
+            <StepItem step={1} title="Clone the repository">
+              <CodeBlock label="terminal">
+                {'git clone https://github.com/UiPath/apollo-ui.git\ncd apollo-ui'}
+              </CodeBlock>
+            </StepItem>
+
+            <StepItem step={2} title="Install dependencies">
+              <CodeBlock label="terminal">{'npm install -g pnpm\npnpm install'}</CodeBlock>
+              <p>
+                This project uses <InlineCode>pnpm</InlineCode> workspaces. Install it globally if
+                you don't have it yet.
+              </p>
+            </StepItem>
+
+            <StepItem step={3} title="Build all packages">
+              <CodeBlock label="terminal">{'pnpm build'}</CodeBlock>
+              <p>
+                Compiles apollo-core, apollo-wind, and apollo-react before Storybook starts.
+              </p>
+            </StepItem>
+
+            <StepItem step={4} title="Start Storybook">
+              <CodeBlock label="terminal">{'pnpm storybook:dev'}</CodeBlock>
+              <p>
+                Opens Apollo Canvas Storybook at <InlineCode>http://localhost:6007</InlineCode>.
+                Changes to source files hot-reload automatically.
+              </p>
+            </StepItem>
+          </div>
+        </>
+      )}
     </div>
   );
 }
@@ -588,20 +670,9 @@ function GettingStartedPage({ globalTheme }: { globalTheme: string }) {
         {/* Header */}
         <h1 className="text-[2rem] font-bold tracking-tight text-foreground">Apollo Canvas</h1>
         <p className="text-base leading-7 text-muted-foreground">
-          A visual workflow canvas built on ReactFlow — nodes, edges, controls, and panels designed
+          A visual workflow canvas built on ReactFlow. Nodes, edges, controls, and panels designed
           for process automation UIs.
         </p>
-
-        <div className="pt-2">
-          <a
-            href="https://github.com/UiPath/apollo-ui"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="text-sm font-medium text-primary underline"
-          >
-            github.com/UiPath/apollo-ui
-          </a>
-        </div>
 
         {/* Tabs */}
         <div className="flex gap-1 border-b border-border pb-0 pt-6">

--- a/packages/apollo-react/src/canvas/stories/GettingStarted.stories.tsx
+++ b/packages/apollo-react/src/canvas/stories/GettingStarted.stories.tsx
@@ -122,7 +122,7 @@ function OverviewTab() {
       </SectionDescription>
 
       <InfoCallout>
-        The canvas is powered by <InlineCode>@uipath/apollo-react/canvas/xyflow/react</InlineCode> —
+        The canvas is powered by <InlineCode>@uipath/apollo-react/canvas/xyflow/react</InlineCode>,
         a re-export of ReactFlow with Apollo-specific extensions. You do not need to install
         ReactFlow separately.
       </InfoCallout>

--- a/packages/apollo-react/src/canvas/stories/GettingStarted.stories.tsx
+++ b/packages/apollo-react/src/canvas/stories/GettingStarted.stories.tsx
@@ -428,8 +428,8 @@ export const Default = { render: () => <MyStory /> };`}
                 <span className="font-medium text-foreground">withCanvasProviders</span> wraps the
                 story in ReactFlowProvider, ExecutionStatusContext, and ValidationStatusContext.{' '}
                 <span className="font-medium text-foreground">useCanvasStory</span> manages
-                node/edge state and returns a ready-to-spread{' '}
-                <InlineCode>canvasProps</InlineCode> object.
+                node/edge state and returns a ready-to-spread <InlineCode>canvasProps</InlineCode>{' '}
+                object.
               </InfoCallout>
             </div>
           </div>
@@ -463,9 +463,7 @@ export const Default = { render: () => <MyStory /> };`}
 
             <StepItem step={3} title="Build all packages">
               <CodeBlock label="terminal">{'pnpm build'}</CodeBlock>
-              <p>
-                Compiles apollo-core, apollo-wind, and apollo-react before Storybook starts.
-              </p>
+              <p>Compiles apollo-core, apollo-wind, and apollo-react before Storybook starts.</p>
             </StepItem>
 
             <StepItem step={4} title="Start Storybook">

--- a/packages/apollo-react/src/canvas/stories/GettingStarted.stories.tsx
+++ b/packages/apollo-react/src/canvas/stories/GettingStarted.stories.tsx
@@ -47,9 +47,13 @@ function CodeBlock({ children, label }: { children: string; label?: string }) {
   const [copied, setCopied] = React.useState(false);
 
   const handleCopy = () => {
-    navigator.clipboard.writeText(children);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
+    navigator.clipboard
+      .writeText(children)
+      .then(() => {
+        setCopied(true);
+        setTimeout(() => setCopied(false), 2000);
+      })
+      .catch(() => {});
   };
 
   return (

--- a/packages/apollo-react/src/canvas/stories/GettingStarted.stories.tsx
+++ b/packages/apollo-react/src/canvas/stories/GettingStarted.stories.tsx
@@ -273,7 +273,7 @@ function QuickStartTab() {
       <div className="rounded-xl border border-border bg-card p-5">
         <p className="mb-1 text-sm font-semibold text-foreground">What are you trying to do?</p>
         <p className="mb-4 text-xs text-muted-foreground">
-          Choose the path that matches your goal — the steps below will update accordingly.
+          Choose the path that matches your goal. The steps below will update accordingly.
         </p>
         <div className="flex flex-col gap-2 sm:flex-row">
           {quickStartPaths.map((p) => (
@@ -444,6 +444,15 @@ export const Default = { render: () => <MyStory /> };`}
               This path is for contributors and team members who want to browse or modify Apollo
               Canvas source files and run Storybook on their machine.
             </p>
+            <ul className="mt-2 list-disc pl-4 space-y-1">
+              <li>
+                <strong>Node.js 22 or later</strong> is required. Check your version with{' '}
+                <InlineCode>node --version</InlineCode>.
+              </li>
+              <li>
+                <strong>pnpm 11.1.3</strong> is the required package manager for this repo.
+              </li>
+            </ul>
           </InfoCallout>
 
           <div className="space-y-6">
@@ -454,10 +463,10 @@ export const Default = { render: () => <MyStory /> };`}
             </StepItem>
 
             <StepItem step={2} title="Install dependencies">
-              <CodeBlock label="terminal">{'npm install -g pnpm\npnpm install'}</CodeBlock>
+              <CodeBlock label="terminal">{'npm install -g pnpm@11.1.3\npnpm install'}</CodeBlock>
               <p>
-                This project uses <InlineCode>pnpm</InlineCode> workspaces. Install it globally if
-                you don't have it yet.
+                This project uses <InlineCode>pnpm</InlineCode> workspaces. Install the pinned
+                version globally if you don't have it yet.
               </p>
             </StepItem>
 

--- a/packages/apollo-wind/src/getting-started/getting-started.stories.tsx
+++ b/packages/apollo-wind/src/getting-started/getting-started.stories.tsx
@@ -115,8 +115,8 @@ function OverviewTab() {
     <div className="space-y-6">
       <SectionDescription>
         Apollo Wind is the Tailwind CSS component library for new React applications. Built on
-        shadcn/ui and Radix primitives, it provides 60+ components, page templates, and full
-        theming support, all consistent with the Apollo design system tokens from apollo-core.
+        shadcn/ui and Radix primitives, it provides 60+ components, page templates, and full theming
+        support, all consistent with the Apollo design system tokens from apollo-core.
       </SectionDescription>
 
       <Divider />
@@ -310,9 +310,7 @@ function QuickStartTab() {
               <CodeBlock label="Components">
                 {`import { Button, Input, Dialog } from '@uipath/apollo-wind';`}
               </CodeBlock>
-              <CodeBlock label="Utilities">
-                {`import { cn } from '@uipath/apollo-wind';`}
-              </CodeBlock>
+              <CodeBlock label="Utilities">{`import { cn } from '@uipath/apollo-wind';`}</CodeBlock>
               <CodeBlock label="CSS theme">
                 {`import '@uipath/apollo-wind/tailwind.css';`}
               </CodeBlock>
@@ -339,9 +337,7 @@ function QuickStartTab() {
             </StepItem>
 
             <StepItem step={2} title="Install dependencies">
-              <CodeBlock label="terminal">
-                {'npm install -g pnpm\npnpm install'}
-              </CodeBlock>
+              <CodeBlock label="terminal">{'npm install -g pnpm\npnpm install'}</CodeBlock>
               <p>
                 This project uses <InlineCode>pnpm</InlineCode> workspaces. Install it globally if
                 you don't have it yet.
@@ -356,9 +352,8 @@ function QuickStartTab() {
             <StepItem step={4} title="Start Storybook">
               <CodeBlock label="terminal">{'pnpm storybook:dev'}</CodeBlock>
               <p>
-                Opens Apollo Wind Storybook at{' '}
-                <InlineCode>http://localhost:6007</InlineCode>. Changes to source files hot-reload
-                automatically.
+                Opens Apollo Wind Storybook at <InlineCode>http://localhost:6007</InlineCode>.
+                Changes to source files hot-reload automatically.
               </p>
             </StepItem>
           </div>
@@ -386,7 +381,11 @@ const components = [
   { category: 'Forms', name: 'Slider', description: 'Range input' },
   { category: 'Forms', name: 'Label', description: 'Form field label' },
   { category: 'Forms', name: 'Search', description: 'Search input with clear action' },
-  { category: 'Forms', name: 'FileUpload', description: 'Drag-and-drop file input with per-file errors' },
+  {
+    category: 'Forms',
+    name: 'FileUpload',
+    description: 'Drag-and-drop file input with per-file errors',
+  },
   { category: 'Forms', name: 'Stepper', description: 'Multi-step form progress' },
   { category: 'Date & Time', name: 'Calendar', description: 'Month calendar picker' },
   { category: 'Date & Time', name: 'DatePicker', description: 'Date input with popover' },
@@ -432,10 +431,22 @@ const components = [
   { category: 'Custom Apollo', name: 'FlowNode', description: 'Workflow canvas node' },
   { category: 'Custom Apollo', name: 'FlowProperties', description: 'Node properties panel' },
   { category: 'Custom Apollo', name: 'GridMaestro', description: 'Maestro-style data grid' },
-  { category: 'Custom Apollo', name: 'ChatComposer', description: 'AI chat input with attachments' },
+  {
+    category: 'Custom Apollo',
+    name: 'ChatComposer',
+    description: 'AI chat input with attachments',
+  },
   { category: 'Custom Apollo', name: 'ChatStepsView', description: 'AI thinking steps display' },
-  { category: 'Custom Apollo', name: 'ChatFirstExperience', description: 'Empty chat onboarding state' },
-  { category: 'Custom Apollo', name: 'ChatPromptSuggestions', description: 'Suggested prompt chips' },
+  {
+    category: 'Custom Apollo',
+    name: 'ChatFirstExperience',
+    description: 'Empty chat onboarding state',
+  },
+  {
+    category: 'Custom Apollo',
+    name: 'ChatPromptSuggestions',
+    description: 'Suggested prompt chips',
+  },
   { category: 'Custom Apollo', name: 'Canvas', description: 'Pannable, zoomable canvas area' },
 ] as const;
 

--- a/packages/apollo-wind/src/getting-started/getting-started.stories.tsx
+++ b/packages/apollo-wind/src/getting-started/getting-started.stories.tsx
@@ -107,517 +107,389 @@ function StepItem({
 }
 
 // ============================================================================
-// Package card
+// Tab: Overview
 // ============================================================================
 
-const installTabs = ['Add to existing project', 'Run locally'] as const;
-type InstallTab = (typeof installTabs)[number];
-
-function PackageCard({
-  name,
-  packageName,
-  description,
-  bestFor,
-  consumerInstall,
-  localDevCommands,
-}: {
-  name: string;
-  packageName: string;
-  description: string;
-  bestFor: string;
-  consumerInstall: string;
-  localDevCommands: string;
-}) {
-  const [activeTab, setActiveTab] = React.useState<InstallTab>('Add to existing project');
-
-  return (
-    <div className="rounded-xl border border-border bg-card p-6">
-      <div className="mb-1 flex items-baseline gap-3">
-        <h3 className="text-lg font-semibold text-foreground">{name}</h3>
-        <InlineCode>{packageName}</InlineCode>
-      </div>
-      <p className="mb-4 text-sm leading-6 text-muted-foreground">{description}</p>
-
-      <p className="mb-5 text-sm leading-6 text-muted-foreground">
-        <span className="font-medium text-foreground">Best for: </span>
-        {bestFor}
-      </p>
-
-      {/* Install path tabs */}
-      <div className="mb-4 inline-flex rounded-lg border border-border bg-muted/50 p-1">
-        {installTabs.map((tab) => (
-          <button
-            type="button"
-            key={tab}
-            className={cn(
-              'cursor-pointer rounded-md px-3 py-1.5 text-sm font-medium transition-colors',
-              activeTab === tab
-                ? 'bg-background text-foreground shadow-sm'
-                : 'text-muted-foreground hover:text-foreground'
-            )}
-            onClick={() => setActiveTab(tab)}
-          >
-            {tab}
-          </button>
-        ))}
-      </div>
-
-      {activeTab === 'Add to existing project' && (
-        <div>
-          <CodeBlock>{consumerInstall}</CodeBlock>
-        </div>
-      )}
-
-      {activeTab === 'Run locally' && (
-        <div>
-          <p className="mb-2 text-sm text-muted-foreground">
-            After cloning the{' '}
-            <a
-              href="https://github.com/UiPath/apollo-ui"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="font-medium text-primary underline"
-            >
-              apollo-ui
-            </a>{' '}
-            monorepo and running <InlineCode>pnpm install</InlineCode>:
-          </p>
-          <CodeBlock>{localDevCommands}</CodeBlock>
-        </div>
-      )}
-    </div>
-  );
-}
-
-// ============================================================================
-// CLI components
-// ============================================================================
-
-const cliComponents = [
-  // Forms
-  { category: 'Forms', name: 'button', description: 'Primary action trigger' },
-  { category: 'Forms', name: 'button-group', description: 'Grouped action buttons' },
-  { category: 'Forms', name: 'input', description: 'Text input field' },
-  { category: 'Forms', name: 'textarea', description: 'Multi-line text input' },
-  { category: 'Forms', name: 'select', description: 'Dropdown selector' },
-  { category: 'Forms', name: 'combobox', description: 'Searchable dropdown' },
-  { category: 'Forms', name: 'multi-select', description: 'Multi-value selector' },
-  { category: 'Forms', name: 'checkbox', description: 'Boolean toggle' },
-  { category: 'Forms', name: 'radio-group', description: 'Single-choice selector' },
-  { category: 'Forms', name: 'switch', description: 'On/off toggle' },
-  { category: 'Forms', name: 'slider', description: 'Range input' },
-  { category: 'Forms', name: 'label', description: 'Form field label' },
-  { category: 'Forms', name: 'search', description: 'Search input with clear action' },
-  {
-    category: 'Forms',
-    name: 'file-upload',
-    description: 'Drag-and-drop file input with per-file errors',
-  },
-  { category: 'Forms', name: 'stepper', description: 'Multi-step form progress' },
-  // Date & Time
-  { category: 'Date & Time', name: 'calendar', description: 'Month calendar picker' },
-  { category: 'Date & Time', name: 'date-picker', description: 'Date input with popover' },
-  {
-    category: 'Date & Time',
-    name: 'datetime-picker',
-    description: 'Combined date and time picker',
-  },
-  // Layout
-  { category: 'Layout', name: 'card', description: 'Content container with header and body' },
-  { category: 'Layout', name: 'separator', description: 'Horizontal or vertical divider' },
-  { category: 'Layout', name: 'resizable', description: 'Draggable split-pane layout' },
-  { category: 'Layout', name: 'scroll-area', description: 'Custom scrollable container' },
-  { category: 'Layout', name: 'aspect-ratio', description: 'Enforce element aspect ratio' },
-  // Navigation
-  { category: 'Navigation', name: 'tabs', description: 'Tabbed content switcher' },
-  { category: 'Navigation', name: 'breadcrumb', description: 'Hierarchical location trail' },
-  { category: 'Navigation', name: 'pagination', description: 'Page navigation controls' },
-  { category: 'Navigation', name: 'accordion', description: 'Collapsible content sections' },
-  { category: 'Navigation', name: 'tree-view', description: 'Hierarchical item tree' },
-  // Overlays
-  { category: 'Overlays', name: 'dialog', description: 'Modal overlay' },
-  { category: 'Overlays', name: 'sheet', description: 'Slide-in side panel' },
-  { category: 'Overlays', name: 'alert-dialog', description: 'Confirmation dialog' },
-  { category: 'Overlays', name: 'popover', description: 'Anchored floating panel' },
-  { category: 'Overlays', name: 'hover-card', description: 'Preview card on hover' },
-  { category: 'Overlays', name: 'dropdown-menu', description: 'Contextual action menu' },
-  { category: 'Overlays', name: 'context-menu', description: 'Right-click menu' },
-  { category: 'Overlays', name: 'command', description: 'Command palette with search' },
-  { category: 'Overlays', name: 'tooltip', description: 'Inline hover hint' },
-  // Data Display
-  { category: 'Data Display', name: 'data-table', description: 'Sortable, filterable table' },
-  { category: 'Data Display', name: 'badge', description: 'Status and label pill' },
-  { category: 'Data Display', name: 'alert', description: 'Inline status message' },
-  { category: 'Data Display', name: 'stats-card', description: 'KPI metric card' },
-  { category: 'Data Display', name: 'empty-state', description: 'Zero-state placeholder' },
-  { category: 'Data Display', name: 'skeleton', description: 'Loading placeholder' },
-  { category: 'Data Display', name: 'progress', description: 'Progress bar' },
-  { category: 'Data Display', name: 'spinner', description: 'Loading indicator' },
-  { category: 'Data Display', name: 'sonner', description: 'Toast notifications' },
-  { category: 'Data Display', name: 'toggle', description: 'Single toggle button' },
-  { category: 'Data Display', name: 'toggle-group', description: 'Segmented toggle controls' },
-  // Custom Apollo
-  { category: 'Custom Apollo', name: 'page-header', description: 'Page title and action bar' },
-  { category: 'Custom Apollo', name: 'global-header', description: 'App-level top navigation' },
-  { category: 'Custom Apollo', name: 'panel-studio', description: 'Studio-style side panel' },
-  { category: 'Custom Apollo', name: 'panel-delegate', description: 'Delegate-style nav panel' },
-  { category: 'Custom Apollo', name: 'panel-flow', description: 'Flow editor nav rail' },
-  { category: 'Custom Apollo', name: 'panel-maestro', description: 'Maestro dashboard panel' },
-  { category: 'Custom Apollo', name: 'toolbar-canvas', description: 'Canvas floating toolbar' },
-  { category: 'Custom Apollo', name: 'toolbar-view', description: 'View mode toolbar' },
-  { category: 'Custom Apollo', name: 'flow-node', description: 'Workflow canvas node' },
-  { category: 'Custom Apollo', name: 'flow-properties', description: 'Node properties panel' },
-  { category: 'Custom Apollo', name: 'grid-maestro', description: 'Maestro-style data grid' },
-  {
-    category: 'Custom Apollo',
-    name: 'chat-composer',
-    description: 'AI chat input with attachments',
-  },
-  { category: 'Custom Apollo', name: 'chat-steps-view', description: 'AI thinking steps display' },
-  {
-    category: 'Custom Apollo',
-    name: 'chat-first-experience',
-    description: 'Empty chat onboarding state',
-  },
-  {
-    category: 'Custom Apollo',
-    name: 'chat-prompt-suggestions',
-    description: 'Suggested prompt chips',
-  },
-  { category: 'Custom Apollo', name: 'canvas', description: 'Pannable, zoomable canvas area' },
-] as const;
-
-function PrereqsTooltip() {
-  const [open, setOpen] = React.useState(false);
-
-  return (
-    <span className="relative inline-block">
-      <button
-        type="button"
-        onMouseEnter={() => setOpen(true)}
-        onMouseLeave={() => setOpen(false)}
-        onFocus={() => setOpen(true)}
-        onBlur={() => setOpen(false)}
-        className="inline-flex cursor-default items-center gap-1 rounded border border-border bg-muted/60 px-1.5 py-0.5 text-xs font-medium text-muted-foreground transition-colors hover:text-foreground"
-      >
-        Prerequisites
-        <svg
-          width="10"
-          height="10"
-          viewBox="0 0 10 10"
-          fill="none"
-          className="shrink-0 opacity-60"
-          aria-hidden="true"
-        >
-          <circle cx="5" cy="5" r="4.5" stroke="currentColor" />
-          <path d="M5 4.5v3M5 3h.01" stroke="currentColor" strokeWidth="1" strokeLinecap="round" />
-        </svg>
-      </button>
-
-      {open && (
-        <div className="absolute bottom-full left-0 z-50 mb-2 w-64 rounded-lg border border-border bg-card p-3 shadow-lg">
-          <p className="mb-2 text-xs font-medium text-foreground">Before you begin</p>
-          <ul className="space-y-1.5 text-xs leading-5 text-muted-foreground">
-            <li>
-              <span className="font-medium text-foreground">Node 18+</span> — required by the shadcn
-              CLI
-            </li>
-            <li>
-              <span className="font-medium text-foreground">Tailwind CSS v4</span> — uses{' '}
-              <code className="rounded bg-muted px-1 py-px font-mono text-[10px]">
-                @import "tailwindcss"
-              </code>
-              , not{' '}
-              <code className="rounded bg-muted px-1 py-px font-mono text-[10px]">
-                tailwind.config.js
-              </code>
-            </li>
-            <li>
-              <span className="font-medium text-foreground">React project</span> — Vite, Next.js, or
-              any React setup
-            </li>
-          </ul>
-        </div>
-      )}
-    </span>
-  );
-}
-
-// ============================================================================
-// Tab: Choose your package
-// ============================================================================
-
-function ChooseYourPackageTab() {
+function OverviewTab() {
   return (
     <div className="space-y-6">
       <SectionDescription>
-        Apollo is split into focused packages. Pick the one that matches what you're building.
+        Apollo Wind is the Tailwind CSS component library for new React applications. Built on
+        shadcn/ui and Radix primitives, it provides 60+ components, page templates, and full
+        theming support, all consistent with the Apollo design system tokens from apollo-core.
       </SectionDescription>
 
-      <PackageCard
-        name="Apollo Wind"
-        packageName="@uipath/apollo-wind"
-        description="The modern UI component library for rapid prototyping and new product interfaces. Built with Tailwind CSS and shadcn/ui — includes 60+ components, page templates, and full theming support."
-        bestFor="Prototyping, new product UIs, and any project using Tailwind CSS."
-        consumerInstall="npm install @uipath/apollo-wind"
-        localDevCommands={`pnpm build\npnpm storybook:dev`}
-      />
+      <Divider />
 
-      <PackageCard
-        name="Apollo React"
-        packageName="@uipath/apollo-react"
-        description="The component library for UiPath workflows and automation products. Built on Material UI with Apollo theming — provides the components and patterns used across workflow-based experiences."
-        bestFor="Workflow interfaces, automation products, and existing Material UI projects."
-        consumerInstall="npm install @uipath/apollo-react"
-        localDevCommands={`pnpm build\npnpm storybook:dev`}
-      />
+      <div>
+        <h3 className="mb-4 text-lg font-semibold text-foreground">What's included</h3>
+        <div className="grid gap-4 sm:grid-cols-2">
+          {[
+            {
+              title: 'Components',
+              description:
+                '60+ production-ready components across Forms, Navigation, Overlays, Data Display, and Layout categories.',
+              examples: ['Button', 'DataTable', 'Dialog', 'Combobox', 'Tabs'],
+            },
+            {
+              title: 'Templates',
+              description:
+                'Full page layouts for common UiPath product patterns: admin pages, delegate views, Studio, Flow, and Maestro.',
+              examples: ['Admin', 'Delegate', 'Studio', 'Flow', 'Maestro'],
+            },
+            {
+              title: 'Theming',
+              description:
+                'Future design language themes with full dark and light mode support. All tokens resolve from CSS custom properties.',
+              examples: ['future-dark', 'future-light', 'vertex', 'canvas'],
+            },
+            {
+              title: 'Design Tokens',
+              description:
+                'Semantic color, spacing, typography, and radius tokens from apollo-core, wired into Tailwind via CSS variables.',
+              examples: ['Colors', 'Spacing', 'Typography', 'Radius'],
+            },
+          ].map(({ title, description, examples }) => (
+            <div key={title} className="rounded-xl border border-border bg-card p-5">
+              <h4 className="mb-1 text-base font-semibold text-foreground">{title}</h4>
+              <p className="mb-3 text-sm leading-6 text-muted-foreground">{description}</p>
+              <div className="flex flex-wrap gap-1.5">
+                {examples.map((e) => (
+                  <InlineCode key={e}>{e}</InlineCode>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
 
-      <PackageCard
-        name="Apollo Core"
-        packageName="@uipath/apollo-core"
-        description="The shared foundation — design tokens, icons, fonts, and CSS variables. Both Apollo Wind and Apollo React depend on this package. Install it directly only if you need tokens without a component library."
-        bestFor="Custom builds that need design tokens, icons, or fonts without a full component library."
-        consumerInstall="npm install @uipath/apollo-core"
-        localDevCommands="pnpm build"
-      />
+      <Divider />
+
+      <div>
+        <h3 className="mb-4 text-lg font-semibold text-foreground">Design principles</h3>
+        <div className="space-y-3">
+          {[
+            {
+              title: 'You own the code',
+              body: 'Components follow the shadcn ownership model. Source is copied into your project. You can read, modify, and update on your own terms.',
+            },
+            {
+              title: 'Tailwind-first',
+              body: 'Styling uses static Tailwind utility classes. No runtime CSS-in-JS or emotion. Works with Tailwind v4 and the @import "tailwindcss" syntax.',
+            },
+            {
+              title: 'Accessible by default',
+              body: 'All interactive components are built on Radix UI primitives, which handle focus management, keyboard navigation, and ARIA attributes.',
+            },
+            {
+              title: 'Token-driven theming',
+              body: 'Visual appearance is controlled entirely by CSS custom properties from apollo-core. Switching themes is a single class change on the root element.',
+            },
+          ].map(({ title, body }) => (
+            <div key={title} className="rounded-lg border border-border bg-card p-4">
+              <p className="mb-1 text-sm font-semibold text-foreground">{title}</p>
+              <p className="text-sm leading-6 text-muted-foreground">{body}</p>
+            </div>
+          ))}
+        </div>
+      </div>
     </div>
   );
 }
 
 // ============================================================================
-// Tab: CLI
+// Tab: Quick Start
 // ============================================================================
 
-function CLITab() {
-  const [copiedComponent, setCopiedComponent] = React.useState<string | null>(null);
+const quickStartPaths = ['Add to existing project', 'Run locally'] as const;
+type QuickStartPath = (typeof quickStartPaths)[number];
 
-  const handleCopyComponent = (name: string) => {
-    navigator.clipboard.writeText(`npx shadcn@latest add https://ui.uipath.com/r/${name}.json`);
-    setCopiedComponent(name);
-    setTimeout(() => setCopiedComponent(null), 2000);
-  };
-
-  const categories = [...new Set(cliComponents.map((c) => c.category))];
+function QuickStartTab() {
+  const [path, setPath] = React.useState<QuickStartPath>('Add to existing project');
 
   return (
     <div className="space-y-8">
-      {/* Why CLI */}
-      <div>
-        <InfoCallout>
-          <p className="mb-2 font-medium text-foreground">Work in progress</p>
-          <p>
-            This is the <span className="font-medium text-foreground">Apollo Wind CLI</span> — a
-            frontend-specific tool for Tailwind-based projects using{' '}
-            <InlineCode>@uipath/apollo-wind</InlineCode>. The registry is not yet published;
-            commands on this page reflect the target experience and will work once it is.
-          </p>
-          <p className="mt-2">
-            Other teams at UiPath are also building CLIs for different parts of the stack. Check the{' '}
-            <a
-              href="https://github.com/UiPath"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="font-medium text-primary underline"
+      {/* Path switcher */}
+      <div className="rounded-xl border border-border bg-card p-5">
+        <p className="mb-1 text-sm font-semibold text-foreground">What are you trying to do?</p>
+        <p className="mb-4 text-xs text-muted-foreground">
+          Choose the path that matches your goal. The steps below will update accordingly.
+        </p>
+        <div className="flex flex-col gap-2 sm:flex-row">
+          {quickStartPaths.map((p) => (
+            <button
+              key={p}
+              type="button"
+              onClick={() => setPath(p)}
+              className={cn(
+                'flex-1 cursor-pointer rounded-lg border px-4 py-3 text-left text-sm transition-colors',
+                path === p
+                  ? 'border-primary bg-primary/10 font-medium text-foreground'
+                  : 'border-border bg-background text-muted-foreground hover:text-foreground'
+              )}
             >
-              UiPath GitHub
-            </a>{' '}
-            for the full picture.
-          </p>
-        </InfoCallout>
-        <div className="mt-6">
-          <SectionDescription>
-            Apollo's CLI follows the shadcn ownership model — components are copied directly into
-            your project rather than installed as a locked package dependency. You own the code, can
-            customize it freely, and updates are an explicit choice, not a forced upgrade.
-          </SectionDescription>
+              <span className="block font-medium text-foreground">{p}</span>
+              <span className="mt-0.5 block text-xs text-muted-foreground">
+                {p === 'Add to existing project'
+                  ? 'Install Apollo Wind as a dependency in your own app'
+                  : 'Clone the apollo-ui repo and run Storybook locally'}
+              </span>
+            </button>
+          ))}
         </div>
       </div>
 
-      <Divider />
+      {path === 'Add to existing project' && (
+        <>
+          <InfoCallout>
+            <p className="mb-1 font-medium text-foreground">Prerequisites</p>
+            <ul className="space-y-1">
+              <li>
+                <span className="font-medium text-foreground">Node 18+</span>: required by the
+                shadcn CLI
+              </li>
+              <li>
+                <span className="font-medium text-foreground">Tailwind CSS v4</span>: uses{' '}
+                <InlineCode>@import "tailwindcss"</InlineCode>, not{' '}
+                <InlineCode>tailwind.config.js</InlineCode>
+              </li>
+              <li>
+                <span className="font-medium text-foreground">React project</span>: Vite, Next.js,
+                or any React setup
+              </li>
+            </ul>
+          </InfoCallout>
 
-      {/* Quick Start */}
-      <div>
-        <h3 className="mb-1 text-lg font-semibold text-foreground">Quick Start</h3>
-        <p className="mb-6 flex flex-wrap items-center gap-2 text-base leading-7 text-muted-foreground">
-          Three commands to get Apollo components and theming into your project. <PrereqsTooltip />
-        </p>
+          <div className="space-y-6">
+            <StepItem step={1} title="Install the package">
+              <CodeBlock label="terminal">{'npm install @uipath/apollo-wind'}</CodeBlock>
+            </StepItem>
 
-        <div className="space-y-4">
-          <StepItem step={1} title="Initialize shadcn">
-            <CodeBlock>{`npx shadcn@latest init`}</CodeBlock>
+            <StepItem step={2} title="Import the CSS theme">
+              <CodeBlock label="main.tsx or _app.tsx">
+                {`import '@uipath/apollo-wind/tailwind.css';`}
+              </CodeBlock>
+              <p>This loads Apollo design tokens and the Tailwind base styles.</p>
+            </StepItem>
+
+            <StepItem step={3} title="Apply the theme class">
+              <CodeBlock label="App.tsx">
+                {`export function App() {
+  return (
+    <div className="future-dark min-h-screen bg-background text-foreground">
+      {/* your app */}
+    </div>
+  );
+}`}
+              </CodeBlock>
+              <p>
+                Switch to light mode by replacing <InlineCode>future-dark</InlineCode> with{' '}
+                <InlineCode>future-light</InlineCode>. All tokens adapt automatically.
+              </p>
+            </StepItem>
+
+            <StepItem step={4} title="Add your first component">
+              <CodeBlock label="terminal">
+                {'npx shadcn@latest add https://ui.uipath.com/r/button.json'}
+              </CodeBlock>
+              <p>
+                Copies the component source into{' '}
+                <InlineCode>src/components/ui/button.tsx</InlineCode>. It's yours to use and modify.
+              </p>
+            </StepItem>
+          </div>
+
+          <Divider />
+
+          <div>
+            <h3 className="mb-3 text-lg font-semibold text-foreground">Import paths</h3>
+            <SectionDescription>
+              Components and utilities are exported from the package root.
+            </SectionDescription>
+            <div className="space-y-3">
+              <CodeBlock label="Components">
+                {`import { Button, Input, Dialog } from '@uipath/apollo-wind';`}
+              </CodeBlock>
+              <CodeBlock label="Utilities">
+                {`import { cn } from '@uipath/apollo-wind';`}
+              </CodeBlock>
+              <CodeBlock label="CSS theme">
+                {`import '@uipath/apollo-wind/tailwind.css';`}
+              </CodeBlock>
+            </div>
+          </div>
+        </>
+      )}
+
+      {path === 'Run locally' && (
+        <>
+          <InfoCallout>
+            <p className="mb-1 font-medium text-foreground">Before you begin</p>
             <p>
-              Creates a <InlineCode>components.json</InlineCode> config in your project root.
+              This path is for contributors and team members who want to browse or modify Apollo
+              Wind source files and run Storybook on their machine.
             </p>
-          </StepItem>
+          </InfoCallout>
 
-          <StepItem step={2} title="Add the Apollo theme preset">
-            <CodeBlock>{`npx shadcn@latest add https://ui.uipath.com/r/theme.json`}</CodeBlock>
-            <p>
-              Installs the Apollo CSS theme file and adds the <InlineCode>future-dark</InlineCode>{' '}
-              and <InlineCode>future-light</InlineCode> classes to your project.
-            </p>
-          </StepItem>
+          <div className="space-y-6">
+            <StepItem step={1} title="Clone the repository">
+              <CodeBlock label="terminal">
+                {'git clone https://github.com/UiPath/apollo-ui.git\ncd apollo-ui'}
+              </CodeBlock>
+            </StepItem>
 
-          <StepItem step={3} title="Add your first component">
-            <CodeBlock>{`npx shadcn@latest add https://ui.uipath.com/r/button.json`}</CodeBlock>
-            <p>
-              Copies the component source into <InlineCode>src/components/ui/button.tsx</InlineCode>
-              . It's yours to use, read, and modify.
-            </p>
-          </StepItem>
-        </div>
-      </div>
+            <StepItem step={2} title="Install dependencies">
+              <CodeBlock label="terminal">
+                {'npm install -g pnpm\npnpm install'}
+              </CodeBlock>
+              <p>
+                This project uses <InlineCode>pnpm</InlineCode> workspaces. Install it globally if
+                you don't have it yet.
+              </p>
+            </StepItem>
 
-      <Divider />
+            <StepItem step={3} title="Build all packages">
+              <CodeBlock label="terminal">{'pnpm build'}</CodeBlock>
+              <p>Compiles apollo-core, apollo-wind, and apollo-react before Storybook starts.</p>
+            </StepItem>
 
-      {/* Theming */}
-      <div>
-        <h3 className="mb-3 text-lg font-semibold text-foreground">Activating the Theme</h3>
-        <SectionDescription>
-          After installing the theme preset, apply the theme class to your root element. All
-          semantic tokens resolve automatically from there.
-        </SectionDescription>
-
-        <CodeBlock label="Apply theme to your app root">
-          {`<div className="future-dark min-h-screen bg-background text-foreground">
-  {/* your app */}
-</div>`}
-        </CodeBlock>
-
-        <p className="mt-4 text-sm text-muted-foreground">
-          Switch to light theme by replacing <InlineCode>future-dark</InlineCode> with{' '}
-          <InlineCode>future-light</InlineCode>. No other changes needed — all tokens adapt
-          automatically.
-        </p>
-      </div>
-
-      <Divider />
-
-      {/* Updating */}
-      <div>
-        <h3 className="mb-3 text-lg font-semibold text-foreground">Updating Components</h3>
-        <SectionDescription>
-          Because components live in your project, updates are opt-in. Re-run the add command to
-          pull the latest version and review the diff before committing.
-        </SectionDescription>
-
-        <CodeBlock>{`npx shadcn@latest add https://ui.uipath.com/r/button.json`}</CodeBlock>
-
-        <p className="mt-3 text-sm text-muted-foreground">
-          shadcn will show you what changed. Accept the update, keep your version, or merge
-          selectively — the choice is yours.
-        </p>
-      </div>
-
-      <Divider />
-
-      {/* Available Components */}
-      <div>
-        <h3 className="mb-3 text-lg font-semibold text-foreground">Available Components</h3>
-        <SectionDescription>
-          Click copy on any row to get the install command for that component.
-        </SectionDescription>
-
-        <div className="overflow-hidden rounded-lg border border-border">
-          <table className="w-full text-sm">
-            <thead>
-              <tr className="border-b border-border bg-muted/50">
-                <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wide text-muted-foreground">
-                  Component
-                </th>
-                <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wide text-muted-foreground">
-                  Description
-                </th>
-                <th className="px-4 py-3 text-right text-xs font-medium uppercase tracking-wide text-muted-foreground">
-                  Install
-                </th>
-              </tr>
-            </thead>
-            <tbody>
-              {categories.map((category) => (
-                <React.Fragment key={category}>
-                  <tr className="border-b border-border bg-muted/30">
-                    <td
-                      colSpan={3}
-                      className="px-4 py-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground"
-                    >
-                      {category}
-                    </td>
-                  </tr>
-                  {cliComponents
-                    .filter((c) => c.category === category)
-                    .map(({ name, description }) => (
-                      <tr
-                        key={name}
-                        className="border-b border-border last:border-0 hover:bg-muted/20"
-                      >
-                        <td className="px-4 py-3 font-medium text-foreground">
-                          <InlineCode>{name}</InlineCode>
-                        </td>
-                        <td className="px-4 py-3 text-muted-foreground">{description}</td>
-                        <td className="px-4 py-3 text-right">
-                          <button
-                            type="button"
-                            onClick={() => handleCopyComponent(name)}
-                            className="cursor-pointer rounded px-2 py-1 text-xs font-medium text-muted-foreground transition-colors hover:text-foreground"
-                          >
-                            {copiedComponent === name ? 'Copied!' : 'Copy'}
-                          </button>
-                        </td>
-                      </tr>
-                    ))}
-                </React.Fragment>
-              ))}
-            </tbody>
-          </table>
-        </div>
-      </div>
+            <StepItem step={4} title="Start Storybook">
+              <CodeBlock label="terminal">{'pnpm storybook:dev'}</CodeBlock>
+              <p>
+                Opens Apollo Wind Storybook at{' '}
+                <InlineCode>http://localhost:6007</InlineCode>. Changes to source files hot-reload
+                automatically.
+              </p>
+            </StepItem>
+          </div>
+        </>
+      )}
     </div>
   );
 }
 
 // ============================================================================
-// Tab: Contributing to Apollo
+// Tab: Components
 // ============================================================================
 
-function ContributingTab() {
+const components = [
+  { category: 'Forms', name: 'Button', description: 'Primary action trigger' },
+  { category: 'Forms', name: 'ButtonGroup', description: 'Grouped action buttons' },
+  { category: 'Forms', name: 'Input', description: 'Text input field' },
+  { category: 'Forms', name: 'Textarea', description: 'Multi-line text input' },
+  { category: 'Forms', name: 'Select', description: 'Dropdown selector' },
+  { category: 'Forms', name: 'Combobox', description: 'Searchable dropdown' },
+  { category: 'Forms', name: 'MultiSelect', description: 'Multi-value selector' },
+  { category: 'Forms', name: 'Checkbox', description: 'Boolean toggle' },
+  { category: 'Forms', name: 'RadioGroup', description: 'Single-choice selector' },
+  { category: 'Forms', name: 'Switch', description: 'On/off toggle' },
+  { category: 'Forms', name: 'Slider', description: 'Range input' },
+  { category: 'Forms', name: 'Label', description: 'Form field label' },
+  { category: 'Forms', name: 'Search', description: 'Search input with clear action' },
+  { category: 'Forms', name: 'FileUpload', description: 'Drag-and-drop file input with per-file errors' },
+  { category: 'Forms', name: 'Stepper', description: 'Multi-step form progress' },
+  { category: 'Date & Time', name: 'Calendar', description: 'Month calendar picker' },
+  { category: 'Date & Time', name: 'DatePicker', description: 'Date input with popover' },
+  { category: 'Date & Time', name: 'DatetimePicker', description: 'Combined date and time picker' },
+  { category: 'Layout', name: 'Card', description: 'Content container with header and body' },
+  { category: 'Layout', name: 'Separator', description: 'Horizontal or vertical divider' },
+  { category: 'Layout', name: 'Resizable', description: 'Draggable split-pane layout' },
+  { category: 'Layout', name: 'ScrollArea', description: 'Custom scrollable container' },
+  { category: 'Layout', name: 'AspectRatio', description: 'Enforce element aspect ratio' },
+  { category: 'Navigation', name: 'Tabs', description: 'Tabbed content switcher' },
+  { category: 'Navigation', name: 'Breadcrumb', description: 'Hierarchical location trail' },
+  { category: 'Navigation', name: 'Pagination', description: 'Page navigation controls' },
+  { category: 'Navigation', name: 'Accordion', description: 'Collapsible content sections' },
+  { category: 'Navigation', name: 'TreeView', description: 'Hierarchical item tree' },
+  { category: 'Overlays', name: 'Dialog', description: 'Modal overlay' },
+  { category: 'Overlays', name: 'Sheet', description: 'Slide-in side panel' },
+  { category: 'Overlays', name: 'AlertDialog', description: 'Confirmation dialog' },
+  { category: 'Overlays', name: 'Popover', description: 'Anchored floating panel' },
+  { category: 'Overlays', name: 'HoverCard', description: 'Preview card on hover' },
+  { category: 'Overlays', name: 'DropdownMenu', description: 'Contextual action menu' },
+  { category: 'Overlays', name: 'ContextMenu', description: 'Right-click menu' },
+  { category: 'Overlays', name: 'Command', description: 'Command palette with search' },
+  { category: 'Overlays', name: 'Tooltip', description: 'Inline hover hint' },
+  { category: 'Data Display', name: 'DataTable', description: 'Sortable, filterable table' },
+  { category: 'Data Display', name: 'Badge', description: 'Status and label pill' },
+  { category: 'Data Display', name: 'Alert', description: 'Inline status message' },
+  { category: 'Data Display', name: 'StatsCard', description: 'KPI metric card' },
+  { category: 'Data Display', name: 'EmptyState', description: 'Zero-state placeholder' },
+  { category: 'Data Display', name: 'Skeleton', description: 'Loading placeholder' },
+  { category: 'Data Display', name: 'Progress', description: 'Progress bar' },
+  { category: 'Data Display', name: 'Spinner', description: 'Loading indicator' },
+  { category: 'Data Display', name: 'Sonner', description: 'Toast notifications' },
+  { category: 'Data Display', name: 'Toggle', description: 'Single toggle button' },
+  { category: 'Data Display', name: 'ToggleGroup', description: 'Segmented toggle controls' },
+  { category: 'Custom Apollo', name: 'PageHeader', description: 'Page title and action bar' },
+  { category: 'Custom Apollo', name: 'GlobalHeader', description: 'App-level top navigation' },
+  { category: 'Custom Apollo', name: 'PanelStudio', description: 'Studio-style side panel' },
+  { category: 'Custom Apollo', name: 'PanelDelegate', description: 'Delegate-style nav panel' },
+  { category: 'Custom Apollo', name: 'PanelFlow', description: 'Flow editor nav rail' },
+  { category: 'Custom Apollo', name: 'PanelMaestro', description: 'Maestro dashboard panel' },
+  { category: 'Custom Apollo', name: 'ToolbarCanvas', description: 'Canvas floating toolbar' },
+  { category: 'Custom Apollo', name: 'ToolbarView', description: 'View mode toolbar' },
+  { category: 'Custom Apollo', name: 'FlowNode', description: 'Workflow canvas node' },
+  { category: 'Custom Apollo', name: 'FlowProperties', description: 'Node properties panel' },
+  { category: 'Custom Apollo', name: 'GridMaestro', description: 'Maestro-style data grid' },
+  { category: 'Custom Apollo', name: 'ChatComposer', description: 'AI chat input with attachments' },
+  { category: 'Custom Apollo', name: 'ChatStepsView', description: 'AI thinking steps display' },
+  { category: 'Custom Apollo', name: 'ChatFirstExperience', description: 'Empty chat onboarding state' },
+  { category: 'Custom Apollo', name: 'ChatPromptSuggestions', description: 'Suggested prompt chips' },
+  { category: 'Custom Apollo', name: 'Canvas', description: 'Pannable, zoomable canvas area' },
+] as const;
+
+function ComponentsTab() {
+  const categories = [...new Set(components.map((c) => c.category))];
+
   return (
-    <div className="space-y-6">
+    <div className="space-y-8">
       <SectionDescription>
-        If you're contributing to the design system itself, clone the monorepo and run locally.
+        All Apollo Wind components organised by category. Open any sidebar story for live examples
+        and full prop documentation.
       </SectionDescription>
 
-      <CodeBlock label="Setup">
-        {`# Install pnpm if you haven't already
-npm install -g pnpm
-
-# Clone the repository
-git clone https://github.com/UiPath/apollo-ui.git
-cd apollo-ui
-
-# Install dependencies
-pnpm install
-
-# Build all packages
-pnpm build
-
-# Start the Apollo Wind Storybook
-pnpm storybook:dev`}
-      </CodeBlock>
-
-      <CodeBlock label="Development">
-        {`# Run all packages in development mode
-pnpm dev
-
-# Run Storybook
-pnpm storybook:dev
-
-# Lint all packages
-pnpm lint
-
-# Run tests
-pnpm test`}
-      </CodeBlock>
+      <div className="overflow-hidden rounded-lg border border-border">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b border-border bg-muted/50">
+              <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                Component
+              </th>
+              <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                Description
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {categories.map((category) => (
+              <React.Fragment key={category}>
+                <tr className="border-b border-border bg-muted/30">
+                  <td
+                    colSpan={2}
+                    className="px-4 py-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground"
+                  >
+                    {category}
+                  </td>
+                </tr>
+                {components
+                  .filter((c) => c.category === category)
+                  .map(({ name, description }) => (
+                    <tr
+                      key={name}
+                      className="border-b border-border last:border-0 hover:bg-muted/20"
+                    >
+                      <td className="px-4 py-3 font-medium text-foreground">
+                        <InlineCode>{name}</InlineCode>
+                      </td>
+                      <td className="px-4 py-3 text-muted-foreground">{description}</td>
+                    </tr>
+                  ))}
+              </React.Fragment>
+            ))}
+          </tbody>
+        </table>
+      </div>
     </div>
   );
 }
@@ -626,11 +498,11 @@ pnpm test`}
 // Page
 // ============================================================================
 
-const tabs = ['Choose your package', 'Contributing to Apollo', 'CLI'] as const;
+const tabs = ['Overview', 'Quick Start', 'Components'] as const;
 type TabId = (typeof tabs)[number];
 
 function GettingStartedPage({ globalTheme }: { globalTheme: string }) {
-  const [activeTab, setActiveTab] = React.useState<TabId>('Choose your package');
+  const [activeTab, setActiveTab] = React.useState<TabId>('Overview');
 
   return (
     <div
@@ -642,27 +514,14 @@ function GettingStartedPage({ globalTheme }: { globalTheme: string }) {
     >
       <div className="mx-auto max-w-3xl space-y-2 p-8">
         {/* Header */}
-        <h1 className="text-[2rem] font-bold tracking-tight text-foreground">
-          UiPath Design System
-        </h1>
+        <h1 className="text-[2rem] font-bold tracking-tight text-foreground">Apollo Wind</h1>
         <p className="text-base leading-7 text-muted-foreground">
-          Apollo v.4 is UiPath's open-source design system for building consistent user experiences
-          across all UiPath products.
+          Tailwind CSS components for new React applications. Built on shadcn/ui and Radix
+          primitives, themed with Apollo design tokens.
         </p>
 
-        <div className="pt-2">
-          <a
-            href="https://github.com/UiPath/apollo-ui"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="text-sm font-medium text-primary underline"
-          >
-            github.com/UiPath/apollo-ui
-          </a>
-        </div>
-
         {/* Tabs */}
-        <div className="flex gap-1 border-b border-border pt-6 pb-0">
+        <div className="flex gap-1 border-b border-border pb-0 pt-6">
           {tabs.map((tab) => (
             <button
               type="button"
@@ -682,9 +541,9 @@ function GettingStartedPage({ globalTheme }: { globalTheme: string }) {
 
         {/* Tab content */}
         <div className="pt-6">
-          {activeTab === 'Choose your package' && <ChooseYourPackageTab />}
-          {activeTab === 'Contributing to Apollo' && <ContributingTab />}
-          {activeTab === 'CLI' && <CLITab />}
+          {activeTab === 'Overview' && <OverviewTab />}
+          {activeTab === 'Quick Start' && <QuickStartTab />}
+          {activeTab === 'Components' && <ComponentsTab />}
         </div>
       </div>
     </div>

--- a/packages/apollo-wind/src/getting-started/getting-started.stories.tsx
+++ b/packages/apollo-wind/src/getting-started/getting-started.stories.tsx
@@ -327,6 +327,15 @@ function QuickStartTab() {
               This path is for contributors and team members who want to browse or modify Apollo
               Wind source files and run Storybook on their machine.
             </p>
+            <ul className="mt-2 list-disc pl-4 space-y-1">
+              <li>
+                <strong>Node.js 22 or later</strong> is required. Check your version with{' '}
+                <InlineCode>node --version</InlineCode>.
+              </li>
+              <li>
+                <strong>pnpm 11.1.3</strong> is the required package manager for this repo.
+              </li>
+            </ul>
           </InfoCallout>
 
           <div className="space-y-6">
@@ -337,10 +346,10 @@ function QuickStartTab() {
             </StepItem>
 
             <StepItem step={2} title="Install dependencies">
-              <CodeBlock label="terminal">{'npm install -g pnpm\npnpm install'}</CodeBlock>
+              <CodeBlock label="terminal">{'npm install -g pnpm@11.1.3\npnpm install'}</CodeBlock>
               <p>
-                This project uses <InlineCode>pnpm</InlineCode> workspaces. Install it globally if
-                you don't have it yet.
+                This project uses <InlineCode>pnpm</InlineCode> workspaces. Install the pinned
+                version globally if you don't have it yet.
               </p>
             </StepItem>
 

--- a/packages/apollo-wind/src/getting-started/getting-started.stories.tsx
+++ b/packages/apollo-wind/src/getting-started/getting-started.stories.tsx
@@ -49,9 +49,13 @@ function CodeBlock({ children, label }: { children: string; label?: string }) {
   const [copied, setCopied] = React.useState(false);
 
   const handleCopy = () => {
-    navigator.clipboard.writeText(children);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
+    navigator.clipboard
+      .writeText(children)
+      .then(() => {
+        setCopied(true);
+        setTimeout(() => setCopied(false), 2000);
+      })
+      .catch(() => {});
   };
 
   return (


### PR DESCRIPTION
## Summary

- **New landing page** (`Introduction/Overview`) — root-level entry point with three package cards (Apollo Wind, Apollo React, Apollo Core), a GitHub repo card, and a decision table helping users pick the right package. Cards link directly to each package's Getting Started story.
- **Apollo Core Getting Started** — new story with three tabs: Overview (what's included), Quick Start (path switcher: Add to existing project / Run locally, plus JS token imports and CSS custom property usage), and Tokens (full 8-card token category grid with links).
- **Apollo Core sidebar restructure** — all token stories (Colors, Typography, Spacing, etc.) moved into a `Theme/` subfolder for visual consistency with the Apollo Wind and Apollo React sidebar structure.
- **Apollo Wind Getting Started** — restructured from "Choose your package / Contributing / CLI" to **Overview | Quick Start | Components**, matching the Apollo React Canvas format. Quick Start uses the same two-path switcher (Add to existing project / Run locally). React and Core package cards removed since the landing page now handles package selection.
- **Apollo React Canvas Getting Started** — Quick Start updated with the same two-path switcher pattern. GitHub inline link removed.
- **Content cleanup** — all em dash characters (` — `) removed from story copy across all three packages and the introduction page. A no-em-dash rule added to `CLAUDE.md` with replacement guidance for future authoring.

## Test plan

- [ ] Visit `/?path=/story/introduction--overview` — landing page loads with three package cards and GitHub card
- [ ] Click "Explore docs →" on each package card — navigates to the correct Getting Started page (not an iframe URL)
- [ ] Apollo Wind: verify Overview / Quick Start / Components tabs render and path switcher toggles correctly
- [ ] Apollo React Canvas: verify Quick Start path switcher shows Add to existing project / Run locally paths
- [ ] Apollo Core: verify Overview / Quick Start / Tokens tabs, token cards link to correct story paths
- [ ] Apollo Core sidebar: confirm Colors, Typography, etc. appear under `Theme/` folder
- [ ] Confirm no ` — ` characters appear in any documentation copy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<img width="1358" height="1201" alt="Screenshot 2026-06-15 at 3 23 32 PM" src="https://github.com/user-attachments/assets/c5480829-3e6b-4852-8b7b-00cc0348b33c" />
