### PR TITLE
perf(apollo-wind): use cnfast for class merging

### DIFF
--- a/packages/apollo-wind/package.json
+++ b/packages/apollo-wind/package.json
@@ -120,7 +120,7 @@
     "@uipath/apollo-core": "workspace:*",
     "autoprefixer": "^10.4.22",
     "class-variance-authority": "^0.7.1",
-    "clsx": "^2.1.1",
+    "cnfast": "0.0.8",
     "cmdk": "^1.1.1",
     "date-fns": "^4.1.0",
     "dompurify": "^3.4.0",
@@ -136,7 +136,6 @@
     "react-resizable-panels": "^4.7.3",
     "recharts": "2.15.4",
     "sonner": "^2.0.7",
-    "tailwind-merge": "^3.4.0",
     "tailwindcss": "^4.1.17",
     "vaul": "^1.1.2",
     "zod": "^4.3.5"

--- a/packages/apollo-wind/src/lib/utils.ts
+++ b/packages/apollo-wind/src/lib/utils.ts
@@ -1,13 +1,4 @@
-import { type ClassValue, clsx } from 'clsx';
-import { twMerge } from 'tailwind-merge';
-
-/**
- * Utility function to merge Tailwind CSS classes with proper precedence
- * Uses clsx for conditional classes and tailwind-merge for deduplication
- */
-export function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs));
-}
+export { cn } from 'cnfast';
 
 /**
  * Safely get a nested value from an object using dot notation

--- a/packages/apollo-wind/src/lib/utils.ts
+++ b/packages/apollo-wind/src/lib/utils.ts
@@ -1,4 +1,12 @@
-export { cn } from 'cnfast';
+import { type ClassValue, cn as cnfast } from 'cnfast';
+
+/**
+ * Utility function to merge Tailwind CSS classes with proper precedence
+ * Uses cnfast for conditional classes and deduplication
+ */
+export function cn(...inputs: ClassValue[]): string {
+  return cnfast(...inputs);
+}
 
 /**
  * Safely get a nested value from an object using dot notation

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1033,9 +1033,9 @@ importers:
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
-      clsx:
-        specifier: ^2.1.1
-        version: 2.1.1
+      cnfast:
+        specifier: 0.0.8
+        version: 0.0.8
       cmdk:
         specifier: ^1.1.1
         version: 1.1.1(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -1081,9 +1081,6 @@ importers:
       sonner:
         specifier: ^2.0.7
         version: 2.0.7(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      tailwind-merge:
-        specifier: ^3.4.0
-        version: 3.6.0
       tailwindcss:
         specifier: ^4.1.17
         version: 4.3.0
@@ -7186,6 +7183,10 @@ packages:
     peerDependencies:
       react: ^18 || ^19 || ^19.0.0-rc
       react-dom: ^18 || ^19 || ^19.0.0-rc
+
+  cnfast@0.0.8:
+    resolution: {integrity: sha512-EjXKMfGfdwtV4AcNSQ6AwQaVzpC1B7IxeiwA3FlhTXz+YFlMKVi4c1JX9tgD2QOlahQXjB8KUXrBaYG+3v871Q==}
+    hasBin: true
 
   code-block-writer@13.0.3:
     resolution: {integrity: sha512-Oofo0pq3IKnsFtuHqSF7TqBfr71aeyZDVJ0HpmqB7FBM2qEigL0iPONSCZSO9pE9dZTAxANe5XHG9Uy0YMv8cg==}
@@ -19398,6 +19399,8 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react'
       - '@types/react-dom'
+
+  cnfast@0.0.8: {}
 
   code-block-writer@13.0.3: {}
 


### PR DESCRIPTION
## Summary

- Replace Apollo Wind's shared `cn` implementation with [`cnfast`](https://github.com/aidenybai/cnfast).
- Remove Apollo Wind's direct runtime dependency on `clsx` and `tailwind-merge`.
- Keep the final diff focused on the production migration; the temporary benchmark harness was removed before this PR.

## Benchmarking

Benchmarks were run locally before removing the harness from the final diff.

Command:

```sh
pnpm --filter @uipath/apollo-wind bench:cn
```

Benchmark corpus:

- `packages/apollo-wind/src`: 155 files
- `packages/apollo-react/src/canvas`: 387 files
- Apollo React perf stories: `CanvasPerformance.stories.tsx`, `Flow.stories.tsx`
- Total source profiles: 544 files
- Harvested class strings: 2,934
- Parity: 0 mismatches across 17,241 generated Apollo cases

| Workload | Cases/pass | Old `twMerge(clsx)` time/pass | `cnfast` time/pass | Speedup | Saved/pass |
| --- | ---: | ---: | ---: | ---: | ---: |
| Apollo `cn()` call-site replay | 707 | 3.53 ms | 0.06 ms | 54.73x | 3.47 ms |
| Apollo class corpus/cache pressure | 2,934 | 44.99 ms | 15.03 ms | 2.99x | 29.96 ms |
| Consumer override matrix | 1,600 | 25.97 ms | 6.77 ms | 3.83x | 19.20 ms |
| Live grid frame stress | 12,000 | 252.24 ms | 75.85 ms | 3.33x | 176.38 ms |

Notes:

- The call-site replay is the closest profile to real Apollo code shape: it materializes actual `cn(...)` calls from Apollo Wind and Apollo React canvas sources, including the existing perf stories.
- The class corpus/cache-pressure profile stresses broad Tailwind conflict resolution across harvested Apollo class strings plus arbitrary values and consumer overrides.
- The consumer override matrix models Apollo base component classes merged with likely downstream `className` overrides.
- These numbers isolate class merging cost only. They do not include React reconciliation, layout, paint, browser scheduling, or FPS.

## Supply-chain and compatibility checks

- `cnfast` is pinned to exact version `0.0.8` in `packages/apollo-wind/package.json` and `pnpm-lock.yaml`.
- The package has no runtime `dependencies` and no install-time lifecycle scripts in its published `package.json`.
- It does expose a CLI binary via `bin`, but Apollo Wind imports only the package entrypoint. The binary is not executed by this change.
- `cnfast` publishes conditional exports for both ESM and CJS:
  - `import` -> `dist/index.mjs`
  - `require` -> `dist/index.cjs`
- Apollo Wind build output was checked:
  - ESM output imports `cnfast`.
  - CJS output requires `cnfast`.
  - Generated declarations keep a local Apollo Wind `cn(...inputs): string` wrapper signature.
- Local smoke checks passed for both module modes:
  - `require('cnfast').cn('px-2', 'px-4') === 'px-4'`
  - `import { cn } from 'cnfast'; cn('px-2', 'px-4') === 'px-4'`
- Automated PR supply-chain/security checks passed on GitHub, including dependency review, production dependency audit, package signature audit, license check, Socket Security, and CodeQL. If a separate manual third-party approval is required, this PR should remain draft until that approval is complete.

## Validation

- `pnpm --filter @uipath/apollo-wind exec biome lint src/lib/utils.ts package.json`
- `pnpm --filter @uipath/apollo-wind test -- src/lib/utils.test.ts`
  - 60 files passed
  - 982 tests passed
- `pnpm --filter @uipath/apollo-wind build`
