### PR TITLE
feat(apollo-vertex): add Badge AI variant

### DIFF
--- a/apps/apollo-vertex/app/components/badge/page.mdx
+++ b/apps/apollo-vertex/app/components/badge/page.mdx
@@ -1,4 +1,5 @@
 import { Badge } from '@/registry/badge/badge'
+import { AiMark } from '@/registry/ai-mark/ai-mark'
 import { AlertTriangle, CircleAlert, Check } from 'lucide-react'
 
 # Badge
@@ -53,6 +54,16 @@ Badges combine a `variant` appearance (primary, secondary, or outline). Icons ar
   <Badge status="success" variant="outline"><Check strokeWidth={2} /> Outline</Badge>
 </div>
 
+### AI
+
+The `ai` status marks AI-generated or AI-suggested content, reusing the default, secondary, and outline variants. Pair it with the AI mark. See the [AI Toolkit](/guidelines/ai-toolkit) for when and how to use the AI expression.
+
+<div className="p-4 border rounded-lg mt-4 flex flex-wrap gap-2">
+  <Badge status="ai"><AiMark /> Picked for you</Badge>
+  <Badge status="ai" variant="secondary"><AiMark /> AI suggested</Badge>
+  <Badge status="ai" variant="outline"><AiMark /> AI generated</Badge>
+</div>
+
 ## Installation
 
 ```bash
@@ -79,4 +90,7 @@ import { Badge } from "@/components/ui/badge"
 
 // With icons (consumer-provided)
 <Badge status="info"><Info /> Ready</Badge>
+
+// AI status — pair with the AI mark
+<Badge status="ai"><AiMark /> Picked for you</Badge>
 ```

--- a/apps/apollo-vertex/registry/badge/badge.tsx
+++ b/apps/apollo-vertex/registry/badge/badge.tsx
@@ -23,6 +23,7 @@ const badgeVariants = cva(
         warning: "",
         success: "",
         error: "",
+        ai: "",
       },
     },
     compoundVariants: [
@@ -98,6 +99,26 @@ const badgeVariants = cva(
         variant: "outline",
         class:
           "border-destructive text-destructive dark:text-destructive bg-transparent",
+      },
+
+      // ai status
+      {
+        status: "ai",
+        variant: "default",
+        class:
+          "border-transparent text-white [background-image:var(--ai-gradient-fill)]",
+      },
+      {
+        status: "ai",
+        variant: "secondary",
+        class:
+          "border-transparent text-foreground dark:text-foreground [background-image:var(--ai-gradient)]",
+      },
+      {
+        status: "ai",
+        variant: "outline",
+        class:
+          "border-transparent text-insight-600 dark:text-insight-400 [background-image:linear-gradient(var(--background),var(--background)),var(--ai-gradient-strong)] [background-origin:border-box] [background-clip:padding-box,border-box]",
       },
     ],
     defaultVariants: {


### PR DESCRIPTION
## Summary

Adds a first-class **AI variant** to Badge via a new `status="ai"` axis, with solid, soft, and outline treatments (combined with `variant="default" | "secondary" | "outline"`).

- `registry/badge/badge.tsx`: `status="ai"` compound variants using `--ai-gradient-fill` (solid, white text, AA), `--ai-gradient` (soft tint), and an `--ai-gradient-strong` gradient border with `text-insight-600/400`.
- `app/components/badge/page.mdx`: an "AI" section documenting the three treatments (with the AiMark) and a link to the AI Toolkit.

## Dependencies

Stacked on **#843 (AI primitives)** for `AiMark`, used in the doc examples. Base will retarget to `main` after #843 merges.

## Part of a set

One of a set splitting the AI visual expression work (originally draft #840). Full set linked below.

### The full set

Merge order (each stacked PR retargets to `main` once its base merges):

1. #844 Foundation: AI tokens + Insight ramp + colors page, base `main` (ROOT)
2. #843 AI primitives (AiMark + AiGlow), base #844
3. #845 Badge AI variant, base #843
4. #846 Button AI variants, base #843
5. #847 Input AI variant, base #843
6. #848 Card AI glow, base #843
7. #840 AI Toolkit guidance page, base #845
