### PR TITLE
feat(apollo-react): add asterisk for required tasks [MST-11607]

### DIFF
--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.stories.tsx
@@ -158,10 +158,18 @@ const sampleTasks: StageTaskItem[][] = [
       id: 'address_verification',
       label: 'Address Verification and a really long label that might wrap',
       icon: <VerificationIcon />,
+      isRequired: true,
     },
     { id: 'property_verification', label: 'Property Verification', icon: <VerificationIcon /> },
   ],
-  [{ id: 'processing_review', label: 'Processing Review', icon: <ProcessIcon /> }],
+  [
+    {
+      id: 'processing_review',
+      label: 'Processing Review',
+      icon: <ProcessIcon />,
+      isRequired: true,
+    },
+  ],
 ];
 
 export const Default: Story = {

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.types.ts
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.types.ts
@@ -24,6 +24,7 @@ export interface StageTaskItem {
   id: string;
   label: string;
   icon?: React.ReactElement;
+  isRequired?: boolean;
   isAdhoc?: boolean;
   isPlaceholder?: boolean;
   taskGroupType?: 'sequential' | 'event-driven' | 'adhoc';

--- a/packages/apollo-react/src/canvas/components/StageNode/TaskContent.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/TaskContent.tsx
@@ -158,7 +158,18 @@ export const TaskContent = memo(
               smartTooltip
               {...(isDragging && { isOpen: false })}
             >
-              <span className="text-sm truncate">{task.label}</span>
+              <Row
+                gap={Spacing.SpacingXs}
+                align="center"
+                style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
+              >
+                <span className="text-sm truncate">{task.label}</span>
+                {task.isRequired && (
+                  <span className="text-sm" style={{ flexShrink: 0 }}>
+                    {'*'}
+                  </span>
+                )}
+              </Row>
             </CanvasTooltip>
           </Row>
           <Row align="center" gap={Spacing.SpacingXs} style={{ flexShrink: 0 }}>


### PR DESCRIPTION
https://uipath.atlassian.net/browse/MST-11607

In the Stage node, this adds an asterisk to all tasks marked as required, and properly cuts off the task name before it would cut off the asterisk

<img width="1007" height="701" alt="Screenshot 2026-07-08 at 3 26 05 PM" src="https://github.com/user-attachments/assets/53e64c20-d046-466f-944a-409d2a74f078" />
