### PR TITLE
feat(apollo-react): add LockableValueField HITL prototype

### DIFF
--- a/apps/storybook/package.json
+++ b/apps/storybook/package.json
@@ -31,7 +31,7 @@
     "@storybook/icons": "^2.0.1",
     "@storybook/react": "^10.4.1",
     "@storybook/react-vite": "^10.4.1",
-    "@tailwindcss/vite": "^4.2.2",
+    "@tailwindcss/vite": "4.3.0",
     "@types/react": "^19.2.6",
     "@types/react-dom": "^19.2.2",
     "@vitejs/plugin-react": "^5.2.0",

--- a/packages/apollo-react/src/canvas/components/NodePropertyPanel/LockableValueField.tsx
+++ b/packages/apollo-react/src/canvas/components/NodePropertyPanel/LockableValueField.tsx
@@ -29,6 +29,7 @@ import {
   TooltipTrigger,
 } from '@uipath/apollo-wind';
 import {
+  Asterisk,
   Calendar as CalendarIcon,
   ChevronDown,
   Code2,
@@ -117,7 +118,7 @@ export const FIELD_TYPE_META: Record<LockableFieldType, FieldTypeMeta> = {
   },
 };
 
-const FIELD_TYPE_ORDER: LockableFieldType[] = [
+export const FIELD_TYPE_ORDER: LockableFieldType[] = [
   'string',
   'integer',
   'date',
@@ -161,12 +162,16 @@ export interface LockableValueFieldProps {
   onFieldTypeChange?: (fieldType: LockableFieldType) => void;
   /** Shows a required-field asterisk next to the default label. Ignored when `label` is provided. */
   required?: boolean;
+  /** Called when the user toggles required/optional. Renders the Required switch when provided. */
+  onRequiredChange?: (required: boolean) => void;
   /** Overrides the default mode-based label (e.g. a field name instead of "String value"). */
   label?: ReactNode;
   /** Extra content rendered after the built-in AI assist / Insert variable buttons (e.g. a delete button). */
   headerActions?: ReactNode;
   /** Forces the header row into its narrow-container icon-only layout, regardless of actual width. For demos/comparisons. */
   compact?: boolean;
+  /** Whether the field-type, AI-assist, and insert-variable controls are always shown or only on hover. Defaults to 'visible'. */
+  controlsVisibility?: 'visible' | 'hover';
   id?: string;
   className?: string;
 }
@@ -201,9 +206,11 @@ export function LockableValueField({
   fieldType = 'string',
   onFieldTypeChange,
   required,
+  onRequiredChange,
   label,
   headerActions,
   compact,
+  controlsVisibility = 'visible',
   id,
   className,
 }: LockableValueFieldProps) {
@@ -214,7 +221,7 @@ export function LockableValueField({
   const collapsedPaddingClass = cn('@max-[259px]:px-1.5', compact && '!px-1.5');
 
   return (
-    <div className={cn('@container flex flex-col gap-1.5', className)}>
+    <div className={cn('@container group flex flex-col gap-1.5', className)}>
       <div className="flex items-center gap-1">
         {label ?? (
           <Label htmlFor={id} className="text-xs font-medium text-foreground-muted">
@@ -224,95 +231,158 @@ export function LockableValueField({
         )}
         <TooltipProvider delayDuration={300}>
           <div className="ml-auto flex items-center gap-0.5">
-            {onFieldTypeChange && (
-              <DropdownMenu>
+            <div
+              className={cn(
+                'flex items-center gap-0.5',
+                controlsVisibility === 'hover' &&
+                  'opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100 has-[[aria-expanded=true]]:opacity-100'
+              )}
+            >
+              {onFieldTypeChange && (
+                <DropdownMenu>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <DropdownMenuTrigger asChild>
+                        <button
+                          type="button"
+                          aria-label="Field type"
+                          className={cn(
+                            'flex h-7 items-center gap-1 rounded-lg px-2 text-[11px] text-foreground-subtle transition hover:bg-surface-overlay hover:text-foreground',
+                            collapsedPaddingClass
+                          )}
+                        >
+                          <typeMeta.icon size={12} />
+                          <span className={collapsedTextClass}>{typeMeta.label}</span>
+                          <ChevronDown size={9} className={collapsedTextClass} />
+                        </button>
+                      </DropdownMenuTrigger>
+                    </TooltipTrigger>
+                    <TooltipContent>Type</TooltipContent>
+                  </Tooltip>
+                  <DropdownMenuContent align="end" className="w-44">
+                    {FIELD_TYPE_ORDER.map((type) => {
+                      const meta = FIELD_TYPE_META[type];
+                      const isActive = type === fieldType;
+                      return (
+                        <DropdownMenuItem key={type} onClick={() => onFieldTypeChange(type)}>
+                          <meta.icon
+                            className={isActive ? 'text-brand' : 'text-foreground-muted'}
+                          />
+                          <span className={cn(isActive && 'font-medium text-brand')}>
+                            {meta.label}
+                          </span>
+                        </DropdownMenuItem>
+                      );
+                    })}
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              )}
+              {onRequiredChange && (
+                <>
+                  <div className={cn('@max-[259px]:hidden', compact && '!hidden')}>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        {/* Wrapped in a span: TooltipTrigger's asChild merge otherwise
+                            overwrites the Switch's own data-state (checked/unchecked)
+                            with the tooltip's open/closed state, breaking its color classes. */}
+                        <span className="inline-flex">
+                          <Switch
+                            size="sm"
+                            checked={!!required}
+                            onCheckedChange={onRequiredChange}
+                            className="data-[state=checked]:bg-brand data-[state=unchecked]:bg-foreground-subtle"
+                            aria-label={required ? 'Required field' : 'Optional field'}
+                          />
+                        </span>
+                      </TooltipTrigger>
+                      <TooltipContent>Required</TooltipContent>
+                    </Tooltip>
+                  </div>
+                  <div className={cn('hidden @max-[259px]:block', compact && '!block')}>
+                    <Popover>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <PopoverTrigger asChild>
+                            <button
+                              type="button"
+                              aria-label={required ? 'Required field' : 'Optional field'}
+                              className="grid size-7 place-items-center rounded-lg text-foreground-subtle transition hover:bg-surface-overlay hover:text-foreground"
+                            >
+                              <Asterisk size={12} />
+                            </button>
+                          </PopoverTrigger>
+                        </TooltipTrigger>
+                        <TooltipContent>Required</TooltipContent>
+                      </Tooltip>
+                      <PopoverContent align="end" className="w-48">
+                        <div className="flex items-center justify-between gap-3">
+                          <span className="text-xs font-medium text-foreground">Required</span>
+                          <Switch
+                            size="sm"
+                            checked={!!required}
+                            onCheckedChange={onRequiredChange}
+                            className="data-[state=checked]:bg-brand data-[state=unchecked]:bg-foreground-subtle"
+                            aria-label={required ? 'Required field' : 'Optional field'}
+                          />
+                        </div>
+                      </PopoverContent>
+                    </Popover>
+                  </div>
+                </>
+              )}
+              <Popover>
                 <Tooltip>
                   <TooltipTrigger asChild>
-                    <DropdownMenuTrigger asChild>
+                    <PopoverTrigger asChild>
                       <button
                         type="button"
-                        aria-label="Field type"
-                        className={cn(
-                          'flex h-7 items-center gap-1 rounded-lg px-2 text-[11px] text-foreground-subtle transition hover:bg-surface-overlay hover:text-foreground',
-                          collapsedPaddingClass
-                        )}
+                        aria-label="AI assist"
+                        className="grid size-7 place-items-center rounded-lg text-foreground-subtle transition hover:bg-surface-overlay hover:text-foreground"
                       >
-                        <typeMeta.icon size={12} />
-                        <span className={collapsedTextClass}>{typeMeta.label}</span>
-                        <ChevronDown size={9} className={collapsedTextClass} />
+                        <Sparkles size={12} />
                       </button>
-                    </DropdownMenuTrigger>
+                    </PopoverTrigger>
                   </TooltipTrigger>
-                  <TooltipContent>Change field type</TooltipContent>
+                  <TooltipContent>Generate with AI</TooltipContent>
                 </Tooltip>
-                <DropdownMenuContent align="end" className="w-44">
-                  {FIELD_TYPE_ORDER.map((type) => {
-                    const meta = FIELD_TYPE_META[type];
-                    const isActive = type === fieldType;
-                    return (
-                      <DropdownMenuItem key={type} onClick={() => onFieldTypeChange(type)}>
-                        <meta.icon className={isActive ? 'text-brand' : 'text-foreground-muted'} />
-                        <span className={cn(isActive && 'font-medium text-brand')}>
-                          {meta.label}
-                        </span>
-                      </DropdownMenuItem>
-                    );
-                  })}
-                </DropdownMenuContent>
-              </DropdownMenu>
-            )}
-            <Popover>
+                <PopoverContent align="end" className="space-y-3">
+                  <div className="space-y-1.5">
+                    <Label htmlFor={promptId} className="text-xs font-medium text-foreground-muted">
+                      Describe what you want
+                    </Label>
+                    <Textarea
+                      id={promptId}
+                      rows={3}
+                      placeholder="Display a value from the previous step"
+                      className="resize-none text-sm"
+                    />
+                  </div>
+                  <span className="block text-[11px] text-foreground-subtle">
+                    Output: String expression
+                  </span>
+                  <Button size="sm" className="w-full">
+                    Generate
+                  </Button>
+                </PopoverContent>
+              </Popover>
               <Tooltip>
                 <TooltipTrigger asChild>
-                  <PopoverTrigger asChild>
-                    <button
-                      type="button"
-                      aria-label="AI assist"
-                      className="grid size-7 place-items-center rounded-lg text-foreground-subtle transition hover:bg-surface-overlay hover:text-foreground"
-                    >
-                      <Sparkles size={12} />
-                    </button>
-                  </PopoverTrigger>
+                  <button
+                    type="button"
+                    aria-label="Insert variable"
+                    className={cn(
+                      'flex h-7 items-center gap-1 rounded-lg px-2 text-[11px] text-foreground-subtle transition hover:bg-surface-overlay hover:text-foreground',
+                      collapsedPaddingClass
+                    )}
+                  >
+                    <span className="font-mono text-[10px]">{'{x}'}</span>
+                    <span className={collapsedTextClass}>Insert</span>
+                    <ChevronDown size={9} className={collapsedTextClass} />
+                  </button>
                 </TooltipTrigger>
-                <TooltipContent>Generate a value with AI</TooltipContent>
+                <TooltipContent>Insert</TooltipContent>
               </Tooltip>
-              <PopoverContent align="end" className="space-y-3">
-                <div className="space-y-1.5">
-                  <Label htmlFor={promptId} className="text-xs font-medium text-foreground-muted">
-                    Describe what you want
-                  </Label>
-                  <Textarea
-                    id={promptId}
-                    rows={3}
-                    placeholder="Display a value from the previous step"
-                    className="resize-none text-sm"
-                  />
-                </div>
-                <span className="block text-[11px] text-foreground-subtle">
-                  Output: String expression
-                </span>
-                <Button size="sm" className="w-full">
-                  Generate
-                </Button>
-              </PopoverContent>
-            </Popover>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <button
-                  type="button"
-                  aria-label="Insert variable"
-                  className={cn(
-                    'flex h-7 items-center gap-1 rounded-lg px-2 text-[11px] text-foreground-subtle transition hover:bg-surface-overlay hover:text-foreground',
-                    collapsedPaddingClass
-                  )}
-                >
-                  <span className="font-mono text-[10px]">{'{x}'}</span>
-                  <span className={collapsedTextClass}>Insert</span>
-                  <ChevronDown size={9} className={collapsedTextClass} />
-                </button>
-              </TooltipTrigger>
-              <TooltipContent>Insert a variable from a previous step</TooltipContent>
-            </Tooltip>
+            </div>
             {headerActions}
           </div>
         </TooltipProvider>

--- a/packages/apollo-react/src/canvas/components/NodePropertyPanel/LockableValueField.tsx
+++ b/packages/apollo-react/src/canvas/components/NodePropertyPanel/LockableValueField.tsx
@@ -31,6 +31,7 @@ import {
 } from '@uipath/apollo-wind';
 import {
   Asterisk,
+  Braces,
   Calendar as CalendarIcon,
   ChevronDown,
   Code2,
@@ -173,6 +174,8 @@ export interface LockableValueFieldProps {
   compact?: boolean;
   /** Whether the field-type, AI-assist, and insert-variable controls are always shown or only on hover. Defaults to 'visible'. */
   controlsVisibility?: 'visible' | 'hover';
+  /** Whether the AI-assist and Insert-variable actions render at all. Set to false for read-only reviewer contexts where field configuration isn't editable. Defaults to true. */
+  showFieldActions?: boolean;
   id?: string;
   className?: string;
 }
@@ -212,6 +215,7 @@ export function LockableValueField({
   headerActions,
   compact,
   controlsVisibility = 'visible',
+  showFieldActions = true,
   id,
   className,
 }: LockableValueFieldProps) {
@@ -355,58 +359,65 @@ export function LockableValueField({
                   </div>
                 </>
               )}
-              <Popover>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <PopoverTrigger asChild>
+              {showFieldActions && (
+                <>
+                  <Popover>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <PopoverTrigger asChild>
+                          <button
+                            type="button"
+                            aria-label="AI assist"
+                            className="grid size-7 place-items-center rounded-lg text-foreground-subtle transition hover:bg-surface-overlay hover:text-foreground"
+                          >
+                            <Sparkles size={12} />
+                          </button>
+                        </PopoverTrigger>
+                      </TooltipTrigger>
+                      <TooltipContent>Generate with AI</TooltipContent>
+                    </Tooltip>
+                    <PopoverContent align="end" className="space-y-3">
+                      <div className="space-y-1.5">
+                        <Label
+                          htmlFor={promptId}
+                          className="text-xs font-medium text-foreground-muted"
+                        >
+                          Describe what you want
+                        </Label>
+                        <Textarea
+                          id={promptId}
+                          rows={3}
+                          placeholder="Display a value from the previous step"
+                          className="resize-none text-sm"
+                        />
+                      </div>
+                      <span className="block text-[11px] text-foreground-subtle">
+                        Output: String expression
+                      </span>
+                      <Button size="sm" className="w-full">
+                        Generate
+                      </Button>
+                    </PopoverContent>
+                  </Popover>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
                       <button
                         type="button"
-                        aria-label="AI assist"
-                        className="grid size-7 place-items-center rounded-lg text-foreground-subtle transition hover:bg-surface-overlay hover:text-foreground"
+                        aria-label="Insert variable"
+                        className={cn(
+                          'flex h-7 items-center gap-1 rounded-lg px-2 text-[11px] text-foreground-subtle transition hover:bg-surface-overlay hover:text-foreground',
+                          collapsedPaddingClass
+                        )}
                       >
-                        <Sparkles size={12} />
+                        <Braces size={12} />
+                        <span className={collapsedTextClass}>Insert</span>
+                        <ChevronDown size={9} className={collapsedTextClass} />
                       </button>
-                    </PopoverTrigger>
-                  </TooltipTrigger>
-                  <TooltipContent>Generate with AI</TooltipContent>
-                </Tooltip>
-                <PopoverContent align="end" className="space-y-3">
-                  <div className="space-y-1.5">
-                    <Label htmlFor={promptId} className="text-xs font-medium text-foreground-muted">
-                      Describe what you want
-                    </Label>
-                    <Textarea
-                      id={promptId}
-                      rows={3}
-                      placeholder="Display a value from the previous step"
-                      className="resize-none text-sm"
-                    />
-                  </div>
-                  <span className="block text-[11px] text-foreground-subtle">
-                    Output: String expression
-                  </span>
-                  <Button size="sm" className="w-full">
-                    Generate
-                  </Button>
-                </PopoverContent>
-              </Popover>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <button
-                    type="button"
-                    aria-label="Insert variable"
-                    className={cn(
-                      'flex h-7 items-center gap-1 rounded-lg px-2 text-[11px] text-foreground-subtle transition hover:bg-surface-overlay hover:text-foreground',
-                      collapsedPaddingClass
-                    )}
-                  >
-                    <span className="font-mono text-[10px]">{'{x}'}</span>
-                    <span className={collapsedTextClass}>Insert</span>
-                    <ChevronDown size={9} className={collapsedTextClass} />
-                  </button>
-                </TooltipTrigger>
-                <TooltipContent>Insert</TooltipContent>
-              </Tooltip>
+                    </TooltipTrigger>
+                    <TooltipContent>Insert</TooltipContent>
+                  </Tooltip>
+                </>
+              )}
             </div>
             {headerActions}
           </div>
@@ -421,7 +432,9 @@ export function LockableValueField({
                 <InputGroupButton
                   icon
                   size="3xs"
-                  aria-label={locked ? 'Locked. Click to unlock.' : 'Unlocked. Click to lock.'}
+                  aria-label={
+                    locked ? 'Read-only. Click to make editable.' : 'Editable. Click to make read-only.'
+                  }
                 >
                   {locked ? <Lock /> : <LockOpen />}
                 </InputGroupButton>
@@ -442,7 +455,7 @@ export function LockableValueField({
                         !locked ? 'text-brand' : 'text-foreground'
                       )}
                     >
-                      Unlocked
+                      Editable
                     </span>
                   </div>
                   <span className="pl-[21px] text-[11px] leading-4 text-foreground-subtle">
@@ -461,7 +474,7 @@ export function LockableValueField({
                         locked ? 'text-brand' : 'text-foreground'
                       )}
                     >
-                      Locked
+                      Read-only
                     </span>
                   </div>
                   <span className="pl-[21px] text-[11px] leading-4 text-foreground-subtle">
@@ -539,7 +552,7 @@ export function LockableValueField({
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
                 <InputGroupButton icon size="3xs" aria-label="Choose value type">
-                  <typeMeta.icon />
+                  {effectiveMode === 'expression' ? <Code2 /> : <Type />}
                 </InputGroupButton>
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end" className="w-56">
@@ -548,7 +561,7 @@ export function LockableValueField({
                   onClick={() => onModeChange?.('fixed')}
                 >
                   <div className="flex items-center gap-2">
-                    <typeMeta.icon
+                    <Type
                       size={13}
                       className={effectiveMode === 'fixed' ? 'text-brand' : 'text-foreground-muted'}
                     />
@@ -600,7 +613,9 @@ export function LockableValueField({
               <InputGroupButton
                 icon
                 size="3xs"
-                aria-label={locked ? 'Locked. Click to unlock.' : 'Unlocked. Click to lock.'}
+                aria-label={
+                  locked ? 'Read-only. Click to make editable.' : 'Editable. Click to make read-only.'
+                }
               >
                 {locked ? <Lock /> : <LockOpen />}
               </InputGroupButton>
@@ -621,7 +636,7 @@ export function LockableValueField({
                       !locked ? 'text-brand' : 'text-foreground'
                     )}
                   >
-                    Unlocked
+                    Editable
                   </span>
                 </div>
                 <span className="pl-[21px] text-[11px] leading-4 text-foreground-subtle">
@@ -637,7 +652,7 @@ export function LockableValueField({
                   <span
                     className={cn('text-xs font-medium', locked ? 'text-brand' : 'text-foreground')}
                   >
-                    Locked
+                    Read-only
                   </span>
                 </div>
                 <span className="pl-[21px] text-[11px] leading-4 text-foreground-subtle">

--- a/packages/apollo-react/src/canvas/components/NodePropertyPanel/LockableValueField.tsx
+++ b/packages/apollo-react/src/canvas/components/NodePropertyPanel/LockableValueField.tsx
@@ -1,28 +1,149 @@
 import {
   Button,
+  Calendar,
   cn,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
+  FileUpload,
   InputGroup,
   InputGroupAddon,
   InputGroupButton,
   InputGroupInput,
   Label,
+  MultiSelect,
   Popover,
   PopoverContent,
   PopoverTrigger,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Switch,
   Textarea,
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
 } from '@uipath/apollo-wind';
-import { ChevronDown, Code2, Lock, LockOpen, Sparkles, Type } from 'lucide-react';
+import {
+  Calendar as CalendarIcon,
+  ChevronDown,
+  Code2,
+  Hash,
+  List,
+  ListChecks,
+  Lock,
+  LockOpen,
+  type LucideIcon,
+  Paperclip,
+  Sparkles,
+  ToggleLeft,
+  Type,
+} from 'lucide-react';
 import type { ReactNode } from 'react';
 import { useId } from 'react';
 
 export type LockableValueFieldMode = 'fixed' | 'expression';
 
+export type LockableFieldType =
+  | 'string'
+  | 'integer'
+  | 'date'
+  | 'boolean'
+  | 'single-select'
+  | 'multi-select'
+  | 'file';
+
+interface FieldTypeMeta {
+  label: string;
+  icon: LucideIcon;
+  supportsExpression: boolean;
+  fixedLabel: string;
+  fixedDescription: string;
+}
+
+export const FIELD_TYPE_META: Record<LockableFieldType, FieldTypeMeta> = {
+  string: {
+    label: 'String',
+    icon: Type,
+    supportsExpression: true,
+    fixedLabel: 'Fixed value',
+    fixedDescription: 'Use a literal string value',
+  },
+  integer: {
+    label: 'Integer',
+    icon: Hash,
+    supportsExpression: true,
+    fixedLabel: 'Fixed value',
+    fixedDescription: 'Use a literal number value',
+  },
+  date: {
+    label: 'Date',
+    icon: CalendarIcon,
+    supportsExpression: true,
+    fixedLabel: 'Fixed date',
+    fixedDescription: 'Use a literal date value',
+  },
+  boolean: {
+    label: 'Boolean',
+    icon: ToggleLeft,
+    supportsExpression: true,
+    fixedLabel: 'Fixed value',
+    fixedDescription: 'Use a literal true or false value',
+  },
+  'single-select': {
+    label: 'Single select',
+    icon: List,
+    supportsExpression: false,
+    fixedLabel: 'Fixed value',
+    fixedDescription: 'Choose one option',
+  },
+  'multi-select': {
+    label: 'Multiselect',
+    icon: ListChecks,
+    supportsExpression: false,
+    fixedLabel: 'Fixed value',
+    fixedDescription: 'Choose one or more options',
+  },
+  file: {
+    label: 'File',
+    icon: Paperclip,
+    supportsExpression: false,
+    fixedLabel: 'Fixed value',
+    fixedDescription: 'Upload a file',
+  },
+};
+
+const FIELD_TYPE_ORDER: LockableFieldType[] = [
+  'string',
+  'integer',
+  'date',
+  'boolean',
+  'single-select',
+  'multi-select',
+  'file',
+];
+
+export const DEMO_SELECT_OPTIONS = [
+  { label: 'Option 1', value: 'option-1' },
+  { label: 'Option 2', value: 'option-2' },
+  { label: 'Option 3', value: 'option-3' },
+];
+
+export function parseListValue(value: string): string[] {
+  try {
+    const parsed = JSON.parse(value);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
 export interface LockableValueFieldProps {
-  /** Current field value. */
+  /** Current field value. Encoding depends on fieldType (e.g. multi-select is a JSON array string). */
   value?: string;
   /** Called when the user edits the value (only fires while unlocked). */
   onValueChange?: (value: string) => void;
@@ -30,16 +151,22 @@ export interface LockableValueFieldProps {
   locked?: boolean;
   /** Called when the user toggles the lock. */
   onLockedChange?: (locked: boolean) => void;
-  /** Fixed value vs. JS expression. Defaults to 'fixed'. */
+  /** Fixed value vs. JS expression. Defaults to 'fixed'. Ignored for types that don't support expressions. */
   mode?: LockableValueFieldMode;
   /** Called when the user switches modes. */
   onModeChange?: (mode: LockableValueFieldMode) => void;
+  /** The field's data type. Defaults to 'string'. Determines which control renders the value. */
+  fieldType?: LockableFieldType;
+  /** Called when the user switches the field type. */
+  onFieldTypeChange?: (fieldType: LockableFieldType) => void;
   /** Shows a required-field asterisk next to the default label. Ignored when `label` is provided. */
   required?: boolean;
   /** Overrides the default mode-based label (e.g. a field name instead of "String value"). */
   label?: ReactNode;
   /** Extra content rendered after the built-in AI assist / Insert variable buttons (e.g. a delete button). */
   headerActions?: ReactNode;
+  /** Forces the header row into its narrow-container icon-only layout, regardless of actual width. For demos/comparisons. */
+  compact?: boolean;
   id?: string;
   className?: string;
 }
@@ -55,12 +182,14 @@ const FIELD_PLACEHOLDER: Record<LockableValueFieldMode, string> = {
 };
 
 /**
- * LockableValueField — a string field that can be locked to read-only and
- * switched between a literal value and a JS expression.
+ * LockableValueField — a field that can be locked to read-only, typed as one
+ * of several data types, and (for scalar types) switched between a literal
+ * value and a JS expression.
  *
  * Prototype: the expression mode is styled as code (monospace) but does not
  * yet carry real syntax highlighting or evaluation. See ExpressionField for
- * the direction a full code-editing surface would take.
+ * the direction a full code-editing surface would take. Select/multiselect
+ * options are demo placeholders; file uploads aren't persisted anywhere.
  */
 export function LockableValueField({
   value = '',
@@ -69,16 +198,23 @@ export function LockableValueField({
   onLockedChange,
   mode = 'fixed',
   onModeChange,
+  fieldType = 'string',
+  onFieldTypeChange,
   required,
   label,
   headerActions,
+  compact,
   id,
   className,
 }: LockableValueFieldProps) {
   const promptId = useId();
+  const typeMeta = FIELD_TYPE_META[fieldType];
+  const effectiveMode = typeMeta.supportsExpression ? mode : 'fixed';
+  const collapsedTextClass = cn('@max-[259px]:hidden', compact && '!hidden');
+  const collapsedPaddingClass = cn('@max-[259px]:px-1.5', compact && '!px-1.5');
 
   return (
-    <div className={cn('flex flex-col gap-1.5', className)}>
+    <div className={cn('@container flex flex-col gap-1.5', className)}>
       <div className="flex items-center gap-1">
         {label ?? (
           <Label htmlFor={id} className="text-xs font-medium text-foreground-muted">
@@ -86,54 +222,280 @@ export function LockableValueField({
             {required && <span className="ml-0.5 text-destructive">*</span>}
           </Label>
         )}
-        <div className="ml-auto flex items-center gap-0.5">
-          <Popover>
-            <PopoverTrigger asChild>
-              <button
-                type="button"
-                aria-label="AI assist"
-                title="AI assist"
-                className="grid size-7 place-items-center rounded-lg text-foreground-subtle transition hover:bg-surface-overlay hover:text-foreground"
-              >
-                <Sparkles size={12} />
-              </button>
-            </PopoverTrigger>
-            <PopoverContent align="end" className="space-y-3">
-              <div className="space-y-1.5">
-                <Label htmlFor={promptId} className="text-xs font-medium text-foreground-muted">
-                  Describe what you want
-                </Label>
-                <Textarea
-                  id={promptId}
-                  rows={3}
-                  placeholder="Display a value from the previous step"
-                  className="resize-none text-sm"
-                />
-              </div>
-              <span className="block text-[11px] text-foreground-subtle">
-                Output: String expression
-              </span>
-              <Button size="sm" className="w-full">
-                Generate
-              </Button>
-            </PopoverContent>
-          </Popover>
-          <button
-            type="button"
-            aria-label="Insert variable"
-            title="Insert variable"
-            className="flex h-7 items-center gap-1 rounded-lg px-2 text-[11px] text-foreground-subtle transition hover:bg-surface-overlay hover:text-foreground"
-          >
-            <span className="font-mono text-[10px]">{'{x}'}</span>
-            <span>Insert</span>
-            <ChevronDown size={9} />
-          </button>
-          {headerActions}
-        </div>
+        <TooltipProvider delayDuration={300}>
+          <div className="ml-auto flex items-center gap-0.5">
+            {onFieldTypeChange && (
+              <DropdownMenu>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <DropdownMenuTrigger asChild>
+                      <button
+                        type="button"
+                        aria-label="Field type"
+                        className={cn(
+                          'flex h-7 items-center gap-1 rounded-lg px-2 text-[11px] text-foreground-subtle transition hover:bg-surface-overlay hover:text-foreground',
+                          collapsedPaddingClass
+                        )}
+                      >
+                        <typeMeta.icon size={12} />
+                        <span className={collapsedTextClass}>{typeMeta.label}</span>
+                        <ChevronDown size={9} className={collapsedTextClass} />
+                      </button>
+                    </DropdownMenuTrigger>
+                  </TooltipTrigger>
+                  <TooltipContent>Change field type</TooltipContent>
+                </Tooltip>
+                <DropdownMenuContent align="end" className="w-44">
+                  {FIELD_TYPE_ORDER.map((type) => {
+                    const meta = FIELD_TYPE_META[type];
+                    const isActive = type === fieldType;
+                    return (
+                      <DropdownMenuItem key={type} onClick={() => onFieldTypeChange(type)}>
+                        <meta.icon className={isActive ? 'text-brand' : 'text-foreground-muted'} />
+                        <span className={cn(isActive && 'font-medium text-brand')}>
+                          {meta.label}
+                        </span>
+                      </DropdownMenuItem>
+                    );
+                  })}
+                </DropdownMenuContent>
+              </DropdownMenu>
+            )}
+            <Popover>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <PopoverTrigger asChild>
+                    <button
+                      type="button"
+                      aria-label="AI assist"
+                      className="grid size-7 place-items-center rounded-lg text-foreground-subtle transition hover:bg-surface-overlay hover:text-foreground"
+                    >
+                      <Sparkles size={12} />
+                    </button>
+                  </PopoverTrigger>
+                </TooltipTrigger>
+                <TooltipContent>Generate a value with AI</TooltipContent>
+              </Tooltip>
+              <PopoverContent align="end" className="space-y-3">
+                <div className="space-y-1.5">
+                  <Label htmlFor={promptId} className="text-xs font-medium text-foreground-muted">
+                    Describe what you want
+                  </Label>
+                  <Textarea
+                    id={promptId}
+                    rows={3}
+                    placeholder="Display a value from the previous step"
+                    className="resize-none text-sm"
+                  />
+                </div>
+                <span className="block text-[11px] text-foreground-subtle">
+                  Output: String expression
+                </span>
+                <Button size="sm" className="w-full">
+                  Generate
+                </Button>
+              </PopoverContent>
+            </Popover>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  type="button"
+                  aria-label="Insert variable"
+                  className={cn(
+                    'flex h-7 items-center gap-1 rounded-lg px-2 text-[11px] text-foreground-subtle transition hover:bg-surface-overlay hover:text-foreground',
+                    collapsedPaddingClass
+                  )}
+                >
+                  <span className="font-mono text-[10px]">{'{x}'}</span>
+                  <span className={collapsedTextClass}>Insert</span>
+                  <ChevronDown size={9} className={collapsedTextClass} />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent>Insert a variable from a previous step</TooltipContent>
+            </Tooltip>
+            {headerActions}
+          </div>
+        </TooltipProvider>
       </div>
 
-      <InputGroup>
-        <InputGroupAddon align="inline-start">
+      {typeMeta.supportsExpression ? (
+        <InputGroup>
+          <InputGroupAddon align="inline-start">
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <InputGroupButton
+                  icon
+                  size="3xs"
+                  aria-label={locked ? 'Locked. Click to unlock.' : 'Unlocked. Click to lock.'}
+                >
+                  {locked ? <Lock /> : <LockOpen />}
+                </InputGroupButton>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="start" className="w-56">
+                <DropdownMenuItem
+                  className="flex-col items-start gap-0.5 py-2"
+                  onClick={() => onLockedChange?.(false)}
+                >
+                  <div className="flex items-center gap-2">
+                    <LockOpen
+                      size={13}
+                      className={!locked ? 'text-brand' : 'text-foreground-muted'}
+                    />
+                    <span
+                      className={cn(
+                        'text-xs font-medium',
+                        !locked ? 'text-brand' : 'text-foreground'
+                      )}
+                    >
+                      Unlocked
+                    </span>
+                  </div>
+                  <span className="pl-[21px] text-[11px] leading-4 text-foreground-subtle">
+                    User can edit this field
+                  </span>
+                </DropdownMenuItem>
+                <DropdownMenuItem
+                  className="flex-col items-start gap-0.5 py-2"
+                  onClick={() => onLockedChange?.(true)}
+                >
+                  <div className="flex items-center gap-2">
+                    <Lock size={13} className={locked ? 'text-brand' : 'text-foreground-muted'} />
+                    <span
+                      className={cn(
+                        'text-xs font-medium',
+                        locked ? 'text-brand' : 'text-foreground'
+                      )}
+                    >
+                      Locked
+                    </span>
+                  </div>
+                  <span className="pl-[21px] text-[11px] leading-4 text-foreground-subtle">
+                    User sees this field as read-only
+                  </span>
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </InputGroupAddon>
+
+          {effectiveMode === 'expression' ? (
+            <InputGroupInput
+              id={id}
+              readOnly={locked}
+              value={value}
+              onChange={(e) => onValueChange?.(e.target.value)}
+              placeholder={FIELD_PLACEHOLDER.expression}
+              className="font-mono"
+            />
+          ) : fieldType === 'boolean' ? (
+            <div className="flex h-full flex-1 items-center px-3">
+              <Switch
+                id={id}
+                checked={value === 'true'}
+                onCheckedChange={(checked) => onValueChange?.(String(checked))}
+                disabled={locked}
+              />
+            </div>
+          ) : fieldType === 'date' ? (
+            <Popover>
+              <PopoverTrigger asChild>
+                <button
+                  type="button"
+                  id={id}
+                  data-slot="input-group-control"
+                  disabled={locked}
+                  className="flex h-full flex-1 items-center text-left text-sm text-foreground outline-none disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                  {value ? (
+                    new Date(value).toLocaleDateString(undefined, {
+                      year: 'numeric',
+                      month: 'long',
+                      day: 'numeric',
+                    })
+                  ) : (
+                    <span className="text-muted-foreground">Pick a date</span>
+                  )}
+                </button>
+              </PopoverTrigger>
+              <PopoverContent align="start" className="w-auto p-0">
+                <Calendar
+                  mode="single"
+                  selected={value ? new Date(value) : undefined}
+                  onSelect={(date) => onValueChange?.(date ? date.toISOString() : '')}
+                  initialFocus
+                />
+              </PopoverContent>
+            </Popover>
+          ) : (
+            <InputGroupInput
+              id={id}
+              type={fieldType === 'integer' ? 'number' : 'text'}
+              readOnly={locked}
+              value={value}
+              onChange={(e) => onValueChange?.(e.target.value)}
+              placeholder={FIELD_PLACEHOLDER.fixed}
+            />
+          )}
+
+          <InputGroupAddon align="inline-end">
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <InputGroupButton icon size="3xs" aria-label="Choose value type">
+                  <typeMeta.icon />
+                </InputGroupButton>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end" className="w-56">
+                <DropdownMenuItem
+                  className="flex-col items-start gap-0.5 py-2"
+                  onClick={() => onModeChange?.('fixed')}
+                >
+                  <div className="flex items-center gap-2">
+                    <typeMeta.icon
+                      size={13}
+                      className={effectiveMode === 'fixed' ? 'text-brand' : 'text-foreground-muted'}
+                    />
+                    <span
+                      className={cn(
+                        'text-xs font-medium',
+                        effectiveMode === 'fixed' ? 'text-brand' : 'text-foreground'
+                      )}
+                    >
+                      {typeMeta.fixedLabel}
+                    </span>
+                  </div>
+                  <span className="pl-[21px] text-[11px] leading-4 text-foreground-subtle">
+                    {typeMeta.fixedDescription}
+                  </span>
+                </DropdownMenuItem>
+                <DropdownMenuItem
+                  className="flex-col items-start gap-0.5 py-2"
+                  onClick={() => onModeChange?.('expression')}
+                >
+                  <div className="flex items-center gap-2">
+                    <Code2
+                      size={13}
+                      className={
+                        effectiveMode === 'expression' ? 'text-brand' : 'text-foreground-muted'
+                      }
+                    />
+                    <span
+                      className={cn(
+                        'text-xs font-medium',
+                        effectiveMode === 'expression' ? 'text-brand' : 'text-foreground'
+                      )}
+                    >
+                      Expression
+                    </span>
+                  </div>
+                  <span className="pl-[21px] text-[11px] leading-4 text-foreground-subtle">
+                    Use a JS expression
+                  </span>
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </InputGroupAddon>
+        </InputGroup>
+      ) : (
+        <div className="flex items-center gap-2">
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
               <InputGroupButton
@@ -185,73 +547,42 @@ export function LockableValueField({
               </DropdownMenuItem>
             </DropdownMenuContent>
           </DropdownMenu>
-        </InputGroupAddon>
 
-        <InputGroupInput
-          id={id}
-          readOnly={locked}
-          value={value}
-          onChange={(e) => onValueChange?.(e.target.value)}
-          placeholder={FIELD_PLACEHOLDER[mode]}
-          className={mode === 'expression' ? 'font-mono' : undefined}
-        />
+          {fieldType === 'single-select' && (
+            <Select value={value || undefined} onValueChange={onValueChange} disabled={locked}>
+              <SelectTrigger id={id} className="flex-1">
+                <SelectValue placeholder="Select an option" />
+              </SelectTrigger>
+              <SelectContent>
+                {DEMO_SELECT_OPTIONS.map((option) => (
+                  <SelectItem key={option.value} value={option.value}>
+                    {option.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          )}
 
-        <InputGroupAddon align="inline-end">
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <InputGroupButton icon size="3xs" aria-label="Choose value type">
-                <Type />
-              </InputGroupButton>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end" className="w-56">
-              <DropdownMenuItem
-                className="flex-col items-start gap-0.5 py-2"
-                onClick={() => onModeChange?.('fixed')}
-              >
-                <div className="flex items-center gap-2">
-                  <Type
-                    size={13}
-                    className={mode === 'fixed' ? 'text-brand' : 'text-foreground-muted'}
-                  />
-                  <span
-                    className={cn(
-                      'text-xs font-medium',
-                      mode === 'fixed' ? 'text-brand' : 'text-foreground'
-                    )}
-                  >
-                    Fixed value
-                  </span>
-                </div>
-                <span className="pl-[21px] text-[11px] leading-4 text-foreground-subtle">
-                  Use a literal string value
-                </span>
-              </DropdownMenuItem>
-              <DropdownMenuItem
-                className="flex-col items-start gap-0.5 py-2"
-                onClick={() => onModeChange?.('expression')}
-              >
-                <div className="flex items-center gap-2">
-                  <Code2
-                    size={13}
-                    className={mode === 'expression' ? 'text-brand' : 'text-foreground-muted'}
-                  />
-                  <span
-                    className={cn(
-                      'text-xs font-medium',
-                      mode === 'expression' ? 'text-brand' : 'text-foreground'
-                    )}
-                  >
-                    Expression
-                  </span>
-                </div>
-                <span className="pl-[21px] text-[11px] leading-4 text-foreground-subtle">
-                  Use a JS expression
-                </span>
-              </DropdownMenuItem>
-            </DropdownMenuContent>
-          </DropdownMenu>
-        </InputGroupAddon>
-      </InputGroup>
+          {fieldType === 'multi-select' && (
+            <MultiSelect
+              className="flex-1"
+              options={DEMO_SELECT_OPTIONS}
+              selected={parseListValue(value)}
+              onChange={(selected) => onValueChange?.(JSON.stringify(selected))}
+              placeholder="Select options..."
+              disabled={locked}
+            />
+          )}
+
+          {fieldType === 'file' && (
+            <FileUpload
+              className="flex-1"
+              disabled={locked}
+              onFilesChange={(files) => onValueChange?.(files.map((f) => f.name).join(', '))}
+            />
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/packages/apollo-react/src/canvas/components/NodePropertyPanel/LockableValueField.tsx
+++ b/packages/apollo-react/src/canvas/components/NodePropertyPanel/LockableValueField.tsx
@@ -1,0 +1,257 @@
+import {
+  Button,
+  cn,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+  InputGroup,
+  InputGroupAddon,
+  InputGroupButton,
+  InputGroupInput,
+  Label,
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+  Textarea,
+} from '@uipath/apollo-wind';
+import { ChevronDown, Code2, Lock, LockOpen, Sparkles, Type } from 'lucide-react';
+import type { ReactNode } from 'react';
+import { useId } from 'react';
+
+export type LockableValueFieldMode = 'fixed' | 'expression';
+
+export interface LockableValueFieldProps {
+  /** Current field value. */
+  value?: string;
+  /** Called when the user edits the value (only fires while unlocked). */
+  onValueChange?: (value: string) => void;
+  /** Whether the field is read-only. Defaults to true. */
+  locked?: boolean;
+  /** Called when the user toggles the lock. */
+  onLockedChange?: (locked: boolean) => void;
+  /** Fixed value vs. JS expression. Defaults to 'fixed'. */
+  mode?: LockableValueFieldMode;
+  /** Called when the user switches modes. */
+  onModeChange?: (mode: LockableValueFieldMode) => void;
+  /** Shows a required-field asterisk next to the default label. Ignored when `label` is provided. */
+  required?: boolean;
+  /** Overrides the default mode-based label (e.g. a field name instead of "String value"). */
+  label?: ReactNode;
+  /** Extra content rendered after the built-in AI assist / Insert variable buttons (e.g. a delete button). */
+  headerActions?: ReactNode;
+  id?: string;
+  className?: string;
+}
+
+const FIELD_LABEL: Record<LockableValueFieldMode, string> = {
+  fixed: 'String value',
+  expression: 'Write a string expression',
+};
+
+const FIELD_PLACEHOLDER: Record<LockableValueFieldMode, string> = {
+  fixed: 'Enter a value',
+  expression: 'Enter an expression',
+};
+
+/**
+ * LockableValueField — a string field that can be locked to read-only and
+ * switched between a literal value and a JS expression.
+ *
+ * Prototype: the expression mode is styled as code (monospace) but does not
+ * yet carry real syntax highlighting or evaluation. See ExpressionField for
+ * the direction a full code-editing surface would take.
+ */
+export function LockableValueField({
+  value = '',
+  onValueChange,
+  locked = true,
+  onLockedChange,
+  mode = 'fixed',
+  onModeChange,
+  required,
+  label,
+  headerActions,
+  id,
+  className,
+}: LockableValueFieldProps) {
+  const promptId = useId();
+
+  return (
+    <div className={cn('flex flex-col gap-1.5', className)}>
+      <div className="flex items-center gap-1">
+        {label ?? (
+          <Label htmlFor={id} className="text-xs font-medium text-foreground-muted">
+            {FIELD_LABEL[mode]}
+            {required && <span className="ml-0.5 text-destructive">*</span>}
+          </Label>
+        )}
+        <div className="ml-auto flex items-center gap-0.5">
+          <Popover>
+            <PopoverTrigger asChild>
+              <button
+                type="button"
+                aria-label="AI assist"
+                title="AI assist"
+                className="grid size-7 place-items-center rounded-lg text-foreground-subtle transition hover:bg-surface-overlay hover:text-foreground"
+              >
+                <Sparkles size={12} />
+              </button>
+            </PopoverTrigger>
+            <PopoverContent align="end" className="space-y-3">
+              <div className="space-y-1.5">
+                <Label htmlFor={promptId} className="text-xs font-medium text-foreground-muted">
+                  Describe what you want
+                </Label>
+                <Textarea
+                  id={promptId}
+                  rows={3}
+                  placeholder="Display a value from the previous step"
+                  className="resize-none text-sm"
+                />
+              </div>
+              <span className="block text-[11px] text-foreground-subtle">
+                Output: String expression
+              </span>
+              <Button size="sm" className="w-full">
+                Generate
+              </Button>
+            </PopoverContent>
+          </Popover>
+          <button
+            type="button"
+            aria-label="Insert variable"
+            title="Insert variable"
+            className="flex h-7 items-center gap-1 rounded-lg px-2 text-[11px] text-foreground-subtle transition hover:bg-surface-overlay hover:text-foreground"
+          >
+            <span className="font-mono text-[10px]">{'{x}'}</span>
+            <span>Insert</span>
+            <ChevronDown size={9} />
+          </button>
+          {headerActions}
+        </div>
+      </div>
+
+      <InputGroup>
+        <InputGroupAddon align="inline-start">
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <InputGroupButton
+                icon
+                size="3xs"
+                aria-label={locked ? 'Locked. Click to unlock.' : 'Unlocked. Click to lock.'}
+              >
+                {locked ? <Lock /> : <LockOpen />}
+              </InputGroupButton>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="start" className="w-56">
+              <DropdownMenuItem
+                className="flex-col items-start gap-0.5 py-2"
+                onClick={() => onLockedChange?.(false)}
+              >
+                <div className="flex items-center gap-2">
+                  <LockOpen
+                    size={13}
+                    className={!locked ? 'text-brand' : 'text-foreground-muted'}
+                  />
+                  <span
+                    className={cn(
+                      'text-xs font-medium',
+                      !locked ? 'text-brand' : 'text-foreground'
+                    )}
+                  >
+                    Unlocked
+                  </span>
+                </div>
+                <span className="pl-[21px] text-[11px] leading-4 text-foreground-subtle">
+                  User can edit this field
+                </span>
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                className="flex-col items-start gap-0.5 py-2"
+                onClick={() => onLockedChange?.(true)}
+              >
+                <div className="flex items-center gap-2">
+                  <Lock size={13} className={locked ? 'text-brand' : 'text-foreground-muted'} />
+                  <span
+                    className={cn('text-xs font-medium', locked ? 'text-brand' : 'text-foreground')}
+                  >
+                    Locked
+                  </span>
+                </div>
+                <span className="pl-[21px] text-[11px] leading-4 text-foreground-subtle">
+                  User sees this field as read-only
+                </span>
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </InputGroupAddon>
+
+        <InputGroupInput
+          id={id}
+          readOnly={locked}
+          value={value}
+          onChange={(e) => onValueChange?.(e.target.value)}
+          placeholder={FIELD_PLACEHOLDER[mode]}
+          className={mode === 'expression' ? 'font-mono' : undefined}
+        />
+
+        <InputGroupAddon align="inline-end">
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <InputGroupButton icon size="3xs" aria-label="Choose value type">
+                <Type />
+              </InputGroupButton>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" className="w-56">
+              <DropdownMenuItem
+                className="flex-col items-start gap-0.5 py-2"
+                onClick={() => onModeChange?.('fixed')}
+              >
+                <div className="flex items-center gap-2">
+                  <Type
+                    size={13}
+                    className={mode === 'fixed' ? 'text-brand' : 'text-foreground-muted'}
+                  />
+                  <span
+                    className={cn(
+                      'text-xs font-medium',
+                      mode === 'fixed' ? 'text-brand' : 'text-foreground'
+                    )}
+                  >
+                    Fixed value
+                  </span>
+                </div>
+                <span className="pl-[21px] text-[11px] leading-4 text-foreground-subtle">
+                  Use a literal string value
+                </span>
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                className="flex-col items-start gap-0.5 py-2"
+                onClick={() => onModeChange?.('expression')}
+              >
+                <div className="flex items-center gap-2">
+                  <Code2
+                    size={13}
+                    className={mode === 'expression' ? 'text-brand' : 'text-foreground-muted'}
+                  />
+                  <span
+                    className={cn(
+                      'text-xs font-medium',
+                      mode === 'expression' ? 'text-brand' : 'text-foreground'
+                    )}
+                  >
+                    Expression
+                  </span>
+                </div>
+                <span className="pl-[21px] text-[11px] leading-4 text-foreground-subtle">
+                  Use a JS expression
+                </span>
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </InputGroupAddon>
+      </InputGroup>
+    </div>
+  );
+}

--- a/packages/apollo-react/src/canvas/components/NodePropertyPanel/LockableValueField.tsx
+++ b/packages/apollo-react/src/canvas/components/NodePropertyPanel/LockableValueField.tsx
@@ -30,6 +30,7 @@ import {
   TooltipTrigger,
 } from '@uipath/apollo-wind';
 import {
+  ALargeSmall,
   Asterisk,
   Braces,
   Calendar as CalendarIcon,
@@ -71,7 +72,7 @@ interface FieldTypeMeta {
 export const FIELD_TYPE_META: Record<LockableFieldType, FieldTypeMeta> = {
   string: {
     label: 'String',
-    icon: Type,
+    icon: ALargeSmall,
     supportsExpression: true,
     fixedLabel: 'Fixed value',
     fixedDescription: 'Use a literal string value',
@@ -427,62 +428,25 @@ export function LockableValueField({
       {typeMeta.supportsExpression ? (
         <InputGroup>
           <InputGroupAddon align="inline-start">
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <InputGroupButton
-                  icon
-                  size="3xs"
-                  aria-label={
-                    locked ? 'Read-only. Click to make editable.' : 'Editable. Click to make read-only.'
-                  }
-                >
-                  {locked ? <Lock /> : <LockOpen />}
-                </InputGroupButton>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="start" className="w-56">
-                <DropdownMenuItem
-                  className="flex-col items-start gap-0.5 py-2"
-                  onClick={() => onLockedChange?.(false)}
-                >
-                  <div className="flex items-center gap-2">
-                    <LockOpen
-                      size={13}
-                      className={!locked ? 'text-brand' : 'text-foreground-muted'}
-                    />
-                    <span
-                      className={cn(
-                        'text-xs font-medium',
-                        !locked ? 'text-brand' : 'text-foreground'
-                      )}
-                    >
-                      Editable
-                    </span>
-                  </div>
-                  <span className="pl-[21px] text-[11px] leading-4 text-foreground-subtle">
-                    User can edit this field
-                  </span>
-                </DropdownMenuItem>
-                <DropdownMenuItem
-                  className="flex-col items-start gap-0.5 py-2"
-                  onClick={() => onLockedChange?.(true)}
-                >
-                  <div className="flex items-center gap-2">
-                    <Lock size={13} className={locked ? 'text-brand' : 'text-foreground-muted'} />
-                    <span
-                      className={cn(
-                        'text-xs font-medium',
-                        locked ? 'text-brand' : 'text-foreground'
-                      )}
-                    >
-                      Read-only
-                    </span>
-                  </div>
-                  <span className="pl-[21px] text-[11px] leading-4 text-foreground-subtle">
-                    User sees this field as read-only
-                  </span>
-                </DropdownMenuItem>
-              </DropdownMenuContent>
-            </DropdownMenu>
+            <TooltipProvider delayDuration={300}>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <InputGroupButton
+                    icon
+                    size="3xs"
+                    onClick={() => onLockedChange?.(!locked)}
+                    aria-label={
+                      locked
+                        ? 'Read-only. Click to make editable.'
+                        : 'Editable. Click to make read-only.'
+                    }
+                  >
+                    {locked ? <Lock /> : <LockOpen />}
+                  </InputGroupButton>
+                </TooltipTrigger>
+                <TooltipContent>{locked ? 'Read-only' : 'Editable'}</TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
           </InputGroupAddon>
 
           {effectiveMode === 'expression' ? (
@@ -608,59 +572,25 @@ export function LockableValueField({
         </InputGroup>
       ) : (
         <div className="flex items-center gap-2">
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <InputGroupButton
-                icon
-                size="3xs"
-                aria-label={
-                  locked ? 'Read-only. Click to make editable.' : 'Editable. Click to make read-only.'
-                }
-              >
-                {locked ? <Lock /> : <LockOpen />}
-              </InputGroupButton>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="start" className="w-56">
-              <DropdownMenuItem
-                className="flex-col items-start gap-0.5 py-2"
-                onClick={() => onLockedChange?.(false)}
-              >
-                <div className="flex items-center gap-2">
-                  <LockOpen
-                    size={13}
-                    className={!locked ? 'text-brand' : 'text-foreground-muted'}
-                  />
-                  <span
-                    className={cn(
-                      'text-xs font-medium',
-                      !locked ? 'text-brand' : 'text-foreground'
-                    )}
-                  >
-                    Editable
-                  </span>
-                </div>
-                <span className="pl-[21px] text-[11px] leading-4 text-foreground-subtle">
-                  User can edit this field
-                </span>
-              </DropdownMenuItem>
-              <DropdownMenuItem
-                className="flex-col items-start gap-0.5 py-2"
-                onClick={() => onLockedChange?.(true)}
-              >
-                <div className="flex items-center gap-2">
-                  <Lock size={13} className={locked ? 'text-brand' : 'text-foreground-muted'} />
-                  <span
-                    className={cn('text-xs font-medium', locked ? 'text-brand' : 'text-foreground')}
-                  >
-                    Read-only
-                  </span>
-                </div>
-                <span className="pl-[21px] text-[11px] leading-4 text-foreground-subtle">
-                  User sees this field as read-only
-                </span>
-              </DropdownMenuItem>
-            </DropdownMenuContent>
-          </DropdownMenu>
+          <TooltipProvider delayDuration={300}>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <InputGroupButton
+                  icon
+                  size="3xs"
+                  onClick={() => onLockedChange?.(!locked)}
+                  aria-label={
+                    locked
+                      ? 'Read-only. Click to make editable.'
+                      : 'Editable. Click to make read-only.'
+                  }
+                >
+                  {locked ? <Lock /> : <LockOpen />}
+                </InputGroupButton>
+              </TooltipTrigger>
+              <TooltipContent>{locked ? 'Read-only' : 'Editable'}</TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
 
           {locked ? (
             <Input

--- a/packages/apollo-react/src/canvas/components/NodePropertyPanel/LockableValueField.tsx
+++ b/packages/apollo-react/src/canvas/components/NodePropertyPanel/LockableValueField.tsx
@@ -7,6 +7,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
   FileUpload,
+  Input,
   InputGroup,
   InputGroupAddon,
   InputGroupButton,
@@ -182,8 +183,8 @@ const FIELD_LABEL: Record<LockableValueFieldMode, string> = {
 };
 
 const FIELD_PLACEHOLDER: Record<LockableValueFieldMode, string> = {
-  fixed: 'Enter a value',
-  expression: 'Enter an expression',
+  fixed: 'String value',
+  expression: 'Write a string expression',
 };
 
 /**
@@ -219,6 +220,30 @@ export function LockableValueField({
   const effectiveMode = typeMeta.supportsExpression ? mode : 'fixed';
   const collapsedTextClass = cn('@max-[259px]:hidden', compact && '!hidden');
   const collapsedPaddingClass = cn('@max-[259px]:px-1.5', compact && '!px-1.5');
+
+  // Locked fields are read-only, not disabled — the raw control (switch, date
+  // picker, select) has nothing left to do once editing is blocked, so it's
+  // replaced with plain, selectable text showing the same value.
+  const lockedDisplayValue =
+    fieldType === 'boolean'
+      ? value === 'true'
+        ? 'True'
+        : 'False'
+      : fieldType === 'date'
+        ? value
+          ? new Date(value).toLocaleDateString(undefined, {
+              year: 'numeric',
+              month: 'long',
+              day: 'numeric',
+            })
+          : ''
+        : fieldType === 'single-select'
+          ? (DEMO_SELECT_OPTIONS.find((option) => option.value === value)?.label ?? '')
+          : fieldType === 'multi-select'
+            ? parseListValue(value)
+                .map((v) => DEMO_SELECT_OPTIONS.find((option) => option.value === v)?.label ?? v)
+                .join(', ')
+            : value;
 
   return (
     <div className={cn('@container group flex flex-col gap-1.5', className)}>
@@ -456,13 +481,19 @@ export function LockableValueField({
               placeholder={FIELD_PLACEHOLDER.expression}
               className="font-mono"
             />
+          ) : locked ? (
+            <InputGroupInput
+              id={id}
+              readOnly
+              value={lockedDisplayValue}
+              placeholder={FIELD_PLACEHOLDER.fixed}
+            />
           ) : fieldType === 'boolean' ? (
             <div className="flex h-full flex-1 items-center px-3">
               <Switch
                 id={id}
                 checked={value === 'true'}
                 onCheckedChange={(checked) => onValueChange?.(String(checked))}
-                disabled={locked}
               />
             </div>
           ) : fieldType === 'date' ? (
@@ -472,8 +503,7 @@ export function LockableValueField({
                   type="button"
                   id={id}
                   data-slot="input-group-control"
-                  disabled={locked}
-                  className="flex h-full flex-1 items-center text-left text-sm text-foreground outline-none disabled:cursor-not-allowed disabled:opacity-50"
+                  className="flex h-full flex-1 items-center text-left text-sm text-foreground outline-none"
                 >
                   {value ? (
                     new Date(value).toLocaleDateString(undefined, {
@@ -499,7 +529,6 @@ export function LockableValueField({
             <InputGroupInput
               id={id}
               type={fieldType === 'integer' ? 'number' : 'text'}
-              readOnly={locked}
               value={value}
               onChange={(e) => onValueChange?.(e.target.value)}
               placeholder={FIELD_PLACEHOLDER.fixed}
@@ -618,8 +647,16 @@ export function LockableValueField({
             </DropdownMenuContent>
           </DropdownMenu>
 
-          {fieldType === 'single-select' && (
-            <Select value={value || undefined} onValueChange={onValueChange} disabled={locked}>
+          {locked ? (
+            <Input
+              id={id}
+              readOnly
+              value={lockedDisplayValue}
+              placeholder={FIELD_PLACEHOLDER.fixed}
+              className="flex-1"
+            />
+          ) : fieldType === 'single-select' ? (
+            <Select value={value || undefined} onValueChange={onValueChange}>
               <SelectTrigger id={id} className="flex-1">
                 <SelectValue placeholder="Select an option" />
               </SelectTrigger>
@@ -631,25 +668,21 @@ export function LockableValueField({
                 ))}
               </SelectContent>
             </Select>
-          )}
-
-          {fieldType === 'multi-select' && (
+          ) : fieldType === 'multi-select' ? (
             <MultiSelect
               className="flex-1"
               options={DEMO_SELECT_OPTIONS}
               selected={parseListValue(value)}
               onChange={(selected) => onValueChange?.(JSON.stringify(selected))}
               placeholder="Select options..."
-              disabled={locked}
             />
-          )}
-
-          {fieldType === 'file' && (
-            <FileUpload
-              className="flex-1"
-              disabled={locked}
-              onFilesChange={(files) => onValueChange?.(files.map((f) => f.name).join(', '))}
-            />
+          ) : (
+            fieldType === 'file' && (
+              <FileUpload
+                className="flex-1"
+                onFilesChange={(files) => onValueChange?.(files.map((f) => f.name).join(', '))}
+              />
+            )
           )}
         </div>
       )}

--- a/packages/apollo-react/src/canvas/components/NodePropertyPanel/LockableValueField.tsx
+++ b/packages/apollo-react/src/canvas/components/NodePropertyPanel/LockableValueField.tsx
@@ -39,16 +39,60 @@ import {
   Hash,
   List,
   ListChecks,
-  Lock,
-  LockOpen,
   type LucideIcon,
   Paperclip,
   Sparkles,
   ToggleLeft,
   Type,
 } from 'lucide-react';
-import type { ReactNode } from 'react';
+import type { ReactNode, SVGProps } from 'react';
 import { useId } from 'react';
+
+/**
+ * Prototype-only: raw Material Symbols Outlined glyphs (FILL 0, wght 400,
+ * GRAD 0, opsz 24) for a side-by-side comparison against lucide's Lock /
+ * LockOpen. Not styled to match lucide's stroke conventions on purpose --
+ * this is here to judge the Material look as-is, unmodified.
+ */
+function MaterialLock({
+  size = 24,
+  className,
+  ...props
+}: { size?: number | string; className?: string } & SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width={size}
+      height={size}
+      viewBox="0 -960 960 960"
+      fill="currentColor"
+      className={className}
+      {...props}
+    >
+      <path d="M240-80q-33 0-56.5-23.5T160-160v-400q0-33 23.5-56.5T240-640h40v-80q0-83 58.5-141.5T480-920q83 0 141.5 58.5T680-720v80h40q33 0 56.5 23.5T800-560v400q0 33-23.5 56.5T720-80H240Zm0-80h480v-400H240v400Zm296.5-143.5Q560-327 560-360t-23.5-56.5Q513-440 480-440t-56.5 23.5Q400-393 400-360t23.5 56.5Q447-280 480-280t56.5-23.5ZM360-640h240v-80q0-50-35-85t-85-35q-50 0-85 35t-35 85v80ZM240-160v-400 400Z" />
+    </svg>
+  );
+}
+
+function MaterialLockOpenRight({
+  size = 24,
+  className,
+  ...props
+}: { size?: number | string; className?: string } & SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width={size}
+      height={size}
+      viewBox="0 -960 960 960"
+      fill="currentColor"
+      className={className}
+      {...props}
+    >
+      <path d="M240-160h480v-400H240v400Zm296.5-143.5Q560-327 560-360t-23.5-56.5Q513-440 480-440t-56.5 23.5Q400-393 400-360t23.5 56.5Q447-280 480-280t56.5-23.5ZM240-160v-400 400Zm0 80q-33 0-56.5-23.5T160-160v-400q0-33 23.5-56.5T240-640h280v-80q0-83 58.5-141.5T720-920q83 0 141.5 58.5T920-720h-80q0-50-35-85t-85-35q-50 0-85 35t-35 85v80h120q33 0 56.5 23.5T800-560v400q0 33-23.5 56.5T720-80H240Z" />
+    </svg>
+  );
+}
 
 export type LockableValueFieldMode = 'fixed' | 'expression';
 
@@ -441,7 +485,7 @@ export function LockableValueField({
                         : 'Editable. Click to make read-only.'
                     }
                   >
-                    {locked ? <Lock /> : <LockOpen />}
+                    {locked ? <MaterialLock size={16} /> : <MaterialLockOpenRight size={16} />}
                   </InputGroupButton>
                 </TooltipTrigger>
                 <TooltipContent>{locked ? 'Read-only' : 'Editable'}</TooltipContent>
@@ -585,7 +629,7 @@ export function LockableValueField({
                       : 'Editable. Click to make read-only.'
                   }
                 >
-                  {locked ? <Lock /> : <LockOpen />}
+                  {locked ? <MaterialLock size={16} /> : <MaterialLockOpenRight size={16} />}
                 </InputGroupButton>
               </TooltipTrigger>
               <TooltipContent>{locked ? 'Read-only' : 'Editable'}</TooltipContent>

--- a/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.stories.tsx
@@ -707,6 +707,8 @@ const JSON_VIEWER_OPTIONS = {
   automaticLayout: true,
 } as const;
 
+const JSON_EDITOR_OPTIONS = { ...JSON_VIEWER_OPTIONS, readOnly: false } as const;
+
 const INLINE_EDITOR_OPTIONS = {
   fontSize: 13,
   lineHeight: 20,
@@ -3058,6 +3060,7 @@ function LockableValueFieldShowcase({
 }
 
 function QuickFormStory() {
+  const monacoTheme = useMonacoTheme();
   const [cases, setCases] = useState<LockableCase[]>(DEFAULT_LOCKABLE_CASES);
   const nextIdRef = useRef(4);
   const [formView, setFormView] = useState<'edit' | 'json'>('edit');
@@ -3470,13 +3473,17 @@ function QuickFormStory() {
                             </Tooltip>
                           </TooltipProvider>
                         </div>
-                        <Textarea
-                          value={jsonDraft}
-                          onChange={(e) => handleJsonChange(e.target.value)}
-                          rows={14}
-                          spellCheck={false}
-                          className="resize-none font-mono text-xs"
-                        />
+                        <div className="h-[320px] overflow-hidden rounded-xl border border-surface-overlay">
+                          <MonacoEditor
+                            height="100%"
+                            language="json"
+                            value={jsonDraft}
+                            onChange={(value) => handleJsonChange(value ?? '')}
+                            theme={monacoTheme}
+                            beforeMount={registerMonacoThemes}
+                            options={JSON_EDITOR_OPTIONS}
+                          />
+                        </div>
                         {jsonError && <span className="text-xs text-destructive">{jsonError}</span>}
                       </div>
                     )}

--- a/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.stories.tsx
@@ -2,6 +2,9 @@ import {
   closestCenter,
   DndContext,
   type DragEndEvent,
+  type DragOverEvent,
+  DragOverlay,
+  type DragStartEvent,
   KeyboardSensor,
   PointerSensor,
   useSensor,
@@ -77,6 +80,7 @@ import {
   GitFork,
   Globe,
   GripVertical,
+  MousePointerClick,
   Pencil,
   Play,
   Plus,
@@ -89,10 +93,12 @@ import {
 } from 'lucide-react';
 import type { CSSProperties, ReactNode } from 'react';
 import { lazy, Suspense, useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 import type { LockableFieldType, LockableValueFieldMode } from './LockableValueField';
 import {
   DEMO_SELECT_OPTIONS,
   FIELD_TYPE_META,
+  FIELD_TYPE_ORDER,
   LockableValueField,
   parseListValue,
 } from './LockableValueField';
@@ -163,6 +169,23 @@ function DebugButton() {
       <Play size={14} />
       Debug
     </button>
+  );
+}
+
+function ApproveRejectActions() {
+  return (
+    <div className="flex items-center gap-2">
+      <Button variant="outline" size="xs" className="h-8">
+        Reject
+      </Button>
+      <button
+        type="button"
+        className="flex h-8 items-center gap-2 rounded-lg bg-brand px-4 text-sm font-semibold text-foreground-on-accent transition hover:bg-brand-hover"
+      >
+        <CircleCheck size={14} />
+        Approve
+      </button>
+    </div>
   );
 }
 
@@ -2558,11 +2581,42 @@ const DEFAULT_LOCKABLE_CASES: LockableCase[] = [
   },
 ];
 
+const REVIEW_LOCKABLE_CASES: LockableCase[] = [
+  {
+    id: 1,
+    title: 'Invoice Number',
+    required: true,
+    value: 'INV-2024-0587',
+    locked: true,
+    mode: 'fixed',
+    fieldType: 'string',
+  },
+  {
+    id: 2,
+    title: 'Submission Date',
+    required: true,
+    value: new Date('2026-07-10').toISOString(),
+    locked: true,
+    mode: 'fixed',
+    fieldType: 'date',
+  },
+  {
+    id: 3,
+    title: 'Approved Amount',
+    required: true,
+    value: '1240',
+    locked: false,
+    mode: 'fixed',
+    fieldType: 'integer',
+  },
+];
+
 function LockableCaseRow({
   id,
   caseTitle,
   onTitleChange,
   required,
+  onRequiredChange,
   onDelete,
   value,
   onValueChange,
@@ -2573,11 +2627,15 @@ function LockableCaseRow({
   fieldType,
   onFieldTypeChange,
   compact,
+  controlsVisibility,
+  insertBefore,
+  insertAfter,
 }: {
   id: number;
   caseTitle: string;
   onTitleChange: (title: string) => void;
   required: boolean;
+  onRequiredChange: (required: boolean) => void;
   onDelete: () => void;
   value: string;
   onValueChange: (value: string) => void;
@@ -2588,6 +2646,11 @@ function LockableCaseRow({
   fieldType: LockableFieldType;
   onFieldTypeChange: (fieldType: LockableFieldType) => void;
   compact?: boolean;
+  controlsVisibility?: 'visible' | 'hover';
+  /** Shows the insertion line above this row (the dragged item would land here). */
+  insertBefore?: boolean;
+  /** Shows the insertion line below this row (the dragged item would land here). */
+  insertAfter?: boolean;
 }) {
   const [editingTitle, setEditingTitle] = useState(false);
   const titleRef = useRef<HTMLInputElement>(null);
@@ -2599,70 +2662,329 @@ function LockableCaseRow({
     <div
       ref={setNodeRef}
       style={{ transform: CSS.Transform.toString(transform), transition }}
-      className={cn('group', isDragging && 'opacity-50')}
+      className="group relative"
     >
-      <LockableValueField
-        id={`return-value-${id}`}
-        label={
-          <div className="flex min-w-0 flex-1 items-center gap-1">
-            <button
-              type="button"
-              {...attributes}
-              {...listeners}
-              aria-label="Drag to reorder"
-              title="Drag to reorder"
-              className="grid size-5 shrink-0 touch-none place-items-center rounded text-foreground-subtle transition hover:bg-surface-overlay hover:text-foreground [cursor:grab]"
-            >
-              <GripVertical size={12} />
-            </button>
-            {editingTitle ? (
-              <input
-                ref={titleRef}
-                value={caseTitle}
-                onChange={(e) => onTitleChange(e.target.value)}
-                onBlur={() => setEditingTitle(false)}
-                onKeyDown={(e) => {
-                  if (e.key === 'Enter' || e.key === 'Escape') setEditingTitle(false);
-                }}
-                className="min-w-0 flex-1 rounded bg-surface-overlay px-1 py-0.5 text-xs font-medium text-foreground outline-none ring-1 ring-brand"
-                autoFocus
-              />
-            ) : (
+      {/* Rendered as a child of this row's own transformed wrapper (not an
+          outer sibling) so it moves in lockstep with the row during the
+          sortable reflow animation instead of drifting out of sync. */}
+      {insertBefore && (
+        <div
+          aria-hidden
+          className="pointer-events-none absolute inset-x-0 -top-2 z-10 h-0.5 rounded-full bg-brand"
+        />
+      )}
+      <div
+        className={cn(isDragging && 'rounded-lg border-2 border-dashed border-brand/50 opacity-50')}
+      >
+        <LockableValueField
+          id={`return-value-${id}`}
+          label={
+            <div className="flex min-w-0 flex-1 items-center gap-1">
               <button
                 type="button"
-                onClick={() => {
-                  setEditingTitle(true);
-                  setTimeout(() => titleRef.current?.select(), 0);
-                }}
-                className="truncate rounded px-1 py-0.5 text-left text-xs font-medium text-foreground-muted transition hover:bg-surface-overlay hover:text-foreground"
+                {...attributes}
+                {...listeners}
+                aria-label="Drag to reorder"
+                title="Drag to reorder"
+                className="grid size-5 shrink-0 touch-none place-items-center rounded text-foreground-subtle transition hover:bg-surface-overlay hover:text-foreground [cursor:grab]"
               >
-                {caseTitle}
-                {required && <span className="ml-0.5 text-destructive">*</span>}
+                <GripVertical size={12} />
               </button>
+              {editingTitle ? (
+                <input
+                  ref={titleRef}
+                  value={caseTitle}
+                  onChange={(e) => onTitleChange(e.target.value)}
+                  onBlur={() => setEditingTitle(false)}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter' || e.key === 'Escape') setEditingTitle(false);
+                  }}
+                  className="min-w-0 flex-1 rounded bg-surface-overlay px-1 py-0.5 text-xs font-medium text-foreground outline-none ring-1 ring-brand"
+                  autoFocus
+                />
+              ) : (
+                <button
+                  type="button"
+                  onClick={() => {
+                    setEditingTitle(true);
+                    setTimeout(() => titleRef.current?.select(), 0);
+                  }}
+                  className="truncate rounded px-1 py-0.5 text-left text-xs font-medium text-foreground-muted transition hover:bg-surface-overlay hover:text-foreground"
+                >
+                  {caseTitle}
+                  {required && <span className="ml-0.5 text-destructive">*</span>}
+                </button>
+              )}
+            </div>
+          }
+          headerActions={
+            <button
+              type="button"
+              onClick={onDelete}
+              aria-label="Delete field"
+              title="Delete field"
+              className="grid size-6 shrink-0 place-items-center rounded text-foreground-subtle opacity-0 transition hover:bg-surface-overlay hover:text-foreground group-hover:opacity-100"
+            >
+              <X size={12} />
+            </button>
+          }
+          value={value}
+          onValueChange={onValueChange}
+          locked={locked}
+          onLockedChange={onLockedChange}
+          mode={mode}
+          onModeChange={onModeChange}
+          fieldType={fieldType}
+          onFieldTypeChange={onFieldTypeChange}
+          required={required}
+          onRequiredChange={onRequiredChange}
+          compact={compact}
+          controlsVisibility={controlsVisibility}
+        />
+      </div>
+      {insertAfter && (
+        <div
+          aria-hidden
+          className="pointer-events-none absolute inset-x-0 -bottom-2 z-10 h-0.5 rounded-full bg-brand"
+        />
+      )}
+    </div>
+  );
+}
+
+interface FormButtonItem {
+  id: number;
+  label: string;
+  variant: 'default' | 'outline';
+}
+
+const DEFAULT_FORM_BUTTONS: FormButtonItem[] = [
+  { id: 1, label: 'Approve', variant: 'default' },
+  { id: 2, label: 'Cancel', variant: 'outline' },
+];
+
+function FormButtonChip({
+  label,
+  onLabelChange,
+  variant,
+  onDelete,
+}: {
+  label: string;
+  onLabelChange: (label: string) => void;
+  variant: 'default' | 'outline';
+  onDelete: () => void;
+}) {
+  const [editing, setEditing] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  return (
+    <div className="group/button relative">
+      {editing ? (
+        <input
+          ref={inputRef}
+          value={label}
+          onChange={(e) => onLabelChange(e.target.value)}
+          onBlur={() => setEditing(false)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' || e.key === 'Escape') setEditing(false);
+          }}
+          autoFocus
+          size={Math.max(label.length, 4)}
+          className={cn(
+            'h-8 rounded-lg px-3 text-sm font-semibold outline-none ring-1 ring-brand',
+            variant === 'default'
+              ? 'bg-brand text-foreground-on-accent'
+              : 'border border-border-subtle bg-transparent text-foreground'
+          )}
+        />
+      ) : (
+        <button
+          type="button"
+          onClick={() => {
+            setEditing(true);
+            setTimeout(() => inputRef.current?.select(), 0);
+          }}
+          className={cn(
+            'flex h-8 items-center rounded-lg px-4 text-sm font-semibold transition',
+            variant === 'default'
+              ? 'bg-brand text-foreground-on-accent hover:bg-brand-hover'
+              : 'border border-border-subtle text-foreground hover:bg-surface-overlay'
+          )}
+        >
+          {label}
+        </button>
+      )}
+      <button
+        type="button"
+        onClick={onDelete}
+        aria-label="Delete button"
+        title="Delete button"
+        className="absolute -right-1.5 -top-1.5 grid size-4 place-items-center rounded-full bg-surface-overlay text-foreground-subtle opacity-0 shadow transition hover:text-foreground group-hover/button:opacity-100"
+      >
+        <X size={10} />
+      </button>
+    </div>
+  );
+}
+
+function FieldDragOverlay({ caseItem }: { caseItem: LockableCase }) {
+  const meta = FIELD_TYPE_META[caseItem.fieldType];
+  return (
+    <div
+      className="flex items-center gap-2 rounded-lg border border-border-subtle bg-surface-raised px-3 py-2 shadow-lg"
+      style={{ cursor: 'grabbing' }}
+    >
+      <GripVertical size={12} className="shrink-0 text-foreground-subtle" />
+      <meta.icon size={12} className="shrink-0 text-foreground-subtle" />
+      <span className="truncate text-xs font-medium text-foreground">
+        {caseItem.title}
+        {caseItem.required && <span className="ml-0.5 text-destructive">*</span>}
+      </span>
+    </div>
+  );
+}
+
+function LockableValueFieldShowcase({
+  controlsVisibility,
+  onControlsVisibilityChange,
+}: {
+  controlsVisibility: 'visible' | 'hover';
+  onControlsVisibilityChange: (visibility: 'visible' | 'hover') => void;
+}) {
+  const [showcaseValue, setShowcaseValue] = useState('');
+  const [showcaseLocked, setShowcaseLocked] = useState(true);
+  const [showcaseMode, setShowcaseMode] = useState<LockableValueFieldMode>('fixed');
+  const [showcaseFieldType, setShowcaseFieldType] = useState<LockableFieldType>('string');
+  const [showcaseRequired, setShowcaseRequired] = useState(true);
+  const [showcaseDetailsExpanded, setShowcaseDetailsExpanded] = useState(false);
+
+  const handleShowcaseFieldTypeChange = (type: LockableFieldType) => {
+    setShowcaseFieldType(type);
+    setShowcaseValue('');
+    if (!FIELD_TYPE_META[type].supportsExpression) {
+      setShowcaseMode('fixed');
+    }
+  };
+
+  return (
+    <div className="flex w-[380px] shrink-0 flex-col gap-4 rounded-2xl border border-border-subtle bg-surface-raised p-5">
+      <div className="flex flex-col gap-1">
+        <span className="text-sm font-semibold text-foreground">LockableValueField</span>
+        <button
+          type="button"
+          onClick={() => setShowcaseDetailsExpanded((v) => !v)}
+          aria-expanded={showcaseDetailsExpanded}
+          className="group/details flex items-start gap-1 text-left text-xs leading-4 text-foreground-muted transition hover:text-foreground"
+        >
+          <span className="flex-1">
+            A reusable string field that can be locked to read-only and switched between a literal
+            value and a JS expression.
+          </span>
+          <ChevronDown
+            size={14}
+            className={cn(
+              'mt-0.5 shrink-0 text-foreground-subtle transition-transform group-hover/details:text-foreground',
+              showcaseDetailsExpanded && 'rotate-180'
             )}
-          </div>
-        }
-        headerActions={
-          <button
-            type="button"
-            onClick={onDelete}
-            aria-label="Delete field"
-            title="Delete field"
-            className="grid size-6 shrink-0 place-items-center rounded text-foreground-subtle opacity-0 transition hover:bg-surface-overlay hover:text-foreground group-hover:opacity-100"
-          >
-            <X size={12} />
-          </button>
-        }
-        value={value}
-        onValueChange={onValueChange}
-        locked={locked}
-        onLockedChange={onLockedChange}
-        mode={mode}
-        onModeChange={onModeChange}
-        fieldType={fieldType}
-        onFieldTypeChange={onFieldTypeChange}
-        compact={compact}
-      />
+          />
+        </button>
+        {showcaseDetailsExpanded && (
+          <ul className="flex list-disc flex-col gap-1.5 pl-4 pt-1 text-xs leading-4 text-foreground-muted">
+            <li>
+              Left lock icon toggles Unlocked / Locked. Locked fields are read-only, not disabled.
+            </li>
+            <li>
+              Right value-mode icon switches between Fixed value and Expression, updating the value
+              styling. Only shown for types an expression can produce.
+            </li>
+            <li>
+              Field type dropdown swaps the control itself: String, Integer, Date, Boolean, Single
+              select, Multiselect, and File each render their own matching input.
+            </li>
+            <li>
+              Required switch toggles the red asterisk on the label. Only shown when
+              onRequiredChange is provided. Collapses to an icon that opens a popover in compact
+              view.
+            </li>
+            <li>Built-in AI-assist popover to describe and generate a value.</li>
+            <li>Insert-variable affordance for binding to upstream data.</li>
+            <li>Built entirely on apollo-wind&apos;s InputGroup primitive.</li>
+            <li>
+              Header row is responsive (container query): the type, required, AI-assist, and
+              insert-variable controls collapse to icon-only once the field gets too narrow for
+              their labels.
+            </li>
+          </ul>
+        )}
+      </div>
+      <div className="flex items-center justify-between border-t border-border-subtle pt-4">
+        <span className="text-[11px] font-medium uppercase tracking-wide text-foreground-subtle">
+          Controls
+        </span>
+        <ToggleGroup
+          type="single"
+          size="xs"
+          value={controlsVisibility}
+          onValueChange={(v) => v && onControlsVisibilityChange(v as 'visible' | 'hover')}
+        >
+          <ToggleGroupItem value="visible" className="!px-2.5 !text-xs">
+            Show
+          </ToggleGroupItem>
+          <ToggleGroupItem value="hover" className="!px-2.5 !text-xs">
+            Hide
+          </ToggleGroupItem>
+        </ToggleGroup>
+      </div>
+      <div className="flex flex-col gap-2">
+        <span className="text-[11px] font-medium uppercase tracking-wide text-foreground-subtle">
+          Full view
+        </span>
+        <LockableValueField
+          label={
+            <Label className="text-xs font-medium text-foreground-muted">
+              Label
+              {showcaseRequired && <span className="ml-0.5 text-destructive">*</span>}
+            </Label>
+          }
+          value={showcaseValue}
+          onValueChange={setShowcaseValue}
+          locked={showcaseLocked}
+          onLockedChange={setShowcaseLocked}
+          mode={showcaseMode}
+          onModeChange={setShowcaseMode}
+          fieldType={showcaseFieldType}
+          onFieldTypeChange={handleShowcaseFieldTypeChange}
+          required={showcaseRequired}
+          onRequiredChange={setShowcaseRequired}
+          controlsVisibility={controlsVisibility}
+        />
+      </div>
+      <div className="flex flex-col gap-2 border-t border-border-subtle pt-4">
+        <span className="text-[11px] font-medium uppercase tracking-wide text-foreground-subtle">
+          Compact view (narrow container)
+        </span>
+        <div className="w-[200px]">
+          <LockableValueField
+            label={
+              <Label className="text-xs font-medium text-foreground-muted">
+                Label
+                {showcaseRequired && <span className="ml-0.5 text-destructive">*</span>}
+              </Label>
+            }
+            value={showcaseValue}
+            onValueChange={setShowcaseValue}
+            locked={showcaseLocked}
+            onLockedChange={setShowcaseLocked}
+            mode={showcaseMode}
+            onModeChange={setShowcaseMode}
+            fieldType={showcaseFieldType}
+            onFieldTypeChange={handleShowcaseFieldTypeChange}
+            required={showcaseRequired}
+            onRequiredChange={setShowcaseRequired}
+            controlsVisibility={controlsVisibility}
+          />
+        </div>
+      </div>
     </div>
   );
 }
@@ -2679,18 +3001,12 @@ function QuickFormStory() {
   const formDescriptionRef = useRef<HTMLInputElement>(null);
   const [jsonDraft, setJsonDraft] = useState(() => JSON.stringify(DEFAULT_LOCKABLE_CASES, null, 2));
   const [jsonError, setJsonError] = useState<string | null>(null);
-  const [showcaseValue, setShowcaseValue] = useState('');
-  const [showcaseLocked, setShowcaseLocked] = useState(true);
-  const [showcaseMode, setShowcaseMode] = useState<LockableValueFieldMode>('fixed');
-  const [showcaseFieldType, setShowcaseFieldType] = useState<LockableFieldType>('string');
-
-  const handleShowcaseFieldTypeChange = (type: LockableFieldType) => {
-    setShowcaseFieldType(type);
-    setShowcaseValue('');
-    if (!FIELD_TYPE_META[type].supportsExpression) {
-      setShowcaseMode('fixed');
-    }
-  };
+  const [showcaseControlsVisibility, setShowcaseControlsVisibility] = useState<'visible' | 'hover'>(
+    'hover'
+  );
+  const [buttons, setButtons] = useState<FormButtonItem[]>(DEFAULT_FORM_BUTTONS);
+  const nextButtonIdRef = useRef(3);
+  const fileInputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
     if (formView !== 'json') {
@@ -2714,7 +3030,7 @@ function QuickFormStory() {
     }
   };
 
-  const addCase = () => {
+  const addCaseWithType = (fieldType: LockableFieldType) => {
     const id = nextIdRef.current++;
     setCases((prev) => [
       ...prev,
@@ -2725,13 +3041,20 @@ function QuickFormStory() {
         value: '',
         locked: true,
         mode: 'fixed',
-        fieldType: 'string',
+        fieldType,
       },
     ]);
   };
   const deleteCase = (id: number) => setCases((prev) => prev.filter((c) => c.id !== id));
   const updateCase = (id: number, patch: Partial<LockableCase>) =>
     setCases((prev) => prev.map((c) => (c.id === id ? { ...c, ...patch } : c)));
+  const addButton = () => {
+    const id = nextButtonIdRef.current++;
+    setButtons((prev) => [...prev, { id, label: 'New button', variant: 'outline' }]);
+  };
+  const deleteButton = (id: number) => setButtons((prev) => prev.filter((b) => b.id !== id));
+  const updateButton = (id: number, patch: Partial<FormButtonItem>) =>
+    setButtons((prev) => prev.map((b) => (b.id === id ? { ...b, ...patch } : b)));
   const updateCaseFieldType = (id: number, fieldType: LockableFieldType) =>
     setCases((prev) =>
       prev.map((c) =>
@@ -2751,15 +3074,36 @@ function QuickFormStory() {
     useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
   );
 
+  const [activeDragId, setActiveDragId] = useState<number | null>(null);
+  const [overDragId, setOverDragId] = useState<number | null>(null);
+
+  const handleDragStart = (event: DragStartEvent) => {
+    setActiveDragId(event.active.id as number);
+  };
+
+  const handleDragOver = (event: DragOverEvent) => {
+    setOverDragId((event.over?.id as number) ?? null);
+  };
+
   const handleDragEnd = (event: DragEndEvent) => {
     const { active, over } = event;
-    if (!over || active.id === over.id) return;
-    setCases((prev) => {
-      const oldIndex = prev.findIndex((c) => c.id === active.id);
-      const newIndex = prev.findIndex((c) => c.id === over.id);
-      return arrayMove(prev, oldIndex, newIndex);
-    });
+    if (over && active.id !== over.id) {
+      setCases((prev) => {
+        const oldIndex = prev.findIndex((c) => c.id === active.id);
+        const newIndex = prev.findIndex((c) => c.id === over.id);
+        return arrayMove(prev, oldIndex, newIndex);
+      });
+    }
+    setActiveDragId(null);
+    setOverDragId(null);
   };
+
+  const handleDragCancel = () => {
+    setActiveDragId(null);
+    setOverDragId(null);
+  };
+
+  const activeCase = cases.find((c) => c.id === activeDragId);
 
   return (
     <div className="flex items-start gap-8">
@@ -2846,9 +3190,27 @@ function QuickFormStory() {
                 <Card>
                   <CardContent className="flex flex-col gap-4 p-4">
                     <div className="flex items-center gap-3.5">
-                      <div className="grid size-11 shrink-0 place-items-center rounded-xl bg-surface-overlay text-foreground-subtle [&>svg]:size-5">
-                        <Upload />
-                      </div>
+                      <input
+                        ref={fileInputRef}
+                        type="file"
+                        className="hidden"
+                        onChange={() => {}}
+                      />
+                      <TooltipProvider delayDuration={300}>
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <button
+                              type="button"
+                              onClick={() => fileInputRef.current?.click()}
+                              aria-label="Upload a file"
+                              className="grid size-11 shrink-0 place-items-center rounded-xl bg-surface-overlay text-foreground-subtle transition hover:bg-surface-overlay/70 hover:text-foreground [&>svg]:size-5"
+                            >
+                              <Upload />
+                            </button>
+                          </TooltipTrigger>
+                          <TooltipContent>Upload a reference file for this form</TooltipContent>
+                        </Tooltip>
+                      </TooltipProvider>
                       <div className="flex min-w-0 flex-1 flex-col justify-center">
                         {editingFormTitle ? (
                           <input
@@ -2907,45 +3269,97 @@ function QuickFormStory() {
                         <DndContext
                           sensors={sensors}
                           collisionDetection={closestCenter}
+                          onDragStart={handleDragStart}
+                          onDragOver={handleDragOver}
                           onDragEnd={handleDragEnd}
+                          onDragCancel={handleDragCancel}
                         >
                           <SortableContext
                             items={cases.map((c) => c.id)}
                             strategy={verticalListSortingStrategy}
                           >
                             <div className="flex flex-col gap-4">
-                              {cases.map((c) => (
-                                <LockableCaseRow
-                                  key={c.id}
-                                  id={c.id}
-                                  caseTitle={c.title}
-                                  onTitleChange={(title) => updateCase(c.id, { title })}
-                                  required={c.required}
-                                  onDelete={() => deleteCase(c.id)}
-                                  value={c.value}
-                                  onValueChange={(value) => updateCase(c.id, { value })}
-                                  locked={c.locked}
-                                  onLockedChange={(locked) => updateCase(c.id, { locked })}
-                                  mode={c.mode}
-                                  onModeChange={(mode) => updateCase(c.id, { mode })}
-                                  fieldType={c.fieldType}
-                                  compact
-                                  onFieldTypeChange={(fieldType) =>
-                                    updateCaseFieldType(c.id, fieldType)
-                                  }
-                                />
-                              ))}
+                              {cases.map((c, index) => {
+                                const activeIndex = cases.findIndex((x) => x.id === activeDragId);
+                                const isOver =
+                                  activeDragId != null &&
+                                  overDragId === c.id &&
+                                  c.id !== activeDragId;
+                                return (
+                                  <LockableCaseRow
+                                    key={c.id}
+                                    id={c.id}
+                                    caseTitle={c.title}
+                                    onTitleChange={(title) => updateCase(c.id, { title })}
+                                    required={c.required}
+                                    onRequiredChange={(required) => updateCase(c.id, { required })}
+                                    onDelete={() => deleteCase(c.id)}
+                                    value={c.value}
+                                    onValueChange={(value) => updateCase(c.id, { value })}
+                                    locked={c.locked}
+                                    onLockedChange={(locked) => updateCase(c.id, { locked })}
+                                    mode={c.mode}
+                                    onModeChange={(mode) => updateCase(c.id, { mode })}
+                                    fieldType={c.fieldType}
+                                    compact
+                                    onFieldTypeChange={(fieldType) =>
+                                      updateCaseFieldType(c.id, fieldType)
+                                    }
+                                    controlsVisibility={showcaseControlsVisibility}
+                                    insertBefore={isOver && activeIndex > index}
+                                    insertAfter={isOver && activeIndex < index}
+                                  />
+                                );
+                              })}
                             </div>
                           </SortableContext>
+                          {createPortal(
+                            <DragOverlay>
+                              {activeCase ? <FieldDragOverlay caseItem={activeCase} /> : null}
+                            </DragOverlay>,
+                            document.body
+                          )}
                         </DndContext>
-                        <button
-                          type="button"
-                          onClick={addCase}
-                          className="flex cursor-pointer items-center gap-1.5 text-xs text-brand transition hover:text-brand-hover"
-                        >
-                          <Plus size={12} />
-                          Add field
-                        </button>
+                        {buttons.length > 0 && (
+                          <div className="flex flex-wrap items-center gap-2">
+                            {buttons.map((b) => (
+                              <FormButtonChip
+                                key={b.id}
+                                label={b.label}
+                                onLabelChange={(label) => updateButton(b.id, { label })}
+                                variant={b.variant}
+                                onDelete={() => deleteButton(b.id)}
+                              />
+                            ))}
+                          </div>
+                        )}
+                        <DropdownMenu>
+                          <DropdownMenuTrigger asChild>
+                            <button
+                              type="button"
+                              className="flex w-fit cursor-pointer items-center gap-1.5 text-xs text-brand transition hover:text-brand-hover"
+                            >
+                              <Plus size={12} />
+                              Add field
+                            </button>
+                          </DropdownMenuTrigger>
+                          <DropdownMenuContent align="start" className="w-44">
+                            {FIELD_TYPE_ORDER.map((type) => {
+                              const meta = FIELD_TYPE_META[type];
+                              return (
+                                <DropdownMenuItem key={type} onClick={() => addCaseWithType(type)}>
+                                  <meta.icon className="text-foreground-muted" />
+                                  <span>{meta.label}</span>
+                                </DropdownMenuItem>
+                              );
+                            })}
+                            <DropdownMenuSeparator />
+                            <DropdownMenuItem onClick={addButton}>
+                              <MousePointerClick className="text-foreground-muted" />
+                              <span>Button</span>
+                            </DropdownMenuItem>
+                          </DropdownMenuContent>
+                        </DropdownMenu>
                       </>
                     )}
                     {formView === 'preview' && (
@@ -3060,83 +3474,133 @@ function QuickFormStory() {
         </NodePropertyPanel>
       </PanelFrame>
 
-      {/* Component showcase */}
-      <div className="flex w-[320px] shrink-0 flex-col gap-4 rounded-2xl border border-border-subtle bg-surface-raised p-5">
-        <div className="flex flex-col gap-1">
-          <span className="text-sm font-semibold text-foreground">LockableValueField</span>
-          <span className="text-xs leading-4 text-foreground-muted">
-            A reusable string field that can be locked to read-only and switched between a literal
-            value and a JS expression.
-          </span>
-        </div>
-        <ul className="flex list-disc flex-col gap-1.5 pl-4 text-xs leading-4 text-foreground-muted">
-          <li>
-            Left lock icon toggles Unlocked / Locked. Locked fields are read-only, not disabled.
-          </li>
-          <li>
-            Right value-mode icon switches between Fixed value and Expression, updating the value
-            styling. Only shown for types an expression can produce.
-          </li>
-          <li>
-            Field type dropdown swaps the control itself: String, Integer, Date, Boolean, Single
-            select, Multiselect, and File each render their own matching input.
-          </li>
-          <li>Built-in AI-assist popover to describe and generate a value.</li>
-          <li>Insert-variable affordance for binding to upstream data.</li>
-          <li>Built entirely on apollo-wind&apos;s InputGroup primitive.</li>
-          <li>
-            Header row is responsive (container query): the type, AI-assist, and insert-variable
-            controls collapse to icon-only once the field gets too narrow for their labels.
-          </li>
-        </ul>
-        <div className="flex flex-col gap-2 border-t border-border-subtle pt-4">
-          <span className="text-[11px] font-medium uppercase tracking-wide text-foreground-subtle">
-            Full view
-          </span>
-          <LockableValueField
-            label={<Label className="text-xs font-medium text-foreground-muted">Label</Label>}
-            value={showcaseValue}
-            onValueChange={setShowcaseValue}
-            locked={showcaseLocked}
-            onLockedChange={setShowcaseLocked}
-            mode={showcaseMode}
-            onModeChange={setShowcaseMode}
-            fieldType={showcaseFieldType}
-            onFieldTypeChange={handleShowcaseFieldTypeChange}
-          />
-        </div>
-        <div className="flex flex-col gap-2 border-t border-border-subtle pt-4">
-          <span className="text-[11px] font-medium uppercase tracking-wide text-foreground-subtle">
-            Compact view (narrow container)
-          </span>
-          <div className="w-[200px]">
-            <LockableValueField
-              label={<Label className="text-xs font-medium text-foreground-muted">Label</Label>}
-              value={showcaseValue}
-              onValueChange={setShowcaseValue}
-              locked={showcaseLocked}
-              onLockedChange={setShowcaseLocked}
-              mode={showcaseMode}
-              onModeChange={setShowcaseMode}
-              fieldType={showcaseFieldType}
-              onFieldTypeChange={handleShowcaseFieldTypeChange}
-            />
-          </div>
-        </div>
-      </div>
+      <LockableValueFieldShowcase
+        controlsVisibility={showcaseControlsVisibility}
+        onControlsVisibilityChange={setShowcaseControlsVisibility}
+      />
     </div>
   );
 }
 
-export const QuickForm: Story = {
-  name: 'Quick Form',
-  render: () => <QuickFormStory />,
+export const InlineEditing: Story = {
+  name: 'Inline Editing',
+  render: () => <InlineEditingStory />,
 };
 
 export const Output: Story = {
   name: 'Input / Output',
   render: () => <InputOutputStory />,
   parameters: { layout: 'fullscreen' },
+};
+
+export const QuickForm: Story = {
+  name: 'Form HITL',
+  render: () => <QuickFormStory />,
+};
+
+function FormHitlReviewStory() {
+  const [cases, setCases] = useState<LockableCase[]>(REVIEW_LOCKABLE_CASES);
+  const [controlsVisibility, setControlsVisibility] = useState<'visible' | 'hover'>('hover');
+
+  const updateCase = (id: number, patch: Partial<LockableCase>) =>
+    setCases((prev) => prev.map((c) => (c.id === id ? { ...c, ...patch } : c)));
+
+  return (
+    <div className="flex items-start gap-8">
+      <PanelFrame>
+        <NodePropertyPanel
+          panelTitle="Properties"
+          nodeIcon={<UserRoundCheck />}
+          nodeLabel="Quick Approve"
+          nodeCategory="Review the extracted invoice details, then approve or reject."
+          action={<ApproveRejectActions />}
+          onClose={() => {}}
+          contentInset="0.875rem"
+          className="h-[760px]"
+        >
+          <Tabs defaultValue="parameters" className="flex min-h-0 flex-1 flex-col">
+            <div className="shrink-0 pt-3 [padding-inline:var(--mf-content-inset,0.875rem)]">
+              <TabsList className={TAB_LIST_CLASS}>
+                <TabsTrigger value="parameters" className={TAB_TRIGGER_CLASS}>
+                  Parameters
+                </TabsTrigger>
+                <TabsTrigger value="error-handling" className={TAB_TRIGGER_CLASS}>
+                  Error handling
+                </TabsTrigger>
+                <TabsTrigger value="advanced" className={TAB_TRIGGER_CLASS}>
+                  Advanced
+                </TabsTrigger>
+              </TabsList>
+            </div>
+            <TabsContent
+              value="parameters"
+              className="mt-0 flex min-h-0 flex-1 flex-col gap-4 overflow-auto py-3 [padding-inline:var(--mf-content-inset,0.875rem)]"
+            >
+              <div className="flex flex-col gap-2">
+                <span className="text-xs font-medium text-foreground-muted">Quick form</span>
+                <Card>
+                  <CardContent className="flex flex-col gap-4 p-4">
+                    <div className="flex items-center gap-3.5">
+                      <div className="grid size-11 shrink-0 place-items-center rounded-xl bg-surface-overlay text-foreground-subtle [&>svg]:size-5">
+                        <Upload />
+                      </div>
+                      <div className="flex min-w-0 flex-1 flex-col justify-center">
+                        <span className="truncate text-base font-semibold leading-5 tracking-[-0.3px] text-foreground">
+                          Quick Approve
+                        </span>
+                        <span className="truncate text-xs leading-4 text-foreground-muted">
+                          Extracted from invoice.pdf &middot; 92% confidence
+                        </span>
+                      </div>
+                    </div>
+                    <div className="flex flex-col gap-4">
+                      {cases.map((c) => (
+                        <LockableValueField
+                          key={c.id}
+                          id={`review-${c.id}`}
+                          label={
+                            <Label
+                              htmlFor={`review-${c.id}`}
+                              className="text-xs font-medium text-foreground-muted"
+                            >
+                              {c.title}
+                              {c.required && <span className="ml-0.5 text-destructive">*</span>}
+                            </Label>
+                          }
+                          value={c.value}
+                          onValueChange={(value) => updateCase(c.id, { value })}
+                          locked={c.locked}
+                          onLockedChange={(locked) => updateCase(c.id, { locked })}
+                          mode={c.mode}
+                          onModeChange={(mode) => updateCase(c.id, { mode })}
+                          fieldType={c.fieldType}
+                          required={c.required}
+                          onRequiredChange={(required) => updateCase(c.id, { required })}
+                          controlsVisibility={controlsVisibility}
+                        />
+                      ))}
+                    </div>
+                  </CardContent>
+                </Card>
+              </div>
+            </TabsContent>
+            <TabsContent value="error-handling" className="mt-0" />
+            <TabsContent value="advanced" className="mt-0" />
+          </Tabs>
+        </NodePropertyPanel>
+      </PanelFrame>
+
+      <LockableValueFieldShowcase
+        controlsVisibility={controlsVisibility}
+        onControlsVisibilityChange={setControlsVisibility}
+      />
+    </div>
+  );
+}
+
+export const FormHitlReview: Story = {
+  name: 'Form HITL Review',
+  render: () => <FormHitlReviewStory />,
 };
 
 // ============================================================================
@@ -3219,11 +3683,6 @@ function InlineEditingStory() {
     </PanelFrame>
   );
 }
-
-export const InlineEditing: Story = {
-  name: 'Inline Editing',
-  render: () => <InlineEditingStory />,
-};
 
 export const AlertsAndErrors: Story = {
   name: 'Alerts and Errors',

--- a/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.stories.tsx
@@ -34,10 +34,16 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
   FileUpload,
+  HoverCard,
+  HoverCardContent,
+  HoverCardTrigger,
   Input,
   Label,
   MetadataForm,
   MultiSelect,
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
   ScrollableTabsList,
   Select,
   SelectContent,
@@ -80,6 +86,7 @@ import {
   GitFork,
   Globe,
   GripVertical,
+  MoreVertical,
   MousePointerClick,
   Pencil,
   Play,
@@ -2767,18 +2774,27 @@ function FormButtonChip({
   label,
   onLabelChange,
   variant,
+  onVariantChange,
   onDelete,
 }: {
   label: string;
   onLabelChange: (label: string) => void;
   variant: 'default' | 'outline';
+  onVariantChange: (variant: 'default' | 'outline') => void;
   onDelete: () => void;
 }) {
   const [editing, setEditing] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
 
   return (
-    <div className="group/button relative">
+    <div
+      className={cn(
+        'group/button flex h-8 items-stretch overflow-hidden rounded-lg text-sm font-semibold transition',
+        variant === 'default'
+          ? 'bg-brand text-foreground-on-accent'
+          : 'border border-border-subtle text-foreground'
+      )}
+    >
       {editing ? (
         <input
           ref={inputRef}
@@ -2790,12 +2806,7 @@ function FormButtonChip({
           }}
           autoFocus
           size={Math.max(label.length, 4)}
-          className={cn(
-            'h-8 rounded-lg px-3 text-sm font-semibold outline-none ring-1 ring-brand',
-            variant === 'default'
-              ? 'bg-brand text-foreground-on-accent'
-              : 'border border-border-subtle bg-transparent text-foreground'
-          )}
+          className="bg-transparent px-3 outline-none"
         />
       ) : (
         <button
@@ -2805,24 +2816,63 @@ function FormButtonChip({
             setTimeout(() => inputRef.current?.select(), 0);
           }}
           className={cn(
-            'flex h-8 items-center rounded-lg px-4 text-sm font-semibold transition',
-            variant === 'default'
-              ? 'bg-brand text-foreground-on-accent hover:bg-brand-hover'
-              : 'border border-border-subtle text-foreground hover:bg-surface-overlay'
+            'px-4 transition',
+            variant === 'default' ? 'hover:bg-brand-hover' : 'hover:bg-surface-overlay'
           )}
         >
           {label}
         </button>
       )}
-      <button
-        type="button"
-        onClick={onDelete}
-        aria-label="Delete button"
-        title="Delete button"
-        className="absolute -right-1.5 -top-1.5 grid size-4 place-items-center rounded-full bg-surface-overlay text-foreground-subtle opacity-0 shadow transition hover:text-foreground group-hover/button:opacity-100"
-      >
-        <X size={10} />
-      </button>
+      <Popover>
+        <TooltipProvider delayDuration={300}>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <PopoverTrigger asChild>
+                <button
+                  type="button"
+                  aria-label="Edit button"
+                  className={cn(
+                    'grid w-0 shrink-0 place-items-center overflow-hidden px-0 opacity-0 transition-all duration-200 group-hover/button:w-8 group-hover/button:px-2 group-hover/button:opacity-100 aria-expanded:w-8 aria-expanded:px-2 aria-expanded:opacity-100',
+                    variant === 'default' ? 'hover:bg-brand-hover' : 'hover:bg-surface-overlay'
+                  )}
+                >
+                  <Pencil size={12} className="shrink-0" />
+                </button>
+              </PopoverTrigger>
+            </TooltipTrigger>
+            <TooltipContent>Edit button</TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+        <PopoverContent align="start" className="w-48 space-y-3">
+          <div className="space-y-1.5">
+            <span className="text-xs font-medium text-foreground-muted">Type</span>
+            <ToggleGroup
+              type="single"
+              value={variant}
+              onValueChange={(value) => {
+                if (value) onVariantChange(value as 'default' | 'outline');
+              }}
+              className="w-full"
+            >
+              <ToggleGroupItem value="default" className="flex-1 text-xs">
+                Primary
+              </ToggleGroupItem>
+              <ToggleGroupItem value="outline" className="flex-1 text-xs">
+                Secondary
+              </ToggleGroupItem>
+            </ToggleGroup>
+          </div>
+          <div className="h-px bg-border-subtle" />
+          <button
+            type="button"
+            onClick={onDelete}
+            className="flex w-full items-center gap-1.5 rounded-lg px-1.5 py-1 text-xs text-destructive transition hover:bg-destructive/10"
+          >
+            <X size={12} />
+            Delete button
+          </button>
+        </PopoverContent>
+      </Popover>
     </div>
   );
 }
@@ -2993,6 +3043,7 @@ function QuickFormStory() {
   const [cases, setCases] = useState<LockableCase[]>(DEFAULT_LOCKABLE_CASES);
   const nextIdRef = useRef(4);
   const [formView, setFormView] = useState<'edit' | 'preview' | 'json'>('edit');
+  const [moreMenuOpen, setMoreMenuOpen] = useState(false);
   const [formTitle, setFormTitle] = useState('Quick Approve');
   const [formDescription, setFormDescription] = useState('Add a description');
   const [editingFormTitle, setEditingFormTitle] = useState(false);
@@ -3140,52 +3191,67 @@ function QuickFormStory() {
               <div className="flex flex-col gap-2">
                 <div className="flex items-center justify-between">
                   <span className="text-xs font-medium text-foreground-muted">Quick form</span>
-                  <TooltipProvider delayDuration={300}>
+                  <div className="flex items-center gap-2">
+                    <Popover open={moreMenuOpen} onOpenChange={setMoreMenuOpen}>
+                      <TooltipProvider delayDuration={300}>
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <PopoverTrigger asChild>
+                              <button
+                                type="button"
+                                aria-label="More options"
+                                className="grid size-7 shrink-0 place-items-center rounded-lg text-foreground-subtle transition hover:bg-surface-overlay hover:text-foreground aria-expanded:bg-surface-overlay aria-expanded:text-foreground"
+                              >
+                                <MoreVertical size={14} />
+                              </button>
+                            </PopoverTrigger>
+                          </TooltipTrigger>
+                          <TooltipContent>More options</TooltipContent>
+                        </Tooltip>
+                      </TooltipProvider>
+                      <PopoverContent align="end" className="w-64 space-y-3">
+                        <button
+                          type="button"
+                          onClick={() => {
+                            setFormView('preview');
+                            setMoreMenuOpen(false);
+                          }}
+                          className="flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-xs font-medium text-foreground transition hover:bg-surface-overlay"
+                        >
+                          <Eye size={14} className="text-foreground-subtle" />
+                          Preview
+                        </button>
+                        <div className="h-px bg-border-subtle" />
+                        <div className="space-y-1.5">
+                          <span className="flex items-center gap-1.5 text-xs font-medium text-foreground">
+                            <Sparkles size={12} className="text-brand" />
+                            Describe the form you want
+                          </span>
+                          <Textarea
+                            rows={3}
+                            placeholder="e.g. An invoice approval form with amount and due date"
+                            className="resize-none text-sm"
+                          />
+                          <Button size="sm" className="w-full">
+                            Generate
+                          </Button>
+                        </div>
+                      </PopoverContent>
+                    </Popover>
                     <ToggleGroup
                       type="single"
                       size="xs"
-                      spacing={2}
-                      value={formView}
-                      onValueChange={(v) => v && setFormView(v as 'edit' | 'preview' | 'json')}
+                      value={formView === 'json' ? 'json' : formView === 'edit' ? 'edit' : ''}
+                      onValueChange={(v) => v && setFormView(v as 'edit' | 'json')}
                     >
-                      <Tooltip>
-                        <TooltipTrigger asChild>
-                          <ToggleGroupItem
-                            value="edit"
-                            aria-label="Edit"
-                            className="!size-7 !rounded-lg !border-none !px-0 text-foreground-subtle transition hover:!bg-surface-overlay hover:!text-foreground data-[state=on]:!bg-surface-overlay data-[state=on]:!text-brand"
-                          >
-                            <Pencil size={12} />
-                          </ToggleGroupItem>
-                        </TooltipTrigger>
-                        <TooltipContent>Edit</TooltipContent>
-                      </Tooltip>
-                      <Tooltip>
-                        <TooltipTrigger asChild>
-                          <ToggleGroupItem
-                            value="preview"
-                            aria-label="Preview"
-                            className="!size-7 !rounded-lg !border-none !px-0 text-foreground-subtle transition hover:!bg-surface-overlay hover:!text-foreground data-[state=on]:!bg-surface-overlay data-[state=on]:!text-brand"
-                          >
-                            <Eye size={12} />
-                          </ToggleGroupItem>
-                        </TooltipTrigger>
-                        <TooltipContent>Preview</TooltipContent>
-                      </Tooltip>
-                      <Tooltip>
-                        <TooltipTrigger asChild>
-                          <ToggleGroupItem
-                            value="json"
-                            aria-label="JSON"
-                            className="!size-7 !rounded-lg !border-none !px-0 text-foreground-subtle transition hover:!bg-surface-overlay hover:!text-foreground data-[state=on]:!bg-surface-overlay data-[state=on]:!text-brand"
-                          >
-                            <Code2 size={12} />
-                          </ToggleGroupItem>
-                        </TooltipTrigger>
-                        <TooltipContent>JSON</TooltipContent>
-                      </Tooltip>
+                      <ToggleGroupItem value="edit" className="!px-2.5 !text-xs">
+                        UI
+                      </ToggleGroupItem>
+                      <ToggleGroupItem value="json" className="!px-2.5 !text-xs">
+                        JSON
+                      </ToggleGroupItem>
                     </ToggleGroup>
-                  </TooltipProvider>
+                  </div>
                 </div>
                 <Card>
                   <CardContent className="flex flex-col gap-4 p-4">
@@ -3196,21 +3262,28 @@ function QuickFormStory() {
                         className="hidden"
                         onChange={() => {}}
                       />
-                      <TooltipProvider delayDuration={300}>
-                        <Tooltip>
-                          <TooltipTrigger asChild>
-                            <button
-                              type="button"
-                              onClick={() => fileInputRef.current?.click()}
-                              aria-label="Upload a file"
-                              className="grid size-11 shrink-0 place-items-center rounded-xl bg-surface-overlay text-foreground-subtle transition hover:bg-surface-overlay/70 hover:text-foreground [&>svg]:size-5"
-                            >
-                              <Upload />
-                            </button>
-                          </TooltipTrigger>
-                          <TooltipContent>Upload a reference file for this form</TooltipContent>
-                        </Tooltip>
-                      </TooltipProvider>
+                      <HoverCard openDelay={300}>
+                        <HoverCardTrigger asChild>
+                          <button
+                            type="button"
+                            onClick={() => fileInputRef.current?.click()}
+                            aria-label="Upload a file"
+                            className="grid size-11 shrink-0 place-items-center rounded-xl bg-surface-overlay text-foreground-subtle transition hover:bg-surface-overlay/70 hover:text-foreground [&>svg]:size-5"
+                          >
+                            <Upload />
+                          </button>
+                        </HoverCardTrigger>
+                        <HoverCardContent align="start" className="w-56 space-y-1.5">
+                          <p className="text-xs font-semibold text-foreground">Upload form logo</p>
+                          <p className="text-xs text-foreground-muted">
+                            Images are automatically resized to fit the logo area.
+                          </p>
+                          <div className="space-y-0.5 text-[11px] text-foreground-subtle">
+                            <div>Type: PNG, JPG, SVG</div>
+                            <div>Size: 512 × 512 px</div>
+                          </div>
+                        </HoverCardContent>
+                      </HoverCard>
                       <div className="flex min-w-0 flex-1 flex-col justify-center">
                         {editingFormTitle ? (
                           <input
@@ -3328,6 +3401,7 @@ function QuickFormStory() {
                                 label={b.label}
                                 onLabelChange={(label) => updateButton(b.id, { label })}
                                 variant={b.variant}
+                                onVariantChange={(variant) => updateButton(b.id, { variant })}
                                 onDelete={() => deleteButton(b.id)}
                               />
                             ))}
@@ -3450,6 +3524,15 @@ function QuickFormStory() {
                             </div>
                           );
                         })}
+                        {buttons.length > 0 && (
+                          <div className="flex flex-wrap items-center gap-2">
+                            {buttons.map((b) => (
+                              <Button key={b.id} variant={b.variant}>
+                                {b.label}
+                              </Button>
+                            ))}
+                          </div>
+                        )}
                       </div>
                     )}
                     {formView === 'json' && (
@@ -3510,7 +3593,6 @@ function FormHitlReviewStory() {
       <PanelFrame>
         <NodePropertyPanel
           panelTitle="Properties"
-          nodeIcon={<UserRoundCheck />}
           nodeLabel="Quick Approve"
           nodeCategory="Review the extracted invoice details, then approve or reject."
           action={<ApproveRejectActions />}

--- a/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.stories.tsx
@@ -77,7 +77,6 @@ import {
   GitFork,
   Globe,
   GripVertical,
-  MousePointerClick,
   Pencil,
   Play,
   Plus,
@@ -3130,7 +3129,7 @@ function QuickFormStory() {
     setCases((prev) => prev.map((c) => (c.id === id ? { ...c, ...patch } : c)));
   const addButton = () => {
     const id = nextButtonIdRef.current++;
-    setButtons((prev) => [...prev, { id, label: 'New button', variant: 'outline' }]);
+    setButtons((prev) => [...prev, { id, label: 'Button', variant: 'outline' }]);
   };
   const deleteButton = (id: number) => setButtons((prev) => prev.filter((b) => b.id !== id));
   const updateButton = (id: number, patch: Partial<FormButtonItem>) =>
@@ -3408,41 +3407,41 @@ function QuickFormStory() {
                             document.body
                           )}
                         </DndContext>
-                        <DropdownMenu>
-                          <DropdownMenuTrigger asChild>
-                            <button
-                              type="button"
-                              className="flex w-fit cursor-pointer items-center gap-1.5 text-xs text-brand transition hover:text-brand-hover"
-                            >
-                              <Plus size={12} />
-                              Add field
-                            </button>
-                          </DropdownMenuTrigger>
-                          <DropdownMenuContent align="start" className="w-44">
-                            <DropdownMenuItem onClick={() => addCaseWithType('string')}>
-                              <Type className="text-foreground-muted" />
-                              <span>Add field</span>
-                            </DropdownMenuItem>
-                            <DropdownMenuItem onClick={addButton}>
-                              <MousePointerClick className="text-foreground-muted" />
-                              <span>Add button</span>
-                            </DropdownMenuItem>
-                          </DropdownMenuContent>
-                        </DropdownMenu>
-                        {buttons.length > 0 && (
-                          <div className="flex flex-wrap items-center gap-2">
-                            {buttons.map((b) => (
-                              <FormButtonChip
-                                key={b.id}
-                                label={b.label}
-                                onLabelChange={(label) => updateButton(b.id, { label })}
-                                variant={b.variant}
-                                onVariantChange={(variant) => updateButton(b.id, { variant })}
-                                onDelete={() => deleteButton(b.id)}
-                              />
-                            ))}
-                          </div>
-                        )}
+                        <button
+                          type="button"
+                          onClick={() => addCaseWithType('string')}
+                          className="flex w-fit cursor-pointer items-center gap-1.5 text-xs text-brand transition hover:text-brand-hover"
+                        >
+                          <Plus size={12} />
+                          Add field
+                        </button>
+                        <div className="flex flex-wrap items-center gap-2">
+                          {buttons.map((b) => (
+                            <FormButtonChip
+                              key={b.id}
+                              label={b.label}
+                              onLabelChange={(label) => updateButton(b.id, { label })}
+                              variant={b.variant}
+                              onVariantChange={(variant) => updateButton(b.id, { variant })}
+                              onDelete={() => deleteButton(b.id)}
+                            />
+                          ))}
+                          <TooltipProvider delayDuration={300}>
+                            <Tooltip>
+                              <TooltipTrigger asChild>
+                                <button
+                                  type="button"
+                                  onClick={addButton}
+                                  aria-label="Add button"
+                                  className="grid size-10 shrink-0 place-items-center rounded-lg text-foreground-subtle transition hover:bg-surface-overlay hover:text-foreground"
+                                >
+                                  <Plus size={16} />
+                                </button>
+                              </TooltipTrigger>
+                              <TooltipContent>Add button</TooltipContent>
+                            </Tooltip>
+                          </TooltipProvider>
+                        </div>
                       </>
                     )}
                     {formView === 'json' && (

--- a/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.stories.tsx
@@ -1,9 +1,28 @@
+import {
+  closestCenter,
+  DndContext,
+  type DragEndEvent,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+} from '@dnd-kit/core';
+import {
+  arrayMove,
+  SortableContext,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
 import type { EditorProps } from '@monaco-editor/react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import type { FormSchema } from '@uipath/apollo-wind';
 import {
   Badge,
   Button,
+  Card,
+  CardContent,
   cn,
   DropdownMenu,
   DropdownMenuContent,
@@ -12,12 +31,21 @@ import {
   DropdownMenuTrigger,
   Input,
   MetadataForm,
+  MultiSelect,
   ScrollableTabsList,
+  Search as SearchInput,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
   Switch,
   Tabs,
   TabsContent,
   TabsList,
   TabsTrigger,
+  ToggleGroup,
+  ToggleGroupItem,
 } from '@uipath/apollo-wind';
 import {
   apolloCoreDarkHCMonaco,
@@ -37,19 +65,22 @@ import {
   CircleOff,
   Code2,
   Copy,
+  FileBracesCorner,
   GitFork,
   Globe,
   GripVertical,
   Play,
   Plus,
   Search,
-  FileBracesCorner,
   Sparkles,
   Type,
+  UserRoundCheck,
   X,
 } from 'lucide-react';
 import type { CSSProperties, ReactNode } from 'react';
-import { Suspense, lazy, useEffect, useRef, useState } from 'react';
+import { lazy, Suspense, useEffect, useRef, useState } from 'react';
+import type { LockableValueFieldMode } from './LockableValueField';
+import { LockableValueField } from './LockableValueField';
 import { NodePropertyPanel } from './NodePropertyPanel';
 
 // @monaco-editor/react uses a CJS build without an `exports` field, which
@@ -2467,6 +2498,319 @@ function InputOutputStory() {
     </div>
   );
 }
+
+// ============================================================================
+// Prototype — LockableValueField
+// ============================================================================
+
+interface LockableCase {
+  id: number;
+  title: string;
+  required: boolean;
+  value: string;
+  locked: boolean;
+  mode: LockableValueFieldMode;
+}
+
+const DEFAULT_LOCKABLE_CASES: LockableCase[] = [
+  { id: 1, title: 'Invoice Number', required: true, value: '', locked: true, mode: 'fixed' },
+  { id: 2, title: 'Submission Date', required: true, value: '', locked: true, mode: 'fixed' },
+  { id: 3, title: 'Approved Amount', required: true, value: '', locked: true, mode: 'fixed' },
+];
+
+function LockableCaseRow({
+  id,
+  caseTitle,
+  onTitleChange,
+  required,
+  onDelete,
+  value,
+  onValueChange,
+  locked,
+  onLockedChange,
+  mode,
+  onModeChange,
+}: {
+  id: number;
+  caseTitle: string;
+  onTitleChange: (title: string) => void;
+  required: boolean;
+  onDelete: () => void;
+  value: string;
+  onValueChange: (value: string) => void;
+  locked: boolean;
+  onLockedChange: (locked: boolean) => void;
+  mode: LockableValueFieldMode;
+  onModeChange: (mode: LockableValueFieldMode) => void;
+}) {
+  const [editingTitle, setEditingTitle] = useState(false);
+  const titleRef = useRef<HTMLInputElement>(null);
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id,
+  });
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={{ transform: CSS.Transform.toString(transform), transition }}
+      className={cn('group', isDragging && 'opacity-50')}
+    >
+      <LockableValueField
+        id={`return-value-${id}`}
+        label={
+          <div className="flex min-w-0 flex-1 items-center gap-1">
+            <button
+              type="button"
+              {...attributes}
+              {...listeners}
+              aria-label="Drag to reorder"
+              title="Drag to reorder"
+              className="grid size-5 shrink-0 touch-none place-items-center rounded text-foreground-subtle transition hover:bg-surface-overlay hover:text-foreground [cursor:grab]"
+            >
+              <GripVertical size={12} />
+            </button>
+            {editingTitle ? (
+              <input
+                ref={titleRef}
+                value={caseTitle}
+                onChange={(e) => onTitleChange(e.target.value)}
+                onBlur={() => setEditingTitle(false)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' || e.key === 'Escape') setEditingTitle(false);
+                }}
+                className="min-w-0 flex-1 rounded bg-surface-overlay px-1 py-0.5 text-xs font-medium text-foreground outline-none ring-1 ring-brand"
+                autoFocus
+              />
+            ) : (
+              <button
+                type="button"
+                onClick={() => {
+                  setEditingTitle(true);
+                  setTimeout(() => titleRef.current?.select(), 0);
+                }}
+                className="truncate rounded px-1 py-0.5 text-left text-xs font-medium text-foreground-muted transition hover:bg-surface-overlay hover:text-foreground"
+              >
+                {caseTitle}
+                {required && <span className="ml-0.5 text-destructive">*</span>}
+              </button>
+            )}
+          </div>
+        }
+        headerActions={
+          <button
+            type="button"
+            onClick={onDelete}
+            aria-label="Delete field"
+            title="Delete field"
+            className="grid size-6 shrink-0 place-items-center rounded text-foreground-subtle opacity-0 transition hover:bg-surface-overlay hover:text-foreground group-hover:opacity-100"
+          >
+            <X size={12} />
+          </button>
+        }
+        value={value}
+        onValueChange={onValueChange}
+        locked={locked}
+        onLockedChange={onLockedChange}
+        mode={mode}
+        onModeChange={onModeChange}
+      />
+    </div>
+  );
+}
+
+const DELIVERY_CHANNEL_OPTIONS = [
+  { label: 'Slack', value: 'slack' },
+  { label: 'Email', value: 'email' },
+  { label: 'Action Center', value: 'action-center' },
+  { label: 'Microsoft Teams', value: 'teams' },
+];
+
+const ASSIGNMENT_GROUP_OPTIONS = [
+  { label: 'All users of group', value: 'all' },
+  { label: 'Specific user', value: 'specific' },
+  { label: 'Group manager', value: 'manager' },
+];
+
+function LockableValueFieldStory() {
+  const [cases, setCases] = useState<LockableCase[]>(DEFAULT_LOCKABLE_CASES);
+  const nextIdRef = useRef(4);
+  const [deliveryChannels, setDeliveryChannels] = useState<string[]>([]);
+  const [assignmentSearch, setAssignmentSearch] = useState('');
+  const [assignmentGroup, setAssignmentGroup] = useState('all');
+  const [formView, setFormView] = useState<'ui' | 'json'>('ui');
+
+  const addCase = () => {
+    const id = nextIdRef.current++;
+    setCases((prev) => [
+      ...prev,
+      { id, title: `Field ${id}`, required: true, value: '', locked: true, mode: 'fixed' },
+    ]);
+  };
+  const deleteCase = (id: number) => setCases((prev) => prev.filter((c) => c.id !== id));
+  const updateCase = (id: number, patch: Partial<LockableCase>) =>
+    setCases((prev) => prev.map((c) => (c.id === id ? { ...c, ...patch } : c)));
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 3 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
+  );
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+    setCases((prev) => {
+      const oldIndex = prev.findIndex((c) => c.id === active.id);
+      const newIndex = prev.findIndex((c) => c.id === over.id);
+      return arrayMove(prev, oldIndex, newIndex);
+    });
+  };
+
+  return (
+    <PanelFrame>
+      <NodePropertyPanel
+        panelTitle="Properties"
+        nodeIcon={<UserRoundCheck />}
+        nodeLabel="Quick Approve"
+        nodeCategory="Quick approve/reject decision for the extracted invoice."
+        action={<DebugButton />}
+        onClose={() => {}}
+        contentInset="0.875rem"
+        className="h-[760px]"
+      >
+        <Tabs defaultValue="parameters" className="flex min-h-0 flex-1 flex-col">
+          <div className="shrink-0 pt-3 [padding-inline:var(--mf-content-inset,0.875rem)]">
+            <TabsList className={TAB_LIST_CLASS}>
+              <TabsTrigger value="parameters" className={TAB_TRIGGER_CLASS}>
+                Parameters
+              </TabsTrigger>
+              <TabsTrigger value="error-handling" className={TAB_TRIGGER_CLASS}>
+                Error handling
+              </TabsTrigger>
+              <TabsTrigger value="advanced" className={TAB_TRIGGER_CLASS}>
+                Advanced
+              </TabsTrigger>
+            </TabsList>
+          </div>
+          <TabsContent
+            value="parameters"
+            className="mt-0 flex min-h-0 flex-1 flex-col gap-4 overflow-auto py-3 [padding-inline:var(--mf-content-inset,0.875rem)]"
+          >
+            {/* Delivery channel */}
+            <div className="flex flex-col gap-1.5">
+              <span className="text-xs font-medium text-foreground-muted">Delivery channel</span>
+              <MultiSelect
+                options={DELIVERY_CHANNEL_OPTIONS}
+                selected={deliveryChannels}
+                onChange={setDeliveryChannels}
+                placeholder="Select channels..."
+              />
+              <span className="text-[11px] leading-4 text-foreground-subtle">
+                Quick approve/reject decision for the extracted invoice.
+              </span>
+            </div>
+
+            {/* Assignment criteria */}
+            <div className="flex flex-col gap-1.5">
+              <span className="text-xs font-medium text-foreground-muted">Assignment criteria</span>
+              <div className="flex gap-2">
+                <SearchInput
+                  className="flex-1"
+                  placeholder="Search group"
+                  value={assignmentSearch}
+                  onChange={setAssignmentSearch}
+                />
+                <Select value={assignmentGroup} onValueChange={setAssignmentGroup}>
+                  <SelectTrigger className="flex-1">
+                    <SelectValue placeholder="All users of group" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {ASSIGNMENT_GROUP_OPTIONS.map((option) => (
+                      <SelectItem key={option.value} value={option.value}>
+                        {option.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            </div>
+
+            {/* Quick form */}
+            <div className="flex flex-col gap-2">
+              <div className="flex items-center justify-between">
+                <span className="text-xs font-medium text-foreground-muted">Quick form</span>
+                <ToggleGroup
+                  type="single"
+                  size="xs"
+                  value={formView}
+                  onValueChange={(v) => v && setFormView(v as 'ui' | 'json')}
+                >
+                  <ToggleGroupItem value="ui">UI</ToggleGroupItem>
+                  <ToggleGroupItem value="json">JSON</ToggleGroupItem>
+                </ToggleGroup>
+              </div>
+              <Card>
+                <CardContent className="flex flex-col gap-4 p-4">
+                  {formView === 'ui' ? (
+                    <>
+                      <DndContext
+                        sensors={sensors}
+                        collisionDetection={closestCenter}
+                        onDragEnd={handleDragEnd}
+                      >
+                        <SortableContext
+                          items={cases.map((c) => c.id)}
+                          strategy={verticalListSortingStrategy}
+                        >
+                          <div className="flex flex-col gap-4">
+                            {cases.map((c) => (
+                              <LockableCaseRow
+                                key={c.id}
+                                id={c.id}
+                                caseTitle={c.title}
+                                onTitleChange={(title) => updateCase(c.id, { title })}
+                                required={c.required}
+                                onDelete={() => deleteCase(c.id)}
+                                value={c.value}
+                                onValueChange={(value) => updateCase(c.id, { value })}
+                                locked={c.locked}
+                                onLockedChange={(locked) => updateCase(c.id, { locked })}
+                                mode={c.mode}
+                                onModeChange={(mode) => updateCase(c.id, { mode })}
+                              />
+                            ))}
+                          </div>
+                        </SortableContext>
+                      </DndContext>
+                      <button
+                        type="button"
+                        onClick={addCase}
+                        className="flex cursor-pointer items-center gap-1.5 text-xs text-brand transition hover:text-brand-hover"
+                      >
+                        <Plus size={12} />
+                        Add case
+                      </button>
+                    </>
+                  ) : (
+                    <pre className="overflow-auto whitespace-pre-wrap text-xs text-foreground-muted">
+                      {JSON.stringify(cases, null, 2)}
+                    </pre>
+                  )}
+                </CardContent>
+              </Card>
+            </div>
+          </TabsContent>
+          <TabsContent value="error-handling" className="mt-0" />
+          <TabsContent value="advanced" className="mt-0" />
+        </Tabs>
+      </NodePropertyPanel>
+    </PanelFrame>
+  );
+}
+
+export const LockableField: Story = {
+  name: 'Lockable Field',
+  render: () => <LockableValueFieldStory />,
+};
 
 export const Output: Story = {
   name: 'Input / Output',

--- a/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.stories.tsx
@@ -24,16 +24,18 @@ import {
   Card,
   CardContent,
   cn,
+  DatePicker,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
+  FileUpload,
   Input,
+  Label,
   MetadataForm,
   MultiSelect,
   ScrollableTabsList,
-  Search as SearchInput,
   Select,
   SelectContent,
   SelectItem,
@@ -44,8 +46,13 @@ import {
   TabsContent,
   TabsList,
   TabsTrigger,
+  Textarea,
   ToggleGroup,
   ToggleGroupItem,
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
 } from '@uipath/apollo-wind';
 import {
   apolloCoreDarkHCMonaco,
@@ -65,22 +72,30 @@ import {
   CircleOff,
   Code2,
   Copy,
+  Eye,
   FileBracesCorner,
   GitFork,
   Globe,
   GripVertical,
+  Pencil,
   Play,
   Plus,
   Search,
   Sparkles,
   Type,
+  Upload,
   UserRoundCheck,
   X,
 } from 'lucide-react';
 import type { CSSProperties, ReactNode } from 'react';
 import { lazy, Suspense, useEffect, useRef, useState } from 'react';
-import type { LockableValueFieldMode } from './LockableValueField';
-import { LockableValueField } from './LockableValueField';
+import type { LockableFieldType, LockableValueFieldMode } from './LockableValueField';
+import {
+  DEMO_SELECT_OPTIONS,
+  FIELD_TYPE_META,
+  LockableValueField,
+  parseListValue,
+} from './LockableValueField';
 import { NodePropertyPanel } from './NodePropertyPanel';
 
 // @monaco-editor/react uses a CJS build without an `exports` field, which
@@ -2510,12 +2525,37 @@ interface LockableCase {
   value: string;
   locked: boolean;
   mode: LockableValueFieldMode;
+  fieldType: LockableFieldType;
 }
 
 const DEFAULT_LOCKABLE_CASES: LockableCase[] = [
-  { id: 1, title: 'Invoice Number', required: true, value: '', locked: true, mode: 'fixed' },
-  { id: 2, title: 'Submission Date', required: true, value: '', locked: true, mode: 'fixed' },
-  { id: 3, title: 'Approved Amount', required: true, value: '', locked: true, mode: 'fixed' },
+  {
+    id: 1,
+    title: 'Invoice Number',
+    required: true,
+    value: '',
+    locked: true,
+    mode: 'fixed',
+    fieldType: 'string',
+  },
+  {
+    id: 2,
+    title: 'Submission Date',
+    required: true,
+    value: '',
+    locked: true,
+    mode: 'fixed',
+    fieldType: 'date',
+  },
+  {
+    id: 3,
+    title: 'Approved Amount',
+    required: true,
+    value: '',
+    locked: true,
+    mode: 'fixed',
+    fieldType: 'integer',
+  },
 ];
 
 function LockableCaseRow({
@@ -2530,6 +2570,9 @@ function LockableCaseRow({
   onLockedChange,
   mode,
   onModeChange,
+  fieldType,
+  onFieldTypeChange,
+  compact,
 }: {
   id: number;
   caseTitle: string;
@@ -2542,6 +2585,9 @@ function LockableCaseRow({
   onLockedChange: (locked: boolean) => void;
   mode: LockableValueFieldMode;
   onModeChange: (mode: LockableValueFieldMode) => void;
+  fieldType: LockableFieldType;
+  onFieldTypeChange: (fieldType: LockableFieldType) => void;
+  compact?: boolean;
 }) {
   const [editingTitle, setEditingTitle] = useState(false);
   const titleRef = useRef<HTMLInputElement>(null);
@@ -2613,42 +2659,92 @@ function LockableCaseRow({
         onLockedChange={onLockedChange}
         mode={mode}
         onModeChange={onModeChange}
+        fieldType={fieldType}
+        onFieldTypeChange={onFieldTypeChange}
+        compact={compact}
       />
     </div>
   );
 }
 
-const DELIVERY_CHANNEL_OPTIONS = [
-  { label: 'Slack', value: 'slack' },
-  { label: 'Email', value: 'email' },
-  { label: 'Action Center', value: 'action-center' },
-  { label: 'Microsoft Teams', value: 'teams' },
-];
-
-const ASSIGNMENT_GROUP_OPTIONS = [
-  { label: 'All users of group', value: 'all' },
-  { label: 'Specific user', value: 'specific' },
-  { label: 'Group manager', value: 'manager' },
-];
-
-function LockableValueFieldStory() {
+function QuickFormStory() {
   const [cases, setCases] = useState<LockableCase[]>(DEFAULT_LOCKABLE_CASES);
   const nextIdRef = useRef(4);
-  const [deliveryChannels, setDeliveryChannels] = useState<string[]>([]);
-  const [assignmentSearch, setAssignmentSearch] = useState('');
-  const [assignmentGroup, setAssignmentGroup] = useState('all');
-  const [formView, setFormView] = useState<'ui' | 'json'>('ui');
+  const [formView, setFormView] = useState<'edit' | 'preview' | 'json'>('edit');
+  const [formTitle, setFormTitle] = useState('Quick Approve');
+  const [formDescription, setFormDescription] = useState('Add a description');
+  const [editingFormTitle, setEditingFormTitle] = useState(false);
+  const [editingFormDescription, setEditingFormDescription] = useState(false);
+  const formTitleRef = useRef<HTMLInputElement>(null);
+  const formDescriptionRef = useRef<HTMLInputElement>(null);
+  const [jsonDraft, setJsonDraft] = useState(() => JSON.stringify(DEFAULT_LOCKABLE_CASES, null, 2));
+  const [jsonError, setJsonError] = useState<string | null>(null);
+  const [showcaseValue, setShowcaseValue] = useState('');
+  const [showcaseLocked, setShowcaseLocked] = useState(true);
+  const [showcaseMode, setShowcaseMode] = useState<LockableValueFieldMode>('fixed');
+  const [showcaseFieldType, setShowcaseFieldType] = useState<LockableFieldType>('string');
+
+  const handleShowcaseFieldTypeChange = (type: LockableFieldType) => {
+    setShowcaseFieldType(type);
+    setShowcaseValue('');
+    if (!FIELD_TYPE_META[type].supportsExpression) {
+      setShowcaseMode('fixed');
+    }
+  };
+
+  useEffect(() => {
+    if (formView !== 'json') {
+      setJsonDraft(JSON.stringify(cases, null, 2));
+      setJsonError(null);
+    }
+  }, [cases, formView]);
+
+  const handleJsonChange = (value: string) => {
+    setJsonDraft(value);
+    try {
+      const parsed = JSON.parse(value);
+      if (!Array.isArray(parsed)) {
+        setJsonError('Expected a JSON array of fields.');
+        return;
+      }
+      setCases(parsed);
+      setJsonError(null);
+    } catch {
+      setJsonError('Invalid JSON.');
+    }
+  };
 
   const addCase = () => {
     const id = nextIdRef.current++;
     setCases((prev) => [
       ...prev,
-      { id, title: `Field ${id}`, required: true, value: '', locked: true, mode: 'fixed' },
+      {
+        id,
+        title: `Field ${id}`,
+        required: true,
+        value: '',
+        locked: true,
+        mode: 'fixed',
+        fieldType: 'string',
+      },
     ]);
   };
   const deleteCase = (id: number) => setCases((prev) => prev.filter((c) => c.id !== id));
   const updateCase = (id: number, patch: Partial<LockableCase>) =>
     setCases((prev) => prev.map((c) => (c.id === id ? { ...c, ...patch } : c)));
+  const updateCaseFieldType = (id: number, fieldType: LockableFieldType) =>
+    setCases((prev) =>
+      prev.map((c) =>
+        c.id === id
+          ? {
+              ...c,
+              fieldType,
+              value: '',
+              mode: FIELD_TYPE_META[fieldType].supportsExpression ? c.mode : 'fixed',
+            }
+          : c
+      )
+    );
 
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 3 } }),
@@ -2666,150 +2762,375 @@ function LockableValueFieldStory() {
   };
 
   return (
-    <PanelFrame>
-      <NodePropertyPanel
-        panelTitle="Properties"
-        nodeIcon={<UserRoundCheck />}
-        nodeLabel="Quick Approve"
-        nodeCategory="Quick approve/reject decision for the extracted invoice."
-        action={<DebugButton />}
-        onClose={() => {}}
-        contentInset="0.875rem"
-        className="h-[760px]"
-      >
-        <Tabs defaultValue="parameters" className="flex min-h-0 flex-1 flex-col">
-          <div className="shrink-0 pt-3 [padding-inline:var(--mf-content-inset,0.875rem)]">
-            <TabsList className={TAB_LIST_CLASS}>
-              <TabsTrigger value="parameters" className={TAB_TRIGGER_CLASS}>
-                Parameters
-              </TabsTrigger>
-              <TabsTrigger value="error-handling" className={TAB_TRIGGER_CLASS}>
-                Error handling
-              </TabsTrigger>
-              <TabsTrigger value="advanced" className={TAB_TRIGGER_CLASS}>
-                Advanced
-              </TabsTrigger>
-            </TabsList>
-          </div>
-          <TabsContent
-            value="parameters"
-            className="mt-0 flex min-h-0 flex-1 flex-col gap-4 overflow-auto py-3 [padding-inline:var(--mf-content-inset,0.875rem)]"
-          >
-            {/* Delivery channel */}
-            <div className="flex flex-col gap-1.5">
-              <span className="text-xs font-medium text-foreground-muted">Delivery channel</span>
-              <MultiSelect
-                options={DELIVERY_CHANNEL_OPTIONS}
-                selected={deliveryChannels}
-                onChange={setDeliveryChannels}
-                placeholder="Select channels..."
-              />
-              <span className="text-[11px] leading-4 text-foreground-subtle">
-                Quick approve/reject decision for the extracted invoice.
-              </span>
+    <div className="flex items-start gap-8">
+      <PanelFrame>
+        <NodePropertyPanel
+          panelTitle="Properties"
+          nodeIcon={<UserRoundCheck />}
+          nodeLabel="Quick Approve"
+          nodeCategory="Quick approve/reject decision for the extracted invoice."
+          action={<DebugButton />}
+          onClose={() => {}}
+          contentInset="0.875rem"
+          className="h-[760px]"
+        >
+          <Tabs defaultValue="parameters" className="flex min-h-0 flex-1 flex-col">
+            <div className="shrink-0 pt-3 [padding-inline:var(--mf-content-inset,0.875rem)]">
+              <TabsList className={TAB_LIST_CLASS}>
+                <TabsTrigger value="parameters" className={TAB_TRIGGER_CLASS}>
+                  Parameters
+                </TabsTrigger>
+                <TabsTrigger value="error-handling" className={TAB_TRIGGER_CLASS}>
+                  Error handling
+                </TabsTrigger>
+                <TabsTrigger value="advanced" className={TAB_TRIGGER_CLASS}>
+                  Advanced
+                </TabsTrigger>
+              </TabsList>
             </div>
-
-            {/* Assignment criteria */}
-            <div className="flex flex-col gap-1.5">
-              <span className="text-xs font-medium text-foreground-muted">Assignment criteria</span>
-              <div className="flex gap-2">
-                <SearchInput
-                  className="flex-1"
-                  placeholder="Search group"
-                  value={assignmentSearch}
-                  onChange={setAssignmentSearch}
-                />
-                <Select value={assignmentGroup} onValueChange={setAssignmentGroup}>
-                  <SelectTrigger className="flex-1">
-                    <SelectValue placeholder="All users of group" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {ASSIGNMENT_GROUP_OPTIONS.map((option) => (
-                      <SelectItem key={option.value} value={option.value}>
-                        {option.label}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </div>
-            </div>
-
-            {/* Quick form */}
-            <div className="flex flex-col gap-2">
-              <div className="flex items-center justify-between">
-                <span className="text-xs font-medium text-foreground-muted">Quick form</span>
-                <ToggleGroup
-                  type="single"
-                  size="xs"
-                  value={formView}
-                  onValueChange={(v) => v && setFormView(v as 'ui' | 'json')}
-                >
-                  <ToggleGroupItem value="ui">UI</ToggleGroupItem>
-                  <ToggleGroupItem value="json">JSON</ToggleGroupItem>
-                </ToggleGroup>
-              </div>
-              <Card>
-                <CardContent className="flex flex-col gap-4 p-4">
-                  {formView === 'ui' ? (
-                    <>
-                      <DndContext
-                        sensors={sensors}
-                        collisionDetection={closestCenter}
-                        onDragEnd={handleDragEnd}
-                      >
-                        <SortableContext
-                          items={cases.map((c) => c.id)}
-                          strategy={verticalListSortingStrategy}
+            <TabsContent
+              value="parameters"
+              className="mt-0 flex min-h-0 flex-1 flex-col gap-4 overflow-auto py-3 [padding-inline:var(--mf-content-inset,0.875rem)]"
+            >
+              {/* Quick form */}
+              <div className="flex flex-col gap-2">
+                <div className="flex items-center justify-between">
+                  <span className="text-xs font-medium text-foreground-muted">Quick form</span>
+                  <TooltipProvider delayDuration={300}>
+                    <ToggleGroup
+                      type="single"
+                      size="xs"
+                      spacing={2}
+                      value={formView}
+                      onValueChange={(v) => v && setFormView(v as 'edit' | 'preview' | 'json')}
+                    >
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <ToggleGroupItem
+                            value="edit"
+                            aria-label="Edit"
+                            className="!size-7 !rounded-lg !border-none !px-0 text-foreground-subtle transition hover:!bg-surface-overlay hover:!text-foreground data-[state=on]:!bg-surface-overlay data-[state=on]:!text-brand"
+                          >
+                            <Pencil size={12} />
+                          </ToggleGroupItem>
+                        </TooltipTrigger>
+                        <TooltipContent>Edit</TooltipContent>
+                      </Tooltip>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <ToggleGroupItem
+                            value="preview"
+                            aria-label="Preview"
+                            className="!size-7 !rounded-lg !border-none !px-0 text-foreground-subtle transition hover:!bg-surface-overlay hover:!text-foreground data-[state=on]:!bg-surface-overlay data-[state=on]:!text-brand"
+                          >
+                            <Eye size={12} />
+                          </ToggleGroupItem>
+                        </TooltipTrigger>
+                        <TooltipContent>Preview</TooltipContent>
+                      </Tooltip>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <ToggleGroupItem
+                            value="json"
+                            aria-label="JSON"
+                            className="!size-7 !rounded-lg !border-none !px-0 text-foreground-subtle transition hover:!bg-surface-overlay hover:!text-foreground data-[state=on]:!bg-surface-overlay data-[state=on]:!text-brand"
+                          >
+                            <Code2 size={12} />
+                          </ToggleGroupItem>
+                        </TooltipTrigger>
+                        <TooltipContent>JSON</TooltipContent>
+                      </Tooltip>
+                    </ToggleGroup>
+                  </TooltipProvider>
+                </div>
+                <Card>
+                  <CardContent className="flex flex-col gap-4 p-4">
+                    <div className="flex items-center gap-3.5">
+                      <div className="grid size-11 shrink-0 place-items-center rounded-xl bg-surface-overlay text-foreground-subtle [&>svg]:size-5">
+                        <Upload />
+                      </div>
+                      <div className="flex min-w-0 flex-1 flex-col justify-center">
+                        {editingFormTitle ? (
+                          <input
+                            ref={formTitleRef}
+                            value={formTitle}
+                            onChange={(e) => setFormTitle(e.target.value)}
+                            onBlur={() => setEditingFormTitle(false)}
+                            onKeyDown={(e) => {
+                              if (e.key === 'Enter' || e.key === 'Escape')
+                                setEditingFormTitle(false);
+                            }}
+                            className="rounded bg-surface-overlay px-1 text-base font-semibold leading-5 tracking-[-0.3px] text-foreground outline-none ring-1 ring-brand"
+                            autoFocus
+                          />
+                        ) : (
+                          <button
+                            type="button"
+                            onClick={() => {
+                              setEditingFormTitle(true);
+                              setTimeout(() => formTitleRef.current?.select(), 0);
+                            }}
+                            className="truncate rounded px-1 text-left text-base font-semibold leading-5 tracking-[-0.3px] text-foreground transition hover:bg-surface-overlay"
+                          >
+                            {formTitle}
+                          </button>
+                        )}
+                        {editingFormDescription ? (
+                          <input
+                            ref={formDescriptionRef}
+                            value={formDescription}
+                            onChange={(e) => setFormDescription(e.target.value)}
+                            onBlur={() => setEditingFormDescription(false)}
+                            onKeyDown={(e) => {
+                              if (e.key === 'Enter' || e.key === 'Escape')
+                                setEditingFormDescription(false);
+                            }}
+                            className="rounded bg-surface-overlay px-1 text-xs leading-4 text-foreground outline-none ring-1 ring-brand"
+                            autoFocus
+                          />
+                        ) : (
+                          <button
+                            type="button"
+                            onClick={() => {
+                              setEditingFormDescription(true);
+                              setTimeout(() => formDescriptionRef.current?.select(), 0);
+                            }}
+                            className="truncate rounded px-1 text-left text-xs leading-4 text-foreground-muted transition hover:bg-surface-overlay hover:text-foreground"
+                          >
+                            {formDescription}
+                          </button>
+                        )}
+                      </div>
+                    </div>
+                    {formView === 'edit' && (
+                      <>
+                        <DndContext
+                          sensors={sensors}
+                          collisionDetection={closestCenter}
+                          onDragEnd={handleDragEnd}
                         >
-                          <div className="flex flex-col gap-4">
-                            {cases.map((c) => (
-                              <LockableCaseRow
-                                key={c.id}
-                                id={c.id}
-                                caseTitle={c.title}
-                                onTitleChange={(title) => updateCase(c.id, { title })}
-                                required={c.required}
-                                onDelete={() => deleteCase(c.id)}
-                                value={c.value}
-                                onValueChange={(value) => updateCase(c.id, { value })}
-                                locked={c.locked}
-                                onLockedChange={(locked) => updateCase(c.id, { locked })}
-                                mode={c.mode}
-                                onModeChange={(mode) => updateCase(c.id, { mode })}
-                              />
-                            ))}
-                          </div>
-                        </SortableContext>
-                      </DndContext>
-                      <button
-                        type="button"
-                        onClick={addCase}
-                        className="flex cursor-pointer items-center gap-1.5 text-xs text-brand transition hover:text-brand-hover"
-                      >
-                        <Plus size={12} />
-                        Add case
-                      </button>
-                    </>
-                  ) : (
-                    <pre className="overflow-auto whitespace-pre-wrap text-xs text-foreground-muted">
-                      {JSON.stringify(cases, null, 2)}
-                    </pre>
-                  )}
-                </CardContent>
-              </Card>
-            </div>
-          </TabsContent>
-          <TabsContent value="error-handling" className="mt-0" />
-          <TabsContent value="advanced" className="mt-0" />
-        </Tabs>
-      </NodePropertyPanel>
-    </PanelFrame>
+                          <SortableContext
+                            items={cases.map((c) => c.id)}
+                            strategy={verticalListSortingStrategy}
+                          >
+                            <div className="flex flex-col gap-4">
+                              {cases.map((c) => (
+                                <LockableCaseRow
+                                  key={c.id}
+                                  id={c.id}
+                                  caseTitle={c.title}
+                                  onTitleChange={(title) => updateCase(c.id, { title })}
+                                  required={c.required}
+                                  onDelete={() => deleteCase(c.id)}
+                                  value={c.value}
+                                  onValueChange={(value) => updateCase(c.id, { value })}
+                                  locked={c.locked}
+                                  onLockedChange={(locked) => updateCase(c.id, { locked })}
+                                  mode={c.mode}
+                                  onModeChange={(mode) => updateCase(c.id, { mode })}
+                                  fieldType={c.fieldType}
+                                  compact
+                                  onFieldTypeChange={(fieldType) =>
+                                    updateCaseFieldType(c.id, fieldType)
+                                  }
+                                />
+                              ))}
+                            </div>
+                          </SortableContext>
+                        </DndContext>
+                        <button
+                          type="button"
+                          onClick={addCase}
+                          className="flex cursor-pointer items-center gap-1.5 text-xs text-brand transition hover:text-brand-hover"
+                        >
+                          <Plus size={12} />
+                          Add field
+                        </button>
+                      </>
+                    )}
+                    {formView === 'preview' && (
+                      <div className="flex flex-col gap-4">
+                        {cases.map((c) => {
+                          const isExpression =
+                            FIELD_TYPE_META[c.fieldType].supportsExpression &&
+                            c.mode === 'expression';
+                          return (
+                            <div key={c.id} className="flex flex-col gap-1.5">
+                              <Label
+                                htmlFor={`preview-${c.id}`}
+                                className="text-xs font-medium text-foreground-muted"
+                              >
+                                {c.title}
+                                {c.required && <span className="ml-0.5 text-destructive">*</span>}
+                              </Label>
+                              {isExpression ? (
+                                <Input
+                                  id={`preview-${c.id}`}
+                                  readOnly={c.locked}
+                                  value={c.value}
+                                  onChange={(e) => updateCase(c.id, { value: e.target.value })}
+                                  placeholder="Enter an expression"
+                                  className="font-mono"
+                                />
+                              ) : c.fieldType === 'boolean' ? (
+                                <Switch
+                                  id={`preview-${c.id}`}
+                                  checked={c.value === 'true'}
+                                  onCheckedChange={(checked) =>
+                                    updateCase(c.id, { value: String(checked) })
+                                  }
+                                  disabled={c.locked}
+                                />
+                              ) : c.fieldType === 'date' ? (
+                                <DatePicker
+                                  disabled={c.locked}
+                                  value={c.value ? new Date(c.value) : undefined}
+                                  onValueChange={(date) =>
+                                    updateCase(c.id, { value: date ? date.toISOString() : '' })
+                                  }
+                                />
+                              ) : c.fieldType === 'single-select' ? (
+                                <Select
+                                  value={c.value || undefined}
+                                  onValueChange={(value) => updateCase(c.id, { value })}
+                                  disabled={c.locked}
+                                >
+                                  <SelectTrigger id={`preview-${c.id}`}>
+                                    <SelectValue placeholder="Select an option" />
+                                  </SelectTrigger>
+                                  <SelectContent>
+                                    {DEMO_SELECT_OPTIONS.map((option) => (
+                                      <SelectItem key={option.value} value={option.value}>
+                                        {option.label}
+                                      </SelectItem>
+                                    ))}
+                                  </SelectContent>
+                                </Select>
+                              ) : c.fieldType === 'multi-select' ? (
+                                <MultiSelect
+                                  options={DEMO_SELECT_OPTIONS}
+                                  selected={parseListValue(c.value)}
+                                  onChange={(selected) =>
+                                    updateCase(c.id, { value: JSON.stringify(selected) })
+                                  }
+                                  placeholder="Select options..."
+                                  disabled={c.locked}
+                                />
+                              ) : c.fieldType === 'file' ? (
+                                <FileUpload
+                                  disabled={c.locked}
+                                  onFilesChange={(files) =>
+                                    updateCase(c.id, { value: files.map((f) => f.name).join(', ') })
+                                  }
+                                />
+                              ) : (
+                                <Input
+                                  id={`preview-${c.id}`}
+                                  type={c.fieldType === 'integer' ? 'number' : 'text'}
+                                  readOnly={c.locked}
+                                  value={c.value}
+                                  onChange={(e) => updateCase(c.id, { value: e.target.value })}
+                                  placeholder="Enter a value"
+                                />
+                              )}
+                            </div>
+                          );
+                        })}
+                      </div>
+                    )}
+                    {formView === 'json' && (
+                      <div className="flex flex-col gap-1.5">
+                        <Textarea
+                          value={jsonDraft}
+                          onChange={(e) => handleJsonChange(e.target.value)}
+                          rows={14}
+                          spellCheck={false}
+                          className="resize-none font-mono text-xs"
+                        />
+                        {jsonError && <span className="text-xs text-destructive">{jsonError}</span>}
+                      </div>
+                    )}
+                  </CardContent>
+                </Card>
+              </div>
+            </TabsContent>
+            <TabsContent value="error-handling" className="mt-0" />
+            <TabsContent value="advanced" className="mt-0" />
+          </Tabs>
+        </NodePropertyPanel>
+      </PanelFrame>
+
+      {/* Component showcase */}
+      <div className="flex w-[320px] shrink-0 flex-col gap-4 rounded-2xl border border-border-subtle bg-surface-raised p-5">
+        <div className="flex flex-col gap-1">
+          <span className="text-sm font-semibold text-foreground">LockableValueField</span>
+          <span className="text-xs leading-4 text-foreground-muted">
+            A reusable string field that can be locked to read-only and switched between a literal
+            value and a JS expression.
+          </span>
+        </div>
+        <ul className="flex list-disc flex-col gap-1.5 pl-4 text-xs leading-4 text-foreground-muted">
+          <li>
+            Left lock icon toggles Unlocked / Locked. Locked fields are read-only, not disabled.
+          </li>
+          <li>
+            Right value-mode icon switches between Fixed value and Expression, updating the value
+            styling. Only shown for types an expression can produce.
+          </li>
+          <li>
+            Field type dropdown swaps the control itself: String, Integer, Date, Boolean, Single
+            select, Multiselect, and File each render their own matching input.
+          </li>
+          <li>Built-in AI-assist popover to describe and generate a value.</li>
+          <li>Insert-variable affordance for binding to upstream data.</li>
+          <li>Built entirely on apollo-wind&apos;s InputGroup primitive.</li>
+          <li>
+            Header row is responsive (container query): the type, AI-assist, and insert-variable
+            controls collapse to icon-only once the field gets too narrow for their labels.
+          </li>
+        </ul>
+        <div className="flex flex-col gap-2 border-t border-border-subtle pt-4">
+          <span className="text-[11px] font-medium uppercase tracking-wide text-foreground-subtle">
+            Full view
+          </span>
+          <LockableValueField
+            label={<Label className="text-xs font-medium text-foreground-muted">Label</Label>}
+            value={showcaseValue}
+            onValueChange={setShowcaseValue}
+            locked={showcaseLocked}
+            onLockedChange={setShowcaseLocked}
+            mode={showcaseMode}
+            onModeChange={setShowcaseMode}
+            fieldType={showcaseFieldType}
+            onFieldTypeChange={handleShowcaseFieldTypeChange}
+          />
+        </div>
+        <div className="flex flex-col gap-2 border-t border-border-subtle pt-4">
+          <span className="text-[11px] font-medium uppercase tracking-wide text-foreground-subtle">
+            Compact view (narrow container)
+          </span>
+          <div className="w-[200px]">
+            <LockableValueField
+              label={<Label className="text-xs font-medium text-foreground-muted">Label</Label>}
+              value={showcaseValue}
+              onValueChange={setShowcaseValue}
+              locked={showcaseLocked}
+              onLockedChange={setShowcaseLocked}
+              mode={showcaseMode}
+              onModeChange={setShowcaseMode}
+              fieldType={showcaseFieldType}
+              onFieldTypeChange={handleShowcaseFieldTypeChange}
+            />
+          </div>
+        </div>
+      </div>
+    </div>
   );
 }
 
-export const LockableField: Story = {
-  name: 'Lockable Field',
-  render: () => <LockableValueFieldStory />,
+export const QuickForm: Story = {
+  name: 'Quick Form',
+  render: () => <QuickFormStory />,
 };
 
 export const Output: Story = {

--- a/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.stories.tsx
@@ -86,6 +86,7 @@ import {
   GitFork,
   Globe,
   GripVertical,
+  Link2,
   MoreVertical,
   MousePointerClick,
   Pencil,
@@ -105,7 +106,6 @@ import type { LockableFieldType, LockableValueFieldMode } from './LockableValueF
 import {
   DEMO_SELECT_OPTIONS,
   FIELD_TYPE_META,
-  FIELD_TYPE_ORDER,
   LockableValueField,
   parseListValue,
 } from './LockableValueField';
@@ -2789,10 +2789,10 @@ function FormButtonChip({
   return (
     <div
       className={cn(
-        'group/button flex h-8 items-stretch overflow-hidden rounded-lg text-sm font-semibold transition',
+        'group/button flex h-10 items-stretch overflow-hidden rounded-lg text-sm font-semibold transition',
         variant === 'default'
           ? 'bg-brand text-foreground-on-accent'
-          : 'border border-border-subtle text-foreground'
+          : 'border border-input bg-background text-foreground future:border-border-subtle future:text-muted-foreground'
       )}
     >
       {editing ? (
@@ -2817,7 +2817,9 @@ function FormButtonChip({
           }}
           className={cn(
             'px-4 transition',
-            variant === 'default' ? 'hover:bg-brand-hover' : 'hover:bg-surface-overlay'
+            variant === 'default'
+              ? 'hover:bg-brand-hover'
+              : 'hover:bg-accent hover:text-accent-foreground future:hover:text-foreground'
           )}
         >
           {label}
@@ -2833,7 +2835,9 @@ function FormButtonChip({
                   aria-label="Edit button"
                   className={cn(
                     'grid w-0 shrink-0 place-items-center overflow-hidden px-0 opacity-0 transition-all duration-200 group-hover/button:w-8 group-hover/button:px-2 group-hover/button:opacity-100 aria-expanded:w-8 aria-expanded:px-2 aria-expanded:opacity-100',
-                    variant === 'default' ? 'hover:bg-brand-hover' : 'hover:bg-surface-overlay'
+                    variant === 'default'
+                      ? 'hover:bg-brand-hover'
+                      : 'hover:bg-accent hover:text-accent-foreground future:hover:text-foreground'
                   )}
                 >
                   <Pencil size={12} className="shrink-0" />
@@ -3176,10 +3180,10 @@ function QuickFormStory() {
                   Parameters
                 </TabsTrigger>
                 <TabsTrigger value="error-handling" className={TAB_TRIGGER_CLASS}>
-                  Error handling
+                  Branching
                 </TabsTrigger>
                 <TabsTrigger value="advanced" className={TAB_TRIGGER_CLASS}>
-                  Advanced
+                  Error handling
                 </TabsTrigger>
               </TabsList>
             </div>
@@ -3220,6 +3224,19 @@ function QuickFormStory() {
                         >
                           <Eye size={14} className="text-foreground-subtle" />
                           Preview
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => {
+                            navigator.clipboard.writeText(
+                              `${window.location.origin}/forms/quick-approve`
+                            );
+                            setMoreMenuOpen(false);
+                          }}
+                          className="flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-xs font-medium text-foreground transition hover:bg-surface-overlay"
+                        >
+                          <Link2 size={14} className="text-foreground-subtle" />
+                          Get URL
                         </button>
                         <div className="h-px bg-border-subtle" />
                         <div className="space-y-1.5">
@@ -3393,6 +3410,27 @@ function QuickFormStory() {
                             document.body
                           )}
                         </DndContext>
+                        <DropdownMenu>
+                          <DropdownMenuTrigger asChild>
+                            <button
+                              type="button"
+                              className="flex w-fit cursor-pointer items-center gap-1.5 text-xs text-brand transition hover:text-brand-hover"
+                            >
+                              <Plus size={12} />
+                              Add field
+                            </button>
+                          </DropdownMenuTrigger>
+                          <DropdownMenuContent align="start" className="w-44">
+                            <DropdownMenuItem onClick={() => addCaseWithType('string')}>
+                              <Type className="text-foreground-muted" />
+                              <span>Add field</span>
+                            </DropdownMenuItem>
+                            <DropdownMenuItem onClick={addButton}>
+                              <MousePointerClick className="text-foreground-muted" />
+                              <span>Add button</span>
+                            </DropdownMenuItem>
+                          </DropdownMenuContent>
+                        </DropdownMenu>
                         {buttons.length > 0 && (
                           <div className="flex flex-wrap items-center gap-2">
                             {buttons.map((b) => (
@@ -3407,33 +3445,6 @@ function QuickFormStory() {
                             ))}
                           </div>
                         )}
-                        <DropdownMenu>
-                          <DropdownMenuTrigger asChild>
-                            <button
-                              type="button"
-                              className="flex w-fit cursor-pointer items-center gap-1.5 text-xs text-brand transition hover:text-brand-hover"
-                            >
-                              <Plus size={12} />
-                              Add field
-                            </button>
-                          </DropdownMenuTrigger>
-                          <DropdownMenuContent align="start" className="w-44">
-                            {FIELD_TYPE_ORDER.map((type) => {
-                              const meta = FIELD_TYPE_META[type];
-                              return (
-                                <DropdownMenuItem key={type} onClick={() => addCaseWithType(type)}>
-                                  <meta.icon className="text-foreground-muted" />
-                                  <span>{meta.label}</span>
-                                </DropdownMenuItem>
-                              );
-                            })}
-                            <DropdownMenuSeparator />
-                            <DropdownMenuItem onClick={addButton}>
-                              <MousePointerClick className="text-foreground-muted" />
-                              <span>Button</span>
-                            </DropdownMenuItem>
-                          </DropdownMenuContent>
-                        </DropdownMenu>
                       </>
                     )}
                     {formView === 'preview' && (
@@ -3442,6 +3453,33 @@ function QuickFormStory() {
                           const isExpression =
                             FIELD_TYPE_META[c.fieldType].supportsExpression &&
                             c.mode === 'expression';
+                          // Locked fields are read-only, not disabled — shown as plain,
+                          // selectable text instead of a greyed-out interactive control.
+                          const lockedDisplayValue =
+                            c.fieldType === 'boolean'
+                              ? c.value === 'true'
+                                ? 'True'
+                                : 'False'
+                              : c.fieldType === 'date'
+                                ? c.value
+                                  ? new Date(c.value).toLocaleDateString(undefined, {
+                                      year: 'numeric',
+                                      month: 'long',
+                                      day: 'numeric',
+                                    })
+                                  : ''
+                                : c.fieldType === 'single-select'
+                                  ? (DEMO_SELECT_OPTIONS.find((option) => option.value === c.value)
+                                      ?.label ?? '')
+                                  : c.fieldType === 'multi-select'
+                                    ? parseListValue(c.value)
+                                        .map(
+                                          (v) =>
+                                            DEMO_SELECT_OPTIONS.find((option) => option.value === v)
+                                              ?.label ?? v
+                                        )
+                                        .join(', ')
+                                    : c.value;
                           return (
                             <div key={c.id} className="flex flex-col gap-1.5">
                               <Label
@@ -3460,6 +3498,8 @@ function QuickFormStory() {
                                   placeholder="Enter an expression"
                                   className="font-mono"
                                 />
+                              ) : c.locked ? (
+                                <Input id={`preview-${c.id}`} readOnly value={lockedDisplayValue} />
                               ) : c.fieldType === 'boolean' ? (
                                 <Switch
                                   id={`preview-${c.id}`}
@@ -3467,11 +3507,9 @@ function QuickFormStory() {
                                   onCheckedChange={(checked) =>
                                     updateCase(c.id, { value: String(checked) })
                                   }
-                                  disabled={c.locked}
                                 />
                               ) : c.fieldType === 'date' ? (
                                 <DatePicker
-                                  disabled={c.locked}
                                   value={c.value ? new Date(c.value) : undefined}
                                   onValueChange={(date) =>
                                     updateCase(c.id, { value: date ? date.toISOString() : '' })
@@ -3481,7 +3519,6 @@ function QuickFormStory() {
                                 <Select
                                   value={c.value || undefined}
                                   onValueChange={(value) => updateCase(c.id, { value })}
-                                  disabled={c.locked}
                                 >
                                   <SelectTrigger id={`preview-${c.id}`}>
                                     <SelectValue placeholder="Select an option" />
@@ -3502,11 +3539,9 @@ function QuickFormStory() {
                                     updateCase(c.id, { value: JSON.stringify(selected) })
                                   }
                                   placeholder="Select options..."
-                                  disabled={c.locked}
                                 />
                               ) : c.fieldType === 'file' ? (
                                 <FileUpload
-                                  disabled={c.locked}
                                   onFilesChange={(files) =>
                                     updateCase(c.id, { value: files.map((f) => f.name).join(', ') })
                                   }
@@ -3515,7 +3550,6 @@ function QuickFormStory() {
                                 <Input
                                   id={`preview-${c.id}`}
                                   type={c.fieldType === 'integer' ? 'number' : 'text'}
-                                  readOnly={c.locked}
                                   value={c.value}
                                   onChange={(e) => updateCase(c.id, { value: e.target.value })}
                                   placeholder="Enter a value"
@@ -3607,10 +3641,10 @@ function FormHitlReviewStory() {
                   Parameters
                 </TabsTrigger>
                 <TabsTrigger value="error-handling" className={TAB_TRIGGER_CLASS}>
-                  Error handling
+                  Branching
                 </TabsTrigger>
                 <TabsTrigger value="advanced" className={TAB_TRIGGER_CLASS}>
-                  Advanced
+                  Error handling
                 </TabsTrigger>
               </TabsList>
             </div>

--- a/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.stories.tsx
@@ -3061,18 +3061,54 @@ function LockableValueFieldShowcase({
 function QuickFormStory() {
   const [cases, setCases] = useState<LockableCase[]>(DEFAULT_LOCKABLE_CASES);
   const nextIdRef = useRef(4);
+  const [formView, setFormView] = useState<'edit' | 'json'>('edit');
   const [formTitle, setFormTitle] = useState('Quick Approve');
   const [formDescription, setFormDescription] = useState('Add a description');
   const [editingFormTitle, setEditingFormTitle] = useState(false);
   const [editingFormDescription, setEditingFormDescription] = useState(false);
   const formTitleRef = useRef<HTMLInputElement>(null);
   const formDescriptionRef = useRef<HTMLInputElement>(null);
+  const [jsonDraft, setJsonDraft] = useState(() => JSON.stringify(DEFAULT_LOCKABLE_CASES, null, 2));
+  const [jsonError, setJsonError] = useState<string | null>(null);
+  const [jsonCopied, setJsonCopied] = useState(false);
   const [showcaseControlsVisibility, setShowcaseControlsVisibility] = useState<'visible' | 'hover'>(
     'visible'
   );
   const [buttons, setButtons] = useState<FormButtonItem[]>(DEFAULT_FORM_BUTTONS);
   const nextButtonIdRef = useRef(3);
   const fileInputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (formView !== 'json') {
+      setJsonDraft(JSON.stringify(cases, null, 2));
+      setJsonError(null);
+    }
+  }, [cases, formView]);
+
+  const handleJsonChange = (value: string) => {
+    setJsonDraft(value);
+    try {
+      const parsed = JSON.parse(value);
+      if (!Array.isArray(parsed)) {
+        setJsonError('Expected a JSON array of fields.');
+        return;
+      }
+      setCases(parsed);
+      setJsonError(null);
+    } catch {
+      setJsonError('Invalid JSON.');
+    }
+  };
+
+  const handleCopyJson = () => {
+    navigator.clipboard
+      ?.writeText(jsonDraft)
+      ?.then(() => {
+        setJsonCopied(true);
+        setTimeout(() => setJsonCopied(false), 1500);
+      })
+      ?.catch(() => {});
+  };
 
   const addCaseWithType = (fieldType: LockableFieldType) => {
     const id = nextIdRef.current++;
@@ -3184,38 +3220,53 @@ function QuickFormStory() {
               <div className="flex flex-col gap-2">
                 <div className="flex items-center justify-between">
                   <span className="text-xs font-medium text-foreground-muted">Quick form</span>
-                  <Popover>
-                    <TooltipProvider delayDuration={300}>
-                      <Tooltip>
-                        <TooltipTrigger asChild>
-                          <PopoverTrigger asChild>
-                            <button
-                              type="button"
-                              aria-label="Generate with AI"
-                              className="grid size-7 shrink-0 place-items-center rounded-lg text-foreground-subtle transition hover:bg-surface-overlay hover:text-foreground aria-expanded:bg-surface-overlay aria-expanded:text-foreground"
-                            >
-                              <Sparkles size={14} />
-                            </button>
-                          </PopoverTrigger>
-                        </TooltipTrigger>
-                        <TooltipContent>Generate with AI</TooltipContent>
-                      </Tooltip>
-                    </TooltipProvider>
-                    <PopoverContent align="end" className="w-64 space-y-1.5">
-                      <span className="flex items-center gap-1.5 text-xs font-medium text-foreground">
-                        <Sparkles size={12} className="text-brand" />
-                        Describe the form you want
-                      </span>
-                      <Textarea
-                        rows={3}
-                        placeholder="e.g. An invoice approval form with amount and due date"
-                        className="resize-none text-sm"
-                      />
-                      <Button size="sm" className="w-full">
-                        Generate
-                      </Button>
-                    </PopoverContent>
-                  </Popover>
+                  <div className="flex items-center gap-2">
+                    <Popover>
+                      <TooltipProvider delayDuration={300}>
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <PopoverTrigger asChild>
+                              <button
+                                type="button"
+                                aria-label="Generate with AI"
+                                className="grid size-7 shrink-0 place-items-center rounded-lg text-foreground-subtle transition hover:bg-surface-overlay hover:text-foreground aria-expanded:bg-surface-overlay aria-expanded:text-foreground"
+                              >
+                                <Sparkles size={14} />
+                              </button>
+                            </PopoverTrigger>
+                          </TooltipTrigger>
+                          <TooltipContent>Generate with AI</TooltipContent>
+                        </Tooltip>
+                      </TooltipProvider>
+                      <PopoverContent align="end" className="w-64 space-y-1.5">
+                        <span className="flex items-center gap-1.5 text-xs font-medium text-foreground">
+                          <Sparkles size={12} className="text-brand" />
+                          Describe the form you want
+                        </span>
+                        <Textarea
+                          rows={3}
+                          placeholder="e.g. An invoice approval form with amount and due date"
+                          className="resize-none text-sm"
+                        />
+                        <Button size="sm" className="w-full">
+                          Generate
+                        </Button>
+                      </PopoverContent>
+                    </Popover>
+                    <ToggleGroup
+                      type="single"
+                      size="xs"
+                      value={formView}
+                      onValueChange={(v) => v && setFormView(v as 'edit' | 'json')}
+                    >
+                      <ToggleGroupItem value="edit" className="!px-2.5 !text-xs">
+                        UI
+                      </ToggleGroupItem>
+                      <ToggleGroupItem value="json" className="!px-2.5 !text-xs">
+                        JSON
+                      </ToggleGroupItem>
+                    </ToggleGroup>
+                  </div>
                 </div>
                 <Card>
                   <CardContent className="flex flex-col gap-4 p-4">
@@ -3301,91 +3352,133 @@ function QuickFormStory() {
                         )}
                       </div>
                     </div>
-                    <DndContext
-                      sensors={sensors}
-                      collisionDetection={closestCenter}
-                      onDragStart={handleDragStart}
-                      onDragOver={handleDragOver}
-                      onDragEnd={handleDragEnd}
-                      onDragCancel={handleDragCancel}
-                    >
-                      <SortableContext
-                        items={cases.map((c) => c.id)}
-                        strategy={verticalListSortingStrategy}
-                      >
-                        <div className="flex flex-col gap-4">
-                          {cases.map((c, index) => {
-                            const activeIndex = cases.findIndex((x) => x.id === activeDragId);
-                            const isOver =
-                              activeDragId != null && overDragId === c.id && c.id !== activeDragId;
-                            return (
-                              <LockableCaseRow
-                                key={c.id}
-                                id={c.id}
-                                caseTitle={c.title}
-                                onTitleChange={(title) => updateCase(c.id, { title })}
-                                required={c.required}
-                                onRequiredChange={(required) => updateCase(c.id, { required })}
-                                onDelete={() => deleteCase(c.id)}
-                                value={c.value}
-                                onValueChange={(value) => updateCase(c.id, { value })}
-                                locked={c.locked}
-                                onLockedChange={(locked) => updateCase(c.id, { locked })}
-                                mode={c.mode}
-                                onModeChange={(mode) => updateCase(c.id, { mode })}
-                                fieldType={c.fieldType}
-                                compact
-                                onFieldTypeChange={(fieldType) =>
-                                  updateCaseFieldType(c.id, fieldType)
-                                }
-                                controlsVisibility={showcaseControlsVisibility}
-                                insertBefore={isOver && activeIndex > index}
-                                insertAfter={isOver && activeIndex < index}
-                              />
-                            );
-                          })}
-                        </div>
-                      </SortableContext>
-                      {createPortal(
-                        <DragOverlay>
-                          {activeCase ? <FieldDragOverlay caseItem={activeCase} /> : null}
-                        </DragOverlay>,
-                        document.body
-                      )}
-                    </DndContext>
-                    <DropdownMenu>
-                      <DropdownMenuTrigger asChild>
-                        <button
-                          type="button"
-                          className="flex w-fit cursor-pointer items-center gap-1.5 text-xs text-brand transition hover:text-brand-hover"
+                    {formView === 'edit' && (
+                      <>
+                        <DndContext
+                          sensors={sensors}
+                          collisionDetection={closestCenter}
+                          onDragStart={handleDragStart}
+                          onDragOver={handleDragOver}
+                          onDragEnd={handleDragEnd}
+                          onDragCancel={handleDragCancel}
                         >
-                          <Plus size={12} />
-                          Add field
-                        </button>
-                      </DropdownMenuTrigger>
-                      <DropdownMenuContent align="start" className="w-44">
-                        <DropdownMenuItem onClick={() => addCaseWithType('string')}>
-                          <Type className="text-foreground-muted" />
-                          <span>Add field</span>
-                        </DropdownMenuItem>
-                        <DropdownMenuItem onClick={addButton}>
-                          <MousePointerClick className="text-foreground-muted" />
-                          <span>Add button</span>
-                        </DropdownMenuItem>
-                      </DropdownMenuContent>
-                    </DropdownMenu>
-                    {buttons.length > 0 && (
-                      <div className="flex flex-wrap items-center gap-2">
-                        {buttons.map((b) => (
-                          <FormButtonChip
-                            key={b.id}
-                            label={b.label}
-                            onLabelChange={(label) => updateButton(b.id, { label })}
-                            variant={b.variant}
-                            onVariantChange={(variant) => updateButton(b.id, { variant })}
-                            onDelete={() => deleteButton(b.id)}
-                          />
-                        ))}
+                          <SortableContext
+                            items={cases.map((c) => c.id)}
+                            strategy={verticalListSortingStrategy}
+                          >
+                            <div className="flex flex-col gap-4">
+                              {cases.map((c, index) => {
+                                const activeIndex = cases.findIndex((x) => x.id === activeDragId);
+                                const isOver =
+                                  activeDragId != null &&
+                                  overDragId === c.id &&
+                                  c.id !== activeDragId;
+                                return (
+                                  <LockableCaseRow
+                                    key={c.id}
+                                    id={c.id}
+                                    caseTitle={c.title}
+                                    onTitleChange={(title) => updateCase(c.id, { title })}
+                                    required={c.required}
+                                    onRequiredChange={(required) => updateCase(c.id, { required })}
+                                    onDelete={() => deleteCase(c.id)}
+                                    value={c.value}
+                                    onValueChange={(value) => updateCase(c.id, { value })}
+                                    locked={c.locked}
+                                    onLockedChange={(locked) => updateCase(c.id, { locked })}
+                                    mode={c.mode}
+                                    onModeChange={(mode) => updateCase(c.id, { mode })}
+                                    fieldType={c.fieldType}
+                                    compact
+                                    onFieldTypeChange={(fieldType) =>
+                                      updateCaseFieldType(c.id, fieldType)
+                                    }
+                                    controlsVisibility={showcaseControlsVisibility}
+                                    insertBefore={isOver && activeIndex > index}
+                                    insertAfter={isOver && activeIndex < index}
+                                  />
+                                );
+                              })}
+                            </div>
+                          </SortableContext>
+                          {createPortal(
+                            <DragOverlay>
+                              {activeCase ? <FieldDragOverlay caseItem={activeCase} /> : null}
+                            </DragOverlay>,
+                            document.body
+                          )}
+                        </DndContext>
+                        <DropdownMenu>
+                          <DropdownMenuTrigger asChild>
+                            <button
+                              type="button"
+                              className="flex w-fit cursor-pointer items-center gap-1.5 text-xs text-brand transition hover:text-brand-hover"
+                            >
+                              <Plus size={12} />
+                              Add field
+                            </button>
+                          </DropdownMenuTrigger>
+                          <DropdownMenuContent align="start" className="w-44">
+                            <DropdownMenuItem onClick={() => addCaseWithType('string')}>
+                              <Type className="text-foreground-muted" />
+                              <span>Add field</span>
+                            </DropdownMenuItem>
+                            <DropdownMenuItem onClick={addButton}>
+                              <MousePointerClick className="text-foreground-muted" />
+                              <span>Add button</span>
+                            </DropdownMenuItem>
+                          </DropdownMenuContent>
+                        </DropdownMenu>
+                        {buttons.length > 0 && (
+                          <div className="flex flex-wrap items-center gap-2">
+                            {buttons.map((b) => (
+                              <FormButtonChip
+                                key={b.id}
+                                label={b.label}
+                                onLabelChange={(label) => updateButton(b.id, { label })}
+                                variant={b.variant}
+                                onVariantChange={(variant) => updateButton(b.id, { variant })}
+                                onDelete={() => deleteButton(b.id)}
+                              />
+                            ))}
+                          </div>
+                        )}
+                      </>
+                    )}
+                    {formView === 'json' && (
+                      <div className="flex flex-col gap-1.5">
+                        <div className="flex items-center justify-between">
+                          <span className="text-xs font-medium text-foreground-muted">
+                            Form schema
+                          </span>
+                          <TooltipProvider delayDuration={300}>
+                            <Tooltip>
+                              <TooltipTrigger asChild>
+                                <button
+                                  type="button"
+                                  onClick={handleCopyJson}
+                                  aria-label="Copy JSON"
+                                  className="grid size-6 shrink-0 place-items-center rounded text-foreground-subtle transition hover:bg-surface-overlay hover:text-foreground"
+                                >
+                                  {jsonCopied ? (
+                                    <CircleCheck size={13} className="text-brand" />
+                                  ) : (
+                                    <Copy size={13} />
+                                  )}
+                                </button>
+                              </TooltipTrigger>
+                              <TooltipContent>{jsonCopied ? 'Copied' : 'Copy JSON'}</TooltipContent>
+                            </Tooltip>
+                          </TooltipProvider>
+                        </div>
+                        <Textarea
+                          value={jsonDraft}
+                          onChange={(e) => handleJsonChange(e.target.value)}
+                          rows={14}
+                          spellCheck={false}
+                          className="resize-none font-mono text-xs"
+                        />
+                        {jsonError && <span className="text-xs text-destructive">{jsonError}</span>}
                       </div>
                     )}
                   </CardContent>

--- a/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.stories.tsx
@@ -27,29 +27,21 @@ import {
   Card,
   CardContent,
   cn,
-  DatePicker,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
-  FileUpload,
   HoverCard,
   HoverCardContent,
   HoverCardTrigger,
   Input,
   Label,
   MetadataForm,
-  MultiSelect,
   Popover,
   PopoverContent,
   PopoverTrigger,
   ScrollableTabsList,
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
   Switch,
   Tabs,
   TabsContent,
@@ -81,13 +73,10 @@ import {
   CircleOff,
   Code2,
   Copy,
-  Eye,
   FileBracesCorner,
   GitFork,
   Globe,
   GripVertical,
-  Link2,
-  MoreVertical,
   MousePointerClick,
   Pencil,
   Play,
@@ -103,12 +92,7 @@ import type { CSSProperties, ReactNode } from 'react';
 import { lazy, Suspense, useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import type { LockableFieldType, LockableValueFieldMode } from './LockableValueField';
-import {
-  DEMO_SELECT_OPTIONS,
-  FIELD_TYPE_META,
-  LockableValueField,
-  parseListValue,
-} from './LockableValueField';
+import { FIELD_TYPE_META, LockableValueField } from './LockableValueField';
 import { NodePropertyPanel } from './NodePropertyPanel';
 
 // @monaco-editor/react uses a CJS build without an `exports` field, which
@@ -2730,7 +2714,11 @@ function LockableCaseRow({
               onClick={onDelete}
               aria-label="Delete field"
               title="Delete field"
-              className="grid size-6 shrink-0 place-items-center rounded text-foreground-subtle opacity-0 transition hover:bg-surface-overlay hover:text-foreground group-hover:opacity-100"
+              className={cn(
+                'grid size-6 shrink-0 place-items-center rounded text-foreground-subtle transition hover:bg-surface-overlay hover:text-foreground',
+                controlsVisibility === 'hover' &&
+                  'opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 has-[[aria-expanded=true]]:opacity-100'
+              )}
             >
               <X size={12} />
             </button>
@@ -2945,7 +2933,8 @@ function LockableValueFieldShowcase({
         {showcaseDetailsExpanded && (
           <ul className="flex list-disc flex-col gap-1.5 pl-4 pt-1 text-xs leading-4 text-foreground-muted">
             <li>
-              Left lock icon toggles Unlocked / Locked. Locked fields are read-only, not disabled.
+              Left lock icon toggles Editable / Read-only. Read-only fields show plain text, not a
+              disabled control.
             </li>
             <li>
               Right value-mode icon switches between Fixed value and Expression, updating the value
@@ -3000,6 +2989,19 @@ function LockableValueFieldShowcase({
               {showcaseRequired && <span className="ml-0.5 text-destructive">*</span>}
             </Label>
           }
+          headerActions={
+            <button
+              type="button"
+              aria-label="Close field"
+              className={cn(
+                'grid size-7 shrink-0 place-items-center rounded-lg text-foreground-subtle transition hover:bg-surface-overlay hover:text-foreground',
+                controlsVisibility === 'hover' &&
+                  'opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100 has-[[aria-expanded=true]]:opacity-100'
+              )}
+            >
+              <X size={14} />
+            </button>
+          }
           value={showcaseValue}
           onValueChange={setShowcaseValue}
           locked={showcaseLocked}
@@ -3025,6 +3027,19 @@ function LockableValueFieldShowcase({
                 {showcaseRequired && <span className="ml-0.5 text-destructive">*</span>}
               </Label>
             }
+            headerActions={
+              <button
+                type="button"
+                aria-label="Close field"
+                className={cn(
+                  'grid size-7 shrink-0 place-items-center rounded-lg text-foreground-subtle transition hover:bg-surface-overlay hover:text-foreground',
+                  controlsVisibility === 'hover' &&
+                    'opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100 has-[[aria-expanded=true]]:opacity-100'
+                )}
+              >
+                <X size={14} />
+              </button>
+            }
             value={showcaseValue}
             onValueChange={setShowcaseValue}
             locked={showcaseLocked}
@@ -3046,44 +3061,18 @@ function LockableValueFieldShowcase({
 function QuickFormStory() {
   const [cases, setCases] = useState<LockableCase[]>(DEFAULT_LOCKABLE_CASES);
   const nextIdRef = useRef(4);
-  const [formView, setFormView] = useState<'edit' | 'preview' | 'json'>('edit');
-  const [moreMenuOpen, setMoreMenuOpen] = useState(false);
   const [formTitle, setFormTitle] = useState('Quick Approve');
   const [formDescription, setFormDescription] = useState('Add a description');
   const [editingFormTitle, setEditingFormTitle] = useState(false);
   const [editingFormDescription, setEditingFormDescription] = useState(false);
   const formTitleRef = useRef<HTMLInputElement>(null);
   const formDescriptionRef = useRef<HTMLInputElement>(null);
-  const [jsonDraft, setJsonDraft] = useState(() => JSON.stringify(DEFAULT_LOCKABLE_CASES, null, 2));
-  const [jsonError, setJsonError] = useState<string | null>(null);
   const [showcaseControlsVisibility, setShowcaseControlsVisibility] = useState<'visible' | 'hover'>(
-    'hover'
+    'visible'
   );
   const [buttons, setButtons] = useState<FormButtonItem[]>(DEFAULT_FORM_BUTTONS);
   const nextButtonIdRef = useRef(3);
   const fileInputRef = useRef<HTMLInputElement>(null);
-
-  useEffect(() => {
-    if (formView !== 'json') {
-      setJsonDraft(JSON.stringify(cases, null, 2));
-      setJsonError(null);
-    }
-  }, [cases, formView]);
-
-  const handleJsonChange = (value: string) => {
-    setJsonDraft(value);
-    try {
-      const parsed = JSON.parse(value);
-      if (!Array.isArray(parsed)) {
-        setJsonError('Expected a JSON array of fields.');
-        return;
-      }
-      setCases(parsed);
-      setJsonError(null);
-    } catch {
-      setJsonError('Invalid JSON.');
-    }
-  };
 
   const addCaseWithType = (fieldType: LockableFieldType) => {
     const id = nextIdRef.current++;
@@ -3195,80 +3184,38 @@ function QuickFormStory() {
               <div className="flex flex-col gap-2">
                 <div className="flex items-center justify-between">
                   <span className="text-xs font-medium text-foreground-muted">Quick form</span>
-                  <div className="flex items-center gap-2">
-                    <Popover open={moreMenuOpen} onOpenChange={setMoreMenuOpen}>
-                      <TooltipProvider delayDuration={300}>
-                        <Tooltip>
-                          <TooltipTrigger asChild>
-                            <PopoverTrigger asChild>
-                              <button
-                                type="button"
-                                aria-label="More options"
-                                className="grid size-7 shrink-0 place-items-center rounded-lg text-foreground-subtle transition hover:bg-surface-overlay hover:text-foreground aria-expanded:bg-surface-overlay aria-expanded:text-foreground"
-                              >
-                                <MoreVertical size={14} />
-                              </button>
-                            </PopoverTrigger>
-                          </TooltipTrigger>
-                          <TooltipContent>More options</TooltipContent>
-                        </Tooltip>
-                      </TooltipProvider>
-                      <PopoverContent align="end" className="w-64 space-y-3">
-                        <button
-                          type="button"
-                          onClick={() => {
-                            setFormView('preview');
-                            setMoreMenuOpen(false);
-                          }}
-                          className="flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-xs font-medium text-foreground transition hover:bg-surface-overlay"
-                        >
-                          <Eye size={14} className="text-foreground-subtle" />
-                          Preview
-                        </button>
-                        <button
-                          type="button"
-                          onClick={() => {
-                            navigator.clipboard.writeText(
-                              `${window.location.origin}/forms/quick-approve`
-                            );
-                            setMoreMenuOpen(false);
-                          }}
-                          className="flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-xs font-medium text-foreground transition hover:bg-surface-overlay"
-                        >
-                          <Link2 size={14} className="text-foreground-subtle" />
-                          Get URL
-                        </button>
-                        <div className="h-px bg-border-subtle" />
-                        <div className="space-y-1.5">
-                          <span className="flex items-center gap-1.5 text-xs font-medium text-foreground">
-                            <Sparkles size={12} className="text-brand" />
-                            Describe the form you want
-                          </span>
-                          <Textarea
-                            rows={3}
-                            placeholder="e.g. An invoice approval form with amount and due date"
-                            className="resize-none text-sm"
-                          />
-                          <Button size="sm" className="w-full">
-                            Generate
-                          </Button>
-                        </div>
-                      </PopoverContent>
-                    </Popover>
-                    <ToggleGroup
-                      type="single"
-                      size="xs"
-                      value={formView === 'json' ? 'json' : formView === 'edit' ? 'edit' : ''}
-                      onValueChange={(v) => v && setFormView(v as 'edit' | 'json')}
-                    >
-                      <ToggleGroupItem value="edit" className="!px-2.5 !text-xs">
-                        UI
-                      </ToggleGroupItem>
-                      <ToggleGroupItem value="json" className="!px-2.5 !text-xs">
-                        JSON
-                      </ToggleGroupItem>
-                    </ToggleGroup>
-                  </div>
+                  <Popover>
+                    <TooltipProvider delayDuration={300}>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <PopoverTrigger asChild>
+                            <button
+                              type="button"
+                              aria-label="Generate with AI"
+                              className="grid size-7 shrink-0 place-items-center rounded-lg text-foreground-subtle transition hover:bg-surface-overlay hover:text-foreground aria-expanded:bg-surface-overlay aria-expanded:text-foreground"
+                            >
+                              <Sparkles size={14} />
+                            </button>
+                          </PopoverTrigger>
+                        </TooltipTrigger>
+                        <TooltipContent>Generate with AI</TooltipContent>
+                      </Tooltip>
+                    </TooltipProvider>
+                    <PopoverContent align="end" className="w-64 space-y-1.5">
+                      <span className="flex items-center gap-1.5 text-xs font-medium text-foreground">
+                        <Sparkles size={12} className="text-brand" />
+                        Describe the form you want
+                      </span>
+                      <Textarea
+                        rows={3}
+                        placeholder="e.g. An invoice approval form with amount and due date"
+                        className="resize-none text-sm"
+                      />
+                      <Button size="sm" className="w-full">
+                        Generate
+                      </Button>
+                    </PopoverContent>
+                  </Popover>
                 </div>
                 <Card>
                   <CardContent className="flex flex-col gap-4 p-4">
@@ -3354,231 +3301,91 @@ function QuickFormStory() {
                         )}
                       </div>
                     </div>
-                    {formView === 'edit' && (
-                      <>
-                        <DndContext
-                          sensors={sensors}
-                          collisionDetection={closestCenter}
-                          onDragStart={handleDragStart}
-                          onDragOver={handleDragOver}
-                          onDragEnd={handleDragEnd}
-                          onDragCancel={handleDragCancel}
-                        >
-                          <SortableContext
-                            items={cases.map((c) => c.id)}
-                            strategy={verticalListSortingStrategy}
-                          >
-                            <div className="flex flex-col gap-4">
-                              {cases.map((c, index) => {
-                                const activeIndex = cases.findIndex((x) => x.id === activeDragId);
-                                const isOver =
-                                  activeDragId != null &&
-                                  overDragId === c.id &&
-                                  c.id !== activeDragId;
-                                return (
-                                  <LockableCaseRow
-                                    key={c.id}
-                                    id={c.id}
-                                    caseTitle={c.title}
-                                    onTitleChange={(title) => updateCase(c.id, { title })}
-                                    required={c.required}
-                                    onRequiredChange={(required) => updateCase(c.id, { required })}
-                                    onDelete={() => deleteCase(c.id)}
-                                    value={c.value}
-                                    onValueChange={(value) => updateCase(c.id, { value })}
-                                    locked={c.locked}
-                                    onLockedChange={(locked) => updateCase(c.id, { locked })}
-                                    mode={c.mode}
-                                    onModeChange={(mode) => updateCase(c.id, { mode })}
-                                    fieldType={c.fieldType}
-                                    compact
-                                    onFieldTypeChange={(fieldType) =>
-                                      updateCaseFieldType(c.id, fieldType)
-                                    }
-                                    controlsVisibility={showcaseControlsVisibility}
-                                    insertBefore={isOver && activeIndex > index}
-                                    insertAfter={isOver && activeIndex < index}
-                                  />
-                                );
-                              })}
-                            </div>
-                          </SortableContext>
-                          {createPortal(
-                            <DragOverlay>
-                              {activeCase ? <FieldDragOverlay caseItem={activeCase} /> : null}
-                            </DragOverlay>,
-                            document.body
-                          )}
-                        </DndContext>
-                        <DropdownMenu>
-                          <DropdownMenuTrigger asChild>
-                            <button
-                              type="button"
-                              className="flex w-fit cursor-pointer items-center gap-1.5 text-xs text-brand transition hover:text-brand-hover"
-                            >
-                              <Plus size={12} />
-                              Add field
-                            </button>
-                          </DropdownMenuTrigger>
-                          <DropdownMenuContent align="start" className="w-44">
-                            <DropdownMenuItem onClick={() => addCaseWithType('string')}>
-                              <Type className="text-foreground-muted" />
-                              <span>Add field</span>
-                            </DropdownMenuItem>
-                            <DropdownMenuItem onClick={addButton}>
-                              <MousePointerClick className="text-foreground-muted" />
-                              <span>Add button</span>
-                            </DropdownMenuItem>
-                          </DropdownMenuContent>
-                        </DropdownMenu>
-                        {buttons.length > 0 && (
-                          <div className="flex flex-wrap items-center gap-2">
-                            {buttons.map((b) => (
-                              <FormButtonChip
-                                key={b.id}
-                                label={b.label}
-                                onLabelChange={(label) => updateButton(b.id, { label })}
-                                variant={b.variant}
-                                onVariantChange={(variant) => updateButton(b.id, { variant })}
-                                onDelete={() => deleteButton(b.id)}
+                    <DndContext
+                      sensors={sensors}
+                      collisionDetection={closestCenter}
+                      onDragStart={handleDragStart}
+                      onDragOver={handleDragOver}
+                      onDragEnd={handleDragEnd}
+                      onDragCancel={handleDragCancel}
+                    >
+                      <SortableContext
+                        items={cases.map((c) => c.id)}
+                        strategy={verticalListSortingStrategy}
+                      >
+                        <div className="flex flex-col gap-4">
+                          {cases.map((c, index) => {
+                            const activeIndex = cases.findIndex((x) => x.id === activeDragId);
+                            const isOver =
+                              activeDragId != null && overDragId === c.id && c.id !== activeDragId;
+                            return (
+                              <LockableCaseRow
+                                key={c.id}
+                                id={c.id}
+                                caseTitle={c.title}
+                                onTitleChange={(title) => updateCase(c.id, { title })}
+                                required={c.required}
+                                onRequiredChange={(required) => updateCase(c.id, { required })}
+                                onDelete={() => deleteCase(c.id)}
+                                value={c.value}
+                                onValueChange={(value) => updateCase(c.id, { value })}
+                                locked={c.locked}
+                                onLockedChange={(locked) => updateCase(c.id, { locked })}
+                                mode={c.mode}
+                                onModeChange={(mode) => updateCase(c.id, { mode })}
+                                fieldType={c.fieldType}
+                                compact
+                                onFieldTypeChange={(fieldType) =>
+                                  updateCaseFieldType(c.id, fieldType)
+                                }
+                                controlsVisibility={showcaseControlsVisibility}
+                                insertBefore={isOver && activeIndex > index}
+                                insertAfter={isOver && activeIndex < index}
                               />
-                            ))}
-                          </div>
-                        )}
-                      </>
-                    )}
-                    {formView === 'preview' && (
-                      <div className="flex flex-col gap-4">
-                        {cases.map((c) => {
-                          const isExpression =
-                            FIELD_TYPE_META[c.fieldType].supportsExpression &&
-                            c.mode === 'expression';
-                          // Locked fields are read-only, not disabled — shown as plain,
-                          // selectable text instead of a greyed-out interactive control.
-                          const lockedDisplayValue =
-                            c.fieldType === 'boolean'
-                              ? c.value === 'true'
-                                ? 'True'
-                                : 'False'
-                              : c.fieldType === 'date'
-                                ? c.value
-                                  ? new Date(c.value).toLocaleDateString(undefined, {
-                                      year: 'numeric',
-                                      month: 'long',
-                                      day: 'numeric',
-                                    })
-                                  : ''
-                                : c.fieldType === 'single-select'
-                                  ? (DEMO_SELECT_OPTIONS.find((option) => option.value === c.value)
-                                      ?.label ?? '')
-                                  : c.fieldType === 'multi-select'
-                                    ? parseListValue(c.value)
-                                        .map(
-                                          (v) =>
-                                            DEMO_SELECT_OPTIONS.find((option) => option.value === v)
-                                              ?.label ?? v
-                                        )
-                                        .join(', ')
-                                    : c.value;
-                          return (
-                            <div key={c.id} className="flex flex-col gap-1.5">
-                              <Label
-                                htmlFor={`preview-${c.id}`}
-                                className="text-xs font-medium text-foreground-muted"
-                              >
-                                {c.title}
-                                {c.required && <span className="ml-0.5 text-destructive">*</span>}
-                              </Label>
-                              {isExpression ? (
-                                <Input
-                                  id={`preview-${c.id}`}
-                                  readOnly={c.locked}
-                                  value={c.value}
-                                  onChange={(e) => updateCase(c.id, { value: e.target.value })}
-                                  placeholder="Enter an expression"
-                                  className="font-mono"
-                                />
-                              ) : c.locked ? (
-                                <Input id={`preview-${c.id}`} readOnly value={lockedDisplayValue} />
-                              ) : c.fieldType === 'boolean' ? (
-                                <Switch
-                                  id={`preview-${c.id}`}
-                                  checked={c.value === 'true'}
-                                  onCheckedChange={(checked) =>
-                                    updateCase(c.id, { value: String(checked) })
-                                  }
-                                />
-                              ) : c.fieldType === 'date' ? (
-                                <DatePicker
-                                  value={c.value ? new Date(c.value) : undefined}
-                                  onValueChange={(date) =>
-                                    updateCase(c.id, { value: date ? date.toISOString() : '' })
-                                  }
-                                />
-                              ) : c.fieldType === 'single-select' ? (
-                                <Select
-                                  value={c.value || undefined}
-                                  onValueChange={(value) => updateCase(c.id, { value })}
-                                >
-                                  <SelectTrigger id={`preview-${c.id}`}>
-                                    <SelectValue placeholder="Select an option" />
-                                  </SelectTrigger>
-                                  <SelectContent>
-                                    {DEMO_SELECT_OPTIONS.map((option) => (
-                                      <SelectItem key={option.value} value={option.value}>
-                                        {option.label}
-                                      </SelectItem>
-                                    ))}
-                                  </SelectContent>
-                                </Select>
-                              ) : c.fieldType === 'multi-select' ? (
-                                <MultiSelect
-                                  options={DEMO_SELECT_OPTIONS}
-                                  selected={parseListValue(c.value)}
-                                  onChange={(selected) =>
-                                    updateCase(c.id, { value: JSON.stringify(selected) })
-                                  }
-                                  placeholder="Select options..."
-                                />
-                              ) : c.fieldType === 'file' ? (
-                                <FileUpload
-                                  onFilesChange={(files) =>
-                                    updateCase(c.id, { value: files.map((f) => f.name).join(', ') })
-                                  }
-                                />
-                              ) : (
-                                <Input
-                                  id={`preview-${c.id}`}
-                                  type={c.fieldType === 'integer' ? 'number' : 'text'}
-                                  value={c.value}
-                                  onChange={(e) => updateCase(c.id, { value: e.target.value })}
-                                  placeholder="Enter a value"
-                                />
-                              )}
-                            </div>
-                          );
-                        })}
-                        {buttons.length > 0 && (
-                          <div className="flex flex-wrap items-center gap-2">
-                            {buttons.map((b) => (
-                              <Button key={b.id} variant={b.variant}>
-                                {b.label}
-                              </Button>
-                            ))}
-                          </div>
-                        )}
-                      </div>
-                    )}
-                    {formView === 'json' && (
-                      <div className="flex flex-col gap-1.5">
-                        <Textarea
-                          value={jsonDraft}
-                          onChange={(e) => handleJsonChange(e.target.value)}
-                          rows={14}
-                          spellCheck={false}
-                          className="resize-none font-mono text-xs"
-                        />
-                        {jsonError && <span className="text-xs text-destructive">{jsonError}</span>}
+                            );
+                          })}
+                        </div>
+                      </SortableContext>
+                      {createPortal(
+                        <DragOverlay>
+                          {activeCase ? <FieldDragOverlay caseItem={activeCase} /> : null}
+                        </DragOverlay>,
+                        document.body
+                      )}
+                    </DndContext>
+                    <DropdownMenu>
+                      <DropdownMenuTrigger asChild>
+                        <button
+                          type="button"
+                          className="flex w-fit cursor-pointer items-center gap-1.5 text-xs text-brand transition hover:text-brand-hover"
+                        >
+                          <Plus size={12} />
+                          Add field
+                        </button>
+                      </DropdownMenuTrigger>
+                      <DropdownMenuContent align="start" className="w-44">
+                        <DropdownMenuItem onClick={() => addCaseWithType('string')}>
+                          <Type className="text-foreground-muted" />
+                          <span>Add field</span>
+                        </DropdownMenuItem>
+                        <DropdownMenuItem onClick={addButton}>
+                          <MousePointerClick className="text-foreground-muted" />
+                          <span>Add button</span>
+                        </DropdownMenuItem>
+                      </DropdownMenuContent>
+                    </DropdownMenu>
+                    {buttons.length > 0 && (
+                      <div className="flex flex-wrap items-center gap-2">
+                        {buttons.map((b) => (
+                          <FormButtonChip
+                            key={b.id}
+                            label={b.label}
+                            onLabelChange={(label) => updateButton(b.id, { label })}
+                            variant={b.variant}
+                            onVariantChange={(variant) => updateButton(b.id, { variant })}
+                            onDelete={() => deleteButton(b.id)}
+                          />
+                        ))}
                       </div>
                     )}
                   </CardContent>
@@ -3617,7 +3424,7 @@ export const QuickForm: Story = {
 
 function FormHitlReviewStory() {
   const [cases, setCases] = useState<LockableCase[]>(REVIEW_LOCKABLE_CASES);
-  const [controlsVisibility, setControlsVisibility] = useState<'visible' | 'hover'>('hover');
+  const [controlsVisibility, setControlsVisibility] = useState<'visible' | 'hover'>('visible');
 
   const updateCase = (id: number, patch: Partial<LockableCase>) =>
     setCases((prev) => prev.map((c) => (c.id === id ? { ...c, ...patch } : c)));
@@ -3691,8 +3498,7 @@ function FormHitlReviewStory() {
                           onModeChange={(mode) => updateCase(c.id, { mode })}
                           fieldType={c.fieldType}
                           required={c.required}
-                          onRequiredChange={(required) => updateCase(c.id, { required })}
-                          controlsVisibility={controlsVisibility}
+                          showFieldActions={false}
                         />
                       ))}
                     </div>

--- a/packages/apollo-react/src/canvas/components/NodePropertyPanel/index.ts
+++ b/packages/apollo-react/src/canvas/components/NodePropertyPanel/index.ts
@@ -1,6 +1,15 @@
 export type { ExpressionFieldProps, ExpressionMode } from './ExpressionField';
 export { ExpressionField } from './ExpressionField';
-export type { LockableValueFieldMode, LockableValueFieldProps } from './LockableValueField';
-export { LockableValueField } from './LockableValueField';
+export type {
+  LockableFieldType,
+  LockableValueFieldMode,
+  LockableValueFieldProps,
+} from './LockableValueField';
+export {
+  DEMO_SELECT_OPTIONS,
+  FIELD_TYPE_META,
+  LockableValueField,
+  parseListValue,
+} from './LockableValueField';
 export { NodePropertyPanel } from './NodePropertyPanel';
 export type { NodePropertyPanelProps } from './NodePropertyPanel.types';

--- a/packages/apollo-react/src/canvas/components/NodePropertyPanel/index.ts
+++ b/packages/apollo-react/src/canvas/components/NodePropertyPanel/index.ts
@@ -1,4 +1,6 @@
 export type { ExpressionFieldProps, ExpressionMode } from './ExpressionField';
 export { ExpressionField } from './ExpressionField';
+export type { LockableValueFieldMode, LockableValueFieldProps } from './LockableValueField';
+export { LockableValueField } from './LockableValueField';
 export { NodePropertyPanel } from './NodePropertyPanel';
 export type { NodePropertyPanelProps } from './NodePropertyPanel.types';

--- a/packages/apollo-wind/src/components/ui/switch.test.tsx
+++ b/packages/apollo-wind/src/components/ui/switch.test.tsx
@@ -135,14 +135,14 @@ describe('Switch', () => {
     it('renders sm size when size="sm"', () => {
       render(<Switch size="sm" aria-label="Toggle" />);
       const switchElement = screen.getByRole('switch');
-      expect(switchElement).toHaveClass('h-5', 'w-9');
+      expect(switchElement).toHaveClass('h-[14px]', 'w-[24px]');
       expect(switchElement).not.toHaveClass('h-6', 'w-11');
     });
 
     it('renders sm thumb when size="sm"', () => {
       render(<Switch size="sm" aria-label="Toggle" />);
       const thumb = screen.getByRole('switch').firstElementChild;
-      expect(thumb).toHaveClass('h-4', 'w-4');
+      expect(thumb).toHaveClass('size-3');
     });
 
     it('has no accessibility violations at sm size', async () => {

--- a/packages/apollo-wind/src/components/ui/switch.tsx
+++ b/packages/apollo-wind/src/components/ui/switch.tsx
@@ -5,12 +5,13 @@ import * as React from 'react';
 import { cn } from '@/lib';
 
 const switchVariants = cva(
-  'peer inline-flex shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-border',
+  'peer inline-flex shrink-0 cursor-pointer items-center rounded-full border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-border',
   {
     variants: {
       size: {
-        default: 'h-6 w-11',
-        sm: 'h-5 w-9',
+        default: 'h-6 w-11 border-2',
+        // Matches shadcn/ui's actual "Small" switch spec (track 14x24, thumb 12px).
+        sm: 'h-[14px] w-[24px] border',
       },
     },
     defaultVariants: {
@@ -25,7 +26,7 @@ const switchThumbVariants = cva(
     variants: {
       size: {
         default: 'h-5 w-5 data-[state=checked]:translate-x-5',
-        sm: 'h-4 w-4 data-[state=checked]:translate-x-4',
+        sm: 'size-3 data-[state=checked]:translate-x-[calc(100%-2px)]',
       },
     },
     defaultVariants: {

--- a/packages/apollo-wind/src/styles/tailwind.css
+++ b/packages/apollo-wind/src/styles/tailwind.css
@@ -11,3 +11,10 @@
 @import "./tailwind.consumer.css";
 
 @source "../**/*.{js,jsx,ts,tsx}";
+
+/* Storybook (apps/storybook/.storybook/preview.tsx) imports this file
+ * directly, making it the Tailwind entry point for the whole app — including
+ * apollo-react's canvas stories. Without this, utility classes unique to
+ * apollo-react (not already used somewhere in apollo-wind) silently produce
+ * no CSS, since they'd never be scanned otherwise. */
+@source "../../../apollo-react/src/**/*.{js,jsx,ts,tsx}";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -131,10 +131,10 @@ importers:
         version: 0.4.6(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       nextra:
         specifier: ^4.6.1
-        version: 4.6.1(next@16.2.6(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
+        version: 4.6.1(next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
       nextra-theme-docs:
         specifier: ^4.6.1
-        version: 4.6.1(@types/react@19.2.8)(next@16.2.6(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(nextra@4.6.1(next@16.2.6(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(use-sync-external-store@1.6.0(react@19.2.3))
+        version: 4.6.1(@types/react@19.2.8)(next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(nextra@4.6.1(next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(use-sync-external-store@1.6.0(react@19.2.3))
       postcss:
         specifier: ^8.5.14
         version: 8.5.15
@@ -336,10 +336,10 @@ importers:
         version: 0.4.6(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       nextra:
         specifier: ^4.6.1
-        version: 4.6.1(next@16.2.6(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
+        version: 4.6.1(next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
       nextra-theme-docs:
         specifier: ^4.6.1
-        version: 4.6.1(@types/react@19.2.8)(next@16.2.6(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(nextra@4.6.1(next@16.2.6(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(use-sync-external-store@1.6.0(react@19.2.3))
+        version: 4.6.1(@types/react@19.2.8)(next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(nextra@4.6.1(next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(use-sync-external-store@1.6.0(react@19.2.3))
       pkce-challenge:
         specifier: ^6.0.0
         version: 6.0.0
@@ -502,8 +502,8 @@ importers:
         specifier: ^10.4.1
         version: 10.4.2(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(esbuild@0.28.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.62.2)(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.8)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.9.3)(vite@7.3.6(@types/node@24.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.43.1)(tsx@4.22.4)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.28.1))
       '@tailwindcss/vite':
-        specifier: ^4.2.2
-        version: 4.2.2(vite@7.3.6(@types/node@24.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.43.1)(tsx@4.22.4)(yaml@2.8.3))
+        specifier: 4.3.0
+        version: 4.3.0(vite@7.3.6(@types/node@24.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.43.1)(tsx@4.22.4)(yaml@2.8.3))
       '@types/react':
         specifier: ^19.2.6
         version: 19.2.8
@@ -5781,21 +5781,12 @@ packages:
   '@tailwindcss/node@4.1.17':
     resolution: {integrity: sha512-csIkHIgLb3JisEFQ0vxr2Y57GUNYh447C8xzwj89U/8fdW8LhProdxvnVH6U8M2Y73QKiTIH+LWbK3V2BBZsAg==}
 
-  '@tailwindcss/node@4.2.2':
-    resolution: {integrity: sha512-pXS+wJ2gZpVXqFaUEjojq7jzMpTGf8rU6ipJz5ovJV6PUGmlJ+jvIwGrzdHdQ80Sg+wmQxUFuoW1UAAwHNEdFA==}
-
   '@tailwindcss/node@4.3.0':
     resolution: {integrity: sha512-aFb4gUhFOgdh9AXo4IzBEOzBkkAxm9VigwDJnMIYv3lcfXCJVesNfbEaBl4BNgVRyid92AmdviqwBUBRKSeY3g==}
 
   '@tailwindcss/oxide-android-arm64@4.1.17':
     resolution: {integrity: sha512-BMqpkJHgOZ5z78qqiGE6ZIRExyaHyuxjgrJ6eBO5+hfrfGkuya0lYfw8fRHG77gdTjWkNWEEm+qeG2cDMxArLQ==}
     engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [android]
-
-  '@tailwindcss/oxide-android-arm64@4.2.2':
-    resolution: {integrity: sha512-dXGR1n+P3B6748jZO/SvHZq7qBOqqzQ+yFrXpoOWWALWndF9MoSKAT3Q0fYgAzYzGhxNYOoysRvYlpixRBBoDg==}
-    engines: {node: '>= 20'}
     cpu: [arm64]
     os: [android]
 
@@ -5811,12 +5802,6 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@tailwindcss/oxide-darwin-arm64@4.2.2':
-    resolution: {integrity: sha512-iq9Qjr6knfMpZHj55/37ouZeykwbDqF21gPFtfnhCCKGDcPI/21FKC9XdMO/XyBM7qKORx6UIhGgg6jLl7BZlg==}
-    engines: {node: '>= 20'}
-    cpu: [arm64]
-    os: [darwin]
-
   '@tailwindcss/oxide-darwin-arm64@4.3.0':
     resolution: {integrity: sha512-oMN/WZRb+SO37BmUElEgeEWuU8E/HXRkiODxJxLe1UTHVXLrdVSgfaJV7pSlhRGMSOiXLuxTIjfsF3wYvz8cgQ==}
     engines: {node: '>= 20'}
@@ -5826,12 +5811,6 @@ packages:
   '@tailwindcss/oxide-darwin-x64@4.1.17':
     resolution: {integrity: sha512-gdhEPLzke2Pog8s12oADwYu0IAw04Y2tlmgVzIN0+046ytcgx8uZmCzEg4VcQh+AHKiS7xaL8kGo/QTiNEGRog==}
     engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [darwin]
-
-  '@tailwindcss/oxide-darwin-x64@4.2.2':
-    resolution: {integrity: sha512-BlR+2c3nzc8f2G639LpL89YY4bdcIdUmiOOkv2GQv4/4M0vJlpXEa0JXNHhCHU7VWOKWT/CjqHdTP8aUuDJkuw==}
-    engines: {node: '>= 20'}
     cpu: [x64]
     os: [darwin]
 
@@ -5847,12 +5826,6 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
-  '@tailwindcss/oxide-freebsd-x64@4.2.2':
-    resolution: {integrity: sha512-YUqUgrGMSu2CDO82hzlQ5qSb5xmx3RUrke/QgnoEx7KvmRJHQuZHZmZTLSuuHwFf0DJPybFMXMYf+WJdxHy/nQ==}
-    engines: {node: '>= 20'}
-    cpu: [x64]
-    os: [freebsd]
-
   '@tailwindcss/oxide-freebsd-x64@4.3.0':
     resolution: {integrity: sha512-zDL5hBkQdH5C6MpqbK3gQAgP80tsMwSI26vjOzjJtNCMUo0lFgOItzHKBIupOZNQxt3ouPH7RPhvNhiTfCe5CQ==}
     engines: {node: '>= 20'}
@@ -5865,12 +5838,6 @@ packages:
     cpu: [arm]
     os: [linux]
 
-  '@tailwindcss/oxide-linux-arm-gnueabihf@4.2.2':
-    resolution: {integrity: sha512-FPdhvsW6g06T9BWT0qTwiVZYE2WIFo2dY5aCSpjG/S/u1tby+wXoslXS0kl3/KXnULlLr1E3NPRRw0g7t2kgaQ==}
-    engines: {node: '>= 20'}
-    cpu: [arm]
-    os: [linux]
-
   '@tailwindcss/oxide-linux-arm-gnueabihf@4.3.0':
     resolution: {integrity: sha512-R06HdNi7A7OEoMsf6d4tjZ71RCWnZQPHj2mnotSFURjNLdBC+cIgXQ7l81CqeoiQftjf6OOblxXMInMgN2VzMA==}
     engines: {node: '>= 20'}
@@ -5880,13 +5847,6 @@ packages:
   '@tailwindcss/oxide-linux-arm64-gnu@4.1.17':
     resolution: {integrity: sha512-HVDOm/mxK6+TbARwdW17WrgDYEGzmoYayrCgmLEw7FxTPLcp/glBisuyWkFz/jb7ZfiAXAXUACfyItn+nTgsdQ==}
     engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-
-  '@tailwindcss/oxide-linux-arm64-gnu@4.2.2':
-    resolution: {integrity: sha512-4og1V+ftEPXGttOO7eCmW7VICmzzJWgMx+QXAJRAhjrSjumCwWqMfkDrNu1LXEQzNAwz28NCUpucgQPrR4S2yw==}
-    engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
@@ -5905,13 +5865,6 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@tailwindcss/oxide-linux-arm64-musl@4.2.2':
-    resolution: {integrity: sha512-oCfG/mS+/+XRlwNjnsNLVwnMWYH7tn/kYPsNPh+JSOMlnt93mYNCKHYzylRhI51X+TbR+ufNhhKKzm6QkqX8ag==}
-    engines: {node: '>= 20'}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
-
   '@tailwindcss/oxide-linux-arm64-musl@4.3.0':
     resolution: {integrity: sha512-Z6sukiQsngnWO+l39X4pPbiWT81IC+PLKF+PHxIlyZbGNb9MODfYlXEVlFvej5BOZInWX01kVyzeLvHsXhfczQ==}
     engines: {node: '>= 20'}
@@ -5922,13 +5875,6 @@ packages:
   '@tailwindcss/oxide-linux-x64-gnu@4.1.17':
     resolution: {integrity: sha512-M3XZuORCGB7VPOEDH+nzpJ21XPvK5PyjlkSFkFziNHGLc5d6g3di2McAAblmaSUNl8IOmzYwLx9NsE7bplNkwQ==}
     engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
-
-  '@tailwindcss/oxide-linux-x64-gnu@4.2.2':
-    resolution: {integrity: sha512-rTAGAkDgqbXHNp/xW0iugLVmX62wOp2PoE39BTCGKjv3Iocf6AFbRP/wZT/kuCxC9QBh9Pu8XPkv/zCZB2mcMg==}
-    engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
@@ -5947,13 +5893,6 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@tailwindcss/oxide-linux-x64-musl@4.2.2':
-    resolution: {integrity: sha512-XW3t3qwbIwiSyRCggeO2zxe3KWaEbM0/kW9e8+0XpBgyKU4ATYzcVSMKteZJ1iukJ3HgHBjbg9P5YPRCVUxlnQ==}
-    engines: {node: '>= 20'}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
-
   '@tailwindcss/oxide-linux-x64-musl@4.3.0':
     resolution: {integrity: sha512-Z0IADbDo8bh6I7h2IQMx601AdXBLfFpEdUotft86evd/8ZPflZe9COPO8Q1vw+pfLWIUo9zN/JGZvwuAJqduqg==}
     engines: {node: '>= 20'}
@@ -5963,18 +5902,6 @@ packages:
 
   '@tailwindcss/oxide-wasm32-wasi@4.1.17':
     resolution: {integrity: sha512-cEytGqSSoy7zK4JRWiTCx43FsKP/zGr0CsuMawhH67ONlH+T79VteQeJQRO/X7L0juEUA8ZyuYikcRBf0vsxhg==}
-    engines: {node: '>=14.0.0'}
-    cpu: [wasm32]
-    bundledDependencies:
-      - '@napi-rs/wasm-runtime'
-      - '@emnapi/core'
-      - '@emnapi/runtime'
-      - '@tybys/wasm-util'
-      - '@emnapi/wasi-threads'
-      - tslib
-
-  '@tailwindcss/oxide-wasm32-wasi@4.2.2':
-    resolution: {integrity: sha512-eKSztKsmEsn1O5lJ4ZAfyn41NfG7vzCg496YiGtMDV86jz1q/irhms5O0VrY6ZwTUkFy/EKG3RfWgxSI3VbZ8Q==}
     engines: {node: '>=14.0.0'}
     cpu: [wasm32]
     bundledDependencies:
@@ -6003,12 +5930,6 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@tailwindcss/oxide-win32-arm64-msvc@4.2.2':
-    resolution: {integrity: sha512-qPmaQM4iKu5mxpsrWZMOZRgZv1tOZpUm+zdhhQP0VhJfyGGO3aUKdbh3gDZc/dPLQwW4eSqWGrrcWNBZWUWaXQ==}
-    engines: {node: '>= 20'}
-    cpu: [arm64]
-    os: [win32]
-
   '@tailwindcss/oxide-win32-arm64-msvc@4.3.0':
     resolution: {integrity: sha512-Pe+RPVTi1T+qymuuRpcdvwSVZjnll/f7n8gBxMMh3xLTctMDKqpdfGimbMyioqtLhUYZxdJ9wGNhV7MKHvgZsQ==}
     engines: {node: '>= 20'}
@@ -6018,12 +5939,6 @@ packages:
   '@tailwindcss/oxide-win32-x64-msvc@4.1.17':
     resolution: {integrity: sha512-SKWM4waLuqx0IH+FMDUw6R66Hu4OuTALFgnleKbqhgGU30DY20NORZMZUKgLRjQXNN2TLzKvh48QXTig4h4bGw==}
     engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [win32]
-
-  '@tailwindcss/oxide-win32-x64-msvc@4.2.2':
-    resolution: {integrity: sha512-1T/37VvI7WyH66b+vqHj/cLwnCxt7Qt3WFu5Q8hk65aOvlwAhs7rAp1VkulBJw/N4tMirXjVnylTR72uI0HGcA==}
-    engines: {node: '>= 20'}
     cpu: [x64]
     os: [win32]
 
@@ -6037,10 +5952,6 @@ packages:
     resolution: {integrity: sha512-F0F7d01fmkQhsTjXezGBLdrl1KresJTcI3DB8EkScCldyKp3Msz4hub4uyYaVnk88BAS1g5DQjjF6F5qczheLA==}
     engines: {node: '>= 10'}
 
-  '@tailwindcss/oxide@4.2.2':
-    resolution: {integrity: sha512-qEUA07+E5kehxYp9BVMpq9E8vnJuBHfJEC0vPC5e7iL/hw7HR61aDKoVoKzrG+QKp56vhNZe4qwkRmMC0zDLvg==}
-    engines: {node: '>= 20'}
-
   '@tailwindcss/oxide@4.3.0':
     resolution: {integrity: sha512-F7HZGBeN9I0/AuuJS5PwcD8xayx5ri5GhjYUDBEVYUkexyA/giwbDNjRVrxSezE3T250OU2K/wp/ltWx3UOefg==}
     engines: {node: '>= 20'}
@@ -6048,8 +5959,8 @@ packages:
   '@tailwindcss/postcss@4.3.0':
     resolution: {integrity: sha512-Jm05Tjx+9yCLGv5qw1c+84Psds8MnyrEQYCB+FFk2lgGiUjlRqdxke4mVTuYrj2xnVZqKim2Apr5ySuQRYAw/w==}
 
-  '@tailwindcss/vite@4.2.2':
-    resolution: {integrity: sha512-mEiF5HO1QqCLXoNEfXVA1Tzo+cYsrqV7w9Juj2wdUFyW07JRenqMG225MvPwr3ZD9N1bFQj46X7r33iHxLUW0w==}
+  '@tailwindcss/vite@4.3.0':
+    resolution: {integrity: sha512-t6J3OrB5Fc0ExuhohouH0fWUGMYL6PTLhW+E7zIk/pdbnJARZDCwjBznFnkh5ynRnIRSI4YjtTH0t6USjJISrw==}
     peerDependencies:
       vite: ^5.2.0 || ^6 || ^7 || ^8
 
@@ -12422,9 +12333,6 @@ packages:
   tailwindcss@4.1.17:
     resolution: {integrity: sha512-j9Ee2YjuQqYT9bbRTfTZht9W/ytp5H+jJpZKiYdP/bpnXARAuELt9ofP0lPnmHjbga7SNQIxdTAXCmtKVYjN+Q==}
 
-  tailwindcss@4.2.2:
-    resolution: {integrity: sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q==}
-
   tailwindcss@4.3.0:
     resolution: {integrity: sha512-y6nxMGB1nMW9R6k96e5gdIFzcfL/gTJRNaqGes1YvkLnPVXzWgbqFF2yLC0T8G774n24cx3Pe8XrKoniCOAH+Q==}
 
@@ -18120,16 +18028,6 @@ snapshots:
       source-map-js: 1.2.1
       tailwindcss: 4.1.17
 
-  '@tailwindcss/node@4.2.2':
-    dependencies:
-      '@jridgewell/remapping': 2.3.5
-      enhanced-resolve: 5.20.0
-      jiti: 2.6.1
-      lightningcss: 1.32.0
-      magic-string: 0.30.21
-      source-map-js: 1.2.1
-      tailwindcss: 4.2.2
-
   '@tailwindcss/node@4.3.0':
     dependencies:
       '@jridgewell/remapping': 2.3.5
@@ -18143,16 +18041,10 @@ snapshots:
   '@tailwindcss/oxide-android-arm64@4.1.17':
     optional: true
 
-  '@tailwindcss/oxide-android-arm64@4.2.2':
-    optional: true
-
   '@tailwindcss/oxide-android-arm64@4.3.0':
     optional: true
 
   '@tailwindcss/oxide-darwin-arm64@4.1.17':
-    optional: true
-
-  '@tailwindcss/oxide-darwin-arm64@4.2.2':
     optional: true
 
   '@tailwindcss/oxide-darwin-arm64@4.3.0':
@@ -18161,16 +18053,10 @@ snapshots:
   '@tailwindcss/oxide-darwin-x64@4.1.17':
     optional: true
 
-  '@tailwindcss/oxide-darwin-x64@4.2.2':
-    optional: true
-
   '@tailwindcss/oxide-darwin-x64@4.3.0':
     optional: true
 
   '@tailwindcss/oxide-freebsd-x64@4.1.17':
-    optional: true
-
-  '@tailwindcss/oxide-freebsd-x64@4.2.2':
     optional: true
 
   '@tailwindcss/oxide-freebsd-x64@4.3.0':
@@ -18179,16 +18065,10 @@ snapshots:
   '@tailwindcss/oxide-linux-arm-gnueabihf@4.1.17':
     optional: true
 
-  '@tailwindcss/oxide-linux-arm-gnueabihf@4.2.2':
-    optional: true
-
   '@tailwindcss/oxide-linux-arm-gnueabihf@4.3.0':
     optional: true
 
   '@tailwindcss/oxide-linux-arm64-gnu@4.1.17':
-    optional: true
-
-  '@tailwindcss/oxide-linux-arm64-gnu@4.2.2':
     optional: true
 
   '@tailwindcss/oxide-linux-arm64-gnu@4.3.0':
@@ -18197,16 +18077,10 @@ snapshots:
   '@tailwindcss/oxide-linux-arm64-musl@4.1.17':
     optional: true
 
-  '@tailwindcss/oxide-linux-arm64-musl@4.2.2':
-    optional: true
-
   '@tailwindcss/oxide-linux-arm64-musl@4.3.0':
     optional: true
 
   '@tailwindcss/oxide-linux-x64-gnu@4.1.17':
-    optional: true
-
-  '@tailwindcss/oxide-linux-x64-gnu@4.2.2':
     optional: true
 
   '@tailwindcss/oxide-linux-x64-gnu@4.3.0':
@@ -18215,16 +18089,10 @@ snapshots:
   '@tailwindcss/oxide-linux-x64-musl@4.1.17':
     optional: true
 
-  '@tailwindcss/oxide-linux-x64-musl@4.2.2':
-    optional: true
-
   '@tailwindcss/oxide-linux-x64-musl@4.3.0':
     optional: true
 
   '@tailwindcss/oxide-wasm32-wasi@4.1.17':
-    optional: true
-
-  '@tailwindcss/oxide-wasm32-wasi@4.2.2':
     optional: true
 
   '@tailwindcss/oxide-wasm32-wasi@4.3.0':
@@ -18233,16 +18101,10 @@ snapshots:
   '@tailwindcss/oxide-win32-arm64-msvc@4.1.17':
     optional: true
 
-  '@tailwindcss/oxide-win32-arm64-msvc@4.2.2':
-    optional: true
-
   '@tailwindcss/oxide-win32-arm64-msvc@4.3.0':
     optional: true
 
   '@tailwindcss/oxide-win32-x64-msvc@4.1.17':
-    optional: true
-
-  '@tailwindcss/oxide-win32-x64-msvc@4.2.2':
     optional: true
 
   '@tailwindcss/oxide-win32-x64-msvc@4.3.0':
@@ -18262,21 +18124,6 @@ snapshots:
       '@tailwindcss/oxide-wasm32-wasi': 4.1.17
       '@tailwindcss/oxide-win32-arm64-msvc': 4.1.17
       '@tailwindcss/oxide-win32-x64-msvc': 4.1.17
-
-  '@tailwindcss/oxide@4.2.2':
-    optionalDependencies:
-      '@tailwindcss/oxide-android-arm64': 4.2.2
-      '@tailwindcss/oxide-darwin-arm64': 4.2.2
-      '@tailwindcss/oxide-darwin-x64': 4.2.2
-      '@tailwindcss/oxide-freebsd-x64': 4.2.2
-      '@tailwindcss/oxide-linux-arm-gnueabihf': 4.2.2
-      '@tailwindcss/oxide-linux-arm64-gnu': 4.2.2
-      '@tailwindcss/oxide-linux-arm64-musl': 4.2.2
-      '@tailwindcss/oxide-linux-x64-gnu': 4.2.2
-      '@tailwindcss/oxide-linux-x64-musl': 4.2.2
-      '@tailwindcss/oxide-wasm32-wasi': 4.2.2
-      '@tailwindcss/oxide-win32-arm64-msvc': 4.2.2
-      '@tailwindcss/oxide-win32-x64-msvc': 4.2.2
 
   '@tailwindcss/oxide@4.3.0':
     optionalDependencies:
@@ -18301,11 +18148,11 @@ snapshots:
       postcss: 8.5.15
       tailwindcss: 4.3.0
 
-  '@tailwindcss/vite@4.2.2(vite@7.3.6(@types/node@24.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.43.1)(tsx@4.22.4)(yaml@2.8.3))':
+  '@tailwindcss/vite@4.3.0(vite@7.3.6(@types/node@24.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.43.1)(tsx@4.22.4)(yaml@2.8.3))':
     dependencies:
-      '@tailwindcss/node': 4.2.2
-      '@tailwindcss/oxide': 4.2.2
-      tailwindcss: 4.2.2
+      '@tailwindcss/node': 4.3.0
+      '@tailwindcss/oxide': 4.3.0
+      tailwindcss: 4.3.0
       vite: 7.3.6(@types/node@24.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.43.1)(tsx@4.22.4)(yaml@2.8.3)
 
   '@tanstack/ai-client@0.8.0':
@@ -23379,13 +23226,13 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
-  nextra-theme-docs@4.6.1(@types/react@19.2.8)(next@16.2.6(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(nextra@4.6.1(next@16.2.6(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(use-sync-external-store@1.6.0(react@19.2.3)):
+  nextra-theme-docs@4.6.1(@types/react@19.2.8)(next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(nextra@4.6.1(next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(use-sync-external-store@1.6.0(react@19.2.3)):
     dependencies:
       '@headlessui/react': 2.2.9(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       clsx: 2.1.1
       next: 16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       next-themes: 0.4.6(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      nextra: 4.6.1(next@16.2.6(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
+      nextra: 4.6.1(next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
       react: 19.2.3
       react-compiler-runtime: 19.1.0-rc.3(react@19.2.3)
       react-dom: 19.2.3(react@19.2.3)
@@ -23397,7 +23244,7 @@ snapshots:
       - immer
       - use-sync-external-store
 
-  nextra@4.6.1(next@16.2.6(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3):
+  nextra@4.6.1(next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3):
     dependencies:
       '@formatjs/intl-localematcher': 0.6.2
       '@headlessui/react': 2.2.9(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -25939,8 +25786,6 @@ snapshots:
   tailwind-merge@3.6.0: {}
 
   tailwindcss@4.1.17: {}
-
-  tailwindcss@4.2.2: {}
 
   tailwindcss@4.3.0: {}
 


### PR DESCRIPTION
## Summary
Prototype for a **Quick Approve** HITL panel demonstrating quick-form building and review inside the Property Panel experience, built on the `InputGroup` primitive from #890.

- **`LockableValueField`** — a reusable field that can be locked to read-only and typed as one of several field types (String, Integer, Date, Boolean, Single select, Multiselect, File):
  - Left lock icon → popover with Unlocked / Locked. Locked fields render as plain read-only text (not a disabled control) across every field type, showing "String value" / "Write a string expression" as placeholder text depending on Fixed vs Expression mode.
  - Right type icon → popover with Fixed value / Expression, styling the value as code in Expression mode.
  - Compact container support: a Required-field toggle that collapses to an icon + popover at narrow widths.
  - AI-assist popover (describe what you want → Generate) and an Insert-variable affordance.

- **"Form HITL" story** — the quick-form builder page:
  - Panel header, tabs (Parameters / Branching / Error handling), delivery-channel multi-select, and assignment search, matching other panel stories.
  - Draggable, reorderable field list (`@dnd-kit`, same pattern as `StageNode`) with a `DragOverlay` + synced insertion-line indicator.
  - "+ Add field" / "Add button" popover (two flat actions — no submenu) positioned above the button row.
  - Inline-editable form buttons (Approve/Cancel/custom): click to rename, hover to reveal an edit icon that expands the button and opens a Type (Primary/Secondary) + Delete popover. Buttons are sized to match the input rows.
  - UI / JSON view toggle plus a "more options" menu (Preview, Get URL, Describe-the-form-you-want AI stub).
  - Upload icon with a hover-card describing accepted file types/size.

- **"Form HITL Review" story** — a read-only reviewer view of the same form (Reject/Approve actions in the header), sharing the same field-rendering logic as the builder's Preview mode.

- **`apollo-wind` Switch** — added a proper `sm` size matching shadcn/ui's actual "Small" switch spec (14×24 track, 12px thumb); `default` size is unchanged.

## Notes for reviewers
- This is a **review prototype**, not production-wired — no schema/backend integration yet, and the AI-assist / Describe-the-form-you-want / Get URL actions are UI-only stubs.
- The requested `user-round-arrow-left` icon isn't in the installed `lucide-react@0.577.0` (added in `1.20.0`); used `UserRoundCheck` instead rather than bumping a shared dependency across a major version for one icon.
- Drag-and-drop uses the `@dnd-kit` dependency already used by `StageNode`, following the same sensor + overlay convention.

## Test plan
- [x] `pnpm exec tsc --noEmit` — clean
- [x] `pnpm biome check` — clean
- [x] `pnpm vitest run` (NodePropertyPanel, Switch) — all existing tests pass, no regressions
- [x] Manually verified in Storybook: lock/unlock read-only behavior across all field types, Fixed/Expression mode + placeholder text, Required toggle (full + compact), drag-reorder, Add field/Add button, inline button editing + Type/Delete popover, button sizing, UI/JSON/Preview toggle, more-options menu, upload hover-card, tab labels, Form HITL Review parity

🤖 Generated with [Claude Code](https://claude.com/claude-code)
