### PR TITLE
fix(apollo-wind): improve Tooltip color contrast (MST-11921)

### DIFF
--- a/packages/apollo-wind/src/components/ui/tooltip.stories.tsx
+++ b/packages/apollo-wind/src/components/ui/tooltip.stories.tsx
@@ -166,11 +166,11 @@ export const TooltipWithRichContent = {
           <TooltipContent className="w-64 p-3">
             <div className="space-y-2">
               <p className="text-sm font-medium">Rate Limiting</p>
-              <p className="text-xs text-muted-foreground">
+              <p className="text-xs text-foreground-inverse/70">
                 Your current plan allows 1,000 requests per minute. Exceeding this limit will result
                 in 429 errors.
               </p>
-              <div className="flex items-center gap-1 text-xs text-muted-foreground">
+              <div className="flex items-center gap-1 text-xs text-foreground-inverse/70">
                 <Keyboard className="h-3 w-3" />
                 Press ⌘K to view full docs
               </div>
@@ -188,10 +188,10 @@ export const TooltipWithRichContent = {
           <TooltipContent className="w-56 p-3">
             <div className="space-y-2">
               <p className="text-sm font-medium">Storage Usage</p>
-              <div className="h-1.5 w-full rounded-full bg-secondary">
+              <div className="h-1.5 w-full rounded-full bg-foreground-inverse/15">
                 <div className="h-full w-3/4 rounded-full bg-primary" />
               </div>
-              <p className="text-xs text-muted-foreground">7.5 GB of 10 GB used</p>
+              <p className="text-xs text-foreground-inverse/70">7.5 GB of 10 GB used</p>
             </div>
           </TooltipContent>
         </Tooltip>
@@ -231,7 +231,9 @@ export const TooltipWithDifferentContent = {
           <TooltipContent>
             <div className="flex items-center gap-2">
               <span>Save</span>
-              <kbd className="rounded border bg-muted px-1.5 py-0.5 text-[10px] font-mono">⌘S</kbd>
+              <kbd className="rounded border border-foreground-inverse/20 bg-foreground-inverse/10 px-1.5 py-0.5 text-[10px] font-mono">
+                ⌘S
+              </kbd>
             </div>
           </TooltipContent>
         </Tooltip>
@@ -376,7 +378,7 @@ export const Examples = {
                     <div className="flex items-center gap-2">
                       <span>{item.label}</span>
                       {item.shortcut && (
-                        <kbd className="rounded border bg-muted px-1.5 py-0.5 text-[10px] font-mono">
+                        <kbd className="rounded border border-foreground-inverse/20 bg-foreground-inverse/10 px-1.5 py-0.5 text-[10px] font-mono">
                           {item.shortcut}
                         </kbd>
                       )}

--- a/packages/apollo-wind/src/components/ui/tooltip.tsx
+++ b/packages/apollo-wind/src/components/ui/tooltip.tsx
@@ -19,7 +19,7 @@ const TooltipContent = React.forwardRef<
     ref={ref}
     sideOffset={sideOffset}
     className={cn(
-      'z-50 overflow-hidden rounded-md border border-border-subtle bg-popover px-3 py-1.5 text-sm text-popover-foreground shadow-md animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-tooltip-content-transform-origin]',
+      'z-50 overflow-hidden rounded-md border border-border-inverse bg-surface-inverse px-3 py-1.5 text-sm text-foreground-inverse shadow-md animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-tooltip-content-transform-origin]',
       className
     )}
     {...props}


### PR DESCRIPTION
## Summary
- Users reported that Tooltip content had too little contrast against the app background, most noticeably in Future Dark, where the tooltip surface was nearly indistinguishable from the page.
- `TooltipContent` was using the same `bg-popover`/`text-popover-foreground` surface family as dialogs and dropdowns, deliberately close in luminance to the page background. That produced a tooltip-to-page contrast ratio of roughly 1.0-1.2:1 across all four core themes (Light, Dark, Future Light, Future Dark), far under the WCAG 3:1 minimum for UI component boundaries.
- Switched `TooltipContent` to the existing `surface-inverse` / `foreground-inverse` / `border-inverse` tokens, the same inversion pattern shadcn/ui itself uses for its own Tooltip (`bg-foreground` / `text-background`). Measured contrast after the change: 15.6-19.1:1 across all four themes.
- Updated the story examples' keyboard-shortcut chips and de-emphasized text/progress-bar colors, which were tuned for the old non-inverted surface and no longer read correctly on the new inverted background.

## Measured contrast (tooltip bg vs. page bg)
| Theme | Before | After |
|---|---|---|
| Light | 1.00:1 | 16.47:1 |
| Dark | 1.24:1 | 15.63:1 |
| Future Light | 1.05:1 | 19.06:1 |
| Future Dark | 1.12:1 | 19.06:1 |

## Test plan
- [x] `biome lint` on changed files, no issues
- [x] `tsc --noEmit` on `apollo-wind` package, no errors
- [x] `vitest run tooltip.test.tsx`, 13/13 passing
- [ ] Engineers to visually confirm in Storybook: `Components/Overlays/Tooltip`, across Light/Dark/Future Light/Future Dark themes

<img width="1065" height="1439" alt="tooltip-solutions" src="https://github.com/user-attachments/assets/1564f163-5384-49ee-8583-88f426e55032" />
