### PR TITLE
fix(apollo-react): make removePreviewFromReactFlow a no-op when no preview is present

### DIFF
--- a/packages/apollo-react/src/canvas/utils/createPreviewNode.test.ts
+++ b/packages/apollo-react/src/canvas/utils/createPreviewNode.test.ts
@@ -1,0 +1,91 @@
+import type { Edge, Node, ReactFlowInstance } from '@uipath/apollo-react/canvas/xyflow/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { PREVIEW_EDGE_ID, PREVIEW_NODE_ID } from '../constants';
+import { removePreviewFromReactFlow } from './createPreviewNode';
+
+interface MockInstance {
+  getNodes: () => Node[];
+  getEdges: () => Edge[];
+  setNodes: ReturnType<typeof vi.fn>;
+  setEdges: ReturnType<typeof vi.fn>;
+}
+
+function createReactFlowInstance(nodes: Node[] = [], edges: Edge[] = []): MockInstance {
+  return {
+    getNodes: () => nodes,
+    getEdges: () => edges,
+    setNodes: vi.fn(),
+    setEdges: vi.fn(),
+  };
+}
+
+const asInstance = (m: MockInstance) => m as unknown as ReactFlowInstance;
+
+const previewNode: Node = {
+  id: PREVIEW_NODE_ID,
+  type: 'preview',
+  position: { x: 0, y: 0 },
+  data: {},
+};
+const regularNode: Node = {
+  id: 'node-1',
+  type: 'default',
+  position: { x: 0, y: 0 },
+  data: {},
+};
+const previewEdge: Edge = {
+  id: PREVIEW_EDGE_ID,
+  source: PREVIEW_NODE_ID,
+  target: 'node-1',
+};
+const regularEdge: Edge = { id: 'edge-1', source: 'node-1', target: 'node-2' };
+
+describe('removePreviewFromReactFlow', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('does not touch nodes or edges when no preview is present', () => {
+    const rf = createReactFlowInstance([regularNode], [regularEdge]);
+    removePreviewFromReactFlow(asInstance(rf));
+    expect(rf.setNodes).not.toHaveBeenCalled();
+    expect(rf.setEdges).not.toHaveBeenCalled();
+  });
+
+  it('does nothing on an empty canvas', () => {
+    const rf = createReactFlowInstance();
+    removePreviewFromReactFlow(asInstance(rf));
+    expect(rf.setNodes).not.toHaveBeenCalled();
+    expect(rf.setEdges).not.toHaveBeenCalled();
+  });
+
+  it('removes the preview node when present', () => {
+    const rf = createReactFlowInstance([regularNode, previewNode]);
+    removePreviewFromReactFlow(asInstance(rf));
+
+    expect(rf.setNodes).toHaveBeenCalledTimes(1);
+    const updater = rf.setNodes.mock.calls[0]?.[0] as (nodes: Node[]) => Node[];
+    expect(updater([regularNode, previewNode])).toEqual([regularNode]);
+    // No preview edge, so edges are left untouched.
+    expect(rf.setEdges).not.toHaveBeenCalled();
+  });
+
+  it('removes preview edges when present', () => {
+    const rf = createReactFlowInstance([regularNode], [regularEdge, previewEdge]);
+    removePreviewFromReactFlow(asInstance(rf));
+
+    expect(rf.setEdges).toHaveBeenCalledTimes(1);
+    const updater = rf.setEdges.mock.calls[0]?.[0] as (edges: Edge[]) => Edge[];
+    expect(updater([regularEdge, previewEdge])).toEqual([regularEdge]);
+    // No preview node, so nodes are left untouched.
+    expect(rf.setNodes).not.toHaveBeenCalled();
+  });
+
+  it('removes both the preview node and its edges when both are present', () => {
+    const rf = createReactFlowInstance([regularNode, previewNode], [regularEdge, previewEdge]);
+    removePreviewFromReactFlow(asInstance(rf));
+
+    expect(rf.setNodes).toHaveBeenCalledTimes(1);
+    expect(rf.setEdges).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/apollo-react/src/canvas/utils/createPreviewNode.ts
+++ b/packages/apollo-react/src/canvas/utils/createPreviewNode.ts
@@ -414,6 +414,10 @@ export function applyPreviewToReactFlow(
  * Removes preview node and edge from React Flow instance
  */
 export function removePreviewFromReactFlow(reactFlowInstance: ReactFlowInstance): void {
-  reactFlowInstance.setNodes((nodes) => nodes.filter((n) => n.id !== PREVIEW_NODE_ID));
-  reactFlowInstance.setEdges((edges) => edges.filter((edge) => !isPreviewEdge(edge)));
+  if (reactFlowInstance.getNodes().some((n) => n.id === PREVIEW_NODE_ID)) {
+    reactFlowInstance.setNodes((nodes) => nodes.filter((n) => n.id !== PREVIEW_NODE_ID));
+  }
+  if (reactFlowInstance.getEdges().some((edge) => isPreviewEdge(edge))) {
+    reactFlowInstance.setEdges((edges) => edges.filter((edge) => !isPreviewEdge(edge)));
+  }
 }


### PR DESCRIPTION
## Summary

`removePreviewFromReactFlow` unconditionally called `setNodes` and `setEdges`. Calling it when there is no preview node/edge on the canvas therefore still triggered a React Flow state update — and the re-render that comes with it — for no reason, which pushed every consumer to hand-roll a "does a preview exist?" pre-check before calling it.

This guards each mutation behind a presence check, so:

- calling it with no preview present is a cheap no-op (no `setNodes` / `setEdges`, no re-render);
- callers can invoke it unconditionally without pre-checking.

Behaviour is unchanged when a preview *is* present, and the public signature is untouched.

## Changes

- `removePreviewFromReactFlow`: only call `setNodes` when a preview node (`id === PREVIEW_NODE_ID`) exists, and `setEdges` when a preview edge (`isPreviewEdge`) exists.
- New `createPreviewNode.test.ts`: 5 cases — no-op when absent, empty canvas, node-only, edge-only, both present.

## Testing

- `vitest run createPreviewNode.test.ts` — 5/5 pass
- `createPreviewGraph.test.ts` regression — 5/5 pass
- `biome lint` / `biome format` clean
