### PR TITLE
feat(apollo-react): add mcp canvas icon

### DIFF
--- a/packages/apollo-react/src/canvas/storybook-utils/manifests/node-definitions.ts
+++ b/packages/apollo-react/src/canvas/storybook-utils/manifests/node-definitions.ts
@@ -623,6 +623,35 @@ export const allNodeManifests: NodeManifest[] = [
     ],
   },
 
+  {
+    nodeType: 'uipath.agent.resource.tool.mcp',
+    version: '1',
+    category: 'agent-tools',
+    tags: ['agentic', 'ai', 'tools', 'functions', 'mcp', 'server'],
+    sortOrder: 0,
+    display: {
+      label: 'MCP Server',
+      icon: 'mcp',
+      shape: 'circle',
+    },
+    handleConfiguration: [
+      {
+        position: 'top',
+        handles: [
+          {
+            id: 'input',
+            type: 'target',
+            handleType: 'artifact',
+            constraints: {
+              allowedSources: [{ nodeType: 'uipath.agent', handleId: 'tools' }],
+              validationMessage: "MCP Servers can only connect to Agent node's tools input",
+            },
+          },
+        ],
+      },
+    ],
+  },
+
   // Agent
   {
     nodeType: 'uipath.agent',

--- a/packages/apollo-react/src/canvas/utils/icon-registry.tsx
+++ b/packages/apollo-react/src/canvas/utils/icon-registry.tsx
@@ -42,6 +42,7 @@ const iconRegistry: Record<string, IconComponent> = {
   uipath: ({ w, h }) => <Icons.UiPathIcon w={w ?? 24} h={h ?? 24} />,
   'agent-diagram': ({ w, h }) => <Icons.AgentDiagramIcon w={w ?? 24} h={h ?? 24} />,
   function: ({ w, h }) => <Icons.FunctionProject w={w ?? 29} h={h ?? 28} />,
+  mcp: ({ w, h }) => <Icons.McpIcon w={w ?? 29} h={h ?? 28} />,
 };
 
 /**


### PR DESCRIPTION
Adding the mcp icon to the icon registry

<img width="317" height="414" alt="Screenshot 2026-07-16 at 12 39 19 PM" src="https://github.com/user-attachments/assets/e5dfbd78-dc13-49ee-bea2-03653c4c4e14" />
