### PR TITLE
Fix Apollo Vertex registry CSS vars

### DIFF
--- a/.github/scripts/test-registry/check-css-vars.ts
+++ b/.github/scripts/test-registry/check-css-vars.ts
@@ -1,0 +1,331 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+interface RegistryFile {
+  path: string;
+}
+
+interface CssVars {
+  theme?: Record<string, string>;
+  light?: Record<string, string>;
+  dark?: Record<string, string>;
+}
+
+interface RegistryItem {
+  name: string;
+  type: string;
+  files?: RegistryFile[];
+  registryDependencies?: string[];
+  cssVars?: CssVars;
+}
+
+interface Registry {
+  items: RegistryItem[];
+}
+
+interface RequiredCssVars {
+  theme: Set<string>;
+  runtime: Map<string, Set<'light' | 'dark'>>;
+}
+
+interface AvailableCssVars {
+  theme: Set<string>;
+  light: Set<string>;
+  dark: Set<string>;
+}
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(__dirname, '../../..');
+const vertexRoot = join(repoRoot, 'apps/apollo-vertex');
+const registryPath = join(vertexRoot, 'registry.json');
+
+const baseRuntimeVars = new Set([
+  'background',
+  'foreground',
+  'card',
+  'card-foreground',
+  'popover',
+  'popover-foreground',
+  'primary',
+  'primary-foreground',
+  'secondary',
+  'secondary-foreground',
+  'muted',
+  'muted-foreground',
+  'accent',
+  'accent-foreground',
+  'destructive',
+  'destructive-foreground',
+  'border',
+  'input',
+  'ring',
+  'chart-1',
+  'chart-2',
+  'chart-3',
+  'chart-4',
+  'chart-5',
+  'sidebar',
+  'sidebar-foreground',
+  'sidebar-primary',
+  'sidebar-primary-foreground',
+  'sidebar-accent',
+  'sidebar-accent-foreground',
+  'sidebar-border',
+  'sidebar-ring',
+  'font-sans',
+  'font-serif',
+  'font-mono',
+  'radius',
+  'spacing',
+]);
+
+const baseThemeVars = new Set([
+  ...Array.from(baseRuntimeVars, (name) => `color-${name}`),
+  'radius-sm',
+  'radius-md',
+  'radius-lg',
+  'radius-xl',
+  'font-sans',
+]);
+
+const cssVarReferencePattern = /var\(\s*--([a-zA-Z0-9_-]+)/g;
+const tailwindColorUtilityPattern =
+  /(?:^|[^a-zA-Z0-9_-])(?:bg|text|border|ring|outline|fill|stroke|caret|decoration|accent|divide|from|via|to)-([a-z][a-z0-9]*(?:-[a-z0-9]+)*)(?=\/|[^a-zA-Z0-9_-]|$)/g;
+
+function readRegistry(): Registry {
+  return JSON.parse(readFileSync(registryPath, 'utf-8')) as Registry;
+}
+
+function normalizeRegistryDependencyName(dependency: string): string {
+  return dependency.startsWith('@uipath/') ? dependency.slice('@uipath/'.length) : dependency;
+}
+
+function collectCssVarReferences(value: string): string[] {
+  return Array.from(value.matchAll(cssVarReferencePattern), (match) => match[1]);
+}
+
+function getRuntimeVarForThemeKey(theme: CssVars, themeKey: string): string | undefined {
+  const value = theme.theme?.[themeKey];
+
+  if (!value) {
+    return undefined;
+  }
+
+  return collectCssVarReferences(value)[0];
+}
+
+function addRuntimeRequirement(
+  required: RequiredCssVars,
+  runtimeVar: string,
+  modes: Array<'light' | 'dark'>
+): void {
+  const existing = required.runtime.get(runtimeVar) ?? new Set<'light' | 'dark'>();
+
+  for (const mode of modes) {
+    existing.add(mode);
+  }
+
+  required.runtime.set(runtimeVar, existing);
+}
+
+function addCssVars(target: AvailableCssVars, cssVars?: CssVars): void {
+  for (const key of Object.keys(cssVars?.theme ?? {})) {
+    target.theme.add(key);
+  }
+
+  for (const key of Object.keys(cssVars?.light ?? {})) {
+    target.light.add(key);
+  }
+
+  for (const key of Object.keys(cssVars?.dark ?? {})) {
+    target.dark.add(key);
+  }
+}
+
+function collectAvailableCssVars(
+  item: RegistryItem,
+  itemsByName: Map<string, RegistryItem>,
+  seen = new Set<string>()
+): AvailableCssVars {
+  const available: AvailableCssVars = {
+    theme: new Set(),
+    light: new Set(),
+    dark: new Set(),
+  };
+
+  if (seen.has(item.name)) {
+    return available;
+  }
+
+  seen.add(item.name);
+  addCssVars(available, item.cssVars);
+
+  for (const dependency of item.registryDependencies ?? []) {
+    const dependencyItem = itemsByName.get(normalizeRegistryDependencyName(dependency));
+
+    if (!dependencyItem) {
+      continue;
+    }
+
+    const dependencyCssVars = collectAvailableCssVars(dependencyItem, itemsByName, seen);
+
+    for (const key of dependencyCssVars.theme) {
+      available.theme.add(key);
+    }
+
+    for (const key of dependencyCssVars.light) {
+      available.light.add(key);
+    }
+
+    for (const key of dependencyCssVars.dark) {
+      available.dark.add(key);
+    }
+  }
+
+  return available;
+}
+
+function collectRequiredCssVars(item: RegistryItem, theme: CssVars): RequiredCssVars {
+  const required: RequiredCssVars = {
+    theme: new Set(),
+    runtime: new Map(),
+  };
+
+  const fileContents = (item.files ?? []).map((file) =>
+    readFileSync(join(vertexRoot, file.path), 'utf-8')
+  );
+
+  for (const content of fileContents) {
+    for (const runtimeVar of collectCssVarReferences(content)) {
+      if (
+        !baseRuntimeVars.has(runtimeVar) &&
+        (theme.light?.[runtimeVar] || theme.dark?.[runtimeVar])
+      ) {
+        addRuntimeRequirement(required, runtimeVar, expectedRuntimeModes(runtimeVar, theme));
+      }
+    }
+
+    for (const match of content.matchAll(tailwindColorUtilityPattern)) {
+      const colorName = match[1];
+      const themeKey = `color-${colorName}`;
+
+      if (!theme.theme?.[themeKey] || baseThemeVars.has(themeKey)) {
+        continue;
+      }
+
+      required.theme.add(themeKey);
+
+      const runtimeVar = getRuntimeVarForThemeKey(theme, themeKey);
+
+      if (runtimeVar && !baseRuntimeVars.has(runtimeVar)) {
+        addRuntimeRequirement(required, runtimeVar, expectedRuntimeModes(runtimeVar, theme));
+      }
+    }
+  }
+
+  for (const value of Object.values(item.cssVars?.theme ?? {})) {
+    for (const runtimeVar of collectCssVarReferences(value)) {
+      if (
+        !baseRuntimeVars.has(runtimeVar) &&
+        (theme.light?.[runtimeVar] || theme.dark?.[runtimeVar])
+      ) {
+        addRuntimeRequirement(required, runtimeVar, expectedRuntimeModes(runtimeVar, theme));
+      }
+    }
+  }
+
+  for (const value of Object.values(item.cssVars?.light ?? {})) {
+    for (const runtimeVar of collectCssVarReferences(value)) {
+      if (!baseRuntimeVars.has(runtimeVar) && theme.light?.[runtimeVar]) {
+        addRuntimeRequirement(required, runtimeVar, ['light']);
+      }
+    }
+  }
+
+  for (const value of Object.values(item.cssVars?.dark ?? {})) {
+    for (const runtimeVar of collectCssVarReferences(value)) {
+      if (!baseRuntimeVars.has(runtimeVar) && theme.dark?.[runtimeVar]) {
+        addRuntimeRequirement(required, runtimeVar, ['dark']);
+      }
+    }
+  }
+
+  return required;
+}
+
+function expectedRuntimeModes(runtimeVar: string, theme: CssVars): Array<'light' | 'dark'> {
+  const modes: Array<'light' | 'dark'> = [];
+
+  if (theme.light?.[runtimeVar]) {
+    modes.push('light');
+  }
+
+  if (theme.dark?.[runtimeVar]) {
+    modes.push('dark');
+  }
+
+  return modes;
+}
+
+function main() {
+  const registry = readRegistry();
+  const themeItem = registry.items.find(
+    (item) => item.name === 'apollo-vertex-theme' && item.type === 'registry:theme'
+  );
+
+  if (!themeItem?.cssVars) {
+    console.error('apollo-vertex-theme cssVars are required for the registry CSS var check.');
+    process.exit(1);
+  }
+
+  const itemsByName = new Map(registry.items.map((item) => [item.name, item]));
+  const errors: string[] = [];
+
+  for (const item of registry.items) {
+    if (!item.files?.length) {
+      continue;
+    }
+
+    const required = collectRequiredCssVars(item, themeItem.cssVars);
+
+    if (required.theme.size === 0 && required.runtime.size === 0) {
+      continue;
+    }
+
+    const available = collectAvailableCssVars(item, itemsByName);
+    const missing: string[] = [];
+
+    for (const themeKey of required.theme) {
+      if (!available.theme.has(themeKey)) {
+        missing.push(`cssVars.theme["${themeKey}"]`);
+      }
+    }
+
+    for (const [runtimeVar, modes] of required.runtime) {
+      for (const mode of modes) {
+        if (!available[mode].has(runtimeVar)) {
+          missing.push(`cssVars.${mode}["${runtimeVar}"]`);
+        }
+      }
+    }
+
+    if (missing.length > 0) {
+      errors.push(
+        [
+          `@uipath/${item.name} uses Apollo CSS variables that are not provided by its registry item or registryDependencies:`,
+          ...missing.map((entry) => `  - ${entry}`),
+        ].join('\n')
+      );
+    }
+  }
+
+  if (errors.length > 0) {
+    console.error(errors.join('\n\n'));
+    process.exit(1);
+  }
+
+  console.log('Registry CSS variable check passed.');
+}
+
+main();

--- a/.github/workflows/apollo-vertex-registry-check.yml
+++ b/.github/workflows/apollo-vertex-registry-check.yml
@@ -55,6 +55,9 @@ jobs:
       - name: Build registry
         run: pnpm --filter apollo-vertex registry:build
 
+      - name: Check registry CSS variables
+        run: node --experimental-strip-types .github/scripts/test-registry/check-css-vars.ts
+
       - name: Generate matrix batches
         id: matrix
         run: |

--- a/apps/apollo-vertex/registry.json
+++ b/apps/apollo-vertex/registry.json
@@ -1117,6 +1117,45 @@
         "@uipath/textarea",
         "@uipath/tooltip"
       ],
+      "cssVars": {
+        "theme": {
+          "color-ai-chat-foreground": "var(--ai-chat-foreground)",
+          "color-ai-chat-muted": "var(--ai-chat-muted)",
+          "color-primary-700": "var(--primary-700)",
+          "color-ai-chat-border": "var(--ai-chat-border)",
+          "color-ai-chat-accent": "var(--ai-chat-accent)",
+          "color-ai-chat-muted-foreground": "var(--ai-chat-muted-foreground)",
+          "color-ai-chat-bubble-user": "var(--ai-chat-bubble-user)",
+          "color-ai-chat-bubble-user-foreground": "var(--ai-chat-bubble-user-foreground)",
+          "color-ai-chat": "var(--ai-chat)"
+        },
+        "light": {
+          "ai-chat-foreground": "oklch(0.2394 0.0455 252.45)",
+          "ai-chat-muted": "oklch(0.955 0.006 260)",
+          "ai-chat-border": "oklch(0.92 0.008 260)",
+          "ai-chat-accent": "oklch(0.64 0.115 208)",
+          "ai-chat-muted-foreground": "oklch(0.50 0.020 260)",
+          "ai-chat-bubble-user": "oklch(0.955 0.008 252)",
+          "ai-chat-bubble-user-foreground": "oklch(0.2394 0.0455 252.45)",
+          "ai-gradient-start": "#6C5AEF",
+          "ai-gradient-end": "#69C7DD",
+          "ai-chat-brand-gradient": "linear-gradient(97.73deg, #5D4ED0 8.79%, #1076A0 91.48%)",
+          "ai-chat": "oklch(0.985 0.002 260)"
+        },
+        "dark": {
+          "ai-chat-foreground": "oklch(0.95 0.010 225)",
+          "ai-chat-muted": "oklch(0.26 0.030 258)",
+          "ai-chat-border": "oklch(0.30 0.040 258)",
+          "ai-chat-accent": "oklch(0.69 0.112 207)",
+          "ai-chat-muted-foreground": "oklch(0.65 0.020 258)",
+          "ai-chat-bubble-user": "oklch(0.28 0.035 255)",
+          "ai-chat-bubble-user-foreground": "oklch(0.95 0.010 225)",
+          "ai-gradient-start": "#6C5AEF",
+          "ai-gradient-end": "#69C7DD",
+          "ai-chat-brand-gradient": "linear-gradient(97.73deg, #9485F5 8.79%, #69C7DD 91.48%)",
+          "ai-chat": "oklch(0.19 0.025 260)"
+        }
+      },
       "files": [
         { "path": "lib/asserts/assert.ts", "type": "registry:lib" },
         {
@@ -1446,6 +1485,23 @@
       "type": "registry:ui",
       "title": "Alert",
       "description": "Displays a callout for user attention.",
+      "cssVars": {
+        "theme": {
+          "color-badge": "var(--badge)",
+          "color-warning": "var(--warning)",
+          "color-warning-foreground": "var(--warning-foreground)"
+        },
+        "light": {
+          "badge": "oklch(0.5995 0.0199 253.42)",
+          "warning": "oklch(0.80 0.1401 80.82)",
+          "warning-foreground": "oklch(0.1660 0.0283 203.3400)"
+        },
+        "dark": {
+          "badge": "oklch(0.7196 0.0135 255.53)",
+          "warning": "oklch(0.6889 0.1401 80.82)",
+          "warning-foreground": "oklch(0.1660 0.0283 203.3400)"
+        }
+      },
       "files": [{ "path": "registry/alert/alert.tsx", "type": "registry:ui" }]
     },
     {
@@ -1488,6 +1544,56 @@
       "title": "Badge",
       "description": "Displays a badge or a component that looks like a badge.",
       "dependencies": ["@radix-ui/react-slot"],
+      "cssVars": {
+        "theme": {
+          "color-badge": "var(--badge)",
+          "color-badge-foreground": "var(--badge-foreground)",
+          "color-info": "var(--info)",
+          "color-info-foreground": "var(--info-foreground)",
+          "color-warning": "var(--warning)",
+          "color-warning-foreground": "var(--warning-foreground)",
+          "color-success": "var(--success)",
+          "color-success-foreground": "var(--success-foreground)",
+          "color-insight-600": "var(--insight-600)",
+          "color-insight-400": "var(--insight-400)"
+        },
+        "light": {
+          "ai-gradient-fill": "linear-gradient(97.73deg, var(--insight-600) 8.79%, var(--primary-700) 91.48%)",
+          "ai-gradient": "linear-gradient(100.64deg, var(--insight-100) 8.29%, var(--primary-50) 88.73%)",
+          "ai-gradient-strong": "linear-gradient(97.73deg, #6C5AEF 8.79%, #69C7DD 91.48%)",
+          "badge": "oklch(0.5995 0.0199 253.42)",
+          "badge-foreground": "oklch(1 0 89.8800)",
+          "info": "oklch(0.52 0.120 210)",
+          "info-foreground": "oklch(1 0 89.8800)",
+          "warning": "oklch(0.80 0.1401 80.82)",
+          "warning-foreground": "oklch(0.1660 0.0283 203.3400)",
+          "success": "oklch(0.57 0.105 152)",
+          "success-foreground": "oklch(1 0 89.8800)",
+          "insight-600": "oklch(0.56 0.20 277)",
+          "insight-400": "oklch(0.70 0.19 277)",
+          "primary-50": "oklch(0.95 0.035 218)",
+          "primary-700": "oklch(0.52 0.120 210)",
+          "insight-100": "oklch(0.92 0.05 277)"
+        },
+        "dark": {
+          "ai-gradient-fill": "linear-gradient(97.73deg, var(--insight-600) 8.79%, var(--primary-700) 91.48%)",
+          "ai-gradient": "linear-gradient(100.64deg, var(--insight-800) 8.29%, var(--primary-800) 88.73%)",
+          "ai-gradient-strong": "linear-gradient(97.73deg, #6C5AEF 8.79%, #69C7DD 91.48%)",
+          "badge": "oklch(0.7196 0.0135 255.53)",
+          "badge-foreground": "oklch(0.1660 0.0283 203.3400)",
+          "info": "oklch(0.69 0.112 207)",
+          "info-foreground": "oklch(0.1660 0.0283 203.3400)",
+          "warning": "oklch(0.6889 0.1401 80.82)",
+          "warning-foreground": "oklch(0.1660 0.0283 203.3400)",
+          "success": "oklch(0.70 0.120 152)",
+          "success-foreground": "oklch(0.1660 0.0283 203.3400)",
+          "insight-600": "oklch(0.56 0.20 277)",
+          "insight-400": "oklch(0.70 0.19 277)",
+          "primary-700": "oklch(0.52 0.120 210)",
+          "primary-800": "oklch(0.46 0.095 220)",
+          "insight-800": "oklch(0.38 0.13 278)"
+        }
+      },
       "files": [{ "path": "registry/badge/badge.tsx", "type": "registry:ui" }]
     },
     {
@@ -1509,6 +1615,41 @@
       "title": "Button",
       "description": "Displays a button or a component that looks like a button.",
       "dependencies": ["@radix-ui/react-slot"],
+      "cssVars": {
+        "theme": {
+          "color-success": "var(--success)",
+          "color-info": "var(--info)",
+          "color-warning": "var(--warning)",
+          "color-insight-400": "var(--insight-400)",
+          "color-insight-600": "var(--insight-600)"
+        },
+        "light": {
+          "success": "oklch(0.57 0.105 152)",
+          "info": "oklch(0.52 0.120 210)",
+          "warning": "oklch(0.80 0.1401 80.82)",
+          "primary-50": "oklch(0.95 0.035 218)",
+          "primary-700": "oklch(0.52 0.120 210)",
+          "insight-100": "oklch(0.92 0.05 277)",
+          "insight-400": "oklch(0.70 0.19 277)",
+          "insight-600": "oklch(0.56 0.20 277)",
+          "ai-gradient": "linear-gradient(100.64deg, var(--insight-100) 8.29%, var(--primary-50) 88.73%)",
+          "ai-gradient-fill": "linear-gradient(97.73deg, var(--insight-600) 8.79%, var(--primary-700) 91.48%)",
+          "ai-gradient-strong": "linear-gradient(97.73deg, #6C5AEF 8.79%, #69C7DD 91.48%)"
+        },
+        "dark": {
+          "success": "oklch(0.70 0.120 152)",
+          "info": "oklch(0.69 0.112 207)",
+          "warning": "oklch(0.6889 0.1401 80.82)",
+          "primary-700": "oklch(0.52 0.120 210)",
+          "primary-800": "oklch(0.46 0.095 220)",
+          "insight-400": "oklch(0.70 0.19 277)",
+          "insight-600": "oklch(0.56 0.20 277)",
+          "insight-800": "oklch(0.38 0.13 278)",
+          "ai-gradient": "linear-gradient(100.64deg, var(--insight-800) 8.29%, var(--primary-800) 88.73%)",
+          "ai-gradient-fill": "linear-gradient(97.73deg, var(--insight-600) 8.79%, var(--primary-700) 91.48%)",
+          "ai-gradient-strong": "linear-gradient(97.73deg, #6C5AEF 8.79%, #69C7DD 91.48%)"
+        }
+      },
       "files": [{ "path": "registry/button/button.tsx", "type": "registry:ui" }]
     },
     {
@@ -1530,6 +1671,27 @@
       "type": "registry:ui",
       "title": "Card",
       "description": "Displays a card with header, content, and footer. Supports solid, glass, and selectable variants.",
+      "cssVars": {
+        "theme": {
+          "color-primary-400": "var(--primary-400)"
+        },
+        "light": {
+          "primary-50": "oklch(0.95 0.035 218)",
+          "primary-400": "oklch(0.75 0.100 210)",
+          "insight-100": "oklch(0.92 0.05 277)",
+          "sidebar": "oklch(0.9723 0.0074 260.7300)",
+          "ai-gradient": "linear-gradient(100.64deg, var(--insight-100) 8.29%, var(--primary-50) 88.73%)",
+          "ai-glass": "color-mix(in srgb, var(--card) 80%, transparent)"
+        },
+        "dark": {
+          "primary-400": "oklch(0.75 0.100 210)",
+          "primary-800": "oklch(0.46 0.095 220)",
+          "insight-800": "oklch(0.38 0.13 278)",
+          "sidebar": "oklch(0.1620 0.0310 257.7000)",
+          "ai-gradient": "linear-gradient(100.64deg, var(--insight-800) 8.29%, var(--primary-800) 88.73%)",
+          "ai-glass": "color-mix(in srgb, var(--card) 90%, transparent)"
+        }
+      },
       "files": [{ "path": "registry/card/card.tsx", "type": "registry:ui" }]
     },
     {
@@ -2113,6 +2275,26 @@
         "spinner",
         "collapsible"
       ],
+      "cssVars": {
+        "theme": {
+          "color-primary-700": "var(--primary-700)",
+          "color-primary-400": "var(--primary-400)",
+          "color-primary-100": "var(--primary-100)",
+          "color-primary-900": "var(--primary-900)"
+        },
+        "light": {
+          "primary-100": "oklch(0.92 0.045 216)",
+          "primary-400": "oklch(0.75 0.100 210)",
+          "primary-700": "oklch(0.52 0.120 210)",
+          "primary-900": "oklch(0.2394 0.0455 252.445)"
+        },
+        "dark": {
+          "primary-100": "oklch(0.92 0.045 216)",
+          "primary-400": "oklch(0.75 0.100 210)",
+          "primary-700": "oklch(0.52 0.120 210)",
+          "primary-900": "oklch(0.2394 0.0455 252.445)"
+        }
+      },
       "files": [
         { "path": "registry/shell/shell.tsx", "type": "registry:ui" },
         {
@@ -2416,6 +2598,23 @@
       "title": "Sonner",
       "description": "An opinionated toast component for React.",
       "dependencies": ["sonner", "next-themes"],
+      "cssVars": {
+        "theme": {
+          "color-info": "var(--info)",
+          "color-success": "var(--success)",
+          "color-warning": "var(--warning)"
+        },
+        "light": {
+          "success": "oklch(0.57 0.105 152)",
+          "warning": "oklch(0.80 0.1401 80.82)",
+          "info": "oklch(0.52 0.120 210)"
+        },
+        "dark": {
+          "success": "oklch(0.70 0.120 152)",
+          "warning": "oklch(0.6889 0.1401 80.82)",
+          "info": "oklch(0.69 0.112 207)"
+        }
+      },
       "files": [{ "path": "registry/sonner/sonner.tsx", "type": "registry:ui" }]
     },
     {


### PR DESCRIPTION
Adds missing Apollo CSS variables to registry items that use non-base Tailwind tokens, including button and card. Adds a strict registry check that scans component source for Apollo-specific CSS variable usage and fails CI unless the item or its registry dependencies provide matching cssVars. Wires the check into the existing Apollo Vertex registry workflow after registry build.\n\nValidated with the strict CSS variable check, registry JSON parse, git diff whitespace check, shadcn registry build, and registry index generation.