### PR TITLE
fix(apollo-react): add accessible name to toolbox search clear button [MST-12402]

### DIFF
--- a/packages/apollo-react/src/canvas/components/Toolbox/SearchBox.test.tsx
+++ b/packages/apollo-react/src/canvas/components/Toolbox/SearchBox.test.tsx
@@ -1,0 +1,29 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '../../utils/testing';
+import { SearchBox } from './SearchBox';
+
+const baseProps = {
+  value: 'query',
+  onChange: vi.fn(),
+  clear: vi.fn(),
+};
+
+describe('SearchBox clear button accessible name', () => {
+  it('exposes a default accessible name on the clear button when a value is present', () => {
+    render(<SearchBox {...baseProps} />);
+
+    expect(screen.getByRole('button', { name: 'Clear search' })).toBeInTheDocument();
+  });
+
+  it('uses the provided clearButtonLabel as the accessible name', () => {
+    render(<SearchBox {...baseProps} clearButtonLabel="Clear search nodes" />);
+
+    expect(screen.getByRole('button', { name: 'Clear search nodes' })).toBeInTheDocument();
+  });
+
+  it('does not render the clear button when there is no value', () => {
+    render(<SearchBox {...baseProps} value="" />);
+
+    expect(screen.queryByRole('button', { name: 'Clear search' })).not.toBeInTheDocument();
+  });
+});

--- a/packages/apollo-react/src/canvas/components/Toolbox/SearchBox.test.tsx
+++ b/packages/apollo-react/src/canvas/components/Toolbox/SearchBox.test.tsx
@@ -15,8 +15,8 @@ describe('SearchBox clear button accessible name', () => {
     expect(screen.getByRole('button', { name: 'Clear search' })).toBeInTheDocument();
   });
 
-  it('uses the provided clearButtonLabel as the accessible name', () => {
-    render(<SearchBox {...baseProps} clearButtonLabel="Clear search nodes" />);
+  it('uses the provided clearButtonAriaLabel as the accessible name', () => {
+    render(<SearchBox {...baseProps} clearButtonAriaLabel="Clear search nodes" />);
 
     expect(screen.getByRole('button', { name: 'Clear search nodes' })).toBeInTheDocument();
   });

--- a/packages/apollo-react/src/canvas/components/Toolbox/SearchBox.tsx
+++ b/packages/apollo-react/src/canvas/components/Toolbox/SearchBox.tsx
@@ -9,6 +9,7 @@ interface SearchBoxProps {
   onChange: (value: string) => void;
   clear: () => void;
   placeholder?: string;
+  clearButtonLabel?: string;
   inputRef?: React.RefObject<HTMLInputElement | null>;
   clearButtonRef?: React.RefObject<HTMLButtonElement | null>;
   onNavigationKeyDown?: (e: React.KeyboardEvent) => void;
@@ -21,6 +22,7 @@ export const SearchBox = memo(function SearchBox({
   onChange,
   clear,
   placeholder = 'Search...',
+  clearButtonLabel = 'Clear search',
   inputRef: externalInputRef,
   clearButtonRef,
   onNavigationKeyDown,
@@ -74,6 +76,7 @@ export const SearchBox = memo(function SearchBox({
             ref={clearButtonRef}
             type="button"
             className="searchbox-clear"
+            aria-label={clearButtonLabel}
             onClick={clear}
             onKeyDown={handleClearButtonKeyDown}
           >

--- a/packages/apollo-react/src/canvas/components/Toolbox/SearchBox.tsx
+++ b/packages/apollo-react/src/canvas/components/Toolbox/SearchBox.tsx
@@ -9,7 +9,7 @@ interface SearchBoxProps {
   onChange: (value: string) => void;
   clear: () => void;
   placeholder?: string;
-  clearButtonLabel?: string;
+  clearButtonAriaLabel?: string;
   inputRef?: React.RefObject<HTMLInputElement | null>;
   clearButtonRef?: React.RefObject<HTMLButtonElement | null>;
   onNavigationKeyDown?: (e: React.KeyboardEvent) => void;
@@ -22,7 +22,7 @@ export const SearchBox = memo(function SearchBox({
   onChange,
   clear,
   placeholder = 'Search...',
-  clearButtonLabel = 'Clear search',
+  clearButtonAriaLabel = 'Clear search',
   inputRef: externalInputRef,
   clearButtonRef,
   onNavigationKeyDown,
@@ -76,7 +76,7 @@ export const SearchBox = memo(function SearchBox({
             ref={clearButtonRef}
             type="button"
             className="searchbox-clear"
-            aria-label={clearButtonLabel}
+            aria-label={clearButtonAriaLabel}
             onClick={clear}
             onKeyDown={handleClearButtonKeyDown}
           >

--- a/packages/apollo-react/src/canvas/components/Toolbox/Toolbox.tsx
+++ b/packages/apollo-react/src/canvas/components/Toolbox/Toolbox.tsx
@@ -164,6 +164,7 @@ export function Toolbox<T>({
 }: ToolboxProps<T>) {
   const { _ } = useSafeLingui();
   const searchPlaceholder = searchPlaceholderProp ?? _({ id: 'toolbox.search', message: 'Search' });
+  const clearSearchLabel = _({ id: 'toolbox.search.clear', message: 'Clear search' });
   const [items, setItems] = useState<ListItem<T>[]>(initialItems);
   const [search, setSearch] = useState('');
   const [searchLoading, setSearchLoading] = useState(false);
@@ -680,6 +681,7 @@ export function Toolbox<T>({
           onChange={handleSearch}
           clear={clearSearch}
           placeholder={searchPlaceholder}
+          clearButtonLabel={clearSearchLabel}
           inputRef={searchInputRef}
           clearButtonRef={clearButtonRef}
           onNavigationKeyDown={handleNavigationKeyDown}

--- a/packages/apollo-react/src/canvas/components/Toolbox/Toolbox.tsx
+++ b/packages/apollo-react/src/canvas/components/Toolbox/Toolbox.tsx
@@ -681,7 +681,7 @@ export function Toolbox<T>({
           onChange={handleSearch}
           clear={clearSearch}
           placeholder={searchPlaceholder}
-          clearButtonLabel={clearSearchLabel}
+          clearButtonAriaLabel={clearSearchLabel}
           inputRef={searchInputRef}
           clearButtonRef={clearButtonRef}
           onNavigationKeyDown={handleNavigationKeyDown}

--- a/packages/apollo-react/src/canvas/locales/en.json
+++ b/packages/apollo-react/src/canvas/locales/en.json
@@ -80,6 +80,7 @@
   "sticky-note.toolbar.edit": "Edit",
   "add-node-panel.search-nodes": "Search nodes",
   "toolbox.search": "Search",
+  "toolbox.search.clear": "Clear search",
   "loop-node.add-node": "Add node to loop",
   "loop-node.mode.parallel": "Parallel",
   "loop-node.mode.sequential": "Sequential",


### PR DESCRIPTION
> [!IMPORTANT]
> 🦾 *Part of the [Case Management accessibility effort](https://uipath-product.slack.com/archives/C07SRTNTCBX/p1784292262447219) automated burndown*

The icon-only "clear" button in the canvas `Toolbox` search field has no accessible name. Its only child is an `aria-hidden` "x" icon and it carries no `aria-label`, so screen readers announce it as an unnamed "button" — a WCAG 2.1 SC 4.1.2 (Name, Role, Value) failure.

The fix adds an optional `clearButtonAriaLabel` prop to `SearchBox` (default `'Clear search'`), applied as the button's `aria-label`, and has `Toolbox` supply a localized value through the package's existing LinguiJS pattern. The default keeps any direct `SearchBox` consumer accessible even without passing the prop, so it's fixed at the source and covers every reuse of the component.

### Changes
- `SearchBox.tsx`: new optional `clearButtonAriaLabel?: string` prop (default `'Clear search'`), rendered as `aria-label` on `<button className="searchbox-clear">`.
- `Toolbox.tsx`: `clearSearchLabel = _({ id: 'toolbox.search.clear', message: 'Clear search' })` (mirrors the existing `searchPlaceholder` line via `useSafeLingui`) passed to `SearchBox`.
- `SearchBox.test.tsx`: new co-located Vitest suite asserting the clear button's accessible name (default and custom), and that it isn't rendered when the field is empty.
- `src/canvas/locales/en.json`: added source string `"toolbox.search.clear": "Clear search"` (English source only — matches how prior canvas keys were added, e.g. commit `f26195f5`; the localization pipeline fills the other locales, and the baked-in `message` default renders English until then).

### Verification

Checked in this repo's Storybook and scanned with axe-core 4.11.0 (the same engine `@storybook/addon-a11y` uses), on story *Apollo React/Canvas/Components/Controls/Toolbox → Default* with the search field populated so the clear button renders.

| | Before (base `main`) | After (this branch) |
|---|---|---|
| axe `button-name` on `.searchbox-clear` | **1 critical violation** — *"Buttons must have discernible text… aria-label attribute does not exist or is empty."* | **0 violations, 1 pass** |
| Chrome accessibility tree | `button` with **no accessible name** | `button "Clear search"` |

This change adds only an `aria-label`, so there is no visual delta to show — the accessibility-tree and axe results above are the proof.

The only behavioral change is an added `aria-label`; no layout or visual impact. The new prop is additive and optional with a safe default — **no breaking change**.

### Resolves
- [MST-12402](https://uipath.atlassian.net/browse/MST-12402) — canvas Toolbox search clear button has no accessible name
- [MST-12445](https://uipath.atlassian.net/browse/MST-12445) — same clear button, pinned to `.searchbox-clear` by a live DOM probe
- [MST-12420](https://uipath.atlassian.net/browse/MST-12420) — partial: only the clear-button half of that ticket; its other half (an unnamed trash button on the task title row) is fixed locally in [PO.Frontend#6507](https://github.com/UiPath/PO.Frontend/pull/6507)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[MST-12402]: https://uipath.atlassian.net/browse/MST-12402?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
