### PR TITLE
feat(apollo-react): add LayersArrowUpRightIcon for Read Entity node

### DIFF
--- a/packages/apollo-react/src/canvas/icons/LayersArrowUpRightIcon.tsx
+++ b/packages/apollo-react/src/canvas/icons/LayersArrowUpRightIcon.tsx
@@ -25,7 +25,9 @@ export const LayersArrowUpRightIcon = ({
     strokeLinejoin="round"
   >
     {/* Scoped to this icon's class; `.arrow` inherits `currentColor` until the icon is hovered. */}
-    <style>{'.layers-arrow-up-right-icon:hover .arrow{stroke:var(--foreground-accent);}'}</style>
+    <style>
+      {'.layers-arrow-up-right-icon:hover .arrow{stroke:var(--foreground-accent, currentColor);}'}
+    </style>
     <path d="M11 13.74 2.5 8.87a1 1 0 0 1 0-1.74L11 2.26a2 2 0 0 1 2 0l8.5 4.87a1 1 0 0 1 0 1.74l-2 1.15" />
     <path d="M11 21.74l-8.5-4.87a1 1 0 0 1 0-1.74l1.5-.845" />
     <path className="arrow" d="M16 14h6v6" />

--- a/packages/apollo-react/src/canvas/icons/LayersArrowUpRightIcon.tsx
+++ b/packages/apollo-react/src/canvas/icons/LayersArrowUpRightIcon.tsx
@@ -1,0 +1,34 @@
+/**
+ * Layers icon with an "open/navigate out" arrow, used for the Data Fabric
+ * "Read Entity" canvas node. The layers glyph inherits the node's text color
+ * via `currentColor`; the arrow sub-paths (`.arrow`) switch to the theme accent
+ * (`--foreground-accent`) while the icon itself is hovered, giving the node a
+ * subtle "opens elsewhere" affordance without recoloring the whole glyph.
+ */
+export const LayersArrowUpRightIcon = ({
+  w = 16,
+  h = 16,
+}: {
+  w?: number | string;
+  h?: number | string;
+}) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    className="layers-arrow-up-right-icon"
+    width={w}
+    height={h}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={2}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    {/* Scoped to this icon's class; `.arrow` inherits `currentColor` until the icon is hovered. */}
+    <style>{'.layers-arrow-up-right-icon:hover .arrow{stroke:var(--foreground-accent);}'}</style>
+    <path d="M11 13.74 2.5 8.87a1 1 0 0 1 0-1.74L11 2.26a2 2 0 0 1 2 0l8.5 4.87a1 1 0 0 1 0 1.74l-2 1.15" />
+    <path d="M11 21.74l-8.5-4.87a1 1 0 0 1 0-1.74l1.5-.845" />
+    <path className="arrow" d="M16 14h6v6" />
+    <path className="arrow" d="m16 20 6-6" />
+  </svg>
+);

--- a/packages/apollo-react/src/canvas/icons/index.ts
+++ b/packages/apollo-react/src/canvas/icons/index.ts
@@ -30,6 +30,7 @@ export { FunctionProject } from './FunctionProject';
 export { GoogleIcon } from './GoogleIcon';
 export { HealthScoreIcon } from './HealthScoreIcon';
 export { HumanIcon } from './HumanIcon';
+export { LayersArrowUpRightIcon } from './LayersArrowUpRightIcon';
 export { LoopIcon } from './LoopIcon';
 export { McpIcon } from './McpIcon';
 export { MemoryIcon } from './MemoryIcon';

--- a/packages/apollo-react/src/canvas/utils/icon-registry.test.tsx
+++ b/packages/apollo-react/src/canvas/utils/icon-registry.test.tsx
@@ -41,4 +41,15 @@ describe('getIcon', () => {
     // The registered UIPath icon renders its own SVG (id), not a Lucide fallback.
     expect(container.querySelector('#case-management-project')).toBeInTheDocument();
   });
+
+  it('returns the LayersArrowUpRight icon for the registered layers-arrow-up-right id', () => {
+    const Icon = getIcon('layers-arrow-up-right');
+    const { container } = render(<Icon w={24} h={24} />);
+    // The registered UIPath icon renders its own SVG (class), not a Lucide/Box fallback
+    // (there is no Lucide `LayersArrowUpRight`, so a miss here would degrade to Box).
+    const svg = container.querySelector('svg.layers-arrow-up-right-icon');
+    expect(svg).toBeInTheDocument();
+    // The two accent-on-hover arrow sub-paths are present.
+    expect(svg?.querySelectorAll('path.arrow')).toHaveLength(2);
+  });
 });

--- a/packages/apollo-react/src/canvas/utils/icon-registry.tsx
+++ b/packages/apollo-react/src/canvas/utils/icon-registry.tsx
@@ -37,6 +37,7 @@ const iconRegistry: Record<string, IconComponent> = {
   'flow-project': ({ w, h }) => <Icons.FlowProject w={w ?? 29} h={h ?? 28} />,
   'case-management': ({ w, h }) => <Icons.CaseManagementProject w={w ?? 29} h={h ?? 28} />,
   decision: ({ w, h }) => <Icons.DecisionIcon w={w ?? 24} h={h ?? 24} />,
+  'layers-arrow-up-right': ({ w, h }) => <Icons.LayersArrowUpRightIcon w={w ?? 24} h={h ?? 24} />,
   switch: ({ w, h }) => <Icons.SwitchIcon w={w ?? 24} h={h ?? 24} />,
   uipath: ({ w, h }) => <Icons.UiPathIcon w={w ?? 24} h={h ?? 24} />,
   'agent-diagram': ({ w, h }) => <Icons.AgentDiagramIcon w={w ?? 24} h={h ?? 24} />,


### PR DESCRIPTION
## What

Adds a new canvas icon — **`LayersArrowUpRightIcon`** — a layers glyph with a "navigate-out" arrow, for the Data Fabric **Read Entity** node in the flow canvas. Registered under the icon key `layers-arrow-up-right`.

## Demo

<img width="291" height="180" alt="image" src="https://github.com/user-attachments/assets/04e53d9d-13c6-41b7-9766-673b59771dd1" />


## Changes
- `packages/apollo-react/src/canvas/icons/LayersArrowUpRightIcon.tsx` — new stateless SVG component.
- `packages/apollo-react/src/canvas/icons/index.ts` — barrel export (also auto-adds it to the Storybook `Theme/Icons` gallery).
- `packages/apollo-react/src/canvas/utils/icon-registry.tsx` — register `layers-arrow-up-right`.

## Hover behavior
The layers glyph inherits the node's text color via `currentColor`. The two arrow sub-paths carry a `.arrow` class and switch to the theme accent (`--foreground-accent`) **while the icon itself is hovered**:

```
.layers-arrow-up-right-icon:hover .arrow { stroke: var(--foreground-accent); }
```

This gives a subtle "reads from elsewhere" affordance without recoloring the whole glyph, and tracks light/dark automatically since it uses the theme token (resolves to `#fa4616` in the canvas theme).

## Downstream
Consumed by `@flow/flow-workbench` — the Read Entity node points its `display.icon` at `layers-arrow-up-right`. That change is in a follow-up flow-workbench PR that merges **after** this releases a new `@uipath/apollo-react`.

## Verification
- `biome check` ✓ (all 3 files)
- `tsc --noEmit` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)