### PR TITLE
feat(apollo-react): add hover visibility option for handle labels

### DIFF
--- a/packages/apollo-react/src/canvas/components/BaseNode/BaseNode.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/BaseNode/BaseNode.stories.tsx
@@ -6,9 +6,9 @@
 
 import type { Meta, StoryObj } from '@storybook/react';
 import { Column } from '@uipath/apollo-react/canvas/layouts';
-import type { Node } from '@uipath/apollo-react/canvas/xyflow/react';
+import type { Edge, Node } from '@uipath/apollo-react/canvas/xyflow/react';
 import { Panel } from '@uipath/apollo-react/canvas/xyflow/react';
-import { Button, Input, Label, Slider, Switch, cn } from '@uipath/apollo-wind';
+import { Button, cn, Input, Label, Slider, Switch } from '@uipath/apollo-wind';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { NodeRegistryProvider } from '../../core';
 import type { CategoryManifest, NodeManifest } from '../../schema';
@@ -22,12 +22,12 @@ import {
 } from '../../storybook-utils';
 import { DefaultCanvasTranslations } from '../../types';
 import type { ValidationErrorSeverity } from '../../types/validation';
+import { CanvasIcon } from '../../utils/icon-registry';
 import { BaseCanvas } from '../BaseCanvas';
 import { CanvasPositionControls } from '../CanvasPositionControls';
 import { NodeInspector } from '../NodeInspector';
-import { CanvasIcon } from '../../utils/icon-registry';
-import { BaseNodeOverrideConfigProvider } from './BaseNodeConfigContext';
 import type { BaseNodeData } from './BaseNode.types';
+import { BaseNodeOverrideConfigProvider } from './BaseNodeConfigContext';
 
 // ============================================================================
 // Meta Configuration
@@ -1243,6 +1243,59 @@ const dynamicHandlesManifest: { nodes: NodeManifest[]; categories: CategoryManif
         },
       ],
     },
+    {
+      nodeType: 'uipath.hover-labels',
+      version: '1.0.0',
+      category: 'control',
+      tags: ['handle', 'label'],
+      sortOrder: 3,
+      display: {
+        label: 'Hover Labels',
+        icon: 'tag',
+        shape: 'square',
+      },
+      handleConfiguration: [
+        {
+          position: 'right',
+          handles: [
+            {
+              id: 'out-hover',
+              type: 'source',
+              handleType: 'output',
+              label: 'Hover label',
+              labelVisibility: 'hover',
+            },
+            {
+              id: 'out-always',
+              type: 'source',
+              handleType: 'output',
+              label: 'Always label',
+              labelVisibility: 'always',
+            },
+          ],
+        },
+      ],
+    },
+    {
+      nodeType: 'uipath.hover-sink',
+      version: '1.0.0',
+      category: 'control',
+      tags: ['handle'],
+      sortOrder: 4,
+      display: {
+        label: 'Sink',
+        shape: 'circle',
+      },
+      handleConfiguration: [
+        {
+          position: 'left',
+          handles: [
+            { id: 'sink-hover', type: 'target', handleType: 'input' },
+            { id: 'sink-always', type: 'target', handleType: 'input' },
+          ],
+        },
+      ],
+    },
   ],
 };
 
@@ -1309,10 +1362,65 @@ function DynamicHandlesStory() {
         height: 96,
         width: 96,
       },
+      {
+        ...createNode({
+          id: 'hover-labels-node',
+          type: 'uipath.hover-labels',
+          position: { x: 1150, y: 200 },
+          data: {
+            nodeType: 'uipath.hover-labels',
+            version: '1.0.0',
+            display: {
+              label: 'Hover Labels',
+              subLabel: 'Hover to toggle labels',
+              shape: 'square',
+            },
+          },
+        }),
+        height: 96,
+        width: 96,
+      },
+      {
+        ...createNode({
+          id: 'hover-sink-node',
+          type: 'uipath.hover-sink',
+          position: { x: 1550, y: 230 },
+          data: {
+            nodeType: 'uipath.hover-sink',
+            version: '1.0.0',
+            display: {
+              label: 'Sink',
+              shape: 'circle',
+            },
+          },
+        }),
+        height: 48,
+        width: 48,
+      },
     ];
   }, [switchData, decisionData]);
 
-  const { canvasProps, setNodes } = useCanvasStory({ initialNodes });
+  const initialEdges = useMemo<Edge[]>(
+    () => [
+      {
+        id: 'e-hover',
+        source: 'hover-labels-node',
+        sourceHandle: 'out-hover',
+        target: 'hover-sink-node',
+        targetHandle: 'sink-hover',
+      },
+      {
+        id: 'e-always',
+        source: 'hover-labels-node',
+        sourceHandle: 'out-always',
+        target: 'hover-sink-node',
+        targetHandle: 'sink-always',
+      },
+    ],
+    []
+  );
+
+  const { canvasProps, setNodes } = useCanvasStory({ initialNodes, initialEdges });
 
   // Sync switch node data when controls change
   useEffect(() => {
@@ -1387,7 +1495,14 @@ function DynamicHandlesStory() {
       </Panel>
       <StoryInfoPanel
         title="Handles"
-        description="Demonstrates repeat expressions (dynamic handle count) and templated handle labels."
+        description={
+          <>
+            Demonstrates repeat expressions (dynamic handle count) and templated handle labels.
+            <br />
+            The Hover Labels node uses labelVisibility: hover, so its label shows only while the
+            node is hovered or selected, while the Always label stays on.
+          </>
+        }
       >
         <Column gap={20}>
           <Column gap={12}>

--- a/packages/apollo-react/src/canvas/components/BaseNode/BaseNode.tsx
+++ b/packages/apollo-react/src/canvas/components/BaseNode/BaseNode.tsx
@@ -228,6 +228,7 @@ const BaseNodeComponent = (props: NodeProps<Node<BaseNodeData>>) => {
         label: h.label,
         visible: h.visible,
         showButton: h.showButton,
+        labelVisibility: h.labelVisibility,
         constraints: h.constraints,
       })),
       visible: group.visible,

--- a/packages/apollo-react/src/canvas/components/ButtonHandle/ButtonHandle.test.tsx
+++ b/packages/apollo-react/src/canvas/components/ButtonHandle/ButtonHandle.test.tsx
@@ -270,6 +270,72 @@ describe('ButtonHandles', () => {
     });
   });
 
+  describe('hover-gated labels (labelVisibility)', () => {
+    const hoverHandle: ButtonHandleConfig = {
+      id: 'tool',
+      type: 'source',
+      handleType: 'artifact',
+      label: 'Tools',
+      showButton: true,
+      labelVisibility: 'hover',
+      onAction: vi.fn(),
+    };
+
+    const getLabelClass = () =>
+      screen.getByText('Tools').closest('[class*="transition-opacity"]')?.className ?? '';
+
+    it('hides the label when the node is neither hovered nor selected', () => {
+      render(<ButtonHandles handles={[hoverHandle]} nodeId="n" position={Position.Top} />);
+      expect(getLabelClass()).toContain('opacity-0');
+    });
+
+    it('reveals the label when the node is hovered', () => {
+      render(<ButtonHandles handles={[hoverHandle]} nodeId="n" position={Position.Top} hovered />);
+      expect(getLabelClass()).toContain('opacity-100');
+    });
+
+    it('reveals the label when the node is selected', () => {
+      render(<ButtonHandles handles={[hoverHandle]} nodeId="n" position={Position.Top} selected />);
+      expect(getLabelClass()).toContain('opacity-100');
+    });
+
+    it('hover-gates the inward label when connectionPosition differs from position', () => {
+      const { rerender } = render(
+        <ButtonHandles
+          handles={[hoverHandle]}
+          nodeId="n"
+          position={Position.Top}
+          connectionPosition={Position.Bottom}
+        />
+      );
+      expect(getLabelClass()).toContain('opacity-0');
+
+      rerender(
+        <ButtonHandles
+          handles={[hoverHandle]}
+          nodeId="n"
+          position={Position.Top}
+          connectionPosition={Position.Bottom}
+          hovered
+        />
+      );
+      expect(getLabelClass()).toContain('opacity-100');
+    });
+
+    it('keeps a default (always) label visible regardless of hover/selection', () => {
+      const alwaysHandle: ButtonHandleConfig = {
+        id: 'tool',
+        type: 'source',
+        handleType: 'artifact',
+        label: 'Tools',
+        showButton: true,
+        onAction: vi.fn(),
+      };
+      render(<ButtonHandles handles={[alwaysHandle]} nodeId="n" position={Position.Top} />);
+      expect(getLabelClass()).toContain('opacity-100');
+    });
+  });
+
   describe('Grid-aligned positioning', () => {
     it('uses grid-aligned positioning for Top handles when nodeWidth is provided', () => {
       const handles: ButtonHandleConfig[] = [

--- a/packages/apollo-react/src/canvas/components/ButtonHandle/ButtonHandle.tsx
+++ b/packages/apollo-react/src/canvas/components/ButtonHandle/ButtonHandle.tsx
@@ -1,6 +1,9 @@
 import { Handle, Position } from '@uipath/apollo-react/canvas/xyflow/react';
 import { memo, useCallback, useMemo, useRef, useState } from 'react';
-import type { HandleConfigurationSpecificPosition } from '../../schema/node-definition/handle';
+import type {
+  HandleConfigurationSpecificPosition,
+  HandleLabelVisibility,
+} from '../../schema/node-definition/handle';
 import { canvasEventBus } from '../../utils/CanvasEventBus';
 import { cx } from '../../utils/CssUtil';
 import { calculateGridAlignedHandlePositions } from '../../utils/handle-positioning';
@@ -44,6 +47,10 @@ type ButtonHandleProps = {
   labelIcon?: React.ReactNode;
   labelBackgroundColor?: string;
   visible?: boolean;
+  /** Whether the label is shown. Defaults to `visible` when omitted. */
+  labelVisible?: boolean;
+  /** When the label is shown. `hover` keeps the add button mounted so the label never reflows. */
+  labelVisibility?: HandleLabelVisibility;
   showButton?: boolean;
   selected?: boolean;
   index?: number; // 0-based index of this handle on the edge
@@ -69,6 +76,8 @@ const ButtonHandleBase = ({
   labelIcon,
   labelBackgroundColor,
   visible = true,
+  labelVisible,
+  labelVisibility,
   showButton = true,
   selected = false,
   index = 0,
@@ -161,6 +170,12 @@ const ButtonHandleBase = ({
   const unmarkAsHovered = useCallback(() => setIsHovered(false), []);
   const showActionButton = !!onAction && type === 'source';
 
+  // Label visibility defaults to the handle's own visibility (current behavior).
+  const resolvedLabelVisible = labelVisible ?? visible;
+  // When the label is hover-gated, keep the add button mounted (opacity-toggled)
+  // so the flex stack never reflows and the label doesn't jump as the button appears.
+  const keepButtonMounted = labelVisibility === 'hover';
+
   const {
     width: handleWidth,
     height: handleHeight,
@@ -205,6 +220,7 @@ const ButtonHandleBase = ({
           label={label}
           labelIcon={labelIcon}
           labelBackgroundColor={labelBackgroundColor}
+          labelVisible={resolvedLabelVisible}
           layout={layout}
         />
         <Handle
@@ -226,7 +242,8 @@ const ButtonHandleBase = ({
         {showActionButton ? (
           <HandleButton
             visible={showButton}
-            labelVisible={visible}
+            labelVisible={resolvedLabelVisible}
+            keepButtonMounted={keepButtonMounted}
             position={connectionPosition}
             onAction={handleButtonClick}
             onMouseEnter={handleButtonMouseEnter}
@@ -285,7 +302,8 @@ const ButtonHandleBase = ({
       {showActionButton ? (
         <HandleButton
           visible={showButton}
-          labelVisible={visible}
+          labelVisible={resolvedLabelVisible}
+          keepButtonMounted={keepButtonMounted}
           position={position}
           onAction={handleButtonClick}
           onMouseEnter={handleButtonMouseEnter}
@@ -303,6 +321,7 @@ const ButtonHandleBase = ({
             backgroundColor={labelBackgroundColor}
             label={label}
             labelIcon={labelIcon}
+            visible={resolvedLabelVisible}
           />
         )
       )}
@@ -321,6 +340,7 @@ function InwardHandleContent({
   label,
   labelIcon,
   labelBackgroundColor,
+  labelVisible = true,
   layout,
 }: {
   handleType: HandleType;
@@ -331,13 +351,16 @@ function InwardHandleContent({
   label?: string;
   labelIcon?: React.ReactNode;
   labelBackgroundColor?: string;
+  labelVisible?: boolean;
   layout: InwardHandleLayout;
 }) {
   const labelElement = label ? (
     <div
+      aria-hidden={labelVisible ? undefined : true}
       className={cx(
         'pointer-events-none flex items-center gap-1.5 whitespace-nowrap rounded-full border border-border bg-surface px-2 py-0.5',
-        'text-xs font-medium leading-4 text-foreground-muted'
+        'text-xs font-medium leading-4 text-foreground-muted transition-opacity duration-250',
+        labelVisible ? 'opacity-100' : 'opacity-0'
       )}
       style={labelBackgroundColor ? { backgroundColor: labelBackgroundColor } : undefined}
     >
@@ -374,6 +397,8 @@ export interface ButtonHandleConfig {
   labelIcon?: React.ReactNode;
   showButton?: boolean;
   labelBackgroundColor?: string;
+  /** When the handle's label is shown. Defaults to `always`. */
+  labelVisibility?: HandleLabelVisibility;
   /** Config-level visibility — controls whether the handle is rendered at all. */
   visible?: boolean;
   /** Runtime visibility — controls opacity (e.g. connected handles stay visible). */
@@ -452,6 +477,10 @@ const ButtonHandlesBase = ({
       />
       {visibleHandles.map((handle, index) => {
         const handleVisible = handle.showHandle ?? visible;
+        // Hover-gated labels follow the node's hover/selection state; others
+        // track the handle's own visibility (current always-on behavior).
+        const labelVisible =
+          handleVisible && (handle.labelVisibility !== 'hover' || selected || hovered);
 
         return (
           <ButtonHandle
@@ -465,10 +494,12 @@ const ButtonHandlesBase = ({
             label={handle.label}
             labelIcon={handle.labelIcon}
             labelBackgroundColor={handle.labelBackgroundColor}
+            labelVisibility={handle.labelVisibility}
             index={index}
             total={visibleHandles.length}
             selected={selected}
             visible={handleVisible}
+            labelVisible={labelVisible}
             showButton={finalSelected && handleVisible && handle.showButton}
             onAction={handle.onAction}
             onMouseEnter={handle.onMouseEnter}

--- a/packages/apollo-react/src/canvas/components/ButtonHandle/HandleButton.test.tsx
+++ b/packages/apollo-react/src/canvas/components/ButtonHandle/HandleButton.test.tsx
@@ -199,3 +199,58 @@ describe('HandleButton hover handlers', () => {
     await expect(user.unhover(button)).resolves.toBeUndefined();
   });
 });
+
+describe('HandleButton mount & label visibility', () => {
+  afterEach(cleanup);
+
+  it('unmounts the add button when not visible (default behavior)', () => {
+    render(<HandleButton visible={false} position={Position.Top} onAction={vi.fn()} />);
+    expect(screen.queryByRole('button', { name: 'Add node' })).toBeNull();
+  });
+
+  it('keeps the add button mounted but transparent when keepButtonMounted and not visible', () => {
+    render(
+      <HandleButton visible={false} keepButtonMounted position={Position.Top} onAction={vi.fn()} />
+    );
+
+    // aria-hidden removes it from the accessible tree (and zeroes its accessible
+    // name), so query with hidden: true and check the label via the attribute.
+    const button = screen.getByRole('button', { hidden: true });
+    expect(button).toHaveAttribute('aria-label', 'Add node');
+    expect(button.className).toContain('opacity-0');
+    expect(button.className).toContain('pointer-events-none');
+    expect(button).toHaveAttribute('aria-hidden', 'true');
+    // disabled (not just tabindex=-1) so aria-hidden is not applied to a focusable element.
+    expect(button).toBeDisabled();
+  });
+
+  it('shows the mounted add button when keepButtonMounted and visible', () => {
+    render(<HandleButton visible keepButtonMounted position={Position.Top} onAction={vi.fn()} />);
+
+    const button = screen.getByRole('button', { name: 'Add node' });
+    expect(button.className).toContain('opacity-100');
+    expect(button.className).toContain('pointer-events-auto');
+  });
+
+  it('fades the label via labelVisible', () => {
+    const { rerender } = render(
+      <HandleButton
+        visible
+        position={Position.Top}
+        onAction={vi.fn()}
+        label="Tools"
+        labelVisible={false}
+      />
+    );
+    expect(screen.getByText('Tools').closest('[class*="transition-opacity"]')?.className).toContain(
+      'opacity-0'
+    );
+
+    rerender(
+      <HandleButton visible position={Position.Top} onAction={vi.fn()} label="Tools" labelVisible />
+    );
+    expect(screen.getByText('Tools').closest('[class*="transition-opacity"]')?.className).toContain(
+      'opacity-100'
+    );
+  });
+});

--- a/packages/apollo-react/src/canvas/components/ButtonHandle/HandleButton.tsx
+++ b/packages/apollo-react/src/canvas/components/ButtonHandle/HandleButton.tsx
@@ -35,6 +35,7 @@ export const HandleButton = memo(
   ({
     visible,
     labelVisible,
+    keepButtonMounted = false,
     position,
     onAction,
     onMouseEnter,
@@ -47,6 +48,12 @@ export const HandleButton = memo(
   }: {
     visible?: boolean;
     labelVisible?: boolean;
+    /**
+     * Keep the add button mounted and toggle its opacity via `visible` instead of
+     * conditionally rendering it. This reserves the button's slot in the flex
+     * stack so the label never reflows/jumps when the button appears or hides.
+     */
+    keepButtonMounted?: boolean;
     position: Position;
     onAction: (event: React.MouseEvent) => void;
     onMouseEnter?: () => void;
@@ -130,20 +137,44 @@ export const HandleButton = memo(
       teardownRef.current = cleanup;
     }, []);
 
+    const addButton = keepButtonMounted ? (
+      // Always mounted: toggle opacity so the slot is reserved and the label never reflows.
+      // When not visible, disable it (non-focusable, non-interactive) and hide it from the
+      // accessibility tree so neither keyboard nor assistive tech reaches an invisible button.
+      // `disabled:opacity-0` overrides the button's default `disabled:opacity-50`.
+      <CanvasInlineButton
+        aria-label="Add node"
+        aria-hidden={visible ? undefined : true}
+        disabled={visible ? undefined : true}
+        onClick={handleClick}
+        onPointerDown={handlePointerDown}
+        onMouseEnter={onMouseEnter}
+        onMouseLeave={onMouseLeave}
+        className={cx(
+          'nodrag nopan transition-opacity duration-250',
+          visible
+            ? 'pointer-events-auto opacity-100'
+            : 'pointer-events-none opacity-0 disabled:opacity-0'
+        )}
+      />
+    ) : (
+      visible && (
+        <CanvasInlineButton
+          aria-label="Add node"
+          onClick={handleClick}
+          onPointerDown={handlePointerDown}
+          onMouseEnter={onMouseEnter}
+          onMouseLeave={onMouseLeave}
+          className="nodrag nopan pointer-events-auto animate-fade-in"
+        />
+      )
+    );
+
     const content = (
       <div
         className={cx('absolute flex items-center pointer-events-none', BUTTON_POSITION[position])}
       >
-        {visible && (
-          <CanvasInlineButton
-            aria-label="Add node"
-            onClick={handleClick}
-            onPointerDown={handlePointerDown}
-            onMouseEnter={onMouseEnter}
-            onMouseLeave={onMouseLeave}
-            className="nodrag nopan pointer-events-auto animate-fade-in"
-          />
-        )}
+        {addButton}
         {label && (
           <InlineLabel
             label={label}
@@ -155,7 +186,7 @@ export const HandleButton = memo(
       </div>
     );
 
-    const shouldRenderPortal = Boolean(visible || (label && labelVisible));
+    const shouldRenderPortal = Boolean(keepButtonMounted || visible || (label && labelVisible));
 
     if (portal) {
       if (!shouldRenderPortal) {
@@ -187,6 +218,7 @@ const InlineLabel = ({
   visible?: boolean;
 }) => (
   <div
+    aria-hidden={visible ? undefined : true}
     className={cx(
       'px-1.5 py-0.5 rounded-sm whitespace-nowrap select-none transition-opacity duration-250 z-10',
       visible ? 'opacity-100' : 'opacity-0'

--- a/packages/apollo-react/src/canvas/components/ButtonHandle/HandleLabel.tsx
+++ b/packages/apollo-react/src/canvas/components/ButtonHandle/HandleLabel.tsx
@@ -19,16 +19,20 @@ export const HandleLabel = ({
   label,
   labelIcon,
   shouldTruncate,
+  visible = true,
 }: {
   position: Position;
   backgroundColor?: string;
   label: string;
   labelIcon?: React.ReactNode;
   shouldTruncate?: boolean;
+  visible?: boolean;
 }) => (
   <div
+    aria-hidden={visible ? undefined : true}
     className={cx(
-      'absolute px-1.5 py-0.5 rounded-sm z-1 whitespace-nowrap select-none',
+      'absolute px-1.5 py-0.5 rounded-sm z-1 whitespace-nowrap select-none transition-opacity duration-250',
+      visible ? 'opacity-100' : 'opacity-0 pointer-events-none',
       LABEL_POSITION[position],
       shouldTruncate && 'max-w-[50px] overflow-hidden'
     )}

--- a/packages/apollo-react/src/canvas/schema/node-definition/handle.ts
+++ b/packages/apollo-react/src/canvas/schema/node-definition/handle.ts
@@ -24,6 +24,14 @@ export const handleTypeSchema = z.enum(['source', 'target']);
  */
 export const handleTypeDisplaySchema = z.enum(['artifact', 'input', 'output']);
 
+/**
+ * When a handle's label is shown.
+ * - `always` (default): label is always visible.
+ * - `hover`: label is shown only while the node is hovered or selected; it
+ *   fades in/out and does not shift position when the add button appears.
+ */
+export const handleLabelVisibilitySchema = z.enum(['always', 'hover']);
+
 export const handleConfigurationSpecificPositionSchema = z.object({
   /** The height of the area where the handles will be located in the node. Has no effect if no top or bottom is set. */
   height: z.number().optional(),
@@ -104,6 +112,9 @@ export const handleManifestSchema = z.object({
   /** Whether to show action button */
   showButton: z.boolean().optional(),
 
+  /** When this handle's label is shown. Defaults to `always`. */
+  labelVisibility: handleLabelVisibilitySchema.optional(),
+
   /** Connection constraints for this handle */
   constraints: connectionConstraintSchema.optional(),
 
@@ -154,6 +165,7 @@ export type HandlePosition = z.infer<typeof handlePositionSchema>;
 export type HandleBoundary = z.infer<typeof handleBoundarySchema>;
 export type HandleType = z.infer<typeof handleTypeSchema>;
 export type HandleCategory = z.infer<typeof handleTypeDisplaySchema>;
+export type HandleLabelVisibility = z.infer<typeof handleLabelVisibilitySchema>;
 export type HandleManifest = z.infer<typeof handleManifestSchema>;
 export type HandleGroupManifest = z.infer<typeof handleGroupManifestSchema>;
 export type HandleGroupOverride = z.infer<typeof handleGroupOverrideSchema>;

--- a/packages/apollo-react/src/canvas/storybook-utils/components/StoryInfoPanel.tsx
+++ b/packages/apollo-react/src/canvas/storybook-utils/components/StoryInfoPanel.tsx
@@ -8,7 +8,7 @@ export interface StoryInfoPanelProps {
   /** Panel title */
   title: string;
   /** Optional description below the title */
-  description?: string;
+  description?: React.ReactNode;
   /** Panel content */
   children?: React.ReactNode;
   /** Whether the panel can be collapsed */


### PR DESCRIPTION
## Summary

Adds a `labelVisibility` option (`always` | `hover`, default `always`) to canvas handle labels (MST-11008). With `hover`, a handle's label is shown only while the node is hovered or selected, fading in and out without shifting position.

## Changes

- `handle.ts`: new `handleLabelVisibilitySchema` (`'always' | 'hover'`) and optional `labelVisibility` on the handle manifest, plus the `HandleLabelVisibility` type.
- `HandleLabel.tsx`: `visible` prop with an opacity transition (`duration-250`).
- `HandleButton.tsx`: `keepButtonMounted` reserves the add-button's flex slot so the label never reflows or jumps when the button toggles.
- `ButtonHandle.tsx`: gate label visibility on `selected || hovered` for `hover` mode, and keep the button mounted accordingly.
- `BaseNode.tsx`: thread `labelVisibility` through to handle groups.
- Storybook: a "Hover Labels" demo node in the BaseNode Handles story (its source handles are wired to a sink so they stay rendered, isolating the label fade). `StoryInfoPanel.description` widened to `ReactNode`.
- Tests: added coverage in `ButtonHandle.test.tsx` and `HandleButton.test.tsx`.


## Demo


https://github.com/user-attachments/assets/718b006e-6320-4091-9d99-d0fe5ec83448



## Flow

```mermaid
flowchart TD
    A[handle manifest: labelVisibility] --> B[BaseNode threads it to handle groups]
    B --> C[ButtonHandle gate]
    C -->|labelVisibility hover| D{selected or hovered?}
    C -->|always / unset| E[label always visible]
    D -->|yes| F[label visible]
    D -->|no| G[label hidden]
    C --> H[HandleButton keepButtonMounted reserves slot]
    H --> I[HandleLabel opacity transition, no reflow]
```

## Testing

- [x] Typecheck passes (`tsc` on apollo-react)
- [x] Unit tests pass (178 tests, 5 files)
- [x] Biome lint clean (only pre-existing warnings)
- [x] Manual Storybook check (BaseNode -> Handles -> Hover Labels)
