### PR TITLE
feat(apollo-react): register case-management canvas icon [MST-11838]

### DIFF
--- a/packages/apollo-react/src/canvas/utils/icon-registry.test.tsx
+++ b/packages/apollo-react/src/canvas/utils/icon-registry.test.tsx
@@ -34,4 +34,11 @@ describe('getIcon', () => {
     expect(img).toBeInTheDocument();
     expect(img).toHaveAttribute('src', 'https://example.com/icon.svg');
   });
+
+  it('returns the CaseManagementProject icon for the registered case-management id', () => {
+    const Icon = getIcon('case-management');
+    const { container } = render(<Icon w={24} h={24} />);
+    // The registered UIPath icon renders its own SVG (id), not a Lucide fallback.
+    expect(container.querySelector('#case-management-project')).toBeInTheDocument();
+  });
 });

--- a/packages/apollo-react/src/canvas/utils/icon-registry.tsx
+++ b/packages/apollo-react/src/canvas/utils/icon-registry.tsx
@@ -35,6 +35,7 @@ const iconRegistry: Record<string, IconComponent> = {
   api: ({ w, h }) => <Icons.ApiProject w={w ?? 29} h={h ?? 28} />,
   'agentic-process': ({ w, h }) => <Icons.BusinessProcessProject w={w ?? 29} h={h ?? 28} />,
   'flow-project': ({ w, h }) => <Icons.FlowProject w={w ?? 29} h={h ?? 28} />,
+  'case-management': ({ w, h }) => <Icons.CaseManagementProject w={w ?? 29} h={h ?? 28} />,
   decision: ({ w, h }) => <Icons.DecisionIcon w={w ?? 24} h={h ?? 24} />,
   switch: ({ w, h }) => <Icons.SwitchIcon w={w ?? 24} h={h ?? 24} />,
   uipath: ({ w, h }) => <Icons.UiPathIcon w={w ?? 24} h={h ?? 24} />,


### PR DESCRIPTION
**Jira:** [MST-11838 — Use case management icon from apollo](https://uipath.atlassian.net/browse/MST-11838)

## What

Adds a `'case-management'` entry to the canvas `getIcon` registry, mapping it to the existing **`CaseManagementProject`** icon component.

## Why

`CaseManagementProject` already ships from `@uipath/apollo-react/canvas/icons` and is used directly by `TaskIcon` (`TaskItemTypeValues.CaseManagement`), but it was never wired into the string-keyed `iconRegistry` in `icon-registry.tsx`. So consumers that resolve icons by id — Flow's node manifests declare `display.icon` as a string — had no id that resolves to it; `'case-management'` fell through to the generic Box/Lucide fallback.

This adds the one registry entry, alongside its sibling project icons (`flow-project`, `agentic-process`, `rpa`), using the same default sizing (`w ?? 29`, `h ?? 28`).

## Downstream

Flow Workbench currently works around this gap with a canvas-side resolution overlay. Once this lands and is consumed, that overlay can be simplified to a plain `getIcon('case-management')`.

## Testing

- Added an `icon-registry.test.tsx` case asserting `getIcon('case-management')` renders the `CaseManagementProject` SVG (matched by its `#case-management-project` id) rather than a Lucide fallback — mirrors the existing registry test pattern.
- `biome format` + `biome lint` clean; full `icon-registry.test.tsx` suite passes (5/5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)