### PR TITLE
feat(apollo-wind): add support for passing containers for portal

### DIFF
--- a/packages/apollo-wind/src/components/ui/dropdown-menu.test.tsx
+++ b/packages/apollo-wind/src/components/ui/dropdown-menu.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { axe } from 'jest-axe';
+import * as React from 'react';
 import { describe, expect, it, vi } from 'vitest';
 import {
   DropdownMenu,
@@ -14,6 +15,7 @@ import {
   DropdownMenuShortcut,
   DropdownMenuTrigger,
 } from './dropdown-menu';
+import { PortalContainerProvider } from './portal-container';
 
 describe('DropdownMenu', () => {
   describe('rendering', () => {
@@ -377,6 +379,50 @@ describe('DropdownMenu', () => {
       await waitFor(() => {
         const item = screen.getByText('Disabled Action');
         expect(item).toHaveAttribute('data-disabled');
+      });
+    });
+  });
+
+  describe('portal container', () => {
+    const OpenMenu = ({ container }: { container?: HTMLElement }) => (
+      <DropdownMenu open>
+        <DropdownMenuTrigger>Open</DropdownMenuTrigger>
+        <DropdownMenuContent container={container}>
+          <DropdownMenuItem>Action</DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    );
+
+    it('portals into the PortalContainerProvider boundary', async () => {
+      render(
+        <div data-testid="host">
+          <PortalContainerProvider>
+            <OpenMenu />
+          </PortalContainerProvider>
+        </div>
+      );
+
+      await waitFor(() => {
+        const item = screen.getByRole('menuitem', { name: 'Action' });
+        expect(screen.getByTestId('host').contains(item)).toBe(true);
+      });
+    });
+
+    it('routes its portal through an explicit container prop', async () => {
+      const Harness = () => {
+        const [target, setTarget] = React.useState<HTMLElement | null>(null);
+        return (
+          <>
+            <div data-testid="custom" ref={setTarget} />
+            {target && <OpenMenu container={target} />}
+          </>
+        );
+      };
+      render(<Harness />);
+
+      await waitFor(() => {
+        const item = screen.getByRole('menuitem', { name: 'Action' });
+        expect(screen.getByTestId('custom').contains(item)).toBe(true);
       });
     });
   });

--- a/packages/apollo-wind/src/components/ui/dropdown-menu.tsx
+++ b/packages/apollo-wind/src/components/ui/dropdown-menu.tsx
@@ -3,7 +3,10 @@
 import * as DropdownMenuPrimitive from '@radix-ui/react-dropdown-menu';
 import { Check, ChevronRight, Circle } from 'lucide-react';
 import * as React from 'react';
-import { usePortalContainer } from '@/components/ui/portal-container';
+import {
+  type PortalContainerOverride,
+  useResolvedPortalContainer,
+} from '@/components/ui/portal-container';
 import { cn } from '@/lib';
 
 const DropdownMenu = DropdownMenuPrimitive.Root;
@@ -57,13 +60,12 @@ DropdownMenuSubContent.displayName = DropdownMenuPrimitive.SubContent.displayNam
 const DropdownMenuContent = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Content> & {
-    container?: HTMLElement | null;
+    container?: PortalContainerOverride;
   }
 >(({ className, sideOffset = 4, container, ...props }, ref) => {
-  const portalContainer = usePortalContainer();
-  const resolvedContainer = container !== undefined ? container : portalContainer;
+  const resolvedContainer = useResolvedPortalContainer(container);
   return (
-    <DropdownMenuPrimitive.Portal container={resolvedContainer ?? undefined}>
+    <DropdownMenuPrimitive.Portal container={resolvedContainer}>
       <DropdownMenuPrimitive.Content
         ref={ref}
         sideOffset={sideOffset}

--- a/packages/apollo-wind/src/components/ui/dropdown-menu.tsx
+++ b/packages/apollo-wind/src/components/ui/dropdown-menu.tsx
@@ -3,9 +3,8 @@
 import * as DropdownMenuPrimitive from '@radix-ui/react-dropdown-menu';
 import { Check, ChevronRight, Circle } from 'lucide-react';
 import * as React from 'react';
-
-import { cn } from '@/lib';
 import { usePortalContainer } from '@/components/ui/portal-container';
+import { cn } from '@/lib';
 
 const DropdownMenu = DropdownMenuPrimitive.Root;
 
@@ -62,8 +61,9 @@ const DropdownMenuContent = React.forwardRef<
   }
 >(({ className, sideOffset = 4, container, ...props }, ref) => {
   const portalContainer = usePortalContainer();
+  const resolvedContainer = container !== undefined ? container : portalContainer;
   return (
-    <DropdownMenuPrimitive.Portal container={container ?? portalContainer ?? undefined}>
+    <DropdownMenuPrimitive.Portal container={resolvedContainer ?? undefined}>
       <DropdownMenuPrimitive.Content
         ref={ref}
         sideOffset={sideOffset}

--- a/packages/apollo-wind/src/components/ui/dropdown-menu.tsx
+++ b/packages/apollo-wind/src/components/ui/dropdown-menu.tsx
@@ -5,6 +5,7 @@ import { Check, ChevronRight, Circle } from 'lucide-react';
 import * as React from 'react';
 
 import { cn } from '@/lib';
+import { usePortalContainer } from '@/components/ui/portal-container';
 
 const DropdownMenu = DropdownMenuPrimitive.Root;
 
@@ -56,20 +57,25 @@ DropdownMenuSubContent.displayName = DropdownMenuPrimitive.SubContent.displayNam
 
 const DropdownMenuContent = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Content>
->(({ className, sideOffset = 4, ...props }, ref) => (
-  <DropdownMenuPrimitive.Portal>
-    <DropdownMenuPrimitive.Content
-      ref={ref}
-      sideOffset={sideOffset}
-      className={cn(
-        'z-50 max-h-[var(--radix-dropdown-menu-content-available-height)] min-w-[8rem] overflow-y-auto overflow-x-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md future:rounded-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-dropdown-menu-content-transform-origin]',
-        className
-      )}
-      {...props}
-    />
-  </DropdownMenuPrimitive.Portal>
-));
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Content> & {
+    container?: HTMLElement | null;
+  }
+>(({ className, sideOffset = 4, container, ...props }, ref) => {
+  const portalContainer = usePortalContainer();
+  return (
+    <DropdownMenuPrimitive.Portal container={container ?? portalContainer ?? undefined}>
+      <DropdownMenuPrimitive.Content
+        ref={ref}
+        sideOffset={sideOffset}
+        className={cn(
+          'z-50 max-h-[var(--radix-dropdown-menu-content-available-height)] min-w-[8rem] overflow-y-auto overflow-x-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md future:rounded-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-dropdown-menu-content-transform-origin]',
+          className
+        )}
+        {...props}
+      />
+    </DropdownMenuPrimitive.Portal>
+  );
+});
 DropdownMenuContent.displayName = DropdownMenuPrimitive.Content.displayName;
 
 const DropdownMenuItem = React.forwardRef<

--- a/packages/apollo-wind/src/components/ui/popover.tsx
+++ b/packages/apollo-wind/src/components/ui/popover.tsx
@@ -1,6 +1,11 @@
+'use client';
+
 import * as PopoverPrimitive from '@radix-ui/react-popover';
 import * as React from 'react';
-import { usePortalContainer } from '@/components/ui/portal-container';
+import {
+  type PortalContainerOverride,
+  useResolvedPortalContainer,
+} from '@/components/ui/portal-container';
 import { cn } from '@/lib';
 
 const Popover = PopoverPrimitive.Root;
@@ -12,13 +17,12 @@ const PopoverAnchor = PopoverPrimitive.Anchor;
 const PopoverContent = React.forwardRef<
   React.ElementRef<typeof PopoverPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content> & {
-    container?: HTMLElement | null;
+    container?: PortalContainerOverride;
   }
 >(({ className, align = 'center', sideOffset = 4, container, ...props }, ref) => {
-  const portalContainer = usePortalContainer();
-  const resolvedContainer = container !== undefined ? container : portalContainer;
+  const resolvedContainer = useResolvedPortalContainer(container);
   return (
-    <PopoverPrimitive.Portal container={resolvedContainer ?? undefined}>
+    <PopoverPrimitive.Portal container={resolvedContainer}>
       <PopoverPrimitive.Content
         ref={ref}
         align={align}

--- a/packages/apollo-wind/src/components/ui/popover.tsx
+++ b/packages/apollo-wind/src/components/ui/popover.tsx
@@ -1,8 +1,7 @@
 import * as PopoverPrimitive from '@radix-ui/react-popover';
 import * as React from 'react';
-
-import { cn } from '@/lib';
 import { usePortalContainer } from '@/components/ui/portal-container';
+import { cn } from '@/lib';
 
 const Popover = PopoverPrimitive.Root;
 
@@ -17,8 +16,9 @@ const PopoverContent = React.forwardRef<
   }
 >(({ className, align = 'center', sideOffset = 4, container, ...props }, ref) => {
   const portalContainer = usePortalContainer();
+  const resolvedContainer = container !== undefined ? container : portalContainer;
   return (
-    <PopoverPrimitive.Portal container={container ?? portalContainer ?? undefined}>
+    <PopoverPrimitive.Portal container={resolvedContainer ?? undefined}>
       <PopoverPrimitive.Content
         ref={ref}
         align={align}

--- a/packages/apollo-wind/src/components/ui/popover.tsx
+++ b/packages/apollo-wind/src/components/ui/popover.tsx
@@ -2,6 +2,7 @@ import * as PopoverPrimitive from '@radix-ui/react-popover';
 import * as React from 'react';
 
 import { cn } from '@/lib';
+import { usePortalContainer } from '@/components/ui/portal-container';
 
 const Popover = PopoverPrimitive.Root;
 
@@ -11,21 +12,26 @@ const PopoverAnchor = PopoverPrimitive.Anchor;
 
 const PopoverContent = React.forwardRef<
   React.ElementRef<typeof PopoverPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content>
->(({ className, align = 'center', sideOffset = 4, ...props }, ref) => (
-  <PopoverPrimitive.Portal>
-    <PopoverPrimitive.Content
-      ref={ref}
-      align={align}
-      sideOffset={sideOffset}
-      className={cn(
-        'z-50 w-72 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none future:rounded-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-popover-content-transform-origin]',
-        className
-      )}
-      {...props}
-    />
-  </PopoverPrimitive.Portal>
-));
+  React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content> & {
+    container?: HTMLElement | null;
+  }
+>(({ className, align = 'center', sideOffset = 4, container, ...props }, ref) => {
+  const portalContainer = usePortalContainer();
+  return (
+    <PopoverPrimitive.Portal container={container ?? portalContainer ?? undefined}>
+      <PopoverPrimitive.Content
+        ref={ref}
+        align={align}
+        sideOffset={sideOffset}
+        className={cn(
+          'z-50 w-72 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none future:rounded-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-popover-content-transform-origin]',
+          className
+        )}
+        {...props}
+      />
+    </PopoverPrimitive.Portal>
+  );
+});
 PopoverContent.displayName = PopoverPrimitive.Content.displayName;
 
 export { Popover, PopoverTrigger, PopoverAnchor, PopoverContent };

--- a/packages/apollo-wind/src/components/ui/portal-container.test.tsx
+++ b/packages/apollo-wind/src/components/ui/portal-container.test.tsx
@@ -1,0 +1,86 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import * as React from 'react';
+import { describe, expect, it } from 'vitest';
+import { Popover, PopoverContent, PopoverTrigger } from './popover';
+import { PortalContainerProvider } from './portal-container';
+
+/**
+ * Popover is used as the vehicle here, but the resolution logic is shared by
+ * Select and DropdownMenu, so these cases cover all three overlays.
+ */
+describe('PortalContainerProvider', () => {
+  it('portals overlay content into the in-tree boundary by default', async () => {
+    render(
+      <div data-testid="host">
+        <PortalContainerProvider>
+          <Popover open>
+            <PopoverTrigger>Open</PopoverTrigger>
+            <PopoverContent>Menu</PopoverContent>
+          </Popover>
+        </PortalContainerProvider>
+      </div>
+    );
+
+    await waitFor(() => {
+      const content = screen.getByText('Menu');
+      expect(screen.getByTestId('host').contains(content)).toBe(true);
+    });
+  });
+
+  it('portals to document.body when no provider is mounted', async () => {
+    render(
+      <div data-testid="host">
+        <Popover open>
+          <PopoverTrigger>Open</PopoverTrigger>
+          <PopoverContent>Menu</PopoverContent>
+        </Popover>
+      </div>
+    );
+
+    await waitFor(() => {
+      const content = screen.getByText('Menu');
+      expect(document.body.contains(content)).toBe(true);
+      expect(screen.getByTestId('host').contains(content)).toBe(false);
+    });
+  });
+
+  it('lets an explicit container prop override the provider', async () => {
+    const Harness = () => {
+      const [target, setTarget] = React.useState<HTMLElement | null>(null);
+      return (
+        <PortalContainerProvider>
+          <div data-testid="custom" ref={setTarget} />
+          <Popover open>
+            <PopoverTrigger>Open</PopoverTrigger>
+            {target && <PopoverContent container={target}>Menu</PopoverContent>}
+          </Popover>
+        </PortalContainerProvider>
+      );
+    };
+    render(<Harness />);
+
+    await waitFor(() => {
+      const content = screen.getByText('Menu');
+      expect(screen.getByTestId('custom').contains(content)).toBe(true);
+    });
+  });
+
+  it('falls back to document.body when container={null}, even under a provider', async () => {
+    render(
+      <div data-testid="host">
+        <PortalContainerProvider>
+          <Popover open>
+            <PopoverTrigger>Open</PopoverTrigger>
+            <PopoverContent container={null}>Menu</PopoverContent>
+          </Popover>
+        </PortalContainerProvider>
+      </div>
+    );
+
+    await waitFor(() => {
+      const content = screen.getByText('Menu');
+      expect(document.body.contains(content)).toBe(true);
+      expect(screen.getByTestId('host').contains(content)).toBe(false);
+    });
+  });
+});

--- a/packages/apollo-wind/src/components/ui/portal-container.test.tsx
+++ b/packages/apollo-wind/src/components/ui/portal-container.test.tsx
@@ -1,12 +1,43 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, renderHook, screen, waitFor } from '@testing-library/react';
 import * as React from 'react';
 import { describe, expect, it } from 'vitest';
 import { Popover, PopoverContent, PopoverTrigger } from './popover';
-import { PortalContainerProvider } from './portal-container';
+import { PortalContainerProvider, useResolvedPortalContainer } from './portal-container';
+
+describe('useResolvedPortalContainer', () => {
+  const provided = document.createElement('div');
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <PortalContainerProvider container={provided}>{children}</PortalContainerProvider>
+  );
+
+  it('returns undefined (Radix default → body) with no override and no provider', () => {
+    const { result } = renderHook(() => useResolvedPortalContainer());
+    expect(result.current).toBeUndefined();
+  });
+
+  it("returns undefined for the 'body' sentinel, even under a provider", () => {
+    const { result } = renderHook(() => useResolvedPortalContainer('body'), { wrapper });
+    expect(result.current).toBeUndefined();
+  });
+
+  it('returns an explicit element override', () => {
+    const el = document.createElement('div');
+    const { result } = renderHook(() => useResolvedPortalContainer(el), { wrapper });
+    expect(result.current).toBe(el);
+  });
+
+  it('inherits the provider for both undefined and null (ref-safe)', () => {
+    const undef = renderHook(() => useResolvedPortalContainer(undefined), { wrapper });
+    expect(undef.result.current).toBe(provided);
+
+    const nul = renderHook(() => useResolvedPortalContainer(null), { wrapper });
+    expect(nul.result.current).toBe(provided);
+  });
+});
 
 /**
- * Popover is used as the vehicle here, but the resolution logic is shared by
- * Select and DropdownMenu, so these cases cover all three overlays.
+ * Popover is the vehicle here, but the resolution is shared by Select and
+ * DropdownMenu, so these cases cover all three overlays.
  */
 describe('PortalContainerProvider', () => {
   it('portals overlay content into the in-tree boundary by default', async () => {
@@ -44,7 +75,9 @@ describe('PortalContainerProvider', () => {
     });
   });
 
-  it('lets an explicit container prop override the provider', async () => {
+  it('lets an explicit container prop override the provider (and tolerates a null ref)', async () => {
+    // `container={target}` is null on the first render — the ref-safe design
+    // must inherit the provider then, not force body, and end up in `custom`.
     const Harness = () => {
       const [target, setTarget] = React.useState<HTMLElement | null>(null);
       return (
@@ -52,7 +85,7 @@ describe('PortalContainerProvider', () => {
           <div data-testid="custom" ref={setTarget} />
           <Popover open>
             <PopoverTrigger>Open</PopoverTrigger>
-            {target && <PopoverContent container={target}>Menu</PopoverContent>}
+            <PopoverContent container={target}>Menu</PopoverContent>
           </Popover>
         </PortalContainerProvider>
       );
@@ -65,7 +98,26 @@ describe('PortalContainerProvider', () => {
     });
   });
 
-  it('falls back to document.body when container={null}, even under a provider', async () => {
+  it("forces document.body with container='body', even under a provider", async () => {
+    render(
+      <div data-testid="host">
+        <PortalContainerProvider>
+          <Popover open>
+            <PopoverTrigger>Open</PopoverTrigger>
+            <PopoverContent container="body">Menu</PopoverContent>
+          </Popover>
+        </PortalContainerProvider>
+      </div>
+    );
+
+    await waitFor(() => {
+      const content = screen.getByText('Menu');
+      expect(document.body.contains(content)).toBe(true);
+      expect(screen.getByTestId('host').contains(content)).toBe(false);
+    });
+  });
+
+  it('inherits the provider (not body) when container={null}', async () => {
     render(
       <div data-testid="host">
         <PortalContainerProvider>
@@ -79,8 +131,7 @@ describe('PortalContainerProvider', () => {
 
     await waitFor(() => {
       const content = screen.getByText('Menu');
-      expect(document.body.contains(content)).toBe(true);
-      expect(screen.getByTestId('host').contains(content)).toBe(false);
+      expect(screen.getByTestId('host').contains(content)).toBe(true);
     });
   });
 });

--- a/packages/apollo-wind/src/components/ui/portal-container.tsx
+++ b/packages/apollo-wind/src/components/ui/portal-container.tsx
@@ -10,7 +10,10 @@ export const usePortalContainer = (): HTMLElement | null =>
 
 export interface PortalContainerProviderProps {
   children: React.ReactNode;
-  /** Node to portal into. Omit to auto-use an in-tree boundary. */
+  /**
+   * Node to portal into. Omit (`undefined`) to auto-use an in-tree boundary;
+   * pass `null` to force Radix's default (`document.body`) for the subtree.
+   */
   container?: HTMLElement | null;
 }
 
@@ -21,12 +24,10 @@ export interface PortalContainerProviderProps {
  * Fixes overlays breaking under shadow-DOM or focus-trapped hosts, where
  * body-level content lands outside the trigger's root. Mount one per React root.
  */
-export function PortalContainerProvider({
-  children,
-  container,
-}: PortalContainerProviderProps) {
+export function PortalContainerProvider({ children, container }: PortalContainerProviderProps) {
   const [boundary, setBoundary] = React.useState<HTMLElement | null>(null);
-  const value = container ?? boundary;
+  // `undefined` → auto boundary; explicit `null` → force `document.body`.
+  const value = container !== undefined ? container : boundary;
   return (
     <PortalContainerContext.Provider value={value}>
       {children}

--- a/packages/apollo-wind/src/components/ui/portal-container.tsx
+++ b/packages/apollo-wind/src/components/ui/portal-container.tsx
@@ -2,7 +2,11 @@
 
 import * as React from 'react';
 
-/** Node overlays portal into; `null` means no provider → `document.body`. */
+/**
+ * Node overlays portal into. `null` means fall back to `document.body` — either
+ * no provider is mounted, or one is but its boundary hasn't attached yet; it is
+ * not a reliable "is a provider mounted?" signal.
+ */
 const PortalContainerContext = React.createContext<HTMLElement | null>(null);
 
 export const usePortalContainer = (): HTMLElement | null =>

--- a/packages/apollo-wind/src/components/ui/portal-container.tsx
+++ b/packages/apollo-wind/src/components/ui/portal-container.tsx
@@ -9,8 +9,7 @@ import * as React from 'react';
  */
 const PortalContainerContext = React.createContext<HTMLElement | null>(null);
 
-export const usePortalContainer = (): HTMLElement | null =>
-  React.useContext(PortalContainerContext);
+const usePortalContainer = (): HTMLElement | null => React.useContext(PortalContainerContext);
 
 /**
  * Per-overlay portal target: `undefined`/`null` inherit the nearest
@@ -57,8 +56,8 @@ export function PortalContainerProvider({ children, container }: PortalContainer
     <PortalContainerContext.Provider value={value}>
       {children}
       {container == null && (
-        // display:contents so the boundary never affects layout.
-        <div ref={setBoundary} style={{ display: 'contents' }} />
+        // `contents` (display:contents) so the boundary never affects layout.
+        <div ref={setBoundary} className="contents" />
       )}
     </PortalContainerContext.Provider>
   );

--- a/packages/apollo-wind/src/components/ui/portal-container.tsx
+++ b/packages/apollo-wind/src/components/ui/portal-container.tsx
@@ -2,36 +2,57 @@
 
 import * as React from 'react';
 
-/** Node that Radix overlays portal into. `null` falls back to `document.body`. */
+/** Node overlays portal into; `null` means no provider → `document.body`. */
 const PortalContainerContext = React.createContext<HTMLElement | null>(null);
 
 export const usePortalContainer = (): HTMLElement | null =>
   React.useContext(PortalContainerContext);
 
+/**
+ * Per-overlay portal target: `undefined`/`null` inherit the nearest
+ * {@link PortalContainerProvider} (or `document.body` if none), `'body'` forces
+ * `document.body`, an element portals into it. `null` inherits rather than
+ * forcing body so `container={ref.current}` is safe before the ref attaches.
+ */
+export type PortalContainerOverride = HTMLElement | 'body' | null;
+
+/**
+ * Resolves an overlay's portal target from its `container` and the ambient
+ * provider, shared so the behavior stays identical across overlays. `undefined`
+ * is Radix's default (`document.body`) and keeps SSR clear of `document`.
+ */
+export function useResolvedPortalContainer(
+  container?: PortalContainerOverride
+): HTMLElement | undefined {
+  const portalContainer = usePortalContainer();
+  if (container === 'body') return undefined;
+  return container ?? portalContainer ?? undefined;
+}
+
 export interface PortalContainerProviderProps {
   children: React.ReactNode;
-  /**
-   * Node to portal into. Omit (`undefined`) to auto-use an in-tree boundary;
-   * pass `null` to force Radix's default (`document.body`) for the subtree.
-   */
+  /** Node to portal into; omit (or pass a not-yet-attached ref, i.e. `null`) for an auto in-tree boundary. */
   container?: HTMLElement | null;
 }
 
 /**
- * Portals overlays into its own subtree instead of `document.body`, keeping
- * them in the same DOM root and focus boundary as their trigger.
+ * Portals Popover/Select/DropdownMenu content (and Combobox/MultiSelect built on
+ * them) into its own subtree instead of `document.body`, keeping overlays in the
+ * trigger's DOM root and focus boundary. Without it they break under shadow-DOM
+ * or focus-trapped hosts, where body-level content escapes the root. Mount one
+ * per React root.
  *
- * Fixes overlays breaking under shadow-DOM or focus-trapped hosts, where
- * body-level content lands outside the trigger's root. Mount one per React root.
+ * Known limitation: an overlay open *on mount* portals to `document.body` for
+ * the first commit (the boundary ref hasn't attached yet) then remounts; pass a
+ * stable `container` you own for that case.
  */
 export function PortalContainerProvider({ children, container }: PortalContainerProviderProps) {
   const [boundary, setBoundary] = React.useState<HTMLElement | null>(null);
-  // `undefined` → auto boundary; explicit `null` → force `document.body`.
-  const value = container !== undefined ? container : boundary;
+  const value = container ?? boundary;
   return (
     <PortalContainerContext.Provider value={value}>
       {children}
-      {container === undefined && (
+      {container == null && (
         // display:contents so the boundary never affects layout.
         <div ref={setBoundary} style={{ display: 'contents' }} />
       )}

--- a/packages/apollo-wind/src/components/ui/portal-container.tsx
+++ b/packages/apollo-wind/src/components/ui/portal-container.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import * as React from 'react';
+
+/** Node that Radix overlays portal into. `null` falls back to `document.body`. */
+const PortalContainerContext = React.createContext<HTMLElement | null>(null);
+
+export const usePortalContainer = (): HTMLElement | null =>
+  React.useContext(PortalContainerContext);
+
+export interface PortalContainerProviderProps {
+  children: React.ReactNode;
+  /** Node to portal into. Omit to auto-use an in-tree boundary. */
+  container?: HTMLElement | null;
+}
+
+/**
+ * Portals overlays into its own subtree instead of `document.body`, keeping
+ * them in the same DOM root and focus boundary as their trigger.
+ *
+ * Fixes overlays breaking under shadow-DOM or focus-trapped hosts, where
+ * body-level content lands outside the trigger's root. Mount one per React root.
+ */
+export function PortalContainerProvider({
+  children,
+  container,
+}: PortalContainerProviderProps) {
+  const [boundary, setBoundary] = React.useState<HTMLElement | null>(null);
+  const value = container ?? boundary;
+  return (
+    <PortalContainerContext.Provider value={value}>
+      {children}
+      {container === undefined && (
+        // display:contents so the boundary never affects layout.
+        <div ref={setBoundary} style={{ display: 'contents' }} />
+      )}
+    </PortalContainerContext.Provider>
+  );
+}

--- a/packages/apollo-wind/src/components/ui/select.test.tsx
+++ b/packages/apollo-wind/src/components/ui/select.test.tsx
@@ -1,7 +1,9 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { axe } from 'jest-axe';
+import * as React from 'react';
 import { describe, expect, it, vi } from 'vitest';
+import { PortalContainerProvider } from './portal-container';
 import {
   Select,
   SelectContent,
@@ -264,5 +266,51 @@ describe('Select', () => {
     render(<SelectExample />);
     const trigger = screen.getByRole('combobox');
     expect(trigger).toHaveAttribute('aria-label', 'Select a fruit');
+  });
+
+  describe('portal container', () => {
+    const OpenSelect = ({ container }: { container?: HTMLElement }) => (
+      <Select open>
+        <SelectTrigger aria-label="Fruit">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent container={container}>
+          <SelectItem value="apple">Apple</SelectItem>
+        </SelectContent>
+      </Select>
+    );
+
+    it('portals into the PortalContainerProvider boundary', async () => {
+      render(
+        <div data-testid="host">
+          <PortalContainerProvider>
+            <OpenSelect />
+          </PortalContainerProvider>
+        </div>
+      );
+
+      await waitFor(() => {
+        const option = screen.getByRole('option', { name: 'Apple' });
+        expect(screen.getByTestId('host').contains(option)).toBe(true);
+      });
+    });
+
+    it('routes its portal through an explicit container prop', async () => {
+      const Harness = () => {
+        const [target, setTarget] = React.useState<HTMLElement | null>(null);
+        return (
+          <>
+            <div data-testid="custom" ref={setTarget} />
+            {target && <OpenSelect container={target} />}
+          </>
+        );
+      };
+      render(<Harness />);
+
+      await waitFor(() => {
+        const option = screen.getByRole('option', { name: 'Apple' });
+        expect(screen.getByTestId('custom').contains(option)).toBe(true);
+      });
+    });
   });
 });

--- a/packages/apollo-wind/src/components/ui/select.tsx
+++ b/packages/apollo-wind/src/components/ui/select.tsx
@@ -1,7 +1,12 @@
+'use client';
+
 import * as SelectPrimitive from '@radix-ui/react-select';
 import { Check, ChevronDown, ChevronUp } from 'lucide-react';
 import * as React from 'react';
-import { usePortalContainer } from '@/components/ui/portal-container';
+import {
+  type PortalContainerOverride,
+  useResolvedPortalContainer,
+} from '@/components/ui/portal-container';
 import { cn } from '@/lib/index';
 
 const Select = SelectPrimitive.Root;
@@ -61,13 +66,12 @@ SelectScrollDownButton.displayName = SelectPrimitive.ScrollDownButton.displayNam
 const SelectContent = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof SelectPrimitive.Content> & {
-    container?: HTMLElement | null;
+    container?: PortalContainerOverride;
   }
 >(({ className, children, position = 'popper', container, ...props }, ref) => {
-  const portalContainer = usePortalContainer();
-  const resolvedContainer = container !== undefined ? container : portalContainer;
+  const resolvedContainer = useResolvedPortalContainer(container);
   return (
-    <SelectPrimitive.Portal container={resolvedContainer ?? undefined}>
+    <SelectPrimitive.Portal container={resolvedContainer}>
       <SelectPrimitive.Content
         ref={ref}
         className={cn(

--- a/packages/apollo-wind/src/components/ui/select.tsx
+++ b/packages/apollo-wind/src/components/ui/select.tsx
@@ -3,6 +3,7 @@ import { Check, ChevronDown, ChevronUp } from 'lucide-react';
 import * as React from 'react';
 
 import { cn } from '@/lib/index';
+import { usePortalContainer } from '@/components/ui/portal-container';
 
 const Select = SelectPrimitive.Root;
 
@@ -60,34 +61,39 @@ SelectScrollDownButton.displayName = SelectPrimitive.ScrollDownButton.displayNam
 
 const SelectContent = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Content>
->(({ className, children, position = 'popper', ...props }, ref) => (
-  <SelectPrimitive.Portal>
-    <SelectPrimitive.Content
-      ref={ref}
-      className={cn(
-        'relative z-50 max-h-[--radix-select-content-available-height] min-w-[8rem] overflow-y-auto overflow-x-hidden rounded-md border bg-popover text-popover-foreground shadow-md future:rounded-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-select-content-transform-origin]',
-        position === 'popper' &&
-          'data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1',
-        className
-      )}
-      position={position}
-      {...props}
-    >
-      <SelectScrollUpButton />
-      <SelectPrimitive.Viewport
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Content> & {
+    container?: HTMLElement | null;
+  }
+>(({ className, children, position = 'popper', container, ...props }, ref) => {
+  const portalContainer = usePortalContainer();
+  return (
+    <SelectPrimitive.Portal container={container ?? portalContainer ?? undefined}>
+      <SelectPrimitive.Content
+        ref={ref}
         className={cn(
-          'p-1',
+          'relative z-50 max-h-[--radix-select-content-available-height] min-w-[8rem] overflow-y-auto overflow-x-hidden rounded-md border bg-popover text-popover-foreground shadow-md future:rounded-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-select-content-transform-origin]',
           position === 'popper' &&
-            'h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)]'
+            'data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1',
+          className
         )}
+        position={position}
+        {...props}
       >
-        {children}
-      </SelectPrimitive.Viewport>
-      <SelectScrollDownButton />
-    </SelectPrimitive.Content>
-  </SelectPrimitive.Portal>
-));
+        <SelectScrollUpButton />
+        <SelectPrimitive.Viewport
+          className={cn(
+            'p-1',
+            position === 'popper' &&
+              'h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)]'
+          )}
+        >
+          {children}
+        </SelectPrimitive.Viewport>
+        <SelectScrollDownButton />
+      </SelectPrimitive.Content>
+    </SelectPrimitive.Portal>
+  );
+});
 SelectContent.displayName = SelectPrimitive.Content.displayName;
 
 const SelectLabel = React.forwardRef<

--- a/packages/apollo-wind/src/components/ui/select.tsx
+++ b/packages/apollo-wind/src/components/ui/select.tsx
@@ -1,9 +1,8 @@
 import * as SelectPrimitive from '@radix-ui/react-select';
 import { Check, ChevronDown, ChevronUp } from 'lucide-react';
 import * as React from 'react';
-
-import { cn } from '@/lib/index';
 import { usePortalContainer } from '@/components/ui/portal-container';
+import { cn } from '@/lib/index';
 
 const Select = SelectPrimitive.Root;
 
@@ -66,8 +65,9 @@ const SelectContent = React.forwardRef<
   }
 >(({ className, children, position = 'popper', container, ...props }, ref) => {
   const portalContainer = usePortalContainer();
+  const resolvedContainer = container !== undefined ? container : portalContainer;
   return (
-    <SelectPrimitive.Portal container={container ?? portalContainer ?? undefined}>
+    <SelectPrimitive.Portal container={resolvedContainer ?? undefined}>
       <SelectPrimitive.Content
         ref={ref}
         className={cn(

--- a/packages/apollo-wind/src/index.ts
+++ b/packages/apollo-wind/src/index.ts
@@ -239,10 +239,7 @@ export {
   PopoverTrigger,
 } from './components/ui/popover';
 
-export {
-  PortalContainerProvider,
-  usePortalContainer,
-} from './components/ui/portal-container';
+export { PortalContainerProvider } from './components/ui/portal-container';
 export type { PortalContainerProviderProps } from './components/ui/portal-container';
 
 export {

--- a/packages/apollo-wind/src/index.ts
+++ b/packages/apollo-wind/src/index.ts
@@ -240,6 +240,12 @@ export {
 } from './components/ui/popover';
 
 export {
+  PortalContainerProvider,
+  usePortalContainer,
+} from './components/ui/portal-container';
+export type { PortalContainerProviderProps } from './components/ui/portal-container';
+
+export {
   Tooltip,
   TooltipContent,
   TooltipPortal,


### PR DESCRIPTION
## Description
In apollo-wind components with popovers there's an issue with using the components in a larger component meant to be embedded in a variety of hosts. There's no way to pass a container to the Portal to control where the popover is placed in the DOM, so the popover is at the mercy of the host that is outside of the owning components DOM/tree.

This PR is meant to add a Portal container provider to allow caller to optionally pass a container that can be rendered inside the parent/owning component to avoid issues with popovers in a host (e.g. focus traps, shadow DOMs, etc.).