### PR TITLE
fix(apollo-react): add breathing room around toolbox list focus ring

### DIFF
--- a/packages/apollo-react/src/canvas/components/Toolbox/ListView.styles.ts
+++ b/packages/apollo-react/src/canvas/components/Toolbox/ListView.styles.ts
@@ -27,7 +27,13 @@ export const ListItemButton = styled(motion.button)`
   cursor: pointer;
   text-align: left;
   width: 100%;
-  transition: all 0.15s ease;
+  // Reserve the focus ring geometry in the resting state (invisible via a
+  // transparent color) so activating a row only flips outline-color. Without
+  // this the outline falls back to UA defaults (3px / currentColor) and every
+  // sub-property jumps at once, flashing a thick dark border under transition.
+  outline: 1px solid transparent;
+  outline-offset: -1px;
+  transition: background-color 0.15s ease, opacity 0.15s ease, outline-color 0.15s ease;
 
   &:hover,
   &.active {
@@ -35,8 +41,7 @@ export const ListItemButton = styled(motion.button)`
   }
 
   &.active {
-    outline: 1px solid var(--canvas-primary);
-    outline-offset: -1px;
+    outline-color: var(--canvas-primary);
   }
 `;
 

--- a/packages/apollo-react/src/canvas/components/Toolbox/ListView.tsx
+++ b/packages/apollo-react/src/canvas/components/Toolbox/ListView.tsx
@@ -164,10 +164,9 @@ const ListViewRow = memo(
   }: RowComponentProps<ListViewRowProps<T>>) => {
     const renderItem = renderedItems[index]!;
 
-    const buttonStyle = useMemo(
-      () => ({ ...style, padding: 0, paddingRight: '4px', height: '32px', outlineOffset: '-1px' }),
-      [style]
-    );
+    // `style` from react-window already carries the row height (rowHeight), so
+    // we only layer on the padding that insets content from the focus ring.
+    const buttonStyle = useMemo(() => ({ ...style, padding: '4px 6px' }), [style]);
 
     const handleButtonClick = useCallback(() => {
       const clickTarget = renderedItems[index];


### PR DESCRIPTION
## Summary

The keyboard-focus outline on Toolbox list rows was rendered tight against the row content, with no breathing room around the icon/label (reported in MST-10972). This adds interior padding so the focus ring sits clear of the content, and along the way fixes a related glitch where the ring briefly flashed a thick dark border when selection moved between rows.

Addresses [MST-10972](https://uipath.atlassian.net/browse/MST-10972).

## Changes

- **Spacing:** Toolbox list rows now use a `40px`-tall button with `4px 6px` padding (was `32px` with `padding: 0`), so the inset focus ring no longer hugs the 32px icon. The button grows into the row's existing vertical slack.
- **Flash fix:** The resting button now declares a stable, invisible `outline: 1px solid transparent` at `outline-offset: -1px`, and the `.active` state flips only `outline-color`. Previously the resting outline fell back to the UA default (`3px` / `currentColor` / `style: none`), so activating a row changed all four outline sub-properties at once and `transition: all` animated a thick dark border before resolving to the thin accent ring (most visible in light theme, where `currentColor` is dark).
- **Transition scoping:** Replaced `transition: all 0.15s ease` with an explicit `background-color, opacity, outline-color` list, so the ring fades in cleanly via color only and no unintended properties animate.
- Removed the now-redundant inline `outlineOffset: '-1px'`; outline offset lives in the resting CSS.

## DEMO

### Before

https://github.com/user-attachments/assets/1d44590e-0663-4568-81ca-0a08b7067899

### After

https://github.com/user-attachments/assets/bddbfb1d-59d4-47ab-afaf-a9fe9f131647

## Testing

- [x] `pnpm lint` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes (apollo-react: 105 files, 1875 tests)
- [x] `pnpm audit --prod` + `npm audit signatures` clean
- [x] Manually verified in Storybook (Toolbox → Default): focus ring has clear spacing around content, and no dark flash when arrowing between rows in light or dark theme.
- [x] Type-safe (no `as any` / suppressions added)


[MST-10972]: https://uipath.atlassian.net/browse/MST-10972?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ