### PR TITLE
refactor(apollo-vertex): extract solution-tests action errors into errors.ts

### DIFF
--- a/apps/apollo-vertex/registry.json
+++ b/apps/apollo-vertex/registry.json
@@ -2886,6 +2886,11 @@
           "target": "components/ui/solution-tests/create-actions.ts"
         },
         {
+          "path": "registry/solution-tests/errors.ts",
+          "type": "registry:ui",
+          "target": "components/ui/solution-tests/errors.ts"
+        },
+        {
           "path": "registry/solution-tests/use-solution-tests.ts",
           "type": "registry:ui",
           "target": "components/ui/solution-tests/use-solution-tests.ts"

--- a/apps/apollo-vertex/registry/solution-tests/create-actions.ts
+++ b/apps/apollo-vertex/registry/solution-tests/create-actions.ts
@@ -9,43 +9,16 @@
 
 import type { SolutionTestsActions } from "./actions";
 import {
-  AGENT_SUCCESS_STATUSES,
   AUTOMATION_FUNCTION_PATH,
   AUTOMATION_FUNCTIONS_SLUG,
   RUN_TESTS_SLUG,
 } from "./constants";
+import { extractFailure, SolutionTestActionError } from "./errors";
 
 export interface SolutionTestActionDeps {
   /** Base URL each action slug is appended to (no trailing slash). */
   triggerBaseUrl: string;
   getToken: () => Promise<string | null> | string | null;
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
-/** The agent reports its outcome in `output_data.status`; the RPC router doesn't. */
-function agentStatus(data: unknown): string | null {
-  if (!isRecord(data)) return null;
-  const output = isRecord(data.output_data) ? data.output_data : data;
-  return typeof output.status === "string" ? output.status : null;
-}
-
-/** App-level failure across both contracts (HTTP stays 200 even on RBAC denial). */
-function detectFailure(data: unknown): string | null {
-  if (!isRecord(data)) return null;
-  // The agent wraps its payload in `output_data`; the RPC router returns it
-  // top-level. Unwrap once so `status_code`/`status` read from the same object.
-  const output = isRecord(data.output_data) ? data.output_data : data;
-  if (typeof output.status_code === "number" && output.status_code >= 400) {
-    return typeof output.error === "string" ? output.error : "request_failed";
-  }
-  const status = agentStatus(data);
-  if (status != null && !AGENT_SUCCESS_STATUSES.has(status)) {
-    return typeof output.message === "string" ? output.message : status;
-  }
-  return null;
 }
 
 export function createSolutionTestActions(
@@ -89,8 +62,8 @@ export function createSolutionTestActions(
       ?.includes("application/json")
       ? await response.json().catch(() => null)
       : null;
-    const failure = detectFailure(data);
-    if (failure) throw new Error(failure);
+    const failure = extractFailure(data);
+    if (failure) throw new SolutionTestActionError(failure);
   }
 
   // automation-functions RPC router; the token goes in the body's `_auth` envelope.

--- a/apps/apollo-vertex/registry/solution-tests/errors.ts
+++ b/apps/apollo-vertex/registry/solution-tests/errors.ts
@@ -1,0 +1,95 @@
+"use client";
+
+/**
+ * Structured failure handling for the Solution Tests write actions. The backend
+ * returns a translatable `UserMessage` ({ key, details, message }) on error, as
+ * the top-level `body` on the RPC contract or `output_data.error_message` on the
+ * agent contract. `extractFailure` reconciles both; the actions throw the result
+ * as a `SolutionTestActionError` that keeps `key` + `details` so consumers can
+ * localize with interpolation rather than losing them to a flattened string.
+ */
+
+import { AGENT_SUCCESS_STATUSES } from "./constants";
+
+export interface ActionFailure {
+  /** Stable failure code; consumers may map it to a localized message. */
+  key?: string;
+  /** Interpolation params for the localized message (e.g. `required_roles`). */
+  details?: Record<string, string>;
+  message?: string;
+}
+
+/** Thrown by the write actions on an app-level failure (HTTP stays 200). */
+export class SolutionTestActionError extends Error {
+  readonly key?: string;
+  readonly details?: Record<string, string>;
+
+  constructor(failure: ActionFailure) {
+    // `message` stays the key so plain `t(err.message)` consumers are unaffected.
+    super(failure.key ?? failure.message ?? "request_failed");
+    this.name = "SolutionTestActionError";
+    this.key = failure.key;
+    this.details = failure.details;
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function toDetails(value: unknown): Record<string, string> | undefined {
+  if (!isRecord(value)) return;
+  const out: Record<string, string> = {};
+  for (const [k, v] of Object.entries(value)) {
+    if (typeof v === "string") out[k] = v;
+  }
+  if (Object.keys(out).length === 0) return;
+  return out;
+}
+
+function fromUserMessage(value: unknown): ActionFailure | null {
+  if (!isRecord(value)) return null;
+  const failure: ActionFailure = {};
+  if (typeof value.key === "string") failure.key = value.key;
+  if (typeof value.message === "string") failure.message = value.message;
+  const details = toDetails(value.details);
+  if (details) failure.details = details;
+  if (!failure.key && !failure.message && !failure.details) return null;
+  return failure;
+}
+
+/** Detect an app-level failure across both contracts, or null on success. */
+export function extractFailure(data: unknown): ActionFailure | null {
+  if (!isRecord(data)) return null;
+  // The agent wraps its payload in `output_data`; the RPC router returns it
+  // top-level. Unwrap once so `status_code`/`status` read from the same object.
+  const output = isRecord(data.output_data) ? data.output_data : data;
+
+  if (typeof output.status_code === "number" && output.status_code >= 400) {
+    // RPC contract: the UserMessage is the top-level `body`.
+    const failure = fromUserMessage(data.body) ?? {};
+    if (typeof output.error === "string") {
+      failure.key ??= output.error;
+      failure.message ??= output.error;
+    }
+    failure.key ??= "request_failed";
+    return failure;
+  }
+
+  if (
+    typeof output.status === "string" &&
+    !AGENT_SUCCESS_STATUSES.has(output.status)
+  ) {
+    // Agent contract: the UserMessage is `output_data.error_message`.
+    const failure = fromUserMessage(output.error_message) ?? {};
+    if (typeof output.message === "string") {
+      failure.key ??= output.message;
+      failure.message ??= output.message;
+    }
+    failure.key ??= output.status;
+    failure.message ??= output.status;
+    return failure;
+  }
+
+  return null;
+}

--- a/apps/apollo-vertex/registry/solution-tests/index.ts
+++ b/apps/apollo-vertex/registry/solution-tests/index.ts
@@ -20,6 +20,8 @@ export { SolutionTests } from "./solution-tests";
 export { SolutionTestsView } from "./solution-tests-view";
 export type { SolutionTestsViewProps } from "./solution-tests-view";
 export { SaveAsTestButton } from "./save-as-test-button";
+export { SolutionTestActionError } from "./errors";
+export type { ActionFailure } from "./errors";
 export {
   SolutionTestsProvider,
   useSolutionTestsContext,


### PR DESCRIPTION
Extracts the app-level failure detection from `create-actions.ts` into a dedicated `errors.ts` module for the Solution Tests registry template. The new module reconciles the backend's translatable `UserMessage` (`{ key, details, message }`) across both the automation-functions RPC contract and the agent contract into a structured `ActionFailure`, thrown as a `SolutionTestActionError` that preserves the i18n `key` and interpolation `details` instead of flattening them to a string. `create-actions.ts` now delegates to `extractFailure`/`SolutionTestActionError`, the new file is registered in `registry.json`, and `SolutionTestActionError`/`ActionFailure` are re-exported from the barrel. This keeps the template in sync with the loan-setup reference app.

👨 Generated with Kluijt Code