### PR TITLE
feat(apollo-wind): add container prop to Popover/Select content for scoped portaling

### DIFF
--- a/packages/apollo-wind/src/components/ui/popover.test.tsx
+++ b/packages/apollo-wind/src/components/ui/popover.test.tsx
@@ -244,23 +244,25 @@ describe('Popover', () => {
     container.setAttribute('data-testid', 'portal-container');
     document.body.appendChild(container);
 
-    render(
-      <Popover>
-        <PopoverTrigger>Open</PopoverTrigger>
-        <PopoverContent container={container}>Contained content</PopoverContent>
-      </Popover>
-    );
+    try {
+      render(
+        <Popover>
+          <PopoverTrigger>Open</PopoverTrigger>
+          <PopoverContent container={container}>Contained content</PopoverContent>
+        </Popover>
+      );
 
-    const trigger = screen.getByRole('button', { name: 'Open' });
-    await user.click(trigger);
+      const trigger = screen.getByRole('button', { name: 'Open' });
+      await user.click(trigger);
 
-    await waitFor(() => {
-      expect(screen.getByText('Contained content')).toBeInTheDocument();
-    });
+      await waitFor(() => {
+        expect(screen.getByText('Contained content')).toBeInTheDocument();
+      });
 
-    expect(container).toContainElement(screen.getByText('Contained content'));
-
-    document.body.removeChild(container);
+      expect(container).toContainElement(screen.getByText('Contained content'));
+    } finally {
+      container.remove();
+    }
   });
 
   it('supports asChild on trigger', async () => {

--- a/packages/apollo-wind/src/components/ui/popover.test.tsx
+++ b/packages/apollo-wind/src/components/ui/popover.test.tsx
@@ -216,6 +216,53 @@ describe('Popover', () => {
     });
   });
 
+  it('defaults to portaling content into document.body', async () => {
+    const user = userEvent.setup();
+    render(
+      <div data-testid="root">
+        <PopoverExample />
+      </div>
+    );
+
+    const trigger = screen.getByRole('button', { name: 'Open Popover' });
+    await user.click(trigger);
+
+    await waitFor(() => {
+      expect(screen.getByText('Popover content goes here')).toBeInTheDocument();
+    });
+
+    const content = screen.getByText('Popover content goes here');
+    const root = screen.getByTestId('root');
+    // Content is portaled out of the app root and into document.body by default.
+    expect(root).not.toContainElement(content);
+    expect(document.body).toContainElement(content);
+  });
+
+  it('renders content into a provided container', async () => {
+    const user = userEvent.setup();
+    const container = document.createElement('div');
+    container.setAttribute('data-testid', 'portal-container');
+    document.body.appendChild(container);
+
+    render(
+      <Popover>
+        <PopoverTrigger>Open</PopoverTrigger>
+        <PopoverContent container={container}>Contained content</PopoverContent>
+      </Popover>
+    );
+
+    const trigger = screen.getByRole('button', { name: 'Open' });
+    await user.click(trigger);
+
+    await waitFor(() => {
+      expect(screen.getByText('Contained content')).toBeInTheDocument();
+    });
+
+    expect(container).toContainElement(screen.getByText('Contained content'));
+
+    document.body.removeChild(container);
+  });
+
   it('supports asChild on trigger', async () => {
     const user = userEvent.setup();
     render(

--- a/packages/apollo-wind/src/components/ui/popover.tsx
+++ b/packages/apollo-wind/src/components/ui/popover.tsx
@@ -11,9 +11,22 @@ const PopoverAnchor = PopoverPrimitive.Anchor;
 
 const PopoverContent = React.forwardRef<
   React.ElementRef<typeof PopoverPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content>
->(({ className, align = 'center', sideOffset = 4, ...props }, ref) => (
-  <PopoverPrimitive.Portal>
+  React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content> & {
+    /**
+     * The container the popover content portals into. Defaults to
+     * `document.body` (Radix's fallback).
+     *
+     * Provide a container when rendering inside a shadow DOM or a
+     * scoped-styles boundary (e.g. `@uipath/traceview` web components):
+     * such consumers inject their CSS into a style scope that cannot reach
+     * `document.body`, so dropdown content portaled to the body is left
+     * unstyled. Pointing the portal at an element inside the style scope
+     * keeps the content within reach of the injected styles.
+     */
+    container?: React.ComponentProps<typeof PopoverPrimitive.Portal>['container'];
+  }
+>(({ className, align = 'center', sideOffset = 4, container, ...props }, ref) => (
+  <PopoverPrimitive.Portal container={container}>
     <PopoverPrimitive.Content
       ref={ref}
       align={align}

--- a/packages/apollo-wind/src/components/ui/popover.tsx
+++ b/packages/apollo-wind/src/components/ui/popover.tsx
@@ -15,13 +15,6 @@ const PopoverContent = React.forwardRef<
     /**
      * The container the popover content portals into. Defaults to
      * `document.body` (Radix's fallback).
-     *
-     * Provide a container when rendering inside a shadow DOM or a
-     * scoped-styles boundary (e.g. `@uipath/traceview` web components):
-     * such consumers inject their CSS into a style scope that cannot reach
-     * `document.body`, so dropdown content portaled to the body is left
-     * unstyled. Pointing the portal at an element inside the style scope
-     * keeps the content within reach of the injected styles.
      */
     container?: React.ComponentProps<typeof PopoverPrimitive.Portal>['container'];
   }

--- a/packages/apollo-wind/src/components/ui/select.test.tsx
+++ b/packages/apollo-wind/src/components/ui/select.test.tsx
@@ -294,27 +294,29 @@ describe('Select', () => {
     container.setAttribute('data-testid', 'portal-container');
     document.body.appendChild(container);
 
-    render(
-      <Select>
-        <SelectTrigger aria-label="Select a fruit">
-          <SelectValue placeholder="Select a fruit" />
-        </SelectTrigger>
-        <SelectContent container={container}>
-          <SelectItem value="apple">Apple</SelectItem>
-          <SelectItem value="banana">Banana</SelectItem>
-        </SelectContent>
-      </Select>
-    );
+    try {
+      render(
+        <Select>
+          <SelectTrigger aria-label="Select a fruit">
+            <SelectValue placeholder="Select a fruit" />
+          </SelectTrigger>
+          <SelectContent container={container}>
+            <SelectItem value="apple">Apple</SelectItem>
+            <SelectItem value="banana">Banana</SelectItem>
+          </SelectContent>
+        </Select>
+      );
 
-    const trigger = screen.getByRole('combobox');
-    await user.click(trigger);
+      const trigger = screen.getByRole('combobox');
+      await user.click(trigger);
 
-    await waitFor(() => {
-      expect(screen.getByRole('option', { name: 'Apple' })).toBeInTheDocument();
-    });
+      await waitFor(() => {
+        expect(screen.getByRole('option', { name: 'Apple' })).toBeInTheDocument();
+      });
 
-    expect(container).toContainElement(screen.getByRole('option', { name: 'Apple' }));
-
-    document.body.removeChild(container);
+      expect(container).toContainElement(screen.getByRole('option', { name: 'Apple' }));
+    } finally {
+      container.remove();
+    }
   });
 });

--- a/packages/apollo-wind/src/components/ui/select.test.tsx
+++ b/packages/apollo-wind/src/components/ui/select.test.tsx
@@ -265,4 +265,56 @@ describe('Select', () => {
     const trigger = screen.getByRole('combobox');
     expect(trigger).toHaveAttribute('aria-label', 'Select a fruit');
   });
+
+  it('defaults to portaling content into document.body', async () => {
+    const user = userEvent.setup();
+    render(
+      <div data-testid="root">
+        <SelectExample />
+      </div>
+    );
+
+    const trigger = screen.getByRole('combobox');
+    await user.click(trigger);
+
+    await waitFor(() => {
+      expect(screen.getByRole('option', { name: 'Apple' })).toBeInTheDocument();
+    });
+
+    const option = screen.getByRole('option', { name: 'Apple' });
+    const root = screen.getByTestId('root');
+    // Content is portaled out of the app root and into document.body by default.
+    expect(root).not.toContainElement(option);
+    expect(document.body).toContainElement(option);
+  });
+
+  it('renders content into a provided container', async () => {
+    const user = userEvent.setup();
+    const container = document.createElement('div');
+    container.setAttribute('data-testid', 'portal-container');
+    document.body.appendChild(container);
+
+    render(
+      <Select>
+        <SelectTrigger aria-label="Select a fruit">
+          <SelectValue placeholder="Select a fruit" />
+        </SelectTrigger>
+        <SelectContent container={container}>
+          <SelectItem value="apple">Apple</SelectItem>
+          <SelectItem value="banana">Banana</SelectItem>
+        </SelectContent>
+      </Select>
+    );
+
+    const trigger = screen.getByRole('combobox');
+    await user.click(trigger);
+
+    await waitFor(() => {
+      expect(screen.getByRole('option', { name: 'Apple' })).toBeInTheDocument();
+    });
+
+    expect(container).toContainElement(screen.getByRole('option', { name: 'Apple' }));
+
+    document.body.removeChild(container);
+  });
 });

--- a/packages/apollo-wind/src/components/ui/select.tsx
+++ b/packages/apollo-wind/src/components/ui/select.tsx
@@ -60,9 +60,22 @@ SelectScrollDownButton.displayName = SelectPrimitive.ScrollDownButton.displayNam
 
 const SelectContent = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Content>
->(({ className, children, position = 'popper', ...props }, ref) => (
-  <SelectPrimitive.Portal>
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Content> & {
+    /**
+     * The container the select content portals into. Defaults to
+     * `document.body` (Radix's fallback).
+     *
+     * Provide a container when rendering inside a shadow DOM or a
+     * scoped-styles boundary (e.g. `@uipath/traceview` web components):
+     * such consumers inject their CSS into a style scope that cannot reach
+     * `document.body`, so dropdown content portaled to the body is left
+     * unstyled. Pointing the portal at an element inside the style scope
+     * keeps the content within reach of the injected styles.
+     */
+    container?: React.ComponentProps<typeof SelectPrimitive.Portal>['container'];
+  }
+>(({ className, children, position = 'popper', container, ...props }, ref) => (
+  <SelectPrimitive.Portal container={container}>
     <SelectPrimitive.Content
       ref={ref}
       className={cn(

--- a/packages/apollo-wind/src/components/ui/select.tsx
+++ b/packages/apollo-wind/src/components/ui/select.tsx
@@ -64,13 +64,6 @@ const SelectContent = React.forwardRef<
     /**
      * The container the select content portals into. Defaults to
      * `document.body` (Radix's fallback).
-     *
-     * Provide a container when rendering inside a shadow DOM or a
-     * scoped-styles boundary (e.g. `@uipath/traceview` web components):
-     * such consumers inject their CSS into a style scope that cannot reach
-     * `document.body`, so dropdown content portaled to the body is left
-     * unstyled. Pointing the portal at an element inside the style scope
-     * keeps the content within reach of the injected styles.
      */
     container?: React.ComponentProps<typeof SelectPrimitive.Portal>['container'];
   }


### PR DESCRIPTION
## Summary

`PopoverContent` and `SelectContent` bake a Radix `Portal` internally with no way to redirect it — content always portals to `document.body`. This adds an optional `container` prop to each, threaded straight into the internal Radix Portal, so consumers can portal dropdown content somewhere other than `document.body`.

This brings Popover/Select to parity with this repo's own **Tooltip**, which already exports `TooltipPortal` for exactly this reason. Fully additive — `container` defaults to `undefined`, preserving Radix's `document.body` fallback, so every existing consumer is unaffected.

## Motivation

Shadow-DOM / scoped-styles consumers (e.g. `@uipath/traceview` web components) inject their CSS into a style scope that cannot reach `document.body`. When a Popover/Select portals its content to the body, it renders **outside** that scope — unstyled in the light-DOM scoped case, and entirely outside the shadow tree (no tokens at all) in the web-component case. Passing a `container` inside the consumer's style scope fixes this without forking the component.

Verified: this unblocks https://github.com/UiPath/traceview-ui/pull/416, allowing traceview to correctly scope styling for the popover/select components it imports from apollo-wind.

## Follow-ups (out of scope, not in this PR)

We may want to add this option for other portaled components: `dialog`, `alert-dialog`, `sheet`, `drawer`, `dropdown-menu`, `context-menu`, and the prompt-editor autocomplete menu. `multi-select` composes `PopoverContent`, so it inherits the capability but doesn't yet forward its own `container`. These can follow the same trivial pattern in separate PRs.
