### PR TITLE
[codex] Add AddNodePanel message type story

### DIFF
--- a/packages/apollo-react/src/canvas/components/AddNodePanel/AddNodePanel.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/AddNodePanel/AddNodePanel.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import type { Node } from '@uipath/apollo-react/canvas/xyflow/react';
 import { Panel, Position, useReactFlow } from '@uipath/apollo-react/canvas/xyflow/react';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { NodeRegistryProvider } from '../../core';
 import { useAddNodeOnConnectEnd, useCanvasEvent } from '../../hooks';
 import type { CategoryManifest, NodeManifest } from '../../schema';
@@ -20,7 +20,7 @@ import { BaseCanvas } from '../BaseCanvas';
 import type { BaseNodeData } from '../BaseNode';
 import { CanvasPositionControls } from '../CanvasPositionControls';
 import type { ListItem } from '../Toolbox';
-import { AddNodePanel } from '.';
+import { AddNodePanel, AddNodePanelEmptyMessage } from '.';
 import { AddNodeManager } from './AddNodeManager';
 import type { AddNodePanelProps, NodeItemData } from './AddNodePanel.types';
 import { createAddNodePreview } from './createAddNodePreview';
@@ -438,6 +438,144 @@ function ShapeTestPanel(props: AddNodePanelProps) {
   );
 }
 
+type DocumentExtractionMessageState = {
+  id: string;
+  label: string;
+  message: string;
+  icon: string;
+  actionLabel?: string;
+  actionHref?: string;
+};
+
+const DOCUMENT_EXTRACTION_MESSAGE_STATES: DocumentExtractionMessageState[] = [
+  {
+    id: 'availability-check-failed',
+    label: 'Availability check failed',
+    icon: 'wifi-off',
+    message:
+      "We couldn't check document extraction availability. Check your connection and try again. If this keeps happening, contact your administrator.",
+    actionLabel: 'Try again',
+  },
+  {
+    id: 'availability-check-pending',
+    label: 'Availability not confirmed',
+    icon: 'hourglass',
+    message:
+      'Document extraction availability has not been confirmed yet. You can continue browsing other nodes while the service status updates.',
+  },
+  {
+    id: 'service-disabled',
+    label: 'Service not enabled',
+    icon: 'circle-alert',
+    message:
+      "Document extraction needs Document Understanding, which isn't enabled for this tenant. A tenant administrator can enable it in Admin > Tenants > Services.",
+    actionLabel: 'Open tenant services',
+    actionHref: '#admin-tenants-services',
+  },
+  {
+    id: 'missing-license',
+    label: 'Missing license',
+    icon: 'badge-alert',
+    message:
+      "You don't have a Communications Mining license, so you can't use document extraction. Ask a tenant administrator to assign the required license, then reopen this panel.",
+    actionLabel: 'Contact administrator',
+  },
+];
+
+function DocumentExtractionMessagePanel({ state }: { state: DocumentExtractionMessageState }) {
+  const panelRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const button = panelRef.current?.querySelector<HTMLButtonElement>(
+      `#toolbox-item-document-extraction-${state.id}`
+    );
+    button?.click();
+  }, [state.id]);
+
+  const items: ListItem<NodeItemData>[] = useMemo(
+    () => [
+      {
+        id: `document-extraction-${state.id}`,
+        name: 'Document extraction',
+        icon: { name: 'file-search' },
+        data: { type: 'document-extraction', category: 'Documents' },
+        children: [],
+      },
+    ],
+    [state.id]
+  );
+
+  return (
+    <div ref={panelRef}>
+      <AddNodePanel
+        title="Add node"
+        items={items}
+        onNodeSelect={(node) => console.log('Selected node:', node)}
+        onClose={() => console.log('Closed selector')}
+        renderEmptyState={() => <DocumentExtractionMessage state={state} />}
+      />
+    </div>
+  );
+}
+
+function DocumentExtractionMessage({ state }: { state: DocumentExtractionMessageState }) {
+  if (!state.actionLabel) {
+    return <AddNodePanelEmptyMessage icon={state.icon} message={state.message} />;
+  }
+
+  if (!state.actionHref) {
+    return (
+      <AddNodePanelEmptyMessage
+        icon={state.icon}
+        message={state.message}
+        actionLabel={state.actionLabel}
+        onAction={() => console.log(`${state.label}: ${state.actionLabel}`)}
+      />
+    );
+  }
+
+  return (
+    <AddNodePanelEmptyMessage
+      icon={state.icon}
+      message={state.message}
+      actionLabel={state.actionLabel}
+      actionHref={state.actionHref}
+      onAction={(event) => {
+        event.preventDefault();
+        console.log(`${state.label}: ${state.actionLabel}`);
+      }}
+    />
+  );
+}
+
+function DocumentExtractionMessagesStory() {
+  return (
+    <div
+      className="min-h-screen w-screen overflow-auto px-8 py-10"
+      style={{ backgroundColor: 'var(--color-background-secondary)' }}
+    >
+      <div className="flex flex-wrap gap-[50px]">
+        {DOCUMENT_EXTRACTION_MESSAGE_STATES.map((state) => (
+          <section key={state.id} className="flex flex-col gap-2">
+            <span className="text-xs font-semibold text-foreground-muted">{state.label}</span>
+            <div
+              style={{
+                width: '320px',
+                backgroundColor: 'var(--canvas-background-raised)',
+                border: '1px solid var(--canvas-border-de-emp)',
+                borderRadius: '8px',
+                boxShadow: '0 4px 12px rgba(0, 0, 0, 0.1)',
+              }}
+            >
+              <DocumentExtractionMessagePanel state={state} />
+            </div>
+          </section>
+        ))}
+      </div>
+    </div>
+  );
+}
+
 /**
  * Story for testing all available node shapes (container, rectangle, square, circle).
  *
@@ -541,6 +679,22 @@ export const AllShapes: Story = {
     },
   },
   render: () => <AllShapesStory />,
+};
+
+export const NodePanelMessaging: Story = {
+  name: 'Add node panel message types',
+  parameters: {
+    docs: {
+      description: {
+        story: [
+          'Previews Document extraction blocker and recovery messages inside the AddNodePanel shell.',
+          '',
+          'These states use the same title, search bar, panel width, and empty body region so the copy and visual treatment can be reviewed together.',
+        ].join('\n'),
+      },
+    },
+  },
+  render: () => <DocumentExtractionMessagesStory />,
 };
 
 export const NodePanelStaticItems: Story = {

--- a/packages/apollo-react/src/canvas/components/AddNodePanel/AddNodePanelEmptyMessage.test.tsx
+++ b/packages/apollo-react/src/canvas/components/AddNodePanel/AddNodePanelEmptyMessage.test.tsx
@@ -1,0 +1,47 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '../../utils/testing';
+import { AddNodePanelEmptyMessage } from './AddNodePanelEmptyMessage';
+
+describe('AddNodePanelEmptyMessage', () => {
+  it('renders message content without an action when no action label is provided', () => {
+    render(<AddNodePanelEmptyMessage icon="hourglass" message="Availability is still pending." />);
+
+    expect(screen.getByRole('status')).toHaveTextContent('Availability is still pending.');
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+  });
+
+  it('renders a button action when actionLabel is provided without actionHref', () => {
+    const onAction = vi.fn();
+
+    render(
+      <AddNodePanelEmptyMessage
+        icon="wifi-off"
+        message="Availability could not be checked."
+        actionLabel="Try again"
+        onAction={onAction}
+      />
+    );
+
+    const button = screen.getByRole('button', { name: 'Try again' });
+    button.click();
+
+    expect(onAction).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders a link action when actionLabel and actionHref are provided', () => {
+    render(
+      <AddNodePanelEmptyMessage
+        icon="circle-alert"
+        message="The service is not enabled."
+        actionLabel="Open tenant services"
+        actionHref="#tenant-services"
+      />
+    );
+
+    expect(screen.getByRole('link', { name: 'Open tenant services' })).toHaveAttribute(
+      'href',
+      '#tenant-services'
+    );
+  });
+});

--- a/packages/apollo-react/src/canvas/components/AddNodePanel/AddNodePanelEmptyMessage.tsx
+++ b/packages/apollo-react/src/canvas/components/AddNodePanel/AddNodePanelEmptyMessage.tsx
@@ -1,0 +1,87 @@
+import type { MouseEventHandler } from 'react';
+import { CanvasIcon } from '../../utils';
+
+interface AddNodePanelEmptyMessageBaseProps {
+  icon: string;
+  message: string;
+}
+
+type AddNodePanelEmptyMessageNoActionProps = {
+  actionLabel?: never;
+  actionHref?: never;
+  onAction?: never;
+};
+
+type AddNodePanelEmptyMessageLinkActionProps = {
+  actionLabel: string;
+  actionHref: string;
+  onAction?: MouseEventHandler<HTMLAnchorElement>;
+};
+
+type AddNodePanelEmptyMessageButtonActionProps = {
+  actionLabel: string;
+  actionHref?: never;
+  onAction: MouseEventHandler<HTMLButtonElement>;
+};
+
+export type AddNodePanelEmptyMessageProps = AddNodePanelEmptyMessageBaseProps &
+  (
+    | AddNodePanelEmptyMessageNoActionProps
+    | AddNodePanelEmptyMessageLinkActionProps
+    | AddNodePanelEmptyMessageButtonActionProps
+  );
+
+function hasButtonAction(
+  props: AddNodePanelEmptyMessageProps
+): props is AddNodePanelEmptyMessageBaseProps & AddNodePanelEmptyMessageButtonActionProps {
+  return Boolean(props.actionLabel && !props.actionHref && props.onAction);
+}
+
+export function AddNodePanelEmptyMessage(props: AddNodePanelEmptyMessageProps) {
+  const { icon, message } = props;
+  const actionClassName =
+    'rounded-md border border-solid px-3 py-1.5 text-xs font-medium no-underline';
+  const actionStyle = {
+    borderColor: 'var(--canvas-border)',
+    color: 'var(--canvas-foreground-emp)',
+    backgroundColor: 'var(--canvas-background)',
+  };
+
+  return (
+    <output
+      className="flex min-h-[250px] flex-1 flex-col items-center justify-center gap-4 px-6 py-8 text-center"
+      aria-live="polite"
+    >
+      <div
+        className="flex h-10 w-10 items-center justify-center rounded-lg"
+        style={{
+          backgroundColor: 'var(--canvas-background-hover)',
+          color: 'var(--canvas-foreground-de-emp)',
+        }}
+      >
+        <CanvasIcon icon={icon} size={22} />
+      </div>
+      <p className="m-0 max-w-[240px] text-sm leading-5 text-foreground-muted">{message}</p>
+      {props.actionLabel && props.actionHref && (
+        <a
+          href={props.actionHref}
+          className={actionClassName}
+          style={actionStyle}
+          onClick={props.onAction}
+        >
+          {props.actionLabel}
+        </a>
+      )}
+      {hasButtonAction(props) && (
+        <button
+          type="button"
+          className={actionClassName}
+          style={actionStyle}
+          onClick={props.onAction}
+        >
+          {props.actionLabel}
+        </button>
+      )}
+    </output>
+  );
+}

--- a/packages/apollo-react/src/canvas/components/AddNodePanel/index.ts
+++ b/packages/apollo-react/src/canvas/components/AddNodePanel/index.ts
@@ -1,6 +1,10 @@
 export type { AddNodeManagerProps } from './AddNodeManager';
 export { AddNodeManager } from './AddNodeManager';
 export { AddNodePanel } from './AddNodePanel';
+export {
+  AddNodePanelEmptyMessage,
+  type AddNodePanelEmptyMessageProps,
+} from './AddNodePanelEmptyMessage';
 export type { AddNodePanelProps, NodeItemData } from './AddNodePanel.types';
 export { AddNodePreview, type AddNodePreviewData } from './AddNodePreview';
 export { type AddNodePreviewOptions, createAddNodePreview } from './createAddNodePreview';

--- a/packages/apollo-react/src/canvas/components/HierarchicalCanvas/HierarchicalCanvas.tsx
+++ b/packages/apollo-react/src/canvas/components/HierarchicalCanvas/HierarchicalCanvas.tsx
@@ -58,7 +58,7 @@ import { AddNodeManager } from '../AddNodePanel/AddNodeManager';
 import { AddNodePreview } from '../AddNodePanel/AddNodePreview';
 import { createAddNodePreview } from '../AddNodePanel/createAddNodePreview';
 import { BaseCanvas, type BaseCanvasRef } from '../BaseCanvas';
-import { BaseNode } from '../BaseNode/BaseNode';
+import { BaseNode } from '../BaseNode';
 import { BlankCanvasNode } from '../BlankCanvasNode';
 import { CanvasPositionControls } from '../CanvasPositionControls';
 import { LoopCanvasNode } from '../LoopNode';

--- a/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.stories.tsx
@@ -845,8 +845,8 @@ const ALERT_ISSUES: Array<{
   },
 ];
 
-const ALERT_ISSUE_COUNT_BY_TAB = ALERT_ISSUES.reduce(
-  (acc, issue) => ({ ...acc, [issue.tab]: (acc[issue.tab] ?? 0) + 1 }),
+const ALERT_ISSUE_COUNT_BY_TAB = ALERT_ISSUES.reduce<Record<CompactTabId, number>>(
+  (acc, issue) => ({ ...acc, [issue.tab]: acc[issue.tab] + 1 }),
   {
     parameters: 0,
     'error-handling': 0,


### PR DESCRIPTION
<img width="1190" height="1080" alt="Screenshot 2026-07-09 at 9 40 36 AM" src="https://github.com/user-attachments/assets/8f5ac0ed-7949-426a-a3b9-03e146588cca" />

## Summary

- Adds a reusable `AddNodePanelEmptyMessage` helper for prescriptive AddNodePanel empty/blocker messaging via the existing `renderEmptyState` extension point.
- Adds a Storybook preview for four Document extraction AddNodePanel message states: availability check failed, availability not confirmed, service not enabled, and missing license.
- Keeps `HierarchicalCanvas` aligned with the local `BaseNode` barrel import.
- Tightens the NodePropertyPanel alert-story issue-count helper that already exists on latest `main`.

## UX Pattern

This story documents blocker, informational, and recovery messages inside the Add Node panel. Each state keeps the same panel shell and title area so reviewers can compare message tone, spacing, and next actions consistently.

- Retryable availability issue: show a short message and a Try again action.
- Informational availability state: explain that status is not confirmed without presenting a no-op action.
- Tenant/service configuration issue: explain what is disabled and provide an Admin services action.
- License/permission issue: explain the blocker and provide a Contact administrator action.

## Validation

- Rebased onto latest `origin/main`.
- `CI=true pnpm --filter @uipath/apollo-react exec vitest --run src/canvas/components/AddNodePanel/AddNodePanelEmptyMessage.test.tsx src/canvas/components/AddNodePanel/AddNodePanel.test.tsx`
- `CI=true pnpm --filter @uipath/apollo-react exec biome format src/canvas/components/AddNodePanel/AddNodePanel.stories.tsx src/canvas/components/AddNodePanel/AddNodePanelEmptyMessage.tsx src/canvas/components/AddNodePanel/AddNodePanelEmptyMessage.test.tsx src/canvas/components/AddNodePanel/index.ts src/canvas/components/HierarchicalCanvas/HierarchicalCanvas.tsx src/canvas/components/NodePropertyPanel/NodePropertyPanel.stories.tsx`
- `CI=true pnpm --filter @uipath/apollo-react build`
- `git diff --check`
- Verified the Storybook story locally on `http://localhost:6008/`.