### PR TITLE
feat(apollo-vertex): add Input AI variant

### DIFF
--- a/apps/apollo-vertex/app/components/input/ai-input-demo.tsx
+++ b/apps/apollo-vertex/app/components/input/ai-input-demo.tsx
@@ -1,0 +1,69 @@
+import { Field, FieldLabel } from "@/components/ui/field";
+import { Input } from "@/components/ui/input";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { AiMark } from "@/registry/ai-mark/ai-mark";
+
+/**
+ * AI input as a composition (not an Input prop): the base Input inside a wrapper
+ * that owns the box + focus ring, with a subtle gradient inset glow shining in
+ * from the right and the AI mark (tooltip on hover) at an equal inset from the
+ * top, bottom, and right. overflow-hidden clips the glow to the rounded shape;
+ * the focus ring lives on the wrapper so it isn't clipped.
+ */
+export function AiInputDemo() {
+  return (
+    <Field className="max-w-sm">
+      <FieldLabel htmlFor="ai-input-demo">Job responsibility</FieldLabel>
+      <div className="relative overflow-hidden rounded-lg border border-input bg-background transition-[color,box-shadow] focus-within:border-ring focus-within:ring-[3px] focus-within:ring-ring/50 dark:bg-input/30">
+        {/* Gradient definition for the mark. */}
+        <svg width={0} height={0} aria-hidden="true" className="absolute">
+          <defs>
+            <linearGradient
+              id="ai-input-demo-mark"
+              x1="2"
+              y1="4"
+              x2="22"
+              y2="20"
+              gradientUnits="userSpaceOnUse"
+            >
+              <stop offset="0" stopColor="var(--ai-gradient-start)" />
+              <stop offset="1" stopColor="var(--ai-gradient-end)" />
+            </linearGradient>
+          </defs>
+        </svg>
+        {/* Subtle gradient inset glow: even purple-to-teal blend, angled down. */}
+        <div
+          aria-hidden="true"
+          className="pointer-events-none absolute top-1/2 right-0 h-20 w-14 -translate-y-[40%] translate-x-1/4 blur-xl"
+          style={{
+            background:
+              "linear-gradient(160deg, var(--ai-glow-start), var(--ai-glow-end))",
+            borderRadius: "40% 60% 38% 62% / 42% 58% 42% 58%",
+          }}
+        />
+        <Input
+          id="ai-input-demo"
+          placeholder="Add job responsibility"
+          className="relative border-0 bg-transparent pr-9 shadow-none focus-visible:ring-0 dark:bg-transparent"
+        />
+        {/* AI mark: equal inset from top, bottom, and right; tooltip on hover. */}
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              aria-label="AI Input"
+              className="absolute top-1/2 right-2.5 -translate-y-1/2 rounded-sm outline-none"
+            >
+              <AiMark gradientId="ai-input-demo-mark" className="size-4" />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent>AI Input</TooltipContent>
+        </Tooltip>
+      </div>
+    </Field>
+  );
+}

--- a/apps/apollo-vertex/app/components/input/page.mdx
+++ b/apps/apollo-vertex/app/components/input/page.mdx
@@ -1,6 +1,7 @@
 import { Input } from '@/registry/input/input'
 import { Label } from '@/registry/label/label'
 import { Button } from '@/registry/button/button'
+import { AiInputDemo } from './ai-input-demo'
 
 # Input
 
@@ -32,6 +33,14 @@ Displays a form input field or a component that looks like an input field.
     <Input type="email" placeholder="Email" />
     <Button type="submit">Subscribe</Button>
   </div>
+</div>
+
+## AI variant
+
+The AI input is a **composition**, not a base Input prop: the standard Input sits inside a wrapper that adds a subtle gradient inset glow and the AI mark (with a tooltip). The wrapper owns the box and focus ring so `overflow-hidden` can clip the glow without clipping the ring. See the [AI Toolkit](/guidelines/ai-toolkit) for the pattern and guidance.
+
+<div className="p-4 border rounded-lg mt-4">
+  <AiInputDemo />
 </div>
 
 ## Installation


### PR DESCRIPTION
## Summary

Documents an **AI variant of Input** as a composition pattern (no new Input prop): a wrapper with a subtle inset glow, the AiMark, and a tooltip around the base `Input`.

- `app/components/input/ai-input-demo.tsx`: the composition demo (inset `--ai-glow-*` glow + AiMark in a tooltip trigger).
- `app/components/input/page.mdx`: an "AI variant" section explaining the composition, with a link to the AI Toolkit.

## Dependencies

Stacked on **#843 (AI primitives)** for `AiMark`, used in the demo. Base will retarget to `main` after #843 merges.

## Part of a set

One of a set splitting the AI visual expression work (originally draft #840). Full set linked below.

### The full set

Merge order (each stacked PR retargets to `main` once its base merges):

1. #844 Foundation: AI tokens + Insight ramp + colors page, base `main` (ROOT)
2. #843 AI primitives (AiMark + AiGlow), base #844
3. #845 Badge AI variant, base #843
4. #846 Button AI variants, base #843
5. #847 Input AI variant, base #843
6. #848 Card AI glow, base #843
7. #840 AI Toolkit guidance page, base #845
