### PR TITLE
fix(apollo-core): scope base design tokens to :root, :host for shadow DOM [MST-12229]

### DIFF
--- a/packages/apollo-core/build-tokens.js
+++ b/packages/apollo-core/build-tokens.js
@@ -35,18 +35,21 @@ StyleDictionary.registerFormat({
 // (palette, fonts, radius) under bare `:root {}`, which never matches inside a
 // shadow root (`:root` = <html>; a shadow root is a DocumentFragment).
 //
-// So shadow-DOM canvas consumers lose the fonts and fall back to Tailwind's
-// `ui-monospace`. Emitting `:root, .apollo-design` too makes them apply via the
-// `apollo-design` theme wrapper — the hook `theme-variables.css` uses for colors.
+// So shadow-DOM canvas consumers (traceview's web component, ap-chat) lose the
+// fonts and fall back to Tailwind's `ui-monospace`. Emitting `:root, :host` too
+// makes the base tokens apply to any shadow host that adopts/injects this sheet;
+// they then inherit through the whole shadow tree (including portaled content),
+// with no `.apollo-design` wrapper required. In the light DOM `:root` still
+// applies; `:host` simply matches nothing there.
 //
 // Delegating to the built-in formatter keeps the generated token body
 // byte-identical; only the selector changes.
 StyleDictionary.registerFormat({
-  name: 'css/variables-apollo-design',
+  name: 'css/variables-shadow-host',
   formatter: function (dictionary, platform) {
     return StyleDictionary.format['css/variables']
       .call(this, dictionary, platform)
-      .replace(':root {', ':root, .apollo-design {');
+      .replace(':root {', ':root, :host {');
   },
 });
 

--- a/packages/apollo-core/build-tokens.js
+++ b/packages/apollo-core/build-tokens.js
@@ -31,19 +31,11 @@ StyleDictionary.registerFormat({
   formatter: _.template(fs.readFileSync(path.join(templateDir, 'css-theme-variables.template'))),
 });
 
-// The built-in `css/variables` format emits `variables.css`'s base tokens
-// (palette, fonts, radius) under bare `:root {}`, which never matches inside a
-// shadow root (`:root` = <html>; a shadow root is a DocumentFragment).
-//
-// So shadow-DOM canvas consumers (traceview's web component, ap-chat) lose the
-// fonts and fall back to Tailwind's `ui-monospace`. Emitting `:root, :host` too
-// makes the base tokens apply to any shadow host that adopts/injects this sheet;
-// they then inherit through the whole shadow tree (including portaled content),
-// with no `.apollo-design` wrapper required. In the light DOM `:root` still
-// applies; `:host` simply matches nothing there.
-//
-// Delegating to the built-in formatter keeps the generated token body
-// byte-identical; only the selector changes.
+// `css/variables` emits base tokens (palette, fonts, radius) under bare `:root {}`,
+// which never matches inside a shadow root — so shadow-DOM consumers (traceview WC,
+// ap-chat) fall back to Tailwind defaults. Adding `:host` scopes the tokens to the
+// shadow host too (inherited through the tree); `:root` still covers the light DOM.
+// Delegating to the built-in formatter keeps the token body byte-identical.
 StyleDictionary.registerFormat({
   name: 'css/variables-shadow-host',
   formatter: function (dictionary, platform) {

--- a/packages/apollo-core/build-tokens.js
+++ b/packages/apollo-core/build-tokens.js
@@ -31,6 +31,25 @@ StyleDictionary.registerFormat({
   formatter: _.template(fs.readFileSync(path.join(templateDir, 'css-theme-variables.template'))),
 });
 
+// The built-in `css/variables` format emits `variables.css`'s base tokens
+// (palette, fonts, radius) under bare `:root {}`, which never matches inside a
+// shadow root (`:root` = <html>; a shadow root is a DocumentFragment).
+//
+// So shadow-DOM canvas consumers lose the fonts and fall back to Tailwind's
+// `ui-monospace`. Emitting `:root, .apollo-design` too makes them apply via the
+// `apollo-design` theme wrapper — the hook `theme-variables.css` uses for colors.
+//
+// Delegating to the built-in formatter keeps the generated token body
+// byte-identical; only the selector changes.
+StyleDictionary.registerFormat({
+  name: 'css/variables-apollo-design',
+  formatter: function (dictionary, platform) {
+    return StyleDictionary.format['css/variables']
+      .call(this, dictionary, platform)
+      .replace(':root {', ':root, .apollo-design {');
+  },
+});
+
 StyleDictionary.registerFormat({
   name: 'scss/scoped-theme-variables',
   formatter: _.template(fs.readFileSync(path.join(templateDir, 'scoped-theme-variables.template'))),

--- a/packages/apollo-core/build-tokens.js
+++ b/packages/apollo-core/build-tokens.js
@@ -39,9 +39,19 @@ StyleDictionary.registerFormat({
 StyleDictionary.registerFormat({
   name: 'css/variables-shadow-host',
   formatter: function (dictionary, platform) {
-    return StyleDictionary.format['css/variables']
-      .call(this, dictionary, platform)
-      .replace(':root {', ':root, :host {');
+    const css = StyleDictionary.format['css/variables'].call(this, dictionary, platform);
+    const scoped = css.replace(':root {', ':root, :host {');
+    // Fail loud if the selector didn't change: a silent no-op (e.g. if a future
+    // Style Dictionary version emits `:root{` or reformats the block) would
+    // regenerate `variables.css` back to bare `:root {}` and reintroduce the
+    // shadow-DOM token-scoping bug this format exists to fix, with no signal.
+    if (scoped === css) {
+      throw new Error(
+        "css/variables-shadow-host: expected ':root {' in the built-in css/variables output but found none — " +
+          'the selector was not rewritten to :root, :host. Shadow-DOM base tokens would be lost.'
+      );
+    }
+    return scoped;
   },
 });
 

--- a/packages/apollo-core/src/tokens/config.js
+++ b/packages/apollo-core/src/tokens/config.js
@@ -76,7 +76,7 @@ module.exports = {
       buildPath: 'src/tokens/css/',
       files: [
         {
-          format: 'css/variables-apollo-design',
+          format: 'css/variables-shadow-host',
           destination: 'variables.css',
           options: {
             showFileHeader: false,

--- a/packages/apollo-core/src/tokens/config.js
+++ b/packages/apollo-core/src/tokens/config.js
@@ -76,7 +76,7 @@ module.exports = {
       buildPath: 'src/tokens/css/',
       files: [
         {
-          format: 'css/variables',
+          format: 'css/variables-apollo-design',
           destination: 'variables.css',
           options: {
             showFileHeader: false,

--- a/web-packages/ap-chat/src/__tests__/ap-chat-element.test.ts
+++ b/web-packages/ap-chat/src/__tests__/ap-chat-element.test.ts
@@ -439,6 +439,27 @@ describe('ApChat Web Component', () => {
       expect(portalContainerAfter).toBe(portalContainer);
     });
 
+    it('should carry the theme class on the portal container and keep it in sync', () => {
+      element.chatServiceInstance = mockService;
+      element.connectedCallback();
+
+      const shadowRoot = element.shadowRoot;
+      const portalContainer = shadowRoot?.querySelector('.portal-container') as HTMLDivElement;
+      expect(portalContainer).not.toBeNull();
+
+      // theme-variables.css activates semantic tokens for the portal subtree via
+      // selectors like `:where(.light)`, so the portal container must carry the
+      // theme class initially and update when the theme changes.
+      expect(portalContainer.classList.contains('light')).toBe(true); // default theme
+
+      element.theme = 'dark';
+
+      expect(portalContainer.classList.contains('dark')).toBe(true);
+      expect(portalContainer.classList.contains('light')).toBe(false);
+      // The base `portal-container` class is preserved across theme changes.
+      expect(portalContainer.classList.contains('portal-container')).toBe(true);
+    });
+
     it('should maintain portal container across locale changes', () => {
       element.chatServiceInstance = mockService;
       element.connectedCallback();

--- a/web-packages/ap-chat/src/ap-chat-element.ts
+++ b/web-packages/ap-chat/src/ap-chat-element.ts
@@ -2,14 +2,12 @@
 // These load into document and are available to Shadow DOM
 import '@uipath/apollo-react/core/fonts/font.css';
 
-import { createElement } from 'react';
-
-import { createRoot, type Root } from 'react-dom/client';
-
 // Import Apollo CSS variables as raw strings for Shadow DOM injection
 // Using ?raw query parameter to import CSS as text instead of injecting globally
 import apolloThemeVariablesCSS from '@uipath/apollo-react/core/tokens/css/theme-variables.css?raw';
 import apolloVariablesCSS from '@uipath/apollo-react/core/tokens/css/variables.css?raw';
+import { createElement } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
 
 import { cleanupReactRenderer, createReactRenderer } from './react-renderer';
 import { AutopilotChatEvent, type AutopilotChatService } from './service';
@@ -245,24 +243,18 @@ export class ApChat extends HTMLElement {
       }
     `;
 
-    // Create a constructable stylesheet for Shadow DOM
-    // Include Apollo design tokens, font faces, and icon styles
-    // Transform CSS selectors to work in Shadow DOM context
-    const transformedVariablesCSS = apolloVariablesCSS.replace(/:root\s*\{/g, ':host {'); // Transform :root to :host for Shadow DOM
-
-    // For theme variables, apply to both :host and all children to ensure proper cascading
-    // This ensures theme variables are available everywhere in the shadow tree
-    const transformedThemeVariablesCSS = apolloThemeVariablesCSS
-      .replace(/:root\s*\{/g, ':host {')
-      .replace(
-        /body\.(light|dark|light-hc|dark-hc)(?:,\s*\.apollo-design\.\1)?\s*\{/g,
-        ':host(.$1), :host(.$1) * {'
-      ); // Apply to host and all descendants
-
+    // Adopt Apollo design tokens, font faces, and icon styles into the Shadow DOM.
+    // No selector rewriting is needed:
+    //  - `variables.css` base tokens (palette, fonts, radius) are scoped to
+    //    `:root, :host` by apollo-core, so `:host` sets them on this element and
+    //    they inherit through the entire shadow tree (including the portal).
+    //  - `theme-variables.css` semantic tokens match any themed element via
+    //    `:where(.light:not(.react-flow))`, which covers the container and portal
+    //    container below (both carry the theme class).
     const shadowStyleSheet = new CSSStyleSheet();
     const allStyles = [
-      transformedVariablesCSS,
-      transformedThemeVariablesCSS,
+      apolloVariablesCSS,
+      apolloThemeVariablesCSS,
       ...fontFaceRules,
       iconStylesText,
     ].join('\n');
@@ -288,7 +280,9 @@ export class ApChat extends HTMLElement {
     `;
     this.shadowRoot.appendChild(hostStyles);
 
-    // Apply theme class to host element for :host(.theme) selectors
+    // Theme class on the host is a convenience hook for external styling; apollo
+    // tokens no longer depend on it (base via :host, semantic via the themed
+    // container/portal below).
     this.className = this._theme || 'light';
 
     // Create container for React
@@ -300,9 +294,9 @@ export class ApChat extends HTMLElement {
     this.shadowRoot.appendChild(this.container);
 
     // Create dedicated portal container for tooltips/popovers at Shadow DOM root
-    // This prevents clipping in embedded mode while being a real HTMLElement for MUI
+    // This prevents clipping in embedded mode while being a real HTMLElement for MUI.
     this.portalContainer = document.createElement('div');
-    this.portalContainer.className = 'portal-container';
+    this.portalContainer.className = `portal-container ${this._theme || 'light'}`;
     this.portalContainer.style.position = 'fixed';
     this.portalContainer.style.top = '0';
     this.portalContainer.style.left = '0';
@@ -373,9 +367,12 @@ export class ApChat extends HTMLElement {
 
     // Update theme class on both host element and container
     const theme = this._theme || 'light';
-    this.className = theme; // For :host(.theme) selectors in Shadow DOM
+    this.className = theme;
     if (this.container) {
       this.container.className = theme;
+    }
+    if (this.portalContainer) {
+      this.portalContainer.className = `portal-container ${theme}`;
     }
 
     const props: ApChatProperties = {


### PR DESCRIPTION
## Problem

The generated `variables.css` (raw color palette, font families like `--font-mono: inconsolata` / `--font-title` / `--font-normal`, `--radius`, …) is scoped to a bare **`:root {}`** block. `:root` only ever matches the document element (`<html>`); a shadow root is a `DocumentFragment`, not an element, so **none of these base tokens apply inside a shadow root**.

**Scope:** only font tokens are affected.
-  Shadow-DOM canvas consumers lose `--font-mono`/`--font-title`/`--font-normal` and fall back to Tailwind's generic `ui-monospace` stack (and get no title/body font at all).
- Semantic colors are unaffected because they live in class-scoped `body.light` / `.apollo-design.light` blocks that match the theme-class wrapper — only the bare-`:root` base tokens fall through the gap.

<img width="410" height="201" alt="image" src="https://github.com/user-attachments/assets/35982ba6-e43a-4935-b9ed-807dd10f2407" />

## Fix

`variables.css` is emitted by Style Dictionary's built-in `css/variables` format, which hardcodes `:root {` (SD v2.8.3 has no `selector` option). Add a small `css/variables-shadow-host` format that **delegates to the built-in formatter and rewrites only the selector to `:root, :host`**, then point `variables.css` at it.

`:root` still covers light-DOM consumers; **`:host` matches any shadow host that adopts or injects this sheet**, so the base tokens apply on the host and inherit through the entire shadow tree — including portaled content — with **no `.apollo-design` wrapper required**. In the light DOM `:host` simply matches nothing.

## Demo

### Before
<img width="1528" height="175" alt="image" src="https://github.com/user-attachments/assets/2b07cf87-d208-4faa-8588-4daee845b5a6" />

### After
<img width="1070" height="362" alt="image" src="https://github.com/user-attachments/assets/8a675c98-24eb-4e71-ac74-22ba5a89941c" />
<img width="477" height="154" alt="image" src="https://github.com/user-attachments/assets/e3957304-429b-45cc-b895-92c879cbc35d" />

## ap-chat

https://github.com/user-attachments/assets/2997357e-26fe-435f-9973-f3644957e8aa

## Verification

- Generated token body is **byte-identical**; only the selector changes (`:root {` → `:root, :host {`).
- **Generated source:** regenerated `variables.css` diff is exactly one line — `:root {` → `:root, :host {`.
- **Compiled artifact:** rebuilt `apollo-react` through the full chain — the base-token block (palette + `--font-mono:inconsolata` + `--font-title`/`--font-normal`) is now `:root, :host {…}`.
- **Live shadow root:** confirmed in a real browser that `--font-mono` resolves to `inconsolata` inside the shadow root (traceview WC and ap-chat) — with no wrapper and no runtime selector rewriting — while semantic `--color-background`/`--color-foreground` resolve on both the container and the portal.

Downstream, this lets shadow-DOM consumers drop client-side `:root` → `:host` rewrite workarounds. ap-chat now adopts `variables.css`/`theme-variables.css` raw (commits on this branch).

_Alternative considered: `:root, .apollo-design`, scoping to the documented Pattern-B wrapper class (and working in a light-DOM subtree without touching `:root`). Chose `:root, :host` because it needs no wrapper, covers portaled/shadow content mounted outside a wrapper, and lets `:host`-based consumers (ap-chat) drop their runtime selector rewrites._
