### PR TITLE
[codex] add tab overflow navigation pattern

### DIFF
--- a/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.stories.tsx
@@ -9,6 +9,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
   MetadataForm,
+  ScrollableTabsList,
   Switch,
   Tabs,
   TabsContent,
@@ -1377,16 +1378,6 @@ function CompactResponsivePanelStory() {
   const steps = httpRequestForm.steps ?? [];
   const [activeStepId, setActiveStepId] = useState(steps[0]?.id ?? '');
 
-  const activeStep = steps.find((s) => s.id === activeStepId);
-
-  const flatSchema: FormSchema = {
-    id: httpRequestForm.id,
-    title: httpRequestForm.title,
-    mode: httpRequestForm.mode,
-    actions: [],
-    sections: activeStep?.sections ?? [],
-  };
-
   return (
     <NodePropertyPanel
       panelTitle="Properties"
@@ -1397,41 +1388,47 @@ function CompactResponsivePanelStory() {
       onClose={() => {}}
       className="h-[480px]"
     >
-      <div className="flex h-full flex-col" style={SURFACE_REMAP}>
-        <div className="shrink-0 border-b border-border-subtle px-[0.875rem] py-2">
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <button
-                type="button"
-                className="flex h-7 items-center gap-1.5 rounded-lg px-2 text-xs font-medium text-foreground transition hover:bg-surface-overlay"
-              >
-                <span>{activeStep?.title}</span>
-                <ChevronDown size={12} className="text-foreground-muted" />
-              </button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="start" className="w-44">
-              {steps.map((step) => (
-                <DropdownMenuItem
-                  key={step.id}
-                  onClick={() => setActiveStepId(step.id)}
-                  className={cn(
-                    'text-sm focus:bg-surface-overlay',
-                    step.id === activeStepId && 'bg-surface-raised font-medium'
-                  )}
-                >
-                  {step.title}
-                </DropdownMenuItem>
-              ))}
-            </DropdownMenuContent>
-          </DropdownMenu>
+      <Tabs
+        value={activeStepId}
+        onValueChange={setActiveStepId}
+        className="flex h-full min-h-0 flex-col"
+        style={SURFACE_REMAP}
+      >
+        <div className="shrink-0 pt-3 [padding-inline:0.875rem]">
+          <ScrollableTabsList
+            className={TAB_LIST_CLASS}
+            scrollButtonClassName="size-6 hover:bg-surface-overlay"
+          >
+            {steps.map((step) => (
+              <TabsTrigger key={step.id} value={step.id} className={TAB_TRIGGER_CLASS}>
+                {step.title}
+              </TabsTrigger>
+            ))}
+          </ScrollableTabsList>
         </div>
-        <div className="min-h-0 flex-1 overflow-y-auto [&_label]:text-foreground-muted">
-          <MetadataForm
-            schema={flatSchema}
-            className="flex flex-col gap-4 pb-6 pt-3 [padding-inline:0.875rem]"
-          />
-        </div>
-      </div>
+        {steps.map((step) => {
+          const flatSchema: FormSchema = {
+            id: httpRequestForm.id,
+            title: httpRequestForm.title,
+            mode: httpRequestForm.mode,
+            actions: [],
+            sections: step.sections,
+          };
+
+          return (
+            <TabsContent
+              key={step.id}
+              value={step.id}
+              className="mt-0 min-h-0 flex-1 overflow-y-auto [&_label]:text-foreground-muted"
+            >
+              <MetadataForm
+                schema={flatSchema}
+                className="flex flex-col gap-4 pb-6 pt-3 [padding-inline:0.875rem]"
+              />
+            </TabsContent>
+          );
+        })}
+      </Tabs>
     </NodePropertyPanel>
   );
 }

--- a/packages/apollo-wind/src/components/ui/tabs.stories.tsx
+++ b/packages/apollo-wind/src/components/ui/tabs.stories.tsx
@@ -5,7 +5,7 @@ import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle }
 import { Input } from './input';
 import { Label } from './label';
 import { Switch } from './switch';
-import { Tabs, TabsContent, TabsList, TabsTrigger } from './tabs';
+import { ScrollableTabsList, Tabs, TabsContent, TabsList, TabsTrigger } from './tabs';
 
 const meta: Meta<typeof Tabs> = {
   title: 'Components/Navigation/Tabs',
@@ -117,6 +117,73 @@ export const Disabled = {
         </div>
       </TabsContent>
     </Tabs>
+  ),
+};
+
+// ============================================================================
+// Overflow
+// ============================================================================
+
+const overflowTabs = [
+  { value: 'parameters', label: 'Parameters' },
+  { value: 'error-handling', label: 'Error handling' },
+  { value: 'advanced', label: 'Advanced' },
+];
+
+const OverflowTabContent = ({ value }: { value: string }) => (
+  <div className="rounded-lg border p-4">
+    <p className="text-sm capitalize">{value.replace('-', ' ')} content</p>
+  </div>
+);
+
+export const Overflow = {
+  name: 'Overflow',
+  render: () => (
+    <div className="flex flex-wrap items-start gap-10">
+      <div className="space-y-3">
+        <div>
+          <p className="text-sm font-medium">Spacious</p>
+          <p className="text-xs text-muted-foreground">All tabs fit in the available width.</p>
+        </div>
+        <Tabs defaultValue="parameters" className="w-[420px]">
+          <TabsList>
+            {overflowTabs.map((tab) => (
+              <TabsTrigger key={tab.value} value={tab.value}>
+                {tab.label}
+              </TabsTrigger>
+            ))}
+          </TabsList>
+          {overflowTabs.map((tab) => (
+            <TabsContent key={tab.value} value={tab.value}>
+              <OverflowTabContent value={tab.value} />
+            </TabsContent>
+          ))}
+        </Tabs>
+      </div>
+
+      <div className="space-y-3">
+        <div>
+          <p className="text-sm font-medium">Compact</p>
+          <p className="text-xs text-muted-foreground">
+            Scroll controls expose tabs that do not fit without changing selection.
+          </p>
+        </div>
+        <Tabs defaultValue="parameters" className="w-[280px]">
+          <ScrollableTabsList aria-label="Compact example tabs">
+            {overflowTabs.map((tab) => (
+              <TabsTrigger key={tab.value} value={tab.value}>
+                {tab.label}
+              </TabsTrigger>
+            ))}
+          </ScrollableTabsList>
+          {overflowTabs.map((tab) => (
+            <TabsContent key={tab.value} value={tab.value}>
+              <OverflowTabContent value={tab.value} />
+            </TabsContent>
+          ))}
+        </Tabs>
+      </div>
+    </div>
   ),
 };
 

--- a/packages/apollo-wind/src/components/ui/tabs.test.tsx
+++ b/packages/apollo-wind/src/components/ui/tabs.test.tsx
@@ -2,7 +2,7 @@ import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { axe } from 'jest-axe';
 import { describe, expect, it, vi } from 'vitest';
-import { Tabs, TabsContent, TabsList, TabsTrigger } from './tabs';
+import { ScrollableTabsList, Tabs, TabsContent, TabsList, TabsTrigger } from './tabs';
 
 describe('Tabs', () => {
   const TabsExample = ({
@@ -178,6 +178,151 @@ describe('Tabs', () => {
     );
 
     expect(screen.getByText('Content 2')).toBeInTheDocument();
+  });
+
+  it('shows stable scroll controls for overflowing tabs', async () => {
+    const user = userEvent.setup();
+    const scrollBy = vi.fn();
+    const scrollWidth = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'scrollWidth');
+    const clientWidth = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'clientWidth');
+    const originalScrollBy = HTMLElement.prototype.scrollBy;
+
+    Object.defineProperty(HTMLElement.prototype, 'scrollWidth', {
+      configurable: true,
+      get: () => 480,
+    });
+    Object.defineProperty(HTMLElement.prototype, 'clientWidth', {
+      configurable: true,
+      get: () => 240,
+    });
+    HTMLElement.prototype.scrollBy = scrollBy;
+
+    try {
+      render(
+        <Tabs defaultValue="tab1">
+          <ScrollableTabsList aria-label="Scrollable tabs">
+            <TabsTrigger value="tab1">Tab 1</TabsTrigger>
+            <TabsTrigger value="tab2">Tab 2</TabsTrigger>
+            <TabsTrigger value="tab3">Tab 3</TabsTrigger>
+          </ScrollableTabsList>
+          <TabsContent value="tab1">Content 1</TabsContent>
+          <TabsContent value="tab2">Content 2</TabsContent>
+          <TabsContent value="tab3">Content 3</TabsContent>
+        </Tabs>
+      );
+
+      const previousButton = await screen.findByRole('button', { name: 'Scroll tabs left' });
+      const nextButton = screen.getByRole('button', { name: 'Scroll tabs right' });
+
+      expect(previousButton).toBeDisabled();
+      expect(nextButton).toBeEnabled();
+
+      await user.click(nextButton);
+      expect(scrollBy).toHaveBeenCalledWith({ left: 240, behavior: 'smooth' });
+      expect(screen.getByRole('tab', { name: 'Tab 1' })).toHaveAttribute('aria-selected', 'true');
+    } finally {
+      if (scrollWidth) Object.defineProperty(HTMLElement.prototype, 'scrollWidth', scrollWidth);
+      else delete (HTMLElement.prototype as Partial<HTMLElement>).scrollWidth;
+      if (clientWidth) Object.defineProperty(HTMLElement.prototype, 'clientWidth', clientWidth);
+      else delete (HTMLElement.prototype as Partial<HTMLElement>).clientWidth;
+      HTMLElement.prototype.scrollBy = originalScrollBy;
+    }
+  });
+
+  it('reveals an initially active tab when it starts outside the viewport', async () => {
+    const scrollBy = vi.fn();
+    const scrollWidth = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'scrollWidth');
+    const clientWidth = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'clientWidth');
+    const originalScrollBy = HTMLElement.prototype.scrollBy;
+    const originalGetBoundingClientRect = HTMLElement.prototype.getBoundingClientRect;
+
+    Object.defineProperty(HTMLElement.prototype, 'scrollWidth', {
+      configurable: true,
+      get: () => 480,
+    });
+    Object.defineProperty(HTMLElement.prototype, 'clientWidth', {
+      configurable: true,
+      get: () => 240,
+    });
+    HTMLElement.prototype.scrollBy = scrollBy;
+    HTMLElement.prototype.getBoundingClientRect = function () {
+      if (this.getAttribute('role') === 'tablist') {
+        return { left: 0, right: 240 } as DOMRect;
+      }
+      if (this.getAttribute('role') === 'tab' && this.dataset.state === 'active') {
+        return { left: 320, right: 400 } as DOMRect;
+      }
+      return originalGetBoundingClientRect.call(this);
+    };
+
+    try {
+      render(
+        <Tabs defaultValue="tab3">
+          <ScrollableTabsList aria-label="Scrollable tabs">
+            <TabsTrigger value="tab1">Tab 1</TabsTrigger>
+            <TabsTrigger value="tab2">Tab 2</TabsTrigger>
+            <TabsTrigger value="tab3">Tab 3</TabsTrigger>
+          </ScrollableTabsList>
+        </Tabs>
+      );
+
+      await waitFor(() => {
+        expect(scrollBy).toHaveBeenCalledWith({ left: 160, behavior: 'smooth' });
+      });
+    } finally {
+      if (scrollWidth) Object.defineProperty(HTMLElement.prototype, 'scrollWidth', scrollWidth);
+      else delete (HTMLElement.prototype as Partial<HTMLElement>).scrollWidth;
+      if (clientWidth) Object.defineProperty(HTMLElement.prototype, 'clientWidth', clientWidth);
+      else delete (HTMLElement.prototype as Partial<HTMLElement>).clientWidth;
+      HTMLElement.prototype.scrollBy = originalScrollBy;
+      HTMLElement.prototype.getBoundingClientRect = originalGetBoundingClientRect;
+    }
+  });
+
+  it('updates overflow controls when tabs are added', async () => {
+    let measuredScrollWidth = 240;
+    const scrollWidth = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'scrollWidth');
+    const clientWidth = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'clientWidth');
+
+    Object.defineProperty(HTMLElement.prototype, 'scrollWidth', {
+      configurable: true,
+      get: () => measuredScrollWidth,
+    });
+    Object.defineProperty(HTMLElement.prototype, 'clientWidth', {
+      configurable: true,
+      get: () => 240,
+    });
+
+    try {
+      const { rerender } = render(
+        <Tabs defaultValue="tab1">
+          <ScrollableTabsList aria-label="Scrollable tabs">
+            <TabsTrigger value="tab1">Tab 1</TabsTrigger>
+            <TabsTrigger value="tab2">Tab 2</TabsTrigger>
+          </ScrollableTabsList>
+        </Tabs>
+      );
+
+      expect(screen.queryByRole('button', { name: 'Scroll tabs right' })).not.toBeInTheDocument();
+
+      measuredScrollWidth = 480;
+      rerender(
+        <Tabs defaultValue="tab1">
+          <ScrollableTabsList aria-label="Scrollable tabs">
+            <TabsTrigger value="tab1">Tab 1</TabsTrigger>
+            <TabsTrigger value="tab2">Tab 2</TabsTrigger>
+            <TabsTrigger value="tab3">Tab 3</TabsTrigger>
+          </ScrollableTabsList>
+        </Tabs>
+      );
+
+      expect(await screen.findByRole('button', { name: 'Scroll tabs right' })).toBeEnabled();
+    } finally {
+      if (scrollWidth) Object.defineProperty(HTMLElement.prototype, 'scrollWidth', scrollWidth);
+      else delete (HTMLElement.prototype as Partial<HTMLElement>).scrollWidth;
+      if (clientWidth) Object.defineProperty(HTMLElement.prototype, 'clientWidth', clientWidth);
+      else delete (HTMLElement.prototype as Partial<HTMLElement>).clientWidth;
+    }
   });
 
   it('applies custom className to TabsList', () => {

--- a/packages/apollo-wind/src/components/ui/tabs.tsx
+++ b/packages/apollo-wind/src/components/ui/tabs.tsx
@@ -1,4 +1,5 @@
 import * as TabsPrimitive from '@radix-ui/react-tabs';
+import { ChevronLeft, ChevronRight } from 'lucide-react';
 import * as React from 'react';
 
 import { cn } from '@/lib';
@@ -19,6 +20,176 @@ const TabsList = React.forwardRef<
   />
 ));
 TabsList.displayName = TabsPrimitive.List.displayName;
+
+interface ScrollableTabsListProps
+  extends React.ComponentPropsWithoutRef<typeof TabsPrimitive.List> {
+  containerClassName?: string;
+  scrollButtonClassName?: string;
+  previousButtonLabel?: string;
+  nextButtonLabel?: string;
+}
+
+const ScrollableTabsList = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.List>,
+  ScrollableTabsListProps
+>(
+  (
+    {
+      className,
+      containerClassName,
+      scrollButtonClassName,
+      previousButtonLabel = 'Scroll tabs left',
+      nextButtonLabel = 'Scroll tabs right',
+      ...props
+    },
+    forwardedRef
+  ) => {
+    const listRef = React.useRef<HTMLDivElement>(null);
+    const [hasOverflow, setHasOverflow] = React.useState(false);
+    const [canScrollLeft, setCanScrollLeft] = React.useState(false);
+    const [canScrollRight, setCanScrollRight] = React.useState(false);
+    const animationFrameRef = React.useRef<number | null>(null);
+    const revealOnNextFrameRef = React.useRef(false);
+
+    React.useImperativeHandle(forwardedRef, () => listRef.current as HTMLDivElement);
+
+    const updateScrollState = React.useCallback(() => {
+      const list = listRef.current;
+      if (!list) return;
+
+      const maxScrollLeft = list.scrollWidth - list.clientWidth;
+      setHasOverflow(maxScrollLeft > 1);
+      setCanScrollLeft(list.scrollLeft > 1);
+      setCanScrollRight(list.scrollLeft < maxScrollLeft - 1);
+    }, []);
+
+    const revealActiveTab = React.useCallback(() => {
+      const list = listRef.current;
+      const activeTab = list?.querySelector<HTMLElement>('[role="tab"][data-state="active"]');
+      if (!list || !activeTab) return;
+
+      const listRect = list.getBoundingClientRect();
+      const activeTabRect = activeTab.getBoundingClientRect();
+
+      if (activeTabRect.left < listRect.left) {
+        list.scrollBy({ left: activeTabRect.left - listRect.left, behavior: 'smooth' });
+      } else if (activeTabRect.right > listRect.right) {
+        list.scrollBy({ left: activeTabRect.right - listRect.right, behavior: 'smooth' });
+      }
+    }, []);
+
+    const scheduleLayoutUpdate = React.useCallback(
+      (revealActive = false) => {
+        revealOnNextFrameRef.current ||= revealActive;
+        if (animationFrameRef.current !== null) return;
+
+        animationFrameRef.current = requestAnimationFrame(() => {
+          animationFrameRef.current = null;
+          updateScrollState();
+
+          if (revealOnNextFrameRef.current) {
+            revealOnNextFrameRef.current = false;
+            revealActiveTab();
+          }
+        });
+      },
+      [revealActiveTab, updateScrollState]
+    );
+
+    React.useEffect(() => {
+      const list = listRef.current;
+      if (!list) return;
+
+      list.scrollLeft = 0;
+      scheduleLayoutUpdate(true);
+
+      const handleScroll = () => scheduleLayoutUpdate();
+      list.addEventListener('scroll', handleScroll);
+
+      const resizeObserver = new ResizeObserver(() => scheduleLayoutUpdate(true));
+      resizeObserver.observe(list);
+
+      const mutationObserver = new MutationObserver((mutations) => {
+        if (
+          mutations.some(
+            (mutation) => mutation.type === 'childList' || mutation.attributeName === 'data-state'
+          )
+        ) {
+          scheduleLayoutUpdate(true);
+        }
+      });
+      mutationObserver.observe(list, {
+        attributes: true,
+        attributeFilter: ['data-state'],
+        childList: true,
+        subtree: true,
+      });
+
+      return () => {
+        list.removeEventListener('scroll', handleScroll);
+        resizeObserver.disconnect();
+        mutationObserver.disconnect();
+        if (animationFrameRef.current !== null) {
+          cancelAnimationFrame(animationFrameRef.current);
+          animationFrameRef.current = null;
+        }
+      };
+    }, [scheduleLayoutUpdate]);
+
+    const scroll = (direction: 'left' | 'right') => {
+      const list = listRef.current;
+      if (!list) return;
+
+      list.scrollBy({
+        left: direction === 'left' ? -list.clientWidth : list.clientWidth,
+        behavior: 'smooth',
+      });
+    };
+
+    const scrollButtonClass = cn(
+      'grid size-8 shrink-0 place-items-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground disabled:pointer-events-none disabled:opacity-30',
+      scrollButtonClassName
+    );
+
+    return (
+      <div className={cn('flex w-full min-w-0 items-center gap-1', containerClassName)}>
+        {hasOverflow && (
+          <button
+            type="button"
+            aria-label={previousButtonLabel}
+            title={previousButtonLabel}
+            disabled={!canScrollLeft}
+            onClick={() => scroll('left')}
+            className={scrollButtonClass}
+          >
+            <ChevronLeft className="size-4 rtl:rotate-180" />
+          </button>
+        )}
+        <TabsList
+          ref={listRef}
+          className={cn(
+            'min-w-0 flex-1 justify-start overflow-x-auto [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden',
+            className
+          )}
+          {...props}
+        />
+        {hasOverflow && (
+          <button
+            type="button"
+            aria-label={nextButtonLabel}
+            title={nextButtonLabel}
+            disabled={!canScrollRight}
+            onClick={() => scroll('right')}
+            className={scrollButtonClass}
+          >
+            <ChevronRight className="size-4 rtl:rotate-180" />
+          </button>
+        )}
+      </div>
+    );
+  }
+);
+ScrollableTabsList.displayName = 'ScrollableTabsList';
 
 const TabsTrigger = React.forwardRef<
   React.ElementRef<typeof TabsPrimitive.Trigger>,
@@ -50,4 +221,5 @@ const TabsContent = React.forwardRef<
 ));
 TabsContent.displayName = TabsPrimitive.Content.displayName;
 
-export { Tabs, TabsList, TabsTrigger, TabsContent };
+export { ScrollableTabsList, Tabs, TabsContent, TabsList, TabsTrigger };
+export type { ScrollableTabsListProps };

--- a/packages/apollo-wind/src/index.ts
+++ b/packages/apollo-wind/src/index.ts
@@ -243,7 +243,14 @@ export { toast, Toaster } from './components/ui/sonner';
 // -----------------------------------------------------------------------------
 // Navigation Components
 // -----------------------------------------------------------------------------
-export { Tabs, TabsContent, TabsList, TabsTrigger } from './components/ui/tabs';
+export {
+  ScrollableTabsList,
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+} from './components/ui/tabs';
+export type { ScrollableTabsListProps } from './components/ui/tabs';
 
 export {
   Breadcrumb,


### PR DESCRIPTION
## Summary

- add a reusable `ScrollableTabsList` overflow pattern to Apollo Wind
- document spacious and compact usage in the Tabs **Overflow** story
- use the shared pattern in the compact Node Property Panel example

## Why

The compact panel previously replaced its tabs with a dropdown when horizontal space was constrained. That hid the available tab set and diverged from the spacious panel. The shared overflow pattern preserves the same tab information architecture at both sizes while keeping hidden tabs discoverable.

## Impact

Apollo Wind consumers can now use `ScrollableTabsList` when a tab row may exceed its available width. Overflow controls stay in stable positions, disable at the boundaries, scroll independently from selection, and reveal the active tab when needed. The Node Property Panel responsive story demonstrates the pattern in context.

## Validation

- Apollo Wind Biome checks and TypeScript typecheck
- Apollo Wind tests: 59 files, 968 tests passed
- Apollo React Biome checks and TypeScript typecheck
- Apollo React tests: 105 files, 1,875 tests passed
- Storybook verification of the Apollo Wind Overflow story and both Node Property Panel responsive states
- confirmed overflow scrolling does not change the selected tab
