### PR TITLE
fix(apollo-react): stage task entry-condition icon sizing and icon-row spacing

### DIFF
--- a/packages/apollo-react/src/canvas/components/StageNode/StageTaskEntryConditionIcon.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageTaskEntryConditionIcon.tsx
@@ -21,6 +21,8 @@ export const StageTaskEntryConditionIcon = ({
           justifyContent: 'center',
           color: 'var(--color-icon-default)',
           flexShrink: 0,
+          // Optically centre the diamond; the adjacent play button sits inset (more so when small).
+          transform: small ? 'translateX(1px)' : 'translateX(0.5px)',
         }}
       >
         <EntryConditionIcon w={small ? 16 : 20} h={small ? 16 : 20} />

--- a/packages/apollo-react/src/canvas/components/StageNode/StageTaskEntryConditionIcon.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageTaskEntryConditionIcon.tsx
@@ -22,6 +22,7 @@ export const StageTaskEntryConditionIcon = ({
           color: 'var(--color-icon-default)',
           flexShrink: 0,
           // Optically centre the diamond; the adjacent play button sits inset (more so when small).
+          // Value is in canvas-local px, so it renders ×canvas zoom — roughly 1–3px on screen in practice.
           transform: small ? 'translateX(1px)' : 'translateX(0.5px)',
         }}
       >

--- a/packages/apollo-react/src/canvas/components/StageNode/TaskContent.test.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/TaskContent.test.tsx
@@ -27,11 +27,13 @@ const baseTask: StageTaskItem = { id: 'task-1', label: 'Run extraction' };
 const renderTaskContent = (overrides?: {
   task?: Partial<StageTaskItem>;
   taskExecution?: StageTaskExecution;
+  onTaskPlay?: (taskId: string) => Promise<void>;
 }) =>
   render(
     <TaskContent
       task={{ ...baseTask, ...overrides?.task }}
       taskExecution={overrides?.taskExecution}
+      onTaskPlay={overrides?.onTaskPlay}
     />
   );
 
@@ -183,5 +185,70 @@ describe('TaskContent - duration tooltip', () => {
     const durationText = screen.getByText('6s');
     const tooltipWrapper = durationText.closest('[data-testid="canvas-tooltip"]');
     expect(tooltipWrapper).toBeNull();
+  });
+});
+
+describe('TaskContent - entry-condition icon', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const getEntryIcon = (container: HTMLElement) =>
+    container.querySelector('[data-tooltip-content="Entry condition"] svg');
+
+  it('renders no entry-condition icon when the task has none', () => {
+    const { container } = renderTaskContent();
+    expect(getEntryIcon(container)).toBeNull();
+  });
+
+  it('renders a 20px entry-condition diamond on a single-row task', () => {
+    const { container } = renderTaskContent({ task: { hasEntryCondition: true } });
+    const icon = getEntryIcon(container);
+    expect(icon).toHaveAttribute('width', '20');
+    expect(icon).toHaveAttribute('height', '20');
+  });
+
+  it('renders a 16px entry-condition diamond on a task with second-row content', () => {
+    const { container } = renderTaskContent({
+      task: { hasEntryCondition: true },
+      taskExecution: { status: 'Completed', duration: '1m' },
+    });
+    const icon = getEntryIcon(container);
+    expect(icon).toHaveAttribute('width', '16');
+    expect(icon).toHaveAttribute('height', '16');
+  });
+});
+
+describe('TaskContent - play button placement', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const playButtonId = `stage-task-play-${baseTask.id}`;
+
+  it('renders a play button with an accessible name when a play handler is supplied', () => {
+    renderTaskContent({ onTaskPlay: vi.fn(async () => {}) });
+    expect(screen.getByRole('button', { name: 'Trigger task' })).toBeInTheDocument();
+    expect(screen.getByTestId(playButtonId)).toBeInTheDocument();
+  });
+
+  it('renders no play button when no play handler is supplied', () => {
+    renderTaskContent();
+    expect(screen.queryByTestId(playButtonId)).not.toBeInTheDocument();
+  });
+
+  it('renders the small play button on the second row for executed tasks with row content', () => {
+    renderTaskContent({
+      onTaskPlay: vi.fn(async () => {}),
+      taskExecution: { status: 'Completed', duration: '1m' },
+    });
+    const playButton = screen.getByTestId(playButtonId);
+    // small variant shrinks the icon via the button's descendant selector
+    expect(playButton.className).toContain('[&_svg]:size-3.5');
+  });
+
+  it('renders no play button for executed tasks without a play handler', () => {
+    renderTaskContent({ taskExecution: { status: 'Completed', duration: '1m' } });
+    expect(screen.queryByTestId(playButtonId)).not.toBeInTheDocument();
   });
 });

--- a/packages/apollo-react/src/canvas/components/StageNode/TaskContent.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/TaskContent.tsx
@@ -2,9 +2,9 @@ import { Padding, Spacing } from '@uipath/apollo-core';
 import { Column, Row } from '@uipath/apollo-react/canvas/layouts';
 import { Badge, Button, Spinner } from '@uipath/apollo-wind';
 import debounce from 'debounce';
+import { CirclePlay } from 'lucide-react';
 import { memo, useCallback, useMemo, useState } from 'react';
 import { useSafeLingui } from '../../../i18n';
-import { TimelinePlayIcon } from '../../icons';
 import { CanvasTooltip } from '../CanvasTooltip';
 import { ExecutionStatusIcon } from '../ExecutionStatusIcon';
 import { StageTaskIcon, StageTaskRetryDuration } from './StageNode.styles';
@@ -82,7 +82,7 @@ const TaskPlayButton = memo(
             padding: 0,
           }}
         >
-          {playLoading ? <Spinner size="sm" /> : <TimelinePlayIcon />}
+          {playLoading ? <Spinner size="sm" /> : <CirclePlay />}
         </Button>
       </CanvasTooltip>
     );

--- a/packages/apollo-react/src/canvas/components/StageNode/TaskContent.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/TaskContent.tsx
@@ -61,9 +61,6 @@ const TaskPlayButton = memo(
       [debouncedTaskPlay, taskId]
     );
 
-    const iconSize = small ? 18 : 22;
-    const buttonSize = small ? '20px' : Spacing.SpacingL;
-
     return (
       <CanvasTooltip content="Trigger task" placement="top">
         <Button
@@ -73,20 +70,21 @@ const TaskPlayButton = memo(
           onClick={handlePlayClick}
           onMouseDown={(e: React.MouseEvent) => e.stopPropagation()}
           onKeyDown={(e: React.KeyboardEvent) => e.stopPropagation()}
-          className="task-menu-icon-button"
+          className={
+            small
+              ? 'task-menu-icon-button h-4 w-4 [&_svg]:size-3.5'
+              : 'task-menu-icon-button h-4 w-4'
+          }
           style={{
             color: 'var(--canvas-icon-default)',
             minWidth: 'unset',
-            width: buttonSize,
-            height: buttonSize,
             padding: 0,
-            ...(small && { marginRight: '-2px' }),
           }}
         >
           {playLoading ? (
-            <Spinner size="sm" style={{ width: iconSize - 2, height: iconSize - 2 }} />
+            <Spinner size="sm" style={{ width: small ? 12 : 14, height: small ? 12 : 14 }} />
           ) : (
-            <TimelinePlayIcon w={iconSize} h={iconSize} />
+            <TimelinePlayIcon />
           )}
         </Button>
       </CanvasTooltip>
@@ -127,7 +125,7 @@ export const TaskContent = memo(
     }, [taskExecution?.badge, taskExecution?.retryCount, taskExecution?.status, _]);
     const hasSecondRowContent =
       taskExecution && (taskExecution.duration || taskExecution.retryDuration || badgeText);
-    const showPlayButtonSmall = onTaskPlay && hasExecutionStatus;
+    const showReplayButton = onTaskPlay && hasExecutionStatus;
     const taskStatusFallbackName = hasExecutionStatus ? getStatusName(taskExecution?.status) : '';
     const taskStatusTooltip = taskExecution?.message || taskStatusFallbackName;
     const durationLabel = useMemo(
@@ -186,8 +184,8 @@ export const TaskContent = memo(
               </CanvasTooltip>
             )}
             {!hasSecondRowContent && <StageTaskEntryConditionIcon task={task} />}
-            {showPlayButtonSmall && !hasSecondRowContent && (
-              <TaskPlayButton taskId={task.id} onTaskPlay={onTaskPlay} small />
+            {showReplayButton && !hasSecondRowContent && (
+              <TaskPlayButton taskId={task.id} onTaskPlay={onTaskPlay} />
             )}
             {onTaskPlay && !hasExecutionStatus && (
               <TaskPlayButton taskId={task.id} onTaskPlay={onTaskPlay} />
@@ -218,7 +216,7 @@ export const TaskContent = memo(
             <Row align="center" gap={Spacing.SpacingXs}>
               {badgeText && <Badge variant={taskExecution.badgeStatus}>{badgeText}</Badge>}
               <StageTaskEntryConditionIcon task={task} small />
-              {showPlayButtonSmall && (
+              {showReplayButton && (
                 <TaskPlayButton taskId={task.id} onTaskPlay={onTaskPlay} small />
               )}
             </Row>

--- a/packages/apollo-react/src/canvas/components/StageNode/TaskContent.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/TaskContent.tsx
@@ -82,11 +82,7 @@ const TaskPlayButton = memo(
             padding: 0,
           }}
         >
-          {playLoading ? (
-            <Spinner size="sm" />
-          ) : (
-            <TimelinePlayIcon />
-          )}
+          {playLoading ? <Spinner size="sm" /> : <TimelinePlayIcon />}
         </Button>
       </CanvasTooltip>
     );

--- a/packages/apollo-react/src/canvas/components/StageNode/TaskContent.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/TaskContent.tsx
@@ -32,6 +32,8 @@ const TaskPlayButton = memo(
     small?: boolean;
   }) => {
     const [playLoading, setPlayLoading] = useState(false);
+    const { _ } = useSafeLingui();
+    const triggerTaskLabel = _({ id: 'stage-node.trigger-task', message: 'Trigger task' });
 
     const debouncedTaskPlay = useMemo(
       () =>
@@ -62,7 +64,7 @@ const TaskPlayButton = memo(
     );
 
     return (
-      <CanvasTooltip content="Trigger task" placement="top">
+      <CanvasTooltip content={triggerTaskLabel} placement="top">
         <Button
           variant="ghost"
           size="icon"
@@ -70,7 +72,7 @@ const TaskPlayButton = memo(
           onClick={handlePlayClick}
           onMouseDown={(e: React.MouseEvent) => e.stopPropagation()}
           onKeyDown={(e: React.KeyboardEvent) => e.stopPropagation()}
-          aria-label="Trigger task"
+          aria-label={triggerTaskLabel}
           className={
             small
               ? 'task-menu-icon-button h-4 w-4 [&_svg]:size-3.5'
@@ -122,7 +124,7 @@ export const TaskContent = memo(
     }, [taskExecution?.badge, taskExecution?.retryCount, taskExecution?.status, _]);
     const hasSecondRowContent =
       taskExecution && (taskExecution.duration || taskExecution.retryDuration || badgeText);
-    const showReplayButton = onTaskPlay && hasExecutionStatus;
+    const showTaskPlayButton = onTaskPlay && hasExecutionStatus;
     const taskStatusFallbackName = hasExecutionStatus ? getStatusName(taskExecution?.status) : '';
     const taskStatusTooltip = taskExecution?.message || taskStatusFallbackName;
     const durationLabel = useMemo(
@@ -181,7 +183,7 @@ export const TaskContent = memo(
               </CanvasTooltip>
             )}
             {!hasSecondRowContent && <StageTaskEntryConditionIcon task={task} />}
-            {showReplayButton && !hasSecondRowContent && (
+            {showTaskPlayButton && !hasSecondRowContent && (
               <TaskPlayButton taskId={task.id} onTaskPlay={onTaskPlay} />
             )}
             {onTaskPlay && !hasExecutionStatus && (
@@ -213,7 +215,7 @@ export const TaskContent = memo(
             <Row align="center" gap={Spacing.SpacingXs}>
               {badgeText && <Badge variant={taskExecution.badgeStatus}>{badgeText}</Badge>}
               <StageTaskEntryConditionIcon task={task} small />
-              {showReplayButton && (
+              {showTaskPlayButton && (
                 <TaskPlayButton taskId={task.id} onTaskPlay={onTaskPlay} small />
               )}
             </Row>

--- a/packages/apollo-react/src/canvas/components/StageNode/TaskContent.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/TaskContent.tsx
@@ -70,6 +70,7 @@ const TaskPlayButton = memo(
           onClick={handlePlayClick}
           onMouseDown={(e: React.MouseEvent) => e.stopPropagation()}
           onKeyDown={(e: React.KeyboardEvent) => e.stopPropagation()}
+          aria-label="Trigger task"
           className={
             small
               ? 'task-menu-icon-button h-4 w-4 [&_svg]:size-3.5'
@@ -82,7 +83,7 @@ const TaskPlayButton = memo(
           }}
         >
           {playLoading ? (
-            <Spinner size="sm" style={{ width: small ? 12 : 14, height: small ? 12 : 14 }} />
+            <Spinner size="sm" />
           ) : (
             <TimelinePlayIcon />
           )}

--- a/packages/apollo-react/src/canvas/components/StageNode/TaskContent.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/TaskContent.tsx
@@ -144,7 +144,7 @@ export const TaskContent = memo(
         style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
         gap={Padding.PadXs}
       >
-        <Row align="center" justify="space-between">
+        <Row align="center" justify="space-between" gap={Spacing.SpacingXs}>
           {/* disable tooltip when dragging to avoid tooltip flickering */}
           <Row
             gap={Spacing.SpacingXs}
@@ -185,9 +185,7 @@ export const TaskContent = memo(
                 </Button>
               </CanvasTooltip>
             )}
-            {!hasSecondRowContent && (
-              <StageTaskEntryConditionIcon task={task} small={!!hasExecutionStatus} />
-            )}
+            {!hasSecondRowContent && <StageTaskEntryConditionIcon task={task} />}
             {showPlayButtonSmall && !hasSecondRowContent && (
               <TaskPlayButton taskId={task.id} onTaskPlay={onTaskPlay} small />
             )}

--- a/packages/apollo-react/src/canvas/icons/TimelinePlayIcon.tsx
+++ b/packages/apollo-react/src/canvas/icons/TimelinePlayIcon.tsx
@@ -1,6 +1,6 @@
 export const TimelinePlayIcon = ({
   w = 24,
-  h = 24,
+  h = 25,
   color = 'currentColor',
 }: {
   w?: number | string;
@@ -13,11 +13,10 @@ export const TimelinePlayIcon = ({
       xmlns="http://www.w3.org/2000/svg"
       width={w}
       height={h}
-      viewBox="0 0.5 24 24"
+      viewBox="0 0 24 25"
       fill="none"
     >
       <path
-        transform="translate(-0.6 -0.625) scale(1.05)"
         d="M12 2.5C17.52 2.5 22 6.98 22 12.5C22 18.02 17.52 22.5 12 22.5C6.48 22.5 2 18.02 2 12.5C2 6.98 6.48 2.5 12 2.5ZM12 4.5C7.59 4.5 4 8.09 4 12.5C4 16.91 7.59 20.5 12 20.5C16.41 20.5 20 16.91 20 12.5C20 8.09 16.41 4.5 12 4.5ZM10 8.5L16 12.5L10 16.5V8.5Z"
         fill={color}
       />

--- a/packages/apollo-react/src/canvas/icons/TimelinePlayIcon.tsx
+++ b/packages/apollo-react/src/canvas/icons/TimelinePlayIcon.tsx
@@ -1,6 +1,6 @@
 export const TimelinePlayIcon = ({
   w = 24,
-  h = 25,
+  h = 24,
   color = 'currentColor',
 }: {
   w?: number | string;
@@ -13,10 +13,11 @@ export const TimelinePlayIcon = ({
       xmlns="http://www.w3.org/2000/svg"
       width={w}
       height={h}
-      viewBox="0 0 24 25"
+      viewBox="0 0.5 24 24"
       fill="none"
     >
       <path
+        transform="translate(-0.6 -0.625) scale(1.05)"
         d="M12 2.5C17.52 2.5 22 6.98 22 12.5C22 18.02 17.52 22.5 12 22.5C6.48 22.5 2 18.02 2 12.5C2 6.98 6.48 2.5 12 2.5ZM12 4.5C7.59 4.5 4 8.09 4 12.5C4 16.91 7.59 20.5 12 20.5C16.41 20.5 20 16.91 20 12.5C20 8.09 16.41 4.5 12 4.5ZM10 8.5L16 12.5L10 16.5V8.5Z"
         fill={color}
       />


### PR DESCRIPTION
## Summary

Fixes [MST-12000](https://uipath.atlassian.net/browse/MST-12000) plus two follow-up spacing/sizing issues design flagged in review. In a stage node, the entry-condition diamond rendered 20px on tasks that hadn't run and 16px once they had, so diamonds in the same stage visibly differed. Per design (Kitty Li), the size should follow the card layout instead: **20px on single-line cards regardless of execution status, 16px only when execution details add a second line**. Separately, the play button read as both off-size and over-spaced next to the status icons; the root cause was subtle (see below), and the fix deletes more sizing code than it adds.

## Demo
<img width="1056" height="682" alt="image" src="https://github.com/user-attachments/assets/ff506a0b-ccea-46c7-83ff-0903b0bf5608" />

## Root cause of the play-button issues

The apollo-wind `Button` base class applies `[&_svg]:size-4`, forcing **every descendant svg to render 16×16 regardless of its width/height attributes**. `TaskPlayButton`'s `iconSize`/`buttonSize` math (18/22px icons in 20/24px buttons) was therefore dead code — the icon always rendered 16px, and the oversized button box plus the icon's padded 24×**25** viewBox produced invisible horizontal padding and a ring ~1px smaller than the lucide status circles (whose stroked circles reach outer radius 11 on the same 24-unit grid).

## Changes

- `StageTaskEntryConditionIcon` (via `TaskContent`): first-row diamond no longer passes `small={!!hasExecutionStatus}` — single-line cards always get the 20px diamond; the second-row 16px call is unchanged.
- `TaskContent`: `gap={Spacing.SpacingXs}` on the first row so a truncated label (and its required `*`) never sits flush against the status icon.
- `TimelinePlayIcon`: normalized to a square 24-unit viewBox centered on the ring, with the glyph scaled 1.05 so its filled ring optically matches the lucide status circles' stroke band. (Long-term this should be a re-exported asset from design.)
- `TaskPlayButton`: now a plain 16×16 ghost Button with the exact classes of the status-icon button (`h-4 w-4`) — alignment and even gaps come from identical geometry instead of the removed negative-margin hacks. A 14px `small` variant (`[&_svg]:size-3.5` override, same pattern as `QuickActionsRow`) shadows the diamond's shrink on the execution second line.
- Renamed `showPlayButtonSmall` → `showReplayButton` — it gates the replay button for already-run tasks and no longer implies a size.

Note: `TimelinePlayer` (agent canvas) uses the same icon; its ring changes imperceptibly (~12.8 → 13.4px) and stays within a pixel of its `TimelinePause` sibling.

## Flow

```mermaid
flowchart TD
    TC[TaskContent] --> Q{execution details<br/>add a second line?}
    Q -->|no - single line| A[diamond 20px + play 16px<br/>matching 16px status button]
    Q -->|yes - two lines| B[second row: diamond 16px + play 14px]
```

## Testing

- [x] `pnpm lint` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes (apollo-react: 107 files, 1915 tests; StageNode + AgentCanvas re-run after each change)
- [ ] `pnpm test:visual` — no local task; runs in CI
- [x] Manual testing / Storybook checked (`StageNode` → `Ad hoc Tasks` story, "Mixed with Parallel" stage with Completed/Failed/not-run entry-condition tasks; sizes and gaps verified against status icons with design)
- [x] Type-safe (no `as any` / type suppressions added)


[MST-12000]: https://uipath.atlassian.net/browse/MST-12000?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ