### PR TITLE
fix(apollo-react): move required asterisk closer to task name

### DIFF
--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.stories.tsx
@@ -2350,6 +2350,7 @@ export const TasksBySection: Story = {
                   taskGroupType: 'event-driven',
                   hasEntryCondition: true,
                   isPlaceholder: true,
+                  isRequired: true,
                 },
               ],
               [

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.stories.tsx
@@ -274,7 +274,16 @@ export const Default: Story = {
             isReadOnly: true,
             tasks: [
               [{ id: '1', label: 'Risk Assessment', icon: <VerificationIcon /> }],
-              [{ id: '2', label: 'Policy Review', icon: <DocumentIcon /> }],
+              [{ id: '2', label: 'Policy Review', icon: <DocumentIcon />, isRequired: true }],
+              [
+                {
+                  id: '3',
+                  label:
+                    'Final task with a long task string, really it is so long that it should cut off',
+                  icon: <DocumentIcon />,
+                  isRequired: true,
+                },
+              ],
             ],
           },
           execution: {
@@ -286,6 +295,10 @@ export const Default: Story = {
               '2': {
                 status: 'Warning',
                 message: 'Policy review requires manual intervention',
+              },
+              '3': {
+                status: 'Warning',
+                message: 'Warning message',
               },
             },
           },
@@ -390,6 +403,7 @@ export const ExecutionStatus: Story = {
                   id: '2',
                   label: 'Document Verification is going to be very very really long',
                   icon: <DocumentIcon />,
+                  isRequired: true,
                 },
               ],
             ],

--- a/packages/apollo-react/src/canvas/components/StageNode/TaskContent.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/TaskContent.tsx
@@ -144,7 +144,7 @@ export const TaskContent = memo(
         style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
         gap={Padding.PadXs}
       >
-        <Row align="center" justify="space-between">
+        <Row align="center" justify="space-between" gap={Spacing.SpacingXs}>
           {/* disable tooltip when dragging to avoid tooltip flickering */}
           <Row
             gap={Spacing.SpacingXs}
@@ -159,11 +159,17 @@ export const TaskContent = memo(
               {...(isDragging && { isOpen: false })}
             >
               <Row
-                gap={Spacing.SpacingXs}
+                gap={'2px'}
                 align="center"
-                style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
+                style={{
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  whiteSpace: 'nowrap',
+                }}
               >
-                <span className="text-sm truncate">{task.label}</span>
+                <span className="text-sm truncate" style={{ minWidth: 0 }}>
+                  {task.label}
+                </span>
                 {task.isRequired && (
                   <span className="text-sm" style={{ flexShrink: 0 }}>
                     {'*'}


### PR DESCRIPTION
Updates the gaps and spacing to move the required task asterisk to be closer to the task name and away from the other icons

<img width="1280" height="532" alt="Screenshot 2026-07-13 at 1 41 29 PM" src="https://github.com/user-attachments/assets/14f8374f-5e3c-4e50-903c-40bbb26f275a" />
<img width="914" height="540" alt="Screenshot 2026-07-13 at 1 41 34 PM" src="https://github.com/user-attachments/assets/b35ea309-7144-42a5-b515-5004e2a6ae27" />
<img width="839" height="515" alt="Screenshot 2026-07-13 at 1 45 20 PM" src="https://github.com/user-attachments/assets/198586eb-5642-4e89-bf47-ae92f7ac4dbd" />
