### PR TITLE
feat(apollo-vertex): add Button AI variants

### DIFF
--- a/apps/apollo-vertex/app/components/button/page.mdx
+++ b/apps/apollo-vertex/app/components/button/page.mdx
@@ -1,4 +1,5 @@
 import { Button } from '@/registry/button/button'
+import { AiMark } from '@/registry/ai-mark/ai-mark'
 import { Mail, Loader2, ChevronRight } from 'lucide-react'
 
 # Button
@@ -37,6 +38,16 @@ Displays a button or a component that looks like a button.
   <Button disabled><Loader2 className="mr-2 h-4 w-4 animate-spin" /> Please wait</Button>
 </div>
 
+## AI
+
+The `ai` (solid), `ai-soft` (secondary-equivalent), and `ai-outline` variants apply the AI expression for AI-initiated actions. Pair with the AI mark. See the [AI Toolkit](/guidelines/ai-toolkit) for guidance.
+
+<div className="p-4 border rounded-lg mt-4 flex flex-wrap gap-2">
+  <Button variant="ai"><AiMark /> Ask AI</Button>
+  <Button variant="ai-soft"><AiMark /> Summarize</Button>
+  <Button variant="ai-outline"><AiMark /> Draft with AI</Button>
+</div>
+
 ## Installation
 
 ```bash
@@ -51,4 +62,9 @@ import { Button } from "@/components/ui/button"
 
 ```tsx
 <Button variant="outline">Button</Button>
+
+// AI variants — pair with the AI mark
+<Button variant="ai"><AiMark /> Ask AI</Button>
+<Button variant="ai-soft"><AiMark /> Summarize</Button>
+<Button variant="ai-outline"><AiMark /> Draft with AI</Button>
 ```

--- a/apps/apollo-vertex/registry/button/button.tsx
+++ b/apps/apollo-vertex/registry/button/button.tsx
@@ -26,6 +26,11 @@ const buttonVariants = cva(
         info: "bg-info text-white hover:bg-info/90 focus-visible:ring-info/20 dark:focus-visible:ring-info/40 dark:bg-info/60",
         warning:
           "bg-warning text-white hover:bg-warning/90 focus-visible:ring-warning/20 dark:focus-visible:ring-warning/40 dark:bg-warning/60",
+        ai: "text-white hover:opacity-90 [background-image:var(--ai-gradient-fill)]",
+        "ai-soft":
+          "text-foreground hover:opacity-90 [background-image:var(--ai-gradient)]",
+        "ai-outline":
+          "border border-transparent text-insight-600 dark:text-insight-400 hover:opacity-90 [background-image:linear-gradient(var(--background),var(--background)),var(--ai-gradient-strong)] [background-origin:border-box] [background-clip:padding-box,border-box]",
       },
       size: {
         default: "h-9 px-4 py-2 has-[>svg]:px-3",


### PR DESCRIPTION
## Summary

Adds first-class **AI variants** to Button: `ai` (solid), `ai-soft` (secondary-equivalent), and `ai-outline`.

- `registry/button/button.tsx`: `ai` uses `--ai-gradient-fill` (white text, AA), `ai-soft` uses `--ai-gradient` (foreground text), `ai-outline` uses an `--ai-gradient-strong` gradient border with `text-insight-600/400`.
- `app/components/button/page.mdx`: an "AI" section documenting the three variants (with the AiMark) and a link to the AI Toolkit.

## Dependencies

Stacked on **#843 (AI primitives)** for `AiMark`, used in the doc examples. Base will retarget to `main` after #843 merges.

## Part of a set

One of a set splitting the AI visual expression work (originally draft #840). Full set linked below.

### The full set

Merge order (each stacked PR retargets to `main` once its base merges):

1. #844 Foundation: AI tokens + Insight ramp + colors page, base `main` (ROOT)
2. #843 AI primitives (AiMark + AiGlow), base #844
3. #845 Badge AI variant, base #843
4. #846 Button AI variants, base #843
5. #847 Input AI variant, base #843
6. #848 Card AI glow, base #843
7. #840 AI Toolkit guidance page, base #845
