### PR TITLE
fix(apollo-vertex): dedupe user-message keys within a run

### DIFF
--- a/apps/apollo-vertex/registry/solution-tests/user-messages-view.tsx
+++ b/apps/apollo-vertex/registry/solution-tests/user-messages-view.tsx
@@ -28,8 +28,10 @@ export const UserMessagesView = ({ messages }: { messages: unknown }) => {
         const displayText = translated === msg.key ? msg.message : translated;
 
         return (
+          // key+timestamp can repeat within a run (e.g. several new-document
+          // warnings); the message text disambiguates them.
           <div
-            key={`${msg.key}-${msg.timestamp}`}
+            key={`${msg.key}-${msg.timestamp}-${msg.message}`}
             className={`rounded-md border-l-4 p-3 text-sm ${categoryBorderStyles[msg.category] ?? "bg-muted/50"}`}
           >
             {displayText}
@@ -68,7 +70,7 @@ export const UserMessagesIcon = ({ messages }: { messages: unknown }) => {
             const MIcon = severityIcons[msg.category] ?? Info;
             return (
               <div
-                key={`${msg.key}-${msg.timestamp}`}
+                key={`${msg.key}-${msg.timestamp}-${msg.message}`}
                 className="flex items-start gap-1.5"
               >
                 <MIcon


### PR DESCRIPTION
Follow-up to #870 (a fix that landed on the branch ~a minute after it was merged, so it missed).

### Problem
`UserMessagesView` keys each message on `` `${msg.key}-${msg.timestamp}` ``. A single run emits several messages of the same kind with an identical key + timestamp (e.g. multiple `SolutionTest_NewDocumentInExtraction` warnings), which triggers React's *"Encountered two children with the same key"* warning and risks dropped/duplicated nodes.

### Fix
Include the message text in the key. It differs per message (each carries its own document name), so keys stay unique — a genuine data-dependent key, no array index needed. Applied to both `.map`s in the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)