### PR TITLE
fix(apollo-react): update badge label for retryCount [MST-11251]

### DIFF
--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.types.ts
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.types.ts
@@ -115,6 +115,12 @@ export interface StageTaskExecution {
   retryDuration?: string;
   badge?: string;
   badgeStatus?: 'warning' | 'info' | 'error';
+  /**
+   * Total run count to display in the badge. Requires `badge` to be set. When `> 1`, Apollo
+   * overrides the `badge` text with a localized "Ran N times" (or "Running again" when `status` is
+   * `'InProgress'`). When `1` or absent, the `badge` string is rendered as-is and must be
+   * pre-localized by the consumer.
+   */
   retryCount?: number;
 }
 

--- a/packages/apollo-react/src/canvas/components/StageNode/TaskContent.test.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/TaskContent.test.tsx
@@ -91,6 +91,77 @@ describe('TaskContent - execution status tooltip', () => {
   });
 });
 
+describe('TaskContent - badge', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders "Running again" when retryCount > 1 and status is InProgress', () => {
+    renderTaskContent({
+      taskExecution: { status: 'InProgress', duration: '1m', retryCount: 2, badge: 'Running' },
+    });
+    expect(screen.getByText('Running again')).toBeInTheDocument();
+  });
+
+  it('renders "Ran N times" when retryCount > 1 and status is not InProgress', () => {
+    renderTaskContent({
+      taskExecution: { status: 'Completed', duration: '1m', retryCount: 2, badge: 'Ran' },
+    });
+    expect(screen.getByText('Ran 2 times')).toBeInTheDocument();
+  });
+
+  it('interpolates the count into the plural form', () => {
+    renderTaskContent({
+      taskExecution: { status: 'Failed', duration: '1m', retryCount: 3, badge: 'Ran' },
+    });
+    expect(screen.getByText('Ran 3 times')).toBeInTheDocument();
+  });
+
+  it('overrides the consumer-supplied badge string when retryCount > 1', () => {
+    renderTaskContent({
+      taskExecution: {
+        status: 'Completed',
+        duration: '1m',
+        retryCount: 2,
+        badge: 'Reworked',
+      },
+    });
+    expect(screen.getByText('Ran 2 times')).toBeInTheDocument();
+    expect(screen.queryByText('Reworked')).not.toBeInTheDocument();
+  });
+
+  it('renders the consumer-supplied badge string as-is when retryCount is 1', () => {
+    renderTaskContent({
+      taskExecution: { status: 'Completed', duration: '1m', retryCount: 1, badge: 'Ran' },
+    });
+    expect(screen.getByText('Ran')).toBeInTheDocument();
+  });
+
+  it('renders the consumer-supplied badge string as-is when retryCount is 1 and status is InProgress', () => {
+    renderTaskContent({
+      taskExecution: { status: 'InProgress', duration: '1m', retryCount: 1, badge: 'Running' },
+    });
+    expect(screen.getByText('Running')).toBeInTheDocument();
+  });
+
+  it('renders the consumer-supplied badge string when retryCount is absent', () => {
+    renderTaskContent({
+      taskExecution: { status: 'Completed', duration: '1m', badge: 'Action needed' },
+    });
+    expect(screen.getByText('Action needed')).toBeInTheDocument();
+  });
+
+  it('renders no badge when no badge string is supplied (even if retryCount > 1)', () => {
+    renderTaskContent({ taskExecution: { status: 'Completed', duration: '1m', retryCount: 2 } });
+    expect(screen.queryByText(/Ran|Running/)).not.toBeInTheDocument();
+  });
+
+  it('renders no badge when neither retryCount nor a badge string is supplied', () => {
+    renderTaskContent({ taskExecution: { status: 'Completed', duration: '1m' } });
+    expect(screen.queryByText(/Ran|Running|Reworked/)).not.toBeInTheDocument();
+  });
+});
+
 describe('TaskContent - duration tooltip', () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/packages/apollo-react/src/canvas/components/StageNode/TaskContent.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/TaskContent.tsx
@@ -3,6 +3,7 @@ import { Column, Row } from '@uipath/apollo-react/canvas/layouts';
 import { Badge, Button, Spinner } from '@uipath/apollo-wind';
 import debounce from 'debounce';
 import { memo, useCallback, useMemo, useState } from 'react';
+import { useSafeLingui } from '../../../i18n';
 import { TimelinePlayIcon } from '../../icons';
 import { CanvasTooltip } from '../CanvasTooltip';
 import { ExecutionStatusIcon } from '../ExecutionStatusIcon';
@@ -19,16 +20,6 @@ const ProcessCanvasIcon = () => (
     <rect x="14" y="14" width="7" height="7" rx="1" />
   </svg>
 );
-
-const generateBadgeText = (taskExecution: StageTaskExecution) => {
-  if (!taskExecution.badge) {
-    return undefined;
-  }
-  if (taskExecution.retryCount && taskExecution.retryCount > 1) {
-    return `${taskExecution.badge} x${taskExecution.retryCount}`;
-  }
-  return taskExecution.badge;
-};
 
 const TaskPlayButton = memo(
   ({
@@ -112,11 +103,30 @@ export interface TaskContentProps {
 
 export const TaskContent = memo(
   ({ task, taskExecution, isDragging, onTaskPlay }: TaskContentProps) => {
+    const { _ } = useSafeLingui();
     const getStatusName = useExecutionStatusLabel();
     const hasExecutionStatus = !!taskExecution?.status;
+    const badgeText = useMemo(() => {
+      if (!taskExecution?.badge) {
+        return undefined;
+      }
+      if (taskExecution.retryCount && taskExecution.retryCount > 1) {
+        if (taskExecution.status === 'InProgress') {
+          return _({
+            id: 'stage-node.task-badge.running-again',
+            message: 'Running again',
+          });
+        }
+        return _({
+          id: 'stage-node.task-badge.ran-n-times',
+          message: '{count, plural, one {Ran # time} other {Ran # times}}',
+          values: { count: taskExecution.retryCount },
+        });
+      }
+      return taskExecution.badge;
+    }, [taskExecution?.badge, taskExecution?.retryCount, taskExecution?.status, _]);
     const hasSecondRowContent =
-      taskExecution &&
-      (taskExecution.duration || taskExecution.retryDuration || taskExecution.badge);
+      taskExecution && (taskExecution.duration || taskExecution.retryDuration || badgeText);
     const showPlayButtonSmall = onTaskPlay && hasExecutionStatus;
     const taskStatusFallbackName = hasExecutionStatus ? getStatusName(taskExecution?.status) : '';
     const taskStatusTooltip = taskExecution?.message || taskStatusFallbackName;
@@ -197,11 +207,7 @@ export const TaskContent = memo(
               )}
             </Row>
             <Row align="center" gap={Spacing.SpacingXs}>
-              {taskExecution?.badge && (
-                <Badge variant={taskExecution.badgeStatus}>
-                  {generateBadgeText(taskExecution) ?? ''}
-                </Badge>
-              )}
+              {badgeText && <Badge variant={taskExecution.badgeStatus}>{badgeText}</Badge>}
               <StageTaskEntryConditionIcon task={task} small />
               {showPlayButtonSmall && (
                 <TaskPlayButton taskId={task.id} onTaskPlay={onTaskPlay} small />

--- a/packages/apollo-react/src/canvas/locales/en.json
+++ b/packages/apollo-react/src/canvas/locales/en.json
@@ -31,6 +31,8 @@
   "stage-node.status.paused": "Paused",
   "stage-node.status.terminated": "Terminated",
   "stage-node.status.warning": "Warning",
+  "stage-node.task-badge.ran-n-times": "{count, plural, one {Ran # time} other {Ran # times}}",
+  "stage-node.task-badge.running-again": "Running again",
   "stage-node.ungroup-parallel-tasks": "Ungroup parallel tasks",
   "stage-node.untitled-stage": "Untitled stage",
   "sticky-note.formatting.bold": "Bold ({boldShortcut})",


### PR DESCRIPTION
## Description

Updated the StageNode task badge to render a human-readable, localized label for retried executions instead of the cryptic x2 suffix. When retryCount > 1, the badge now reads "Ran N times" (or "Running again" while the task is in progress) using the consumer app's Lingui catalog.

## Key Changes 
- Replaced the inline generateBadgeText helper with a memoized badgeText derived inside TaskContent so it can resolve translations via useSafeLingui
- Added stage-node.task-badge.ran-n-times to canvas/locales/en.json with ICU plural form {count, plural, one {Ran # time} other {Ran # times}}
- Added stage-node.task-badge.running-again to canvas/locales/en.json for the InProgress variant
- When retryCount > 1, the localized label fully overrides the consumer-supplied badge string. When retryCount is 1 or absent, the consumer's badge string is rendered as-is (must be pre-localized)
- Documented the new contract on StageTaskExecution.retryCount in StageNode.types.ts
- Added a TaskContent - badge test suite covering InProgress vs other statuses, plural interpolation, override behavior when retryCount > 1, pass-through when retryCount is 1 or absent, and no-badge cases

## Implementation Details
- Badge rendering is gated on the resolved badgeText instead of taskExecution.badge, so the second row collapses correctly when no label is produced
- hasSecondRowContent now reads from badgeText to stay consistent with what actually renders
- useSafeLingui is used so the component degrades gracefully when no I18nProvider is mounted