### PR TITLE
fix(apollo-vertex): type solution-tests live queries against react-db

### DIFF
--- a/apps/apollo-vertex/registry.json
+++ b/apps/apollo-vertex/registry.json
@@ -2676,6 +2676,11 @@
           "target": "components/ui/solution-tests/use-solution-tests.ts"
         },
         {
+          "path": "registry/solution-tests/use-solution-test-collection.ts",
+          "type": "registry:ui",
+          "target": "components/ui/solution-tests/use-solution-test-collection.ts"
+        },
+        {
           "path": "registry/solution-tests/use-solution-test-batch-runs.ts",
           "type": "registry:ui",
           "target": "components/ui/solution-tests/use-solution-test-batch-runs.ts"

--- a/apps/apollo-vertex/registry/solution-tests/use-baseline-jobs.ts
+++ b/apps/apollo-vertex/registry/solution-tests/use-baseline-jobs.ts
@@ -16,6 +16,7 @@ import { useSolutionTestsActions } from "./context";
 import type { AttachmentFetcher, MutationHook } from "./mutations";
 import { JobRole } from "./types";
 import type { SolutionTestJob } from "./types";
+import { useSolutionTestCollection } from "./use-solution-test-collection";
 
 export interface UseBaselineJobsResult {
   jobs: SolutionTestJob[];
@@ -24,12 +25,8 @@ export interface UseBaselineJobsResult {
 
 /** Live baseline jobs for a test. */
 export function useBaselineJobs(testId: string): UseBaselineJobsResult {
-  const solution = useSolution();
-  const collection = solution?.api.collections.solutionTests[ENTITY.jobs];
-  const { data, isLoading } = useLiveQuery<SolutionTestJob>(
-    (q) => (collection ? q.from({ jobs: collection }) : null),
-    [collection],
-  );
+  const collection = useSolutionTestCollection(ENTITY.jobs);
+  const { data, isLoading } = useLiveQuery(() => collection, [collection]);
   const jobs = (data ?? []).filter(
     (job) => job.SolutionTestId === testId && job.JobRole === JobRole.Baseline,
   );

--- a/apps/apollo-vertex/registry/solution-tests/use-run-results.ts
+++ b/apps/apollo-vertex/registry/solution-tests/use-run-results.ts
@@ -20,6 +20,7 @@ import type {
   SolutionTestJob,
   SolutionTestRunResult,
 } from "./types";
+import { useSolutionTestCollection } from "./use-solution-test-collection";
 
 export interface UseRunResultsResult {
   results: SolutionTestRunResult[];
@@ -44,16 +45,14 @@ function isBaselineJobResult(
 
 /** Live run results for a run, excluding entry-point jobs (role != Baseline). */
 export function useRunResults(runId: string): UseRunResultsResult {
-  const solution = useSolution();
-  const resultsCollection =
-    solution?.api.collections.solutionTests[ENTITY.runResults];
-  const jobsCollection = solution?.api.collections.solutionTests[ENTITY.jobs];
-  const { data, isReady: resultsReady } = useLiveQuery<SolutionTestRunResult>(
-    (q) => (resultsCollection ? q.from({ results: resultsCollection }) : null),
+  const resultsCollection = useSolutionTestCollection(ENTITY.runResults);
+  const jobsCollection = useSolutionTestCollection(ENTITY.jobs);
+  const { data, isReady: resultsReady } = useLiveQuery(
+    () => resultsCollection,
     [resultsCollection],
   );
-  const { data: jobsData, isReady: jobsReady } = useLiveQuery<SolutionTestJob>(
-    (q) => (jobsCollection ? q.from({ jobs: jobsCollection }) : null),
+  const { data: jobsData, isReady: jobsReady } = useLiveQuery(
+    () => jobsCollection,
     [jobsCollection],
   );
   // The role filter needs both collections. Until both are ready, stay loading

--- a/apps/apollo-vertex/registry/solution-tests/use-solution-test-batch-runs.ts
+++ b/apps/apollo-vertex/registry/solution-tests/use-solution-test-batch-runs.ts
@@ -6,9 +6,9 @@
  */
 
 import { useLiveQuery } from "@tanstack/react-db";
-import { useSolution } from "@uipath/vs-core";
 import { ENTITY } from "./constants";
 import type { SolutionTestBatchRun } from "./types";
+import { useSolutionTestCollection } from "./use-solution-test-collection";
 
 export interface UseSolutionTestBatchRunsResult {
   batchRuns: SolutionTestBatchRun[];
@@ -17,11 +17,7 @@ export interface UseSolutionTestBatchRunsResult {
 
 /** Live list of batch runs. */
 export function useSolutionTestBatchRuns(): UseSolutionTestBatchRunsResult {
-  const solution = useSolution();
-  const collection = solution?.api.collections.solutionTests[ENTITY.batchRuns];
-  const { data, isLoading } = useLiveQuery<SolutionTestBatchRun>(
-    (q) => (collection ? q.from({ batchRuns: collection }) : null),
-    [collection],
-  );
+  const collection = useSolutionTestCollection(ENTITY.batchRuns);
+  const { data, isLoading } = useLiveQuery(() => collection, [collection]);
   return { batchRuns: data ?? [], isLoading };
 }

--- a/apps/apollo-vertex/registry/solution-tests/use-solution-test-collection.ts
+++ b/apps/apollo-vertex/registry/solution-tests/use-solution-test-collection.ts
@@ -1,0 +1,45 @@
+"use client";
+
+/**
+ * Resolve a typed Solution Tests collection by entity name. The entity name
+ * determines the row type, so callers cannot mismatch the two. Throws when used
+ * outside a SolutionProvider or when the named collection is not registered.
+ */
+
+import type { Collection } from "@tanstack/react-db";
+import { useSolution } from "@uipath/vs-core";
+import { ENTITY } from "./constants";
+import type {
+  SolutionTest,
+  SolutionTestBatchRun,
+  SolutionTestJob,
+  SolutionTestRun,
+  SolutionTestRunResult,
+} from "./types";
+
+/** Row type stored in each Solution Tests collection, keyed by its entity name. */
+type SolutionTestRow = {
+  [ENTITY.tests]: SolutionTest;
+  [ENTITY.batchRuns]: SolutionTestBatchRun;
+  [ENTITY.runs]: SolutionTestRun;
+  [ENTITY.jobs]: SolutionTestJob;
+  [ENTITY.runResults]: SolutionTestRunResult;
+};
+
+export function useSolutionTestCollection<K extends keyof SolutionTestRow>(
+  entity: K,
+): Collection<SolutionTestRow[K]> {
+  const solution = useSolution();
+  if (!solution) {
+    throw new Error(
+      "useSolutionTestCollection must be used within a SolutionProvider.",
+    );
+  }
+  const selected = solution.api.collections.solutionTests[entity];
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion
+  const collection = selected as Collection<SolutionTestRow[K]> | undefined;
+  if (!collection) {
+    throw new Error(`Solution Tests collection "${entity}" is unavailable.`);
+  }
+  return collection;
+}

--- a/apps/apollo-vertex/registry/solution-tests/use-solution-test-runs.ts
+++ b/apps/apollo-vertex/registry/solution-tests/use-solution-test-runs.ts
@@ -6,9 +6,9 @@
  */
 
 import { useLiveQuery } from "@tanstack/react-db";
-import { useSolution } from "@uipath/vs-core";
 import { ENTITY } from "./constants";
 import type { SolutionTestRun } from "./types";
+import { useSolutionTestCollection } from "./use-solution-test-collection";
 
 export interface UseSolutionTestRunsResult {
   runs: SolutionTestRun[];
@@ -17,11 +17,7 @@ export interface UseSolutionTestRunsResult {
 
 /** Live list of all runs (the view filters by batch in memory). */
 export function useSolutionTestRuns(): UseSolutionTestRunsResult {
-  const solution = useSolution();
-  const collection = solution?.api.collections.solutionTests[ENTITY.runs];
-  const { data, isLoading } = useLiveQuery<SolutionTestRun>(
-    (q) => (collection ? q.from({ runs: collection }) : null),
-    [collection],
-  );
+  const collection = useSolutionTestCollection(ENTITY.runs);
+  const { data, isLoading } = useLiveQuery(() => collection, [collection]);
   return { runs: data ?? [], isLoading };
 }

--- a/apps/apollo-vertex/registry/solution-tests/use-solution-tests.ts
+++ b/apps/apollo-vertex/registry/solution-tests/use-solution-tests.ts
@@ -13,6 +13,7 @@ import { ENTITY } from "./constants";
 import { useSolutionTestsActions } from "./context";
 import type { MutationHook } from "./mutations";
 import type { SolutionTest } from "./types";
+import { useSolutionTestCollection } from "./use-solution-test-collection";
 
 export interface UseSolutionTestsResult {
   tests: SolutionTest[];
@@ -21,12 +22,8 @@ export interface UseSolutionTestsResult {
 
 /** Live list of solution tests. */
 export function useSolutionTests(): UseSolutionTestsResult {
-  const solution = useSolution();
-  const collection = solution?.api.collections.solutionTests[ENTITY.tests];
-  const { data, isLoading } = useLiveQuery<SolutionTest>(
-    (q) => (collection ? q.from({ tests: collection }) : null),
-    [collection],
-  );
+  const collection = useSolutionTestCollection(ENTITY.tests);
+  const { data, isLoading } = useLiveQuery(() => collection, [collection]);
   return { tests: data ?? [], isLoading };
 }
 


### PR DESCRIPTION
This PR does two things:

- Amend collection types (noticed issues during implementation)
- Throw when collections are undefined instead of a silent fallback

👨 Generated with Kluijt Code