### PR TITLE
fix(workspace): bump hono to 4.12.25 for 5 security advisories

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ overrides:
   tmp: ^0.2.6
   picomatch: '>=4.0.4'
   postcss: ^8.5.14
-  hono: ^4.12.21
+  hono: ^4.12.25
   esbuild: ^0.28.1
   ws@>=8.0.0 <9: ^8.21.0
   '@opentelemetry/core': ^2.8.0
@@ -2657,7 +2657,7 @@ packages:
     resolution: {integrity: sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
-      hono: ^4.12.21
+      hono: ^4.12.25
 
   '@hookform/resolvers@5.2.2':
     resolution: {integrity: sha512-A/IxlMLShx3KjV/HeTcTfaMxdwy690+L/ZADoeaTltLx+CVuzkeVIPuybK3jrRfw7YZnmdKsVVHAlEPIAEUNlA==}
@@ -8390,8 +8390,8 @@ packages:
     resolution: {integrity: sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==}
     engines: {node: '>=0.10.0'}
 
-  hono@4.12.23:
-    resolution: {integrity: sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==}
+  hono@4.12.25:
+    resolution: {integrity: sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==}
     engines: {node: '>=16.9.0'}
 
   hook-std@4.0.0:
@@ -14433,9 +14433,9 @@ snapshots:
       react-dom: 19.2.3(react@19.2.3)
       use-sync-external-store: 1.6.0(react@19.2.3)
 
-  '@hono/node-server@1.19.13(hono@4.12.23)':
+  '@hono/node-server@1.19.13(hono@4.12.25)':
     dependencies:
-      hono: 4.12.23
+      hono: 4.12.25
 
   '@hookform/resolvers@5.2.2(react-hook-form@7.66.1(react@19.2.3))':
     dependencies:
@@ -15008,7 +15008,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.26.0(zod@3.25.76)':
     dependencies:
-      '@hono/node-server': 1.19.13(hono@4.12.23)
+      '@hono/node-server': 1.19.13(hono@4.12.25)
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
       content-type: 1.0.5
@@ -15018,7 +15018,7 @@ snapshots:
       eventsource-parser: 3.0.6
       express: 5.2.1
       express-rate-limit: 8.5.1(express@5.2.1)
-      hono: 4.12.23
+      hono: 4.12.25
       jose: 6.1.3
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.0
@@ -20672,7 +20672,7 @@ snapshots:
     dependencies:
       parse-passwd: 1.0.0
 
-  hono@4.12.23: {}
+  hono@4.12.25: {}
 
   hook-std@4.0.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -23,6 +23,7 @@ minimumReleaseAgeExclude:
   - 'dompurify'                   # 3.4.10 — GHSA-vxr8-fq34-vvx9 (+gvmj/x4vx/rp9w/r47g/hpcv/76mc), vetted 2026-06-16: cure53 publisher ✓, advisory ✓, integrity ✓, no deps
   - '@opentelemetry/core'         # 2.8.0 — GHSA-8988-4f7v-96qf (moderate, CVE-2026-54285), vetted 2026-06-16: SLSA provenance ✓, OIDC publisher ✓, advisory ✓, integrity ✓
   - '@opentelemetry/resources'    # 2.8.0 — lockstep with core (sdk-logs/resources pin core exactly), vetted 2026-06-16: SLSA provenance ✓, OIDC publisher ✓, integrity ✓, no new deps
+  - 'hono'                         # 4.12.25 — GHSA-88fw-hqm2-52qc (high) +rv63/wwfh/j6c9/wgpf (moderate), vetted 2026-06-16: publisher yusukebe (sole maintainer, unchanged) ✓, registry signature ✓, release tag+diff security-only ✓, integrity ✓, no deps
 # Refuse transitive git/tarball deps (pnpm 11 default; kept explicit for clarity)
 blockExoticSubdeps: true
 
@@ -33,7 +34,7 @@ overrides:
   tmp: "^0.2.6"
   picomatch: ">=4.0.4"
   postcss: "^8.5.14"
-  hono: "^4.12.21"
+  hono: "^4.12.25"                      # GHSA-88fw-hqm2-52qc (high)/rv63/wwfh/j6c9/wgpf (moderate) — vetted 2026-06-16; transitive via @modelcontextprotocol/sdk + @hono/node-server (both pin ^4)
   # Security pins (vetted 2026-06-16)
   esbuild: "^0.28.1"                    # GHSA-gv7w-rqvm-qjhr (high)/GHSA-g7r4-m6w7-qqqr (low) — vite pins esbuild ^0.27.0 and tsx pins ~0.25.0; only vite 8 (major migration) would widen
   "ws@>=8.0.0 <9": "^8.21.0"            # GHSA-96hv-2xvq-fx4p (high) — latest engine.io-client (6.6.5) still pins ws ~8.20.1; blocked upstream at Socket.IO


### PR DESCRIPTION
## Summary

Resolves all **5 `hono` advisories** reported by `pnpm audit` / Dependabot (1 high, 4 moderate). `hono` is transitive via `apps__apollo-vertex > shadcn > @modelcontextprotocol/sdk` (and its `@hono/node-server`). Both parents pin caret ranges (`^4` / `^4.11.4`), so the patched `>=4.12.25` is admitted.

| GHSA | Severity | Issue |
|---|---|---|
| GHSA-88fw-hqm2-52qc | high | CORS wildcard reflects origin with credentials |
| GHSA-wwfh-h76j-fc44 | moderate | serve-static path traversal via `%5C` on Windows |
| GHSA-j6c9-x7qj-28xf | moderate | AWS Lambda merges `Set-Cookie` headers |
| GHSA-rv63-4mwf-qqc2 | moderate | body-limit bypass via understated `Content-Length` |
| GHSA-wgpf-jwqj-8h8p | moderate | Lambda@Edge drops repeated request headers |

## Changes

- Bumped the existing `hono` override `^4.12.21` → `^4.12.25` in `pnpm-workspace.yaml`.
- Added a `minimumReleaseAgeExclude` entry for `hono` (4.12.25 is 7 days old, inside the 14-day quarantine).

## Supply-chain vetting (2026-06-16)

All six checks passed:
- **Publisher:** `yusukebe` (sole maintainer, unchanged from 4.12.23)
- **Signatures:** npm registry signature present, same keyid; neither version ships sigstore (consistent baseline, not a regression)
- **GitHub release:** tag `v4.12.25` is exclusively the 5 matching security fixes, single commit
- **Integrity:** sha512 confirmed
- **Dependency diff:** zero runtime deps in both versions, none added
- **Advisory cross-ref:** all 5 GHSAs match audit output; patched version confirmed

## Verification

- Lockfile diff is **hono-only** (every changed line references hono)
- `pnpm audit` → exit 0 (no known vulnerabilities)
- `pnpm check:dependencies` → exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)