### PR TITLE
feat(apollo-react): add task breakpoints to case-management StageNode [MST-12196]

### DIFF
--- a/packages/apollo-react/src/canvas/components/StageNode/AdhocTask.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/AdhocTask.tsx
@@ -2,6 +2,7 @@ import { memo, useCallback, useRef } from 'react';
 import type { NodeMenuItem } from '../NodeContextMenu';
 import { StageTask } from './StageNode.styles';
 import type { StageTaskExecution, StageTaskItem } from './StageNode.types';
+import { TaskBreakpointDot } from './TaskBreakpointDot';
 import { TaskContent } from './TaskContent';
 import { TaskMenu, type TaskMenuHandle } from './TaskMenu';
 
@@ -50,6 +51,7 @@ const AdhocTaskItemComponent = ({
       onClick={handleClick}
       {...(getContextMenuItems && !isTaskLoading && { onContextMenu: handleContextMenu })}
     >
+      <TaskBreakpointDot taskId={task.id} active={!!taskExecution?.breakpoint} />
       <TaskContent task={task} taskExecution={taskExecution} onTaskPlay={onTaskPlay} />
       {getContextMenuItems && (
         <TaskMenu

--- a/packages/apollo-react/src/canvas/components/StageNode/DraggableTask.test.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/DraggableTask.test.tsx
@@ -356,4 +356,24 @@ describe('DraggableTask', () => {
       expect(container.querySelector('[data-testid="stage-task-task-1"]')).toBeInTheDocument();
     });
   });
+
+  describe('Breakpoint marker', () => {
+    it('renders the breakpoint dot for a sequential task with a breakpoint set', () => {
+      render(<DraggableTask {...defaultProps} taskExecution={{ breakpoint: true }} />);
+
+      expect(screen.getByTestId('stage-task-breakpoint-task-1')).toBeInTheDocument();
+    });
+
+    it('does not render the breakpoint dot when no breakpoint is set', () => {
+      render(<DraggableTask {...defaultProps} taskExecution={{ status: 'InProgress' }} />);
+
+      expect(screen.queryByTestId('stage-task-breakpoint-task-1')).not.toBeInTheDocument();
+    });
+
+    it('marker is display-only and does not intercept pointer events', () => {
+      render(<DraggableTask {...defaultProps} taskExecution={{ breakpoint: true }} />);
+
+      expect(screen.getByTestId('stage-task-breakpoint-task-1')).toHaveClass('pointer-events-none');
+    });
+  });
 });

--- a/packages/apollo-react/src/canvas/components/StageNode/DraggableTask.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/DraggableTask.tsx
@@ -10,6 +10,7 @@ import {
   StageTaskDragPlaceholderWrapper,
   StageTaskWrapper,
 } from './StageNode.styles';
+import { TaskBreakpointDot } from './TaskBreakpointDot';
 import { TaskContent } from './TaskContent';
 import { TaskMenu, type TaskMenuHandle } from './TaskMenu';
 
@@ -91,6 +92,7 @@ const DraggableTaskComponent = ({
       onClick={handleClick}
       {...(getContextMenuItems && !isTaskLoading && { onContextMenu: handleContextMenu })}
     >
+      <TaskBreakpointDot taskId={task.id} active={!!taskExecution?.breakpoint} />
       <TaskContent task={task} taskExecution={taskExecution} />
 
       {getContextMenuItems && (

--- a/packages/apollo-react/src/canvas/components/StageNode/EventDrivenTask.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/EventDrivenTask.tsx
@@ -2,6 +2,7 @@ import { memo, useCallback, useRef } from 'react';
 import type { NodeMenuItem } from '../NodeContextMenu';
 import { StageTask } from './StageNode.styles';
 import type { StageTaskExecution, StageTaskItem } from './StageNode.types';
+import { TaskBreakpointDot } from './TaskBreakpointDot';
 import { TaskContent } from './TaskContent';
 import { TaskMenu, type TaskMenuHandle } from './TaskMenu';
 
@@ -48,6 +49,7 @@ const EventDrivenTaskItemComponent = ({
       onClick={handleClick}
       {...(getContextMenuItems && !isTaskLoading && { onContextMenu: handleContextMenu })}
     >
+      <TaskBreakpointDot taskId={task.id} active={!!taskExecution?.breakpoint} />
       <TaskContent task={task} taskExecution={taskExecution} />
 
       {getContextMenuItems && (

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.breakpoints.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.breakpoints.stories.tsx
@@ -1,0 +1,308 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import {
+  ConnectionMode,
+  Panel,
+  ReactFlowProvider,
+  useEdgesState,
+  useNodesState,
+} from '@uipath/apollo-react/canvas/xyflow/react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { DefaultCanvasTranslations } from '../../types';
+import { BaseCanvas } from '../BaseCanvas';
+import { CanvasPositionControls } from '../CanvasPositionControls';
+import type { NodeMenuItem } from '../NodeContextMenu';
+import { StageConnectionEdge } from './StageConnectionEdge';
+import { StageEdge } from './StageEdge';
+import { StageNode } from './StageNode';
+import { StageNodeWrapper } from './StageNode.stories.utils';
+import type {
+  StageNodeProps,
+  StageTaskExecution,
+  StageTaskItem,
+  StageTaskStatus,
+} from './StageNode.types';
+
+// ============================================================================
+// StageNode: Breakpoints feature
+//
+// A task carries a breakpoint when its `execution.taskStatus[id].breakpoint` is
+// true. The marker is a solid red dot at the top-left corner of the task card
+// (debugger-gutter style) and is display-only. Adding and removing breakpoints is
+// done through the task's right-click / task menu, whose items the consumer
+// (PO.frontend) supplies via `getTaskContextMenuItems`; these stories wire that up
+// the same way.
+// ============================================================================
+
+const ProcessIcon = () => (
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+    <rect x="3" y="3" width="7" height="7" rx="1" />
+    <rect x="14" y="3" width="7" height="7" rx="1" />
+    <rect x="3" y="14" width="7" height="7" rx="1" />
+    <rect x="14" y="14" width="7" height="7" rx="1" />
+  </svg>
+);
+
+const VerificationIcon = () => (
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+    <path d="M9 11L12 14L20 6" />
+    <path d="M20 12V18C20 19.1046 19.1046 20 18 20H6C4.89543 20 4 19.1046 4 18V6C4 4.89543 4.89543 4 6 4H13" />
+  </svg>
+);
+
+const DocumentIcon = () => (
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+    <path d="M14 2H6C4.9 2 4 2.9 4 4V20C4 21.1 4.9 22 6 22H18C19.1 22 20 21.1 20 20V8L14 2Z" />
+    <path d="M14 2V8H20" />
+    <path d="M8 12H16" />
+    <path d="M8 16H16" />
+  </svg>
+);
+
+const meta: Meta<StageNodeProps> = {
+  title: 'Components/Nodes/StageNode/Breakpoints',
+  component: StageNode,
+  parameters: {
+    layout: 'fullscreen',
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const BREAKPOINT_TASKS: StageTaskItem[][] = [
+  [{ id: 'classify', label: 'Classify Request', icon: <ProcessIcon /> }],
+  [{ id: 'review', label: 'Review and Decide', icon: <VerificationIcon /> }],
+  [{ id: 'notify', label: 'Notify Outcome', icon: <DocumentIcon /> }],
+];
+
+// Reusable interactive playground: manages breakpoint state for an arbitrary task
+// list. A set breakpoint shows a solid, display-only marker; adding and removing
+// is done through the task's right-click menu (wired via getTaskContextMenuItems),
+// exactly as the consumer (PO.frontend) does it.
+const BreakpointPlaygroundStory = ({
+  stageLabel,
+  tasks,
+  initialBreakpoints,
+  taskStatuses,
+  allowBreakpoint,
+  isReadOnly,
+}: {
+  stageLabel: string;
+  tasks: StageTaskItem[][];
+  initialBreakpoints: string[];
+  /** Fixed execution statuses per task id (e.g. a paused or completed task). */
+  taskStatuses?: Record<string, StageTaskStatus>;
+  /** Optional predicate gating which tasks can host a breakpoint. */
+  allowBreakpoint?: (task: StageTaskItem) => boolean;
+  /** Render the stage read-only (like Debug view). The breakpoint menu must still work. */
+  isReadOnly?: boolean;
+}) => {
+  const nodeTypes = useMemo(() => ({ stage: StageNodeWrapper }), []);
+  const edgeTypes = useMemo(() => ({ stage: StageEdge }), []);
+
+  const [breakpoints, setBreakpoints] = useState<Set<string>>(() => new Set(initialBreakpoints));
+
+  const toggleBreakpoint = useCallback((taskId: string) => {
+    setBreakpoints((prev) => {
+      const next = new Set(prev);
+      if (next.has(taskId)) {
+        next.delete(taskId);
+      } else {
+        next.add(taskId);
+      }
+      return next;
+    });
+  }, []);
+
+  // Derives the stage node's data from the current breakpoint set plus the fixed
+  // task statuses. A set breakpoint is a static solid dot; a paused task shows the
+  // card's amber border and pause icon (from its status), not a changed dot.
+  const buildData = useCallback(() => {
+    const taskStatus: Record<string, StageTaskExecution> = {};
+    let anyPaused = false;
+    for (const group of tasks) {
+      for (const task of group) {
+        const status = taskStatuses?.[task.id];
+        const armed = breakpoints.has(task.id);
+        if (!status && !armed) {
+          continue;
+        }
+        if (status === 'Paused') {
+          anyPaused = true;
+        }
+        taskStatus[task.id] = {
+          ...(status
+            ? { status, ...(status === 'Paused' ? { message: 'Paused on breakpoint' } : {}) }
+            : {}),
+          ...(armed ? { breakpoint: true } : {}),
+        };
+      }
+    }
+    return {
+      stageDetails: { label: stageLabel, tasks, isReadOnly },
+      execution: {
+        stageStatus: anyPaused ? { status: 'Paused' as const, label: 'Paused on breakpoint' } : {},
+        taskStatus,
+      },
+      // Breakpoints are added/removed through the task's right-click menu (works read-only too).
+      getTaskContextMenuItems: ({ task }: { task: StageTaskItem }): NodeMenuItem[] => {
+        // Restricted tasks get no breakpoint action.
+        if (allowBreakpoint && !allowBreakpoint(task)) {
+          return [];
+        }
+        return [
+          {
+            id: 'toggle-breakpoint',
+            label: breakpoints.has(task.id) ? 'Remove breakpoint' : 'Add breakpoint',
+            onClick: () => toggleBreakpoint(task.id),
+          },
+        ];
+      },
+    };
+  }, [tasks, taskStatuses, breakpoints, stageLabel, toggleBreakpoint, allowBreakpoint, isReadOnly]);
+
+  const [nodes, setNodes, onNodesChange] = useNodesState([
+    { id: 'debug-stage', type: 'stage', position: { x: 320, y: 96 }, data: buildData() },
+  ]);
+  const [edges, , onEdgesChange] = useEdgesState([]);
+
+  // Write fresh data into React Flow's own node state whenever the breakpoint set
+  // changes, so the stage re-renders immediately. Overlaying a derived `nodes`
+  // prop did not reliably re-sync to the store, which left a toggle visually
+  // stale until the next canvas interaction.
+  useEffect(() => {
+    setNodes((prev) =>
+      prev.map((node) => (node.id === 'debug-stage' ? { ...node, data: buildData() } : node))
+    );
+  }, [buildData, setNodes]);
+
+  return (
+    <div style={{ width: '100vw', height: '100vh' }}>
+      <ReactFlowProvider>
+        <BaseCanvas
+          nodes={nodes}
+          edges={edges}
+          onNodesChange={onNodesChange}
+          onEdgesChange={onEdgesChange}
+          nodeTypes={nodeTypes}
+          edgeTypes={edgeTypes}
+          mode="design"
+          connectionMode={ConnectionMode.Strict}
+          defaultEdgeOptions={{ type: 'stage' }}
+          connectionLineComponent={StageConnectionEdge}
+          elevateEdgesOnSelect
+        >
+          <Panel position="bottom-right">
+            <CanvasPositionControls translations={DefaultCanvasTranslations} />
+          </Panel>
+        </BaseCanvas>
+      </ReactFlowProvider>
+    </div>
+  );
+};
+
+// The full breakpoint lifecycle in one stage:
+// - "Classify Request": completed with a breakpoint -> solid dot (passed).
+// - "Review and Decide": the run is paused here on its breakpoint -> solid dot
+//   plus the card's amber Paused border and pause icon (the dot itself is static).
+// - "Notify Outcome": no breakpoint.
+// Right-click any task to add / remove its breakpoint.
+export const Interactive: Story = {
+  name: 'Interactive (right-click to add/remove)',
+  render: () => (
+    <BreakpointPlaygroundStory
+      stageLabel="HR Review"
+      tasks={BREAKPOINT_TASKS}
+      initialBreakpoints={['classify', 'review']}
+      taskStatuses={{ classify: 'Completed', review: 'Paused' }}
+    />
+  ),
+};
+
+// Breakpoints apply to every task type, not just sequential ones: sequential,
+// ad hoc, and event-driven tasks all render the same corner marker. Right-click
+// a task to add / remove a breakpoint.
+const TASK_TYPE_TASKS: StageTaskItem[][] = [
+  [{ id: 'seq-review', label: 'Review and Decide', icon: <VerificationIcon /> }],
+  [{ id: 'adhoc-manual', label: 'Manual Check', icon: <ProcessIcon />, isAdhoc: true }],
+  [
+    {
+      id: 'evt-escalation',
+      label: 'On Escalation',
+      icon: <DocumentIcon />,
+      taskGroupType: 'event-driven',
+    },
+  ],
+];
+
+export const AcrossTaskTypes: Story = {
+  name: 'Across task types (sequential, ad hoc, event-driven)',
+  render: () => (
+    <BreakpointPlaygroundStory
+      stageLabel="Loan Application"
+      tasks={TASK_TYPE_TASKS}
+      initialBreakpoints={['seq-review', 'adhoc-manual', 'evt-escalation']}
+      taskStatuses={{ 'seq-review': 'Paused' }}
+    />
+  ),
+};
+
+// Only some tasks may host a breakpoint. Here only sequential tasks qualify: the
+// right-click menu on an ad hoc or event-driven task offers no breakpoint action.
+// This mirrors how a consumer suppresses breakpoints on node types that cannot be
+// paused on (the story gates this in its own getTaskContextMenuItems).
+export const Restricted: Story = {
+  name: 'Restricted (menu gated per task)',
+  render: () => (
+    <BreakpointPlaygroundStory
+      stageLabel="Loan Application"
+      tasks={TASK_TYPE_TASKS}
+      initialBreakpoints={['seq-review']}
+      allowBreakpoint={(task) => !task.isAdhoc && task.taskGroupType !== 'event-driven'}
+    />
+  ),
+};
+
+// Read-only stage (as in Debug view): editing is disabled, but the breakpoint
+// right-click menu (Add/Remove) must still work. "Review and Decide" is paused,
+// shown by the amber card border and pause icon.
+export const ReadOnlyDebugView: Story = {
+  name: 'Read-only / Debug view',
+  render: () => (
+    <BreakpointPlaygroundStory
+      stageLabel="Loan Application"
+      tasks={BREAKPOINT_TASKS}
+      initialBreakpoints={['classify', 'review']}
+      taskStatuses={{ classify: 'Completed', review: 'Paused' }}
+      isReadOnly
+    />
+  ),
+};
+
+// Breakpoints on tasks inside parallel groups. "Credit Check"/"Fraud Check" and
+// "Notify Applicant"/"Write Audit Log" are two parallel groups (rendered with the
+// parallel bracket + label); breakpoints sit on tasks within them so you can see
+// the marker on parallel tasks (add/remove via right-click).
+const BREAKPOINT_PARALLEL_TASKS: StageTaskItem[][] = [
+  [{ id: 'intake', label: 'Intake Request', icon: <ProcessIcon /> }],
+  [
+    { id: 'credit', label: 'Credit Check', icon: <VerificationIcon /> },
+    { id: 'fraud', label: 'Fraud Check', icon: <VerificationIcon /> },
+  ],
+  [
+    { id: 'notify-applicant', label: 'Notify Applicant', icon: <DocumentIcon /> },
+    { id: 'audit-log', label: 'Write Audit Log', icon: <DocumentIcon /> },
+  ],
+  [{ id: 'finalize', label: 'Finalize', icon: <ProcessIcon /> }],
+];
+
+export const ParallelTaskGroups: Story = {
+  name: 'Parallel task groups',
+  render: () => (
+    <BreakpointPlaygroundStory
+      stageLabel="Loan Application"
+      tasks={BREAKPOINT_PARALLEL_TASKS}
+      initialBreakpoints={['credit', 'notify-applicant', 'finalize']}
+    />
+  ),
+};

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.test.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.test.tsx
@@ -1311,3 +1311,58 @@ describe('StageNode - getTaskContextMenuItems', () => {
     expect(onCustom).toHaveBeenCalledTimes(1);
   });
 });
+
+// Sequential tasks render through DraggableTask, which is mocked in this suite
+// (see vi.mock('./DraggableTask') above), so the real breakpoint dot cannot be
+// asserted here for that path. The sequential path is covered against the real
+// component in DraggableTask.test.tsx; the ad hoc and event-driven paths use the
+// real task components and are verified below.
+describe('StageNode - Breakpoints on adhoc and event-driven tasks', () => {
+  it('renders a breakpoint marker on an armed adhoc task', () => {
+    renderStageNode({
+      stageDetails: {
+        label: 'Test Stage',
+        isReadOnly: true,
+        tasks: [[{ id: 'adhoc-1', label: 'Adhoc Task', isAdhoc: true }]],
+      },
+      execution: {
+        stageStatus: {},
+        taskStatus: { 'adhoc-1': { breakpoint: true } },
+      },
+    });
+
+    expect(screen.getByTestId('stage-task-breakpoint-adhoc-1')).toBeInTheDocument();
+  });
+
+  it('renders a breakpoint marker on an armed event-driven task', () => {
+    renderStageNode({
+      stageDetails: {
+        label: 'Test Stage',
+        isReadOnly: true,
+        tasks: [[{ id: 'evt-1', label: 'Event Task', taskGroupType: 'event-driven' }]],
+      },
+      execution: {
+        stageStatus: {},
+        taskStatus: { 'evt-1': { breakpoint: true } },
+      },
+    });
+
+    expect(screen.getByTestId('stage-task-breakpoint-evt-1')).toBeInTheDocument();
+  });
+
+  it('does not render a breakpoint marker on an unarmed adhoc task', () => {
+    renderStageNode({
+      stageDetails: {
+        label: 'Test Stage',
+        isReadOnly: true,
+        tasks: [[{ id: 'adhoc-1', label: 'Adhoc Task', isAdhoc: true }]],
+      },
+      execution: {
+        stageStatus: {},
+        taskStatus: {},
+      },
+    });
+
+    expect(screen.queryByTestId('stage-task-breakpoint-adhoc-1')).not.toBeInTheDocument();
+  });
+});

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.types.ts
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.types.ts
@@ -123,6 +123,12 @@ export interface StageTaskExecution {
    * pre-localized by the consumer.
    */
   retryCount?: number;
+  /**
+   * When `true`, the task shows a breakpoint marker (a red gutter dot) indicating the
+   * debugger will pause on this task. Breakpoints attach to individual tasks, not to the
+   * stage container.
+   */
+  breakpoint?: boolean;
 }
 
 export interface StageTaskDragOverlayProps {

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.utils.test.ts
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import type { NodeMenuAction, NodeMenuItem } from '../NodeContextMenu';
+import type { NodeMenuItem } from '../NodeContextMenu';
 import { INDENTATION_WIDTH } from './StageNode.styles';
 import type { StageTaskItem } from './StageNode.types';
 import {

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNodeAdhocTaskGroups.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNodeAdhocTaskGroups.tsx
@@ -78,15 +78,14 @@ const StageNodeAdhocTaskGroupsInner = ({
       <StageTaskList>
         {adhocTasks.map(({ task }) => {
           const taskExecution = execution?.taskStatus?.[task.id];
-          const customItems =
-            !isReadOnly && !hasBuiltInTaskActions
-              ? (getTaskContextMenuItems?.({
-                  task,
-                  taskGroupType: 'adhoc',
-                  isParallel: false,
-                }) ?? [])
-              : [];
-          const hasMenu = !isReadOnly && (hasBuiltInTaskActions || customItems.length > 0);
+          // Consumer items (e.g. breakpoints) are allowed even in read-only/Debug view;
+          // only the built-in edit actions are gated on !isReadOnly. When built-in actions
+          // already guarantee a menu we skip the eager consumer call; otherwise we ask the
+          // consumer whether it contributes any items.
+          const hasMenu =
+            (!isReadOnly && hasBuiltInTaskActions) ||
+            (getTaskContextMenuItems?.({ task, taskGroupType: 'adhoc', isParallel: false })
+              ?.length ?? 0) > 0;
           return (
             <AdhocTaskItem
               key={task.id}

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNodeEventDrivenTaskGroups.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNodeEventDrivenTaskGroups.tsx
@@ -77,15 +77,14 @@ const StageNodeEventDrivenTaskGroupsInner = ({
       <StageTaskList>
         {eventDrivenTasks.map(({ task }) => {
           const taskExecution = execution?.taskStatus?.[task.id];
-          const customItems =
-            !isReadOnly && !hasBuiltInTaskActions
-              ? (getTaskContextMenuItems?.({
-                  task,
-                  taskGroupType: 'event-driven',
-                  isParallel: false,
-                }) ?? [])
-              : [];
-          const hasMenu = !isReadOnly && (hasBuiltInTaskActions || customItems.length > 0);
+          // Consumer items (e.g. breakpoints) are allowed even in read-only/Debug view;
+          // only the built-in edit actions are gated on !isReadOnly. When built-in actions
+          // already guarantee a menu we skip the eager consumer call; otherwise we ask the
+          // consumer whether it contributes any items.
+          const hasMenu =
+            (!isReadOnly && hasBuiltInTaskActions) ||
+            (getTaskContextMenuItems?.({ task, taskGroupType: 'event-driven', isParallel: false })
+              ?.length ?? 0) > 0;
           return (
             <EventDrivenTaskItem
               key={task.id}

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNodeSequentialTaskGroups.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNodeSequentialTaskGroups.tsx
@@ -229,16 +229,17 @@ export const StageNodeSequentialTaskGroups = ({
                     )}
                     {taskGroup.map((task) => {
                       const taskExecution = execution?.taskStatus?.[task.id];
-                      const customItems =
-                        !isReadOnly && !hasBuiltInTaskActions
-                          ? (getTaskContextMenuItems?.({
-                              task,
-                              taskGroupType: 'sequential',
-                              isParallel,
-                            }) ?? [])
-                          : [];
+                      // Consumer items (e.g. breakpoints) are allowed even in read-only/Debug
+                      // view; only the built-in edit actions are gated on !isReadOnly. When
+                      // built-in actions already guarantee a menu we skip the eager consumer
+                      // call; otherwise we ask the consumer whether it contributes any items.
                       const hasMenu =
-                        !isReadOnly && (hasBuiltInTaskActions || customItems.length > 0);
+                        (!isReadOnly && hasBuiltInTaskActions) ||
+                        (getTaskContextMenuItems?.({
+                          task,
+                          taskGroupType: 'sequential',
+                          isParallel,
+                        })?.length ?? 0) > 0;
                       return (
                         <DraggableTask
                           key={task.id}

--- a/packages/apollo-react/src/canvas/components/StageNode/TaskBreakpointDot.test.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/TaskBreakpointDot.test.tsx
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '../../utils/testing';
+import { TaskBreakpointDot } from './TaskBreakpointDot';
+
+// The marker is display-only; adding/removing breakpoints is done via the task's
+// right-click menu (consumer-supplied). These tests cover the marker itself.
+describe('TaskBreakpointDot', () => {
+  it('renders nothing when no breakpoint is set', () => {
+    render(<TaskBreakpointDot taskId="t1" active={false} />);
+
+    expect(screen.queryByTestId('stage-task-breakpoint-t1')).not.toBeInTheDocument();
+  });
+
+  it('renders a solid marker when a breakpoint is set', () => {
+    render(<TaskBreakpointDot taskId="t1" active={true} />);
+
+    expect(screen.getByTestId('stage-task-breakpoint-t1')).toBeInTheDocument();
+  });
+
+  it('is display-only and never intercepts pointer events', () => {
+    // Breakpoints are managed via the task menu / hover toolbar; the marker itself
+    // must let clicks/drags on the card corner pass through to the task.
+    render(<TaskBreakpointDot taskId="t1" active={true} />);
+
+    expect(screen.getByTestId('stage-task-breakpoint-t1')).toHaveClass('pointer-events-none');
+  });
+
+  it('is static: the marker never animates (matches Flow, which does not pulse)', () => {
+    const { container } = render(<TaskBreakpointDot taskId="t1" active={true} />);
+
+    expect(container.querySelector('[class*="animate-"]')).not.toBeInTheDocument();
+  });
+});

--- a/packages/apollo-react/src/canvas/components/StageNode/TaskBreakpointDot.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/TaskBreakpointDot.tsx
@@ -1,0 +1,33 @@
+import { memo } from 'react';
+
+export interface TaskBreakpointDotProps {
+  /** Whether a breakpoint is set (placed) on this task. */
+  active: boolean;
+  /** Task id, used for a stable test id. */
+  taskId: string;
+}
+
+/**
+ * Breakpoint marker for a stage task, at the top-left corner of the task card.
+ *
+ * Mirrors the Flow/BPMN canvas breakpoint (`DebugBreakpoint`): a 14px solid circle
+ * filled with the canvas error-icon color, no border, shadow, or animation.
+ *
+ * Display only: it renders nothing until a breakpoint is set and never intercepts
+ * pointer events. Adding and removing breakpoints is done through the task's
+ * right-click menu (items supplied by the consumer via `getTaskContextMenuItems`).
+ */
+function TaskBreakpointDotInner({ active, taskId }: TaskBreakpointDotProps) {
+  if (!active) {
+    return null;
+  }
+
+  return (
+    <span
+      data-testid={`stage-task-breakpoint-${taskId}`}
+      className="pointer-events-none absolute -top-1.5 -left-1.5 z-10 h-3.5 w-3.5 rounded-full bg-(--canvas-error-icon)"
+    />
+  );
+}
+
+export const TaskBreakpointDot = memo(TaskBreakpointDotInner);


### PR DESCRIPTION
## Description

Adds task-level breakpoint markers to the case-management `StageNode` (**MST-12196**).

A task shows a breakpoint when its `execution.taskStatus[id].breakpoint` is `true`: a 14px solid red dot at the top-left corner of the task card, matching the Flow/BPMN canvas breakpoint (`DebugBreakpoint`) — canvas error color, no border, shadow, or animation. The marker is **display-only** and never intercepts pointer events. It works for every task type: **sequential, ad hoc, and event-driven**, including tasks inside **parallel groups**.

Adding and removing breakpoints is done through the task's **right-click / task menu**. `StageNode` does not generate that menu item — the consumer (PO.frontend, via its debug provider) supplies it through the existing `getTaskContextMenuItems` callback, and `StageNode` renders it. This PR also ensures those consumer-supplied items open the menu **even in read-only / Debug view** and when the stage exposes built-in edit actions.

**Public API (additive):** the only new surface is `StageTaskExecution.breakpoint?: boolean`, which drives the marker. No other `StageNode` props are introduced; the right-click add/remove flows through the existing `getTaskContextMenuItems`.

### How it fits together

```mermaid
flowchart LR
    MENU["Right-click / task menu<br/>Add / Remove breakpoint<br/>(consumer item via getTaskContextMenuItems)"] --> APP["Consumer (PO.frontend)<br/>updates execution.taskStatus[id].breakpoint"]
    APP --> BP["execution.taskStatus[id].breakpoint === true"]
    BP --> DOT["Solid red marker on the task<br/>(sequential / ad hoc / event-driven, incl. parallel)"]
```

## Demo

Storybook: **Components/Nodes/StageNode → Breakpoints**
- **Interactive (right-click to add/remove)** — add/remove via the task menu; a paused task also shows the amber card border + pause icon.
- **Across task types (sequential, ad hoc, event-driven)**
- **Restricted (menu gated per task)** — consumer withholds the action for tasks that can't host a breakpoint.
- **Read-only / Debug view** — editing disabled, breakpoint menu still works.
- **Parallel task groups**

https://github.com/user-attachments/assets/dd0cfabb-5103-4580-82c5-7ec788184fe2




## Risks of rolling out

- Low. Additive and opt-in: a stage that passes no breakpoint data renders exactly as before.
- No feature flags added or removed; no API removed (only `StageTaskExecution.breakpoint` added).
- The marker is `pointer-events-none`, so it can't block clicks/drags on the task card.
- The one behavior change to existing menus: consumer-supplied task context-menu items now open the menu regardless of read-only state / built-in actions (previously they could be suppressed). This is required for the breakpoint menu to work in Debug view and is backwards-compatible for consumers that don't supply custom items.

## Feature flag

- [ ] If this introduces a new feature flag, make sure first to create it in [Gitops](http://flags.uipath.com/) and specify the flag in alpha, staging and prod

_No new feature flag introduced._

## Tests

- [ ] I validated theme and locale
- [x] I added unit tests
- [x] I added component tests
- [ ] I added Playwright E2E tests
- [x] I manually tested my changes or added other kinds of tests (Please add details below)

Details:
- Unit: `TaskBreakpointDot.test.tsx` — renders only when a breakpoint is set, is `pointer-events-none`, and is static (no animation).
- Component: `StageNode.test.tsx` covers the ad hoc and event-driven paths; `DraggableTask.test.tsx` covers the sequential path (marker present/absent + display-only).
- Manual: exercised the five Storybook stories under **StageNode → Breakpoints**.
