### PR TITLE
fix(canvas): tighten gap between task label and required indicator

### DIFF
--- a/packages/apollo-react/src/canvas/components/StageNode/TaskContent.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/TaskContent.tsx
@@ -159,7 +159,7 @@ export const TaskContent = memo(
               {...(isDragging && { isOpen: false })}
             >
               <Row
-                gap={Spacing.SpacingXs}
+                gap={'2px'}
                 align="center"
                 style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
               >


### PR DESCRIPTION
## Problem

In `StageNode`'s `TaskContent`, a truncated task label showed what looked like a large whitespace before the required-task `*` indicator (visible on the long-name required task in the StageNode `Default` story).

## Root cause

The whitespace was not appended to `task.label` and was not a truncation artifact. The `Row` wrapping the label span and the `*` span used `gap={Spacing.SpacingXs}` (8px) as its flex gap. When the label truncates, the ellipsis sits flush against the right edge of the `truncate` box, so the fixed 8px gap becomes visually obvious right before the `*`. With short labels the surrounding empty space hides it, which is why it appeared to only happen on truncation.

## Fix

Change that `Row`'s `gap` from `Spacing.SpacingXs` (8px) to `2px`, matching the tight spacing already used by the second row in the same component.

```diff
 <Row
-  gap={Spacing.SpacingXs}
+  gap={'2px'}
   align="center"
   style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
 >
   <span className="text-sm truncate">{task.label}</span>
```

Only the label-to-`*` gap is affected. The icon-to-label gap (`Row` at line 149) is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01La8dNWwufiJXB3AeNPA4nm)_