### PR TITLE
feat(apollo-vertex): document Card AI glow

### DIFF
--- a/apps/apollo-vertex/app/components/card/ai-glow-demo.tsx
+++ b/apps/apollo-vertex/app/components/card/ai-glow-demo.tsx
@@ -1,0 +1,64 @@
+import { AiGlow } from "@/registry/ai-glow/ai-glow";
+import {
+  Card,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/registry/card/card";
+
+/** A single card lifted off the surface by the `card` glow. */
+export function AiGlowCardDemo() {
+  return (
+    <div className="relative w-full max-w-sm">
+      <AiGlow />
+      <div className="relative">
+        <Card
+          variant="glass"
+          className="bg-[var(--ai-glass)] dark:bg-[var(--ai-glass)]"
+        >
+          <CardHeader>
+            <CardTitle>Recommended plan</CardTitle>
+            <CardDescription>
+              The glow marks this as the AI pick without a border or a solid
+              color block.
+            </CardDescription>
+          </CardHeader>
+        </Card>
+      </div>
+    </div>
+  );
+}
+
+const ITEMS = [
+  {
+    title: "Consolidate duplicate vendors",
+    description: "Merge three records into one to clean up reporting.",
+  },
+  {
+    title: "Renegotiate the storage tier",
+    description: "Usage has been under 40% for two quarters.",
+  },
+];
+
+/** A group of cards sharing one wash from the `group` glow. */
+export function AiGlowGroupDemo() {
+  return (
+    <div className="relative w-full max-w-2xl">
+      <AiGlow variant="group" />
+      <div className="relative grid gap-4 sm:grid-cols-2">
+        {ITEMS.map((item) => (
+          <Card
+            key={item.title}
+            variant="glass"
+            className="bg-[var(--ai-glass)] dark:bg-[var(--ai-glass)]"
+          >
+            <CardHeader>
+              <CardTitle>{item.title}</CardTitle>
+              <CardDescription>{item.description}</CardDescription>
+            </CardHeader>
+          </Card>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/apollo-vertex/app/components/card/page.mdx
+++ b/apps/apollo-vertex/app/components/card/page.mdx
@@ -3,6 +3,7 @@ import { Button } from '@/registry/button/button'
 import { Input } from '@/registry/input/input'
 import { Label } from '@/registry/label/label'
 import { SelectableCardDemo } from './selectable-card-demo'
+import { AiGlowCardDemo, AiGlowGroupDemo } from './ai-glow-demo'
 
 # Card
 
@@ -75,7 +76,7 @@ Use `variant="solid"` for a flat card with a solid background and border.
 
 ## Selectable
 
-Cards can be made selectable with `selectable="standard"` or `selectable="ai"`. Selectable cards render as a `<button>` with `aria-pressed` for accessibility. They show a glow effect on hover and when selected.
+Cards can be made selectable with `selectable="standard"` or `selectable="ai"`. Selectable cards render as a `<button>` with `aria-pressed` for accessibility. They show a glow effect on hover and when selected. The `ai` glow uses the AI gradient; see the [AI Toolkit](/guidelines/ai-toolkit) for guidance and richer AI card compositions.
 
 <div className="mt-4">
   <SelectableCardDemo />
@@ -91,6 +92,51 @@ Cards can be made selectable with `selectable="standard"` or `selectable="ai"`. 
   <CardTitle>AI Mode</CardTitle>
   <CardDescription>Uses an AI gradient glow when selected.</CardDescription>
 </Card>
+```
+
+## AI glow
+
+A glow, an AI gradient shadow, can sit behind a card or a group of cards to mark it as AI without a border or a solid fill. It is a composition rather than a Card prop: render the `AiGlow` primitive as the first child of a `relative` parent, then layer the content above it in its own `relative` wrapper. The glow is decorative, so it is `aria-hidden` and ignores pointer events. For when to reach for a glow, see the [AI Toolkit](/guidelines/ai-toolkit).
+
+Give the card the translucent AI glass surface (`variant="glass"` with `bg-[var(--ai-glass)]`) so the colored glow reads through it instead of sitting behind an opaque fill.
+
+### Behind a single card
+
+The `card` variant is a soft blurred blob. Pair it with a label so the emphasis is explained, and limit it to one best match per view.
+
+<div className="flex justify-center p-8 rounded-lg mt-4 border">
+  <AiGlowCardDemo />
+</div>
+
+```tsx
+<div className="relative">
+  <AiGlow />
+  <div className="relative">
+    <Card variant="glass" className="bg-[var(--ai-glass)] dark:bg-[var(--ai-glass)]">
+      {/* ... */}
+    </Card>
+  </div>
+</div>
+```
+
+### Behind a card group
+
+The `group` variant is a wider, amorphous wash. Set the AI context once at the group level instead of marking every card, so the mark keeps its meaning.
+
+<div className="p-8 rounded-lg mt-4 border overflow-hidden">
+  <AiGlowGroupDemo />
+</div>
+
+```tsx
+<div className="relative">
+  <AiGlow variant="group" />
+  <div className="relative grid gap-4 sm:grid-cols-2">
+    <Card variant="glass" className="bg-[var(--ai-glass)] dark:bg-[var(--ai-glass)]">
+      {/* ... */}
+    </Card>
+    {/* ...more cards */}
+  </div>
+</div>
 ```
 
 ## Installation

--- a/apps/apollo-vertex/registry/card/card.tsx
+++ b/apps/apollo-vertex/registry/card/card.tsx
@@ -66,7 +66,7 @@ function Card({
         ) : (
           <div
             className={cn(
-              "absolute inset-0 rounded-2xl pointer-events-none blur-xl bg-primary-400/15 dark:bg-primary-400/30",
+              "absolute inset-0 rounded-2xl pointer-events-none blur-xl bg-primary-400/15 dark:bg-primary-400/20",
               "transition-opacity duration-150",
               selected ? "opacity-100" : "opacity-0",
             )}
@@ -76,7 +76,7 @@ function Card({
         {/* Hover glow: always primary */}
         <div
           className={cn(
-            "absolute inset-0 rounded-2xl pointer-events-none blur-xl bg-primary-400/15 dark:bg-primary-400/50",
+            "absolute inset-0 rounded-2xl pointer-events-none blur-xl bg-primary-400/15 dark:bg-primary-400/20",
             "opacity-0 transition-opacity duration-150",
             !selected && "group-hover/card:opacity-100",
           )}


### PR DESCRIPTION
## Summary

Documents the **AI glow** behind cards and card groups, and softens the selectable glow.

- `app/components/card/page.mdx`: a new "AI glow" section showing the single-card and group recipes (compose `<AiGlow>` behind a `relative` parent with a translucent `--ai-glass` card on top so the glow reads through), with a link to the AI Toolkit.
- `app/components/card/ai-glow-demo.tsx`: the single-card and group glow demos.
- `registry/card/card.tsx`: soften the selectable glow opacity in dark mode (`/30`, `/50` → `/20`).

## Dependencies

Stacked on **#843 (AI primitives)** for `AiGlow`, used in the demos. Base will retarget to `main` after #843 merges.

## Part of a set

One of a set splitting the AI visual expression work (originally draft #840). Full set linked below.

### The full set

Merge order (each stacked PR retargets to `main` once its base merges):

1. #844 Foundation: AI tokens + Insight ramp + colors page, base `main` (ROOT)
2. #843 AI primitives (AiMark + AiGlow), base #844
3. #845 Badge AI variant, base #843
4. #846 Button AI variants, base #843
5. #847 Input AI variant, base #843
6. #848 Card AI glow, base #843
7. #840 AI Toolkit guidance page, base #845
