### PR TITLE
feat(apollo-wind): scrollable tabs + per-tab error badges in tabbed MetadataForm

### DIFF
--- a/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.tsx
+++ b/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.tsx
@@ -51,6 +51,8 @@ export function NodePropertyPanel({
   children,
   headerExtra,
   sectionVariant,
+  activeStepId,
+  onActiveStepChange,
 }: NodePropertyPanelProps) {
   const hasNodeHeader = !!(nodeLabel || nodeCategory || nodeIcon || action);
 
@@ -145,6 +147,8 @@ export function NodePropertyPanel({
               plugins={plugins}
               stepVariant="tabs"
               sectionVariant={sectionVariant}
+              activeStepId={activeStepId}
+              onActiveStepChange={onActiveStepChange}
               onSubmit={onSubmit}
               disabled={disabled}
               className="flex min-h-0 flex-1 flex-col"
@@ -152,14 +156,14 @@ export function NodePropertyPanel({
           </div>
         </div>
       ) : (
-        // Single-page schema: classic behavior — this wrapper scrolls the whole form.
+        // Single-page schema: classic behavior — this wrapper scrolls the whole
+        // form. No stepVariant: it only applies to step-based schemas.
         <div className="min-h-0 flex-1 overflow-auto">
           <div style={SURFACE_REMAP} className="[&_label]:text-foreground-muted">
             <MetadataForm
               key={resetKey}
               schema={formSchema}
               plugins={plugins}
-              stepVariant="tabs"
               sectionVariant={sectionVariant}
               onSubmit={onSubmit}
               disabled={disabled}

--- a/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.tsx
+++ b/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.tsx
@@ -130,7 +130,29 @@ export function NodePropertyPanel({
         <div className="py-4 text-xs text-foreground-subtle [padding-inline:var(--mf-content-inset,1.5rem)]">
           No form schema defined for this node.
         </div>
+      ) : formSchema.steps ? (
+        // Tabbed schema: MetadataForm owns the scroll so its tab bar pins under
+        // the header. This wrapper is a height-filling flex column, NOT the
+        // scroll container — the form's inset/padding move inside TabbedStepForm.
+        <div className="flex min-h-0 flex-1 flex-col">
+          <div
+            style={SURFACE_REMAP}
+            className="flex min-h-0 flex-1 flex-col [&_label]:text-foreground-muted"
+          >
+            <MetadataForm
+              key={resetKey}
+              schema={formSchema}
+              plugins={plugins}
+              stepVariant="tabs"
+              sectionVariant={sectionVariant}
+              onSubmit={onSubmit}
+              disabled={disabled}
+              className="flex min-h-0 flex-1 flex-col"
+            />
+          </div>
+        </div>
       ) : (
+        // Single-page schema: classic behavior — this wrapper scrolls the whole form.
         <div className="min-h-0 flex-1 overflow-auto">
           <div style={SURFACE_REMAP} className="[&_label]:text-foreground-muted">
             <MetadataForm

--- a/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.tsx
+++ b/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.tsx
@@ -50,6 +50,7 @@ export function NodePropertyPanel({
   contentInset = '1.5rem',
   children,
   headerExtra,
+  sectionVariant,
 }: NodePropertyPanelProps) {
   const hasNodeHeader = !!(nodeLabel || nodeCategory || nodeIcon || action);
 
@@ -137,6 +138,7 @@ export function NodePropertyPanel({
               schema={formSchema}
               plugins={plugins}
               stepVariant="tabs"
+              sectionVariant={sectionVariant}
               onSubmit={onSubmit}
               disabled={disabled}
               className="flex flex-col gap-4 pb-6 pt-3 [padding-inline:var(--mf-content-inset)]"

--- a/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.types.ts
+++ b/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.types.ts
@@ -29,6 +29,13 @@ export interface NodePropertyPanelProps {
    * verbatim to the underlying single form instance.
    */
   plugins?: FormPlugin[];
+  /**
+   * Visual treatment for each form section, forwarded to `MetadataForm`.
+   * `'card'` (default) frames every section in a bordered box; `'plain'` drops
+   * the border/rounding/horizontal padding so sections read as flush headers —
+   * for hosts that already frame the panel and want a borderless list.
+   */
+  sectionVariant?: 'card' | 'plain';
   /** Called when the form is submitted (only when the schema defines a submit action). */
   onSubmit?: (data: unknown) => void | Promise<void>;
   /** Disables all fields (e.g. read-only nodes). */

--- a/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.types.ts
+++ b/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.types.ts
@@ -36,6 +36,17 @@ export interface NodePropertyPanelProps {
    * for hosts that already frame the panel and want a borderless list.
    */
   sectionVariant?: 'card' | 'plain';
+  /**
+   * Controlled active tab id for a tabbed (multi-step) schema. Persist it
+   * across node switches to keep the user on the same tab; an id absent from
+   * the current node's tabs falls back to the first tab. Omit for uncontrolled.
+   */
+  activeStepId?: string;
+  /**
+   * Fires with the tab id whenever the user selects a tab, in both controlled
+   * and uncontrolled mode. Pair it with `activeStepId` to persist the selection.
+   */
+  onActiveStepChange?: (stepId: string) => void;
   /** Called when the form is submitted (only when the schema defines a submit action). */
   onSubmit?: (data: unknown) => void | Promise<void>;
   /** Disables all fields (e.g. read-only nodes). */

--- a/packages/apollo-wind/src/components/forms/form-schema.ts
+++ b/packages/apollo-wind/src/components/forms/form-schema.ts
@@ -339,6 +339,14 @@ export interface FormStep {
   validation?: 'onChange' | 'onBlur' | 'onSubmit';
   canSkip?: boolean;
   conditions?: FieldCondition[]; // Show/hide entire step
+  /**
+   * Message shown (in the `tabs` step variant) when this step has no visible
+   * sections. A step that sets this stays in the tab bar even while empty and
+   * renders the message in place of its content — e.g. a "Parameters" tab that
+   * always shows, reading "No available parameters" for a node with no inputs.
+   * Steps without both sections and `emptyState` are hidden from the tab bar.
+   */
+  emptyState?: string;
 }
 
 export interface FormAction {

--- a/packages/apollo-wind/src/components/forms/metadata-form.stories.tsx
+++ b/packages/apollo-wind/src/components/forms/metadata-form.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useState } from 'react';
 import {
   Controller,
   type FieldValues,
@@ -874,6 +875,134 @@ export const TabbedSteps: Story = {
   args: {
     schema: tabbedNodeSchema,
     stepVariant: 'tabs',
+  },
+};
+
+// A tabbed node schema exercising both section shapes the properties panel
+// produces: Parameters carries two titled, collapsible sections (where the two
+// sectionVariants differ visibly), while Error handling and Advanced each hold a
+// single untitled, non-collapsible section — mirroring the consumer rule that a
+// tab's lone section drops the collapse affordance and title because the tab
+// already labels it. `card` frames each section in its own bordered box; `plain`
+// renders flush headers separated by hairline dividers (the host frames the
+// panel).
+const sectionVariantSchema: FormSchema = {
+  id: 'section-variant-demo',
+  title: 'Node properties',
+  actions: [],
+  initialData: {
+    'inputs.method': 'GET',
+    'inputs.url': 'https://api.example.com/v1/orders',
+    'inputs.timeout': 30,
+    'inputs.errorHandlingEnabled': false,
+    nodeId: 'httpRequest1',
+    'display.label': 'HTTP request',
+  },
+  steps: [
+    {
+      id: 'parameters',
+      title: 'Parameters',
+      sections: [
+        {
+          id: 'connection',
+          title: 'Connection',
+          collapsible: true,
+          defaultExpanded: true,
+          fields: [
+            {
+              name: 'inputs.method',
+              type: 'select',
+              label: 'Method',
+              options: [
+                { label: 'GET', value: 'GET' },
+                { label: 'POST', value: 'POST' },
+                { label: 'PUT', value: 'PUT' },
+              ],
+            },
+            { name: 'inputs.url', type: 'text', label: 'URL' },
+          ],
+        },
+        {
+          id: 'options',
+          title: 'Options',
+          collapsible: true,
+          defaultExpanded: true,
+          fields: [{ name: 'inputs.timeout', type: 'number', label: 'Timeout (s)' }],
+        },
+      ],
+    },
+    {
+      id: 'error-handling',
+      title: 'Error handling',
+      sections: [
+        // Sole section in its tab: no title, no collapse — the tab labels it.
+        {
+          id: 'error',
+          fields: [
+            {
+              name: 'inputs.errorHandlingEnabled',
+              type: 'switch',
+              label: 'Enable error handling',
+              description: 'Add an error output handle on the node to catch and handle failures.',
+            },
+          ],
+        },
+      ],
+    },
+    {
+      id: 'advanced',
+      title: 'Advanced',
+      sections: [
+        // Sole section in its tab: no title, no collapse — the tab labels it.
+        {
+          id: 'general',
+          fields: [
+            { name: 'nodeId', type: 'text', label: 'ID', disabled: true },
+            { name: 'display.label', type: 'text', label: 'Label' },
+            { name: 'display.description', type: 'textarea', label: 'Description' },
+          ],
+        },
+      ],
+    },
+  ],
+};
+
+/**
+ * Section variants (card vs plain)
+ *
+ * Flip the toggle to compare the two `sectionVariant` treatments live. `card`
+ * (default) wraps each section in its own bordered, rounded box. `plain` drops
+ * the border, rounding, and horizontal padding so sections read as flush headers
+ * over their content. `plain` assumes the host already frames the panel, so the
+ * form is rendered inside a narrow panel-like container here to match that use
+ * case (the canvas node properties panel).
+ */
+export const SectionVariants: Story = {
+  render: (args) => {
+    const [plain, setPlain] = useState(true);
+    return (
+      // Canvas backdrop + panel frame matching the NodePropertyPanel stories:
+      // the canvas sits on `--surface` and the docked panel is a raised,
+      // subtly-bordered card (bg-surface-raised) floating over it. The variant
+      // toggle floats on the canvas, centered above the panel it controls.
+      <div className="flex flex-col items-center gap-6 rounded-lg bg-surface p-10">
+        <div className="flex items-center gap-2">
+          <Switch id="section-variant-toggle" checked={plain} onCheckedChange={setPlain} />
+          <Label htmlFor="section-variant-toggle">
+            Plain sections (host-framed) {'·'} currently{' '}
+            <code>sectionVariant="{plain ? 'plain' : 'card'}"</code>
+          </Label>
+        </div>
+        <div className="w-[380px] overflow-hidden rounded-2xl border border-border-subtle bg-surface-raised px-4 py-3 shadow-lg">
+          <MetadataForm
+            {...args}
+            schema={sectionVariantSchema}
+            stepVariant="tabs"
+            sectionVariant={plain ? 'plain' : 'card'}
+          />
+        </div>
+      </div>
+    );
   },
 };
 

--- a/packages/apollo-wind/src/components/forms/metadata-form.stories.tsx
+++ b/packages/apollo-wind/src/components/forms/metadata-form.stories.tsx
@@ -881,7 +881,7 @@ export const TabbedSteps: Story = {
 // A tabbed node schema exercising both section shapes the properties panel
 // produces: Parameters carries two titled, collapsible sections (where the two
 // sectionVariants differ visibly), while Error handling and Advanced each hold a
-// single untitled, non-collapsible section — mirroring the consumer rule that a
+// single untitled, non-collapsible section. That mirrors the consumer rule that a
 // tab's lone section drops the collapse affordance and title because the tab
 // already labels it. `card` frames each section in its own bordered box; `plain`
 // renders flush headers separated by hairline dividers (the host frames the
@@ -935,7 +935,7 @@ const sectionVariantSchema: FormSchema = {
       id: 'error-handling',
       title: 'Error handling',
       sections: [
-        // Sole section in its tab: no title, no collapse — the tab labels it.
+        // Sole section in its tab: no title, no collapse. The tab labels it.
         {
           id: 'error',
           fields: [
@@ -953,7 +953,7 @@ const sectionVariantSchema: FormSchema = {
       id: 'advanced',
       title: 'Advanced',
       sections: [
-        // Sole section in its tab: no title, no collapse — the tab labels it.
+        // Sole section in its tab: no title, no collapse. The tab labels it.
         {
           id: 'general',
           fields: [

--- a/packages/apollo-wind/src/components/forms/metadata-form.test.tsx
+++ b/packages/apollo-wind/src/components/forms/metadata-form.test.tsx
@@ -2,8 +2,8 @@ import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { axe } from 'jest-axe';
 import { describe, expect, it, vi } from 'vitest';
-import { MetadataForm } from './metadata-form';
 import type { FormPlugin, FormSchema } from './form-schema';
+import { MetadataForm } from './metadata-form';
 
 // Basic form schema for tests
 const basicSchema: FormSchema = {
@@ -463,6 +463,138 @@ describe('MetadataForm', () => {
         name: /Parameters/,
       });
       await waitFor(() => expect(within(parametersTab).getByText('3')).toBeInTheDocument());
+    });
+
+    it('controlled: an activeStepId not among the visible steps clamps to the first tab without firing onActiveStepChange', async () => {
+      const onActiveStepChange = vi.fn();
+      render(
+        <MetadataForm
+          schema={tabbedSchema}
+          stepVariant="tabs"
+          activeStepId="does-not-exist"
+          onActiveStepChange={onActiveStepChange}
+        />
+      );
+
+      // Clamped to the first visible tab rather than stranded on a dead id.
+      const parametersTab = await screen.findByRole('tab', { name: 'Parameters' });
+      await waitFor(() => expect(parametersTab).toHaveAttribute('data-state', 'active'));
+      // Clamping is internal: it must not fire the change callback (nor mutate the caller's value).
+      expect(onActiveStepChange).not.toHaveBeenCalled();
+    });
+
+    it('controlled: selecting a tab fires onActiveStepChange but leaves the displayed tab to the caller', async () => {
+      const user = userEvent.setup();
+      const onActiveStepChange = vi.fn();
+      render(
+        <MetadataForm
+          schema={tabbedSchema}
+          stepVariant="tabs"
+          activeStepId="parameters"
+          onActiveStepChange={onActiveStepChange}
+        />
+      );
+
+      await user.click(screen.getByRole('tab', { name: 'Advanced' }));
+
+      // Callback fires with the selection...
+      expect(onActiveStepChange).toHaveBeenCalledWith('advanced');
+      // ...but the form stays on the caller-controlled tab until the caller updates activeStepId.
+      await waitFor(() =>
+        expect(screen.getByRole('tab', { name: 'Parameters' })).toHaveAttribute(
+          'data-state',
+          'active'
+        )
+      );
+    });
+
+    it('uncontrolled: selecting a tab both fires onActiveStepChange and moves to that tab', async () => {
+      const user = userEvent.setup();
+      const onActiveStepChange = vi.fn();
+      render(
+        <MetadataForm
+          schema={tabbedSchema}
+          stepVariant="tabs"
+          onActiveStepChange={onActiveStepChange}
+        />
+      );
+
+      await user.click(screen.getByRole('tab', { name: 'Advanced' }));
+
+      expect(onActiveStepChange).toHaveBeenCalledWith('advanced');
+      await waitFor(() =>
+        expect(screen.getByRole('tab', { name: 'Advanced' })).toHaveAttribute(
+          'data-state',
+          'active'
+        )
+      );
+    });
+
+    it('keeps an otherwise-empty step in the tab bar when it defines an emptyState, and renders that message', async () => {
+      const withEmptyState: FormSchema = {
+        id: 'with-empty-state',
+        title: 'With empty state',
+        actions: [],
+        steps: [
+          {
+            id: 'parameters',
+            title: 'Parameters',
+            sections: [{ id: 'p', fields: [{ name: 'field1', type: 'text', label: 'Field 1' }] }],
+          },
+          {
+            id: 'advanced',
+            title: 'Advanced',
+            emptyState: 'No advanced settings for this node.',
+            sections: [],
+          },
+        ],
+      };
+
+      const user = userEvent.setup();
+      render(<MetadataForm schema={withEmptyState} stepVariant="tabs" />);
+
+      // The empty step still gets a tab (unlike a section-less, message-less step, which is omitted).
+      const advancedTab = await screen.findByRole('tab', { name: 'Advanced' });
+      await user.click(advancedTab);
+
+      // Its emptyState message renders in place of sections.
+      await waitFor(() =>
+        expect(screen.getByText('No advanced settings for this node.')).toBeInTheDocument()
+      );
+    });
+
+    it('omits a step whose sections are all hidden by section conditions and has no emptyState (no blank tab)', async () => {
+      const schema: FormSchema = {
+        id: 'hidden-sections',
+        title: 'Hidden sections',
+        actions: [],
+        steps: [
+          {
+            id: 'parameters',
+            title: 'Parameters',
+            sections: [{ id: 'p', fields: [{ name: 'field1', type: 'text', label: 'Field 1' }] }],
+          },
+          {
+            id: 'conditional',
+            title: 'Conditional',
+            sections: [
+              {
+                id: 'c',
+                // Hidden until field1 === 'show-me'; field1 is empty here.
+                conditions: [{ when: 'field1', is: 'show-me' }],
+                fields: [{ name: 'field2', type: 'text', label: 'Field 2' }],
+              },
+            ],
+          },
+        ],
+      };
+
+      render(<MetadataForm schema={schema} stepVariant="tabs" />);
+
+      // The Conditional step's only section is hidden and it has no emptyState,
+      // so it must not surface a blank tab.
+      expect(await screen.findByRole('tab', { name: 'Parameters' })).toBeInTheDocument();
+      expect(screen.queryByRole('tab', { name: 'Conditional' })).not.toBeInTheDocument();
     });
   });
 });

--- a/packages/apollo-wind/src/components/forms/metadata-form.test.tsx
+++ b/packages/apollo-wind/src/components/forms/metadata-form.test.tsx
@@ -1,9 +1,9 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { axe } from 'jest-axe';
 import { describe, expect, it, vi } from 'vitest';
 import { MetadataForm } from './metadata-form';
-import type { FormSchema } from './form-schema';
+import type { FormPlugin, FormSchema } from './form-schema';
 
 // Basic form schema for tests
 const basicSchema: FormSchema = {
@@ -417,6 +417,52 @@ describe('MetadataForm', () => {
       // TabbedStepForm renders nothing, so FormActions (and its default Submit) is suppressed.
       expect(screen.queryByRole('tab')).not.toBeInTheDocument();
       expect(screen.queryByRole('button', { name: 'Submit' })).not.toBeInTheDocument();
+    });
+
+    it("badges a tab with the count of its errored fields, including a tab that isn't active", async () => {
+      // Seed an error on `field2`, which lives on the (inactive) Advanced tab.
+      const seedError: FormPlugin = {
+        name: 'seed-error',
+        version: '1.0.0',
+        onFormInit: (context) => {
+          context.form.setError('field2', { message: 'Bad value' });
+        },
+      };
+
+      render(<MetadataForm schema={tabbedSchema} stepVariant="tabs" plugins={[seedError]} />);
+
+      // The Advanced tab (not active) shows a "1" badge for its single errored field.
+      const advancedTab = await screen.findByRole('tab', { name: /Advanced/ });
+      await waitFor(() => expect(within(advancedTab).getByText('1')).toBeInTheDocument());
+
+      // The Parameters tab has no errored field, so it stays badge-free.
+      expect(screen.getByRole('tab', { name: 'Parameters' })).toBeInTheDocument();
+      expect(within(screen.getByRole('tab', { name: 'Parameters' })).queryByText('1')).toBeNull();
+    });
+
+    it('counts each issue of a composite field whose error is an array (not just the field)', async () => {
+      // A composite field (e.g. a connector editor) surfaces several issues at once,
+      // stored as an array of errors under one field name. The badge should reflect
+      // the issue count, not collapse the whole field to a single "1".
+      const seedArrayError: FormPlugin = {
+        name: 'seed-array-error',
+        version: '1.0.0',
+        onFormInit: (context) => {
+          context.form.setError('field1.0', { message: 'Channel is required' });
+          context.form.setError('field1.1', {
+            message: 'Timestamp is required',
+          });
+          context.form.setError('field1.2', { message: 'Message is required' });
+        },
+      };
+
+      render(<MetadataForm schema={tabbedSchema} stepVariant="tabs" plugins={[seedArrayError]} />);
+
+      // `field1` lives on Parameters; its three issues make the badge read "3".
+      const parametersTab = await screen.findByRole('tab', {
+        name: /Parameters/,
+      });
+      await waitFor(() => expect(within(parametersTab).getByText('3')).toBeInTheDocument());
     });
   });
 });

--- a/packages/apollo-wind/src/components/forms/metadata-form.tsx
+++ b/packages/apollo-wind/src/components/forms/metadata-form.tsx
@@ -57,6 +57,19 @@ interface MetadataFormProps {
    * (single-page, wizard, tabs).
    */
   sectionVariant?: 'card' | 'plain';
+  /**
+   * Controlled active step id for the `tabs` step variant. When provided the
+   * caller owns which tab is selected — persist it across remounts to keep the
+   * user on the same tab when switching between nodes. If the id isn't one of
+   * the currently visible steps, the form shows the first tab without mutating
+   * the caller's value. Omit for uncontrolled (internal) tab state.
+   */
+  activeStepId?: string;
+  /**
+   * Fires with the step id whenever the user selects a tab, in both controlled
+   * and uncontrolled mode. Pair it with `activeStepId` to persist the selection.
+   */
+  onActiveStepChange?: (stepId: string) => void;
 }
 
 // Stable default to prevent re-renders
@@ -71,6 +84,8 @@ export function MetadataForm({
   autoComplete,
   stepVariant = 'wizard',
   sectionVariant = 'card',
+  activeStepId,
+  onActiveStepChange,
 }: MetadataFormProps) {
   const [currentStep, setCurrentStep] = useState(0);
   const [customComponents, setCustomComponents] = useState<
@@ -209,6 +224,8 @@ export function MetadataForm({
             customComponents={customComponents}
             disabled={disabled}
             sectionVariant={sectionVariant}
+            activeStepId={activeStepId}
+            onActiveStepChange={onActiveStepChange}
             onReset={() => reset()}
           />
         );
@@ -278,7 +295,7 @@ function SinglePageForm({
   );
 
   return (
-    // Plain sections carry their own vertical rhythm (py-3 + divider), so the
+    // Plain sections carry their own vertical rhythm (py-4 + divider), so the
     // list adds no extra gap; card sections are spaced apart as separate boxes.
     <div className={sectionVariant === 'plain' ? undefined : 'space-y-2'}>
       {visibleSections.map((section) => (
@@ -377,6 +394,8 @@ function MultiStepForm({
 
 interface TabbedStepFormProps extends SinglePageFormProps {
   onReset: () => void;
+  activeStepId?: string;
+  onActiveStepChange?: (stepId: string) => void;
 }
 
 function TabbedStepForm({
@@ -386,20 +405,28 @@ function TabbedStepForm({
   disabled,
   sectionVariant,
   onReset,
+  activeStepId,
+  onActiveStepChange,
 }: TabbedStepFormProps) {
   const steps = schema.steps || [];
 
-  // Hide steps that have no sections or whose conditions evaluate to false, so a
-  // node that doesn't supply a given step (e.g. a trigger with no parameters)
-  // never renders an empty tab.
-  const visibleSteps = steps.filter(
-    (step) =>
-      step.sections.length > 0 && (!step.conditions || context.evaluateConditions(step.conditions))
-  );
+  // Hide steps whose conditions evaluate to false, or that would render nothing:
+  // a step needs at least one *currently visible* section (sections hidden by
+  // their own `section.conditions` don't count, matching the render path and the
+  // error-count walk below) or an `emptyState` message. A step with an
+  // `emptyState` stays in the tab bar even while empty (e.g. an always-shown
+  // "Parameters" tab) and renders that message in place of its sections.
+  const visibleSteps = steps.filter((step) => {
+    if (step.conditions && !context.evaluateConditions(step.conditions)) return false;
+    const hasVisibleSection = step.sections.some(
+      (section) => !section.conditions || context.evaluateConditions(section.conditions)
+    );
+    return hasVisibleSection || step.emptyState !== undefined;
+  });
 
   // Subscribe to validation state so a tab's error badge updates live as errors
-  // are set/cleared. Without this subscription the getters on `context.errors`
-  // don't re-render this component when only the error state changes.
+  // are set/cleared. This subscription is what re-renders the component (and
+  // feeds `getFieldState` below) when only the error state changes.
   const formState = useFormState({ control: context.form.control });
 
   // Per-step error count = number of validation issues on that step. A plain
@@ -434,18 +461,30 @@ function TabbedStepForm({
     errorCountByStepId[step.id] = count;
   }
 
-  // Clamp the active tab to a still-visible step so a step that disappears
-  // (condition flips, manifest swap) can't strand the form on a dead tab.
-  const [activeTab, setActiveTab] = useState<string>('');
-  const currentTab = visibleSteps.some((step) => step.id === activeTab)
-    ? activeTab
+  // Active tab: controlled by the caller when `activeStepId` is provided (so it
+  // can persist across remounts — e.g. keep the user on the same tab when
+  // switching nodes), otherwise internal state. Either way it's clamped to a
+  // still-visible step, so a step that disappears (condition flips, manifest
+  // swap, or a node-specific tab absent on the next node) falls back to the
+  // first tab instead of stranding the form on a dead tab.
+  const [internalTab, setInternalTab] = useState<string>('');
+  const controlled = activeStepId !== undefined;
+  const requestedTab = controlled ? activeStepId : internalTab;
+  const currentTab = visibleSteps.some((step) => step.id === requestedTab)
+    ? requestedTab
     : (visibleSteps[0]?.id ?? '');
+  const selectTab = (stepId: string) => {
+    if (!controlled) setInternalTab(stepId);
+    onActiveStepChange?.(stepId);
+  };
 
-  // Persist the clamp into state: once a selected step disappears we settle on the
-  // fallback, so a later reappearance doesn't snap the user back to the old tab.
+  // Uncontrolled only: settle internal state on the clamped value so a step that
+  // disappeared and later reappears doesn't snap the user back to it. In
+  // controlled mode the caller owns the value and we never overwrite it, so a
+  // node-specific tab stays remembered for nodes that do have it.
   useEffect(() => {
-    if (activeTab !== currentTab) setActiveTab(currentTab);
-  }, [activeTab, currentTab]);
+    if (!controlled && internalTab !== currentTab) setInternalTab(currentTab);
+  }, [controlled, internalTab, currentTab]);
 
   if (visibleSteps.length === 0) return null;
 
@@ -453,7 +492,7 @@ function TabbedStepForm({
     <>
       <Tabs
         value={currentTab}
-        onValueChange={setActiveTab}
+        onValueChange={selectTab}
         className="flex min-h-0 flex-1 flex-col gap-1"
       >
         {/* Pinned tab bar: shrink-0 keeps it under the panel header while the
@@ -493,36 +532,50 @@ function TabbedStepForm({
           </ScrollableTabsList>
         </div>
 
-        {visibleSteps.map((step) => (
-          // The active tab is the scroll container so the tab bar above stays
-          // pinned and the scrollbar sits at the panel edge; the inner wrapper
-          // carries the content inset + bottom padding. Plain drops space-y-2
-          // (sections self-space); card keeps the 2-unit rhythm between boxes.
-          <TabsContent key={step.id} value={step.id} className="mt-0 min-h-0 flex-1 overflow-auto">
-            <div
-              className={
-                sectionVariant === 'plain'
-                  ? 'pb-6 [padding-inline:var(--mf-content-inset,0px)]'
-                  : 'space-y-2 pb-6 [padding-inline:var(--mf-content-inset,0px)]'
-              }
+        {visibleSteps.map((step) => {
+          const stepSections = step.sections.filter(
+            (section) => !section.conditions || context.evaluateConditions(section.conditions)
+          );
+          return (
+            // The active tab is the scroll container so the tab bar above stays
+            // pinned and the scrollbar sits at the panel edge; the inner wrapper
+            // carries the content inset + bottom padding. Plain drops space-y-2
+            // (sections self-space) and gets its leading whitespace from the first
+            // section's own py-4/pt-4; card boxes have none, so the wrapper adds a
+            // matching pt-4 to keep the first card off the tab strip by the same
+            // amount. A step with no visible sections renders its `emptyState`.
+            <TabsContent
+              key={step.id}
+              value={step.id}
+              className="mt-0 min-h-0 flex-1 overflow-auto"
             >
-              {step.sections
-                .filter(
-                  (section) => !section.conditions || context.evaluateConditions(section.conditions)
-                )
-                .map((section) => (
-                  <FormSection
-                    key={section.id}
-                    section={section}
-                    context={context}
-                    customComponents={customComponents}
-                    disabled={disabled}
-                    sectionVariant={sectionVariant}
-                  />
-                ))}
-            </div>
-          </TabsContent>
-        ))}
+              {stepSections.length === 0 && step.emptyState !== undefined ? (
+                <div className="pt-4 text-sm text-muted-foreground [padding-inline:var(--mf-content-inset,0px)]">
+                  {step.emptyState}
+                </div>
+              ) : (
+                <div
+                  className={
+                    sectionVariant === 'plain'
+                      ? 'pb-6 [padding-inline:var(--mf-content-inset,0px)]'
+                      : 'space-y-2 pb-6 pt-4 [padding-inline:var(--mf-content-inset,0px)]'
+                  }
+                >
+                  {stepSections.map((section) => (
+                    <FormSection
+                      key={section.id}
+                      section={section}
+                      context={context}
+                      customComponents={customComponents}
+                      disabled={disabled}
+                      sectionVariant={sectionVariant}
+                    />
+                  ))}
+                </div>
+              )}
+            </TabsContent>
+          );
+        })}
       </Tabs>
       <FormActions schema={schema} context={context} onReset={onReset} />
     </>
@@ -590,12 +643,15 @@ function FormSection({
     </div>
   );
 
-  // If no title, render fields directly without a header. In the plain variant
-  // (properties panel) a titleless section is typically a tab's sole section,
-  // where the host drops the title/collapse chrome. Add a top inset equal to the
-  // accordion trigger's py-3 so the first field lines up with where a section
-  // header would sit — otherwise a single-section tab hugs the tab strip tighter
-  // than a multi-section tab whose leading header carries that padding.
+  // Titleless section: render fields directly, with no header (the sole-section
+  // case where the host drops the title/collapse chrome). Card keeps its
+  // long-standing behavior — bare fields, no extra padding — so existing
+  // single-page/wizard layouts (e.g. contactFormSchema) are unchanged. Plain
+  // adds the header-aligned pt-4/pb-4 and the between-sections divider so a
+  // titleless section lines up with where a section header would sit. Any
+  // tab-specific top inset for the card variant is supplied by the
+  // TabbedStepForm content wrapper's pt-4, not here, so it can't leak into
+  // non-tabbed layouts.
   if (!section.title) {
     return isPlain ? (
       <div className={`${dividerClassName} pb-4 pt-4`}>{fieldsGrid}</div>
@@ -626,17 +682,15 @@ function FormSection({
       >
         <AccordionItem value={section.id} className={wrapperClassName}>
           <AccordionTrigger className={triggerClassName}>{section.title}</AccordionTrigger>
-          {/* AccordionContent adds pb-4 pt-0 internally; plain tightens it to pb-3. */}
-          <AccordionContent className={isPlain ? 'pb-4' : undefined}>
-            {innerContent}
-          </AccordionContent>
+          {/* AccordionContent adds pb-4 pt-0 internally, which both variants keep. */}
+          <AccordionContent>{innerContent}</AccordionContent>
         </AccordionItem>
       </Accordion>
     );
   }
 
   // Non-collapsible section - match Accordion structure exactly, including the
-  // plain variant's divider + tightened header/content padding.
+  // plain variant's divider and left-packed semibold header.
   return (
     <div className={isPlain ? dividerClassName : wrapperClassName}>
       {/* Match AccordionPrimitive.Header + Trigger structure */}
@@ -651,9 +705,9 @@ function FormSection({
           {section.title}
         </div>
       </div>
-      {/* Match AccordionContent: outer has text-sm, inner has pb-4 pt-0 (pb-3 in plain) */}
+      {/* Match AccordionContent: outer has text-sm, inner has pb-4 pt-0 */}
       <div className="text-sm">
-        <div className={isPlain ? 'pb-4 pt-0' : 'pb-4 pt-0'}>{innerContent}</div>
+        <div className="pb-4 pt-0">{innerContent}</div>
       </div>
     </div>
   );

--- a/packages/apollo-wind/src/components/forms/metadata-form.tsx
+++ b/packages/apollo-wind/src/components/forms/metadata-form.tsx
@@ -1,6 +1,6 @@
 import { standardSchemaResolver } from '@hookform/resolvers/standard-schema';
 import React, { useEffect, useMemo, useRef, useState } from 'react';
-import { type FieldValues, FormProvider, useForm } from 'react-hook-form';
+import { type FieldValues, FormProvider, useForm, useFormState } from 'react-hook-form';
 import { z } from 'zod/v4';
 import {
   Accordion,
@@ -9,7 +9,7 @@ import {
   AccordionTrigger,
 } from '@/components/ui/accordion';
 import { Button } from '@/components/ui/button';
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { ScrollableTabsList, Tabs, TabsContent, TabsTrigger } from '@/components/ui/tabs';
 
 import { DataFetcher } from './data-fetcher';
 import { FormFieldRenderer } from './field-renderer';
@@ -46,6 +46,17 @@ interface MetadataFormProps {
    * across every step. Ignored for single-page (`sections`) schemas.
    */
   stepVariant?: 'wizard' | 'tabs';
+  /**
+   * Visual treatment for each titled section. `'card'` (default) wraps every
+   * section in a bordered, rounded, horizontally-padded box. `'plain'` drops the
+   * border, rounding, and horizontal padding so sections read as flush headers
+   * over their content, separated by a full-width hairline divider between
+   * consecutive sections — used by hosts (e.g. the canvas properties panel) that
+   * already frame the form and want a borderless list. Applies to both
+   * collapsible (accordion) and non-collapsible sections across every layout
+   * (single-page, wizard, tabs).
+   */
+  sectionVariant?: 'card' | 'plain';
 }
 
 // Stable default to prevent re-renders
@@ -59,6 +70,7 @@ export function MetadataForm({
   disabled = false,
   autoComplete,
   stepVariant = 'wizard',
+  sectionVariant = 'card',
 }: MetadataFormProps) {
   const [currentStep, setCurrentStep] = useState(0);
   const [customComponents, setCustomComponents] = useState<
@@ -196,6 +208,7 @@ export function MetadataForm({
             context={context}
             customComponents={customComponents}
             disabled={disabled}
+            sectionVariant={sectionVariant}
             onReset={() => reset()}
           />
         );
@@ -208,6 +221,7 @@ export function MetadataForm({
           setCurrentStep={setCurrentStep}
           customComponents={customComponents}
           disabled={disabled}
+          sectionVariant={sectionVariant}
         />
       );
     }
@@ -218,6 +232,7 @@ export function MetadataForm({
         context={context}
         customComponents={customComponents}
         disabled={disabled}
+        sectionVariant={sectionVariant}
       />
     );
   };
@@ -245,9 +260,16 @@ interface SinglePageFormProps {
   context: FormContext;
   customComponents: Record<string, React.ComponentType<CustomFieldComponentProps>>;
   disabled?: boolean;
+  sectionVariant?: 'card' | 'plain';
 }
 
-function SinglePageForm({ schema, context, customComponents, disabled }: SinglePageFormProps) {
+function SinglePageForm({
+  schema,
+  context,
+  customComponents,
+  disabled,
+  sectionVariant,
+}: SinglePageFormProps) {
   const sections = schema.sections || [];
 
   // Filter visible sections
@@ -256,7 +278,9 @@ function SinglePageForm({ schema, context, customComponents, disabled }: SingleP
   );
 
   return (
-    <div className="space-y-2">
+    // Plain sections carry their own vertical rhythm (py-3 + divider), so the
+    // list adds no extra gap; card sections are spaced apart as separate boxes.
+    <div className={sectionVariant === 'plain' ? undefined : 'space-y-2'}>
       {visibleSections.map((section) => (
         <FormSection
           key={section.id}
@@ -264,6 +288,7 @@ function SinglePageForm({ schema, context, customComponents, disabled }: SingleP
           context={context}
           customComponents={customComponents}
           disabled={disabled}
+          sectionVariant={sectionVariant}
         />
       ))}
     </div>
@@ -282,6 +307,7 @@ function MultiStepForm({
   setCurrentStep,
   customComponents,
   disabled,
+  sectionVariant,
 }: MultiStepFormProps) {
   const steps = schema.steps || [];
   const step = steps[currentStep];
@@ -310,8 +336,8 @@ function MultiStepForm({
         </div>
       </div>
 
-      {/* Step content */}
-      <div className="space-y-2">
+      {/* Step content (plain sections carry their own rhythm, see SinglePageForm) */}
+      <div className={sectionVariant === 'plain' ? undefined : 'space-y-2'}>
         {step.sections.map((section) => (
           <FormSection
             key={section.id}
@@ -319,6 +345,7 @@ function MultiStepForm({
             context={context}
             customComponents={customComponents}
             disabled={disabled}
+            sectionVariant={sectionVariant}
           />
         ))}
       </div>
@@ -357,6 +384,7 @@ function TabbedStepForm({
   context,
   customComponents,
   disabled,
+  sectionVariant,
   onReset,
 }: TabbedStepFormProps) {
   const steps = schema.steps || [];
@@ -368,6 +396,43 @@ function TabbedStepForm({
     (step) =>
       step.sections.length > 0 && (!step.conditions || context.evaluateConditions(step.conditions))
   );
+
+  // Subscribe to validation state so a tab's error badge updates live as errors
+  // are set/cleared. Without this subscription the getters on `context.errors`
+  // don't re-render this component when only the error state changes.
+  const formState = useFormState({ control: context.form.control });
+
+  // Per-step error count = number of validation issues on that step. A plain
+  // field contributes 1; a composite field whose error is an array of issues
+  // (e.g. a connector editor holding many sub-fields) contributes one per issue,
+  // so the badge reflects what the user sees inside it rather than always "1".
+  // Fields on inactive tabs are counted too (their errors persist in form state
+  // even while unmounted), so a badge surfaces a problem the user can't currently
+  // see. Conditionally-hidden sections AND individually-hidden fields are skipped
+  // (mirroring FormFieldRenderer) so a badge never points at something the form
+  // isn't showing and the user can't reach to fix.
+  //
+  // Recomputed every render on purpose: `formState` (the reactive dependency) and
+  // `visibleSteps` (a fresh array from `steps.filter`) both change per render, so
+  // memoizing would never hit; the walk over sections/fields is cheap.
+  const errorCountByStepId: Record<string, number> = {};
+  for (const step of visibleSteps) {
+    let count = 0;
+    for (const section of step.sections) {
+      if (section.conditions && !context.evaluateConditions(section.conditions)) {
+        continue;
+      }
+      for (const field of section.fields) {
+        if (field.rules && !RulesEngine.isFieldVisible(field.rules, context.values)) {
+          continue;
+        }
+        const fieldError: unknown = context.form.getFieldState(field.name, formState).error;
+        if (!fieldError) continue;
+        count += Array.isArray(fieldError) ? fieldError.filter(Boolean).length : 1;
+      }
+    }
+    errorCountByStepId[step.id] = count;
+  }
 
   // Clamp the active tab to a still-visible step so a step that disappears
   // (condition flips, manifest swap) can't strand the form on a dead tab.
@@ -386,24 +451,52 @@ function TabbedStepForm({
 
   return (
     <>
-      <Tabs value={currentTab} onValueChange={setActiveTab} className="flex flex-col gap-4">
-        {/* Segmented pill tabs (properties-panel style). Horizontal scroll when
-          tabs overflow a narrow panel; scrollbar is hidden so tabs stay on one
-          line without clipping. */}
-        <TabsList className="h-auto justify-start gap-0.5 overflow-x-auto rounded-lg bg-transparent p-0.5 text-muted-foreground [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
-          {visibleSteps.map((step) => (
-            <TabsTrigger
-              key={step.id}
-              value={step.id}
-              className="inline-flex h-6 shrink-0 items-center whitespace-nowrap rounded-md px-2.5 text-xs font-medium text-muted-foreground shadow-none transition-colors hover:text-foreground data-[state=active]:bg-surface-overlay data-[state=active]:text-foreground data-[state=active]:shadow-sm"
-            >
-              {step.title}
-            </TabsTrigger>
-          ))}
-        </TabsList>
+      <Tabs value={currentTab} onValueChange={setActiveTab} className="flex flex-col gap-1">
+        {/* Segmented pill tabs (properties-panel style). When the tabs overflow a
+          narrow panel, ScrollableTabsList reveals prev/next chevrons and auto-
+          scrolls the active tab into view; in a wide panel it renders no chevrons
+          and reads identically to a plain tab strip. */}
+        {/* px-0 cancels the list's built-in p-1 horizontal padding so the first
+            tab's pill edge sits flush on the host content inset; py-0.5 keeps a
+            little vertical breathing room. The label stays inset inside the pill,
+            as segmented pill tabs do. */}
+        <ScrollableTabsList
+          className="h-auto justify-start gap-0.5 rounded-lg bg-transparent px-0 py-0.5 text-muted-foreground"
+          scrollButtonClassName="size-6 hover:bg-surface-overlay"
+        >
+          {visibleSteps.map((step) => {
+            const errorCount = errorCountByStepId[step.id] ?? 0;
+            return (
+              <TabsTrigger
+                key={step.id}
+                value={step.id}
+                className="inline-flex h-6 shrink-0 items-center gap-1.5 whitespace-nowrap rounded-md px-2.5 text-xs font-medium text-muted-foreground shadow-none transition-colors hover:text-foreground data-[state=active]:bg-surface-overlay data-[state=active]:text-foreground data-[state=active]:shadow-sm"
+              >
+                {step.title}
+                {errorCount > 0 && (
+                  <span
+                    role="img"
+                    aria-label={`${errorCount} ${errorCount === 1 ? 'issue' : 'issues'}`}
+                    title={`${errorCount} ${errorCount === 1 ? 'issue' : 'issues'}`}
+                    className="grid h-4 min-w-4 place-items-center rounded-full bg-error px-1 text-[10px] font-semibold leading-none text-foreground-on-accent"
+                  >
+                    {errorCount}
+                  </span>
+                )}
+              </TabsTrigger>
+            );
+          })}
+        </ScrollableTabsList>
 
         {visibleSteps.map((step) => (
-          <TabsContent key={step.id} value={step.id} className="space-y-2">
+          // Plain: cancel TabsContent's built-in mt-2 — the first section's own
+          // pt-3 already provides the tab-strip inset, and stacking both makes
+          // the tab→content gap as large as the full section-to-section rhythm.
+          <TabsContent
+            key={step.id}
+            value={step.id}
+            className={sectionVariant === 'plain' ? 'mt-0' : 'space-y-2'}
+          >
             {step.sections
               .filter(
                 (section) => !section.conditions || context.evaluateConditions(section.conditions)
@@ -415,6 +508,7 @@ function TabbedStepForm({
                   context={context}
                   customComponents={customComponents}
                   disabled={disabled}
+                  sectionVariant={sectionVariant}
                 />
               ))}
           </TabsContent>
@@ -430,11 +524,41 @@ interface FormSectionProps {
   context: FormContext;
   customComponents: Record<string, React.ComponentType<CustomFieldComponentProps>>;
   disabled?: boolean;
+  sectionVariant?: 'card' | 'plain';
 }
 
-function FormSection({ section, context, customComponents, disabled }: FormSectionProps) {
+function FormSection({
+  section,
+  context,
+  customComponents,
+  disabled,
+  sectionVariant = 'card',
+}: FormSectionProps) {
   const gridColumns = context.schema.layout?.columns || 1;
   const gap = context.schema.layout?.gap || 4;
+
+  // `'card'` frames each section in a bordered, rounded, horizontally-padded box;
+  // `'plain'` drops all of that — plus the accordion's default bottom border — and
+  // instead separates stacked sections with a full-width hairline divider above
+  // every section except the first, so groups stay distinguishable without boxes
+  // (the host provides the frame + horizontal inset). Sections carry symmetric
+  // vertical padding (py-3 header / pb-3 content) so the inter-section rhythm
+  // (12px + divider + 12px) reads clearly against the tighter field gap; the
+  // parent list renders plain sections with no extra gap of its own.
+  const isPlain = sectionVariant === 'plain';
+  // Lives on each section's OUTERMOST element (the Accordion root for
+  // collapsible sections, not the AccordionItem — an item is always its
+  // Accordion's first child) so `first:` resolves against the sibling list.
+  const dividerClassName = 'border-t first:border-t-0';
+  const wrapperClassName = isPlain ? 'border-b-0' : 'border rounded-lg px-3';
+  // Plain: the chevron sits immediately right of the title (packed left with a
+  // small gap) rather than pushed to the far edge, and the header no longer
+  // underlines on hover — it reads as a section label, not a link. Semibold
+  // (vs the field labels' medium) keeps the header distinguishable from its own
+  // fields even when the collapse chevron is absent.
+  const triggerClassName = isPlain
+    ? 'justify-start gap-2 py-3 text-sm font-semibold hover:no-underline'
+    : 'text-sm font-medium';
 
   const fieldsGrid = (
     <div
@@ -456,9 +580,18 @@ function FormSection({ section, context, customComponents, disabled }: FormSecti
     </div>
   );
 
-  // If no title, render fields directly without wrapper
+  // If no title, render fields directly without a header. In the plain variant
+  // (properties panel) a titleless section is typically a tab's sole section,
+  // where the host drops the title/collapse chrome. Add a top inset equal to the
+  // accordion trigger's py-3 so the first field lines up with where a section
+  // header would sit — otherwise a single-section tab hugs the tab strip tighter
+  // than a multi-section tab whose leading header carries that padding.
   if (!section.title) {
-    return fieldsGrid;
+    return isPlain ? (
+      <div className={`${dividerClassName} pb-3 pt-3`}>{fieldsGrid}</div>
+    ) : (
+      fieldsGrid
+    );
   }
 
   // Shared inner content (without padding - wrapper handles that)
@@ -476,28 +609,41 @@ function FormSection({ section, context, customComponents, disabled }: FormSecti
     const defaultValue = section.defaultExpanded !== false ? [section.id] : [];
 
     return (
-      <Accordion type="multiple" defaultValue={defaultValue}>
-        <AccordionItem value={section.id} className="border rounded-lg px-3">
-          <AccordionTrigger className="text-sm font-medium">{section.title}</AccordionTrigger>
-          {/* AccordionContent adds pb-4 pt-0 wrapper internally */}
-          <AccordionContent>{innerContent}</AccordionContent>
+      <Accordion
+        type="multiple"
+        defaultValue={defaultValue}
+        className={isPlain ? dividerClassName : undefined}
+      >
+        <AccordionItem value={section.id} className={wrapperClassName}>
+          <AccordionTrigger className={triggerClassName}>{section.title}</AccordionTrigger>
+          {/* AccordionContent adds pb-4 pt-0 internally; plain tightens it to pb-3. */}
+          <AccordionContent className={isPlain ? 'pb-3' : undefined}>
+            {innerContent}
+          </AccordionContent>
         </AccordionItem>
       </Accordion>
     );
   }
 
-  // Non-collapsible section - match AccordionItem/Trigger/Content structure exactly
+  // Non-collapsible section - match Accordion structure exactly, including the
+  // plain variant's divider + tightened header/content padding.
   return (
-    <div className="border rounded-lg px-3">
+    <div className={isPlain ? dividerClassName : wrapperClassName}>
       {/* Match AccordionPrimitive.Header + Trigger structure */}
       <div className="flex">
-        <div className="flex flex-1 items-center justify-between py-4 text-sm font-medium">
+        <div
+          className={
+            isPlain
+              ? 'flex flex-1 items-center justify-start gap-2 py-3 text-sm font-semibold'
+              : 'flex flex-1 items-center justify-between py-4 text-sm font-medium'
+          }
+        >
           {section.title}
         </div>
       </div>
-      {/* Match AccordionContent: outer has text-sm, inner has pb-4 pt-0 */}
+      {/* Match AccordionContent: outer has text-sm, inner has pb-4 pt-0 (pb-3 in plain) */}
       <div className="text-sm">
-        <div className="pb-4 pt-0">{innerContent}</div>
+        <div className={isPlain ? 'pb-3 pt-0' : 'pb-4 pt-0'}>{innerContent}</div>
       </div>
     </div>
   );

--- a/packages/apollo-wind/src/components/forms/metadata-form.tsx
+++ b/packages/apollo-wind/src/components/forms/metadata-form.tsx
@@ -451,66 +451,76 @@ function TabbedStepForm({
 
   return (
     <>
-      <Tabs value={currentTab} onValueChange={setActiveTab} className="flex flex-col gap-1">
-        {/* Segmented pill tabs (properties-panel style). When the tabs overflow a
-          narrow panel, ScrollableTabsList reveals prev/next chevrons and auto-
-          scrolls the active tab into view; in a wide panel it renders no chevrons
-          and reads identically to a plain tab strip. */}
-        {/* px-0 cancels the list's built-in p-1 horizontal padding so the first
-            tab's pill edge sits flush on the host content inset; py-0.5 keeps a
-            little vertical breathing room. The label stays inset inside the pill,
-            as segmented pill tabs do. */}
-        <ScrollableTabsList
-          className="h-auto justify-start gap-0.5 rounded-lg bg-transparent px-0 py-0.5 text-muted-foreground"
-          scrollButtonClassName="size-6 hover:bg-surface-overlay"
-        >
-          {visibleSteps.map((step) => {
-            const errorCount = errorCountByStepId[step.id] ?? 0;
-            return (
-              <TabsTrigger
-                key={step.id}
-                value={step.id}
-                className="inline-flex h-6 shrink-0 items-center gap-1.5 whitespace-nowrap rounded-md px-2.5 text-xs font-medium text-muted-foreground shadow-none transition-colors hover:text-foreground data-[state=active]:bg-surface-overlay data-[state=active]:text-foreground data-[state=active]:shadow-sm"
-              >
-                {step.title}
-                {errorCount > 0 && (
-                  <span
-                    role="img"
-                    aria-label={`${errorCount} ${errorCount === 1 ? 'issue' : 'issues'}`}
-                    title={`${errorCount} ${errorCount === 1 ? 'issue' : 'issues'}`}
-                    className="grid h-4 min-w-4 place-items-center rounded-full bg-error px-1 text-[10px] font-semibold leading-none text-foreground-on-accent"
-                  >
-                    {errorCount}
-                  </span>
-                )}
-              </TabsTrigger>
-            );
-          })}
-        </ScrollableTabsList>
+      <Tabs
+        value={currentTab}
+        onValueChange={setActiveTab}
+        className="flex min-h-0 flex-1 flex-col gap-1"
+      >
+        {/* Pinned tab bar: shrink-0 keeps it under the panel header while the
+            active tab's content scrolls below. The wrapper supplies the
+            horizontal inset (matching the content) so the tab strip lines up
+            with the fields; px-0 on the list keeps the first pill flush to it.
+            Segmented pill tabs (properties-panel style): in a narrow panel
+            ScrollableTabsList reveals prev/next chevrons and auto-scrolls the
+            active tab into view; in a wide panel it reads as a plain strip. */}
+        <div className="shrink-0 pt-3 [padding-inline:var(--mf-content-inset,0px)]">
+          <ScrollableTabsList
+            className="h-auto justify-start gap-0.5 rounded-lg bg-transparent px-0 py-0.5 text-muted-foreground"
+            scrollButtonClassName="size-6 hover:bg-surface-overlay"
+          >
+            {visibleSteps.map((step) => {
+              const errorCount = errorCountByStepId[step.id] ?? 0;
+              return (
+                <TabsTrigger
+                  key={step.id}
+                  value={step.id}
+                  className="inline-flex h-6 shrink-0 items-center gap-1.5 whitespace-nowrap rounded-md px-2.5 text-xs font-medium text-muted-foreground shadow-none transition-colors hover:text-foreground data-[state=active]:bg-surface-overlay data-[state=active]:text-foreground data-[state=active]:shadow-sm"
+                >
+                  {step.title}
+                  {errorCount > 0 && (
+                    <span
+                      role="img"
+                      aria-label={`${errorCount} ${errorCount === 1 ? 'issue' : 'issues'}`}
+                      title={`${errorCount} ${errorCount === 1 ? 'issue' : 'issues'}`}
+                      className="grid h-4 min-w-4 place-items-center rounded-full bg-error px-1 text-[10px] font-semibold leading-none text-foreground-on-accent"
+                    >
+                      {errorCount}
+                    </span>
+                  )}
+                </TabsTrigger>
+              );
+            })}
+          </ScrollableTabsList>
+        </div>
 
         {visibleSteps.map((step) => (
-          // Plain: cancel TabsContent's built-in mt-2 — the first section's own
-          // pt-3 already provides the tab-strip inset, and stacking both makes
-          // the tab→content gap as large as the full section-to-section rhythm.
-          <TabsContent
-            key={step.id}
-            value={step.id}
-            className={sectionVariant === 'plain' ? 'mt-0' : 'space-y-2'}
-          >
-            {step.sections
-              .filter(
-                (section) => !section.conditions || context.evaluateConditions(section.conditions)
-              )
-              .map((section) => (
-                <FormSection
-                  key={section.id}
-                  section={section}
-                  context={context}
-                  customComponents={customComponents}
-                  disabled={disabled}
-                  sectionVariant={sectionVariant}
-                />
-              ))}
+          // The active tab is the scroll container so the tab bar above stays
+          // pinned and the scrollbar sits at the panel edge; the inner wrapper
+          // carries the content inset + bottom padding. Plain drops space-y-2
+          // (sections self-space); card keeps the 2-unit rhythm between boxes.
+          <TabsContent key={step.id} value={step.id} className="mt-0 min-h-0 flex-1 overflow-auto">
+            <div
+              className={
+                sectionVariant === 'plain'
+                  ? 'pb-6 [padding-inline:var(--mf-content-inset,0px)]'
+                  : 'space-y-2 pb-6 [padding-inline:var(--mf-content-inset,0px)]'
+              }
+            >
+              {step.sections
+                .filter(
+                  (section) => !section.conditions || context.evaluateConditions(section.conditions)
+                )
+                .map((section) => (
+                  <FormSection
+                    key={section.id}
+                    section={section}
+                    context={context}
+                    customComponents={customComponents}
+                    disabled={disabled}
+                    sectionVariant={sectionVariant}
+                  />
+                ))}
+            </div>
           </TabsContent>
         ))}
       </Tabs>
@@ -542,8 +552,8 @@ function FormSection({
   // instead separates stacked sections with a full-width hairline divider above
   // every section except the first, so groups stay distinguishable without boxes
   // (the host provides the frame + horizontal inset). Sections carry symmetric
-  // vertical padding (py-3 header / pb-3 content) so the inter-section rhythm
-  // (12px + divider + 12px) reads clearly against the tighter field gap; the
+  // vertical padding (py-4 header / pb-4 content) so the inter-section rhythm
+  // (16px + divider + 16px) reads clearly against the tighter field gap; the
   // parent list renders plain sections with no extra gap of its own.
   const isPlain = sectionVariant === 'plain';
   // Lives on each section's OUTERMOST element (the Accordion root for
@@ -557,7 +567,7 @@ function FormSection({
   // (vs the field labels' medium) keeps the header distinguishable from its own
   // fields even when the collapse chevron is absent.
   const triggerClassName = isPlain
-    ? 'justify-start gap-2 py-3 text-sm font-semibold hover:no-underline'
+    ? 'justify-start gap-2 py-4 text-sm font-semibold hover:no-underline'
     : 'text-sm font-medium';
 
   const fieldsGrid = (
@@ -588,7 +598,7 @@ function FormSection({
   // than a multi-section tab whose leading header carries that padding.
   if (!section.title) {
     return isPlain ? (
-      <div className={`${dividerClassName} pb-3 pt-3`}>{fieldsGrid}</div>
+      <div className={`${dividerClassName} pb-4 pt-4`}>{fieldsGrid}</div>
     ) : (
       fieldsGrid
     );
@@ -617,7 +627,7 @@ function FormSection({
         <AccordionItem value={section.id} className={wrapperClassName}>
           <AccordionTrigger className={triggerClassName}>{section.title}</AccordionTrigger>
           {/* AccordionContent adds pb-4 pt-0 internally; plain tightens it to pb-3. */}
-          <AccordionContent className={isPlain ? 'pb-3' : undefined}>
+          <AccordionContent className={isPlain ? 'pb-4' : undefined}>
             {innerContent}
           </AccordionContent>
         </AccordionItem>
@@ -634,7 +644,7 @@ function FormSection({
         <div
           className={
             isPlain
-              ? 'flex flex-1 items-center justify-start gap-2 py-3 text-sm font-semibold'
+              ? 'flex flex-1 items-center justify-start gap-2 py-4 text-sm font-semibold'
               : 'flex flex-1 items-center justify-between py-4 text-sm font-medium'
           }
         >
@@ -643,7 +653,7 @@ function FormSection({
       </div>
       {/* Match AccordionContent: outer has text-sm, inner has pb-4 pt-0 (pb-3 in plain) */}
       <div className="text-sm">
-        <div className={isPlain ? 'pb-3 pt-0' : 'pb-4 pt-0'}>{innerContent}</div>
+        <div className={isPlain ? 'pb-4 pt-0' : 'pb-4 pt-0'}>{innerContent}</div>
       </div>
     </div>
   );


### PR DESCRIPTION
## What

Adapts the tabbed `MetadataForm` (properties-panel form) so it holds up in a narrow panel, surfaces validation state on the tab strip, and adds a borderless section treatment for hosts that frame the panel themselves.

- **Scrollable tabs** — `TabbedStepForm` renders its tab strip with `ScrollableTabsList` instead of a plain `TabsList`. When the tabs overflow a narrow panel they get prev/next chevrons and the active tab auto-scrolls into view. Wide panels are unchanged (no chevrons render when nothing overflows).
- **Per-tab error badges** — each tab shows a count badge of its fields that currently have errors, computed from react-hook-form state via `useFormState` (so it updates live). Fields on **inactive** tabs are counted too, so a hidden validation problem still surfaces on its tab. Composite fields whose error is an array (e.g. a connector editor) contribute one per issue rather than collapsing to `1`. Conditionally-hidden sections **and individually-hidden fields** are skipped, so a badge never points at something the user can't reach. The badge is exposed to assistive tech as `"N issue(s)"` (`role="img"` + `aria-label`).
- **`sectionVariant` (`'card'` | `'plain'`)** — `'plain'` drops the border, rounding, and horizontal padding so sections read as flush semibold headers over their content, separated by a full-width hairline divider between consecutive sections, for hosts (the canvas properties panel) that already frame the form. Applies to collapsible, non-collapsible, and titleless sections. `NodePropertyPanel` forwards the prop through to `MetadataForm`.

## Why

Consumed by `flow-workbench`'s redesigned node properties panel, which docks narrow. Today the built-in tab strip clips overflowing tabs with no affordance, and validation errors on non-active tabs are invisible. Both fixes live here because the tab strip is owned by `TabbedStepForm`; the consumer drives it purely through `schema.steps` + form plugins, so no consumer-side change is needed (errors are already in form state via the consumer's validation plugin). The `plain` variant lets that panel frame the form itself and render sections as a flush, borderless list.

## Testing

- `pnpm --filter @uipath/apollo-wind test` — 987 pass, incl. tests asserting a badge on an errored (inactive) tab and a per-issue count for a composite (array) error.
- biome lint + format clean, `tsc` clean.
- Added a `SectionVariants` story with a live `card`/`plain` toggle so the two treatments can be compared in a panel-like container, covering both titled collapsible sections and sole untitled sections (the two shapes the properties panel produces).

## Notes

- Additive: badges only appear when fields have errors; the scrollable list reads identically to a plain strip when nothing overflows; `sectionVariant` defaults to `'card'`, so existing single-page/wizard/card layouts are unchanged.
- `dev-packages` label added to publish a dev build for `flow-workbench` to consume.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
