### PR TITLE
fix(apollo-react): make in-progress execution spinner info-colored [MST-12191]

### DIFF
--- a/packages/apollo-react/src/canvas/components/ExecutionStatusIcon/ExecutionStatusIcon.test.tsx
+++ b/packages/apollo-react/src/canvas/components/ExecutionStatusIcon/ExecutionStatusIcon.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/react';
+import type { CSSProperties } from 'react';
 import { describe, expect, it, vi } from 'vitest';
 import { ExecutionStatusIcon, getExecutionStatusColor } from './ExecutionStatusIcon';
 
@@ -9,10 +10,19 @@ vi.mock('../../utils/icon-registry', () => ({
 }));
 
 vi.mock('@uipath/apollo-wind', () => ({
-  Spinner: () => <span data-testid="spinner" />,
+  Spinner: ({ className, style }: { className?: string; style?: CSSProperties }) => (
+    <span className={className} data-testid="spinner" style={style} />
+  ),
 }));
 
 describe('ExecutionStatusIcon', () => {
+  it('renders InProgress as an info-colored spinner', () => {
+    render(<ExecutionStatusIcon status="InProgress" size={20} />);
+
+    const spinner = screen.getByTestId('spinner');
+    expect(spinner.className).toContain('[&>svg]:text-[color:var(--color-info-icon)]');
+  });
+
   it('renders UserCancelled with the cancelled glyph and info color', () => {
     render(<ExecutionStatusIcon status="UserCancelled" size={20} />);
 

--- a/packages/apollo-react/src/canvas/components/ExecutionStatusIcon/ExecutionStatusIcon.test.tsx
+++ b/packages/apollo-react/src/canvas/components/ExecutionStatusIcon/ExecutionStatusIcon.test.tsx
@@ -22,11 +22,14 @@ vi.mock('@uipath/apollo-wind', () => ({
 }));
 
 describe('ExecutionStatusIcon', () => {
-  it('renders InProgress as a primary-colored spinner', () => {
+  it('renders InProgress as a primary-colored spinner via getExecutionStatusColor', () => {
     render(<ExecutionStatusIcon status="InProgress" size={20} />);
 
     const spinner = screen.getByTestId('spinner');
-    expect(spinner.className).toContain('[&>svg]:text-[color:var(--color-primary)]');
+    expect(spinner.className).toContain('[&>svg]:text-[color:var(--spinner-color)]');
+    expect(spinner.style.getPropertyValue('--spinner-color')).toBe(
+      getExecutionStatusColor('InProgress')
+    );
     expect(spinner).toHaveAttribute('data-label', 'In progress');
   });
 
@@ -43,5 +46,9 @@ describe('ExecutionStatusIcon', () => {
 describe('getExecutionStatusColor', () => {
   it('keeps UserCancelled aligned with info-colored execution states', () => {
     expect(getExecutionStatusColor('UserCancelled')).toBe('var(--color-info-icon)');
+  });
+
+  it('maps InProgress to the primary color', () => {
+    expect(getExecutionStatusColor('InProgress')).toBe('var(--color-primary)');
   });
 });

--- a/packages/apollo-react/src/canvas/components/ExecutionStatusIcon/ExecutionStatusIcon.test.tsx
+++ b/packages/apollo-react/src/canvas/components/ExecutionStatusIcon/ExecutionStatusIcon.test.tsx
@@ -10,9 +10,15 @@ vi.mock('../../utils/icon-registry', () => ({
 }));
 
 vi.mock('@uipath/apollo-wind', () => ({
-  Spinner: ({ className, style }: { className?: string; style?: CSSProperties }) => (
-    <span className={className} data-testid="spinner" style={style} />
-  ),
+  Spinner: ({
+    className,
+    style,
+    label,
+  }: {
+    className?: string;
+    style?: CSSProperties;
+    label?: string;
+  }) => <span className={className} data-label={label} data-testid="spinner" style={style} />,
 }));
 
 describe('ExecutionStatusIcon', () => {
@@ -21,6 +27,7 @@ describe('ExecutionStatusIcon', () => {
 
     const spinner = screen.getByTestId('spinner');
     expect(spinner.className).toContain('[&>svg]:text-[color:var(--color-info-icon)]');
+    expect(spinner).toHaveAttribute('data-label', 'In progress');
   });
 
   it('renders UserCancelled with the cancelled glyph and info color', () => {

--- a/packages/apollo-react/src/canvas/components/ExecutionStatusIcon/ExecutionStatusIcon.test.tsx
+++ b/packages/apollo-react/src/canvas/components/ExecutionStatusIcon/ExecutionStatusIcon.test.tsx
@@ -22,11 +22,11 @@ vi.mock('@uipath/apollo-wind', () => ({
 }));
 
 describe('ExecutionStatusIcon', () => {
-  it('renders InProgress as an info-colored spinner', () => {
+  it('renders InProgress as a primary-colored spinner', () => {
     render(<ExecutionStatusIcon status="InProgress" size={20} />);
 
     const spinner = screen.getByTestId('spinner');
-    expect(spinner.className).toContain('[&>svg]:text-[color:var(--color-info-icon)]');
+    expect(spinner.className).toContain('[&>svg]:text-[color:var(--color-primary)]');
     expect(spinner).toHaveAttribute('data-label', 'In progress');
   });
 

--- a/packages/apollo-react/src/canvas/components/ExecutionStatusIcon/ExecutionStatusIcon.tsx
+++ b/packages/apollo-react/src/canvas/components/ExecutionStatusIcon/ExecutionStatusIcon.tsx
@@ -73,7 +73,7 @@ export function ExecutionStatusIcon({
           <Spinner
             size="sm"
             label={_({ id: 'stage-node.status.in-progress', message: 'In progress' })}
-            className="[&>svg]:text-[color:var(--color-info-icon)]"
+            className="[&>svg]:text-[color:var(--color-primary)] [&>svg]:[stroke-width:3]"
             style={{ backgroundColor: 'transparent', width: size, height: size }}
           />
         );

--- a/packages/apollo-react/src/canvas/components/ExecutionStatusIcon/ExecutionStatusIcon.tsx
+++ b/packages/apollo-react/src/canvas/components/ExecutionStatusIcon/ExecutionStatusIcon.tsx
@@ -1,5 +1,5 @@
 import { Spinner } from '@uipath/apollo-wind';
-import { useMemo } from 'react';
+import { type CSSProperties, useMemo } from 'react';
 import { useSafeLingui } from '../../../i18n';
 import { CanvasIcon } from '../../utils/icon-registry';
 
@@ -8,7 +8,7 @@ export function getExecutionStatusColor(status: string | undefined): string {
     case 'NotExecuted':
       return 'var(--color-foreground-de-emp)';
     case 'InProgress':
-      return 'var(--color-info-icon)';
+      return 'var(--color-primary)';
     case 'Completed':
       return 'var(--color-success-icon)';
     case 'ActionNeeded':
@@ -73,8 +73,15 @@ export function ExecutionStatusIcon({
           <Spinner
             size="sm"
             label={_({ id: 'stage-node.status.in-progress', message: 'In progress' })}
-            className="[&>svg]:text-[color:var(--color-primary)] [&>svg]:[stroke-width:3]"
-            style={{ backgroundColor: 'transparent', width: size, height: size }}
+            className="[&>svg]:text-[color:var(--spinner-color)] [&>svg]:[stroke-width:3]"
+            style={
+              {
+                '--spinner-color': color,
+                backgroundColor: 'transparent',
+                width: size,
+                height: size,
+              } as CSSProperties
+            }
           />
         );
       case 'Completed':

--- a/packages/apollo-react/src/canvas/components/ExecutionStatusIcon/ExecutionStatusIcon.tsx
+++ b/packages/apollo-react/src/canvas/components/ExecutionStatusIcon/ExecutionStatusIcon.tsx
@@ -1,5 +1,6 @@
 import { Spinner } from '@uipath/apollo-wind';
 import { useMemo } from 'react';
+import { useSafeLingui } from '../../../i18n';
 import { CanvasIcon } from '../../utils/icon-registry';
 
 export function getExecutionStatusColor(status: string | undefined): string {
@@ -61,15 +62,17 @@ export function ExecutionStatusIcon({
     | string;
   size?: number;
 }) {
+  const { _ } = useSafeLingui();
+
   return useMemo(() => {
     const color = getExecutionStatusColor(status);
 
     switch (status) {
       case 'InProgress':
-        // Spinner colors its inner icon muted-grey by default, so force the info color onto it.
         return (
           <Spinner
             size="sm"
+            label={_({ id: 'stage-node.status.in-progress', message: 'In progress' })}
             className="[&>svg]:text-[color:var(--color-info-icon)]"
             style={{ backgroundColor: 'transparent', width: size, height: size }}
           />
@@ -94,5 +97,5 @@ export function ExecutionStatusIcon({
       default:
         return null;
     }
-  }, [status, size]);
+  }, [status, size, _]);
 }

--- a/packages/apollo-react/src/canvas/components/ExecutionStatusIcon/ExecutionStatusIcon.tsx
+++ b/packages/apollo-react/src/canvas/components/ExecutionStatusIcon/ExecutionStatusIcon.tsx
@@ -66,9 +66,11 @@ export function ExecutionStatusIcon({
 
     switch (status) {
       case 'InProgress':
+        // Spinner colors its inner icon muted-grey by default, so force the info color onto it.
         return (
           <Spinner
             size="sm"
+            className="[&>svg]:text-[color:var(--color-info-icon)]"
             style={{ backgroundColor: 'transparent', width: size, height: size }}
           />
         );


### PR DESCRIPTION
## Summary

The `InProgress` branch of `ExecutionStatusIcon` rendered apollo-wind's `Spinner` without applying the `var(--color-info-icon)` it already computes, so running stage nodes and task rows showed apollo-wind's default muted-grey spinner (`text-muted-foreground`) — barely visible on the canvas. This applies the info color, bringing in-progress in line with every other execution status. Fixes COX feedback that the in-progress indicator is hardly visible (MST-12191).

## Demo

<img width="164" height="231" alt="image" src="https://github.com/user-attachments/assets/efb85b09-4628-4ef6-b2a5-3fc7e88d4d88" />
<img width="196" height="265" alt="image" src="https://github.com/user-attachments/assets/6fc96bd8-e7ac-4b10-85d0-804010b72656" />
<img width="166" height="234" alt="image" src="https://github.com/user-attachments/assets/5b78f5e0-3e0d-4f17-941d-0c459e674d0f" />
<img width="177" height="220" alt="image" src="https://github.com/user-attachments/assets/3c2a4f92-f2f5-4727-8043-da163977c4c3" />

... cont.

## Changes

- **`ExecutionStatusIcon.tsx`** — color the InProgress spinner via `className="[&>svg]:text-[color:var(--color-info-icon)]"`. `Spinner` forwards `className` only to its outer `<div>` and hardcodes `text-muted-foreground` on the inner `Loader2`, so a descendant-svg override is needed; it wins on specificity (0,1,1 > 0,1,0). Same `[&>svg]:` pattern already used in `BaseNodeInnerShape.tsx`.
- **`ExecutionStatusIcon.test.tsx`** — the `Spinner` mock now forwards `className`; added a test asserting the InProgress spinner carries the info color.

## Flow

```mermaid
flowchart TD
    A[status = InProgress] --> B["getExecutionStatusColor()<br/>= var(--color-info-icon)"]
    B --> C{InProgress branch}
    C -->|before: color dropped| D["Spinner default<br/>text-muted-foreground (grey)"]
    C -->|after: color applied| E["[&>svg]:text-[color:var(--color-info-icon)]<br/>overrides muted grey"]
```

## E2E Impact

N/A — apollo-ui component-library change. Verified visually in Storybook (`ExecutionStatusIcon` story): the In Progress spinner now renders info-blue, matching the other statuses.

## Testing

- [x] `vitest run ExecutionStatusIcon` — 3/3 pass
- [x] `biome check` — clean
- [x] `tsc --noEmit` — 0 errors
- [x] Manual: Storybook `ExecutionStatusIcon` / `StageNode` stories
- [x] Type-safe (no `as any` / suppressions added)

## Notes

This fix lives in `@uipath/apollo-react`. It needs a release and a dependency bump in PO.Frontend before it reaches the product; no PO.Frontend source change is required.
