### PR TITLE
feat(apollo-react): add sticky note editor extension seam

### DIFF
--- a/packages/apollo-react/src/canvas/components/StickyNoteNode/FormattingToolbar.test.tsx
+++ b/packages/apollo-react/src/canvas/components/StickyNoteNode/FormattingToolbar.test.tsx
@@ -151,4 +151,27 @@ describe('FormattingToolbar', () => {
     const prevented = !toolbarContainer.dispatchEvent(mouseDownEvent);
     expect(prevented).toBe(true);
   });
+
+  it('disables custom actions when no action handler is available', () => {
+    const ref = { current: null } as React.RefObject<HTMLTextAreaElement | null>;
+
+    renderWithI18n(
+      <FormattingToolbar
+        textAreaRef={ref}
+        borderColor="#42A1FF"
+        activeFormats={defaultFormats}
+        onFormat={vi.fn()}
+        actions={[
+          {
+            id: 'embed-media',
+            label: 'Embed media',
+            icon: <span aria-hidden="true">M</span>,
+            onAction: vi.fn(),
+          },
+        ]}
+      />
+    );
+
+    expect(screen.getByRole('button', { name: 'Embed media' })).toBeDisabled();
+  });
 });

--- a/packages/apollo-react/src/canvas/components/StickyNoteNode/FormattingToolbar.test.tsx
+++ b/packages/apollo-react/src/canvas/components/StickyNoteNode/FormattingToolbar.test.tsx
@@ -102,6 +102,9 @@ describe('FormattingToolbar', () => {
     expect(screen.getByRole('button', { name: /^Strikethrough \(.+X\)$/ })).toBeTruthy();
     expect(screen.getByRole('button', { name: /^Bullet list$/ })).toBeTruthy();
     expect(screen.getByRole('button', { name: /^Numbered list$/ })).toBeTruthy();
+    for (const button of screen.getAllByRole('button')) {
+      expect(button).toHaveAttribute('type', 'button');
+    }
   });
 
   it('renders translated labels when a non-English locale is active', () => {

--- a/packages/apollo-react/src/canvas/components/StickyNoteNode/FormattingToolbar.tsx
+++ b/packages/apollo-react/src/canvas/components/StickyNoteNode/FormattingToolbar.tsx
@@ -1,5 +1,5 @@
 import { CanvasIcon } from '@uipath/apollo-react/canvas';
-import { memo, type RefObject, useCallback } from 'react';
+import { type FocusEvent, memo, type RefObject, useCallback } from 'react';
 import { useSafeLingui } from '../../../i18n';
 import { CanvasTooltip } from '../CanvasTooltip';
 import type { ActiveFormats } from './markdown-formatting';
@@ -19,19 +19,23 @@ import type { StickyNoteFormattingAction, TextSelection } from './StickyNoteNode
 import { getModifierKey, isMac, readTextSelection } from './StickyNoteNode.utils';
 
 interface FormattingToolbarProps {
+  containerRef?: RefObject<HTMLDivElement | null>;
   textAreaRef: RefObject<HTMLTextAreaElement | null>;
   borderColor: string;
   activeFormats: ActiveFormats;
   onFormat: (result: TextSelection) => void;
+  onBlur?: (event: FocusEvent<HTMLDivElement>) => void;
   actions?: readonly StickyNoteFormattingAction[];
   onAction?: (action: StickyNoteFormattingAction, anchorRect: DOMRectReadOnly) => void;
 }
 
 const FormattingToolbarComponent = ({
+  containerRef,
   textAreaRef,
   borderColor,
   activeFormats,
   onFormat,
+  onBlur,
   actions = [],
   onAction,
 }: FormattingToolbarProps) => {
@@ -87,10 +91,12 @@ const FormattingToolbarComponent = ({
 
   return (
     <FormattingToolbarContainer
+      ref={containerRef}
       role="toolbar"
       aria-label={toolbarLabel}
       borderColor={borderColor}
       onMouseDown={(e) => e.preventDefault()}
+      onBlur={onBlur}
       className="nodrag nowheel"
     >
       <CanvasTooltip content={boldLabel} placement="top" delay>

--- a/packages/apollo-react/src/canvas/components/StickyNoteNode/FormattingToolbar.tsx
+++ b/packages/apollo-react/src/canvas/components/StickyNoteNode/FormattingToolbar.tsx
@@ -101,6 +101,7 @@ const FormattingToolbarComponent = ({
     >
       <CanvasTooltip content={boldLabel} placement="top" delay>
         <FormattingButton
+          type="button"
           isActive={activeFormats.bold}
           onClick={handleBold}
           aria-label={boldLabel}
@@ -111,6 +112,7 @@ const FormattingToolbarComponent = ({
       </CanvasTooltip>
       <CanvasTooltip content={italicLabel} placement="top" delay>
         <FormattingButton
+          type="button"
           isActive={activeFormats.italic}
           onClick={handleItalic}
           aria-label={italicLabel}
@@ -121,6 +123,7 @@ const FormattingToolbarComponent = ({
       </CanvasTooltip>
       <CanvasTooltip content={strikethroughLabel} placement="top" delay>
         <FormattingButton
+          type="button"
           isActive={activeFormats.strikethrough}
           onClick={handleStrikethrough}
           aria-label={strikethroughLabel}
@@ -134,6 +137,7 @@ const FormattingToolbarComponent = ({
 
       <CanvasTooltip content={bulletListLabel} placement="top" delay>
         <FormattingButton
+          type="button"
           isActive={activeFormats.bulletList}
           onClick={handleBulletList}
           aria-label={bulletListLabel}
@@ -144,6 +148,7 @@ const FormattingToolbarComponent = ({
       </CanvasTooltip>
       <CanvasTooltip content={numberedListLabel} placement="top" delay>
         <FormattingButton
+          type="button"
           isActive={activeFormats.numberedList}
           onClick={handleNumberedList}
           aria-label={numberedListLabel}

--- a/packages/apollo-react/src/canvas/components/StickyNoteNode/FormattingToolbar.tsx
+++ b/packages/apollo-react/src/canvas/components/StickyNoteNode/FormattingToolbar.tsx
@@ -144,7 +144,7 @@ const FormattingToolbarComponent = ({
           <FormattingButton
             type="button"
             isActive={false}
-            disabled={action.disabled}
+            disabled={action.disabled || !onAction}
             onClick={(event) => onAction?.(action, event.currentTarget.getBoundingClientRect())}
             aria-label={action.label}
           >

--- a/packages/apollo-react/src/canvas/components/StickyNoteNode/FormattingToolbar.tsx
+++ b/packages/apollo-react/src/canvas/components/StickyNoteNode/FormattingToolbar.tsx
@@ -100,7 +100,12 @@ const FormattingToolbarComponent = ({
       className="nodrag nowheel"
     >
       <CanvasTooltip content={boldLabel} placement="top" delay>
-        <FormattingButton isActive={activeFormats.bold} onClick={handleBold} aria-label={boldLabel}>
+        <FormattingButton
+          isActive={activeFormats.bold}
+          onClick={handleBold}
+          aria-label={boldLabel}
+          aria-pressed={activeFormats.bold}
+        >
           <CanvasIcon icon="bold" size={14} />
         </FormattingButton>
       </CanvasTooltip>
@@ -109,6 +114,7 @@ const FormattingToolbarComponent = ({
           isActive={activeFormats.italic}
           onClick={handleItalic}
           aria-label={italicLabel}
+          aria-pressed={activeFormats.italic}
         >
           <CanvasIcon icon="italic" size={14} />
         </FormattingButton>
@@ -118,6 +124,7 @@ const FormattingToolbarComponent = ({
           isActive={activeFormats.strikethrough}
           onClick={handleStrikethrough}
           aria-label={strikethroughLabel}
+          aria-pressed={activeFormats.strikethrough}
         >
           <CanvasIcon icon="strikethrough" size={14} />
         </FormattingButton>
@@ -130,6 +137,7 @@ const FormattingToolbarComponent = ({
           isActive={activeFormats.bulletList}
           onClick={handleBulletList}
           aria-label={bulletListLabel}
+          aria-pressed={activeFormats.bulletList}
         >
           <CanvasIcon icon="list" size={14} />
         </FormattingButton>
@@ -139,6 +147,7 @@ const FormattingToolbarComponent = ({
           isActive={activeFormats.numberedList}
           onClick={handleNumberedList}
           aria-label={numberedListLabel}
+          aria-pressed={activeFormats.numberedList}
         >
           <CanvasIcon icon="list-ordered" size={14} />
         </FormattingButton>

--- a/packages/apollo-react/src/canvas/components/StickyNoteNode/FormattingToolbar.tsx
+++ b/packages/apollo-react/src/canvas/components/StickyNoteNode/FormattingToolbar.tsx
@@ -24,7 +24,7 @@ interface FormattingToolbarProps {
   activeFormats: ActiveFormats;
   onFormat: (result: TextSelection) => void;
   actions?: readonly StickyNoteFormattingAction[];
-  onAction?: (action: StickyNoteFormattingAction) => void;
+  onAction?: (action: StickyNoteFormattingAction, anchorRect: DOMRectReadOnly) => void;
 }
 
 const FormattingToolbarComponent = ({
@@ -145,7 +145,7 @@ const FormattingToolbarComponent = ({
             type="button"
             isActive={false}
             disabled={action.disabled}
-            onClick={() => onAction?.(action)}
+            onClick={(event) => onAction?.(action, event.currentTarget.getBoundingClientRect())}
             aria-label={action.label}
           >
             {action.icon}

--- a/packages/apollo-react/src/canvas/components/StickyNoteNode/FormattingToolbar.tsx
+++ b/packages/apollo-react/src/canvas/components/StickyNoteNode/FormattingToolbar.tsx
@@ -15,14 +15,16 @@ import {
   FormattingToolbarContainer,
   ToolbarSeparator,
 } from './StickyNoteNode.styles';
-import type { TextSelection } from './StickyNoteNode.types';
-import { getModifierKey, isMac } from './StickyNoteNode.utils';
+import type { StickyNoteFormattingAction, TextSelection } from './StickyNoteNode.types';
+import { getModifierKey, isMac, readTextSelection } from './StickyNoteNode.utils';
 
 interface FormattingToolbarProps {
   textAreaRef: RefObject<HTMLTextAreaElement | null>;
   borderColor: string;
   activeFormats: ActiveFormats;
   onFormat: (result: TextSelection) => void;
+  actions?: readonly StickyNoteFormattingAction[];
+  onAction?: (action: StickyNoteFormattingAction) => void;
 }
 
 const FormattingToolbarComponent = ({
@@ -30,6 +32,8 @@ const FormattingToolbarComponent = ({
   borderColor,
   activeFormats,
   onFormat,
+  actions = [],
+  onAction,
 }: FormattingToolbarProps) => {
   const { _ } = useSafeLingui();
   const mod = getModifierKey();
@@ -40,13 +44,7 @@ const FormattingToolbarComponent = ({
       const textarea = textAreaRef.current;
       if (!textarea) return;
 
-      const input: TextSelection = {
-        value: textarea.value,
-        selectionStart: textarea.selectionStart,
-        selectionEnd: textarea.selectionEnd,
-      };
-
-      onFormat(formatFn(input));
+      onFormat(formatFn(readTextSelection(textarea)));
       textarea.focus();
     },
     [textAreaRef, onFormat]
@@ -139,6 +137,21 @@ const FormattingToolbarComponent = ({
           <CanvasIcon icon="list-ordered" size={14} />
         </FormattingButton>
       </CanvasTooltip>
+
+      {actions.length > 0 && <ToolbarSeparator />}
+      {actions.map((action) => (
+        <CanvasTooltip key={action.id} content={action.label} placement="top" delay>
+          <FormattingButton
+            type="button"
+            isActive={false}
+            disabled={action.disabled}
+            onClick={() => onAction?.(action)}
+            aria-label={action.label}
+          >
+            {action.icon}
+          </FormattingButton>
+        </CanvasTooltip>
+      ))}
     </FormattingToolbarContainer>
   );
 };

--- a/packages/apollo-react/src/canvas/components/StickyNoteNode/StickyNoteNode.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/StickyNoteNode/StickyNoteNode.stories.tsx
@@ -85,7 +85,27 @@ const nodeTypesWithCallbacks = {
   stickyNote: StickyNoteWithCallbacks,
 };
 
-const DEMO_IMAGE_URL = 'https://placehold.co/640x360/png?text=Sticky+note+image';
+const DEMO_MEDIA = {
+  image: {
+    alt: 'Embedded image',
+    defaultUrl: 'https://placehold.co/320x180/png?text=Sticky+note+image',
+  },
+  youtube: {
+    alt: 'Embedded YouTube video',
+    defaultUrl: 'https://www.youtube.com/watch?v=M7lc1UVf-VE',
+  },
+  publicVideo: {
+    alt: 'Embedded public video',
+    defaultUrl: 'https://interactive-examples.mdn.mozilla.net/media/cc0-videos/flower.mp4',
+  },
+} as const;
+
+type DemoMediaKind = keyof typeof DEMO_MEDIA;
+type DemoEmbedType = 'image' | 'video';
+
+type DemoMediaDialog = {
+  context: StickyNoteEditorActionContext;
+};
 
 function isHttpsUrl(value: string): boolean {
   try {
@@ -95,12 +115,64 @@ function isHttpsUrl(value: string): boolean {
   }
 }
 
-function insertImageAtSelection(
+function getYouTubeEmbedUrl(value: string): string | null {
+  try {
+    const url = new URL(value);
+    if (url.protocol !== 'https:') return null;
+
+    const host = url.hostname.replace(/^www\./, '');
+    let videoId: string | null = null;
+
+    if (host === 'youtu.be') {
+      videoId = url.pathname.split('/').filter(Boolean)[0] ?? null;
+    } else if (
+      host === 'youtube.com' ||
+      host === 'm.youtube.com' ||
+      host === 'youtube-nocookie.com'
+    ) {
+      if (url.pathname === '/watch') videoId = url.searchParams.get('v');
+      if (url.pathname.startsWith('/embed/') || url.pathname.startsWith('/shorts/')) {
+        videoId = url.pathname.split('/').filter(Boolean)[1] ?? null;
+      }
+    }
+
+    return videoId && /^[\w-]{11}$/.test(videoId)
+      ? `https://www.youtube-nocookie.com/embed/${videoId}`
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+function isYouTubeUrl(value: string): boolean {
+  try {
+    const host = new URL(value).hostname.replace(/^www\./, '');
+    return (
+      host === 'youtube.com' ||
+      host === 'm.youtube.com' ||
+      host === 'youtube-nocookie.com' ||
+      host === 'youtu.be'
+    );
+  } catch {
+    return false;
+  }
+}
+
+function createDemoMediaMarkdown(kind: DemoMediaKind, fullWidth: boolean): string {
+  const media = DEMO_MEDIA[kind];
+  const layoutTitle = fullWidth ? ' "full-width"' : '';
+  return `![${media.alt}](${media.defaultUrl}${layoutTitle})`;
+}
+
+function insertMediaAtSelection(
   currentValue: string,
   selection: TextSelection,
-  imageUrl: string
+  alt: string,
+  mediaUrl: string,
+  fullWidth: boolean
 ): TextSelection {
-  const markdown = `![Embedded image](${imageUrl})`;
+  const layoutTitle = fullWidth ? ' "full-width"' : '';
+  const markdown = `![${alt}](${mediaUrl}${layoutTitle})`;
   const selectionIsCurrent = currentValue === selection.value;
   const start = selectionIsCurrent ? selection.selectionStart : currentValue.length;
   const end = selectionIsCurrent ? selection.selectionEnd : currentValue.length;
@@ -113,65 +185,141 @@ function insertImageAtSelection(
 }
 
 function StickyNoteWithEditorExtensions(props: StickyNoteNodeProps) {
-  const [actionContext, setActionContext] = useState<StickyNoteEditorActionContext | null>(null);
-  const [imageUrl, setImageUrl] = useState(DEMO_IMAGE_URL);
+  const [dialog, setDialog] = useState<DemoMediaDialog | null>(null);
+  const [embedType, setEmbedType] = useState<DemoEmbedType>('image');
+  const [mediaUrl, setMediaUrl] = useState('');
+  const [makeFullWidth, setMakeFullWidth] = useState(true);
   const [validationMessage, setValidationMessage] = useState('');
-  const imageUrlInputRef = useRef<HTMLInputElement>(null);
+  const mediaUrlInputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
-    if (!actionContext) return;
-    requestAnimationFrame(() => imageUrlInputRef.current?.focus());
-  }, [actionContext]);
+    if (!dialog) return;
+    requestAnimationFrame(() => mediaUrlInputRef.current?.focus());
+  }, [dialog]);
 
-  const openImageDialog = useCallback((context: StickyNoteEditorActionContext) => {
+  const openMediaDialog = useCallback((context: StickyNoteEditorActionContext) => {
+    setEmbedType('image');
+    setMediaUrl(DEMO_MEDIA.image.defaultUrl);
+    setMakeFullWidth(true);
     setValidationMessage('');
-    setActionContext(context);
+    setDialog({ context });
   }, []);
 
-  const cancelImageDialog = useCallback(() => {
-    actionContext?.resume();
-    setActionContext(null);
+  const selectEmbedType = useCallback((type: DemoEmbedType) => {
+    setEmbedType(type);
+    setMediaUrl(type === 'image' ? DEMO_MEDIA.image.defaultUrl : DEMO_MEDIA.youtube.defaultUrl);
     setValidationMessage('');
-  }, [actionContext]);
+  }, []);
 
-  const insertImage = useCallback(() => {
-    if (!actionContext) return;
-    if (!isHttpsUrl(imageUrl)) {
-      setValidationMessage('Enter a valid HTTPS image URL.');
+  const cancelMediaDialog = useCallback(() => {
+    dialog?.context.resume();
+    setDialog(null);
+    setValidationMessage('');
+  }, [dialog]);
+
+  const insertMedia = useCallback(() => {
+    if (!dialog) return;
+    if (!isHttpsUrl(mediaUrl)) {
+      setValidationMessage('Enter a valid HTTPS URL.');
+      return;
+    }
+    const youtubeEmbedUrl = embedType === 'video' ? getYouTubeEmbedUrl(mediaUrl) : null;
+    if (embedType === 'video' && isYouTubeUrl(mediaUrl) && !youtubeEmbedUrl) {
+      setValidationMessage('Enter a valid public YouTube URL.');
       return;
     }
 
-    actionContext.commit(
-      insertImageAtSelection(actionContext.currentValue(), actionContext.selection, imageUrl)
+    const media =
+      embedType === 'image'
+        ? DEMO_MEDIA.image
+        : youtubeEmbedUrl
+          ? DEMO_MEDIA.youtube
+          : DEMO_MEDIA.publicVideo;
+    dialog.context.commit(
+      insertMediaAtSelection(
+        dialog.context.currentValue(),
+        dialog.context.selection,
+        media.alt,
+        mediaUrl,
+        makeFullWidth
+      )
     );
-    setActionContext(null);
+    setDialog(null);
     setValidationMessage('');
-  }, [actionContext, imageUrl]);
+  }, [dialog, embedType, makeFullWidth, mediaUrl]);
 
   const formattingActions = useMemo<readonly StickyNoteFormattingAction[]>(
     () => [
       {
-        id: 'embed-demo-image',
+        id: 'embed-demo-media',
         icon: <CanvasIcon icon="image-plus" size={14} />,
-        label: 'Embed demo image',
-        onAction: openImageDialog,
+        label: 'Embed media',
+        onAction: openMediaDialog,
       },
     ],
-    [openImageDialog]
+    [openMediaDialog]
   );
 
   const renderMarkdown = useCallback(
     (content: string) => (
       <ReactMarkdown
         components={{
-          img: ({ src, alt }) => (
-            <img
-              src={src}
-              alt={alt ?? ''}
-              draggable={false}
-              style={{ display: 'block', width: '100%', height: 'auto', borderRadius: 6 }}
-            />
-          ),
+          img: ({ src, alt, title }) => {
+            const fullWidth = title === 'full-width';
+
+            if (alt === DEMO_MEDIA.youtube.alt) {
+              const embedUrl = getYouTubeEmbedUrl(src ?? '');
+              return embedUrl ? (
+                <iframe
+                  src={embedUrl}
+                  title={alt}
+                  allow="autoplay; encrypted-media; picture-in-picture"
+                  allowFullScreen
+                  style={{
+                    width: fullWidth ? '100%' : 320,
+                    maxWidth: '100%',
+                    aspectRatio: '16 / 9',
+                    border: 0,
+                    borderRadius: 6,
+                  }}
+                />
+              ) : null;
+            }
+
+            if (alt === DEMO_MEDIA.publicVideo.alt) {
+              return (
+                <video
+                  src={src}
+                  aria-label={alt}
+                  controls
+                  muted
+                  preload="metadata"
+                  style={{
+                    display: 'block',
+                    width: fullWidth ? '100%' : 320,
+                    maxWidth: '100%',
+                    height: 'auto',
+                    borderRadius: 6,
+                  }}
+                />
+              );
+            }
+
+            return (
+              <img
+                src={src}
+                alt={alt ?? ''}
+                draggable={false}
+                style={{
+                  display: 'block',
+                  width: fullWidth ? '100%' : 'auto',
+                  maxWidth: '100%',
+                  height: 'auto',
+                  borderRadius: 6,
+                }}
+              />
+            );
+          },
         }}
       >
         {content}
@@ -187,7 +335,7 @@ function StickyNoteWithEditorExtensions(props: StickyNoteNodeProps) {
         formattingActions={formattingActions}
         renderMarkdown={renderMarkdown}
       />
-      {actionContext &&
+      {dialog &&
         typeof document !== 'undefined' &&
         createPortal(
           <div
@@ -197,33 +345,32 @@ function StickyNoteWithEditorExtensions(props: StickyNoteNodeProps) {
               inset: 0,
               zIndex: 10000,
               display: 'grid',
-              placeItems: 'center',
-              background: 'rgb(0 0 0 / 45%)',
+              placeItems: 'start center',
+              paddingTop: 72,
             }}
             onMouseDown={(event) => {
-              if (event.target === event.currentTarget) cancelImageDialog();
+              if (event.target === event.currentTarget) cancelMediaDialog();
             }}
           >
             <form
               role="dialog"
-              aria-modal="true"
-              aria-labelledby="sticky-note-image-dialog-title"
+              aria-labelledby="sticky-note-media-dialog-title"
               onSubmit={(event) => {
                 event.preventDefault();
-                insertImage();
+                insertMedia();
               }}
               style={{
-                width: 'min(440px, calc(100vw - 32px))',
-                padding: 20,
+                width: 'min(380px, calc(100vw - 32px))',
+                padding: 16,
                 border: '1px solid var(--canvas-border-de-emp)',
-                borderRadius: 12,
+                borderRadius: 8,
                 color: 'var(--canvas-foreground)',
                 background: 'var(--canvas-background-raised)',
-                boxShadow: '0 20px 50px rgb(0 0 0 / 35%)',
+                boxShadow: '0 12px 32px rgb(0 0 0 / 28%)',
               }}
             >
-              <h2 id="sticky-note-image-dialog-title" style={{ margin: '0 0 8px', fontSize: 18 }}>
-                Embed demo image
+              <h2 id="sticky-note-media-dialog-title" style={{ margin: '0 0 8px', fontSize: 18 }}>
+                Embed media
               </h2>
               <p
                 style={{
@@ -232,21 +379,44 @@ function StickyNoteWithEditorExtensions(props: StickyNoteNodeProps) {
                   fontSize: 13,
                 }}
               >
-                The image Markdown is inserted at the saved cursor. If the note changes while this
-                dialog is open, it is appended instead.
+                Choose an image or video link. YouTube and direct public video URLs use the same
+                Video option.
               </p>
+              <fieldset style={{ margin: '0 0 14px', padding: 0, border: 0 }}>
+                <legend style={{ marginBottom: 6, fontSize: 13 }}>Media type</legend>
+                <div style={{ display: 'flex', gap: 16 }}>
+                  <label style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: 13 }}>
+                    <input
+                      type="radio"
+                      name="sticky-note-demo-media-type"
+                      checked={embedType === 'image'}
+                      onChange={() => selectEmbedType('image')}
+                    />
+                    Image
+                  </label>
+                  <label style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: 13 }}>
+                    <input
+                      type="radio"
+                      name="sticky-note-demo-media-type"
+                      checked={embedType === 'video'}
+                      onChange={() => selectEmbedType('video')}
+                    />
+                    Video
+                  </label>
+                </div>
+              </fieldset>
               <label
-                htmlFor="sticky-note-demo-image-url"
+                htmlFor="sticky-note-demo-media-url"
                 style={{ display: 'block', fontSize: 13 }}
               >
-                HTTPS image URL
+                {embedType === 'image' ? 'HTTPS image URL' : 'YouTube or public video URL'}
               </label>
               <input
-                ref={imageUrlInputRef}
-                id="sticky-note-demo-image-url"
-                value={imageUrl}
+                ref={mediaUrlInputRef}
+                id="sticky-note-demo-media-url"
+                value={mediaUrl}
                 onChange={(event) => {
-                  setImageUrl(event.target.value);
+                  setMediaUrl(event.target.value);
                   setValidationMessage('');
                 }}
                 style={{
@@ -260,17 +430,45 @@ function StickyNoteWithEditorExtensions(props: StickyNoteNodeProps) {
                   background: 'var(--canvas-background)',
                 }}
               />
+              {embedType === 'video' && (
+                <p
+                  style={{
+                    margin: '6px 0 0',
+                    color: 'var(--canvas-foreground-de-emp)',
+                    fontSize: 12,
+                  }}
+                >
+                  Accepts YouTube watch, share, Shorts, and embed URLs, or a direct public video URL
+                  such as MP4.
+                </p>
+              )}
+              <label
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 8,
+                  marginTop: 14,
+                  fontSize: 13,
+                }}
+              >
+                <input
+                  type="checkbox"
+                  checked={makeFullWidth}
+                  onChange={(event) => setMakeFullWidth(event.target.checked)}
+                />
+                Make full width
+              </label>
               {validationMessage && (
                 <p role="alert" style={{ margin: '8px 0 0', color: 'var(--canvas-error-icon)' }}>
                   {validationMessage}
                 </p>
               )}
               <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 8, marginTop: 20 }}>
-                <button type="button" onClick={cancelImageDialog} style={{ padding: '8px 14px' }}>
+                <button type="button" onClick={cancelMediaDialog} style={{ padding: '8px 14px' }}>
                   Cancel
                 </button>
                 <button type="submit" style={{ padding: '8px 14px' }}>
-                  Insert image
+                  Insert media
                 </button>
               </div>
             </form>
@@ -843,15 +1041,33 @@ function WithCallbacksStory() {
 
 function EditorExtensionsStory() {
   const initialNodes = useMemo<Node<StickyNoteData>[]>(() => {
-    const note = createStickyNote(
+    const editorNote = createStickyNote(
       'sticky-editor-extensions',
       'yellow',
-      '**Try the editor extension**\n\nPlace the cursor here → and choose the image button.',
-      { x: 430, y: 190 },
-      { width: 420, height: 360 }
+      '**Complete media playground**\n\nPlace the cursor or select text, then choose **Embed media**. Pick Image or Video, toggle **Make full width**, insert or cancel, then press Escape to preview.',
+      { x: 50, y: 190 },
+      { width: 420, height: 400 }
+    );
+    const galleryNote = createStickyNote(
+      'sticky-media-gallery',
+      'blue',
+      [
+        '## Rendered media gallery',
+        '### Full-width image',
+        createDemoMediaMarkdown('image', true),
+        '### Full-width YouTube video',
+        createDemoMediaMarkdown('youtube', true),
+        '### Full-width public video',
+        createDemoMediaMarkdown('publicVideo', true),
+      ].join('\n\n'),
+      { x: 560, y: 80 },
+      { width: 360, height: 520 }
     );
 
-    return [{ ...note, selected: true, data: { ...note.data, autoFocus: true } }];
+    return [
+      { ...editorNote, selected: true, data: { ...editorNote.data, autoFocus: true } },
+      galleryNote,
+    ];
   }, []);
 
   const { canvasProps } = useCanvasStory({
@@ -862,8 +1078,10 @@ function EditorExtensionsStory() {
   return (
     <BaseCanvas {...canvasProps} mode="design">
       <StoryInfoPanel
-        title="Sticky Note Editor Extensions"
-        description="Move the cursor, click the image-plus action after the list buttons, then insert or cancel. Press Escape after inserting to preview the rendered image. This exercises selection capture, external-dialog focus, commit/resume, and custom rendering."
+        title="Complete Sticky Note Media Extension"
+        description="One Embed media action opens one popover. Choose Image or Video; Video automatically handles YouTube and direct public links. Test cursor insertion or selected-text replacement, HTTPS validation, optional full width, cancel/resume, stale-content append fallback, tooltip, and custom rendering. Press Escape after inserting to preview. The blue note shows all three rendered outcomes."
+        collapsible
+        defaultCollapsed
       />
       <Panel position="bottom-right">
         <CanvasPositionControls translations={DefaultCanvasTranslations} />

--- a/packages/apollo-react/src/canvas/components/StickyNoteNode/StickyNoteNode.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/StickyNoteNode/StickyNoteNode.stories.tsx
@@ -1,13 +1,22 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { CanvasIcon } from '@uipath/apollo-react/canvas';
 import type { Edge, Node } from '@uipath/apollo-react/canvas/xyflow/react';
 import { Panel, Position } from '@uipath/apollo-react/canvas/xyflow/react';
-import { useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import ReactMarkdown from 'react-markdown';
 import { StoryInfoPanel, useCanvasStory, withCanvasProviders } from '../../storybook-utils';
 import { DefaultCanvasTranslations } from '../../types';
 import { BaseCanvas } from '../BaseCanvas';
 import { CanvasPositionControls } from '../CanvasPositionControls';
-import { StickyNoteNode } from './StickyNoteNode';
-import type { StickyNoteColor, StickyNoteData } from './StickyNoteNode.types';
+import { StickyNoteNode, type StickyNoteNodeProps } from './StickyNoteNode';
+import type {
+  StickyNoteColor,
+  StickyNoteData,
+  StickyNoteEditorActionContext,
+  StickyNoteFormattingAction,
+  TextSelection,
+} from './StickyNoteNode.types';
 
 // ============================================================================
 // Meta Configuration
@@ -32,7 +41,7 @@ const STORY_LOOP_SUCCESS_HANDLE_ID = 'success';
 // ============================================================================
 
 // StickyNote wrapper with console logging for callbacks
-const StickyNoteWithCallbacks = (props: any) => {
+const StickyNoteWithCallbacks = (props: StickyNoteNodeProps) => {
   const handleContentChange = (content: string) => {
     console.log('📝 Content changed:', {
       nodeId: props.id,
@@ -76,7 +85,207 @@ const nodeTypesWithCallbacks = {
   stickyNote: StickyNoteWithCallbacks,
 };
 
-const ReadOnlyStickyNote = (props: any) => <StickyNoteNode {...props} readOnly />;
+const DEMO_IMAGE_URL = 'https://placehold.co/640x360/png?text=Sticky+note+image';
+
+function isHttpsUrl(value: string): boolean {
+  try {
+    return new URL(value).protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
+function insertImageAtSelection(
+  currentValue: string,
+  selection: TextSelection,
+  imageUrl: string
+): TextSelection {
+  const markdown = `![Embedded image](${imageUrl})`;
+  const selectionIsCurrent = currentValue === selection.value;
+  const start = selectionIsCurrent ? selection.selectionStart : currentValue.length;
+  const end = selectionIsCurrent ? selection.selectionEnd : currentValue.length;
+  const prefix = start > 0 && currentValue[start - 1] !== '\n' ? '\n\n' : '';
+  const suffix = end < currentValue.length && currentValue[end] !== '\n' ? '\n\n' : '';
+  const value = `${currentValue.slice(0, start)}${prefix}${markdown}${suffix}${currentValue.slice(end)}`;
+  const cursor = start + prefix.length + markdown.length;
+
+  return { value, selectionStart: cursor, selectionEnd: cursor };
+}
+
+function StickyNoteWithEditorExtensions(props: StickyNoteNodeProps) {
+  const [actionContext, setActionContext] = useState<StickyNoteEditorActionContext | null>(null);
+  const [imageUrl, setImageUrl] = useState(DEMO_IMAGE_URL);
+  const [validationMessage, setValidationMessage] = useState('');
+  const imageUrlInputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (!actionContext) return;
+    requestAnimationFrame(() => imageUrlInputRef.current?.focus());
+  }, [actionContext]);
+
+  const openImageDialog = useCallback((context: StickyNoteEditorActionContext) => {
+    setValidationMessage('');
+    setActionContext(context);
+  }, []);
+
+  const cancelImageDialog = useCallback(() => {
+    actionContext?.resume();
+    setActionContext(null);
+    setValidationMessage('');
+  }, [actionContext]);
+
+  const insertImage = useCallback(() => {
+    if (!actionContext) return;
+    if (!isHttpsUrl(imageUrl)) {
+      setValidationMessage('Enter a valid HTTPS image URL.');
+      return;
+    }
+
+    actionContext.commit(
+      insertImageAtSelection(actionContext.currentValue(), actionContext.selection, imageUrl)
+    );
+    setActionContext(null);
+    setValidationMessage('');
+  }, [actionContext, imageUrl]);
+
+  const formattingActions = useMemo<readonly StickyNoteFormattingAction[]>(
+    () => [
+      {
+        id: 'embed-demo-image',
+        icon: <CanvasIcon icon="image-plus" size={14} />,
+        label: 'Embed demo image',
+        onAction: openImageDialog,
+      },
+    ],
+    [openImageDialog]
+  );
+
+  const renderMarkdown = useCallback(
+    (content: string) => (
+      <ReactMarkdown
+        components={{
+          img: ({ src, alt }) => (
+            <img
+              src={src}
+              alt={alt ?? ''}
+              draggable={false}
+              style={{ display: 'block', width: '100%', height: 'auto', borderRadius: 6 }}
+            />
+          ),
+        }}
+      >
+        {content}
+      </ReactMarkdown>
+    ),
+    []
+  );
+
+  return (
+    <>
+      <StickyNoteNode
+        {...props}
+        formattingActions={formattingActions}
+        renderMarkdown={renderMarkdown}
+      />
+      {actionContext &&
+        typeof document !== 'undefined' &&
+        createPortal(
+          <div
+            role="presentation"
+            style={{
+              position: 'fixed',
+              inset: 0,
+              zIndex: 10000,
+              display: 'grid',
+              placeItems: 'center',
+              background: 'rgb(0 0 0 / 45%)',
+            }}
+            onMouseDown={(event) => {
+              if (event.target === event.currentTarget) cancelImageDialog();
+            }}
+          >
+            <form
+              role="dialog"
+              aria-modal="true"
+              aria-labelledby="sticky-note-image-dialog-title"
+              onSubmit={(event) => {
+                event.preventDefault();
+                insertImage();
+              }}
+              style={{
+                width: 'min(440px, calc(100vw - 32px))',
+                padding: 20,
+                border: '1px solid var(--canvas-border-de-emp)',
+                borderRadius: 12,
+                color: 'var(--canvas-foreground)',
+                background: 'var(--canvas-background-raised)',
+                boxShadow: '0 20px 50px rgb(0 0 0 / 35%)',
+              }}
+            >
+              <h2 id="sticky-note-image-dialog-title" style={{ margin: '0 0 8px', fontSize: 18 }}>
+                Embed demo image
+              </h2>
+              <p
+                style={{
+                  margin: '0 0 16px',
+                  color: 'var(--canvas-foreground-de-emp)',
+                  fontSize: 13,
+                }}
+              >
+                The image Markdown is inserted at the saved cursor. If the note changes while this
+                dialog is open, it is appended instead.
+              </p>
+              <label
+                htmlFor="sticky-note-demo-image-url"
+                style={{ display: 'block', fontSize: 13 }}
+              >
+                HTTPS image URL
+              </label>
+              <input
+                ref={imageUrlInputRef}
+                id="sticky-note-demo-image-url"
+                value={imageUrl}
+                onChange={(event) => {
+                  setImageUrl(event.target.value);
+                  setValidationMessage('');
+                }}
+                style={{
+                  boxSizing: 'border-box',
+                  width: '100%',
+                  marginTop: 6,
+                  padding: '9px 10px',
+                  border: '1px solid var(--canvas-border)',
+                  borderRadius: 6,
+                  color: 'var(--canvas-foreground)',
+                  background: 'var(--canvas-background)',
+                }}
+              />
+              {validationMessage && (
+                <p role="alert" style={{ margin: '8px 0 0', color: 'var(--canvas-error-icon)' }}>
+                  {validationMessage}
+                </p>
+              )}
+              <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 8, marginTop: 20 }}>
+                <button type="button" onClick={cancelImageDialog} style={{ padding: '8px 14px' }}>
+                  Cancel
+                </button>
+                <button type="submit" style={{ padding: '8px 14px' }}>
+                  Insert image
+                </button>
+              </div>
+            </form>
+          </div>,
+          document.body
+        )}
+    </>
+  );
+}
+
+const nodeTypesWithEditorExtensions = {
+  stickyNote: StickyNoteWithEditorExtensions,
+};
+
+const ReadOnlyStickyNote = (props: StickyNoteNodeProps) => <StickyNoteNode {...props} readOnly />;
 
 const nodeTypesReadOnly = {
   stickyNote: ReadOnlyStickyNote,
@@ -632,6 +841,37 @@ function WithCallbacksStory() {
   );
 }
 
+function EditorExtensionsStory() {
+  const initialNodes = useMemo<Node<StickyNoteData>[]>(() => {
+    const note = createStickyNote(
+      'sticky-editor-extensions',
+      'yellow',
+      '**Try the editor extension**\n\nPlace the cursor here → and choose the image button.',
+      { x: 430, y: 190 },
+      { width: 420, height: 360 }
+    );
+
+    return [{ ...note, selected: true, data: { ...note.data, autoFocus: true } }];
+  }, []);
+
+  const { canvasProps } = useCanvasStory({
+    initialNodes,
+    additionalNodeTypes: nodeTypesWithEditorExtensions,
+  });
+
+  return (
+    <BaseCanvas {...canvasProps} mode="design">
+      <StoryInfoPanel
+        title="Sticky Note Editor Extensions"
+        description="Move the cursor, click the image-plus action after the list buttons, then insert or cancel. Press Escape after inserting to preview the rendered image. This exercises selection capture, external-dialog focus, commit/resume, and custom rendering."
+      />
+      <Panel position="bottom-right">
+        <CanvasPositionControls translations={DefaultCanvasTranslations} />
+      </Panel>
+    </BaseCanvas>
+  );
+}
+
 function ReadOnlyStory() {
   const initialNodes = useMemo<Node<StickyNoteData>[]>(
     () => [
@@ -678,6 +918,10 @@ export const StickyNotesInLoopContainers: Story = {
 
 export const WithCallbacks: Story = {
   render: () => <WithCallbacksStory />,
+};
+
+export const EditorExtensions: Story = {
+  render: () => <EditorExtensionsStory />,
 };
 
 export const ReadOnly: Story = {

--- a/packages/apollo-react/src/canvas/components/StickyNoteNode/StickyNoteNode.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/StickyNoteNode/StickyNoteNode.stories.tsx
@@ -175,7 +175,12 @@ function parseMediaTitle(title?: string): MediaMetadata | null {
     title
       .split(';')
       .slice(1)
-      .map((part) => part.split('='))
+      .flatMap((part): [string, string][] => {
+        const separatorIndex = part.indexOf('=');
+        if (separatorIndex <= 0 || separatorIndex === part.length - 1) return [];
+
+        return [[part.slice(0, separatorIndex), part.slice(separatorIndex + 1)]];
+      })
   );
   const kind = values.kind;
   const layout = values.layout;

--- a/packages/apollo-react/src/canvas/components/StickyNoteNode/StickyNoteNode.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/StickyNoteNode/StickyNoteNode.stories.tsx
@@ -88,7 +88,7 @@ const nodeTypesWithCallbacks = {
 const DEMO_MEDIA = {
   image: {
     alt: 'Embedded image',
-    defaultUrl: 'https://placehold.co/320x180/png?text=Sticky+note+image',
+    defaultUrl: 'https://placehold.co/200x113/png?text=Sticky+note+image',
   },
   youtube: {
     alt: 'Embedded YouTube video',
@@ -119,6 +119,7 @@ type YouTubeUrlInfo = {
 };
 
 const MEDIA_TITLE_PREFIX = 'sticky-note-media';
+const DEMO_NATURAL_MEDIA_WIDTH = 200;
 
 function isHttpsUrl(value: string): boolean {
   try {
@@ -311,7 +312,7 @@ function StickyNoteWithEditorExtensions(props: StickyNoteNodeProps) {
                   allow="autoplay; encrypted-media; picture-in-picture"
                   allowFullScreen
                   style={{
-                    width: fullWidth ? '100%' : 320,
+                    width: fullWidth ? '100%' : DEMO_NATURAL_MEDIA_WIDTH,
                     maxWidth: '100%',
                     aspectRatio: '16 / 9',
                     border: 0,
@@ -331,7 +332,7 @@ function StickyNoteWithEditorExtensions(props: StickyNoteNodeProps) {
                   preload="metadata"
                   style={{
                     display: 'block',
-                    width: fullWidth ? '100%' : 320,
+                    width: fullWidth ? '100%' : DEMO_NATURAL_MEDIA_WIDTH,
                     maxWidth: '100%',
                     height: 'auto',
                     borderRadius: 6,
@@ -1111,10 +1112,16 @@ function EditorExtensionsStory() {
         '## Rendered media gallery',
         '### Full-width image',
         createDemoMediaMarkdown('image', true),
+        '### Natural-width image',
+        createDemoMediaMarkdown('image', false),
         '### Full-width YouTube video',
         createDemoMediaMarkdown('youtube', true),
+        '### Natural-width YouTube video',
+        createDemoMediaMarkdown('youtube', false),
         '### Full-width public video',
         createDemoMediaMarkdown('publicVideo', true),
+        '### Natural-width public video',
+        createDemoMediaMarkdown('publicVideo', false),
       ].join('\n\n'),
       { x: 560, y: 80 },
       { width: 360, height: 520 }
@@ -1135,7 +1142,7 @@ function EditorExtensionsStory() {
     <BaseCanvas {...canvasProps} mode="design">
       <StoryInfoPanel
         title="Complete Sticky Note Media Extension"
-        description="One Embed media action opens one popover. Choose Image or Video; Video automatically handles YouTube and direct public links. Test cursor insertion or selected-text replacement, HTTPS validation, optional full width, cancel/resume, stale-content append fallback, tooltip, and custom rendering. Press Escape after inserting to preview. The blue note shows all three rendered outcomes."
+        description="One Embed media action opens one popover. Choose Image or Video; Video automatically handles YouTube and direct public links. Test cursor insertion or selected-text replacement, HTTPS validation, optional full width, cancel/resume, stale-content append fallback, tooltip, and custom rendering. Press Escape after inserting to preview. The blue note compares natural and full width for every media type."
         collapsible
         defaultCollapsed
       />

--- a/packages/apollo-react/src/canvas/components/StickyNoteNode/StickyNoteNode.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/StickyNoteNode/StickyNoteNode.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { CanvasIcon } from '@uipath/apollo-react/canvas';
 import type { Edge, Node } from '@uipath/apollo-react/canvas/xyflow/react';
-import { Panel, Position } from '@uipath/apollo-react/canvas/xyflow/react';
+import { Panel, Position, useReactFlow } from '@uipath/apollo-react/canvas/xyflow/react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import ReactMarkdown from 'react-markdown';
@@ -102,10 +102,23 @@ const DEMO_MEDIA = {
 
 type DemoMediaKind = keyof typeof DEMO_MEDIA;
 type DemoEmbedType = 'image' | 'video';
+type MediaLayout = 'full-width' | 'natural-width';
 
 type DemoMediaDialog = {
   context: StickyNoteEditorActionContext;
 };
+
+type MediaMetadata = {
+  kind: DemoMediaKind;
+  layout: MediaLayout;
+};
+
+type YouTubeUrlInfo = {
+  recognized: boolean;
+  embedUrl: string | null;
+};
+
+const MEDIA_TITLE_PREFIX = 'sticky-note-media';
 
 function isHttpsUrl(value: string): boolean {
   try {
@@ -115,64 +128,77 @@ function isHttpsUrl(value: string): boolean {
   }
 }
 
-function getYouTubeEmbedUrl(value: string): string | null {
+function parseYouTubeUrl(value: string): YouTubeUrlInfo {
   try {
     const url = new URL(value);
-    if (url.protocol !== 'https:') return null;
-
     const host = url.hostname.replace(/^www\./, '');
-    let videoId: string | null = null;
-
-    if (host === 'youtu.be') {
-      videoId = url.pathname.split('/').filter(Boolean)[0] ?? null;
-    } else if (
-      host === 'youtube.com' ||
-      host === 'm.youtube.com' ||
-      host === 'youtube-nocookie.com'
-    ) {
-      if (url.pathname === '/watch') videoId = url.searchParams.get('v');
-      if (url.pathname.startsWith('/embed/') || url.pathname.startsWith('/shorts/')) {
-        videoId = url.pathname.split('/').filter(Boolean)[1] ?? null;
-      }
-    }
-
-    return videoId && /^[\w-]{11}$/.test(videoId)
-      ? `https://www.youtube-nocookie.com/embed/${videoId}`
-      : null;
-  } catch {
-    return null;
-  }
-}
-
-function isYouTubeUrl(value: string): boolean {
-  try {
-    const host = new URL(value).hostname.replace(/^www\./, '');
-    return (
+    const recognized =
       host === 'youtube.com' ||
       host === 'm.youtube.com' ||
       host === 'youtube-nocookie.com' ||
-      host === 'youtu.be'
-    );
+      host === 'youtu.be';
+
+    if (!recognized) return { recognized: false, embedUrl: null };
+    if (url.protocol !== 'https:') return { recognized: true, embedUrl: null };
+
+    let videoId: string | null = null;
+    if (host === 'youtu.be') {
+      videoId = url.pathname.split('/').filter(Boolean)[0] ?? null;
+    } else if (url.pathname === '/watch') {
+      videoId = url.searchParams.get('v');
+    } else if (url.pathname.startsWith('/embed/') || url.pathname.startsWith('/shorts/')) {
+      videoId = url.pathname.split('/').filter(Boolean)[1] ?? null;
+    }
+
+    return {
+      recognized: true,
+      embedUrl:
+        videoId && /^[\w-]{11}$/.test(videoId)
+          ? `https://www.youtube-nocookie.com/embed/${videoId}`
+          : null,
+    };
   } catch {
-    return false;
+    return { recognized: false, embedUrl: null };
   }
 }
 
+function serializeMediaTitle(kind: DemoMediaKind, fullWidth: boolean): string {
+  const layout: MediaLayout = fullWidth ? 'full-width' : 'natural-width';
+  return `${MEDIA_TITLE_PREFIX};kind=${kind};layout=${layout}`;
+}
+
+function parseMediaTitle(title?: string): MediaMetadata | null {
+  if (!title?.startsWith(`${MEDIA_TITLE_PREFIX};`)) return null;
+
+  const values = Object.fromEntries(
+    title
+      .split(';')
+      .slice(1)
+      .map((part) => part.split('='))
+  );
+  const kind = values.kind;
+  const layout = values.layout;
+  if (!(kind === 'image' || kind === 'youtube' || kind === 'publicVideo')) return null;
+  if (!(layout === 'full-width' || layout === 'natural-width')) return null;
+  return { kind, layout };
+}
+
+function serializeMediaMarkdown(kind: DemoMediaKind, mediaUrl: string, fullWidth: boolean): string {
+  return `![${DEMO_MEDIA[kind].alt}](${mediaUrl} "${serializeMediaTitle(kind, fullWidth)}")`;
+}
+
 function createDemoMediaMarkdown(kind: DemoMediaKind, fullWidth: boolean): string {
-  const media = DEMO_MEDIA[kind];
-  const layoutTitle = fullWidth ? ' "full-width"' : '';
-  return `![${media.alt}](${media.defaultUrl}${layoutTitle})`;
+  return serializeMediaMarkdown(kind, DEMO_MEDIA[kind].defaultUrl, fullWidth);
 }
 
 function insertMediaAtSelection(
   currentValue: string,
   selection: TextSelection,
-  alt: string,
+  kind: DemoMediaKind,
   mediaUrl: string,
   fullWidth: boolean
 ): TextSelection {
-  const layoutTitle = fullWidth ? ' "full-width"' : '';
-  const markdown = `![${alt}](${mediaUrl}${layoutTitle})`;
+  const markdown = serializeMediaMarkdown(kind, mediaUrl, fullWidth);
   const selectionIsCurrent = currentValue === selection.value;
   const start = selectionIsCurrent ? selection.selectionStart : currentValue.length;
   const end = selectionIsCurrent ? selection.selectionEnd : currentValue.length;
@@ -185,11 +211,13 @@ function insertMediaAtSelection(
 }
 
 function StickyNoteWithEditorExtensions(props: StickyNoteNodeProps) {
+  const { updateNodeData } = useReactFlow();
   const [dialog, setDialog] = useState<DemoMediaDialog | null>(null);
   const [embedType, setEmbedType] = useState<DemoEmbedType>('image');
   const [mediaUrl, setMediaUrl] = useState('');
   const [makeFullWidth, setMakeFullWidth] = useState(true);
   const [validationMessage, setValidationMessage] = useState('');
+  const [externalUpdateSimulated, setExternalUpdateSimulated] = useState(false);
   const mediaUrlInputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
@@ -202,6 +230,7 @@ function StickyNoteWithEditorExtensions(props: StickyNoteNodeProps) {
     setMediaUrl(DEMO_MEDIA.image.defaultUrl);
     setMakeFullWidth(true);
     setValidationMessage('');
+    setExternalUpdateSimulated(false);
     setDialog({ context });
   }, []);
 
@@ -223,23 +252,19 @@ function StickyNoteWithEditorExtensions(props: StickyNoteNodeProps) {
       setValidationMessage('Enter a valid HTTPS URL.');
       return;
     }
-    const youtubeEmbedUrl = embedType === 'video' ? getYouTubeEmbedUrl(mediaUrl) : null;
-    if (embedType === 'video' && isYouTubeUrl(mediaUrl) && !youtubeEmbedUrl) {
+    const youtube = embedType === 'video' ? parseYouTubeUrl(mediaUrl) : null;
+    if (youtube?.recognized && !youtube.embedUrl) {
       setValidationMessage('Enter a valid public YouTube URL.');
       return;
     }
 
-    const media =
-      embedType === 'image'
-        ? DEMO_MEDIA.image
-        : youtubeEmbedUrl
-          ? DEMO_MEDIA.youtube
-          : DEMO_MEDIA.publicVideo;
+    const kind: DemoMediaKind =
+      embedType === 'image' ? 'image' : youtube?.embedUrl ? 'youtube' : 'publicVideo';
     dialog.context.commit(
       insertMediaAtSelection(
         dialog.context.currentValue(),
         dialog.context.selection,
-        media.alt,
+        kind,
         mediaUrl,
         makeFullWidth
       )
@@ -247,6 +272,14 @@ function StickyNoteWithEditorExtensions(props: StickyNoteNodeProps) {
     setDialog(null);
     setValidationMessage('');
   }, [dialog, embedType, makeFullWidth, mediaUrl]);
+
+  const simulateExternalUpdate = useCallback(() => {
+    if (!dialog) return;
+    updateNodeData(props.id, {
+      content: `${dialog.context.currentValue()}\n\n_External note update applied while the media popover was open._`,
+    });
+    setExternalUpdateSimulated(true);
+  }, [dialog, props.id, updateNodeData]);
 
   const formattingActions = useMemo<readonly StickyNoteFormattingAction[]>(
     () => [
@@ -265,14 +298,16 @@ function StickyNoteWithEditorExtensions(props: StickyNoteNodeProps) {
       <ReactMarkdown
         components={{
           img: ({ src, alt, title }) => {
-            const fullWidth = title === 'full-width';
+            const metadata = parseMediaTitle(title);
+            if (!metadata) return <img src={src} alt={alt ?? ''} draggable={false} />;
+            const fullWidth = metadata.layout === 'full-width';
 
-            if (alt === DEMO_MEDIA.youtube.alt) {
-              const embedUrl = getYouTubeEmbedUrl(src ?? '');
+            if (metadata.kind === 'youtube') {
+              const embedUrl = parseYouTubeUrl(src ?? '').embedUrl;
               return embedUrl ? (
                 <iframe
                   src={embedUrl}
-                  title={alt}
+                  title={alt ?? DEMO_MEDIA.youtube.alt}
                   allow="autoplay; encrypted-media; picture-in-picture"
                   allowFullScreen
                   style={{
@@ -286,11 +321,11 @@ function StickyNoteWithEditorExtensions(props: StickyNoteNodeProps) {
               ) : null;
             }
 
-            if (alt === DEMO_MEDIA.publicVideo.alt) {
+            if (metadata.kind === 'publicVideo') {
               return (
                 <video
                   src={src}
-                  aria-label={alt}
+                  aria-label={alt ?? DEMO_MEDIA.publicVideo.alt}
                   controls
                   muted
                   preload="metadata"
@@ -344,9 +379,6 @@ function StickyNoteWithEditorExtensions(props: StickyNoteNodeProps) {
               position: 'fixed',
               inset: 0,
               zIndex: 10000,
-              display: 'grid',
-              placeItems: 'start center',
-              paddingTop: 72,
             }}
             onMouseDown={(event) => {
               if (event.target === event.currentTarget) cancelMediaDialog();
@@ -360,6 +392,15 @@ function StickyNoteWithEditorExtensions(props: StickyNoteNodeProps) {
                 insertMedia();
               }}
               style={{
+                position: 'absolute',
+                top: Math.max(
+                  16,
+                  Math.min(dialog.context.anchorRect.bottom + 8, window.innerHeight - 430)
+                ),
+                left: Math.max(
+                  16,
+                  Math.min(dialog.context.anchorRect.left, window.innerWidth - 396)
+                ),
                 width: 'min(380px, calc(100vw - 32px))',
                 padding: 16,
                 border: '1px solid var(--canvas-border-de-emp)',
@@ -458,6 +499,21 @@ function StickyNoteWithEditorExtensions(props: StickyNoteNodeProps) {
                 />
                 Make full width
               </label>
+              <div style={{ marginTop: 12 }}>
+                <button
+                  type="button"
+                  disabled={externalUpdateSimulated}
+                  onClick={simulateExternalUpdate}
+                  style={{ padding: '6px 10px' }}
+                >
+                  Simulate external note update
+                </button>
+                {externalUpdateSimulated && (
+                  <output style={{ display: 'block', margin: '6px 0 0', fontSize: 12 }}>
+                    External content applied. Insert now to verify end-of-note fallback.
+                  </output>
+                )}
+              </div>
               {validationMessage && (
                 <p role="alert" style={{ margin: '8px 0 0', color: 'var(--canvas-error-icon)' }}>
                   {validationMessage}
@@ -1044,7 +1100,7 @@ function EditorExtensionsStory() {
     const editorNote = createStickyNote(
       'sticky-editor-extensions',
       'yellow',
-      '**Complete media playground**\n\nPlace the cursor or select text, then choose **Embed media**. Pick Image or Video, toggle **Make full width**, insert or cancel, then press Escape to preview.',
+      '**Complete media playground**\n\nPlace the cursor or select text, then choose **Embed media**. Pick Image or Video, toggle **Make full width**, insert or cancel, then press Escape to preview. Use **Simulate external note update** to test end-of-note fallback.',
       { x: 50, y: 190 },
       { width: 420, height: 400 }
     );

--- a/packages/apollo-react/src/canvas/components/StickyNoteNode/StickyNoteNode.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/StickyNoteNode/StickyNoteNode.stories.tsx
@@ -4,7 +4,7 @@ import type { Edge, Node } from '@uipath/apollo-react/canvas/xyflow/react';
 import { Panel, Position, useReactFlow } from '@uipath/apollo-react/canvas/xyflow/react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
-import ReactMarkdown from 'react-markdown';
+import type { Components } from 'react-markdown';
 import { StoryInfoPanel, useCanvasStory, withCanvasProviders } from '../../storybook-utils';
 import { DefaultCanvasTranslations } from '../../types';
 import { BaseCanvas } from '../BaseCanvas';
@@ -294,73 +294,67 @@ function StickyNoteWithEditorExtensions(props: StickyNoteNodeProps) {
     [openMediaDialog]
   );
 
-  const renderMarkdown = useCallback(
-    (content: string) => (
-      <ReactMarkdown
-        components={{
-          img: ({ src, alt, title }) => {
-            const metadata = parseMediaTitle(title);
-            if (!metadata) return <img src={src} alt={alt ?? ''} draggable={false} />;
-            const fullWidth = metadata.layout === 'full-width';
+  const markdownComponents = useMemo<Components>(
+    () => ({
+      img: ({ src, alt, title }) => {
+        const metadata = parseMediaTitle(title);
+        if (!metadata) return <img src={src} alt={alt ?? ''} draggable={false} />;
+        const fullWidth = metadata.layout === 'full-width';
 
-            if (metadata.kind === 'youtube') {
-              const embedUrl = parseYouTubeUrl(src ?? '').embedUrl;
-              return embedUrl ? (
-                <iframe
-                  src={embedUrl}
-                  title={alt ?? DEMO_MEDIA.youtube.alt}
-                  allow="autoplay; encrypted-media; picture-in-picture"
-                  allowFullScreen
-                  style={{
-                    width: fullWidth ? '100%' : DEMO_NATURAL_MEDIA_WIDTH,
-                    maxWidth: '100%',
-                    aspectRatio: '16 / 9',
-                    border: 0,
-                    borderRadius: 6,
-                  }}
-                />
-              ) : null;
-            }
+        if (metadata.kind === 'youtube') {
+          const embedUrl = parseYouTubeUrl(src ?? '').embedUrl;
+          return embedUrl ? (
+            <iframe
+              src={embedUrl}
+              title={alt ?? DEMO_MEDIA.youtube.alt}
+              allow="autoplay; encrypted-media; picture-in-picture"
+              allowFullScreen
+              style={{
+                width: fullWidth ? '100%' : DEMO_NATURAL_MEDIA_WIDTH,
+                maxWidth: '100%',
+                aspectRatio: '16 / 9',
+                border: 0,
+                borderRadius: 6,
+              }}
+            />
+          ) : null;
+        }
 
-            if (metadata.kind === 'publicVideo') {
-              return (
-                <video
-                  src={src}
-                  aria-label={alt ?? DEMO_MEDIA.publicVideo.alt}
-                  controls
-                  muted
-                  preload="metadata"
-                  style={{
-                    display: 'block',
-                    width: fullWidth ? '100%' : DEMO_NATURAL_MEDIA_WIDTH,
-                    maxWidth: '100%',
-                    height: 'auto',
-                    borderRadius: 6,
-                  }}
-                />
-              );
-            }
+        if (metadata.kind === 'publicVideo') {
+          return (
+            <video
+              src={src}
+              aria-label={alt ?? DEMO_MEDIA.publicVideo.alt}
+              controls
+              muted
+              preload="metadata"
+              style={{
+                display: 'block',
+                width: fullWidth ? '100%' : DEMO_NATURAL_MEDIA_WIDTH,
+                maxWidth: '100%',
+                height: 'auto',
+                borderRadius: 6,
+              }}
+            />
+          );
+        }
 
-            return (
-              <img
-                src={src}
-                alt={alt ?? ''}
-                draggable={false}
-                style={{
-                  display: 'block',
-                  width: fullWidth ? '100%' : 'auto',
-                  maxWidth: '100%',
-                  height: 'auto',
-                  borderRadius: 6,
-                }}
-              />
-            );
-          },
-        }}
-      >
-        {content}
-      </ReactMarkdown>
-    ),
+        return (
+          <img
+            src={src}
+            alt={alt ?? ''}
+            draggable={false}
+            style={{
+              display: 'block',
+              width: fullWidth ? '100%' : 'auto',
+              maxWidth: '100%',
+              height: 'auto',
+              borderRadius: 6,
+            }}
+          />
+        );
+      },
+    }),
     []
   );
 
@@ -369,7 +363,7 @@ function StickyNoteWithEditorExtensions(props: StickyNoteNodeProps) {
       <StickyNoteNode
         {...props}
         formattingActions={formattingActions}
-        renderMarkdown={renderMarkdown}
+        markdownComponents={markdownComponents}
       />
       {dialog &&
         typeof document !== 'undefined' &&

--- a/packages/apollo-react/src/canvas/components/StickyNoteNode/StickyNoteNode.styles.ts
+++ b/packages/apollo-react/src/canvas/components/StickyNoteNode/StickyNoteNode.styles.ts
@@ -345,6 +345,7 @@ export const ColorOption = styled.button<{ color: string; isSelected: boolean }>
 `;
 
 export const FormattingToolbarContainer = styled.div<{ borderColor: string }>`
+  order: -1;
   display: flex;
   align-items: center;
   gap: 1px;

--- a/packages/apollo-react/src/canvas/components/StickyNoteNode/StickyNoteNode.test.tsx
+++ b/packages/apollo-react/src/canvas/components/StickyNoteNode/StickyNoteNode.test.tsx
@@ -177,7 +177,10 @@ describe('StickyNoteNode editor extensions', () => {
     const editor = screen.getByRole<HTMLTextAreaElement>('textbox');
     fireEvent.change(editor, { target: { value: 'Before draft After' } });
     editor.setSelectionRange(12, 12);
-    fireEvent.click(screen.getByRole('button', { name: 'Embed media' }));
+    const embedMediaButton = screen.getByRole('button', { name: 'Embed media' });
+    const anchorRect = embedMediaButton.getBoundingClientRect();
+    vi.spyOn(embedMediaButton, 'getBoundingClientRect').mockReturnValue(anchorRect);
+    fireEvent.click(embedMediaButton);
 
     expect(editorContext?.selection).toEqual({
       value: 'Before draft After',
@@ -185,6 +188,7 @@ describe('StickyNoteNode editor extensions', () => {
       selectionEnd: 12,
     });
     expect(editorContext?.currentValue()).toBe('Before draft After');
+    expect(editorContext?.anchorRect).toBe(anchorRect);
     expect(onContentChange).not.toHaveBeenCalled();
 
     act(() => {

--- a/packages/apollo-react/src/canvas/components/StickyNoteNode/StickyNoteNode.test.tsx
+++ b/packages/apollo-react/src/canvas/components/StickyNoteNode/StickyNoteNode.test.tsx
@@ -265,16 +265,17 @@ describe('StickyNoteNode editor extensions', () => {
     view.rerender(
       <StickyNoteNode
         {...defaultProps}
-        data={{ color: 'yellow', content: 'Externally updated' }}
+        data={{ color: 'yellow', content: '**Externally updated**' }}
         onContentChange={onContentChange}
         formattingActions={formattingActions}
       />
     );
 
-    expect(editorContext?.currentValue()).toBe('Externally updated');
+    expect(editorContext?.currentValue()).toBe('**Externally updated**');
     act(() => editorContext?.resume());
 
-    expect(screen.getByRole('textbox')).toHaveValue('Externally updated');
+    expect(screen.getByRole('textbox')).toHaveValue('**Externally updated**');
+    expect(screen.getByRole('button', { name: /^Bold/ })).toHaveAttribute('aria-pressed', 'true');
     expect(onContentChange).not.toHaveBeenCalled();
     expect(mockUpdateNodeData).not.toHaveBeenCalled();
   });

--- a/packages/apollo-react/src/canvas/components/StickyNoteNode/StickyNoteNode.test.tsx
+++ b/packages/apollo-react/src/canvas/components/StickyNoteNode/StickyNoteNode.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const { mockDeleteElements, mockUpdateNodeData } = vi.hoisted(() => ({
@@ -37,6 +37,10 @@ vi.mock('@uipath/apollo-react/canvas/xyflow/react', async (importOriginal) => ({
 }));
 
 import { StickyNoteNode, type StickyNoteNodeProps } from './StickyNoteNode';
+import type {
+  StickyNoteEditorActionContext,
+  StickyNoteFormattingAction,
+} from './StickyNoteNode.types';
 
 const defaultProps: StickyNoteNodeProps = {
   id: 'sticky-note-1',
@@ -57,7 +61,7 @@ const defaultProps: StickyNoteNodeProps = {
 };
 
 function renderStickyNoteNode(props: Partial<StickyNoteNodeProps> = {}) {
-  render(<StickyNoteNode {...defaultProps} {...props} />);
+  return render(<StickyNoteNode {...defaultProps} {...props} />);
 }
 
 function startEditing() {
@@ -140,6 +144,111 @@ describe('StickyNoteNode resize lifecycle', () => {
     fireEvent.change(textarea, { target: { value: 'Discard this edit' } });
     fireEvent.keyDown(textarea, { key: 'Escape' });
 
+    expect(onContentChange).not.toHaveBeenCalled();
+    expect(mockUpdateNodeData).not.toHaveBeenCalled();
+  });
+});
+
+describe('StickyNoteNode editor extensions', () => {
+  it('renders custom content and lets an editor action commit the captured selection once', () => {
+    let editorContext: StickyNoteEditorActionContext | undefined;
+    const onContentChange = vi.fn();
+    const formattingActions: readonly StickyNoteFormattingAction[] = [
+      {
+        id: 'embed-media',
+        label: 'Embed media',
+        icon: <span aria-hidden="true">M</span>,
+        onAction: (context) => {
+          editorContext = context;
+        },
+      },
+    ];
+
+    renderStickyNoteNode({
+      data: { color: 'yellow', content: 'BeforeAfter' },
+      onContentChange,
+      formattingActions,
+      renderMarkdown: (content) => <span>Custom: {content}</span>,
+    });
+
+    expect(screen.getByText('Custom: BeforeAfter')).toBeInTheDocument();
+
+    fireEvent.doubleClick(screen.getByText('Custom: BeforeAfter'));
+    const editor = screen.getByRole<HTMLTextAreaElement>('textbox');
+    fireEvent.change(editor, { target: { value: 'Before draft After' } });
+    editor.setSelectionRange(12, 12);
+    fireEvent.click(screen.getByRole('button', { name: 'Embed media' }));
+
+    expect(editorContext?.selection).toEqual({
+      value: 'Before draft After',
+      selectionStart: 12,
+      selectionEnd: 12,
+    });
+    expect(editorContext?.currentValue()).toBe('Before draft After');
+    expect(onContentChange).not.toHaveBeenCalled();
+
+    act(() => {
+      editorContext?.commit({
+        value: 'Before draft media After',
+        selectionStart: 18,
+        selectionEnd: 18,
+      });
+      editorContext?.commit({
+        value: 'A second commit must be ignored',
+        selectionStart: 0,
+        selectionEnd: 0,
+      });
+    });
+
+    expect(onContentChange).toHaveBeenCalledOnce();
+    expect(onContentChange).toHaveBeenCalledWith('Before draft media After');
+    expect(mockUpdateNodeData).toHaveBeenCalledOnce();
+    expect(mockUpdateNodeData).toHaveBeenCalledWith('sticky-note-1', {
+      content: 'Before draft media After',
+    });
+    expect(editor).toHaveValue('Before draft media After');
+  });
+
+  it('reads and resumes with externally updated content after the editor loses focus', () => {
+    let editorContext: StickyNoteEditorActionContext | undefined;
+    const onContentChange = vi.fn();
+    const formattingActions: readonly StickyNoteFormattingAction[] = [
+      {
+        id: 'embed-media',
+        label: 'Embed media',
+        icon: <span aria-hidden="true">M</span>,
+        onAction: (context) => {
+          editorContext = context;
+        },
+      },
+    ];
+
+    const view = renderStickyNoteNode({
+      data: { color: 'yellow', content: 'Original' },
+      onContentChange,
+      formattingActions,
+    });
+
+    fireEvent.doubleClick(screen.getByText('Original'));
+    const editor = screen.getByRole<HTMLTextAreaElement>('textbox');
+    fireEvent.change(editor, { target: { value: 'Draft' } });
+    editor.setSelectionRange(5, 5);
+    fireEvent.click(screen.getByRole('button', { name: 'Embed media' }));
+
+    fireEvent.blur(editor);
+    view.rerender(
+      <StickyNoteNode
+        {...defaultProps}
+        data={{ color: 'yellow', content: 'Externally updated' }}
+        onContentChange={onContentChange}
+        formattingActions={formattingActions}
+      />
+    );
+
+    expect(editorContext?.currentValue()).toBe('Externally updated');
+    act(() => editorContext?.resume());
+
+    expect(screen.getByRole('textbox')).toHaveValue('Externally updated');
     expect(onContentChange).not.toHaveBeenCalled();
     expect(mockUpdateNodeData).not.toHaveBeenCalled();
   });

--- a/packages/apollo-react/src/canvas/components/StickyNoteNode/StickyNoteNode.test.tsx
+++ b/packages/apollo-react/src/canvas/components/StickyNoteNode/StickyNoteNode.test.tsx
@@ -1,4 +1,5 @@
 import { act, fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const { mockDeleteElements, mockUpdateNodeData } = vi.hoisted(() => ({
@@ -150,7 +151,29 @@ describe('StickyNoteNode resize lifecycle', () => {
 });
 
 describe('StickyNoteNode editor extensions', () => {
-  it('renders custom content and lets an editor action commit the captured selection once', () => {
+  it('merges custom Markdown components into the built-in rendering pipeline', () => {
+    const { container } = renderStickyNoteNode({
+      data: {
+        color: 'yellow',
+        content:
+          '~~Completed~~\nNext line\n\n![Media](https://example.com/image.png)\n\n[Docs](https://example.com)',
+      },
+      markdownComponents: {
+        img: ({ alt }) => <span>Custom media: {alt}</span>,
+      },
+    });
+
+    expect(container.querySelector('del')).toHaveTextContent('Completed');
+    expect(container.querySelector('br')).toBeInTheDocument();
+    expect(screen.getByText('Custom media: Media')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Docs' })).toHaveAttribute('target', '_blank');
+    expect(screen.getByRole('link', { name: 'Docs' })).toHaveAttribute(
+      'rel',
+      'noopener noreferrer'
+    );
+  });
+
+  it('lets an editor action commit the captured selection once', () => {
     let editorContext: StickyNoteEditorActionContext | undefined;
     const onContentChange = vi.fn();
     const formattingActions: readonly StickyNoteFormattingAction[] = [
@@ -168,12 +191,11 @@ describe('StickyNoteNode editor extensions', () => {
       data: { color: 'yellow', content: 'BeforeAfter' },
       onContentChange,
       formattingActions,
-      renderMarkdown: (content) => <span>Custom: {content}</span>,
     });
 
-    expect(screen.getByText('Custom: BeforeAfter')).toBeInTheDocument();
+    expect(screen.getByText('BeforeAfter')).toBeInTheDocument();
 
-    fireEvent.doubleClick(screen.getByText('Custom: BeforeAfter'));
+    fireEvent.doubleClick(screen.getByText('BeforeAfter'));
     const editor = screen.getByRole<HTMLTextAreaElement>('textbox');
     fireEvent.change(editor, { target: { value: 'Before draft After' } });
     editor.setSelectionRange(12, 12);
@@ -255,6 +277,64 @@ describe('StickyNoteNode editor extensions', () => {
     expect(screen.getByRole('textbox')).toHaveValue('Externally updated');
     expect(onContentChange).not.toHaveBeenCalled();
     expect(mockUpdateNodeData).not.toHaveBeenCalled();
+  });
+
+  it('persists pending edits on the first ordinary blur after an action resumes', () => {
+    let editorContext: StickyNoteEditorActionContext | undefined;
+    const onContentChange = vi.fn();
+    const formattingActions: readonly StickyNoteFormattingAction[] = [
+      {
+        id: 'embed-media',
+        label: 'Embed media',
+        icon: <span aria-hidden="true">M</span>,
+        onAction: (context) => {
+          editorContext = context;
+        },
+      },
+    ];
+
+    renderStickyNoteNode({ onContentChange, formattingActions });
+
+    const editor = startEditing();
+    fireEvent.change(editor, { target: { value: 'Pending draft' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Embed media' }));
+    fireEvent.blur(editor);
+
+    act(() => editorContext?.resume());
+    fireEvent.blur(screen.getByRole('textbox'));
+
+    expect(onContentChange).toHaveBeenCalledOnce();
+    expect(onContentChange).toHaveBeenCalledWith('Pending draft');
+    expect(mockUpdateNodeData).toHaveBeenCalledOnce();
+    expect(mockUpdateNodeData).toHaveBeenCalledWith('sticky-note-1', {
+      content: 'Pending draft',
+    });
+  });
+
+  it('keeps the toolbar mounted while keyboard focus moves to a custom action', async () => {
+    const user = userEvent.setup();
+    const onAction = vi.fn();
+    const formattingActions: readonly StickyNoteFormattingAction[] = [
+      {
+        id: 'embed-media',
+        label: 'Embed media',
+        icon: <span aria-hidden="true">M</span>,
+        onAction,
+      },
+    ];
+
+    renderStickyNoteNode({ formattingActions });
+
+    startEditing();
+    for (let index = 0; index < 6; index += 1) await user.tab();
+
+    const embedMediaButton = screen.getByRole('button', { name: 'Embed media' });
+    expect(embedMediaButton).toHaveFocus();
+    expect(screen.getByRole('textbox')).toBeInTheDocument();
+
+    await user.keyboard('{Enter}');
+
+    expect(onAction).toHaveBeenCalledOnce();
   });
 
   it('restores normal blur persistence when a consumer action throws', () => {

--- a/packages/apollo-react/src/canvas/components/StickyNoteNode/StickyNoteNode.test.tsx
+++ b/packages/apollo-react/src/canvas/components/StickyNoteNode/StickyNoteNode.test.tsx
@@ -326,9 +326,15 @@ describe('StickyNoteNode editor extensions', () => {
     renderStickyNoteNode({ formattingActions });
 
     startEditing();
-    for (let index = 0; index < 6; index += 1) await user.tab();
-
     const embedMediaButton = screen.getByRole('button', { name: 'Embed media' });
+    for (
+      let attempt = 0;
+      attempt < 10 && document.activeElement !== embedMediaButton;
+      attempt += 1
+    ) {
+      await user.tab();
+    }
+
     expect(embedMediaButton).toHaveFocus();
     expect(screen.getByRole('textbox')).toBeInTheDocument();
 

--- a/packages/apollo-react/src/canvas/components/StickyNoteNode/StickyNoteNode.test.tsx
+++ b/packages/apollo-react/src/canvas/components/StickyNoteNode/StickyNoteNode.test.tsx
@@ -256,4 +256,39 @@ describe('StickyNoteNode editor extensions', () => {
     expect(onContentChange).not.toHaveBeenCalled();
     expect(mockUpdateNodeData).not.toHaveBeenCalled();
   });
+
+  it('restores normal blur persistence when a consumer action throws', () => {
+    const onContentChange = vi.fn();
+    const actionError = new Error('Consumer action failed');
+    const formattingActions: readonly StickyNoteFormattingAction[] = [
+      {
+        id: 'embed-media',
+        label: 'Embed media',
+        icon: <span aria-hidden="true">M</span>,
+        onAction: () => {
+          throw actionError;
+        },
+      },
+    ];
+
+    renderStickyNoteNode({ onContentChange, formattingActions });
+
+    const editor = startEditing();
+    fireEvent.change(editor, { target: { value: 'Persist after action failure' } });
+
+    const handleError = vi.fn((event: ErrorEvent) => event.preventDefault());
+    window.addEventListener('error', handleError);
+    fireEvent.click(screen.getByRole('button', { name: 'Embed media' }));
+    window.removeEventListener('error', handleError);
+
+    fireEvent.blur(editor);
+
+    expect(handleError).toHaveBeenCalledOnce();
+    expect(handleError.mock.calls[0]?.[0].error).toBe(actionError);
+    expect(onContentChange).toHaveBeenCalledOnce();
+    expect(onContentChange).toHaveBeenCalledWith('Persist after action failure');
+    expect(mockUpdateNodeData).toHaveBeenCalledWith('sticky-note-1', {
+      content: 'Persist after action failure',
+    });
+  });
 });

--- a/packages/apollo-react/src/canvas/components/StickyNoteNode/StickyNoteNode.test.tsx
+++ b/packages/apollo-react/src/canvas/components/StickyNoteNode/StickyNoteNode.test.tsx
@@ -1,5 +1,6 @@
 import { act, fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import type { Components } from 'react-markdown';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const { mockDeleteElements, mockUpdateNodeData } = vi.hoisted(() => ({
@@ -160,7 +161,8 @@ describe('StickyNoteNode editor extensions', () => {
       },
       markdownComponents: {
         img: ({ alt }) => <span>Custom media: {alt}</span>,
-      },
+        a: ({ children }) => <span>Unsafe custom link: {children}</span>,
+      } as Components,
     });
 
     expect(container.querySelector('del')).toHaveTextContent('Completed');

--- a/packages/apollo-react/src/canvas/components/StickyNoteNode/StickyNoteNode.tsx
+++ b/packages/apollo-react/src/canvas/components/StickyNoteNode/StickyNoteNode.tsx
@@ -4,7 +4,7 @@ import type { NodeProps } from '@uipath/apollo-react/canvas/xyflow/react';
 import { NodeResizeControl, useReactFlow } from '@uipath/apollo-react/canvas/xyflow/react';
 import type { ResizeDragEvent, ResizeParams } from '@uipath/apollo-react/canvas/xyflow/system';
 import { AnimatePresence } from 'motion/react';
-import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { memo, type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { flushSync } from 'react-dom';
 import ReactMarkdown from 'react-markdown';
 import remarkBreaks from 'remark-breaks';
@@ -36,9 +36,14 @@ import {
   stickyNoteGlobalStyles,
   TopCornerIndicators,
 } from './StickyNoteNode.styles';
-import type { StickyNoteColor, StickyNoteData, TextSelection } from './StickyNoteNode.types';
+import type {
+  StickyNoteColor,
+  StickyNoteData,
+  StickyNoteFormattingAction,
+  TextSelection,
+} from './StickyNoteNode.types';
 import { STICKY_NOTE_COLORS, withAlpha } from './StickyNoteNode.types';
-import { preserveNewlines } from './StickyNoteNode.utils';
+import { preserveNewlines, readTextSelection } from './StickyNoteNode.utils';
 import { useMarkdownShortcuts } from './useMarkdownShortcuts';
 import { useScrollCapture } from './useScrollCapture';
 
@@ -52,6 +57,8 @@ export interface StickyNoteNodeProps extends NodeProps {
   onResize?: (width: number, height: number) => void;
   onResizeStart?: () => void;
   onResizeEnd?: () => void;
+  formattingActions?: readonly StickyNoteFormattingAction[];
+  renderMarkdown?: (content: string) => ReactNode;
 }
 
 const minWidth = GRID_SPACING * 8;
@@ -70,6 +77,8 @@ const StickyNoteNodeComponent = ({
   onResize,
   onResizeStart,
   onResizeEnd,
+  formattingActions = [],
+  renderMarkdown,
 }: StickyNoteNodeProps) => {
   const { _ } = useSafeLingui();
   const { updateNodeData, deleteElements } = useReactFlow();
@@ -78,6 +87,7 @@ const StickyNoteNodeComponent = ({
   const [isResizing, setIsResizing] = useState(false);
   const [isColorPickerOpen, setIsColorPickerOpen] = useState(false);
   const [localContent, setLocalContent] = useState(data.content || '');
+  const latestContentRef = useRef(localContent);
   const textAreaRef = useRef<HTMLTextAreaElement>(null);
   const skipBlurRef = useRef<string | null>(null);
   const { ref: markdownRef, scrollCaptureProps } = useScrollCapture();
@@ -94,9 +104,14 @@ const StickyNoteNodeComponent = ({
   const color = STICKY_NOTE_COLORS[colorKey] ?? STICKY_NOTE_COLORS.yellow;
   const colorWithAlpha = withAlpha(color);
 
+  const updateLocalContent = useCallback((content: string) => {
+    latestContentRef.current = content;
+    setLocalContent(content);
+  }, []);
+
   useEffect(() => {
-    setLocalContent(data.content || '');
-  }, [data.content]);
+    updateLocalContent(data.content || '');
+  }, [data.content, updateLocalContent]);
 
   // Handle autoFocus - focus textarea when entering edit mode
   useEffect(() => {
@@ -119,9 +134,9 @@ const StickyNoteNodeComponent = ({
   useEffect(() => {
     if (readOnly) {
       setIsEditing(false);
-      setLocalContent(data.content || '');
+      updateLocalContent(data.content || '');
     }
-  }, [readOnly, data.content]);
+  }, [readOnly, data.content, updateLocalContent]);
 
   const handleDoubleClick = useCallback(() => {
     if (readOnly || isEditing) return;
@@ -150,21 +165,75 @@ const StickyNoteNodeComponent = ({
     }
   }, [id, localContent, data.content, updateNodeData, onContentChange, readOnly]);
 
-  const handleChange = useCallback((e: React.ChangeEvent<HTMLTextAreaElement>) => {
-    skipBlurRef.current = null;
-    setLocalContent(e.target.value);
-  }, []);
+  const handleChange = useCallback(
+    (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+      skipBlurRef.current = null;
+      updateLocalContent(e.target.value);
+    },
+    [updateLocalContent]
+  );
 
-  const handleFormat = useCallback((result: TextSelection) => {
-    setLocalContent(result.value);
-    setActiveFormats(detectActiveFormats(result));
-    requestAnimationFrame(() => {
-      if (textAreaRef.current) {
-        textAreaRef.current.selectionStart = result.selectionStart;
-        textAreaRef.current.selectionEnd = result.selectionEnd;
-      }
-    });
-  }, []);
+  const handleFormat = useCallback(
+    (result: TextSelection) => {
+      updateLocalContent(result.value);
+      setActiveFormats(detectActiveFormats(result));
+      requestAnimationFrame(() => {
+        if (textAreaRef.current) {
+          textAreaRef.current.selectionStart = result.selectionStart;
+          textAreaRef.current.selectionEnd = result.selectionEnd;
+        }
+      });
+    },
+    [updateLocalContent]
+  );
+
+  const handleFormattingAction = useCallback(
+    (action: StickyNoteFormattingAction) => {
+      const textarea = textAreaRef.current;
+      if (!textarea) return;
+
+      const selection = readTextSelection(textarea);
+      skipBlurRef.current = selection.value;
+      let completed = false;
+
+      const restoreSelection = (next: TextSelection) => {
+        setIsEditing(true);
+        requestAnimationFrame(() => {
+          const currentTextarea = textAreaRef.current;
+          if (!currentTextarea) return;
+
+          const length = next.value.length;
+          currentTextarea.focus();
+          currentTextarea.selectionStart = Math.max(0, Math.min(length, next.selectionStart));
+          currentTextarea.selectionEnd = Math.max(0, Math.min(length, next.selectionEnd));
+        });
+      };
+
+      const complete = (next: TextSelection, shouldPersist: boolean) => {
+        if (completed) return;
+        completed = true;
+        skipBlurRef.current = next.value;
+        if (shouldPersist) {
+          updateLocalContent(next.value);
+          setActiveFormats(detectActiveFormats(next));
+          onContentChange?.(next.value);
+          updateNodeData(id, { content: next.value });
+        }
+        restoreSelection(next);
+      };
+
+      action.onAction({
+        selection,
+        currentValue: () => textAreaRef.current?.value ?? latestContentRef.current,
+        commit: (next) => complete(next, true),
+        resume: () => {
+          const currentValue = textAreaRef.current?.value ?? latestContentRef.current;
+          complete({ ...selection, value: currentValue }, false);
+        },
+      });
+    },
+    [id, onContentChange, updateLocalContent, updateNodeData]
+  );
 
   const updateActiveFormats = useCallback(() => {
     if (!textAreaRef.current) return;
@@ -184,7 +253,7 @@ const StickyNoteNodeComponent = ({
       if (e.key === 'Escape') {
         skipBlurRef.current = textAreaRef.current?.value ?? localContent;
         setIsEditing(false);
-        setLocalContent(data.content || '');
+        updateLocalContent(data.content || '');
         textAreaRef.current?.blur();
         return;
       }
@@ -205,7 +274,7 @@ const StickyNoteNodeComponent = ({
       }
       shortcutKeyDown(e);
     },
-    [data.content, localContent, shortcutKeyDown, handleFormat]
+    [data.content, localContent, shortcutKeyDown, handleFormat, updateLocalContent]
   );
 
   // Resize handlers
@@ -420,6 +489,8 @@ const StickyNoteNodeComponent = ({
                 borderColor={color}
                 activeFormats={activeFormats}
                 onFormat={handleFormat}
+                actions={formattingActions}
+                onAction={handleFormattingAction}
               />
               <StickyNoteTextArea
                 ref={textAreaRef}
@@ -437,12 +508,16 @@ const StickyNoteNodeComponent = ({
           ) : (
             <StickyNoteMarkdown ref={markdownRef} {...scrollCaptureProps}>
               {localContent ? (
-                <ReactMarkdown
-                  remarkPlugins={[remarkGfm, remarkBreaks]}
-                  components={markdownComponents}
-                >
-                  {preserveNewlines(localContent)}
-                </ReactMarkdown>
+                renderMarkdown ? (
+                  renderMarkdown(localContent)
+                ) : (
+                  <ReactMarkdown
+                    remarkPlugins={[remarkGfm, remarkBreaks]}
+                    components={markdownComponents}
+                  >
+                    {preserveNewlines(localContent)}
+                  </ReactMarkdown>
+                )
               ) : (
                 // Render placeholder if renderPlaceholderOnSelect is enabled, node is selected, and the content is empty
                 renderPlaceholderOnSelect &&

--- a/packages/apollo-react/src/canvas/components/StickyNoteNode/StickyNoteNode.tsx
+++ b/packages/apollo-react/src/canvas/components/StickyNoteNode/StickyNoteNode.tsx
@@ -77,7 +77,7 @@ const StickyNoteNodeComponent = ({
   onResize,
   onResizeStart,
   onResizeEnd,
-  formattingActions = [],
+  formattingActions,
   renderMarkdown,
 }: StickyNoteNodeProps) => {
   const { _ } = useSafeLingui();
@@ -222,16 +222,25 @@ const StickyNoteNodeComponent = ({
         restoreSelection(next);
       };
 
-      action.onAction({
-        selection,
-        anchorRect,
-        currentValue: () => textAreaRef.current?.value ?? latestContentRef.current,
-        commit: (next) => complete(next, true),
-        resume: () => {
-          const currentValue = textAreaRef.current?.value ?? latestContentRef.current;
-          complete({ ...selection, value: currentValue }, false);
-        },
-      });
+      try {
+        action.onAction({
+          selection,
+          anchorRect,
+          currentValue: () => textAreaRef.current?.value ?? latestContentRef.current,
+          commit: (next) => complete(next, true),
+          resume: () => {
+            const currentValue = textAreaRef.current?.value ?? latestContentRef.current;
+            complete({ ...selection, value: currentValue }, false);
+          },
+        });
+      } catch (error) {
+        if (!completed) {
+          completed = true;
+          skipBlurRef.current = null;
+          restoreSelection(selection);
+        }
+        throw error;
+      }
     },
     [id, onContentChange, updateLocalContent, updateNodeData]
   );

--- a/packages/apollo-react/src/canvas/components/StickyNoteNode/StickyNoteNode.tsx
+++ b/packages/apollo-react/src/canvas/components/StickyNoteNode/StickyNoteNode.tsx
@@ -58,7 +58,7 @@ export interface StickyNoteNodeProps extends NodeProps {
   onResizeStart?: () => void;
   onResizeEnd?: () => void;
   formattingActions?: readonly StickyNoteFormattingAction[];
-  markdownComponents?: Components;
+  markdownComponents?: Omit<Components, 'a'>;
 }
 
 const minWidth = GRID_SPACING * 8;
@@ -394,7 +394,7 @@ const StickyNoteNodeComponent = ({
   );
 
   const markdownComponents = useMemo<Components>(
-    () => ({ ...builtInMarkdownComponents, ...customMarkdownComponents }),
+    () => ({ ...customMarkdownComponents, ...builtInMarkdownComponents }),
     [builtInMarkdownComponents, customMarkdownComponents]
   );
 

--- a/packages/apollo-react/src/canvas/components/StickyNoteNode/StickyNoteNode.tsx
+++ b/packages/apollo-react/src/canvas/components/StickyNoteNode/StickyNoteNode.tsx
@@ -188,7 +188,7 @@ const StickyNoteNodeComponent = ({
   );
 
   const handleFormattingAction = useCallback(
-    (action: StickyNoteFormattingAction) => {
+    (action: StickyNoteFormattingAction, anchorRect: DOMRectReadOnly) => {
       const textarea = textAreaRef.current;
       if (!textarea) return;
 
@@ -224,6 +224,7 @@ const StickyNoteNodeComponent = ({
 
       action.onAction({
         selection,
+        anchorRect,
         currentValue: () => textAreaRef.current?.value ?? latestContentRef.current,
         commit: (next) => complete(next, true),
         resume: () => {

--- a/packages/apollo-react/src/canvas/components/StickyNoteNode/StickyNoteNode.tsx
+++ b/packages/apollo-react/src/canvas/components/StickyNoteNode/StickyNoteNode.tsx
@@ -226,9 +226,9 @@ const StickyNoteNodeComponent = ({
         if (completed) return;
         completed = true;
         skipBlurRef.current = shouldPersist ? next.value : null;
+        setActiveFormats(detectActiveFormats(next));
         if (shouldPersist) {
           updateLocalContent(next.value);
-          setActiveFormats(detectActiveFormats(next));
           onContentChange?.(next.value);
           updateNodeData(id, { content: next.value });
         }

--- a/packages/apollo-react/src/canvas/components/StickyNoteNode/StickyNoteNode.tsx
+++ b/packages/apollo-react/src/canvas/components/StickyNoteNode/StickyNoteNode.tsx
@@ -4,9 +4,9 @@ import type { NodeProps } from '@uipath/apollo-react/canvas/xyflow/react';
 import { NodeResizeControl, useReactFlow } from '@uipath/apollo-react/canvas/xyflow/react';
 import type { ResizeDragEvent, ResizeParams } from '@uipath/apollo-react/canvas/xyflow/system';
 import { AnimatePresence } from 'motion/react';
-import { memo, type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { flushSync } from 'react-dom';
-import ReactMarkdown from 'react-markdown';
+import ReactMarkdown, { type Components } from 'react-markdown';
 import remarkBreaks from 'remark-breaks';
 import remarkGfm from 'remark-gfm';
 import { useSafeLingui } from '../../../i18n';
@@ -58,7 +58,7 @@ export interface StickyNoteNodeProps extends NodeProps {
   onResizeStart?: () => void;
   onResizeEnd?: () => void;
   formattingActions?: readonly StickyNoteFormattingAction[];
-  renderMarkdown?: (content: string) => ReactNode;
+  markdownComponents?: Components;
 }
 
 const minWidth = GRID_SPACING * 8;
@@ -78,7 +78,7 @@ const StickyNoteNodeComponent = ({
   onResizeStart,
   onResizeEnd,
   formattingActions,
-  renderMarkdown,
+  markdownComponents: customMarkdownComponents,
 }: StickyNoteNodeProps) => {
   const { _ } = useSafeLingui();
   const { updateNodeData, deleteElements } = useReactFlow();
@@ -89,6 +89,7 @@ const StickyNoteNodeComponent = ({
   const [localContent, setLocalContent] = useState(data.content || '');
   const latestContentRef = useRef(localContent);
   const textAreaRef = useRef<HTMLTextAreaElement>(null);
+  const formattingToolbarRef = useRef<HTMLDivElement>(null);
   const skipBlurRef = useRef<string | null>(null);
   const { ref: markdownRef, scrollCaptureProps } = useScrollCapture();
   const colorButtonRef = useRef<HTMLDivElement>(null);
@@ -149,21 +150,33 @@ const StickyNoteNodeComponent = ({
     }, 0);
   }, [isEditing, readOnly]);
 
-  const handleBlur = useCallback(() => {
-    setIsEditing(false);
-    if (readOnly) return;
+  const handleBlur = useCallback(
+    (event: React.FocusEvent<HTMLElement>) => {
+      const nextTarget = event.relatedTarget;
+      if (
+        nextTarget instanceof Node &&
+        (textAreaRef.current?.contains(nextTarget) ||
+          formattingToolbarRef.current?.contains(nextTarget))
+      ) {
+        return;
+      }
 
-    const content = textAreaRef.current?.value ?? localContent;
-    if (skipBlurRef.current === content) {
-      skipBlurRef.current = null;
-      return;
-    }
+      setIsEditing(false);
+      if (readOnly) return;
 
-    if (content !== data.content) {
-      onContentChange?.(content);
-      updateNodeData(id, { content });
-    }
-  }, [id, localContent, data.content, updateNodeData, onContentChange, readOnly]);
+      const content = textAreaRef.current?.value ?? localContent;
+      if (skipBlurRef.current === content) {
+        skipBlurRef.current = null;
+        return;
+      }
+
+      if (content !== data.content) {
+        onContentChange?.(content);
+        updateNodeData(id, { content });
+      }
+    },
+    [id, localContent, data.content, updateNodeData, onContentChange, readOnly]
+  );
 
   const handleChange = useCallback(
     (e: React.ChangeEvent<HTMLTextAreaElement>) => {
@@ -212,7 +225,7 @@ const StickyNoteNodeComponent = ({
       const complete = (next: TextSelection, shouldPersist: boolean) => {
         if (completed) return;
         completed = true;
-        skipBlurRef.current = next.value;
+        skipBlurRef.current = shouldPersist ? next.value : null;
         if (shouldPersist) {
           updateLocalContent(next.value);
           setActiveFormats(detectActiveFormats(next));
@@ -358,9 +371,9 @@ const StickyNoteNodeComponent = ({
   }, [id, deleteElements]);
 
   // Custom markdown components to handle link clicks properly in React Flow nodes
-  const markdownComponents = useMemo(
+  const builtInMarkdownComponents = useMemo<Components>(
     () => ({
-      a: ({ href, children, ...props }: React.AnchorHTMLAttributes<HTMLAnchorElement>) => (
+      a: ({ node: _node, href, children, ...props }) => (
         <a
           {...props}
           href={href}
@@ -378,6 +391,11 @@ const StickyNoteNodeComponent = ({
       ),
     }),
     []
+  );
+
+  const markdownComponents = useMemo<Components>(
+    () => ({ ...builtInMarkdownComponents, ...customMarkdownComponents }),
+    [builtInMarkdownComponents, customMarkdownComponents]
   );
 
   // Build toolbar config with only Edit and Color buttons
@@ -494,14 +512,6 @@ const StickyNoteNodeComponent = ({
           <BottomCornerIndicators visible={selected && !readOnly} />
           {isEditing ? (
             <>
-              <FormattingToolbar
-                textAreaRef={textAreaRef}
-                borderColor={color}
-                activeFormats={activeFormats}
-                onFormat={handleFormat}
-                actions={formattingActions}
-                onAction={handleFormattingAction}
-              />
               <StickyNoteTextArea
                 ref={textAreaRef}
                 value={localContent}
@@ -514,20 +524,26 @@ const StickyNoteNodeComponent = ({
                 isEditing={isEditing}
                 className="nodrag nowheel"
               />
+              <FormattingToolbar
+                containerRef={formattingToolbarRef}
+                textAreaRef={textAreaRef}
+                borderColor={color}
+                activeFormats={activeFormats}
+                onFormat={handleFormat}
+                onBlur={handleBlur}
+                actions={formattingActions}
+                onAction={handleFormattingAction}
+              />
             </>
           ) : (
             <StickyNoteMarkdown ref={markdownRef} {...scrollCaptureProps}>
               {localContent ? (
-                renderMarkdown ? (
-                  renderMarkdown(localContent)
-                ) : (
-                  <ReactMarkdown
-                    remarkPlugins={[remarkGfm, remarkBreaks]}
-                    components={markdownComponents}
-                  >
-                    {preserveNewlines(localContent)}
-                  </ReactMarkdown>
-                )
+                <ReactMarkdown
+                  remarkPlugins={[remarkGfm, remarkBreaks]}
+                  components={markdownComponents}
+                >
+                  {preserveNewlines(localContent)}
+                </ReactMarkdown>
               ) : (
                 // Render placeholder if renderPlaceholderOnSelect is enabled, node is selected, and the content is empty
                 renderPlaceholderOnSelect &&

--- a/packages/apollo-react/src/canvas/components/StickyNoteNode/StickyNoteNode.types.ts
+++ b/packages/apollo-react/src/canvas/components/StickyNoteNode/StickyNoteNode.types.ts
@@ -1,3 +1,5 @@
+import type { ReactNode } from 'react';
+
 /**
  * Base color values for sticky notes.
  * Use `withAlpha()` to derive background colors with transparency.
@@ -61,6 +63,27 @@ export type TextSelection = {
   selectionStart: number;
   selectionEnd: number;
 };
+
+/** Editor state and completion controls passed to an external sticky-note action. */
+export interface StickyNoteEditorActionContext {
+  /** Immutable content and selection captured before the action opens external UI. */
+  selection: TextSelection;
+  /** Reads the latest editor value when the external action completes. */
+  currentValue(): string;
+  /** Persists one content update, resumes editing, and restores the supplied selection. */
+  commit(next: TextSelection): void;
+  /** Resumes editing without changing content. */
+  resume(): void;
+}
+
+/** A consumer-provided action rendered after the built-in text-formatting controls. */
+export interface StickyNoteFormattingAction {
+  id: string;
+  icon: ReactNode;
+  label: string;
+  disabled?: boolean;
+  onAction(context: StickyNoteEditorActionContext): void;
+}
 
 /** Available formatting actions for the toolbar and keyboard shortcuts */
 export type FormattingAction = 'bold' | 'italic' | 'strikethrough' | 'bulletList' | 'numberedList';

--- a/packages/apollo-react/src/canvas/components/StickyNoteNode/StickyNoteNode.types.ts
+++ b/packages/apollo-react/src/canvas/components/StickyNoteNode/StickyNoteNode.types.ts
@@ -68,6 +68,8 @@ export type TextSelection = {
 export interface StickyNoteEditorActionContext {
   /** Immutable content and selection captured before the action opens external UI. */
   selection: TextSelection;
+  /** Stable toolbar-trigger bounds for positioning external UI after the toolbar unmounts. */
+  anchorRect: DOMRectReadOnly;
   /** Reads the latest editor value when the external action completes. */
   currentValue(): string;
   /** Persists one content update, resumes editing, and restores the supplied selection. */

--- a/packages/apollo-react/src/canvas/components/StickyNoteNode/StickyNoteNode.utils.ts
+++ b/packages/apollo-react/src/canvas/components/StickyNoteNode/StickyNoteNode.utils.ts
@@ -1,3 +1,12 @@
+import type { TextSelection } from './StickyNoteNode.types';
+
+/** Reads the value and selection range from a sticky-note textarea. */
+export const readTextSelection = (textarea: HTMLTextAreaElement): TextSelection => ({
+  value: textarea.value,
+  selectionStart: textarea.selectionStart,
+  selectionEnd: textarea.selectionEnd,
+});
+
 // Markdown collapses 3+ consecutive newlines into a single paragraph break.
 // Insert &nbsp; paragraphs to prevent markdown parser from collapsing consecutive newlines.
 export const preserveNewlines = (markdown: string): string => {


### PR DESCRIPTION
## Summary
- add consumer-defined actions to the sticky-note formatting toolbar
- provide a dialog-safe editor context with captured selection, latest content, exactly-once commit/resume controls, and a stable trigger rectangle for anchored UI
- allow consumers to extend the existing Markdown pipeline through additive `markdownComponents` overrides
- add a complete interactive media story with one `Embed media` action and one anchored popover

## Demo 

https://github.com/user-attachments/assets/5a330e89-99c6-4145-b9b2-b56bc7847578



## Media story UX
- one toolbar action with the `Embed media` tooltip
- one anchored popover with Image or Video choices
- Video accepts both YouTube and direct public video URLs and auto-detects the renderer
- optional `Make full width`
- cursor insertion or selected-text replacement
- stale-content end-of-note fallback via `Simulate external note update`
- HTTPS validation, Cancel/resume, and full-width/natural-width rendering

## Why
Flow needs an upstream extension seam to support link-based image and video embeds without patching generated Apollo package output.

## Developer impact
The API is additive. Existing StickyNoteNode consumers keep the current behavior when `formattingActions` and `markdownComponents` are not supplied. Consumer component overrides are merged into Apollo Markdown defaults, preserving GFM, line breaks, and safe link handling.

## Local Storybook test
Run `pnpm storybook:dev`, then open:
`http://localhost:6007/?path=/story/apollo-react-canvas-components-nodes-stickynotenode--editor-extensions`

Use the single `Embed media` action. Choose Image or Video, edit the prefilled URL, toggle `Make full width`, and insert or cancel. Press Escape after inserting to preview. For Video, test the prefilled YouTube URL or a direct public MP4 URL. Use `Simulate external note update` before inserting to verify end-of-note fallback.

## Ticket
MST-12137

## Validation
- interactive Storybook image, YouTube, direct-video, width on/off, cancel, validation, and stale-append paths: passed
- focused StickyNoteNode tests: 18 passed
- focused Biome lint: passed
- `@uipath/apollo-react` production build: passed
- full Apollo React suite: 1,920 passed; the same 8 unrelated storage tests fail locally under Node 26 because global localStorage is unavailable

The Flow Workbench dependency update will follow after this change is merged and published.