### PR TITLE
feat(apollo-react): add uipath.case.stage manifest and drive StageNode handles from it [MST-12554]

### DIFF
--- a/packages/apollo-react/src/canvas/components/CaseFlow/case-flow.manifest.test.ts
+++ b/packages/apollo-react/src/canvas/components/CaseFlow/case-flow.manifest.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import { categoryManifestSchema, nodeManifestSchema } from '../../schema/node-definition';
+import {
+  caseFlowCategories,
+  caseFlowManifest,
+  caseManagementStageManifest,
+  caseManagementTriggerManifest,
+} from './case-flow.manifest';
+
+describe('case-flow manifests', () => {
+  it('trigger manifest parses against nodeManifestSchema', () => {
+    expect(() => nodeManifestSchema.parse(caseManagementTriggerManifest)).not.toThrow();
+  });
+
+  it('stage manifest parses against nodeManifestSchema', () => {
+    expect(() => nodeManifestSchema.parse(caseManagementStageManifest)).not.toThrow();
+  });
+
+  it('categories parse against categoryManifestSchema', () => {
+    for (const category of caseFlowCategories) {
+      expect(() => categoryManifestSchema.parse(category)).not.toThrow();
+    }
+  });
+
+  it('registers both node manifests in the combined manifest', () => {
+    const nodeTypes = caseFlowManifest.nodes.map((node) => node.nodeType);
+    expect(nodeTypes).toContain('uipath.case.trigger');
+    expect(nodeTypes).toContain('uipath.case.stage');
+  });
+
+  it('every node manifest category resolves to a declared category', () => {
+    const categoryIds = new Set(caseFlowCategories.map((category) => category.id));
+    for (const node of caseFlowManifest.nodes) {
+      expect(categoryIds.has(node.category)).toBe(true);
+    }
+  });
+
+  it('trigger output targets the stage category', () => {
+    const output = caseManagementTriggerManifest.handleConfiguration?.[0]?.handles[0];
+    expect(output?.constraints?.allowedTargetCategories).toContain(
+      caseManagementStageManifest.category
+    );
+  });
+
+  it('stage input accepts the trigger category', () => {
+    const left = caseManagementStageManifest.handleConfiguration?.find(
+      (group) => group.position === 'left'
+    );
+    expect(left?.handles[0]?.constraints?.allowedSourceCategories).toContain(
+      caseManagementTriggerManifest.category
+    );
+  });
+
+  it('stage handle ids are unique', () => {
+    const ids = (caseManagementStageManifest.handleConfiguration ?? []).flatMap((group) =>
+      group.handles.map((handle) => handle.id)
+    );
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('only the next handle shows the add button', () => {
+    const buttonHandles = (caseManagementStageManifest.handleConfiguration ?? [])
+      .flatMap((group) => group.handles)
+      .filter((handle) => handle.showButton);
+    expect(buttonHandles.map((handle) => handle.id)).toEqual(['next']);
+  });
+});

--- a/packages/apollo-react/src/canvas/components/CaseFlow/case-flow.manifest.ts
+++ b/packages/apollo-react/src/canvas/components/CaseFlow/case-flow.manifest.ts
@@ -4,8 +4,10 @@
  * Phase 1 manifests for case-management node types.
  * See: https://uipath.atlassian.net/wiki/spaces/~5d0b4d163e70300bc9758674/pages/90446398009/Case+Unified+schema+onboarding
  *
- * Scope (this file): trigger nodes only.
- * Stage, exception stage, task, condition, and edge manifests are intentionally out of scope.
+ * Scope (this file): trigger and stage nodes. Exception stages are regular stages
+ * with `stageType: 'secondary'` instance data (the two node types were combined),
+ * so they share the stage manifest. Task, condition, and edge manifests are
+ * intentionally out of scope.
  */
 
 import type { CategoryManifest, NodeManifest } from '../../schema/node-definition';
@@ -23,6 +25,15 @@ export const caseFlowCategories: CategoryManifest[] = [
     colorDark: 'linear-gradient(135deg, #E65100 0%, #EF6C00 100%)',
     icon: 'zap',
     tags: ['trigger', 'start', 'case', 'event'],
+  },
+  {
+    id: 'case-stage',
+    name: 'Stages',
+    sortOrder: 1,
+    color: 'linear-gradient(135deg, #E3F2FD 0%, #BBDEFB 100%)',
+    colorDark: 'linear-gradient(135deg, #0D47A1 0%, #1565C0 100%)',
+    icon: 'square-plus',
+    tags: ['stage', 'case'],
   },
 ];
 
@@ -92,11 +103,121 @@ export const caseManagementTriggerManifest: NodeManifest = {
 };
 
 // ============================================================================
+// Stage Nodes
+// ============================================================================
+
+/**
+ * Stage node manifest per the unified-schema onboarding doc, adjusted per review:
+ * `display.shape` is `'container'` (the doc's `'group'` is not a valid `NodeShape`),
+ * the doc's top condition handles are omitted (conditions have no manifest or visual
+ * display yet), and category ids follow the ones landed here
+ * (`case-management-trigger`), not the doc's `case-trigger` shorthand.
+ */
+export const caseManagementStageManifest: NodeManifest = {
+  nodeType: 'uipath.case.stage',
+  version: '1.0.0',
+  description: 'A stage in the case lifecycle containing tasks and SLA configuration.',
+  category: 'case-stage',
+  tags: ['stage', 'case'],
+  sortOrder: 0,
+  display: {
+    label: 'Stage',
+    description: 'A grouping of tasks',
+    icon: 'square-plus',
+    shape: 'container',
+    shadow: false,
+  },
+  handleConfiguration: [
+    // LEFT: target from the trigger or previous stages
+    {
+      position: 'left',
+      handles: [
+        {
+          id: 'input',
+          type: 'target',
+          handleType: 'input',
+          isDefaultForType: true,
+          constraints: {
+            allowedSourceCategories: ['case-management-trigger', 'case-stage'],
+          },
+        },
+      ],
+    },
+    // RIGHT: source to the next stage, with the standard add button
+    {
+      position: 'right',
+      handles: [
+        {
+          id: 'next',
+          type: 'source',
+          handleType: 'output',
+          showButton: true,
+          isDefaultForType: true,
+          constraints: {
+            allowedTargetCategories: ['case-stage'],
+            forbiddenTargetCategories: ['case-management-trigger'],
+          },
+        },
+      ],
+    },
+    // BOTTOM: re-entry output back to earlier stages
+    {
+      position: 'bottom',
+      handles: [
+        {
+          id: 'reentry',
+          type: 'source',
+          handleType: 'output',
+          showButton: false,
+          constraints: {
+            allowedTargetCategories: ['case-stage'],
+          },
+        },
+      ],
+    },
+  ],
+  // Mirrors the current stage node's data model (PO.Frontend
+  // CaseManagementJsonStageNodeDataSchema): tasks, entry/exit rules, SLA rules,
+  // and the secondary (exception) stage marker. Loosely typed like the trigger's
+  // context/bindings; the consumer's zod schemas remain the source of truth.
+  inputDefinition: {
+    name: { type: 'string', description: 'Stage display name' },
+    tasks: {
+      type: 'array',
+      items: { type: 'array', items: { type: 'object' } },
+      description:
+        'Task groups: the outer array is execution order, tasks within an inner array run in parallel.',
+    },
+    entryConditions: {
+      type: 'array',
+      items: { type: 'object' },
+      description: 'Stage entry rules.',
+    },
+    exitConditions: {
+      type: 'array',
+      items: { type: 'object' },
+      description: 'Stage exit rules.',
+    },
+    slaRules: {
+      type: 'array',
+      items: { type: 'object' },
+      description: 'SLA rules with escalations; the last entry is the default rule.',
+    },
+    stageType: {
+      type: 'string',
+      enum: ['primary', 'secondary'],
+      nullable: true,
+      description: 'Set to "secondary" for exception stages (the combined node type).',
+    },
+  },
+};
+
+// ============================================================================
 // Combined Manifest
 // ============================================================================
 
 export const caseFlowManifest = {
   version: '1.0.0',
   categories: caseFlowCategories,
-  nodes: [caseManagementTriggerManifest],
+  nodes: [caseManagementTriggerManifest, caseManagementStageManifest],
 };

--- a/packages/apollo-react/src/canvas/components/CaseFlow/index.ts
+++ b/packages/apollo-react/src/canvas/components/CaseFlow/index.ts
@@ -1,5 +1,6 @@
 export {
   caseFlowCategories,
   caseFlowManifest,
+  caseManagementStageManifest,
   caseManagementTriggerManifest,
 } from './case-flow.manifest';

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.stories.tsx
@@ -313,6 +313,41 @@ export const Default: Story = {
   },
 };
 
+export const ManifestAddNextStage: Story = {
+  name: 'Manifest Add Next Stage',
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Handles come from caseManagementStageManifest. Providing onHandleAction renders the standard add button on the right source handle (the next handle). Hover or select the stage to reveal it.',
+      },
+    },
+    nodes: [
+      {
+        id: 'stage-manifest-demo',
+        type: 'stage',
+        position: { x: 48, y: 96 },
+        width: DEFAULT_STAGE_WIDTH,
+        data: {
+          stageDetails: {
+            label: 'Intake',
+            tasks: sampleTasks,
+            sla: '4h',
+          },
+          execution: {
+            stageStatus: {
+              slaText: 'SLA: 4h',
+            },
+          },
+          onHandleAction: () => {
+            console.info('Add next stage: this would append a new stage after Intake');
+          },
+        },
+      },
+    ],
+  },
+};
+
 export const WithTaskIcons: Story = {
   name: 'With Task Icons',
   parameters: {
@@ -567,25 +602,25 @@ export const ExecutionStatus: Story = {
         id: 'e1',
         type: 'stage',
         source: '0',
-        sourceHandle: '0____source____right',
+        sourceHandle: 'next',
         target: '1',
-        targetHandle: '1____target____left',
+        targetHandle: 'input',
       },
       {
         id: 'e2',
         type: 'stage',
         source: '1',
-        sourceHandle: '1____source____right',
+        sourceHandle: 'next',
         target: '2',
-        targetHandle: '2____target____left',
+        targetHandle: 'input',
       },
       {
         id: 'e3',
         type: 'stage',
         source: '2',
-        sourceHandle: '2____source____right',
+        sourceHandle: 'next',
         target: '3',
-        targetHandle: '3____target____left',
+        targetHandle: 'input',
       },
     ] as Edge[],
   },
@@ -1043,33 +1078,33 @@ export const LoanProcessingWorkflow: Story = {
         id: 'e1',
         type: 'stage',
         source: 'application',
-        sourceHandle: 'application____source____right',
+        sourceHandle: 'next',
         target: 'processing',
-        targetHandle: 'processing____target____left',
+        targetHandle: 'input',
       },
       {
         id: 'e2',
         type: 'stage',
         source: 'processing',
-        sourceHandle: 'processing____source____right',
+        sourceHandle: 'next',
         target: 'underwriting',
-        targetHandle: 'underwriting____target____left',
+        targetHandle: 'input',
       },
       {
         id: 'e3',
         type: 'stage',
         source: 'underwriting',
-        sourceHandle: 'underwriting____source____right',
+        sourceHandle: 'next',
         target: 'closing',
-        targetHandle: 'closing____target____left',
+        targetHandle: 'input',
       },
       {
         id: 'e4',
         type: 'stage',
         source: 'closing',
-        sourceHandle: 'closing____source____right',
+        sourceHandle: 'next',
         target: 'funding',
-        targetHandle: 'funding____target____left',
+        targetHandle: 'input',
       },
     ] as Edge[],
   },

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.test.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.test.tsx
@@ -169,11 +169,6 @@ vi.mock('../BaseCanvas/ConnectedHandlesContext', () => ({
   useConnectedHandles: () => new Set(),
 }));
 
-// Mock useButtonHandles
-vi.mock('../ButtonHandle/useButtonHandles', () => ({
-  useButtonHandles: () => null,
-}));
-
 vi.mock('@uipath/apollo-react/canvas/xyflow/react', async () => {
   const actual = await vi.importActual('@uipath/apollo-react/canvas/xyflow/react');
   return {
@@ -188,6 +183,24 @@ vi.mock('@uipath/apollo-react/canvas/xyflow/react', async () => {
       };
       return selector(mockState);
     },
+    // xyflow's Handle renders nothing outside a real Node context (it needs a node
+    // id from context). Stub it, mirroring the data-handleid attribute the real
+    // component sets, so manifest-driven handle rendering is testable here.
+    Handle: ({
+      children,
+      id,
+      className,
+      style,
+    }: {
+      children?: React.ReactNode;
+      id?: string;
+      className?: string;
+      style?: React.CSSProperties;
+    }) => (
+      <div data-testid="xyflow-handle" data-handleid={id} className={className} style={style}>
+        {children}
+      </div>
+    ),
   };
 });
 
@@ -1364,5 +1377,70 @@ describe('StageNode - Breakpoints on adhoc and event-driven tasks', () => {
     });
 
     expect(screen.queryByTestId('stage-task-breakpoint-adhoc-1')).not.toBeInTheDocument();
+  });
+});
+
+describe('StageNode - Manifest-Driven Handles', () => {
+  it('renders the add button on the next handle when selected and onHandleAction is provided', () => {
+    renderStageNode({ onHandleAction: vi.fn() });
+
+    expect(screen.getByRole('button', { name: 'Add node' })).toBeInTheDocument();
+  });
+
+  it('fires onHandleAction with the manifest next handle id', async () => {
+    const user = userEvent.setup();
+    const onHandleAction = vi.fn();
+    renderStageNode({ onHandleAction });
+
+    await user.click(screen.getByRole('button', { name: 'Add node' }));
+
+    expect(onHandleAction).toHaveBeenCalledTimes(1);
+    expect(onHandleAction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        nodeId: 'stage-1',
+        handleId: 'next',
+        handleType: 'output',
+      })
+    );
+  });
+
+  it('does not render the add button when onHandleAction is not provided', () => {
+    renderStageNode();
+
+    expect(screen.queryByRole('button', { name: 'Add node' })).not.toBeInTheDocument();
+  });
+
+  it('does not render the add button in read-only mode', () => {
+    renderStageNode({
+      onHandleAction: vi.fn(),
+      stageDetails: {
+        label: 'Test Stage',
+        isReadOnly: true,
+        tasks: [[createTask('task-1', 'Task 1')]],
+      },
+    });
+
+    expect(screen.queryByRole('button', { name: 'Add node' })).not.toBeInTheDocument();
+  });
+
+  it('does not render the add button on exception stages', () => {
+    renderStageNode({
+      onHandleAction: vi.fn(),
+      stageDetails: {
+        label: 'Exception Stage',
+        isException: true,
+        tasks: [[createTask('task-1', 'Task 1')]],
+      },
+    });
+
+    expect(screen.queryByRole('button', { name: 'Add node' })).not.toBeInTheDocument();
+  });
+
+  it('renders the manifest handle ids from the unified flow schema', () => {
+    const { container } = renderStageNode({ onHandleAction: vi.fn() });
+
+    for (const handleId of ['input', 'next', 'reentry']) {
+      expect(container.querySelector(`[data-handleid="${handleId}"]`)).not.toBeNull();
+    }
   });
 });

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.tsx
@@ -28,6 +28,9 @@ const StageNodeInner = (props: StageNodeProps) => {
     onAddTaskFromToolbox,
     onTaskToolboxSearch,
     onReplaceTaskFromToolbox,
+    onHandleAction,
+    onHandleMouseEnter,
+    onHandleMouseLeave,
   } = props;
 
   const taskWidth = width ? width - STAGE_CONTENT_INSET : undefined;
@@ -198,6 +201,9 @@ const StageNodeInner = (props: StageNodeProps) => {
         selected={selected}
         isHovered={isHovered}
         isException={isException}
+        onHandleAction={onHandleAction}
+        onHandleMouseEnter={onHandleMouseEnter}
+        onHandleMouseLeave={onHandleMouseLeave}
       />
     </div>
   );

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.types.ts
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.types.ts
@@ -1,5 +1,6 @@
 import type { NodeProps } from '@uipath/apollo-react/canvas/xyflow/react';
 import type { GroupModificationType } from '../../utils/GroupModificationUtils';
+import type { HandleActionEvent, HandleMouseEvent } from '../ButtonHandle/ButtonHandle';
 import type { NodeMenuItem } from '../NodeContextMenu';
 import type { ListItem, ToolboxSearchHandler } from '../Toolbox';
 
@@ -100,6 +101,17 @@ export interface StageNodeBaseProps {
   getTaskContextMenuItems?: (args: StageTaskContextMenuArgs) => NodeMenuItem[] | undefined;
   hideParallelOptions?: boolean;
   loadingTaskIds?: ReadonlySet<string>;
+  /**
+   * Fired when the manifest-driven add button on a source handle is clicked.
+   * `HandleActionEvent.handleId` is the manifest handle id from
+   * `caseManagementStageManifest` (the add button lives on `next`). The add
+   * button only renders when this callback is provided.
+   */
+  onHandleAction?: (event: HandleActionEvent) => void;
+  /** Fired when the pointer enters a handle's add button (e.g. to show a preview node). */
+  onHandleMouseEnter?: (event: HandleMouseEvent) => void;
+  /** Fired when the pointer leaves a handle's add button. */
+  onHandleMouseLeave?: (event: HandleMouseEvent) => void;
 }
 
 export interface StageNodeCanvasProps extends NodeProps, StageNodeBaseProps {}

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNodeHandles.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNodeHandles.tsx
@@ -2,7 +2,12 @@ import { Position, useStore } from '@uipath/apollo-react/canvas/xyflow/react';
 import { memo, useMemo } from 'react';
 import type { HandleGroupManifest } from '../../schema/node-definition';
 import { useConnectedHandles } from '../BaseCanvas/ConnectedHandlesContext';
+import type { HandleActionEvent, HandleMouseEvent } from '../ButtonHandle/ButtonHandle';
 import { useButtonHandles } from '../ButtonHandle/useButtonHandles';
+import { caseManagementStageManifest } from '../CaseFlow/case-flow.manifest';
+
+/** Height of the stage header strip that left/right notches align to. */
+const HANDLE_LANE_HEIGHT = 64;
 
 const StageNodeHandlesInner = ({
   id,
@@ -10,12 +15,18 @@ const StageNodeHandlesInner = ({
   selected,
   isHovered,
   isException,
+  onHandleAction,
+  onHandleMouseEnter,
+  onHandleMouseLeave,
 }: {
   id: string;
   isReadOnly: boolean;
   selected: boolean;
   isHovered: boolean;
   isException?: boolean;
+  onHandleAction?: (event: HandleActionEvent) => void;
+  onHandleMouseEnter?: (event: HandleMouseEvent) => void;
+  onHandleMouseLeave?: (event: HandleMouseEvent) => void;
 }) => {
   const isConnecting = useStore((state) => !!state.connectionClickStartHandle);
   const connectedHandleIds = useConnectedHandles(id);
@@ -24,72 +35,35 @@ const StageNodeHandlesInner = ({
     return !isReadOnly && (selected || isHovered || isConnecting || hasConnections);
   }, [hasConnections, isConnecting, selected, isHovered, isReadOnly]);
 
-  const handleConfigurations: HandleGroupManifest[] = useMemo(
-    () =>
-      isException
-        ? []
-        : [
-            {
-              position: Position.Left,
-              handles: [
-                {
-                  id: `${id}____target____left`,
-                  type: 'target',
-                  handleType: 'input',
-                },
-              ],
-              visible: selected || isHovered || isConnecting,
-              customPositionAndOffsets: {
-                top: 0,
-                height: 64,
-              },
-            },
-            {
-              position: Position.Right,
-              handles: [
-                {
-                  id: `${id}____source____right`,
-                  type: 'source',
-                  handleType: 'output',
-                },
-              ],
-              visible: selected || isHovered || isConnecting,
-              customPositionAndOffsets: {
-                top: 0,
-                height: 64,
-              },
-            },
-            {
-              position: Position.Bottom,
-              handles: [
-                {
-                  id: `${id}____target____bottom`,
-                  type: 'target',
-                  handleType: 'input',
-                },
-              ],
-              visible: selected || isHovered || isConnecting,
-            },
-            {
-              position: Position.Bottom,
-              handles: [
-                {
-                  id: `${id}____source____bottom`,
-                  type: 'source',
-                  handleType: 'output',
-                },
-              ],
-              visible: selected || isHovered || isConnecting,
-            },
-          ],
-    [isException, id, selected, isHovered, isConnecting]
-  );
+  // Handle groups come straight from `caseManagementStageManifest` (ids included,
+  // per the unified flow schema); the runtime contributes only hover visibility
+  // and the header-aligned notch offsets. Edges must reference the manifest handle
+  // ids (`input` / `next` / `reentry`); edges saved with the legacy instance-scoped
+  // ids must be migrated to the manifest ids to keep rendering.
+  const handleConfigurations: HandleGroupManifest[] = useMemo(() => {
+    if (isException) return [];
+
+    const visible = selected || isHovered || isConnecting;
+    return (caseManagementStageManifest.handleConfiguration ?? []).map((group) => ({
+      ...group,
+      visible,
+      customPositionAndOffsets:
+        group.position === Position.Left || group.position === Position.Right
+          ? { top: 0, height: HANDLE_LANE_HEIGHT }
+          : undefined,
+    }));
+  }, [isException, selected, isHovered, isConnecting]);
 
   const handleElements = useButtonHandles({
     handleConfigurations,
     shouldShowHandles,
     nodeId: id,
     selected,
+    hovered: isHovered,
+    showAddButton: !isReadOnly,
+    handleAction: onHandleAction,
+    handleMouseEnter: onHandleMouseEnter,
+    handleMouseLeave: onHandleMouseLeave,
   });
 
   return handleElements;


### PR DESCRIPTION
CLAUDE BUG BURN-DOWN

https://claude.ai/code/session_012dGQD9cuKGicUg426htYEy

## Description

Follow-up to [MST-12554](https://uipath.atlassian.net/browse/MST-12554) (add-stage handle on trigger vs. stages is inconsistent), taking the direction from the [Case unified-schema onboarding doc](https://uipath.atlassian.net/wiki/spaces/~5d0b4d163e70300bc9758674/pages/90446398009/Case+Unified+schema+onboarding): the stage node adopts the apollo manifest system rather than PO.Frontend keeping a custom add button.

**What's in here:**

1. **`caseManagementStageManifest` (`uipath.case.stage`)** in `CaseFlow/case-flow.manifest.ts`, per the onboarding doc's stage manifest, adjusted per review:
   - `display.shape: 'container'` (the doc's `'group'` is not a valid `NodeShape`); icon `square-plus`.
   - The doc's top condition handles are omitted (conditions have no manifest or visual display yet); handles are `input` (left target), `next` (right source, `showButton: true`), `reentry` (bottom source).
   - `inputDefinition` mirrors the current stage node data model: `name`, `tasks`, `entryConditions`, `exitConditions`, `slaRules`, `stageType` (`'secondary'` = exception stage, the combined node type).
   - A `case-stage` category is added, which also makes the trigger manifest's existing `allowedTargetCategories: ['case-stage']` constraint resolvable. Category ids follow the ones already landed here (`case-management-trigger`).
2. **`StageNodeHandles` follows the unified flow schema strictly**: handle groups and ids come straight from the manifest (`input`/`next`/`reentry`, same pattern as the trigger's `output`). No instance-scoped id rewriting and no legacy bottom target anchor. Runtime contributes only hover visibility and header-aligned notch offsets.
3. **New optional `StageNode` props** `onHandleAction` / `onHandleMouseEnter` / `onHandleMouseLeave`, threaded to the handles. `onHandleAction` emits the manifest handle id (`next`). The add button renders only when `onHandleAction` is provided, so existing consumers see no change until they opt in.

**Consumer side (PO.Frontend, will be handled in UiPath/PO.Frontend#6373):**
- `Stage.tsx` passes the new callbacks (replacing the custom circular `StageNodeAddNodeButtonComponent`).
- Stage edge generation must emit the manifest handle ids, like it already does for the v24 trigger's `output` handle.
- Pre-unified-schema documents' stage edges (e.g. `"targetHandle": "stage-1____target____bottom"`) need the unified-schema edge migration to render against the new handle ids.

## Testing

- `case-flow.manifest.test.ts`: both manifests parse against `nodeManifestSchema`, categories parse, category cross-references resolve, handle ids unique, only `next` shows the button.
- `StageNode.test.tsx`: add button renders and fires `onHandleAction` with the manifest `next` handle id; hidden without `onHandleAction`, in read-only, and on exception stages; manifest handle ids (`input`/`next`/`reentry`) render. Un-mocked `useButtonHandles` (was stubbed to `null`) and stubbed xyflow's `Handle` so handle rendering is actually exercised.
- Full `apollo-react` suite green locally; `tsc --noEmit` clean; package build passes; Biome lint/format clean.
- New Storybook story `StageNode / Manifest Add Next Stage` showing the opt-in add button.

## Checklist

- [x] Uses tokens/design-system conventions
- [x] TypeScript types included
- [x] Storybook story
- [x] Unit tests
- [ ] Visual regression tests (existing StageNode VR coverage applies; no new variant snapshots added)
- [x] No linting errors


[MST-12554]: https://uipath.atlassian.net/browse/MST-12554?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ