### PR TITLE
chore(storybook): enable react-scan in published builds

### DIFF
--- a/apps/storybook/.storybook/main.ts
+++ b/apps/storybook/.storybook/main.ts
@@ -7,11 +7,6 @@ import { mergeAlias } from 'vite';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
-// react-scan is a dev-only tool — skip it in production Storybook builds.
-// main.ts runs in Node (Storybook CLI) so we use process.env.
-// preview.tsx runs in the browser (Vite) so it uses import.meta.env.MODE instead.
-const isDev = process.env.NODE_ENV !== 'production';
-
 // react-scan must install its devtools hook before React initializes.
 // Two Storybook behaviors interfere with this:
 //   1. A <head> script copies __REACT_DEVTOOLS_GLOBAL_HOOK__ from the parent frame
@@ -22,15 +17,13 @@ const isDev = process.env.NODE_ENV !== 'production';
 // forcing bippy to install a fresh hook. This all executes before React loads
 // (React is loaded via type="module" scripts, which are deferred).
 let reactScanHook = '';
-if (isDev) {
-  try {
-    reactScanHook = readFileSync(
-      resolve(__dirname, '../node_modules/react-scan/dist/install-hook.global.js'),
-      'utf-8'
-    );
-  } catch {
-    // react-scan optional; Storybook works without it
-  }
+try {
+  reactScanHook = readFileSync(
+    resolve(__dirname, '../node_modules/react-scan/dist/install-hook.global.js'),
+    'utf-8'
+  );
+} catch {
+  // react-scan optional; Storybook works without it
 }
 
 const config: StorybookConfig = {
@@ -121,7 +114,10 @@ const config: StorybookConfig = {
       }
     </style>
   `,
-  previewBody: isDev
+  // Only delete the stale devtools hook when we actually have react-scan's
+  // installer to put back. Without it, deleting the hook would break React
+  // DevTools while reinstalling nothing (react-scan is optional).
+  previewBody: reactScanHook
     ? (body) =>
         `<script>delete window.__REACT_DEVTOOLS_GLOBAL_HOOK__;${reactScanHook}</script>\n${body}`
     : undefined,

--- a/apps/storybook/.storybook/preview.tsx
+++ b/apps/storybook/.storybook/preview.tsx
@@ -16,19 +16,15 @@ import { ApolloDocsContainer } from './DocsContainer';
 import { GlobalStyles } from './GlobalStyles';
 import { ALL_THEMES, clampThemeForMaterial, DEFAULT_THEME, type ThemeMode } from './themes';
 
-const isDev = import.meta.env.MODE !== 'production';
-
 // The react-scan devtools hook is installed via previewBody in main.ts
 // (must happen before React initializes). Here we configure the overlay/canvas
 // and start paused — toggling happens via the toolbar global in the decorator.
-if (isDev) {
-  try {
-    const { scan, setOptions } = await import('react-scan');
-    scan({ enabled: true, showToolbar: true, allowInIframe: true });
-    setOptions({ enabled: false });
-  } catch {
-    // react-scan optional; preview works without it
-  }
+try {
+  const { scan, setOptions } = await import('react-scan');
+  scan({ enabled: true, showToolbar: true, allowInIframe: true });
+  setOptions({ enabled: false });
+} catch {
+  // react-scan optional; preview works without it
 }
 
 // Apollo core + canvas CSS
@@ -229,20 +225,18 @@ const preview: Preview = {
     theme: {
       description: 'Toggle design language theme',
     },
-    ...(isDev && {
-      reactScan: {
-        description: 'Toggle React Scan rendering highlights',
-        toolbar: {
-          title: 'React Scan',
-          icon: 'beaker',
-          items: [
-            { value: 'off', title: 'React Scan: Off' },
-            { value: 'on', title: 'React Scan: On' },
-          ],
-          dynamicTitle: true,
-        },
+    reactScan: {
+      description: 'Toggle React Scan rendering highlights',
+      toolbar: {
+        title: 'React Scan',
+        icon: 'beaker',
+        items: [
+          { value: 'off', title: 'React Scan: Off' },
+          { value: 'on', title: 'React Scan: On' },
+        ],
+        dynamicTitle: true,
       },
-    }),
+    },
     // Locale toolbar — sets <html lang>, which `ApI18nProvider` picks up as its
     // fallback locale (see packages/apollo-react/src/i18n/ApI18nProvider.tsx).
     locale: {
@@ -279,14 +273,16 @@ const preview: Preview = {
 
       // Toggle react-scan
       useEffect(() => {
-        if (isDev) {
-          import('react-scan').then(({ setOptions }) => {
+        import('react-scan')
+          .then(({ setOptions }) => {
             setOptions({
               enabled: reactScanEnabled,
               showToolbar: reactScanEnabled,
             });
+          })
+          .catch(() => {
+            // react-scan optional; preview works without it
           });
-        }
       }, [reactScanEnabled]);
 
       // Write synchronously during the decorator render so the freshly-mounted ApI18nProvider


### PR DESCRIPTION
## What

Enable [react-scan](https://github.com/aidenybai/react-scan) in published Storybook builds. Previously it was gated to dev-only and was completely absent from production builds.

## Why

react-scan was gated behind `isDev` checks in `main.ts` and `preview.tsx`, so in production builds the devtools hook was never installed and the toolbar toggle was absent. We want the render-highlight tooling available to anyone viewing the published Storybook.

## Changes

Removed all four `isDev` gates (and the now-unused `isDev` declarations):

**`main.ts`**
- The react-scan hook file is always read (still wrapped in `try/catch` for graceful absence).
- `previewBody` always injects the hook script instead of being `undefined` in production.

**`preview.tsx`**
- `scan()` init always runs.
- The `reactScan` toolbar global is always registered.
- The decorator's `setOptions` toggle always runs.

## Behavior

Published Storybook now matches dev: hook installed, toolbar toggle present, **default off** (driven by `initialGlobals.reactScan: 'off'`). Viewers opt in via the beaker toolbar item; nothing scans until toggled on.

## Pipeline note

`react-scan` stays in `devDependencies`. The Vercel deploy pipeline builds via GitHub Actions with `pnpm install --frozen-lockfile` (no `--prod`, `NODE_ENV` unset at install/build), so devDeps are installed and Vite bundles the dynamic import at build time. Vercel itself only packages the prebuilt `storybook-static` (`installCommand`/`buildCommand` are no-ops), so it never prunes deps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)