### PR TITLE
fix(apollo-react): description rendering [MST-11496]

### DIFF
--- a/packages/apollo-react/src/canvas/components/BaseNode/NodeLabel.tsx
+++ b/packages/apollo-react/src/canvas/components/BaseNode/NodeLabel.tsx
@@ -120,7 +120,7 @@ const SubHeader = forwardRef<HTMLDivElement, SubHeaderProps>(
       data-testid={dataTestId}
       onDoubleClick={onDoubleClick}
       className={cx(
-        'text-center text-xs leading-[18px] text-foreground-muted wrap-break-word overflow-hidden',
+        'text-center text-xs leading-[18px] text-foreground-muted wrap-break-word overflow-hidden whitespace-pre-line',
         shape === 'rectangle' ? 'w-full text-left line-clamp-2' : 'line-clamp-5',
         className
       )}


### PR DESCRIPTION
## Description
The canvas `BaseNode` sub-label (used for node descriptions) rendered with the default `white-space: normal`, which collapses newline characters into single spaces — so a multi-line description showed as one run-on line on the canvas.

Added `whitespace-pre-line` to the `SubHeader` element (`[data-testid="node-sublabel"]`) so real newlines in descriptions are preserved. It collapses runs of spaces/tabs (no odd spacing) and still wraps + `line-clamp`s as before.

This lives in apollo-react so every consumer of `BaseNode` (Maestro Case Management **and** Flow) gets the fix, rather than each app patching it in its own stylesheet.

Context: originally worked around in PO.Frontend ([PO.Frontend#6285](https://github.com/UiPath/PO.Frontend/pull/6285)); moved here per review feedback so Flow benefits too.

## Demo
before
<img width="1707" height="1032" alt="Screenshot 2026-07-20 at 9 09 59 AM" src="https://github.com/user-attachments/assets/b5addb08-8142-40be-9d6e-ec3d77acc021" />

after

https://github.com/user-attachments/assets/79b01ae4-a7b9-49a3-ba99-9a55985b1eab

