### PR TITLE
feat(apollo-vertex): add ShareWithUiPathCheckbox registry component

### DIFF
--- a/apps/apollo-vertex/registry.json
+++ b/apps/apollo-vertex/registry.json
@@ -2076,6 +2076,19 @@
       ]
     },
     {
+      "name": "share-with-uipath-checkbox",
+      "type": "registry:ui",
+      "title": "Share With UiPath Checkbox",
+      "description": "A labeled opt-in checkbox for sharing feedback data with UiPath — the outer-loop consent control on Platform Feedback submission surfaces.",
+      "registryDependencies": ["@uipath/checkbox", "@uipath/label"],
+      "files": [
+        {
+          "path": "registry/share-with-uipath-checkbox/share-with-uipath-checkbox.tsx",
+          "type": "registry:ui"
+        }
+      ]
+    },
+    {
       "name": "sheet",
       "type": "registry:ui",
       "title": "Sheet",

--- a/apps/apollo-vertex/registry/share-with-uipath-checkbox/share-with-uipath-checkbox.tsx
+++ b/apps/apollo-vertex/registry/share-with-uipath-checkbox/share-with-uipath-checkbox.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { useId } from "react";
+
+import { Checkbox } from "@/registry/checkbox/checkbox";
+import { Label } from "@/registry/label/label";
+import { cn } from "@/lib/utils";
+
+type ShareWithUiPathCheckboxProps = {
+  /** Controlled checked state of the opt-in. */
+  checked: boolean;
+  onCheckedChange: (checked: boolean) => void;
+  /**
+   * The opt-in copy. Required so consumers plug in their own translated,
+   * legal-approved string (e.g. "Share feedback data with UiPath to help
+   * troubleshoot and improve the product").
+   */
+  label: string;
+  disabled?: boolean;
+  /** Extra classes for the wrapper — typically spacing (e.g. `mb-3`). */
+  className?: string;
+  /** Label text size. `sm` => `text-xs`, `default` => `text-sm`. */
+  size?: "default" | "sm";
+};
+
+function ShareWithUiPathCheckbox({
+  checked,
+  onCheckedChange,
+  label,
+  disabled,
+  className,
+  size = "default",
+}: ShareWithUiPathCheckboxProps) {
+  // Self-generated id keeps the label association unique even when several
+  // instances mount on the same page.
+  const id = useId();
+
+  return (
+    <div
+      data-slot="share-with-uipath-checkbox"
+      className={cn("flex items-center gap-2", className)}
+    >
+      <Checkbox
+        id={id}
+        checked={checked}
+        // Radix yields `boolean | "indeterminate"`; collapse to a plain boolean
+        // so consumers never have to.
+        onCheckedChange={(value) => onCheckedChange(value === true)}
+        disabled={disabled}
+      />
+      <Label
+        htmlFor={id}
+        className={cn("font-normal", size === "sm" ? "text-xs" : "text-sm")}
+      >
+        {label}
+      </Label>
+    </div>
+  );
+}
+
+export { ShareWithUiPathCheckbox };
+export type { ShareWithUiPathCheckboxProps };


### PR DESCRIPTION
## Summary

Adds a `ShareWithUiPathCheckbox` to the apollo-vertex shadcn registry — a labeled opt-in checkbox for the **"Share feedback data with UiPath to help troubleshoot and improve the product"** consent on Platform Feedback submission surfaces.

Multiple verticals repeat this exact opt-in today (FINS QAQC + LoanSetup, each with an inline `Checkbox` + `Label`), so it belongs in the shared registry. This is the source component for the FINS consumer PR ([fins-vertical-solution#574](https://github.com/UiPath/fins-vertical-solution/pull/574)) — **merge this first**.

## Design

- **Composition over duplication** (per AGENTS.md): builds on the existing `@uipath/checkbox` + `@uipath/label` primitives rather than re-implementing.
- **`label` is a required prop** — consumers plug in their own translated, legal-approved string (same pattern as `feedback-vote-widget`).
- **`size` variant** (`sm` → `text-xs`, `default` → `text-sm`) covers the minor typographic differences between the existing call sites.
- **`className`** for wrapper spacing.
- Collapses Radix's `boolean | "indeterminate"` to a plain boolean so consumers don't have to.
- Self-generated `useId` for the label association.

## Validation

- `shadcn build` emits `r/share-with-uipath-checkbox.json` with the right `registryDependencies`.
- `tsc --noEmit` and `oxlint --type-aware` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)