### PR TITLE
[codex] Add property panel alerts and errors story

### DIFF
--- a/packages/apollo-react/src/canvas/components/HierarchicalCanvas/HierarchicalCanvas.tsx
+++ b/packages/apollo-react/src/canvas/components/HierarchicalCanvas/HierarchicalCanvas.tsx
@@ -58,7 +58,7 @@ import { AddNodeManager } from '../AddNodePanel/AddNodeManager';
 import { AddNodePreview } from '../AddNodePanel/AddNodePreview';
 import { createAddNodePreview } from '../AddNodePanel/createAddNodePreview';
 import { BaseCanvas, type BaseCanvasRef } from '../BaseCanvas';
-import { BaseNode } from '../BaseNode';
+import { BaseNode } from '../BaseNode/BaseNode';
 import { BlankCanvasNode } from '../BlankCanvasNode';
 import { CanvasPositionControls } from '../CanvasPositionControls';
 import { LoopCanvasNode } from '../LoopNode';

--- a/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.stories.tsx
@@ -2,6 +2,7 @@ import MonacoEditor from '@monaco-editor/react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import type { FormSchema } from '@uipath/apollo-wind';
 import {
+  Badge,
   cn,
   DropdownMenu,
   DropdownMenuContent,
@@ -26,6 +27,7 @@ import {
 } from '@uipath/apollo-wind/editor-themes';
 import {
   ChevronDown,
+  CircleAlert,
   CircleCheck,
   Code2,
   GitFork,
@@ -627,6 +629,8 @@ function CasePanel({
   monacoTheme,
   defaultExpanded = false,
   defaultValue = '',
+  errorMessage,
+  errorAction,
 }: {
   caseTitle: string;
   onTitleChange: (title: string) => void;
@@ -634,10 +638,13 @@ function CasePanel({
   monacoTheme: string;
   defaultExpanded?: boolean;
   defaultValue?: string;
+  errorMessage?: string;
+  errorAction?: string;
 }) {
   const [expanded, setExpanded] = useState(defaultExpanded);
   const [editingTitle, setEditingTitle] = useState(false);
   const titleRef = useRef<HTMLInputElement>(null);
+  const hasError = Boolean(errorMessage);
 
   return (
     <div className="overflow-hidden rounded-xl border border-border-subtle">
@@ -681,6 +688,11 @@ function CasePanel({
             {caseTitle}
           </button>
         )}
+        {hasError && (
+          <Badge variant="error" className="h-5 gap-1 px-1.5 text-[10px] font-medium">
+            <CircleAlert size={10} />1
+          </Badge>
+        )}
         <button
           type="button"
           onClick={onDelete}
@@ -720,7 +732,10 @@ function CasePanel({
           </div>
           <div className="px-3 pb-3">
             <div
-              className="overflow-hidden rounded-xl border border-border-subtle"
+              className={cn(
+                'relative overflow-hidden rounded-xl border',
+                hasError ? 'border-error' : 'border-border-subtle'
+              )}
               style={{ height: '120px' }}
             >
               <MonacoEditor
@@ -732,9 +747,145 @@ function CasePanel({
                 options={COMPACT_EDITOR_OPTIONS}
               />
             </div>
+            {hasError && errorMessage && (
+              <InlineValidationMessage message={errorMessage} action={errorAction} />
+            )}
           </div>
         </>
       )}
+    </div>
+  );
+}
+
+type CompactTabId = 'parameters' | 'error-handling' | 'advanced';
+
+const ALERT_ISSUES: Array<{
+  id: string;
+  tab: CompactTabId;
+  tabLabel: string;
+  field: string;
+  message: string;
+  action: string;
+}> = [
+  {
+    id: 'condition',
+    tab: 'parameters',
+    tabLabel: 'Parameters',
+    field: 'Case 1 condition',
+    message: 'Condition cannot be evaluated because the expression returns text.',
+    action: 'Return a boolean expression, for example input.status === "active".',
+  },
+  {
+    id: 'fallback',
+    tab: 'error-handling',
+    tabLabel: 'Error handling',
+    field: 'Fallback path',
+    message: 'No fallback path is configured for failed case evaluation.',
+    action: 'Choose a fallback branch or enable Default branch.',
+  },
+  {
+    id: 'timeout',
+    tab: 'advanced',
+    tabLabel: 'Advanced',
+    field: 'Timeout',
+    message: 'Retry duration exceeds the node timeout.',
+    action: 'Increase timeout to 60 seconds or reduce retries to 1.',
+  },
+];
+
+const ALERT_ISSUE_COUNT_BY_TAB = ALERT_ISSUES.reduce(
+  (acc, issue) => ({ ...acc, [issue.tab]: (acc[issue.tab] ?? 0) + 1 }),
+  {
+    parameters: 0,
+    'error-handling': 0,
+    advanced: 0,
+  }
+);
+
+function TabLabelWithError({ label, count }: { label: string; count: number }) {
+  return (
+    <span className="inline-flex items-center gap-1.5">
+      <span>{label}</span>
+      <span
+        title={`${count} issue${count === 1 ? '' : 's'}`}
+        className="grid h-4 min-w-4 place-items-center rounded-full bg-error px-1 text-[10px] font-semibold leading-none text-foreground-on-accent"
+      >
+        {count}
+      </span>
+    </span>
+  );
+}
+
+function InlineValidationMessage({ message, action }: { message: string; action?: string }) {
+  return (
+    <div className="mt-2 px-0.5 py-1 text-xs">
+      <p className="leading-4 text-error">{message}</p>
+      {action && <p className="mt-0.5 leading-4 text-foreground-muted">{action}</p>}
+    </div>
+  );
+}
+
+function ErrorFieldBlock({
+  title,
+  message,
+  action,
+}: {
+  title: string;
+  message: string;
+  action: string;
+}) {
+  return (
+    <div className="rounded-xl border border-error/50 bg-error-background/25 p-3">
+      <div className="flex items-start gap-2">
+        <CircleAlert size={14} className="mt-0.5 shrink-0 text-error" />
+        <div className="min-w-0 flex-1">
+          <p className="text-xs font-semibold text-foreground">{title}</p>
+          <p className="mt-1 text-xs leading-4 text-error">{message}</p>
+          <p className="mt-1 text-xs leading-4 text-foreground-muted">{action}</p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+const ALERT_PATTERN_NOTES = [
+  {
+    title: 'Tab error count',
+    description: 'Marks each tab with the number of issues inside that section.',
+  },
+  {
+    title: 'Inline field error',
+    description: 'Places the message and next action directly under the invalid code editor.',
+  },
+  {
+    title: 'Section error block',
+    description:
+      'Explains tab-specific configuration problems when the field is not currently visible.',
+  },
+];
+
+function AlertPatternNoteCard() {
+  return (
+    <div className="w-[320px] rounded-xl border border-border-subtle bg-surface-overlay p-4 shadow-sm">
+      <div className="flex items-start gap-2">
+        <CircleAlert size={15} className="mt-0.5 shrink-0 text-error" />
+        <div className="min-w-0">
+          <h3 className="text-sm font-semibold text-foreground">Alert and error types included</h3>
+          <p className="mt-1 text-xs leading-4 text-foreground-muted">
+            The story combines tab-level cues with local, action-oriented messages.
+          </p>
+        </div>
+      </div>
+      <div className="mt-3 flex flex-col gap-2">
+        {ALERT_PATTERN_NOTES.map((note) => (
+          <div key={note.title} className="flex gap-2">
+            <span className="mt-1.5 size-1.5 shrink-0 rounded-full bg-error" />
+            <p className="text-xs leading-4 text-foreground-muted">
+              <span className="font-medium text-foreground">{note.title}:</span> {note.description}
+            </p>
+          </div>
+        ))}
+      </div>
     </div>
   );
 }
@@ -896,6 +1047,197 @@ export const CompactEditor: Story = {
   name: 'Editor Compact',
   render: () => <CompactEditorStory />,
 };
+
+function AlertsAndErrorsStory() {
+  const monacoTheme = useMonacoTheme();
+  const [activeTab, setActiveTab] = useState<CompactTabId>('parameters');
+  const [cases, setCases] = useState([{ id: 1, title: 'Case 1' }]);
+  const nextIdRef = useRef(2);
+  const [defaultBranch, setDefaultBranch] = useState(false);
+  const [label, setLabel] = useState('Switch');
+  const [category, setCategory] = useState('Control');
+  const [editingLabel, setEditingLabel] = useState(false);
+  const [editingCategory, setEditingCategory] = useState(false);
+  const labelRef = useRef<HTMLInputElement>(null);
+  const categoryRef = useRef<HTMLInputElement>(null);
+
+  const addCase = () => {
+    const id = nextIdRef.current++;
+    setCases((prev) => [...prev, { id, title: `Case ${id}` }]);
+  };
+  const deleteCase = (id: number) => setCases((prev) => prev.filter((c) => c.id !== id));
+  const updateCaseTitle = (id: number, title: string) =>
+    setCases((prev) => prev.map((c) => (c.id === id ? { ...c, title } : c)));
+  const conditionIssue = ALERT_ISSUES.find((issue) => issue.id === 'condition');
+
+  return (
+    <div className="flex items-start gap-8">
+      <div className="flex w-[320px] shrink-0 flex-col gap-4">
+        <AlertPatternNoteCard />
+      </div>
+      <PanelFrame>
+        <NodePropertyPanel
+          panelTitle="Properties"
+          onClose={() => {}}
+          contentInset="0.875rem"
+          className="h-[760px]"
+        >
+          <div className="flex h-full flex-col">
+            <div className="flex shrink-0 items-center justify-between gap-4 py-4 [padding-inline:var(--mf-content-inset,0.875rem)]">
+              <div className="flex min-w-0 flex-1 items-center gap-3.5">
+                <div className="grid size-11 shrink-0 place-items-center rounded-xl bg-surface-overlay text-foreground-subtle [&>svg]:size-5">
+                  <GitFork />
+                </div>
+                <div className="flex min-w-0 flex-1 flex-col justify-center">
+                  {editingLabel ? (
+                    <input
+                      ref={labelRef}
+                      value={label}
+                      onChange={(e) => setLabel(e.target.value)}
+                      onBlur={() => setEditingLabel(false)}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter' || e.key === 'Escape') setEditingLabel(false);
+                      }}
+                      className="w-full rounded bg-surface-overlay px-1.5 py-0.5 text-base font-semibold leading-5 tracking-[-0.3px] text-foreground outline-none ring-1 ring-brand"
+                      autoFocus
+                    />
+                  ) : (
+                    <button
+                      type="button"
+                      onClick={() => {
+                        setEditingLabel(true);
+                        setTimeout(() => labelRef.current?.select(), 0);
+                      }}
+                      className="truncate rounded px-1.5 py-0.5 text-left text-base font-semibold leading-5 tracking-[-0.3px] text-foreground transition hover:bg-surface-overlay"
+                    >
+                      {label}
+                    </button>
+                  )}
+                  {editingCategory ? (
+                    <input
+                      ref={categoryRef}
+                      value={category}
+                      onChange={(e) => setCategory(e.target.value)}
+                      onBlur={() => setEditingCategory(false)}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter' || e.key === 'Escape') setEditingCategory(false);
+                      }}
+                      className="w-full rounded bg-surface-overlay px-1.5 py-0.5 text-xs leading-4 text-foreground outline-none ring-1 ring-brand"
+                      autoFocus
+                    />
+                  ) : (
+                    <button
+                      type="button"
+                      onClick={() => {
+                        setEditingCategory(true);
+                        setTimeout(() => categoryRef.current?.select(), 0);
+                      }}
+                      className="truncate rounded px-1.5 py-0.5 text-left text-xs leading-4 text-foreground-muted transition hover:bg-surface-overlay"
+                    >
+                      {category}
+                    </button>
+                  )}
+                </div>
+              </div>
+              <div className="shrink-0">
+                <DebugButton />
+              </div>
+            </div>
+
+            <Tabs
+              value={activeTab}
+              onValueChange={(value) => setActiveTab(value as CompactTabId)}
+              className="flex min-h-0 flex-1 flex-col"
+            >
+              <div className="shrink-0 pt-3 [padding-inline:var(--mf-content-inset,0.875rem)]">
+                <TabsList className={TAB_LIST_CLASS}>
+                  <TabsTrigger value="parameters" className={TAB_TRIGGER_CLASS}>
+                    <TabLabelWithError
+                      label="Parameters"
+                      count={ALERT_ISSUE_COUNT_BY_TAB.parameters}
+                    />
+                  </TabsTrigger>
+                  <TabsTrigger value="error-handling" className={TAB_TRIGGER_CLASS}>
+                    <TabLabelWithError
+                      label="Error handling"
+                      count={ALERT_ISSUE_COUNT_BY_TAB['error-handling']}
+                    />
+                  </TabsTrigger>
+                  <TabsTrigger value="advanced" className={TAB_TRIGGER_CLASS}>
+                    <TabLabelWithError label="Advanced" count={ALERT_ISSUE_COUNT_BY_TAB.advanced} />
+                  </TabsTrigger>
+                </TabsList>
+              </div>
+
+              <TabsContent value="parameters" className="mt-0 min-h-0 flex-1 overflow-auto">
+                <div className="py-2 [padding-inline:var(--mf-content-inset,0.875rem)]">
+                  <span className="text-sm font-medium text-foreground-muted">Cases</span>
+                </div>
+                <div className="flex flex-col gap-2 pb-1 [padding-inline:var(--mf-content-inset,0.875rem)]">
+                  {cases.map((c, i) => (
+                    <CasePanel
+                      key={c.id}
+                      caseTitle={c.title}
+                      onTitleChange={(title) => updateCaseTitle(c.id, title)}
+                      onDelete={() => deleteCase(c.id)}
+                      monacoTheme={monacoTheme}
+                      defaultExpanded={i === 0}
+                      defaultValue={i === 0 ? 'input.status' : ''}
+                      errorMessage={i === 0 ? conditionIssue?.message : undefined}
+                      errorAction={i === 0 ? conditionIssue?.action : undefined}
+                    />
+                  ))}
+                </div>
+                <button
+                  type="button"
+                  onClick={addCase}
+                  className="flex items-center gap-1.5 py-3 text-xs text-brand transition hover:text-brand-hover [padding-inline:var(--mf-content-inset,0.875rem)]"
+                >
+                  <Plus size={12} />
+                  Add case
+                </button>
+                <div className="flex items-center gap-2 py-3 [padding-inline:var(--mf-content-inset,0.875rem)]">
+                  <Switch size="sm" checked={defaultBranch} onCheckedChange={setDefaultBranch} />
+                  <span className="text-xs text-foreground-muted">Default branch</span>
+                </div>
+              </TabsContent>
+
+              <TabsContent value="error-handling" className="mt-0 min-h-0 flex-1 overflow-auto">
+                <div className="flex flex-col gap-3 py-3 [padding-inline:var(--mf-content-inset,0.875rem)]">
+                  <div className="flex flex-col gap-2">
+                    <span className="text-sm font-medium text-foreground-muted">
+                      Failure behavior
+                    </span>
+                    <ErrorFieldBlock
+                      title="Fallback path"
+                      message="No fallback path is configured for failed case evaluation."
+                      action="Choose a fallback branch or enable Default branch before running this node."
+                    />
+                  </div>
+                </div>
+              </TabsContent>
+
+              <TabsContent value="advanced" className="mt-0 min-h-0 flex-1 overflow-auto">
+                <div className="flex flex-col gap-3 py-3 [padding-inline:var(--mf-content-inset,0.875rem)]">
+                  <div className="flex flex-col gap-2">
+                    <span className="text-sm font-medium text-foreground-muted">
+                      Execution limits
+                    </span>
+                    <ErrorFieldBlock
+                      title="Timeout"
+                      message="Retry duration exceeds the node timeout."
+                      action="Increase timeout to 60 seconds or reduce retries to 1."
+                    />
+                  </div>
+                </div>
+              </TabsContent>
+            </Tabs>
+          </div>
+        </NodePropertyPanel>
+      </PanelFrame>
+    </div>
+  );
+}
 
 // ============================================================================
 // Input Editor
@@ -1370,6 +1712,11 @@ function InlineEditingStory() {
 export const InlineEditing: Story = {
   name: 'Inline Editing',
   render: () => <InlineEditingStory />,
+};
+
+export const AlertsAndErrors: Story = {
+  name: 'Alerts and Errors',
+  render: () => <AlertsAndErrorsStory />,
 };
 
 const SURFACE_REMAP = { '--surface-raised': 'var(--surface-overlay)' } as CSSProperties;


### PR DESCRIPTION
## Summary

- Adds an `Alerts and Errors` Storybook variant for the Node Property Panel.
- Demonstrates tab-level error counts, inline code-editor validation, and tab-specific section errors for Parameters, Error handling, and Advanced.
- Places the alert/error pattern notes in a left-side review rail beside the panel preview so designers and engineers can review the guidance and UI together.

## Why

This provides a focused design-review surface for validating how users discover where errors live in a property panel and what action they should take next.

## Validation

- `node_modules/.bin/tsc --noEmit --project packages/apollo-react/tsconfig.json`
- `../../node_modules/.bin/biome check src/canvas/components/NodePropertyPanel/NodePropertyPanel.stories.tsx`
- Refreshed Storybook preview at `/story/apollo-react-canvas-components-panels-node-property-panel--alerts-and-errors`
