### PR TITLE
Solution Tests: typed live-query hooks, delete loading state, refetch, toasts [AGVSOL-3355]

### DIFF
--- a/apps/apollo-vertex/registry/solution-tests/expanded-run-tests.tsx
+++ b/apps/apollo-vertex/registry/solution-tests/expanded-run-tests.tsx
@@ -38,6 +38,7 @@ export const ExpandedRunTests = ({ runs, tests }: ExpandedRunTestsProps) => {
       onOpenDetails={(run, subjectId) => setDetailsTarget({ run, subjectId })}
       onForceStop={(runId) =>
         forceStopRun.mutate(runId, {
+          onSuccess: () => toast.success(t("force_stop_initiated")),
           onError: () => toast.error(t("failed_to_force_stop_run")),
         })
       }

--- a/apps/apollo-vertex/registry/solution-tests/solution-tests.tsx
+++ b/apps/apollo-vertex/registry/solution-tests/solution-tests.tsx
@@ -137,11 +137,13 @@ export const SolutionTests = () => {
       }
       onDeleteTest={(testId) => {
         deleteTest.mutate(testId, {
-          onSuccess: () => toast.success(t("test_deleted")),
+          onSuccess: () => {
+            toast.success(t("test_deleted"));
+            setDeleteConfirmId(null);
+          },
           onError: (err) =>
             toast.error(err.message || t("failed_to_delete_test")),
         });
-        setDeleteConfirmId(null);
       }}
       onForceStopBatch={(batchId) =>
         forceStopBatch.mutate(batchId, {

--- a/apps/apollo-vertex/registry/solution-tests/solution-tests.tsx
+++ b/apps/apollo-vertex/registry/solution-tests/solution-tests.tsx
@@ -147,6 +147,7 @@ export const SolutionTests = () => {
       }}
       onForceStopBatch={(batchId) =>
         forceStopBatch.mutate(batchId, {
+          onSuccess: () => toast.success(t("force_stop_initiated")),
           onError: (err) =>
             toast.error(err.message || t("failed_to_force_stop_batch")),
         })

--- a/apps/apollo-vertex/registry/solution-tests/use-baseline-jobs.ts
+++ b/apps/apollo-vertex/registry/solution-tests/use-baseline-jobs.ts
@@ -26,7 +26,10 @@ export interface UseBaselineJobsResult {
 /** Live baseline jobs for a test. */
 export function useBaselineJobs(testId: string): UseBaselineJobsResult {
   const collection = useSolutionTestCollection(ENTITY.jobs);
-  const { data, isLoading } = useLiveQuery(() => collection, [collection]);
+  const { data, isLoading } = useLiveQuery(
+    (q) => q.from({ jobs: collection }),
+    [collection],
+  );
   const jobs = (data ?? []).filter(
     (job) => job.SolutionTestId === testId && job.JobRole === JobRole.Baseline,
   );

--- a/apps/apollo-vertex/registry/solution-tests/use-baseline-jobs.ts
+++ b/apps/apollo-vertex/registry/solution-tests/use-baseline-jobs.ts
@@ -39,8 +39,12 @@ export function useBaselineJobs(testId: string): UseBaselineJobsResult {
 /** Remove a job from the test's expected (baseline) results. */
 export function useRemoveJobBaseline(): MutationHook<string> {
   const actions = useSolutionTestsActions();
+  const jobsCollection = useSolutionTestCollection(ENTITY.jobs);
   return useMutation({
-    mutationFn: (baselineId: string) => actions.removeJobBaseline(baselineId),
+    mutationFn: async (baselineId: string) => {
+      await actions.removeJobBaseline(baselineId);
+      await jobsCollection.utils.refetch();
+    },
   });
 }
 

--- a/apps/apollo-vertex/registry/solution-tests/use-run-results.ts
+++ b/apps/apollo-vertex/registry/solution-tests/use-run-results.ts
@@ -48,11 +48,11 @@ export function useRunResults(runId: string): UseRunResultsResult {
   const resultsCollection = useSolutionTestCollection(ENTITY.runResults);
   const jobsCollection = useSolutionTestCollection(ENTITY.jobs);
   const { data, isReady: resultsReady } = useLiveQuery(
-    () => resultsCollection,
+    (q) => q.from({ results: resultsCollection }),
     [resultsCollection],
   );
   const { data: jobsData, isReady: jobsReady } = useLiveQuery(
-    () => jobsCollection,
+    (q) => q.from({ jobs: jobsCollection }),
     [jobsCollection],
   );
   // The role filter needs both collections. Until both are ready, stay loading

--- a/apps/apollo-vertex/registry/solution-tests/use-solution-test-batch-runs.ts
+++ b/apps/apollo-vertex/registry/solution-tests/use-solution-test-batch-runs.ts
@@ -18,6 +18,9 @@ export interface UseSolutionTestBatchRunsResult {
 /** Live list of batch runs. */
 export function useSolutionTestBatchRuns(): UseSolutionTestBatchRunsResult {
   const collection = useSolutionTestCollection(ENTITY.batchRuns);
-  const { data, isLoading } = useLiveQuery(() => collection, [collection]);
+  const { data, isLoading } = useLiveQuery(
+    (q) => q.from({ batchRuns: collection }),
+    [collection],
+  );
   return { batchRuns: data ?? [], isLoading };
 }

--- a/apps/apollo-vertex/registry/solution-tests/use-solution-test-runs.ts
+++ b/apps/apollo-vertex/registry/solution-tests/use-solution-test-runs.ts
@@ -18,6 +18,9 @@ export interface UseSolutionTestRunsResult {
 /** Live list of all runs (the view filters by batch in memory). */
 export function useSolutionTestRuns(): UseSolutionTestRunsResult {
   const collection = useSolutionTestCollection(ENTITY.runs);
-  const { data, isLoading } = useLiveQuery(() => collection, [collection]);
+  const { data, isLoading } = useLiveQuery(
+    (q) => q.from({ runs: collection }),
+    [collection],
+  );
   return { runs: data ?? [], isLoading };
 }

--- a/apps/apollo-vertex/registry/solution-tests/use-solution-tests.ts
+++ b/apps/apollo-vertex/registry/solution-tests/use-solution-tests.ts
@@ -73,7 +73,15 @@ export function useToggleTestActive(): MutationHook<{
 /** Delete a test. */
 export function useDeleteTest(): MutationHook<string> {
   const actions = useSolutionTestsActions();
+  const testsCollection = useSolutionTestCollection(ENTITY.tests);
+  const jobsCollection = useSolutionTestCollection(ENTITY.jobs);
   return useMutation({
-    mutationFn: (testId: string) => actions.deleteTest(testId),
+    mutationFn: async (testId: string) => {
+      await actions.deleteTest(testId);
+      await Promise.all([
+        testsCollection.utils.refetch(),
+        jobsCollection.utils.refetch(),
+      ]);
+    },
   });
 }

--- a/apps/apollo-vertex/registry/solution-tests/use-solution-tests.ts
+++ b/apps/apollo-vertex/registry/solution-tests/use-solution-tests.ts
@@ -23,7 +23,10 @@ export interface UseSolutionTestsResult {
 /** Live list of solution tests. */
 export function useSolutionTests(): UseSolutionTestsResult {
   const collection = useSolutionTestCollection(ENTITY.tests);
-  const { data, isLoading } = useLiveQuery(() => collection, [collection]);
+  const { data, isLoading } = useLiveQuery(
+    (q) => q.from({ tests: collection }),
+    [collection],
+  );
   return { tests: data ?? [], isLoading };
 }
 

--- a/apps/apollo-vertex/types/optional-deps.d.ts
+++ b/apps/apollo-vertex/types/optional-deps.d.ts
@@ -1,7 +1,7 @@
 declare module "@tanstack/react-db" {
   // Minimal stand-ins for @tanstack/db (re-exported by react-db). The phantom
-  // `__row` on Collection carries the row type so `useLiveQuery` can infer it;
-  // QueryResult is opaque (query-builder hooks supply their row type explicitly).
+  // `__row` carries the row type through the query builder so `useLiveQuery`
+  // infers it from a typed `q.from({...})` source.
   export interface Collection<T = unknown> {
     readonly __row?: T;
     // Optimistic, server-synced row mutation (Immer-style draft). The returned
@@ -11,21 +11,24 @@ declare module "@tanstack/react-db" {
       callback: (draft: T) => void,
     ): { isPersisted: { promise: Promise<unknown> } };
   }
-  interface QueryResult {
-    readonly __query?: true;
+  interface QueryResult<T = unknown> {
+    readonly __row?: T;
+  }
+  // Result of a source the stub can't type (e.g. the generic entity
+  // collections). It carries no row type, so the row type is supplied by an
+  // explicit `useLiveQuery` type argument instead.
+  interface UntypedQueryResult {
+    readonly __untyped?: true;
   }
   interface QueryBuilder {
-    from(source: Record<string, unknown>): QueryResult;
+    from<T>(source: Record<string, Collection<T>>): QueryResult<T>;
+    from(source: Record<string, unknown>): UntypedQueryResult;
   }
 
-  // Accepts both the direct-collection form (`() => collection`, used by the
-  // Solution Tests read hooks — row type inferred from the Collection) and the
-  // query-builder form (`(q) => q.from({...})`, used by the identity/entity
-  // hooks — row type supplied explicitly).
   export function useLiveQuery<T>(
     queryFn: (
       q: QueryBuilder,
-    ) => Collection<T> | QueryResult | undefined | null,
+    ) => Collection<T> | QueryResult<T> | UntypedQueryResult | undefined | null,
     deps?: Array<unknown>,
   ): { data: T[] | undefined; isLoading: boolean; isReady: boolean };
 }

--- a/apps/apollo-vertex/types/optional-deps.d.ts
+++ b/apps/apollo-vertex/types/optional-deps.d.ts
@@ -10,6 +10,10 @@ declare module "@tanstack/react-db" {
       id: string,
       callback: (draft: T) => void,
     ): { isPersisted: { promise: Promise<unknown> } };
+    // `utils.refetch()` re-pulls the source so the collection reflects writes
+    // made out of band (e.g. through a backend trigger rather than the
+    // collection's own mutators).
+    readonly utils: { refetch(): Promise<void> };
   }
   interface QueryResult<T = unknown> {
     readonly __row?: T;


### PR DESCRIPTION
Closes some last implementation gaps in the Solution Tests registry component.

- **Typed live-query hooks** — switch the read hooks to the inferring `q.from(...)` form so the on-demand collections sync, and rework the `@tanstack/react-db` type stub to infer row types from the source (dropping the unsafe casts and `oxlint-disable` lines).
- **Delete loading state** — keep the confirm dialog open with its spinner until the delete mutation resolves, instead of closing it immediately.
- **Refetch after backend writes** — refetch the related collections after delete-test (`tests` + `jobs`) and remove-baseline (`jobs`), since those go through a backend trigger and don't otherwise update the synced collections.
- **Force-stop success toasts** — add success toasts to the batch and run force-stop actions, which previously only toasted on error.

👨 Generated with Kluijt Code