### PR TITLE
fix(apollo-react): compute node height from handle count to stop flicker [MST-11677]

### DIFF
--- a/packages/apollo-react/src/canvas/components/AgentCanvas/nodes/AgentNode.test.tsx
+++ b/packages/apollo-react/src/canvas/components/AgentCanvas/nodes/AgentNode.test.tsx
@@ -1,9 +1,9 @@
 import { render, screen } from '@testing-library/react';
 import type { ReactElement } from 'react';
 import { describe, expect, it, vi } from 'vitest';
-import { BaseCanvasModeProvider } from '../../BaseCanvas/BaseCanvasModeProvider';
 import { NodeRegistryProvider } from '../../../core/NodeRegistryProvider';
 import type { AgentNodeTranslations } from '../../../types';
+import { BaseCanvasModeProvider } from '../../BaseCanvas/BaseCanvasModeProvider';
 import { agentFlowManifest } from '../agent-flow.manifest';
 import { AgentNodeElement } from './AgentNode';
 
@@ -26,6 +26,8 @@ vi.mock('@uipath/apollo-react/canvas/xyflow/react', () => ({
   useReactFlow: () => ({
     setNodes: vi.fn(),
     setEdges: vi.fn(),
+    updateNode: vi.fn(),
+    getNode: vi.fn(),
   }),
 }));
 

--- a/packages/apollo-react/src/canvas/components/BaseNode/BaseNode.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/BaseNode/BaseNode.stories.tsx
@@ -164,29 +164,70 @@ function createShapeStatusGrid(): Node<BaseNodeData>[] {
 // Size Grid Definitions
 // ============================================================================
 
-const SQUARE_SIZES = [48, 64, 80, 96, 112, 128] as const;
-const RECTANGLE_CONFIGS = [
-  { width: 128, height: 48 },
-  { width: 160, height: 64 },
-  { width: 192, height: 80 },
-  { width: 256, height: 96 },
-  { width: 320, height: 112 },
+const RECTANGLE_WIDTHS = [128, 160, 192, 256, 320] as const;
+
+const SQUARE_WIDTHS = [96, 128, 160] as const;
+
+// Circle height floor is (maxSideHandles * 2 + 2) * 16, so these counts yield
+// 96/128/160px. Width is set to match, keeping circles round.
+const SIZE_STEPS = [
+  { size: 96, handles: 2 },
+  { size: 128, handles: 3 },
+  { size: 160, handles: 4 },
 ] as const;
 
+const sizeInputs = (count: number) =>
+  Array.from({ length: count }, (_, i) => ({
+    id: `in-${i}`,
+    type: 'target' as const,
+    handleType: 'input' as const,
+  }));
+
+// Registers proportional circle types whose height grows with handle count.
+// Merged with the default manifests so squares/rectangles keep their built-in types.
+const sizeGridManifest: { nodes: NodeManifest[]; categories: CategoryManifest[] } = {
+  categories: [
+    ...allCategoryManifests,
+    {
+      id: 'sizing',
+      name: 'Sizing',
+      sortOrder: 99,
+      color: '#6c757d',
+      colorDark: '#495057',
+      icon: 'git-branch',
+      tags: [],
+    },
+  ],
+  nodes: [
+    ...allNodeManifests,
+    ...SIZE_STEPS.map(({ size, handles }) => ({
+      nodeType: `uipath.size-circle-${size}`,
+      version: '1.0.0',
+      category: 'sizing',
+      tags: ['sizing'],
+      sortOrder: size,
+      display: { label: String(size), shape: 'circle' as const, icon: 'construction' },
+      handleConfiguration: [{ position: 'left' as const, handles: sizeInputs(handles) }],
+    })),
+  ],
+};
+
 /**
- * Creates nodes demonstrating various sizes.
+ * Creates nodes demonstrating sizing. Squares vary by width with a computed
+ * height; circles grow proportionally with handle count (height is derived).
+ * Rectangles vary by width at a fixed 96px height.
  */
 function createSizeGrid(): Node<BaseNodeData>[] {
   const nodes: Node<BaseNodeData>[] = [];
-  let xOffset = 96;
 
-  // Row 1: Square shapes
-  SQUARE_SIZES.forEach((size) => {
+  // Squares: width varies, height is left to the node (settles at the 96px floor).
+  let sqX = 80;
+  SQUARE_WIDTHS.forEach((size) => {
     nodes.push({
       ...createNode({
-        id: `sq-${size}`,
+        id: `square-${size}`,
         type: 'uipath.blank-node',
-        position: { x: xOffset, y: 96 },
+        position: { x: sqX, y: 80 },
         data: {
           nodeType: 'uipath.blank-node',
           version: '1.0.0',
@@ -194,21 +235,20 @@ function createSizeGrid(): Node<BaseNodeData>[] {
         },
       }),
       width: size,
-      height: size,
     });
-    xOffset += size + 32;
+    sqX += size + 64;
   });
 
-  // Row 2: Circle shapes
-  xOffset = 96;
-  SQUARE_SIZES.forEach((size) => {
+  // Circles: handle-driven, proportional (width = height = size).
+  let cX = 80;
+  SIZE_STEPS.forEach(({ size }) => {
     nodes.push({
       ...createNode({
-        id: `c-${size}`,
-        type: 'uipath.blank-node',
-        position: { x: xOffset, y: 272 },
+        id: `circle-${size}`,
+        type: `uipath.size-circle-${size}`,
+        position: { x: cX, y: 240 },
         data: {
-          nodeType: 'uipath.blank-node',
+          nodeType: `uipath.size-circle-${size}`,
           version: '1.0.0',
           display: { label: String(size), shape: 'circle' },
         },
@@ -216,13 +256,13 @@ function createSizeGrid(): Node<BaseNodeData>[] {
       width: size,
       height: size,
     });
-    xOffset += size + 32;
+    cX += size + 64;
   });
 
-  // Row 3-4: Rectangle shapes
-  let rectX = 96;
-  let rectY = 448;
-  RECTANGLE_CONFIGS.forEach(({ width, height }, index) => {
+  // Rectangles: width varies, height stays at the 96px floor.
+  let rectX = 80;
+  const rectY = 464;
+  RECTANGLE_WIDTHS.forEach((width, index) => {
     nodes.push({
       ...createNode({
         id: `r-${index}`,
@@ -231,18 +271,13 @@ function createSizeGrid(): Node<BaseNodeData>[] {
         data: {
           nodeType: 'uipath.agent',
           version: '1.0.0',
-          display: { label: `${width}×${height}`, shape: 'rectangle' },
+          display: { label: `${width}×96`, shape: 'rectangle' },
         },
       }),
       width,
-      height,
+      height: 96,
     });
-
-    rectX += width + 32;
-    if (index === 2) {
-      rectX = 96;
-      rectY = 560;
-    }
+    rectX += width + 64;
   });
 
   return nodes;
@@ -1144,7 +1179,7 @@ function SizesStory() {
       </Panel>
       <StoryInfoPanel
         title="Sizes"
-        description="Nodes at various dimensions aligned to the 16px grid — squares and circles from 48–128px, rectangles from 128×48 to 320×112."
+        description="Node height is decided by the handle count, not the width prop: height is (maxSideHandles * 2 + 2) * 16, with a 96px minimum. Squares and rectangles vary by width at a computed height (96px with default handles). Circles grow 96 to 160px as handles increase (2 to 4 per side), staying round."
       />
     </BaseCanvas>
   );
@@ -1669,6 +1704,14 @@ export const ExecutionStates: Story = {
 
 export const Sizes: Story = {
   name: 'Sizes',
+  // Register the story-only proportional square/circle types (see sizeGridManifest).
+  decorators: [
+    (Story) => (
+      <NodeRegistryProvider manifest={sizeGridManifest}>
+        <Story />
+      </NodeRegistryProvider>
+    ),
+  ],
   render: () => <SizesStory />,
 };
 

--- a/packages/apollo-react/src/canvas/components/BaseNode/BaseNode.test.tsx
+++ b/packages/apollo-react/src/canvas/components/BaseNode/BaseNode.test.tsx
@@ -219,7 +219,7 @@ describe('BaseNode', () => {
       expect(floorVar()).toBe('160px');
     });
 
-    it('ignores the measured height prop when computing the floor', () => {
+    it('derives height from handles/footer, not the incoming height prop', () => {
       mockHandleConfigs.current = makeHandles(Position.Left, 2);
       const { rerender } = render(<BaseNode {...defaultProps} height={500} />);
       expect(floorVar()).toBe('96px');

--- a/packages/apollo-react/src/canvas/components/BaseNode/BaseNode.test.tsx
+++ b/packages/apollo-react/src/canvas/components/BaseNode/BaseNode.test.tsx
@@ -275,6 +275,19 @@ describe('BaseNode', () => {
       render(<BaseNode {...defaultProps} />);
       expect(floorVar()).toBe('160px');
     });
+
+    it('passes the computed height to handles, ignoring the measured height prop', () => {
+      // 4 handles → computedHeight 160. A stale/small measured prop must be ignored so
+      // handles are grid-aligned from the first render (no percentage→grid jump).
+      mockHandleConfigs.current = makeHandles(Position.Left, 4);
+      render(<BaseNode {...defaultProps} height={12} />);
+      const opts = mockUseButtonHandles.mock.calls.at(-1)?.[0] as {
+        nodeHeight?: number;
+        nodeWidth?: number;
+      };
+      expect(opts.nodeHeight).toBe(160);
+      expect(opts.nodeWidth).toBe(96); // getContainerWidth default for a square node
+    });
   });
 
   describe('Loading state', () => {

--- a/packages/apollo-react/src/canvas/components/BaseNode/BaseNode.test.tsx
+++ b/packages/apollo-react/src/canvas/components/BaseNode/BaseNode.test.tsx
@@ -12,6 +12,8 @@ const DEFAULT_MANIFEST = {
 // Hoisted mocks — available inside vi.mock factories
 const {
   mockUpdateNode,
+  mockGetNode,
+  mockNodeState,
   mockHandleConfigs,
   mockManifest,
   mockUseButtonHandles,
@@ -22,6 +24,9 @@ const {
   mockNodeToolbar,
 } = vi.hoisted(() => ({
   mockUpdateNode: vi.fn(),
+  mockGetNode: vi.fn(),
+  // Simulates React Flow's stored node: updateNode writes height here, getNode reads it.
+  mockNodeState: { current: { height: undefined as number | undefined } },
   mockHandleConfigs: { current: undefined as HandleGroupManifest[] | undefined },
   mockManifest: {
     current: {
@@ -39,12 +44,25 @@ const {
   mockNodeToolbar: vi.fn() as any,
 }));
 
+// getNode reflects whatever updateNode last wrote, so the height-sync effect converges
+// exactly as it does against React Flow's real store.
+mockGetNode.mockImplementation(() => mockNodeState.current);
+mockUpdateNode.mockImplementation((_id: string, patch: { height?: number }) => {
+  if (patch?.height !== undefined) {
+    mockNodeState.current = { ...mockNodeState.current, height: patch.height };
+  }
+});
+
 // xyflow is globally mocked in canvas-mocks.ts; extend with test-specific overrides.
 vi.mock('@uipath/apollo-react/canvas/xyflow/react', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@uipath/apollo-react/canvas/xyflow/react')>()),
   useStore: () => mockIsConnecting.current,
   useUpdateNodeInternals: () => vi.fn(),
-  useReactFlow: () => ({ updateNodeData: vi.fn(), updateNode: mockUpdateNode }),
+  useReactFlow: () => ({
+    updateNodeData: vi.fn(),
+    updateNode: mockUpdateNode,
+    getNode: mockGetNode,
+  }),
 }));
 
 vi.mock('../../hooks', () => ({
@@ -155,6 +173,8 @@ const makeHandles = (position: Position, count: number): HandleGroupManifest[] =
 describe('BaseNode', () => {
   afterEach(() => {
     mockUpdateNode.mockClear();
+    mockGetNode.mockClear();
+    mockNodeState.current = { height: undefined };
     mockUseButtonHandles.mockClear();
     mockNodeToolbar.mockClear();
     mockHandleConfigs.current = undefined;
@@ -165,75 +185,28 @@ describe('BaseNode', () => {
     mockIsConnecting.current = false;
   });
 
-  describe('Height computation', () => {
-    // Override the rAF mock from canvas-mocks to run synchronously
-    // so updateNode calls complete during the effect flush within act/render.
-    const savedRAF = window.requestAnimationFrame;
-    beforeEach(() => {
-      window.requestAnimationFrame = (cb) => {
-        cb(performance.now());
-        return 0;
-      };
-    });
-    afterEach(() => {
-      window.requestAnimationFrame = savedRAF;
-    });
+  // The handle count sets `--node-h` (the node height), which is also written to
+  // React Flow's node.height so measured height, edges, and handle spacing agree.
+  // It is a pure function of handles/footer (never reads the measured height), so the
+  // write-back is idempotent and converges (no flicker loop).
+  // Height = max(96 default | footer height, (maxHandlesPerSide * 2 + 2) * 16).
+  describe('Height computation (floor + node.height sync)', () => {
+    // Read the `--node-h` CSS var off the outer wrapper (parent of base-container).
+    const floorVar = () =>
+      screen.getByTestId('base-container').parentElement?.style.getPropertyValue('--node-h');
 
-    it('expands height when handles exceed base height', () => {
-      // 4 handles × 40px = 160px > 96px default
-      mockHandleConfigs.current = makeHandles(Position.Left, 4);
-      render(<BaseNode {...defaultProps} height={96} />);
-      expect(mockUpdateNode).toHaveBeenCalledWith('test-node', { height: 160 });
-    });
-
-    it('does not expand when handles fit within base height', () => {
-      // 2 handles × 40px = 80px < 96px default
+    it('sets the floor to the 96px default when handles fit within it', () => {
+      // 2 handles → (2*2+2)*16 = 96 == default
       mockHandleConfigs.current = makeHandles(Position.Left, 2);
-      render(<BaseNode {...defaultProps} height={96} />);
-      expect(mockUpdateNode).not.toHaveBeenCalled();
+      render(<BaseNode {...defaultProps} />);
+      expect(floorVar()).toBe('96px');
     });
 
-    it('respects user-provided height as the base', () => {
-      // height=200, 2 handles need 80px < 200 → no expansion
-      mockHandleConfigs.current = makeHandles(Position.Left, 2);
-      render(<BaseNode {...defaultProps} height={200} />);
-      expect(mockUpdateNode).not.toHaveBeenCalled();
-    });
-
-    it('shrinks back to default when handles are removed', () => {
-      // Start with 4 handles (160px needed)
+    it('expands the floor to fit the handle count', () => {
+      // 4 handles → (4*2+2)*16 = 160 > 96 default
       mockHandleConfigs.current = makeHandles(Position.Left, 4);
-      const { rerender } = render(<BaseNode {...defaultProps} height={96} />);
-      expect(mockUpdateNode).toHaveBeenCalledWith('test-node', { height: 160 });
-
-      // Simulate React Flow updating height to match our sync
-      // Note: new data={{}} ref on each rerender to break through React.memo
-      mockUpdateNode.mockClear();
-      rerender(<BaseNode {...defaultProps} height={160} data={{}} />);
-      expect(mockUpdateNode).not.toHaveBeenCalled();
-
-      // Remove handles — should shrink back to DEFAULT_NODE_SIZE (96)
-      mockHandleConfigs.current = [];
-      mockUpdateNode.mockClear();
-      rerender(<BaseNode {...defaultProps} height={160} data={{}} />);
-      expect(mockUpdateNode).toHaveBeenCalledWith('test-node', { height: 96 });
-    });
-
-    it('shrinks back to user-provided height after handle removal', () => {
-      // User height=200, 8 handles need 288px
-      mockHandleConfigs.current = makeHandles(Position.Left, 8);
-      const { rerender } = render(<BaseNode {...defaultProps} height={200} />);
-      expect(mockUpdateNode).toHaveBeenCalledWith('test-node', { height: 288 });
-
-      // Simulate React Flow updating height
-      mockUpdateNode.mockClear();
-      rerender(<BaseNode {...defaultProps} height={288} data={{}} />);
-
-      // Remove handles — should return to 200, not DEFAULT_NODE_SIZE (96)
-      mockHandleConfigs.current = [];
-      mockUpdateNode.mockClear();
-      rerender(<BaseNode {...defaultProps} height={288} data={{}} />);
-      expect(mockUpdateNode).toHaveBeenCalledWith('test-node', { height: 200 });
+      render(<BaseNode {...defaultProps} />);
+      expect(floorVar()).toBe('160px');
     });
 
     it('uses max of left and right handle counts', () => {
@@ -242,8 +215,65 @@ describe('BaseNode', () => {
         ...makeHandles(Position.Left, 2),
         ...makeHandles(Position.Right, 4),
       ];
-      render(<BaseNode {...defaultProps} height={96} />);
-      expect(mockUpdateNode).toHaveBeenCalledWith('test-node', { height: 160 });
+      render(<BaseNode {...defaultProps} />);
+      expect(floorVar()).toBe('160px');
+    });
+
+    it('ignores the measured height prop when computing the floor', () => {
+      mockHandleConfigs.current = makeHandles(Position.Left, 2);
+      const { rerender } = render(<BaseNode {...defaultProps} height={500} />);
+      expect(floorVar()).toBe('96px');
+      rerender(<BaseNode {...defaultProps} height={12} data={{}} />);
+      expect(floorVar()).toBe('96px');
+    });
+
+    it('writes the floor to node.height and converges without repeat writes', () => {
+      // 3 handles → 128px floor, written once to node.height.
+      mockHandleConfigs.current = makeHandles(Position.Left, 3);
+      const { rerender } = render(<BaseNode {...defaultProps} />);
+      expect(mockUpdateNode).toHaveBeenCalledWith('test-node', { height: 128 });
+      expect(mockUpdateNode).toHaveBeenCalledTimes(1);
+
+      // Re-render with the handle set unchanged: node.height already equals the floor,
+      // so the guard skips the write — no oscillation.
+      mockUpdateNode.mockClear();
+      rerender(<BaseNode {...defaultProps} data={{}} />);
+      expect(mockUpdateNode).not.toHaveBeenCalled();
+    });
+
+    it('does not write when node.height already equals the floor', () => {
+      // Persisted node already at the correct height → no redundant write on mount.
+      mockNodeState.current = { height: 96 };
+      mockHandleConfigs.current = makeHandles(Position.Left, 2);
+      render(<BaseNode {...defaultProps} />);
+      expect(mockUpdateNode).not.toHaveBeenCalled();
+    });
+
+    it('deflates the floor and settles when a handle is removed (MST-11677)', () => {
+      mockHandleConfigs.current = makeHandles(Position.Left, 3);
+      const { rerender } = render(<BaseNode {...defaultProps} />);
+      expect(floorVar()).toBe('128px');
+      expect(mockUpdateNode).toHaveBeenLastCalledWith('test-node', { height: 128 });
+
+      // Remove a handle → floor drops to 96, written once, then settles.
+      mockUpdateNode.mockClear();
+      mockHandleConfigs.current = makeHandles(Position.Left, 2);
+      rerender(<BaseNode {...defaultProps} data={{}} />);
+      expect(floorVar()).toBe('96px');
+      expect(mockUpdateNode).toHaveBeenCalledWith('test-node', { height: 96 });
+
+      mockUpdateNode.mockClear();
+      rerender(<BaseNode {...defaultProps} data={{}} />);
+      expect(floorVar()).toBe('96px');
+      expect(mockUpdateNode).not.toHaveBeenCalledWith('test-node', { height: 128 });
+      expect(mockUpdateNode).not.toHaveBeenCalled();
+    });
+
+    it('uses the fixed footer height as the floor when it exceeds the handle floor', () => {
+      mockOverrideConfig.current = { footerComponent: 'footer', footerVariant: 'single' };
+      mockHandleConfigs.current = makeHandles(Position.Left, 2);
+      render(<BaseNode {...defaultProps} />);
+      expect(floorVar()).toBe('160px');
     });
   });
 

--- a/packages/apollo-react/src/canvas/components/BaseNode/BaseNode.tsx
+++ b/packages/apollo-react/src/canvas/components/BaseNode/BaseNode.tsx
@@ -82,7 +82,7 @@ const getIntrinsicHeight = (
 };
 
 const BaseNodeComponent = (props: NodeProps<Node<BaseNodeData>>) => {
-  const { type, data, selected, id, dragging, width, height, parentId } = props;
+  const { type, data, selected, id, dragging, width, parentId } = props;
 
   // Read runtime configuration from context (provided by parent node components)
   const {
@@ -519,8 +519,9 @@ const BaseNodeComponent = (props: NodeProps<Node<BaseNodeData>>) => {
     hovered: isHovered,
     showAddButton: mode === 'design' && !multipleNodesSelected && !isConnecting && !dragging,
     showNotches,
-    nodeWidth: width,
-    nodeHeight: height,
+    // Deterministic geometry (not the measured props) so handles are grid-aligned from first render.
+    nodeWidth: containerWidth,
+    nodeHeight: computedHeight,
     shouldShowAddButtonFn,
     portalActions: !!parentId,
   });
@@ -561,8 +562,8 @@ const BaseNodeComponent = (props: NodeProps<Node<BaseNodeData>>) => {
             id={handle.id}
             defaultPosition={defaultPosition as Position}
             handleType={handleVisualType}
-            nodeWidth={width}
-            nodeHeight={height}
+            nodeWidth={containerWidth}
+            nodeHeight={computedHeight}
             label={handle.label}
             showButton={shouldShowButton}
             selected={selected}
@@ -580,8 +581,8 @@ const BaseNodeComponent = (props: NodeProps<Node<BaseNodeData>>) => {
     useSmartHandles,
     handleConfigurations,
     shouldShowHandles,
-    width,
-    height,
+    containerWidth,
+    computedHeight,
     mode,
     selected,
     showNotches,
@@ -727,7 +728,7 @@ const BaseNodeComponent = (props: NodeProps<Node<BaseNodeData>>) => {
   // Wrap with SmartHandleProvider only when smart handles are enabled
   if (useSmartHandles) {
     return (
-      <SmartHandleProvider nodeWidth={width} nodeHeight={height}>
+      <SmartHandleProvider nodeWidth={containerWidth} nodeHeight={computedHeight}>
         {nodeContent}
       </SmartHandleProvider>
     );

--- a/packages/apollo-react/src/canvas/components/BaseNode/BaseNode.tsx
+++ b/packages/apollo-react/src/canvas/components/BaseNode/BaseNode.tsx
@@ -63,11 +63,11 @@ const getContainerWidth = (shape: NodeShape | undefined, width: number | undefin
   return defaultWidth;
 };
 
-const getContainerHeight = (
-  height: number | undefined,
+// Intrinsic height: the fixed footer height when a footer is present, else the default.
+const getIntrinsicHeight = (
   hasFooter: boolean,
   footerVariant: FooterVariant | undefined
-): number | 'auto' => {
+): number => {
   if (hasFooter) {
     switch (footerVariant) {
       case 'button':
@@ -76,13 +76,9 @@ const getContainerHeight = (
         return NODE_HEIGHT_FOOTER_SINGLE;
       case 'double':
         return NODE_HEIGHT_FOOTER_DOUBLE;
-      default:
-        return 'auto';
     }
   }
-  // Use `||` rather than `??` — React Flow can pass `height: 0` before measurement,
-  // and we want that to fall through to the default rather than collapse the node.
-  return height || NODE_HEIGHT_DEFAULT;
+  return NODE_HEIGHT_DEFAULT;
 };
 
 const BaseNodeComponent = (props: NodeProps<Node<BaseNodeData>>) => {
@@ -111,22 +107,13 @@ const BaseNodeComponent = (props: NodeProps<Node<BaseNodeData>>) => {
   } = useBaseNodeOverrideConfig();
 
   const updateNodeInternals = useUpdateNodeInternals();
-  const { updateNodeData, updateNode } = useReactFlow();
+  const { updateNodeData, updateNode, getNode } = useReactFlow();
   const containerRef = useRef<HTMLDivElement>(null);
   const [isHovered, setIsHovered] = useState(false);
   const [isFocused, setIsFocused] = useState(false);
 
-  // Tracks the height we last synced to React Flow via updateNode, so we can
-  // distinguish our own handle-based writes from external changes (user-specified
-  // height, React Flow measurement, resize).
-  const syncedHeightRef = useRef<number | undefined>(undefined);
-  // The "base" height — what the node height would be without handle inflation.
-  // Updated when height changes from an external source (not our sync).
-  const baseHeightRef = useRef<number>(DEFAULT_NODE_SIZE);
-
-  if (height && height !== syncedHeightRef.current) {
-    baseHeightRef.current = height;
-  }
+  // Height is driven by computedHeight (below), a pure function of handle count/footer.
+  // It never reads the measured height, so writing it back can't loop.
 
   // Get execution status from external source
   const executionState = useNodeExecutionState(id);
@@ -260,10 +247,9 @@ const BaseNodeComponent = (props: NodeProps<Node<BaseNodeData>>) => {
     };
   }, [adornmentsProp, statusContext]);
 
-  // Compute height: max of base height (user-specified or measured) and handle minimum.
-  // baseHeightRef is updated above from external height changes; handle inflation
-  // is computed from the current handleConfigurations.
-  // biome-ignore lint/correctness/useExhaustiveDependencies: height updates baseHeightRef above and intentionally retriggers this memo.
+  // Computed node height: max of the handle-count floor and the intrinsic default/footer
+  // height. Pure (never reads the measured `height`); written to node.height below as
+  // the authoritative size, so node content is expected to fit within it.
   const computedHeight = useMemo(() => {
     const leftHandles = handleConfigurations
       .filter((config) => config.position === Position.Left && config.visible !== false)
@@ -282,31 +268,21 @@ const BaseNodeComponent = (props: NodeProps<Node<BaseNodeData>>) => {
     const leftRightHandles = Math.max(leftHandles, rightHandles);
 
     // Each handle gets a 2-grid-space lane (32px), plus 2-grid-space padding at top + bottom of node.
-    const minNodeHeight = (leftRightHandles * 2 + 2) * GRID_SPACING;
-    return Math.max(baseHeightRef.current, minNodeHeight);
-  }, [handleConfigurations, height]);
+    const handleFloor = (leftRightHandles * 2 + 2) * GRID_SPACING;
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: handle configuration changes require React Flow handle recalculation.
+    return Math.max(getIntrinsicHeight(!!footerComponent, footerVariant), handleFloor);
+  }, [handleConfigurations, footerComponent, footerVariant]);
+
+  // Write computedHeight to node.height and recalculate handle positions. Compare
+  // against node.height (not the measured `height` prop) so a lagging measurement
+  // can't retrigger the write.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: handleConfigurations triggers handle recalculation.
   useEffect(() => {
-    updateNodeInternals(id);
-  }, [handleConfigurations, id, updateNodeInternals]);
-
-  // Sync computed height to node when it differs from React Flow's current value
-  useEffect(() => {
-    if (computedHeight !== undefined && computedHeight !== height) {
-      syncedHeightRef.current = computedHeight;
-      const frameId = requestAnimationFrame(() => {
-        updateNode(id, { height: computedHeight });
-        updateNodeInternals(id);
-      });
-
-      return () => {
-        cancelAnimationFrame(frameId);
-      };
+    if (getNode(id)?.height !== computedHeight) {
+      updateNode(id, { height: computedHeight });
     }
-
-    return undefined;
-  }, [computedHeight, height, id, updateNode, updateNodeInternals]);
+    updateNodeInternals(id);
+  }, [handleConfigurations, computedHeight, id, getNode, updateNode, updateNodeInternals]);
 
   const displayLabel = display.label;
   const displayShape = display.shape ?? 'square';
@@ -320,7 +296,6 @@ const BaseNodeComponent = (props: NodeProps<Node<BaseNodeData>>) => {
   // Display customization from props (not data)
   const displayLabelTooltip = labelTooltip;
   const displayLabelBackgroundColor = labelBackgroundColor;
-  const displayFooterVariant = footerVariant;
 
   // SubLabel: Component prop takes precedence, then plain string from display.
   const displaySubLabel = useMemo(() => {
@@ -343,10 +318,10 @@ const BaseNodeComponent = (props: NodeProps<Node<BaseNodeData>>) => {
   // ---------------------------------------------------------------------------
   const hasFooter = !!displayFooter;
   const containerWidth = getContainerWidth(displayShape, width);
-  const containerHeight = getContainerHeight(height, hasFooter, displayFooterVariant);
+  const containerHeight = computedHeight;
 
   const nodeVars = useMemo((): React.CSSProperties => {
-    const numH = typeof containerHeight === 'number' ? containerHeight : DEFAULT_NODE_SIZE;
+    const numH = containerHeight;
 
     const getRadius = (basis: number, ratio: number) => {
       return displayShape === 'circle'
@@ -378,7 +353,7 @@ const BaseNodeComponent = (props: NodeProps<Node<BaseNodeData>>) => {
 
     return {
       '--node-w': `${containerWidth}px`,
-      '--node-h': typeof containerHeight === 'number' ? `${containerHeight}px` : 'auto',
+      '--node-h': `${containerHeight}px`,
       '--node-radius': nodeRadius,
       '--node-gap': `${(gap - NODE_BORDER_SIZE * 2) / 2}px`,
       '--inner-w': `${innerW}px`,

--- a/packages/apollo-react/src/canvas/components/BaseNode/BaseNodeConfigContext.tsx
+++ b/packages/apollo-react/src/canvas/components/BaseNode/BaseNodeConfigContext.tsx
@@ -45,6 +45,7 @@ export interface BaseNodeOverrideConfig {
   // Display Customization
   labelTooltip?: string;
   labelBackgroundColor?: string;
+  /** When providing a `footerComponent`, also set `footerVariant` to a sized variant (`button` | `single` | `double`). */
   footerVariant?: FooterVariant;
   footerComponent?: React.ReactNode;
   subLabelComponent?: React.ReactNode;

--- a/packages/apollo-react/src/canvas/stores/animatedViewportManager.ts
+++ b/packages/apollo-react/src/canvas/stores/animatedViewportManager.ts
@@ -237,10 +237,11 @@ class AnimatedViewportManager {
     const nodeBounds: NodeBounds = {
       x: node.position.x,
       y: node.position.y,
-      // Prefer measured dimensions: node width/height are content-driven and may be
-      // unset in the store until React Flow's ResizeObserver reports them.
-      width: node.measured?.width ?? node.width ?? 200,
-      height: node.measured?.height ?? node.height ?? 100,
+      // Prefer measured dimensions, falling back to explicit size then a default.
+      // `||` (not `??`) so a transient 0 from React Flow before measurement falls
+      // through instead of feeding a zero-sized bound into the viewport math.
+      width: node.measured?.width || node.width || 200,
+      height: node.measured?.height || node.height || 100,
     };
 
     // Calculate the viewport that focuses on the node with padding
@@ -337,10 +338,11 @@ class AnimatedViewportManager {
     return {
       x: node.position.x,
       y: node.position.y,
-      // Prefer measured dimensions: node width/height are content-driven and may be
-      // unset in the store until React Flow's ResizeObserver reports them.
-      width: node.measured?.width ?? node.width ?? 200,
-      height: node.measured?.height ?? node.height ?? 100,
+      // Prefer measured dimensions, falling back to explicit size then a default.
+      // `||` (not `??`) so a transient 0 from React Flow before measurement falls
+      // through instead of feeding a zero-sized bound into the viewport math.
+      width: node.measured?.width || node.width || 200,
+      height: node.measured?.height || node.height || 100,
     };
   }
 

--- a/packages/apollo-react/src/canvas/stores/animatedViewportManager.ts
+++ b/packages/apollo-react/src/canvas/stores/animatedViewportManager.ts
@@ -237,8 +237,10 @@ class AnimatedViewportManager {
     const nodeBounds: NodeBounds = {
       x: node.position.x,
       y: node.position.y,
-      width: node.width || 200,
-      height: node.height || 100,
+      // Prefer measured dimensions: node width/height are content-driven and may be
+      // unset in the store until React Flow's ResizeObserver reports them.
+      width: node.measured?.width ?? node.width ?? 200,
+      height: node.measured?.height ?? node.height ?? 100,
     };
 
     // Calculate the viewport that focuses on the node with padding
@@ -335,8 +337,10 @@ class AnimatedViewportManager {
     return {
       x: node.position.x,
       y: node.position.y,
-      width: node.width || 200,
-      height: node.height || 100,
+      // Prefer measured dimensions: node width/height are content-driven and may be
+      // unset in the store until React Flow's ResizeObserver reports them.
+      width: node.measured?.width ?? node.width ?? 200,
+      height: node.measured?.height ?? node.height ?? 100,
     };
   }
 


### PR DESCRIPTION
## Summary

Fixes the Switch-node height flicker (MST-11677): deleting a case from an unconnected Switch made it oscillate between the 2-handle (96px) and 3-handle (128px) sizes. Root cause was a feedback loop where `BaseNode` derived its height from the *measured* `height` prop and wrote it back via `updateNode` inside a `requestAnimationFrame`.

## Changes

- **`computedHeight` is now a pure function of visible handle count + intrinsic footer/default height** (`getIntrinsicHeight`). It never reads the measured `height` prop, so the value written back can't feed into its own input — the loop is structurally gone.
- **A single, synchronous `useEffect` writes `computedHeight` to `node.height`** (no rAF), only when it differs from the *explicit* `getNode(id)?.height`, then calls `updateNodeInternals`. Comparing against the explicit height (not the measured prop) means a lagging ResizeObserver measurement can't retrigger the write. Convergent and idempotent.
- Keeping `node.height` authoritative fixes the downstream model: measured height, edge anchoring, fit-view, selection bounds, and handle spacing all agree with the rendered body (fixes handles overflowing on high-fan-out nodes).
- `animatedViewportManager` now reads `node.measured?.height ?? node.height ?? …`, matching the package's dominant convention (previously `node.height || 100`, which went stale when height wasn't written).
- Removed the old `baseHeightRef`/`syncedHeightRef` bookkeeping and the dead `getContainerHeight` height param.

## Testing

- [x] `pnpm lint` (Biome) passes
- [x] `pnpm typecheck` passes
- [x] Tests pass — rewritten height suite asserts the write-once/converge behavior, the 128→96 deflation settles with no re-inflation, and no write when already correct (full apollo-react suite green, 1885)
- [ ] `pnpm test:visual` — runs in CI
- [x] No `as any` / type suppressions added
