### PR TITLE
fix(apollo-react): add horizontal padding to BaseNode inline edit inputs [MST-12529]

### DIFF
--- a/packages/apollo-react/src/canvas/components/BaseNode/NodeLabel.test.tsx
+++ b/packages/apollo-react/src/canvas/components/BaseNode/NodeLabel.test.tsx
@@ -559,5 +559,18 @@ describe('NodeLabel', () => {
 
       expect(screen.getByText('Test Node')).toBeInTheDocument();
     });
+
+    it('should apply horizontal padding to the edit inputs regardless of background color', async () => {
+      const user = userEvent.setup();
+      render(<NodeLabel {...defaultProps} />);
+
+      await user.dblClick(screen.getByText('Test Node'));
+
+      const labelInput = screen.getByRole('textbox', { name: 'Edit node name' });
+      const subLabelInput = screen.getByRole('textbox', { name: 'Edit node description' });
+
+      expect(labelInput.className).toContain('px-1.5');
+      expect(subLabelInput.className).toContain('px-1.5');
+    });
   });
 });

--- a/packages/apollo-react/src/canvas/components/BaseNode/NodeLabel.tsx
+++ b/packages/apollo-react/src/canvas/components/BaseNode/NodeLabel.tsx
@@ -171,12 +171,12 @@ const EditableLabel = forwardRef<HTMLTextAreaElement, EditableLabelProps>(
       onKeyDown={onKeyDown}
       onBlur={onBlur}
       className={cx(
-        'nodrag nowheel resize-none font-[inherit] text-foreground border-none rounded-sm outline-1 outline-dashed outline-border-de-emp max-w-full',
+        'nodrag nowheel resize-none font-[inherit] text-foreground border-none rounded-sm outline-1 outline-dashed outline-border-de-emp max-w-full px-1.5',
         variant === 'subtext'
           ? 'text-xs leading-[18px] font-normal mb-0'
           : 'text-sm leading-[18px] font-semibold mb-0.5',
         shape === 'rectangle' ? 'field-sizing-fixed w-full' : 'field-sizing-content text-center',
-        backgroundColor && 'px-1.5 py-0.5'
+        backgroundColor && 'py-0.5'
       )}
       style={backgroundColor ? { backgroundColor } : undefined}
     />


### PR DESCRIPTION
CLAUDE BUG BURN-DOWN

Claude session: https://claude.ai/code/session_01CcawHHGweJQJN34afuLHjM

## Summary
- Double-clicking a `BaseNode` label/sub-label (e.g. a Case Management trigger name) to edit it renders a dashed-outline textarea with text flush against the edges, because `EditableLabel` only applied `px-1.5`/`py-0.5` when a `labelBackgroundColor` was set.
- `labelBackgroundColor` is only used by `AgentNode`/`ResourceNode`; every other `BaseNode` consumer (including Case Management triggers) edits with zero horizontal padding.
- Made the horizontal padding (`px-1.5`) unconditional in `EditableLabel` (`NodeLabel.tsx`), keeping the vertical `py-0.5` tied to `labelBackgroundColor` (matching the `Header`/`SubHeader` "chip" styling, which is unaffected by this change).

## Root cause
`packages/apollo-react/src/canvas/components/BaseNode/NodeLabel.tsx` - `EditableLabel`'s className previously gated `px-1.5 py-0.5` behind `backgroundColor && ...`, so inline edit inputs without a background color got no padding despite always rendering a visible `outline-dashed` box.

## Test plan
- [x] `pnpm turbo run lint:fix --filter=@uipath/apollo-react` (no diagnostics on changed files)
- [x] `pnpm turbo run build --filter=@uipath/apollo-react` (build + type declarations succeed)
- [x] `vitest --run` for `NodeLabel.test.tsx` / `BaseNode.test.tsx` / `BaseNodeContainer.test.tsx` (79/79 passing)
- [x] Added a regression test asserting the edit inputs carry `px-1.5` regardless of `labelBackgroundColor`

Fixes MST-12529.

## Demo
<img width="683" height="305" alt="image" src="https://github.com/user-attachments/assets/0b466a93-bf2f-4f6f-b2e1-72ea775cbf1c" />


---
_Generated by [Claude Code](https://claude.ai/code/session_01CcawHHGweJQJN34afuLHjM)_