### PR TITLE
MST-11724: Improve action needed badge affordance

### DIFF
--- a/packages/apollo-react/src/canvas/components/BaseNode/BaseNode.test.tsx
+++ b/packages/apollo-react/src/canvas/components/BaseNode/BaseNode.test.tsx
@@ -105,6 +105,7 @@ vi.mock('@uipath/apollo-react/canvas/utils', () => ({
 }));
 vi.mock('../../utils/icon-registry', () => ({
   getIcon: () => () => <div data-testid="node-icon">Icon</div>,
+  CanvasIcon: ({ icon }: { icon: string }) => <span data-testid={`canvas-icon-${icon}`} />,
 }));
 vi.mock('../../utils/manifest-resolver', () => ({
   resolveDisplay: (display: Record<string, unknown> | undefined) => ({
@@ -353,6 +354,27 @@ describe('BaseNode', () => {
 
       expect(onHandleMouseEnter).toHaveBeenCalledWith(payload);
       expect(onHandleMouseLeave).toHaveBeenCalledWith(payload);
+    });
+  });
+
+  describe('Action needed badge', () => {
+    it('renders as an accessible clickable control and invokes onActionNeeded', () => {
+      const onActionNeeded = vi.fn();
+      mockOverrideConfig.current = {
+        executionStatusOverride: 'ActionNeeded',
+        onActionNeeded,
+      };
+
+      render(<BaseNode {...defaultProps} />);
+
+      const actionBadge = screen.getByRole('button', { name: 'Action needed' });
+      expect(actionBadge).toHaveClass('cursor-pointer');
+      expect(actionBadge).toHaveClass('nodrag');
+      expect(actionBadge).toHaveClass('focus-visible:outline-2');
+
+      fireEvent.click(actionBadge);
+
+      expect(onActionNeeded).toHaveBeenCalledWith('test-node');
     });
   });
 

--- a/packages/apollo-react/src/canvas/components/BaseNode/BaseNode.tsx
+++ b/packages/apollo-react/src/canvas/components/BaseNode/BaseNode.tsx
@@ -728,7 +728,7 @@ const BaseNodeComponent = (props: NodeProps<Node<BaseNodeData>>) => {
           return (
             <button
               type="button"
-              className="absolute z-10 flex items-center gap-1 rounded-full bg-amber-400 text-[11px] font-semibold text-stone-900 shadow-sm transition-colors hover:bg-amber-300"
+              className="nodrag absolute z-10 flex cursor-pointer items-center gap-1 rounded-full bg-amber-400 text-[11px] font-semibold text-stone-900 shadow-sm transition-colors hover:bg-amber-300 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-amber-500"
               style={{
                 top: badgeInset,
                 left: `calc(var(--node-w) - ${badgeInset + NODE_BADGE_SIZE}px)`,


### PR DESCRIPTION
## Summary
- Adds pointer cursor, nodrag behavior, and focus-visible styling to the BaseNode Action needed badge
- Adds focused coverage for the ActionNeeded badge click callback and interactive classes

## Validation
- CI=true pnpm --filter @uipath/apollo-react exec vitest --run src/canvas/components/BaseNode/BaseNode.test.tsx
- Verified in Storybook at the BaseNode Execution States story

https://github.com/user-attachments/assets/8f863e78-126a-4fe2-90fe-15bbaf080b3f