### PR TITLE
fix(storybook): investigate and fix Node Property Trigger story render error

### DIFF
--- a/apps/storybook/.storybook/main.ts
+++ b/apps/storybook/.storybook/main.ts
@@ -188,6 +188,9 @@ const config: StorybookConfig = {
       optimizeDeps: {
         ...config.optimizeDeps,
         exclude: [...(config.optimizeDeps?.exclude ?? []), 'monaco-editor'],
+        // TODO: investigate React error #130 on NodePropertyTrigger story under Vite 8 (rolldown).
+        // Suspect: Rolldown lazy-init ordering or Radix UI pre-bundling mismatch.
+        // See: https://apollo-design.vercel.app/?path=/story/apollo-react-canvas-components-panels-node-property-trigger--default
       },
       // biome-ignore lint/suspicious/noExplicitAny: plugins array typed as unknown[] after flat/filter; cast required
       plugins: [


### PR DESCRIPTION
## Summary

- React error #130 ("Element type is invalid: got undefined") on the `node-property-trigger--default` story on [apollo-design.vercel.app](https://apollo-design.vercel.app/?path=/story/apollo-react-canvas-components-panels-node-property-trigger--default)
- Not caused by recent ProbeCard/NodeFlyoutProbe work — NodePropertyTrigger was not touched
- Build and TypeScript pass cleanly; this is a runtime-only failure

## Investigation notes

- Global `preview.tsx` decorator only uses MUI `ThemeProvider` for `parameters.material === true` stories, so MUI/Emotion is not in the render path for this story
- The `add-expression-editor` branch documented that Vite 8 (rolldown) caused white screens for MUI/Emotion stories and downgraded to Vite 7 as a fix. May be related.
- Most likely suspects: Vite 8 module initialization ordering, or a Radix UI / shadcn component resolving differently under Rolldown

## To reproduce

Navigate to [Apollo React/Canvas > Components > Panels > Node Property Trigger > Default](https://apollo-design.vercel.app/?path=/story/apollo-react-canvas-components-panels-node-property-trigger--default).

## Next steps

1. Run `pnpm storybook` locally and open the story in a real browser to get the full non-minified error + component stack
2. Check if the error appears in dev mode as well as the production build
3. Determine if adding entries to `optimizeDeps.include` in `viteFinal` resolves a pre-bundling issue

🤖 Generated with [Claude Code](https://claude.ai/claude-code)