### PR TITLE
perf(workspace): bundle optimizations — apollo-react font dedup + apollo-wind tree-shaking [MST-11264]

### DIFF
--- a/packages/apollo-react/font-reexport/JP/jp.css
+++ b/packages/apollo-react/font-reexport/JP/jp.css
@@ -1,0 +1,1 @@
+@import "@uipath/apollo-core/fonts/JP/jp.css";

--- a/packages/apollo-react/font-reexport/KR/kr.css
+++ b/packages/apollo-react/font-reexport/KR/kr.css
@@ -1,0 +1,1 @@
+@import "@uipath/apollo-core/fonts/KR/kr.css";

--- a/packages/apollo-react/font-reexport/SC/sc.css
+++ b/packages/apollo-react/font-reexport/SC/sc.css
@@ -1,0 +1,1 @@
+@import "@uipath/apollo-core/fonts/SC/sc.css";

--- a/packages/apollo-react/font-reexport/TC/tc.css
+++ b/packages/apollo-react/font-reexport/TC/tc.css
@@ -1,0 +1,1 @@
+@import "@uipath/apollo-core/fonts/TC/tc.css";

--- a/packages/apollo-react/font-reexport/apollo/apollo.css
+++ b/packages/apollo-react/font-reexport/apollo/apollo.css
@@ -1,0 +1,1 @@
+@import "@uipath/apollo-core/fonts/apollo/apollo.css";

--- a/packages/apollo-react/font-reexport/font.css
+++ b/packages/apollo-react/font-reexport/font.css
@@ -1,0 +1,1 @@
+@import "@uipath/apollo-core/fonts/font.css";

--- a/packages/apollo-react/rslib.config.ts
+++ b/packages/apollo-react/rslib.config.ts
@@ -86,8 +86,10 @@ export default defineConfig({
       { from: '../apollo-core/dist/tokens/scss', to: './core/tokens/scss' },
       { from: '../apollo-core/dist/tokens/less', to: './core/tokens/less' },
       { from: '../apollo-core/dist/tokens/jss', to: './core/tokens/jss' },
-      // Copy fonts from apollo-core to make them available at @uipath/apollo-react/core/fonts/*
-      { from: '../apollo-core/dist/fonts', to: './core/fonts' },
+      // Re-export apollo-core's fonts at @uipath/apollo-react/core/fonts/* WITHOUT copying the
+      // ~42MB of binaries: ship thin CSS shims that `@import "@uipath/apollo-core/fonts/..."`.
+      // apollo-core is a hard dependency, so consumers always have the actual font files.
+      { from: './font-reexport', to: './core/fonts' },
       // Copy xyflow CSS files to make them available at @uipath/apollo-react/canvas/xyflow/*
       { from: './node_modules/@xyflow/react/dist/style.css', to: './canvas/xyflow' },
       { from: './node_modules/@xyflow/react/dist/base.css', to: './canvas/xyflow' },

--- a/packages/apollo-wind/package.json
+++ b/packages/apollo-wind/package.json
@@ -6,6 +6,9 @@
   "main": "./dist/index.js",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "sideEffects": [
+    "**/*.css"
+  ],
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",


### PR DESCRIPTION
## ⚡ De-duplicate apollo-react fonts — MST-11264

> [!IMPORTANT]
> **Stacked on #832** (base = `feat/bundle-size-analyzer`). Review/merge that first; this retargets to `main` afterward.

apollo-react's build copied apollo-core's **entire font set (~42 MB)** into `dist/core/fonts`. Since `@uipath/apollo-core` is a hard dependency, that's pure duplication. This replaces the binary copy with thin CSS shims that `@import "@uipath/apollo-core/fonts/…"` — fonts ship **once** (in apollo-core); consumers keep loading them via the unchanged `@uipath/apollo-react/core/fonts/*.css` paths.

### Result (verified)
- **Published size: 45.9 MB → 7.2 MB packed (−84%)**.
- `dist/core` **before/after build diff**: only font binaries removed (1189 files, all under `core/fonts/`); **`core/tokens` untouched**; all 6 font CSS entry points preserved.
- A **storybook build still loads the full font set** (1174 woff2 + 1180 `@font-face`) through the shim — the bare `@import` resolves in the bundler.
- Org search: every UiPath consumer uses `core/fonts/font.css` (a bundler); none import raw font files.

> [!WARNING]
> Drops **raw font-file** access via the apollo-react path (`@uipath/apollo-react/core/fonts/<x>.woff2`). No known UiPath-org consumers; raw files remain available at `@uipath/apollo-core/fonts/*`. Versioning call for reviewers.

🔗 https://uipath.atlassian.net/browse/MST-11264

🤖 Generated with [Claude Code](https://claude.com/claude-code)
