### PR TITLE
feat: tabbed node property panel (MetadataForm stepVariant="tabs" + NodePropertyPanel)

### DIFF
--- a/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.stories.tsx
@@ -1,0 +1,298 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import type { FormSchema } from '@uipath/apollo-wind';
+import { Globe, Play } from 'lucide-react';
+import type { ReactNode } from 'react';
+import { NodePropertyPanel } from './NodePropertyPanel';
+
+// ============================================================================
+// Layout helpers
+// ============================================================================
+
+const CanvasBackground = ({ children }: { children: ReactNode }) => (
+  <div
+    className="flex min-h-screen items-center justify-center p-10"
+    style={{ backgroundColor: 'var(--surface, var(--color-background))' }}
+  >
+    {children}
+  </div>
+);
+
+const PanelFrame = ({ children }: { children: ReactNode }) => (
+  <div className="w-[380px] overflow-hidden rounded-2xl border border-border-subtle shadow-lg">
+    {children}
+  </div>
+);
+
+function RunButton() {
+  return (
+    <button
+      type="button"
+      className="flex h-8 items-center gap-2 rounded-lg bg-brand px-4 text-sm font-semibold text-foreground-on-accent transition hover:bg-brand-hover"
+    >
+      <Play size={14} />
+      Run
+    </button>
+  );
+}
+
+// ============================================================================
+// Shared FormSchema (steps = tabs; sections within each step hold the fields)
+// ============================================================================
+
+const httpRequestForm: FormSchema = {
+  id: 'http-request',
+  title: 'HTTP Request',
+  mode: 'onChange',
+  steps: [
+    {
+      id: 'parameters',
+      title: 'Parameters',
+      sections: [
+        {
+          id: 'main',
+          fields: [
+            {
+              type: 'text',
+              name: 'endpoint',
+              label: 'Endpoint',
+              placeholder: 'https://...',
+              description: 'The URL of the HTTP endpoint to call.',
+              defaultValue: 'https://finance.internal/api/invoices',
+            },
+            {
+              type: 'select',
+              name: 'method',
+              label: 'Method',
+              defaultValue: 'GET',
+              dataSource: {
+                type: 'static',
+                options: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE'].map((v) => ({
+                  label: v,
+                  value: v,
+                })),
+              },
+            },
+            {
+              type: 'select',
+              name: 'auth_type',
+              label: 'Auth type',
+              defaultValue: 'bearer',
+              dataSource: {
+                type: 'static',
+                options: ['none', 'bearer', 'api-key', 'oauth'].map((v) => ({
+                  label: v,
+                  value: v,
+                })),
+              },
+            },
+            {
+              type: 'number',
+              name: 'timeout_ms',
+              label: 'Timeout (ms)',
+              placeholder: '5000',
+              description: 'Request timeout in milliseconds.',
+              defaultValue: 10000,
+            },
+            {
+              type: 'switch',
+              name: 'retry_on_failure',
+              label: 'Retry on failure',
+              defaultValue: true,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      id: 'error-handling',
+      title: 'Error handling',
+      sections: [
+        {
+          id: 'errors',
+          fields: [
+            {
+              type: 'switch',
+              name: 'error_handling_enabled',
+              label: 'Enable error handling',
+              description: 'Add an error output handle on the node to catch and handle failures.',
+              defaultValue: false,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      id: 'advanced',
+      title: 'Advanced',
+      sections: [
+        {
+          id: 'adv',
+          fields: [
+            {
+              type: 'text',
+              name: 'node_id',
+              label: 'ID',
+              defaultValue: 'httpRequest1',
+              disabled: true,
+            },
+            { type: 'text', name: 'label', label: 'Label', defaultValue: 'Fetch invoice details' },
+            { type: 'textarea', name: 'description', label: 'Description' },
+          ],
+        },
+      ],
+    },
+  ],
+};
+
+// Manual trigger: no Parameters step, so that tab is omitted automatically.
+const manualTriggerForm: FormSchema = {
+  id: 'manual-trigger',
+  title: 'Manual trigger',
+  mode: 'onChange',
+  actions: [],
+  steps: [
+    {
+      id: 'error-handling',
+      title: 'Error handling',
+      sections: [
+        {
+          id: 'errors',
+          fields: [
+            {
+              type: 'switch',
+              name: 'error_handling_enabled',
+              label: 'Enable error handling',
+              description: 'Add an error output handle on the node to catch and handle failures.',
+              defaultValue: false,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      id: 'advanced',
+      title: 'Advanced',
+      sections: [
+        {
+          id: 'adv',
+          fields: [
+            {
+              type: 'text',
+              name: 'node_id',
+              label: 'ID',
+              defaultValue: 'manualTrigger1',
+              disabled: true,
+            },
+            { type: 'text', name: 'label', label: 'Label', defaultValue: 'Manual trigger' },
+            { type: 'textarea', name: 'description', label: 'Description' },
+          ],
+        },
+      ],
+    },
+  ],
+};
+
+// ============================================================================
+// Meta
+// ============================================================================
+
+const meta: Meta<typeof NodePropertyPanel> = {
+  title: 'Components/Panels/Node Property Panel',
+  component: NodePropertyPanel,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component: `
+The **NodePropertyPanel** is a presentational, docked properties panel for canvas
+nodes. It owns the chrome (optional title bar, node identity row, action slot) and
+renders a single \`MetadataForm\` from the \`schema\` you pass in. Multi-step schemas
+render as tabs (Parameters, Error handling, Advanced).
+
+Because it is one form instance, values and validation are shared across tabs and
+nothing is lost when switching tabs. The caller supplies \`schema\` and \`plugins\`,
+so real-time change handling and custom fields stay on the consumer side.
+
+The title bar is optional: omit \`panelTitle\` when the host panel system (e.g.
+dockview) renders its own drag handle and close button.
+        `,
+      },
+    },
+  },
+  decorators: [
+    (Story) => (
+      <CanvasBackground>
+        <Story />
+      </CanvasBackground>
+    ),
+  ],
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof NodePropertyPanel>;
+
+// ============================================================================
+// Stories
+// ============================================================================
+
+/**
+ * The full panel: title bar, node identity row with a Run action, and a
+ * multi-step schema rendered as tabs.
+ */
+export const Default: Story = {
+  render: () => (
+    <PanelFrame>
+      <NodePropertyPanel
+        panelTitle="Properties"
+        nodeIcon={<Globe />}
+        nodeLabel="Fetch invoice details"
+        nodeCategory="HTTP Request"
+        action={<RunButton />}
+        schema={httpRequestForm}
+        contentInset="0.75rem"
+        onClose={() => {}}
+        className="h-[640px]"
+      />
+    </PanelFrame>
+  ),
+};
+
+/**
+ * Host-owned title bar: when dockview (or another panel system) renders the
+ * draggable "Properties" header, omit `panelTitle` so the panel starts at the
+ * node identity row.
+ */
+export const EmbeddedNoTitleBar: Story = {
+  render: () => (
+    <PanelFrame>
+      <NodePropertyPanel
+        nodeLabel="Fetch invoice details"
+        nodeCategory="HTTP Request"
+        action={<RunButton />}
+        schema={httpRequestForm}
+        className="h-[600px]"
+      />
+    </PanelFrame>
+  ),
+};
+
+/**
+ * A node with no parameters (Manual trigger). The Parameters tab is omitted
+ * automatically because that step has no sections.
+ */
+export const NoParametersTab: Story = {
+  render: () => (
+    <PanelFrame>
+      <NodePropertyPanel
+        panelTitle="Properties"
+        nodeLabel="Manual trigger"
+        nodeCategory="Starts a flow run manually"
+        action={<RunButton />}
+        schema={manualTriggerForm}
+        onClose={() => {}}
+        className="h-[600px]"
+      />
+    </PanelFrame>
+  ),
+};

--- a/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.test.tsx
+++ b/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.test.tsx
@@ -1,0 +1,70 @@
+import type { FormSchema } from '@uipath/apollo-wind';
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '../../utils/testing';
+import { NodePropertyPanel } from './NodePropertyPanel';
+
+const MULTI_STEP: FormSchema = {
+  id: 'http',
+  title: 'HTTP',
+  steps: [
+    {
+      id: 'parameters',
+      title: 'Parameters',
+      sections: [{ id: 'p', fields: [{ id: 'url', name: 'url', type: 'text', label: 'URL' }] }],
+    },
+    {
+      id: 'advanced',
+      title: 'Advanced',
+      sections: [{ id: 'a', fields: [{ id: 'nid', name: 'nid', type: 'text', label: 'ID' }] }],
+    },
+  ],
+};
+
+describe('NodePropertyPanel', () => {
+  it('renders the title bar when panelTitle is set', () => {
+    render(<NodePropertyPanel panelTitle="Properties" schema={MULTI_STEP} />);
+    expect(screen.getByText('Properties')).toBeInTheDocument();
+  });
+
+  it('hides the title bar (and close) when panelTitle is omitted', () => {
+    render(<NodePropertyPanel schema={MULTI_STEP} />);
+    expect(screen.queryByLabelText('Close')).not.toBeInTheDocument();
+  });
+
+  it('calls onClose when the close button is clicked', () => {
+    const onClose = vi.fn();
+    const { getByRole } = render(
+      <NodePropertyPanel panelTitle="Properties" schema={MULTI_STEP} onClose={onClose} />
+    );
+    getByRole('button', { name: 'Close' }).click();
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it('renders the node label and category in the identity row', () => {
+    render(
+      <NodePropertyPanel
+        nodeLabel="Fetch invoice details"
+        nodeCategory="HTTP Request"
+        schema={MULTI_STEP}
+      />
+    );
+    expect(screen.getByText('Fetch invoice details')).toBeInTheDocument();
+    expect(screen.getByText('HTTP Request')).toBeInTheDocument();
+  });
+
+  it('renders a tab per step for a multi-step schema', () => {
+    render(<NodePropertyPanel schema={MULTI_STEP} />);
+    expect(screen.getByRole('tab', { name: 'Parameters' })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: 'Advanced' })).toBeInTheDocument();
+  });
+
+  it('renders the empty state when no schema is provided', () => {
+    render(<NodePropertyPanel />);
+    expect(screen.getByText(/No form schema/i)).toBeInTheDocument();
+  });
+
+  it('does not render a Submit button by default (live-edit surface)', () => {
+    render(<NodePropertyPanel schema={MULTI_STEP} />);
+    expect(screen.queryByRole('button', { name: /submit/i })).not.toBeInTheDocument();
+  });
+});

--- a/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.tsx
+++ b/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.tsx
@@ -1,0 +1,142 @@
+import { cn, MetadataForm } from '@uipath/apollo-wind';
+import { GripVertical, X } from 'lucide-react';
+import { type CSSProperties, useMemo } from 'react';
+import type { NodePropertyPanelProps } from './NodePropertyPanel.types';
+
+// Remap surface-raised -> surface-overlay so inputs read lighter than the panel.
+const SURFACE_REMAP = { '--surface-raised': 'var(--surface-overlay)' } as CSSProperties;
+
+/**
+ * NodePropertyPanel — a presentational, docked properties panel for canvas nodes.
+ *
+ * The panel owns only the *chrome*: an optional title bar (drag handle + close),
+ * a node identity row (icon / label / category + an action slot), and the form
+ * frame. The form itself is a single `MetadataForm` rendered from the `schema`
+ * you pass in, with multi-step schemas presented as tabs (Parameters, Error
+ * handling, Advanced, ...).
+ *
+ * The caller owns everything domain-specific: schema assembly, real-time change
+ * handling, custom field components, and validation are all supplied through
+ * `schema` + `plugins`. The panel renders ONE form instance, so values and
+ * validation are shared across tabs and nothing is lost when switching tabs.
+ *
+ * @example
+ * ```tsx
+ * <NodePropertyPanel
+ *   panelTitle="Properties"               // omit when dockview owns the title bar
+ *   nodeLabel="Fetch invoice details"
+ *   nodeCategory="HTTP Request"
+ *   action={<RunButton />}
+ *   schema={assembledSchema}              // caller-built FormSchema (steps = tabs)
+ *   plugins={formPlugins}                 // real-time onChange, custom fields
+ *   resetKey={selectedNodeId}             // remount on node change
+ *   onClose={() => deselect()}
+ * />
+ * ```
+ */
+export function NodePropertyPanel({
+  panelTitle,
+  onClose,
+  nodeIcon,
+  nodeLabel,
+  nodeCategory,
+  action,
+  schema,
+  plugins,
+  onSubmit,
+  disabled,
+  resetKey,
+  className,
+  contentInset = '1.5rem',
+}: NodePropertyPanelProps) {
+  const hasNodeHeader = !!(nodeLabel || nodeCategory || nodeIcon || action);
+
+  // This panel is a live-edit surface: changes persist via plugins/onChange, so
+  // there is no Submit button by default. Callers can still opt in by setting
+  // `actions` on the schema. Memoized so MetadataForm's identity stays stable.
+  const formSchema = useMemo(
+    () => (schema && schema.actions === undefined ? { ...schema, actions: [] } : schema),
+    [schema]
+  );
+
+  return (
+    <div className={cn('flex min-h-0 flex-col bg-surface-raised', className)}>
+      {/* ── Title bar (optional; host panel system may own it) ── */}
+      {panelTitle && (
+        <div className="flex h-10 shrink-0 items-center justify-between border-b border-border-subtle px-2">
+          <div className="flex items-center gap-1">
+            <div className="grid size-8 place-items-center text-foreground-subtle">
+              <GripVertical size={14} />
+            </div>
+            <span className="text-sm font-semibold text-foreground">{panelTitle}</span>
+          </div>
+          {onClose && (
+            <button
+              type="button"
+              onClick={onClose}
+              title="Close"
+              aria-label="Close"
+              className="grid size-6 place-items-center rounded text-foreground-muted transition hover:bg-surface-overlay hover:text-foreground"
+            >
+              <X size={14} />
+            </button>
+          )}
+        </div>
+      )}
+
+      {/* ── Node identity row ── */}
+      {hasNodeHeader && (
+        <div className="flex shrink-0 items-center justify-between gap-4 border-b border-border-subtle px-6 py-4">
+          <div className="flex min-w-0 flex-1 items-center gap-3">
+            {nodeIcon && (
+              <div className="grid size-11 shrink-0 place-items-center rounded-xl bg-surface-overlay text-foreground-subtle [&>svg]:size-5">
+                {nodeIcon}
+              </div>
+            )}
+            <div className="flex min-w-0 flex-1 flex-col justify-center">
+              {nodeLabel && (
+                // <span>, not <p>: host apps (e.g. Angular Material's `.mat-typography p`)
+                // inject a bottom margin on <p> that breaks the header alignment.
+                <span className="block truncate text-lg font-semibold leading-6 tracking-[-0.4px] text-foreground">
+                  {nodeLabel}
+                </span>
+              )}
+              {nodeCategory && (
+                <span className="block truncate text-sm leading-5 text-foreground-muted">
+                  {nodeCategory}
+                </span>
+              )}
+            </div>
+          </div>
+          {action && <div className="flex shrink-0 items-center gap-2">{action}</div>}
+        </div>
+      )}
+
+      {/* ── Form ── */}
+      {!formSchema ? (
+        <div className="px-6 py-4 text-xs text-foreground-subtle">
+          No form schema defined for this node.
+        </div>
+      ) : (
+        <div className="min-h-0 flex-1 overflow-auto">
+          <div
+            style={{ ...SURFACE_REMAP, '--mf-content-inset': contentInset } as CSSProperties}
+            className="[&_label]:text-foreground-muted"
+          >
+            {/* Horizontal padding + the tab underline's full-bleed both derive from
+                `--mf-content-inset`, so they stay in lockstep. */}
+            <MetadataForm
+              key={resetKey}
+              schema={formSchema}
+              plugins={plugins}
+              stepVariant="tabs"
+              onSubmit={onSubmit}
+              disabled={disabled}
+              className="flex flex-col gap-4 pb-6 pt-3 [padding-inline:var(--mf-content-inset)]"
+            />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.types.ts
+++ b/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.types.ts
@@ -1,0 +1,49 @@
+import type { FormPlugin, FormSchema } from '@uipath/apollo-wind';
+import type { ReactNode } from 'react';
+
+export interface NodePropertyPanelProps {
+  /**
+   * Title shown in the drag-handle header row (e.g. "Properties"). Omit to hide
+   * the title bar when the host panel system (e.g. dockview) renders its own.
+   */
+  panelTitle?: string;
+  /** Called when the X close button is clicked. The button only renders when both `panelTitle` and `onClose` are provided. */
+  onClose?: () => void;
+  /** Optional icon rendered left of the node name in the identity row. */
+  nodeIcon?: ReactNode;
+  /** The node's display label shown in the node identity row. */
+  nodeLabel?: string;
+  /** Category/subtitle text shown below `nodeLabel` (e.g. "HTTP Request"). */
+  nodeCategory?: string;
+  /** Action slot rendered on the right of the identity row (e.g. a Run button). */
+  action?: ReactNode;
+  /**
+   * Form schema to render. A multi-step schema (`steps`) renders as tabs; a
+   * single-page schema (`sections`) renders as a flat form. The caller owns
+   * schema assembly, so all field definitions and `initialData` live here.
+   */
+  schema?: FormSchema;
+  /**
+   * MetadataForm plugins. This is how the caller wires real-time change
+   * handling, custom field components, and validation. The panel forwards them
+   * verbatim to the underlying single form instance.
+   */
+  plugins?: FormPlugin[];
+  /** Called when the form is submitted (only when the schema defines a submit action). */
+  onSubmit?: (data: unknown) => void | Promise<void>;
+  /** Disables all fields (e.g. read-only nodes). */
+  disabled?: boolean;
+  /**
+   * Change this (e.g. to the selected node id) to remount the form with fresh
+   * initial data. The form reads `schema.initialData` once per mount, so a
+   * stable identity per selected node prevents stale values across selections.
+   */
+  resetKey?: string;
+  className?: string;
+  /**
+   * Horizontal inset (any CSS length) applied to the form content. It also drives
+   * the tab underline's full-bleed: the tab bar extends past this inset to the panel
+   * edges and re-insets its labels to line up with the fields. Default `1.5rem`.
+   */
+  contentInset?: string;
+}

--- a/packages/apollo-react/src/canvas/components/NodePropertyPanel/index.ts
+++ b/packages/apollo-react/src/canvas/components/NodePropertyPanel/index.ts
@@ -1,0 +1,2 @@
+export { NodePropertyPanel } from './NodePropertyPanel';
+export type { NodePropertyPanelProps } from './NodePropertyPanel.types';

--- a/packages/apollo-react/src/canvas/components/index.ts
+++ b/packages/apollo-react/src/canvas/components/index.ts
@@ -18,6 +18,7 @@ export * from './MiniCanvasNavigator';
 export * from './NodeContextMenu';
 export * from './NodeInspector';
 export * from './NodePropertiesPanel';
+export * from './NodePropertyPanel';
 export * from './shared';
 export * from './StageNode';
 export * from './StickyNoteNode';

--- a/packages/apollo-wind/src/components/forms/metadata-form.stories.tsx
+++ b/packages/apollo-wind/src/components/forms/metadata-form.stories.tsx
@@ -1,26 +1,15 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { MetadataForm } from './metadata-form';
-import { FormStateViewer } from './form-state-viewer';
-import type { FormSchema } from './form-schema';
-import { useForm, FormProvider, type FieldValues, type UseFormReturn } from 'react-hook-form';
-import { RuleBuilder } from './rules-engine';
-import { autoSavePlugin, analyticsPlugin } from './form-plugins';
-import { setupDemoMocks } from './demo-mocks';
 import {
-  cascadingDropdownsSchema,
-  computedFieldsSchema,
-  conditionalSectionsSchema,
-  conditionalQuestionsSchema,
-  automationJobSchema,
-  multiStepSchema,
-  fileUploadSchema,
-  FileUploadExample,
-} from './form-examples';
-import { SchemaViewer } from './schema-viewer';
+  Controller,
+  type FieldValues,
+  FormProvider,
+  type UseFormReturn,
+  useForm,
+  useFormContext,
+} from 'react-hook-form';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import { Switch } from '@/components/ui/switch';
 import {
   Select,
   SelectContent,
@@ -28,8 +17,25 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
-import { useFormContext, Controller } from 'react-hook-form';
 import { Toaster } from '@/components/ui/sonner';
+import { Switch } from '@/components/ui/switch';
+import { setupDemoMocks } from './demo-mocks';
+import {
+  automationJobSchema,
+  cascadingDropdownsSchema,
+  computedFieldsSchema,
+  conditionalQuestionsSchema,
+  conditionalSectionsSchema,
+  FileUploadExample,
+  fileUploadSchema,
+  multiStepSchema,
+} from './form-examples';
+import { analyticsPlugin, autoSavePlugin } from './form-plugins';
+import type { FormSchema } from './form-schema';
+import { FormStateViewer } from './form-state-viewer';
+import { MetadataForm } from './metadata-form';
+import { RuleBuilder } from './rules-engine';
+import { SchemaViewer } from './schema-viewer';
 
 // Setup mocks for cascading dropdown examples
 setupDemoMocks();
@@ -764,6 +770,110 @@ export const MultiStepWizard: Story = {
       console.log('Onboarding complete:', data);
       alert('Welcome! Your account is set up.');
     },
+  },
+};
+
+// ============================================================================
+// TABBED MULTI-STEP
+// ============================================================================
+
+// A node-style schema whose steps map to tabs. Parameters comes from the node,
+// while Error handling and Advanced are common across node types. A node with no
+// parameters simply omits the Parameters step and its tab is not rendered.
+const tabbedNodeSchema: FormSchema = {
+  id: 'scheduled-trigger',
+  title: 'Scheduled trigger',
+  // No submit button: this mirrors a properties panel that persists on change.
+  actions: [],
+  initialData: {
+    'inputs.interval': 1,
+    'inputs.unit': 'week',
+    'inputs.at': '09:00',
+    'inputs.ends': 'never',
+    'inputs.errorHandlingEnabled': false,
+    nodeId: 'scheduledTrigger1',
+    'display.label': 'Scheduled trigger',
+  },
+  steps: [
+    {
+      id: 'parameters',
+      title: 'Parameters',
+      sections: [
+        {
+          id: 'schedule',
+          fields: [
+            { name: 'inputs.interval', type: 'number', label: 'Repeat every' },
+            {
+              name: 'inputs.unit',
+              type: 'select',
+              label: 'Unit',
+              options: [
+                { label: 'Hour', value: 'hour' },
+                { label: 'Day', value: 'day' },
+                { label: 'Week', value: 'week' },
+              ],
+            },
+            { name: 'inputs.at', type: 'text', label: 'At' },
+            {
+              name: 'inputs.ends',
+              type: 'select',
+              label: 'Ends',
+              options: [
+                { label: 'Never', value: 'never' },
+                { label: 'On date', value: 'on-date' },
+                { label: 'After occurrences', value: 'after' },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+    {
+      id: 'error-handling',
+      title: 'Error handling',
+      sections: [
+        {
+          id: 'error',
+          fields: [
+            {
+              name: 'inputs.errorHandlingEnabled',
+              type: 'switch',
+              label: 'Enable error handling',
+              description: 'Add an error output handle on the node to catch and handle failures.',
+            },
+          ],
+        },
+      ],
+    },
+    {
+      id: 'advanced',
+      title: 'Advanced',
+      sections: [
+        {
+          id: 'general',
+          fields: [
+            { name: 'nodeId', type: 'text', label: 'ID', disabled: true },
+            { name: 'display.label', type: 'text', label: 'Label' },
+            { name: 'display.description', type: 'textarea', label: 'Description' },
+          ],
+        },
+      ],
+    },
+  ],
+};
+
+/**
+ * Tabbed Steps (stepVariant="tabs")
+ *
+ * Renders a multi-step schema as a tab bar over a single form instance. Values
+ * and validation are shared across every tab, so switching tabs never loses
+ * edits. This is the node properties panel layout: Parameters comes from the
+ * node, Error handling and Advanced are common across node types.
+ */
+export const TabbedSteps: Story = {
+  args: {
+    schema: tabbedNodeSchema,
+    stepVariant: 'tabs',
   },
 };
 

--- a/packages/apollo-wind/src/components/forms/metadata-form.test.tsx
+++ b/packages/apollo-wind/src/components/forms/metadata-form.test.tsx
@@ -333,4 +333,90 @@ describe('MetadataForm', () => {
       });
     });
   });
+
+  describe('tabbed multi-step form (stepVariant="tabs")', () => {
+    const tabbedSchema: FormSchema = {
+      id: 'tabbed',
+      title: 'Tabbed Form',
+      steps: [
+        {
+          id: 'parameters',
+          title: 'Parameters',
+          sections: [
+            {
+              id: 'p',
+              fields: [
+                {
+                  name: 'field1',
+                  type: 'text',
+                  label: 'Field 1',
+                  placeholder: 'Params field',
+                  defaultValue: '',
+                },
+              ],
+            },
+          ],
+        },
+        {
+          id: 'advanced',
+          title: 'Advanced',
+          sections: [
+            {
+              id: 'a',
+              fields: [
+                {
+                  name: 'field2',
+                  type: 'text',
+                  label: 'Field 2',
+                  placeholder: 'Advanced field',
+                  defaultValue: '',
+                },
+              ],
+            },
+          ],
+        },
+        // A step with no sections must not produce a tab (e.g. a trigger with no parameters).
+        { id: 'empty', title: 'Should Not Render', sections: [] },
+      ],
+    };
+
+    it('renders one tab per non-empty step and omits empty steps', () => {
+      render(<MetadataForm schema={tabbedSchema} stepVariant="tabs" />);
+
+      expect(screen.getByRole('tab', { name: 'Parameters' })).toBeInTheDocument();
+      expect(screen.getByRole('tab', { name: 'Advanced' })).toBeInTheDocument();
+      expect(screen.queryByRole('tab', { name: 'Should Not Render' })).not.toBeInTheDocument();
+    });
+
+    it('keeps a value entered in one tab after switching tabs (single shared form instance)', async () => {
+      const user = userEvent.setup();
+      render(<MetadataForm schema={tabbedSchema} stepVariant="tabs" />);
+
+      await user.type(screen.getByPlaceholderText('Params field'), 'hello');
+
+      // Switch to the Advanced tab, then back to Parameters.
+      await user.click(screen.getByRole('tab', { name: 'Advanced' }));
+      await waitFor(() =>
+        expect(screen.getByPlaceholderText('Advanced field')).toBeInTheDocument()
+      );
+
+      await user.click(screen.getByRole('tab', { name: 'Parameters' }));
+
+      // Value survives because every tab shares one react-hook-form instance.
+      await waitFor(() => expect(screen.getByPlaceholderText('Params field')).toHaveValue('hello'));
+    });
+
+    it('renders no Submit action when every step is empty (no phantom default Submit)', () => {
+      const allEmpty: FormSchema = {
+        id: 'all-empty',
+        title: 'All Empty',
+        steps: [{ id: 'empty', title: 'Empty', sections: [] }],
+      };
+      render(<MetadataForm schema={allEmpty} stepVariant="tabs" />);
+
+      // TabbedStepForm renders nothing, so FormActions (and its default Submit) is suppressed.
+      expect(screen.queryByRole('tab')).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: 'Submit' })).not.toBeInTheDocument();
+    });
+  });
 });

--- a/packages/apollo-wind/src/components/forms/metadata-form.tsx
+++ b/packages/apollo-wind/src/components/forms/metadata-form.tsx
@@ -1,8 +1,7 @@
+import { standardSchemaResolver } from '@hookform/resolvers/standard-schema';
 import React, { useEffect, useMemo, useRef, useState } from 'react';
-
 import { type FieldValues, FormProvider, useForm } from 'react-hook-form';
 import { z } from 'zod/v4';
-
 import {
   Accordion,
   AccordionContent,
@@ -10,7 +9,7 @@ import {
   AccordionTrigger,
 } from '@/components/ui/accordion';
 import { Button } from '@/components/ui/button';
-import { standardSchemaResolver } from '@hookform/resolvers/standard-schema';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 
 import { DataFetcher } from './data-fetcher';
 import { FormFieldRenderer } from './field-renderer';
@@ -40,6 +39,13 @@ interface MetadataFormProps {
   disabled?: boolean;
   /** Disable browser autocomplete suggestions. Defaults to undefined (browser default). */
   autoComplete?: 'off' | 'on';
+  /**
+   * Presentation for multi-step schemas. `'wizard'` (default) shows Previous/Next
+   * navigation with a Submit button on the final step. `'tabs'` renders the steps
+   * as a tab bar over a single form instance, so values and validation are shared
+   * across every step. Ignored for single-page (`sections`) schemas.
+   */
+  stepVariant?: 'wizard' | 'tabs';
 }
 
 // Stable default to prevent re-renders
@@ -52,6 +58,7 @@ export function MetadataForm({
   className,
   disabled = false,
   autoComplete,
+  stepVariant = 'wizard',
 }: MetadataFormProps) {
   const [currentStep, setCurrentStep] = useState(0);
   const [customComponents, setCustomComponents] = useState<
@@ -182,6 +189,17 @@ export function MetadataForm({
   // Render based on form structure
   const renderContent = () => {
     if (schema.steps) {
+      if (stepVariant === 'tabs') {
+        return (
+          <TabbedStepForm
+            schema={schema}
+            context={context}
+            customComponents={customComponents}
+            disabled={disabled}
+            onReset={() => reset()}
+          />
+        );
+      }
       return (
         <MultiStepForm
           schema={schema}
@@ -209,7 +227,9 @@ export function MetadataForm({
       <form onSubmit={handleFormSubmit} className={className} autoComplete={autoComplete}>
         {renderContent()}
 
-        {/* Only render FormActions for single-page forms - multi-step forms have their own navigation */}
+        {/* Wizard forms own their navigation/Submit, and tabbed forms render
+            FormActions inside TabbedStepForm so it's suppressed when no tab is
+            visible. Only single-page forms render FormActions here. */}
         {!schema.steps && <FormActions schema={schema} context={context} onReset={() => reset()} />}
       </form>
     </FormProvider>
@@ -325,6 +345,88 @@ function MultiStepForm({
         )}
       </div>
     </div>
+  );
+}
+
+interface TabbedStepFormProps extends SinglePageFormProps {
+  onReset: () => void;
+}
+
+function TabbedStepForm({
+  schema,
+  context,
+  customComponents,
+  disabled,
+  onReset,
+}: TabbedStepFormProps) {
+  const steps = schema.steps || [];
+
+  // Hide steps that have no sections or whose conditions evaluate to false, so a
+  // node that doesn't supply a given step (e.g. a trigger with no parameters)
+  // never renders an empty tab.
+  const visibleSteps = steps.filter(
+    (step) =>
+      step.sections.length > 0 && (!step.conditions || context.evaluateConditions(step.conditions))
+  );
+
+  // Clamp the active tab to a still-visible step so a step that disappears
+  // (condition flips, manifest swap) can't strand the form on a dead tab.
+  const [activeTab, setActiveTab] = useState<string>('');
+  const currentTab = visibleSteps.some((step) => step.id === activeTab)
+    ? activeTab
+    : (visibleSteps[0]?.id ?? '');
+
+  // Persist the clamp into state: once a selected step disappears we settle on the
+  // fallback, so a later reappearance doesn't snap the user back to the old tab.
+  useEffect(() => {
+    if (activeTab !== currentTab) setActiveTab(currentTab);
+  }, [activeTab, currentTab]);
+
+  if (visibleSteps.length === 0) return null;
+
+  return (
+    <>
+      <Tabs value={currentTab} onValueChange={setActiveTab} className="flex flex-col gap-4">
+        {/* Underline tabs (properties-panel style), overriding the primitive's
+          default segmented/pill look. Scoped here so the shared Tabs primitive
+          stays segmented for other consumers. */}
+        {/* Horizontal scroll when the tabs overflow a narrow panel (scrollbar hidden; tabs
+          stay on one line instead of clipping). The underline can optionally bleed past the
+          form's horizontal padding to the panel edges: a consumer sets `--mf-content-inset`
+          to its content inset and the list bleeds by that, re-insetting the labels. Default
+          0 keeps the underline at content width — correct for any padding. */}
+        <TabsList className="h-auto justify-start gap-4 overflow-x-auto rounded-none border-b border-border bg-transparent py-0 text-muted-foreground [-ms-overflow-style:none] [margin-inline:calc(var(--mf-content-inset,0px)*-1)] [padding-inline:var(--mf-content-inset,0px)] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+          {visibleSteps.map((step) => (
+            <TabsTrigger
+              key={step.id}
+              value={step.id}
+              className="-mb-px shrink-0 whitespace-nowrap rounded-none border-b-2 border-transparent bg-transparent px-1 pb-2 pt-1 font-medium text-muted-foreground shadow-none transition-colors hover:text-foreground data-[state=active]:border-primary data-[state=active]:bg-transparent data-[state=active]:text-foreground data-[state=active]:shadow-none"
+            >
+              {step.title}
+            </TabsTrigger>
+          ))}
+        </TabsList>
+
+        {visibleSteps.map((step) => (
+          <TabsContent key={step.id} value={step.id} className="space-y-2">
+            {step.sections
+              .filter(
+                (section) => !section.conditions || context.evaluateConditions(section.conditions)
+              )
+              .map((section) => (
+                <FormSection
+                  key={section.id}
+                  section={section}
+                  context={context}
+                  customComponents={customComponents}
+                  disabled={disabled}
+                />
+              ))}
+          </TabsContent>
+        ))}
+      </Tabs>
+      <FormActions schema={schema} context={context} onReset={onReset} />
+    </>
   );
 }
 


### PR DESCRIPTION
## What

Adds a tabbed presentation for node property forms, in two layers.

### 1. `apollo-wind` — `MetadataForm` `stepVariant="tabs"`
- New `stepVariant?: 'wizard' | 'tabs'` (default `'wizard'`; no change to existing forms).
- `'tabs'` renders a multi-step `FormSchema`'s steps as a tab bar over a **single** RHF instance — values and validation are shared across tabs (no per-tab form state loss). Hides empty / conditioned-out steps, clamps the active tab to a still-visible step (and persists the clamp so a reappearing step doesn't snap back), and offers an opt-in full-bleed underline via `--mf-content-inset` (default `0` → underline at content width, safe for any consumer).
- Unit tests + a `Forms/Examples → Tabbed Steps` story.

### 2. `apollo-react` — `NodePropertyPanel`
- Presentational docked properties panel: optional title bar, node identity row (icon / label / category + an `action` slot), and one `MetadataForm` (`stepVariant="tabs"`).
- Caller-driven: takes `schema` + `plugins` directly (no manifest fetch / no `NodeRegistryProvider` requirement), forwards `plugins` so real-time change handling and custom field components stay consumer-side, `resetKey` for per-node remount, `disabled`, and a single `contentInset` controlling content padding + the tab underline. No Submit button by default (live-edit surface).
- Unit tests + stories (with / without title bar, and a no-parameters trigger).

## Relationship to #809
Supersedes the `NodePropertyPanel` from #809. That version fetched `manifest.form` via `useNodeManifest` (required a `NodeRegistryProvider`) and rendered one `MetadataForm` **per tab** — losing field state on tab switch, dropping `initialData`, and showing a per-tab Submit. This branch moves the tab presentation into `MetadataForm` (single instance) and makes `NodePropertyPanel` a thin chrome wrapper that takes `schema` + `plugins`. That contract is what makes it consumable from flow-workbench (validated in a dev-published POC).

## Test plan
- `apollo-wind`: 17/17 metadata-form tests (incl. tabs render + value retention across tab switch).
- `apollo-react`: 7/7 NodePropertyPanel tests.
- Typecheck + Biome clean on both packages.
- Storybook: `Forms/Examples → Tabbed Steps`, `Components/Panels/Node Property Panel`.

> Note: local `storybook dev` is currently broken on `main` (vite 8.0.16 → rolldown 1.0.3 dev-optimizer `init_*-not-defined` crash). That's pre-existing and unrelated to this feature; CI's `storybook build` is unaffected. Tracking the rolldown fix separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
