### PR TITLE
feat(apollo-vertex): add AiMark and AiGlow primitives

### DIFF
--- a/apps/apollo-vertex/app/foundation/colors/page.mdx
+++ b/apps/apollo-vertex/app/foundation/colors/page.mdx
@@ -53,23 +53,41 @@ Shadow tokens use a consistent structure: a diffuse ambient layer plus an offset
   ))}
 </div>
 
-## AI Gradient
+## AI Gradients
 
-A special two-stop gradient used for AI-adjacent UI surfaces.
+Gradient tokens for the AI expression. Each swatch resolves the live token, so it reflects the current theme. The fill and strong gradients are the same in light and dark; the text and subtle gradients shift ramp steps per theme. See the [AI Toolkit](/guidelines/ai-toolkit) for usage and contrast guidance.
 
-<div className="not-prose my-6 grid grid-cols-2 gap-3">
+<div className="not-prose my-6 grid grid-cols-1 sm:grid-cols-2 gap-3">
   <div className="rounded-lg border border-border overflow-hidden">
-    <div className="h-20" style={{ background: 'linear-gradient(100.64deg, rgb(238, 224, 255) 8.29%, rgb(207, 217, 255) 88.73%)' }} />
+    <div className="h-20" style={{ background: 'var(--ai-gradient-fill)' }} />
     <div className="p-3">
-      <span className="text-sm font-medium text-foreground">Light</span>
-      <code className="block text-xs font-mono text-muted-foreground mt-1">--ai-gradient</code>
+      <span className="text-sm font-medium text-foreground">Fill</span>
+      <code className="block text-xs font-mono text-muted-foreground mt-1">--ai-gradient-fill</code>
+      <span className="block text-xs text-muted-foreground mt-1">Solid fill behind white text (passes AA).</span>
     </div>
   </div>
   <div className="rounded-lg border border-border overflow-hidden">
-    <div className="h-20" style={{ background: 'linear-gradient(98.69deg, rgb(108, 90, 239) 8.79%, rgb(105, 199, 221) 91.48%)' }} />
+    <div className="h-20" style={{ background: 'var(--ai-gradient-text)' }} />
     <div className="p-3">
-      <span className="text-sm font-medium text-foreground">Dark</span>
-      <code className="block text-xs font-mono text-muted-foreground mt-1">--ai-gradient (dark)</code>
+      <span className="text-sm font-medium text-foreground">Text</span>
+      <code className="block text-xs font-mono text-muted-foreground mt-1">--ai-gradient-text</code>
+      <span className="block text-xs text-muted-foreground mt-1">Gradient-clipped text; lifts to lighter steps in dark.</span>
+    </div>
+  </div>
+  <div className="rounded-lg border border-border overflow-hidden">
+    <div className="h-20" style={{ background: 'var(--ai-gradient-strong)' }} />
+    <div className="p-3">
+      <span className="text-sm font-medium text-foreground">Strong</span>
+      <code className="block text-xs font-mono text-muted-foreground mt-1">--ai-gradient-strong</code>
+      <span className="block text-xs text-muted-foreground mt-1">Decorative marks, icon fills, and glows.</span>
+    </div>
+  </div>
+  <div className="rounded-lg border border-border overflow-hidden">
+    <div className="h-20" style={{ background: 'var(--ai-gradient)' }} />
+    <div className="p-3">
+      <span className="text-sm font-medium text-foreground">Subtle</span>
+      <code className="block text-xs font-mono text-muted-foreground mt-1">--ai-gradient</code>
+      <span className="block text-xs text-muted-foreground mt-1">Soft surface tint and inset glow; deeper steps in dark.</span>
     </div>
   </div>
 </div>

--- a/apps/apollo-vertex/lib/foundation-tokens.ts
+++ b/apps/apollo-vertex/lib/foundation-tokens.ts
@@ -234,6 +234,81 @@ export const colorGroups: ColorGroup[] = [
     ],
   },
   {
+    heading: "Insight",
+    tokens: [
+      {
+        token: "insight-50",
+        label: "Insight 50",
+        description: "Lightest tint",
+        lightValue: "oklch(0.96 0.03 277)",
+        darkValue: "oklch(0.96 0.03 277)",
+      },
+      {
+        token: "insight-100",
+        label: "Insight 100",
+        description: "",
+        lightValue: "oklch(0.92 0.05 277)",
+        darkValue: "oklch(0.92 0.05 277)",
+      },
+      {
+        token: "insight-200",
+        label: "Insight 200",
+        description: "",
+        lightValue: "oklch(0.86 0.09 277)",
+        darkValue: "oklch(0.86 0.09 277)",
+      },
+      {
+        token: "insight-300",
+        label: "Insight 300",
+        description: "",
+        lightValue: "oklch(0.78 0.14 277)",
+        darkValue: "oklch(0.78 0.14 277)",
+      },
+      {
+        token: "insight-400",
+        label: "Insight 400",
+        description: "",
+        lightValue: "oklch(0.70 0.19 277)",
+        darkValue: "oklch(0.70 0.19 277)",
+      },
+      {
+        token: "insight-500",
+        label: "Insight 500",
+        description: "Mid-point",
+        lightValue: "oklch(0.62 0.22 277)",
+        darkValue: "oklch(0.62 0.22 277)",
+      },
+      {
+        token: "insight-600",
+        label: "Insight 600",
+        description: "Default insight",
+        lightValue: "oklch(0.56 0.20 277)",
+        darkValue: "oklch(0.56 0.20 277)",
+      },
+      {
+        token: "insight-700",
+        label: "Insight 700",
+        description: "",
+        lightValue: "oklch(0.48 0.17 277)",
+        darkValue: "oklch(0.48 0.17 277)",
+      },
+      {
+        token: "insight-800",
+        label: "Insight 800",
+        description: "",
+        lightValue: "oklch(0.38 0.13 278)",
+        darkValue: "oklch(0.38 0.13 278)",
+      },
+      {
+        token: "insight-900",
+        label: "Insight 900",
+        description: "Darkest shade",
+        lightValue: "oklch(0.30 0.10 278)",
+        darkValue: "oklch(0.30 0.10 278)",
+      },
+    ],
+  },
+  {
     heading: "Status",
     tokens: [
       {

--- a/apps/apollo-vertex/registry.json
+++ b/apps/apollo-vertex/registry.json
@@ -204,7 +204,12 @@
           "ai-chat-muted": "oklch(0.955 0.006 260)",
           "ai-chat-muted-foreground": "oklch(0.50 0.020 260)",
           "ai-chat-brand-gradient": "linear-gradient(97.73deg, #5D4ED0 8.79%, #1076A0 91.48%)",
-          "ai-gradient": "linear-gradient(100.64deg, rgb(238, 224, 255) 8.29%, rgb(207, 217, 255) 88.73%)",
+          "ai-gradient": "linear-gradient(100.64deg, var(--insight-100) 8.29%, var(--primary-50) 88.73%)",
+          "ai-glow-start": "var(--insight-100)",
+          "ai-glow-end": "var(--primary-50)",
+          "ai-glass": "color-mix(in srgb, var(--card) 80%, transparent)",
+          "ai-gradient-fill": "linear-gradient(97.73deg, var(--insight-600) 8.79%, var(--primary-700) 91.48%)",
+          "ai-gradient-text": "linear-gradient(97.73deg, var(--insight-600) 8.79%, var(--primary-700) 91.48%)",
           "ai-gradient-strong": "linear-gradient(97.73deg, #6C5AEF 8.79%, #69C7DD 91.48%)",
           "ai-gradient-start": "#6C5AEF",
           "ai-gradient-end": "#69C7DD"
@@ -306,7 +311,12 @@
           "ai-chat-muted": "oklch(0.26 0.030 258)",
           "ai-chat-muted-foreground": "oklch(0.65 0.020 258)",
           "ai-chat-brand-gradient": "linear-gradient(97.73deg, #9485F5 8.79%, #69C7DD 91.48%)",
-          "ai-gradient": "linear-gradient(98.69deg, rgb(108, 90, 239) 8.79%, rgb(105, 199, 221) 91.48%)",
+          "ai-gradient": "linear-gradient(100.64deg, var(--insight-800) 8.29%, var(--primary-800) 88.73%)",
+          "ai-glow-start": "var(--insight-800)",
+          "ai-glow-end": "var(--primary-800)",
+          "ai-glass": "color-mix(in srgb, var(--card) 90%, transparent)",
+          "ai-gradient-fill": "linear-gradient(97.73deg, var(--insight-600) 8.79%, var(--primary-700) 91.48%)",
+          "ai-gradient-text": "linear-gradient(97.73deg, var(--insight-400) 8.79%, var(--primary-400) 91.48%)",
           "ai-gradient-strong": "linear-gradient(97.73deg, #6C5AEF 8.79%, #69C7DD 91.48%)",
           "ai-gradient-start": "#6C5AEF",
           "ai-gradient-end": "#69C7DD"
@@ -2580,227 +2590,6 @@
         {
           "path": "registry/protected-feature-route/protected-feature-route.tsx",
           "type": "registry:ui"
-        }
-      ]
-    },
-    {
-      "name": "solution-tests",
-      "type": "registry:ui",
-      "title": "Solution Tests",
-      "description": "Page-level view for managing UiPath Solution Tests — test cases, batch runs, KPI trend, run-result baselines, and adopt/update/remove actions. Domain-neutral: the smart container reads the generic UiPathST* entity collections from your vs-core solution via collection-backed hooks, and the subject entity is parameterized via SolutionTestsConfig.",
-      "dependencies": [
-        "@tanstack/react-db@^0.1.86",
-        "@tanstack/react-query@^5.90.0",
-        "@tanstack/react-table",
-        "@tanstack/react-router",
-        "@uipath/vs-core@^2.0.6",
-        "@uipath/uipath-typescript@^1.0.0",
-        "react-i18next",
-        "recharts@2.15.4",
-        "sonner",
-        "lucide-react",
-        "zod"
-      ],
-      "registryDependencies": [
-        "@uipath/alert",
-        "@uipath/badge",
-        "@uipath/button",
-        "@uipath/card",
-        "@uipath/chart",
-        "@uipath/data-table",
-        "@uipath/dialog",
-        "@uipath/empty",
-        "@uipath/page-header",
-        "@uipath/skeleton",
-        "@uipath/sonner",
-        "@uipath/spinner",
-        "@uipath/switch",
-        "@uipath/table",
-        "@uipath/tabs",
-        "@uipath/tooltip"
-      ],
-      "files": [
-        {
-          "path": "registry/solution-tests/index.ts",
-          "type": "registry:ui",
-          "target": "components/ui/solution-tests/index.ts"
-        },
-        {
-          "path": "registry/solution-tests/solution-tests-view.tsx",
-          "type": "registry:ui",
-          "target": "components/ui/solution-tests/solution-tests-view.tsx"
-        },
-        {
-          "path": "registry/solution-tests/solution-tests.tsx",
-          "type": "registry:ui",
-          "target": "components/ui/solution-tests/solution-tests.tsx"
-        },
-        {
-          "path": "registry/solution-tests/context.tsx",
-          "type": "registry:ui",
-          "target": "components/ui/solution-tests/context.tsx"
-        },
-        {
-          "path": "registry/solution-tests/hooks.ts",
-          "type": "registry:ui",
-          "target": "components/ui/solution-tests/hooks.ts"
-        },
-        {
-          "path": "registry/solution-tests/constants.ts",
-          "type": "registry:ui",
-          "target": "components/ui/solution-tests/constants.ts"
-        },
-        {
-          "path": "registry/solution-tests/mutations.ts",
-          "type": "registry:ui",
-          "target": "components/ui/solution-tests/mutations.ts"
-        },
-        {
-          "path": "registry/solution-tests/attachments.ts",
-          "type": "registry:ui",
-          "target": "components/ui/solution-tests/attachments.ts"
-        },
-        {
-          "path": "registry/solution-tests/actions.ts",
-          "type": "registry:ui",
-          "target": "components/ui/solution-tests/actions.ts"
-        },
-        {
-          "path": "registry/solution-tests/create-actions.ts",
-          "type": "registry:ui",
-          "target": "components/ui/solution-tests/create-actions.ts"
-        },
-        {
-          "path": "registry/solution-tests/use-solution-tests.ts",
-          "type": "registry:ui",
-          "target": "components/ui/solution-tests/use-solution-tests.ts"
-        },
-        {
-          "path": "registry/solution-tests/use-solution-test-collection.ts",
-          "type": "registry:ui",
-          "target": "components/ui/solution-tests/use-solution-test-collection.ts"
-        },
-        {
-          "path": "registry/solution-tests/use-solution-test-batch-runs.ts",
-          "type": "registry:ui",
-          "target": "components/ui/solution-tests/use-solution-test-batch-runs.ts"
-        },
-        {
-          "path": "registry/solution-tests/use-solution-test-runs.ts",
-          "type": "registry:ui",
-          "target": "components/ui/solution-tests/use-solution-test-runs.ts"
-        },
-        {
-          "path": "registry/solution-tests/use-baseline-jobs.ts",
-          "type": "registry:ui",
-          "target": "components/ui/solution-tests/use-baseline-jobs.ts"
-        },
-        {
-          "path": "registry/solution-tests/use-run-results.ts",
-          "type": "registry:ui",
-          "target": "components/ui/solution-tests/use-run-results.ts"
-        },
-        {
-          "path": "registry/solution-tests/use-force-stop.ts",
-          "type": "registry:ui",
-          "target": "components/ui/solution-tests/use-force-stop.ts"
-        },
-        {
-          "path": "registry/solution-tests/config.ts",
-          "type": "registry:ui",
-          "target": "components/ui/solution-tests/config.ts"
-        },
-        {
-          "path": "registry/solution-tests/types.ts",
-          "type": "registry:ui",
-          "target": "components/ui/solution-tests/types.ts"
-        },
-        {
-          "path": "registry/solution-tests/tabs.ts",
-          "type": "registry:ui",
-          "target": "components/ui/solution-tests/tabs.ts"
-        },
-        {
-          "path": "registry/solution-tests/status-maps.ts",
-          "type": "registry:ui",
-          "target": "components/ui/solution-tests/status-maps.ts"
-        },
-        {
-          "path": "registry/solution-tests/utils.ts",
-          "type": "registry:ui",
-          "target": "components/ui/solution-tests/utils.ts"
-        },
-        { "path": "lib/renderValueOrEmptyState.ts", "type": "registry:lib" },
-        { "path": "lib/constants.ts", "type": "registry:lib" },
-        {
-          "path": "registry/solution-tests/user-messages.ts",
-          "type": "registry:ui",
-          "target": "components/ui/solution-tests/user-messages.ts"
-        },
-        {
-          "path": "registry/solution-tests/user-messages-view.tsx",
-          "type": "registry:ui",
-          "target": "components/ui/solution-tests/user-messages-view.tsx"
-        },
-        {
-          "path": "registry/solution-tests/json-viewer-dialog.tsx",
-          "type": "registry:ui",
-          "target": "components/ui/solution-tests/json-viewer-dialog.tsx"
-        },
-        {
-          "path": "registry/solution-tests/delete-confirm-dialog.tsx",
-          "type": "registry:ui",
-          "target": "components/ui/solution-tests/delete-confirm-dialog.tsx"
-        },
-        {
-          "path": "registry/solution-tests/evaluator-results-view.tsx",
-          "type": "registry:ui",
-          "target": "components/ui/solution-tests/evaluator-results-view.tsx"
-        },
-        {
-          "path": "registry/solution-tests/kpi-bar.tsx",
-          "type": "registry:ui",
-          "target": "components/ui/solution-tests/kpi-bar.tsx"
-        },
-        {
-          "path": "registry/solution-tests/expanded-agents.tsx",
-          "type": "registry:ui",
-          "target": "components/ui/solution-tests/expanded-agents.tsx"
-        },
-        {
-          "path": "registry/solution-tests/expanded-agents-view.tsx",
-          "type": "registry:ui",
-          "target": "components/ui/solution-tests/expanded-agents-view.tsx"
-        },
-        {
-          "path": "registry/solution-tests/result-expanded-content.tsx",
-          "type": "registry:ui",
-          "target": "components/ui/solution-tests/result-expanded-content.tsx"
-        },
-        {
-          "path": "registry/solution-tests/run-confirm-dialog.tsx",
-          "type": "registry:ui",
-          "target": "components/ui/solution-tests/run-confirm-dialog.tsx"
-        },
-        {
-          "path": "registry/solution-tests/run-details-dialog.tsx",
-          "type": "registry:ui",
-          "target": "components/ui/solution-tests/run-details-dialog.tsx"
-        },
-        {
-          "path": "registry/solution-tests/run-details-dialog-view.tsx",
-          "type": "registry:ui",
-          "target": "components/ui/solution-tests/run-details-dialog-view.tsx"
-        },
-        {
-          "path": "registry/solution-tests/expanded-run-tests.tsx",
-          "type": "registry:ui",
-          "target": "components/ui/solution-tests/expanded-run-tests.tsx"
-        },
-        {
-          "path": "registry/solution-tests/expanded-run-tests-view.tsx",
-          "type": "registry:ui",
-          "target": "components/ui/solution-tests/expanded-run-tests-view.tsx"
         }
       ]
     }

--- a/apps/apollo-vertex/registry.json
+++ b/apps/apollo-vertex/registry.json
@@ -2592,6 +2592,227 @@
           "type": "registry:ui"
         }
       ]
+    },
+    {
+      "name": "solution-tests",
+      "type": "registry:ui",
+      "title": "Solution Tests",
+      "description": "Page-level view for managing UiPath Solution Tests — test cases, batch runs, KPI trend, run-result baselines, and adopt/update/remove actions. Domain-neutral: the smart container reads the generic UiPathST* entity collections from your vs-core solution via collection-backed hooks, and the subject entity is parameterized via SolutionTestsConfig.",
+      "dependencies": [
+        "@tanstack/react-db@^0.1.86",
+        "@tanstack/react-query@^5.90.0",
+        "@tanstack/react-table",
+        "@tanstack/react-router",
+        "@uipath/vs-core@^2.0.6",
+        "@uipath/uipath-typescript@^1.0.0",
+        "react-i18next",
+        "recharts@2.15.4",
+        "sonner",
+        "lucide-react",
+        "zod"
+      ],
+      "registryDependencies": [
+        "@uipath/alert",
+        "@uipath/badge",
+        "@uipath/button",
+        "@uipath/card",
+        "@uipath/chart",
+        "@uipath/data-table",
+        "@uipath/dialog",
+        "@uipath/empty",
+        "@uipath/page-header",
+        "@uipath/skeleton",
+        "@uipath/sonner",
+        "@uipath/spinner",
+        "@uipath/switch",
+        "@uipath/table",
+        "@uipath/tabs",
+        "@uipath/tooltip"
+      ],
+      "files": [
+        {
+          "path": "registry/solution-tests/index.ts",
+          "type": "registry:ui",
+          "target": "components/ui/solution-tests/index.ts"
+        },
+        {
+          "path": "registry/solution-tests/solution-tests-view.tsx",
+          "type": "registry:ui",
+          "target": "components/ui/solution-tests/solution-tests-view.tsx"
+        },
+        {
+          "path": "registry/solution-tests/solution-tests.tsx",
+          "type": "registry:ui",
+          "target": "components/ui/solution-tests/solution-tests.tsx"
+        },
+        {
+          "path": "registry/solution-tests/context.tsx",
+          "type": "registry:ui",
+          "target": "components/ui/solution-tests/context.tsx"
+        },
+        {
+          "path": "registry/solution-tests/hooks.ts",
+          "type": "registry:ui",
+          "target": "components/ui/solution-tests/hooks.ts"
+        },
+        {
+          "path": "registry/solution-tests/constants.ts",
+          "type": "registry:ui",
+          "target": "components/ui/solution-tests/constants.ts"
+        },
+        {
+          "path": "registry/solution-tests/mutations.ts",
+          "type": "registry:ui",
+          "target": "components/ui/solution-tests/mutations.ts"
+        },
+        {
+          "path": "registry/solution-tests/attachments.ts",
+          "type": "registry:ui",
+          "target": "components/ui/solution-tests/attachments.ts"
+        },
+        {
+          "path": "registry/solution-tests/actions.ts",
+          "type": "registry:ui",
+          "target": "components/ui/solution-tests/actions.ts"
+        },
+        {
+          "path": "registry/solution-tests/create-actions.ts",
+          "type": "registry:ui",
+          "target": "components/ui/solution-tests/create-actions.ts"
+        },
+        {
+          "path": "registry/solution-tests/use-solution-tests.ts",
+          "type": "registry:ui",
+          "target": "components/ui/solution-tests/use-solution-tests.ts"
+        },
+        {
+          "path": "registry/solution-tests/use-solution-test-collection.ts",
+          "type": "registry:ui",
+          "target": "components/ui/solution-tests/use-solution-test-collection.ts"
+        },
+        {
+          "path": "registry/solution-tests/use-solution-test-batch-runs.ts",
+          "type": "registry:ui",
+          "target": "components/ui/solution-tests/use-solution-test-batch-runs.ts"
+        },
+        {
+          "path": "registry/solution-tests/use-solution-test-runs.ts",
+          "type": "registry:ui",
+          "target": "components/ui/solution-tests/use-solution-test-runs.ts"
+        },
+        {
+          "path": "registry/solution-tests/use-baseline-jobs.ts",
+          "type": "registry:ui",
+          "target": "components/ui/solution-tests/use-baseline-jobs.ts"
+        },
+        {
+          "path": "registry/solution-tests/use-run-results.ts",
+          "type": "registry:ui",
+          "target": "components/ui/solution-tests/use-run-results.ts"
+        },
+        {
+          "path": "registry/solution-tests/use-force-stop.ts",
+          "type": "registry:ui",
+          "target": "components/ui/solution-tests/use-force-stop.ts"
+        },
+        {
+          "path": "registry/solution-tests/config.ts",
+          "type": "registry:ui",
+          "target": "components/ui/solution-tests/config.ts"
+        },
+        {
+          "path": "registry/solution-tests/types.ts",
+          "type": "registry:ui",
+          "target": "components/ui/solution-tests/types.ts"
+        },
+        {
+          "path": "registry/solution-tests/tabs.ts",
+          "type": "registry:ui",
+          "target": "components/ui/solution-tests/tabs.ts"
+        },
+        {
+          "path": "registry/solution-tests/status-maps.ts",
+          "type": "registry:ui",
+          "target": "components/ui/solution-tests/status-maps.ts"
+        },
+        {
+          "path": "registry/solution-tests/utils.ts",
+          "type": "registry:ui",
+          "target": "components/ui/solution-tests/utils.ts"
+        },
+        { "path": "lib/renderValueOrEmptyState.ts", "type": "registry:lib" },
+        { "path": "lib/constants.ts", "type": "registry:lib" },
+        {
+          "path": "registry/solution-tests/user-messages.ts",
+          "type": "registry:ui",
+          "target": "components/ui/solution-tests/user-messages.ts"
+        },
+        {
+          "path": "registry/solution-tests/user-messages-view.tsx",
+          "type": "registry:ui",
+          "target": "components/ui/solution-tests/user-messages-view.tsx"
+        },
+        {
+          "path": "registry/solution-tests/json-viewer-dialog.tsx",
+          "type": "registry:ui",
+          "target": "components/ui/solution-tests/json-viewer-dialog.tsx"
+        },
+        {
+          "path": "registry/solution-tests/delete-confirm-dialog.tsx",
+          "type": "registry:ui",
+          "target": "components/ui/solution-tests/delete-confirm-dialog.tsx"
+        },
+        {
+          "path": "registry/solution-tests/evaluator-results-view.tsx",
+          "type": "registry:ui",
+          "target": "components/ui/solution-tests/evaluator-results-view.tsx"
+        },
+        {
+          "path": "registry/solution-tests/kpi-bar.tsx",
+          "type": "registry:ui",
+          "target": "components/ui/solution-tests/kpi-bar.tsx"
+        },
+        {
+          "path": "registry/solution-tests/expanded-agents.tsx",
+          "type": "registry:ui",
+          "target": "components/ui/solution-tests/expanded-agents.tsx"
+        },
+        {
+          "path": "registry/solution-tests/expanded-agents-view.tsx",
+          "type": "registry:ui",
+          "target": "components/ui/solution-tests/expanded-agents-view.tsx"
+        },
+        {
+          "path": "registry/solution-tests/result-expanded-content.tsx",
+          "type": "registry:ui",
+          "target": "components/ui/solution-tests/result-expanded-content.tsx"
+        },
+        {
+          "path": "registry/solution-tests/run-confirm-dialog.tsx",
+          "type": "registry:ui",
+          "target": "components/ui/solution-tests/run-confirm-dialog.tsx"
+        },
+        {
+          "path": "registry/solution-tests/run-details-dialog.tsx",
+          "type": "registry:ui",
+          "target": "components/ui/solution-tests/run-details-dialog.tsx"
+        },
+        {
+          "path": "registry/solution-tests/run-details-dialog-view.tsx",
+          "type": "registry:ui",
+          "target": "components/ui/solution-tests/run-details-dialog-view.tsx"
+        },
+        {
+          "path": "registry/solution-tests/expanded-run-tests.tsx",
+          "type": "registry:ui",
+          "target": "components/ui/solution-tests/expanded-run-tests.tsx"
+        },
+        {
+          "path": "registry/solution-tests/expanded-run-tests-view.tsx",
+          "type": "registry:ui",
+          "target": "components/ui/solution-tests/expanded-run-tests-view.tsx"
+        }
+      ]
     }
   ]
 }

--- a/apps/apollo-vertex/registry/ai-glow/ai-glow.tsx
+++ b/apps/apollo-vertex/registry/ai-glow/ai-glow.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import { cva, type VariantProps } from "class-variance-authority";
+import { useId } from "react";
+import { cn } from "@/lib/utils";
+
+// Organic blob for the group glow. The shape is mirrored (fuller lobe on the
+// right) via a clip path, while the gradient lives in the unflipped root space
+// so it always runs violet (left) to teal (right).
+const GROUP_BLOB =
+  "M124.909 87.7963L40.0002 119.001L40.0471 121.245L88.6762 130.906C132.72 132.472 223.153 135.555 232.53 135.359C244.251 135.113 315.666 133.619 447.602 128.917C579.537 124.214 504.087 109.289 446.803 90.7685C428.089 88.9151 405.086 89.6999 383 82.3956C360.914 75.0913 357.352 70.9186 338.481 61.6054C319.611 52.2922 308.392 55.8035 286.366 51.4103C264.341 47.0172 245.606 44.1934 181.911 40.9756C118.215 37.7579 138.966 43.5125 129.849 43.7033C122.556 43.8559 113.044 50.082 109.2 53.176L124.454 66.084L124.909 87.7963Z";
+
+const aiGlowVariants = cva("pointer-events-none absolute", {
+  variants: {
+    variant: {
+      // Soft oblong blob behind a single card.
+      card: "-inset-x-4 -inset-y-3 opacity-70 blur-xl dark:opacity-60",
+      // Wider amorphous wash behind a group of cards; bleeds past the edges.
+      group: "-inset-y-14 -left-40 -right-44",
+    },
+  },
+  defaultVariants: {
+    variant: "card",
+  },
+});
+
+interface AiGlowProps
+  extends React.ComponentProps<"div">,
+    VariantProps<typeof aiGlowVariants> {}
+
+/**
+ * A decorative AI glow that sits behind a card or a group of cards. Render it as
+ * the first child of a `relative` parent, with the content layered above it in a
+ * `relative` wrapper:
+ *
+ * ```tsx
+ * <div className="relative">
+ *   <AiGlow />
+ *   <div className="relative">{card}</div>
+ * </div>
+ * ```
+ *
+ * The `card` variant is a blurred gradient blob; the `group` variant is a wider,
+ * organic SVG wash. The element is `aria-hidden` and ignores pointer events.
+ */
+function AiGlow({ variant = "card", className, style, ...props }: AiGlowProps) {
+  const blurId = useId();
+  const gradientId = useId();
+  const clipId = useId();
+
+  if (variant === "group") {
+    return (
+      <div
+        data-slot="ai-glow"
+        data-variant="group"
+        aria-hidden="true"
+        className={cn(aiGlowVariants({ variant }), className)}
+        style={{ transform: "rotate(-6deg)", ...style }}
+        {...props}
+      >
+        <svg
+          viewBox="0 0 561 176"
+          preserveAspectRatio="none"
+          className="h-full w-full overflow-visible dark:opacity-60"
+          aria-hidden="true"
+        >
+          <defs>
+            <filter id={blurId} x="-60%" y="-120%" width="220%" height="340%">
+              <feGaussianBlur stdDeviation="20" />
+            </filter>
+            <linearGradient
+              id={gradientId}
+              gradientUnits="userSpaceOnUse"
+              x1="40"
+              y1="88"
+              x2="520"
+              y2="88"
+            >
+              <stop stopColor="var(--ai-glow-start)" stopOpacity="1" />
+              <stop
+                offset="1"
+                stopColor="var(--ai-glow-end)"
+                stopOpacity="0.25"
+              />
+            </linearGradient>
+            <clipPath id={clipId}>
+              <path transform="translate(561 0) scale(-1 1)" d={GROUP_BLOB} />
+            </clipPath>
+          </defs>
+          <g filter={`url(#${blurId})`}>
+            <rect
+              width="561"
+              height="176"
+              fill={`url(#${gradientId})`}
+              fillOpacity="1"
+              clipPath={`url(#${clipId})`}
+            />
+          </g>
+        </svg>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      data-slot="ai-glow"
+      data-variant="card"
+      aria-hidden="true"
+      className={cn(aiGlowVariants({ variant }), className)}
+      style={{
+        backgroundImage:
+          "linear-gradient(120deg, var(--ai-glow-start), var(--ai-glow-end))",
+        borderRadius: "40% 60% 38% 62% / 42% 58% 42% 58%",
+        transform: "rotate(-4deg)",
+        ...style,
+      }}
+      {...props}
+    />
+  );
+}
+
+export { AiGlow, aiGlowVariants };
+export type { AiGlowProps };

--- a/apps/apollo-vertex/registry/ai-mark/ai-mark.tsx
+++ b/apps/apollo-vertex/registry/ai-mark/ai-mark.tsx
@@ -1,0 +1,28 @@
+interface AiMarkProps {
+  size?: number;
+  className?: string;
+  /** Paint with this gradient def id (e.g. "ai-mark-gradient") instead of currentColor. */
+  gradientId?: string;
+}
+
+/**
+ * The AI mark: a filled four-pointed star (Lucide's `astroid`, v1.12.0, inlined
+ * because the installed lucide-react predates it). Paints with currentColor by
+ * default, or a gradient via `gradientId` referencing an SVG <linearGradient> def.
+ */
+export function AiMark({ size = 24, className, gradientId }: AiMarkProps) {
+  const fill = gradientId ? `url(#${gradientId})` : "currentColor";
+
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill={fill}
+      className={className}
+      aria-hidden="true"
+    >
+      <path d="M12.983 21.186a1 1 0 0 1-1.966 0 10 10 0 0 0-8.203-8.203 1 1 0 0 1 0-1.966 10 10 0 0 0 8.203-8.203 1 1 0 0 1 1.966 0 10 10 0 0 0 8.203 8.203 1 1 0 0 1 0 1.966 10 10 0 0 0-8.203 8.203" />
+    </svg>
+  );
+}


### PR DESCRIPTION
## Summary

Two shared building blocks for the AI visual expression, used by the per-component AI PRs and the AI Toolkit page.

- **AiMark** (`registry/ai-mark/ai-mark.tsx`): the filled astroid mark (currentColor, or a gradient via `gradientId`).
- **AiGlow** (`registry/ai-glow/ai-glow.tsx`): a decorative card/group glow on the theme-aware `--ai-glow-*` tokens (Insight to Primary).

## Dependencies

Stacked on **#844 (Foundation)** for the AI tokens. Base retargets to `main` after #844 merges.

## Open decision for the dev team

Both primitives are intentionally not registered in `registry.json` and have no `@/components/ui/*` alias yet (imported via `@/registry/...`). Their canonical home is deferred. Wire the registry entry and alias once decided.

## Part of a set

One of a set splitting the AI visual expression work (originally draft #840). Full set linked below.

### The full set

Merge order (each stacked PR retargets to `main` once its base merges):

1. #844 Foundation: AI tokens + Insight ramp + colors page, base `main` (ROOT)
2. #843 AI primitives (AiMark + AiGlow), base #844
3. #845 Badge AI variant, base #843
4. #846 Button AI variants, base #843
5. #847 Input AI variant, base #843
6. #848 Card AI glow, base #843
7. #840 AI Toolkit guidance page, base #845
