### PR TITLE
fix(apollo-react): square task status and play icon hover backgrounds [MST-12525]

### DIFF
--- a/packages/apollo-react/src/canvas/components/StageNode/TaskContent.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/TaskContent.tsx
@@ -75,8 +75,8 @@ const TaskPlayButton = memo(
           aria-label={triggerTaskLabel}
           className={
             small
-              ? 'task-menu-icon-button h-4 w-4 [&_svg]:size-3.5'
-              : 'task-menu-icon-button h-4 w-4'
+              ? 'task-menu-icon-button h-4 w-4 [&_svg]:size-3.5 rounded-sm'
+              : 'task-menu-icon-button h-4 w-4 rounded-sm'
           }
           style={{
             color: 'var(--canvas-icon-default)',
@@ -181,7 +181,7 @@ export const TaskContent = memo(
                 <Button
                   variant="ghost"
                   size="icon"
-                  className="h-4 w-4"
+                  className="h-4 w-4 rounded-sm"
                   aria-label={taskStatusTooltip}
                 >
                   <ExecutionStatusIcon status={taskExecution.status} />


### PR DESCRIPTION
## Summary

The task-row **status icon** and the **play/replay icon** rendered their hover background as a **circle** instead of a rounded square. Both are 16×16 apollo-wind ghost `Button`s, and the Button's base `rounded-lg` (8px) is exactly half of 16px, so all four corners fully round into a circle. This adds `rounded-sm` (4px) so the 16px hover background reads as a rounded square, consistent with the larger (24px) stage-header status buttons.

Fixes MST-12525.

## Demo

<img width="358" height="201" alt="image" src="https://github.com/user-attachments/assets/2d8ea42d-6950-489b-8594-813e010d8c6d" />
<img width="1059" height="651" alt="image" src="https://github.com/user-attachments/assets/239be786-270f-4ddb-9520-a29677619870" />
<img width="701" height="204" alt="image" src="https://github.com/user-attachments/assets/2298fc0c-8492-4e56-9f3f-f7085ab81d22" />


## Changes

- `packages/apollo-react/src/canvas/components/StageNode/TaskContent.tsx`
  - Status icon `Button`: `h-4 w-4` → `h-4 w-4 rounded-sm`
  - `TaskPlayButton` (both size variants): added `rounded-sm`

## Context

After the canvas wind integration (`f1a0c399`) these buttons were a rounded square at 24px (`h-6 w-6`). A later change (`b9234d2e`) shrank them to 16px (`h-4 w-4`) without adjusting the corner radius, which turned the ghost hover background into a circle. This keeps the intended 16px sizing and corrects the radius rather than reverting the size.

## Testing

- [x] `pnpm lint` passes (JS / CSS / deps)
- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes (apollo-react: 116 files, 2061 tests)
- [ ] `pnpm test:visual` — runs in CI (no static-snapshot impact; the radius only affects the hover state, which snapshots don't capture)
- [x] Manual / Storybook: verified in the StageNode *Default* and *Ad hoc Tasks* stories that the status and play buttons render 16×16 with a 4px radius (rounded square, not a circle)
- [x] Type-safe (no `as any` / type suppressions)
