### PR TITLE
[codex] fix Storybook page errors

### DIFF
--- a/packages/apollo-react/src/canvas/components/HierarchicalCanvas/HierarchicalCanvas.tsx
+++ b/packages/apollo-react/src/canvas/components/HierarchicalCanvas/HierarchicalCanvas.tsx
@@ -58,7 +58,7 @@ import { AddNodeManager } from '../AddNodePanel/AddNodeManager';
 import { AddNodePreview } from '../AddNodePanel/AddNodePreview';
 import { createAddNodePreview } from '../AddNodePanel/createAddNodePreview';
 import { BaseCanvas, type BaseCanvasRef } from '../BaseCanvas';
-import { BaseNode } from '../BaseNode';
+import { BaseNode } from '../BaseNode/BaseNode';
 import { BlankCanvasNode } from '../BlankCanvasNode';
 import { CanvasPositionControls } from '../CanvasPositionControls';
 import { LoopCanvasNode } from '../LoopNode';


### PR DESCRIPTION
## Summary

- Rebased fix-page-error onto latest main.
- Fixes a Storybook runtime import-cycle failure by importing BaseNode from its concrete module in HierarchicalCanvas instead of the BaseNode barrel.
- Verified the reported NodePropertyTrigger story renders locally without React error #130 after the rebase, and fixed the additional HierarchicalCanvas page error found during local Storybook runtime checks.

## Root cause

The broader Storybook runtime pass surfaced ReferenceError: Cannot access BaseNode before initialization from HierarchicalCanvas.tsx. The component imported BaseNode through the folder barrel, which can participate in circular module initialization. Importing the concrete BaseNode/BaseNode module avoids that cycle.

## Validation

- pnpm --dir packages/apollo-react test -- NodePropertyTrigger.test.tsx
- pnpm --dir apps/storybook storybook:build
- Local Storybook iframe check for apollo-react-canvas-components-panels-node-property-trigger--default
- Local Storybook iframe check for apollo-react-canvas-components-canvas-hierarchicalcanvas--default