### PR TITLE
Add node alignment hinting

### DIFF
--- a/packages/apollo-react/src/canvas/components/AlignmentGuides/AlignmentGuides.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/AlignmentGuides/AlignmentGuides.stories.tsx
@@ -1,13 +1,13 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import type { Edge, Node, OnNodeDrag } from '@uipath/apollo-react/canvas/xyflow/react';
-import { Panel, useViewport } from '@uipath/apollo-react/canvas/xyflow/react';
+import { BackgroundVariant, Panel, useViewport } from '@uipath/apollo-react/canvas/xyflow/react';
 import { useCallback, useMemo, useState } from 'react';
 import { createNode, StoryInfoPanel, useCanvasStory, withCanvasProviders } from '../../storybook-utils';
 import { DefaultCanvasTranslations } from '../../types';
 import { BaseCanvas } from '../BaseCanvas';
 import type { BaseNodeData } from '../BaseNode/BaseNode.types';
 import { CanvasPositionControls } from '../CanvasPositionControls';
-import type { AlignmentGuideLine } from './AlignmentGuides.types';
+import type { AlignmentGuideLine, NodeBounds } from './AlignmentGuides.types';
 import { AlignmentGuidesOverlay } from './AlignmentGuidesOverlay';
 import { computeAlignmentGuides, toBounds, useAlignmentGuides } from './useAlignmentGuides';
 
@@ -545,4 +545,325 @@ function ThresholdPlaygroundDemo() {
 export const ThresholdPlayground: Story = {
   name: 'Variant: Threshold Playground',
   render: () => <ThresholdPlaygroundDemo />,
+};
+
+// ============================================================================
+// Variant: Multi-select Drag. Dragging a multi-selected group compares the
+// group's combined bounding box against the rest of the canvas, not just one
+// node in isolation.
+// ============================================================================
+
+function groupBounds(boundsList: NodeBounds[]): NodeBounds {
+  const x1 = Math.min(...boundsList.map((b) => b.x1));
+  const y1 = Math.min(...boundsList.map((b) => b.y1));
+  const x2 = Math.max(...boundsList.map((b) => b.x2));
+  const y2 = Math.max(...boundsList.map((b) => b.y2));
+  return { id: '__group__', x1, y1, x2, y2, cx: (x1 + x2) / 2, cy: (y1 + y2) / 2 };
+}
+
+function GroupBoundsOverlay({ bounds }: { bounds: NodeBounds | null }) {
+  const { x: viewportX, y: viewportY, zoom } = useViewport();
+
+  if (!bounds) return null;
+
+  return (
+    <div
+      className="pointer-events-none absolute rounded-md border border-dashed"
+      style={{
+        left: bounds.x1 * zoom + viewportX - 8,
+        top: bounds.y1 * zoom + viewportY - 8,
+        width: (bounds.x2 - bounds.x1) * zoom + 16,
+        height: (bounds.y2 - bounds.y1) * zoom + 16,
+        borderColor: 'var(--canvas-selection-indicator)',
+      }}
+    />
+  );
+}
+
+function useMultiSelectAlignmentGuides(nodes: Node[], thresholdPx = 8) {
+  const { zoom } = useViewport();
+  const [guides, setGuides] = useState<AlignmentGuideLine[]>([]);
+  const [draggedGroupBounds, setDraggedGroupBounds] = useState<NodeBounds | null>(null);
+
+  const onNodeDrag = useCallback<OnNodeDrag>(
+    (_event, _node, draggedNodes) => {
+      const draggedIds = new Set(draggedNodes.map((n) => n.id));
+      const others = nodes.filter((n) => !draggedIds.has(n.id)).map(toBounds);
+      const group = groupBounds(draggedNodes.map(toBounds));
+      setDraggedGroupBounds(group);
+      setGuides(computeAlignmentGuides(group, others, thresholdPx / zoom));
+    },
+    [nodes, thresholdPx, zoom]
+  );
+
+  const onNodeDragStop = useCallback<OnNodeDrag>(() => {
+    setGuides([]);
+    setDraggedGroupBounds(null);
+  }, []);
+
+  return useMemo(
+    () => ({ guides, draggedGroupBounds, onNodeDrag, onNodeDragStop }),
+    [guides, draggedGroupBounds, onNodeDrag, onNodeDragStop]
+  );
+}
+
+function MultiSelectDemo() {
+  const initialNodes = useMemo(() => createWorkflowNodes(), []);
+  const { nodes, canvasProps } = useCanvasStory({ initialNodes, initialEdges: workflowEdges });
+  const { guides, draggedGroupBounds, onNodeDrag, onNodeDragStop } = useMultiSelectAlignmentGuides(nodes);
+
+  return (
+    <BaseCanvas {...canvasProps} mode="design" onNodeDrag={onNodeDrag} onNodeDragStop={onNodeDragStop}>
+      <AlignmentGuidesOverlay guides={guides} />
+      <GroupBoundsOverlay bounds={draggedGroupBounds} />
+      <StoryInfoPanel title="Multi-select drag">
+        <p className="mt-2 max-w-xs text-sm text-muted-foreground">
+          Shift-click multiple nodes (or Shift-drag a selection box over empty canvas), then drag
+          the group. Guides compare the whole selection's bounding box, outlined here, against
+          the rest of the canvas, not just one node in isolation.
+        </p>
+      </StoryInfoPanel>
+      <Panel position="bottom-right">
+        <CanvasPositionControls translations={DefaultCanvasTranslations} />
+      </Panel>
+    </BaseCanvas>
+  );
+}
+
+export const MultiSelectDrag: Story = {
+  name: 'Variant: Multi-select Drag',
+  render: () => <MultiSelectDemo />,
+};
+
+// ============================================================================
+// Variant: Grid-snap Interplay. Node-to-node guides and xyflow's native
+// snapToGrid are independent systems that already compose: grid-snap
+// quantizes the raw drag position, guides just read whatever position
+// results and compare it to the rest of the canvas.
+// ============================================================================
+
+function GridSnapInterplayDemo() {
+  const [gridSnapEnabled, setGridSnapEnabled] = useState(false);
+  const initialNodes = useMemo(() => createWorkflowNodes(), []);
+  const { nodes, canvasProps } = useCanvasStory({ initialNodes, initialEdges: workflowEdges });
+  const { guides, onNodeDrag, onNodeDragStop } = useAlignmentGuides(nodes);
+
+  return (
+    <BaseCanvas
+      {...canvasProps}
+      mode="design"
+      onNodeDrag={onNodeDrag}
+      onNodeDragStop={onNodeDragStop}
+      snapToGrid={gridSnapEnabled}
+      snapGrid={[16, 16]}
+      backgroundVariant={gridSnapEnabled ? BackgroundVariant.Lines : undefined}
+      backgroundGap={16}
+    >
+      <AlignmentGuidesOverlay guides={guides} />
+      <StoryInfoPanel title="Grid-snap interplay">
+        <div className="mt-2 flex max-w-xs flex-col gap-2">
+          <p className="text-sm text-muted-foreground">
+            Grid snap, xyflow's native snapToGrid, and these node-to-node guides are independent
+            of each other. Grid-snap quantizes the raw drag position to 16px, and guides simply
+            compare whatever position results against the rest of the canvas. No special
+            integration code is needed for the two to coexist.
+          </p>
+          <label className="flex items-center gap-2 text-sm">
+            <input
+              type="checkbox"
+              checked={gridSnapEnabled}
+              onChange={(e) => setGridSnapEnabled(e.target.checked)}
+            />
+            Grid snap (16px)
+          </label>
+        </div>
+      </StoryInfoPanel>
+      <Panel position="bottom-right">
+        <CanvasPositionControls translations={DefaultCanvasTranslations} />
+      </Panel>
+    </BaseCanvas>
+  );
+}
+
+export const GridSnapInterplay: Story = {
+  name: 'Variant: Grid-snap Interplay',
+  render: () => <GridSnapInterplayDemo />,
+};
+
+// ============================================================================
+// Variant: Equal-spacing Detection. When the dragged node has a neighbor on
+// each side, roughly aligned on the other axis, with matching gaps, both
+// gaps are highlighted with a shared label. Limited to the dragged node's
+// immediate neighbors, not full n-way spacing detection across the canvas.
+// ============================================================================
+
+interface EqualSpacingMatch {
+  orientation: 'horizontal' | 'vertical';
+  gap: number;
+  firstGapStart: number;
+  firstGapEnd: number;
+  secondGapStart: number;
+  secondGapEnd: number;
+  /** Position along the perpendicular axis to draw the indicator at (dragged node's center). */
+  crossPosition: number;
+}
+
+function findEqualSpacing(dragged: NodeBounds, others: NodeBounds[], tolerance: number): EqualSpacingMatch[] {
+  const matches: EqualSpacingMatch[] = [];
+
+  const rowOthers = others.filter((o) => o.y1 < dragged.y2 && o.y2 > dragged.y1);
+  const left = rowOthers.filter((o) => o.x2 <= dragged.x1).sort((a, b) => b.x2 - a.x2)[0];
+  const right = rowOthers.filter((o) => o.x1 >= dragged.x2).sort((a, b) => a.x1 - b.x1)[0];
+  if (left && right) {
+    const leftGap = dragged.x1 - left.x2;
+    const rightGap = right.x1 - dragged.x2;
+    if (leftGap > 0 && rightGap > 0 && Math.abs(leftGap - rightGap) <= tolerance) {
+      matches.push({
+        orientation: 'horizontal',
+        gap: Math.round((leftGap + rightGap) / 2),
+        firstGapStart: left.x2,
+        firstGapEnd: dragged.x1,
+        secondGapStart: dragged.x2,
+        secondGapEnd: right.x1,
+        crossPosition: dragged.cy,
+      });
+    }
+  }
+
+  const columnOthers = others.filter((o) => o.x1 < dragged.x2 && o.x2 > dragged.x1);
+  const above = columnOthers.filter((o) => o.y2 <= dragged.y1).sort((a, b) => b.y2 - a.y2)[0];
+  const below = columnOthers.filter((o) => o.y1 >= dragged.y2).sort((a, b) => a.y1 - b.y1)[0];
+  if (above && below) {
+    const aboveGap = dragged.y1 - above.y2;
+    const belowGap = below.y1 - dragged.y2;
+    if (aboveGap > 0 && belowGap > 0 && Math.abs(aboveGap - belowGap) <= tolerance) {
+      matches.push({
+        orientation: 'vertical',
+        gap: Math.round((aboveGap + belowGap) / 2),
+        firstGapStart: above.y2,
+        firstGapEnd: dragged.y1,
+        secondGapStart: dragged.y2,
+        secondGapEnd: below.y1,
+        crossPosition: dragged.cx,
+      });
+    }
+  }
+
+  return matches;
+}
+
+function EqualSpacingOverlay({ matches }: { matches: EqualSpacingMatch[] }) {
+  const { x: viewportX, y: viewportY, zoom } = useViewport();
+
+  if (matches.length === 0) return null;
+
+  return (
+    <div className="pointer-events-none absolute inset-0 z-40 overflow-hidden">
+      {matches.map((match) => {
+        const isHorizontal = match.orientation === 'horizontal';
+        const barStyle = (start: number, end: number) =>
+          isHorizontal
+            ? {
+                top: match.crossPosition * zoom + viewportY - 1,
+                left: start * zoom + viewportX,
+                width: (end - start) * zoom,
+                height: 2,
+              }
+            : {
+                left: match.crossPosition * zoom + viewportX - 1,
+                top: start * zoom + viewportY,
+                width: 2,
+                height: (end - start) * zoom,
+              };
+        const labelStyle = isHorizontal
+          ? {
+              top: match.crossPosition * zoom + viewportY - 20,
+              left: ((match.firstGapEnd + match.secondGapStart) / 2) * zoom + viewportX - 20,
+            }
+          : {
+              left: match.crossPosition * zoom + viewportX + 6,
+              top: ((match.firstGapEnd + match.secondGapStart) / 2) * zoom + viewportY - 10,
+            };
+
+        return (
+          <div key={match.orientation}>
+            <div
+              className="absolute rounded-full bg-[var(--canvas-warning-icon)]"
+              style={barStyle(match.firstGapStart, match.firstGapEnd)}
+            />
+            <div
+              className="absolute rounded-full bg-[var(--canvas-warning-icon)]"
+              style={barStyle(match.secondGapStart, match.secondGapEnd)}
+            />
+            <div
+              className="absolute rounded bg-[var(--canvas-warning-icon)] px-1.5 py-0.5 text-[10px] font-medium text-[var(--canvas-foreground-inverse)]"
+              style={labelStyle}
+            >
+              {match.gap}px equal
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function useEqualSpacing(nodes: Node[], draggedNodeId: string | null, thresholdPx = 8): EqualSpacingMatch[] {
+  const { zoom } = useViewport();
+
+  return useMemo(() => {
+    if (!draggedNodeId) return [];
+    const draggedNode = nodes.find((n) => n.id === draggedNodeId);
+    if (!draggedNode) return [];
+    const dragged = toBounds(draggedNode);
+    const others = nodes.filter((n) => n.id !== draggedNodeId).map(toBounds);
+    return findEqualSpacing(dragged, others, thresholdPx / zoom);
+  }, [nodes, draggedNodeId, thresholdPx, zoom]);
+}
+
+function EqualSpacingDemo() {
+  const initialNodes = useMemo(() => createWorkflowNodes(), []);
+  const { nodes, canvasProps } = useCanvasStory({ initialNodes, initialEdges: workflowEdges });
+  const [draggedNodeId, setDraggedNodeId] = useState<string | null>(null);
+  const { guides, onNodeDrag: baseOnNodeDrag, onNodeDragStop: baseOnNodeDragStop } = useAlignmentGuides(nodes);
+  const equalSpacingMatches = useEqualSpacing(nodes, draggedNodeId);
+
+  const onNodeDrag = useCallback<OnNodeDrag>(
+    (event, node, draggedNodes) => {
+      setDraggedNodeId(node.id);
+      baseOnNodeDrag(event, node, draggedNodes);
+    },
+    [baseOnNodeDrag]
+  );
+
+  const onNodeDragStop = useCallback<OnNodeDrag>(
+    (event, node, draggedNodes) => {
+      setDraggedNodeId(null);
+      baseOnNodeDragStop(event, node, draggedNodes);
+    },
+    [baseOnNodeDragStop]
+  );
+
+  return (
+    <BaseCanvas {...canvasProps} mode="design" onNodeDrag={onNodeDrag} onNodeDragStop={onNodeDragStop}>
+      <AlignmentGuidesOverlay guides={guides} />
+      <EqualSpacingOverlay matches={equalSpacingMatches} />
+      <StoryInfoPanel title="Equal-spacing detection">
+        <p className="mt-2 max-w-xs text-sm text-muted-foreground">
+          Drag "Route" between the Start/Notify columns. When its gap to the left neighbor
+          matches its gap to the right neighbor within tolerance, both gaps get a highlighted
+          tick and a shared "Npx equal" label, similar to Figma. Limited to the dragged node's
+          immediate left/right or top/bottom neighbor, not full n-way spacing across the canvas.
+        </p>
+      </StoryInfoPanel>
+      <Panel position="bottom-right">
+        <CanvasPositionControls translations={DefaultCanvasTranslations} />
+      </Panel>
+    </BaseCanvas>
+  );
+}
+
+export const EqualSpacingDetection: Story = {
+  name: 'Variant: Equal-spacing Detection',
+  render: () => <EqualSpacingDemo />,
 };

--- a/packages/apollo-react/src/canvas/components/AlignmentGuides/AlignmentGuides.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/AlignmentGuides/AlignmentGuides.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import type { Edge, Node } from '@uipath/apollo-react/canvas/xyflow/react';
-import { Panel } from '@uipath/apollo-react/canvas/xyflow/react';
-import { useMemo } from 'react';
+import type { Edge, Node, OnNodeDrag } from '@uipath/apollo-react/canvas/xyflow/react';
+import { Panel, useViewport } from '@uipath/apollo-react/canvas/xyflow/react';
+import { useCallback, useMemo, useState } from 'react';
 import { createNode, StoryInfoPanel, useCanvasStory, withCanvasProviders } from '../../storybook-utils';
 import { DefaultCanvasTranslations } from '../../types';
 import { BaseCanvas } from '../BaseCanvas';
@@ -9,7 +9,7 @@ import type { BaseNodeData } from '../BaseNode/BaseNode.types';
 import { CanvasPositionControls } from '../CanvasPositionControls';
 import type { AlignmentGuideLine } from './AlignmentGuides.types';
 import { AlignmentGuidesOverlay } from './AlignmentGuidesOverlay';
-import { useAlignmentGuides } from './useAlignmentGuides';
+import { computeAlignmentGuides, toBounds, useAlignmentGuides } from './useAlignmentGuides';
 
 const meta: Meta = {
   title: 'Components/Canvas/AlignmentGuides',
@@ -19,6 +19,11 @@ const meta: Meta = {
 export default meta;
 
 type Story = StoryObj;
+
+// ============================================================================
+// Shared workflow fixture. Every variant below drags nodes on the same layout
+// so the pages are directly comparable.
+// ============================================================================
 
 function createWorkflowNodes(): Node<BaseNodeData>[] {
   return [
@@ -78,20 +83,19 @@ const workflowEdges: Edge[] = [
   { id: 'e-reject-notify', source: 'reject', sourceHandle: 'output', target: 'notify', targetHandle: 'input' },
 ];
 
+// ============================================================================
+// Baseline: dashed lines, edge + center detection, zoom-aware threshold.
+// ============================================================================
+
 function AlignmentGuidesDemo() {
   const initialNodes = useMemo(() => createWorkflowNodes(), []);
   const { nodes, canvasProps } = useCanvasStory({ initialNodes, initialEdges: workflowEdges });
   const { guides, onNodeDrag, onNodeDragStop } = useAlignmentGuides(nodes);
 
   return (
-    <BaseCanvas
-      {...canvasProps}
-      mode="design"
-      onNodeDrag={onNodeDrag}
-      onNodeDragStop={onNodeDragStop}
-    >
+    <BaseCanvas {...canvasProps} mode="design" onNodeDrag={onNodeDrag} onNodeDragStop={onNodeDragStop}>
       <AlignmentGuidesOverlay guides={guides} />
-      <StoryInfoPanel title="Alignment guides">
+      <StoryInfoPanel title="Alignment guides (baseline)">
         <p className="mt-2 max-w-xs text-sm text-muted-foreground">
           Drag any node. Dashed guide lines appear when its edges or center line up with another
           node's edges or center. Guides are visual only, nothing snaps into place.
@@ -105,16 +109,34 @@ function AlignmentGuidesDemo() {
 }
 
 export const AlignmentGuidesPrototype: Story = {
-  name: 'Alignment Guides',
+  name: 'Alignment Guides (Baseline)',
   render: () => <AlignmentGuidesDemo />,
 };
 
-// Hand-authored guides matching createWorkflowNodes(): a vertical line through the
-// decision/trigger/notify column plus a horizontal line through the top row
-// (fetch/approve), rendered with no drag required so both axes are visible at once.
+// ============================================================================
+// Static preview: hardcoded guides, no drag required. Useful as a fixed
+// reference when comparing screenshots or reviewing async.
+// ============================================================================
+
 const staticGuides: AlignmentGuideLine[] = [
-  { id: 'vertical-620', orientation: 'vertical', position: 620, start: 80, end: 536 },
-  { id: 'horizontal-120', orientation: 'horizontal', position: 120, start: 80, end: 996 },
+  {
+    id: 'vertical-620',
+    orientation: 'vertical',
+    position: 620,
+    start: 80,
+    end: 536,
+    kind: 'edge',
+    matchedNodeIds: ['trigger', 'notify'],
+  },
+  {
+    id: 'horizontal-120',
+    orientation: 'horizontal',
+    position: 120,
+    start: 80,
+    end: 996,
+    kind: 'edge',
+    matchedNodeIds: ['fetch', 'approve'],
+  },
 ];
 
 function StaticGuidesDemo() {
@@ -140,4 +162,387 @@ function StaticGuidesDemo() {
 export const StaticPreview: Story = {
   name: 'Static Guide Preview',
   render: () => <StaticGuidesDemo />,
+};
+
+// ============================================================================
+// Variant: Center vs. Edge Styling. Center-only matches render as a thicker
+// dotted line in a distinct color, so it's clear which kind of match fired.
+// ============================================================================
+
+function CenterVsEdgeOverlay({ guides }: { guides: AlignmentGuideLine[] }) {
+  const { x: viewportX, y: viewportY, zoom } = useViewport();
+
+  if (guides.length === 0) return null;
+
+  return (
+    <div className="pointer-events-none absolute inset-0 z-40 overflow-hidden">
+      {guides.map((guide) => {
+        const isVertical = guide.orientation === 'vertical';
+        const isCenter = guide.kind === 'center';
+        const style = isVertical
+          ? {
+              left: guide.position * zoom + viewportX,
+              top: guide.start * zoom + viewportY,
+              height: (guide.end - guide.start) * zoom,
+            }
+          : {
+              top: guide.position * zoom + viewportY,
+              left: guide.start * zoom + viewportX,
+              width: (guide.end - guide.start) * zoom,
+            };
+        const className = isVertical
+          ? isCenter
+            ? 'absolute border-l-2 border-dotted'
+            : 'absolute border-l border-dashed'
+          : isCenter
+            ? 'absolute border-t-2 border-dotted'
+            : 'absolute border-t border-dashed';
+
+        return (
+          <div
+            key={guide.id}
+            className={className}
+            style={{
+              ...style,
+              borderColor: isCenter ? 'var(--canvas-warning-icon)' : 'var(--canvas-selection-indicator)',
+            }}
+          />
+        );
+      })}
+    </div>
+  );
+}
+
+function CenterVsEdgeDemo() {
+  const initialNodes = useMemo(() => createWorkflowNodes(), []);
+  const { nodes, canvasProps } = useCanvasStory({ initialNodes, initialEdges: workflowEdges });
+  const { guides, onNodeDrag, onNodeDragStop } = useAlignmentGuides(nodes);
+
+  return (
+    <BaseCanvas {...canvasProps} mode="design" onNodeDrag={onNodeDrag} onNodeDragStop={onNodeDragStop}>
+      <CenterVsEdgeOverlay guides={guides} />
+      <StoryInfoPanel title="Center vs. edge styling">
+        <p className="mt-2 max-w-xs text-sm text-muted-foreground">
+          Same detection as the baseline, but a center-to-center match renders as a thicker
+          dotted amber line instead of the default dashed line, so you can tell at a glance
+          whether you're aligned on an edge or a center.
+        </p>
+      </StoryInfoPanel>
+      <Panel position="bottom-right">
+        <CanvasPositionControls translations={DefaultCanvasTranslations} />
+      </Panel>
+    </BaseCanvas>
+  );
+}
+
+export const CenterVsEdgeStyling: Story = {
+  name: 'Variant: Center vs Edge Styling',
+  render: () => <CenterVsEdgeDemo />,
+};
+
+// ============================================================================
+// Variant: Spacing Labels. Shows the gap (in px) between the dragged node
+// and the matched span while a guide is active.
+// ============================================================================
+
+function SpacingLabelsOverlay({
+  guides,
+  nodes,
+  draggedNodeId,
+}: {
+  guides: AlignmentGuideLine[];
+  nodes: Node[];
+  draggedNodeId: string | null;
+}) {
+  const { x: viewportX, y: viewportY, zoom } = useViewport();
+  const draggedNode = draggedNodeId ? nodes.find((n) => n.id === draggedNodeId) : undefined;
+
+  if (guides.length === 0 || !draggedNode) return null;
+
+  const dragged = toBounds(draggedNode);
+
+  return (
+    <div className="pointer-events-none absolute inset-0 z-40 overflow-hidden">
+      {guides.map((guide) => {
+        const isVertical = guide.orientation === 'vertical';
+        const lineStyle = isVertical
+          ? {
+              left: guide.position * zoom + viewportX,
+              top: guide.start * zoom + viewportY,
+              height: (guide.end - guide.start) * zoom,
+            }
+          : {
+              top: guide.position * zoom + viewportY,
+              left: guide.start * zoom + viewportX,
+              width: (guide.end - guide.start) * zoom,
+            };
+
+        // Gap between the dragged node and the nearer end of the matched span,
+        // a simplification of "distance to nearest object", not full equal-spacing detection.
+        const gapFlow = isVertical
+          ? Math.min(Math.abs(dragged.y1 - guide.start), Math.abs(guide.end - dragged.y2))
+          : Math.min(Math.abs(dragged.x1 - guide.start), Math.abs(guide.end - dragged.x2));
+        const gapPx = Math.round(gapFlow * zoom);
+
+        const labelStyle = isVertical
+          ? {
+              left: guide.position * zoom + viewportX + 6,
+              top: (guide.start + (guide.end - guide.start) / 2) * zoom + viewportY - 10,
+            }
+          : {
+              top: guide.position * zoom + viewportY - 20,
+              left: guide.start * zoom + viewportX + ((guide.end - guide.start) * zoom) / 2 - 16,
+            };
+
+        return (
+          <div key={guide.id}>
+            <div
+              className={isVertical ? 'absolute border-l border-dashed' : 'absolute border-t border-dashed'}
+              style={{ ...lineStyle, borderColor: 'var(--canvas-selection-indicator)' }}
+            />
+            <div
+              className="absolute rounded bg-[var(--canvas-selection-indicator)] px-1.5 py-0.5 text-[10px] font-medium text-[var(--canvas-foreground-inverse)]"
+              style={labelStyle}
+            >
+              {gapPx}px
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function SpacingLabelsDemo() {
+  const initialNodes = useMemo(() => createWorkflowNodes(), []);
+  const { nodes, canvasProps } = useCanvasStory({ initialNodes, initialEdges: workflowEdges });
+  const [draggedNodeId, setDraggedNodeId] = useState<string | null>(null);
+  const { guides, onNodeDrag: baseOnNodeDrag, onNodeDragStop: baseOnNodeDragStop } = useAlignmentGuides(nodes);
+
+  const onNodeDrag = useCallback<OnNodeDrag>(
+    (event, node, draggedNodes) => {
+      setDraggedNodeId(node.id);
+      baseOnNodeDrag(event, node, draggedNodes);
+    },
+    [baseOnNodeDrag]
+  );
+
+  const onNodeDragStop = useCallback<OnNodeDrag>(
+    (event, node, draggedNodes) => {
+      setDraggedNodeId(null);
+      baseOnNodeDragStop(event, node, draggedNodes);
+    },
+    [baseOnNodeDragStop]
+  );
+
+  return (
+    <BaseCanvas {...canvasProps} mode="design" onNodeDrag={onNodeDrag} onNodeDragStop={onNodeDragStop}>
+      <SpacingLabelsOverlay guides={guides} nodes={nodes} draggedNodeId={draggedNodeId} />
+      <StoryInfoPanel title="Spacing labels">
+        <p className="mt-2 max-w-xs text-sm text-muted-foreground">
+          Shows the gap in px between the dragged node and the matched span while a guide is
+          active. A fuller "equal spacing between 3+ nodes" indicator, like Figma's tick marks,
+          is a natural next step but isn't built here yet.
+        </p>
+      </StoryInfoPanel>
+      <Panel position="bottom-right">
+        <CanvasPositionControls translations={DefaultCanvasTranslations} />
+      </Panel>
+    </BaseCanvas>
+  );
+}
+
+export const SpacingLabels: Story = {
+  name: 'Variant: Spacing Labels',
+  render: () => <SpacingLabelsDemo />,
+};
+
+// ============================================================================
+// Variant: Highlighted Match. The guide line plus a ring highlight around
+// every node the line is actually aligned with.
+// ============================================================================
+
+function HighlightedMatchOverlay({ guides, nodes }: { guides: AlignmentGuideLine[]; nodes: Node[] }) {
+  const { x: viewportX, y: viewportY, zoom } = useViewport();
+  const matchedIds = useMemo(() => new Set(guides.flatMap((g) => g.matchedNodeIds)), [guides]);
+
+  if (guides.length === 0) return null;
+
+  return (
+    <>
+      <AlignmentGuidesOverlay guides={guides} />
+      <div className="pointer-events-none absolute inset-0 z-30 overflow-hidden">
+        {nodes
+          .filter((n) => matchedIds.has(n.id))
+          .map((n) => {
+            const bounds = toBounds(n);
+            return (
+              <div
+                key={n.id}
+                className="absolute rounded-md ring-2 ring-[var(--canvas-selection-indicator)]"
+                style={{
+                  left: bounds.x1 * zoom + viewportX - 4,
+                  top: bounds.y1 * zoom + viewportY - 4,
+                  width: (bounds.x2 - bounds.x1) * zoom + 8,
+                  height: (bounds.y2 - bounds.y1) * zoom + 8,
+                }}
+              />
+            );
+          })}
+      </div>
+    </>
+  );
+}
+
+function HighlightedMatchDemo() {
+  const initialNodes = useMemo(() => createWorkflowNodes(), []);
+  const { nodes, canvasProps } = useCanvasStory({ initialNodes, initialEdges: workflowEdges });
+  const { guides, onNodeDrag, onNodeDragStop } = useAlignmentGuides(nodes);
+
+  return (
+    <BaseCanvas {...canvasProps} mode="design" onNodeDrag={onNodeDrag} onNodeDragStop={onNodeDragStop}>
+      <HighlightedMatchOverlay guides={guides} nodes={nodes} />
+      <StoryInfoPanel title="Highlighted match">
+        <p className="mt-2 max-w-xs text-sm text-muted-foreground">
+          In addition to the guide line, the specific node(s) you're aligned with get a subtle
+          ring highlight, useful once there are many nodes and it's not obvious at a glance
+          which one a line is relative to.
+        </p>
+      </StoryInfoPanel>
+      <Panel position="bottom-right">
+        <CanvasPositionControls translations={DefaultCanvasTranslations} />
+      </Panel>
+    </BaseCanvas>
+  );
+}
+
+export const HighlightedMatch: Story = {
+  name: 'Variant: Highlighted Match',
+  render: () => <HighlightedMatchDemo />,
+};
+
+// ============================================================================
+// Variant: Magnetic Snap. Same detection, but the dragged node's position
+// snaps onto the matched edge/center instead of only drawing a line.
+// ============================================================================
+
+function useMagneticSnap(
+  nodes: Node[],
+  setNodes: React.Dispatch<React.SetStateAction<Node[]>>,
+  thresholdPx = 8
+) {
+  const { zoom } = useViewport();
+  const [guides, setGuides] = useState<AlignmentGuideLine[]>([]);
+
+  const onNodeDrag = useCallback<OnNodeDrag>(
+    (_event, draggedNode) => {
+      const threshold = thresholdPx / zoom;
+      const dragged = toBounds(draggedNode);
+      const others = nodes.filter((n) => n.id !== draggedNode.id).map(toBounds);
+      const computed = computeAlignmentGuides(dragged, others, threshold);
+      setGuides(computed);
+
+      const vGuide = computed.find((g) => g.orientation === 'vertical');
+      const hGuide = computed.find((g) => g.orientation === 'horizontal');
+      if (!vGuide && !hGuide) return;
+
+      const snapDelta = (guide: AlignmentGuideLine | undefined, values: number[]) => {
+        if (!guide) return 0;
+        const closest = values.reduce((a, b) =>
+          Math.abs(b - guide.position) < Math.abs(a - guide.position) ? b : a
+        );
+        return guide.position - closest;
+      };
+
+      const dx = snapDelta(vGuide, [dragged.x1, dragged.cx, dragged.x2]);
+      const dy = snapDelta(hGuide, [dragged.y1, dragged.cy, dragged.y2]);
+      if (dx === 0 && dy === 0) return;
+
+      setNodes((nds) =>
+        nds.map((n) =>
+          n.id === draggedNode.id
+            ? { ...n, position: { x: n.position.x + dx, y: n.position.y + dy } }
+            : n
+        )
+      );
+    },
+    [nodes, setNodes, thresholdPx, zoom]
+  );
+
+  const onNodeDragStop = useCallback<OnNodeDrag>(() => setGuides([]), []);
+
+  return useMemo(() => ({ guides, onNodeDrag, onNodeDragStop }), [guides, onNodeDrag, onNodeDragStop]);
+}
+
+function MagneticSnapDemo() {
+  const initialNodes = useMemo(() => createWorkflowNodes(), []);
+  const { nodes, setNodes, canvasProps } = useCanvasStory({ initialNodes, initialEdges: workflowEdges });
+  const { guides, onNodeDrag, onNodeDragStop } = useMagneticSnap(nodes, setNodes);
+
+  return (
+    <BaseCanvas {...canvasProps} mode="design" onNodeDrag={onNodeDrag} onNodeDragStop={onNodeDragStop}>
+      <AlignmentGuidesOverlay guides={guides} />
+      <StoryInfoPanel title="Magnetic snap">
+        <p className="mt-2 max-w-xs text-sm text-muted-foreground">
+          Same detection as the baseline, but once within range the node's position snaps
+          exactly onto the aligned edge or center instead of only showing a line. Trade-off:
+          less control over sub-pixel placement, and it can fight slightly with the raw mouse
+          position while dragging.
+        </p>
+      </StoryInfoPanel>
+      <Panel position="bottom-right">
+        <CanvasPositionControls translations={DefaultCanvasTranslations} />
+      </Panel>
+    </BaseCanvas>
+  );
+}
+
+export const MagneticSnap: Story = {
+  name: 'Variant: Magnetic Snap',
+  render: () => <MagneticSnapDemo />,
+};
+
+// ============================================================================
+// Variant: Threshold Playground. Tune the match distance live to compare
+// how forgiving or precise the guides feel.
+// ============================================================================
+
+function ThresholdPlaygroundDemo() {
+  const [thresholdPx, setThresholdPx] = useState(8);
+  const initialNodes = useMemo(() => createWorkflowNodes(), []);
+  const { nodes, canvasProps } = useCanvasStory({ initialNodes, initialEdges: workflowEdges });
+  const { guides, onNodeDrag, onNodeDragStop } = useAlignmentGuides(nodes, { thresholdPx });
+
+  return (
+    <BaseCanvas {...canvasProps} mode="design" onNodeDrag={onNodeDrag} onNodeDragStop={onNodeDragStop}>
+      <AlignmentGuidesOverlay guides={guides} />
+      <StoryInfoPanel title="Threshold playground">
+        <div className="mt-2 flex max-w-xs flex-col gap-2">
+          <p className="text-sm text-muted-foreground">
+            Tune the match distance live to compare how forgiving or precise the guides feel at
+            different zoom levels.
+          </p>
+          <label className="flex items-center gap-2 text-sm">
+            <span className="w-14 shrink-0">{thresholdPx}px</span>
+            <input
+              type="range"
+              min={2}
+              max={32}
+              value={thresholdPx}
+              onChange={(e) => setThresholdPx(Number(e.target.value))}
+              className="w-full"
+            />
+          </label>
+        </div>
+      </StoryInfoPanel>
+      <Panel position="bottom-right">
+        <CanvasPositionControls translations={DefaultCanvasTranslations} />
+      </Panel>
+    </BaseCanvas>
+  );
+}
+
+export const ThresholdPlayground: Story = {
+  name: 'Variant: Threshold Playground',
+  render: () => <ThresholdPlaygroundDemo />,
 };

--- a/packages/apollo-react/src/canvas/components/AlignmentGuides/AlignmentGuides.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/AlignmentGuides/AlignmentGuides.stories.tsx
@@ -1,0 +1,109 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import type { Edge, Node } from '@uipath/apollo-react/canvas/xyflow/react';
+import { Panel } from '@uipath/apollo-react/canvas/xyflow/react';
+import { useMemo } from 'react';
+import { createNode, StoryInfoPanel, useCanvasStory, withCanvasProviders } from '../../storybook-utils';
+import { DefaultCanvasTranslations } from '../../types';
+import { BaseCanvas } from '../BaseCanvas';
+import type { BaseNodeData } from '../BaseNode/BaseNode.types';
+import { CanvasPositionControls } from '../CanvasPositionControls';
+import { AlignmentGuidesOverlay } from './AlignmentGuidesOverlay';
+import { useAlignmentGuides } from './useAlignmentGuides';
+
+const meta: Meta = {
+  title: 'Templates/Canvas Alignment Guides',
+  decorators: [withCanvasProviders()],
+  parameters: { layout: 'fullscreen' },
+};
+export default meta;
+
+type Story = StoryObj;
+
+function createWorkflowNodes(): Node<BaseNodeData>[] {
+  return [
+    createNode({
+      id: 'trigger',
+      type: 'uipath.manual-trigger',
+      position: { x: 80, y: 280 },
+      display: { label: 'Start', subLabel: 'Manual trigger', icon: 'play' },
+    }),
+    createNode({
+      id: 'fetch',
+      type: 'uipath.blank-node',
+      position: { x: 340, y: 120 },
+      display: { label: 'Fetch Data', subLabel: 'HTTP request', icon: 'cloud-download' },
+    }),
+    createNode({
+      id: 'validate',
+      type: 'uipath.blank-node',
+      position: { x: 340, y: 440 },
+      display: { label: 'Validate', subLabel: 'Schema check', icon: 'shield-check' },
+    }),
+    createNode({
+      id: 'decision',
+      type: 'uipath.blank-node',
+      position: { x: 620, y: 280 },
+      display: { label: 'Route', subLabel: 'Decision', icon: 'git-branch' },
+    }),
+    createNode({
+      id: 'approve',
+      type: 'uipath.blank-node',
+      position: { x: 900, y: 120 },
+      display: { label: 'Approve', subLabel: 'Human review', icon: 'user-check' },
+    }),
+    createNode({
+      id: 'reject',
+      type: 'uipath.blank-node',
+      position: { x: 900, y: 440 },
+      display: { label: 'Reject', subLabel: 'Auto reject', icon: 'x-circle' },
+    }),
+    createNode({
+      id: 'notify',
+      type: 'uipath.blank-node',
+      position: { x: 1180, y: 280 },
+      display: { label: 'Notify', subLabel: 'Send email', icon: 'mail' },
+    }),
+  ];
+}
+
+const workflowEdges: Edge[] = [
+  { id: 'e-trigger-fetch', source: 'trigger', sourceHandle: 'output', target: 'fetch', targetHandle: 'input' },
+  { id: 'e-trigger-validate', source: 'trigger', sourceHandle: 'output', target: 'validate', targetHandle: 'input' },
+  { id: 'e-fetch-decision', source: 'fetch', sourceHandle: 'output', target: 'decision', targetHandle: 'input' },
+  { id: 'e-validate-decision', source: 'validate', sourceHandle: 'output', target: 'decision', targetHandle: 'input' },
+  { id: 'e-decision-approve', source: 'decision', sourceHandle: 'output', target: 'approve', targetHandle: 'input' },
+  { id: 'e-decision-reject', source: 'decision', sourceHandle: 'output', target: 'reject', targetHandle: 'input' },
+  { id: 'e-approve-notify', source: 'approve', sourceHandle: 'output', target: 'notify', targetHandle: 'input' },
+  { id: 'e-reject-notify', source: 'reject', sourceHandle: 'output', target: 'notify', targetHandle: 'input' },
+];
+
+function AlignmentGuidesDemo() {
+  const initialNodes = useMemo(() => createWorkflowNodes(), []);
+  const { nodes, canvasProps } = useCanvasStory({ initialNodes, initialEdges: workflowEdges });
+  const { guides, onNodeDrag, onNodeDragStop } = useAlignmentGuides(nodes);
+
+  return (
+    <BaseCanvas
+      {...canvasProps}
+      mode="design"
+      onNodeDrag={onNodeDrag}
+      onNodeDragStop={onNodeDragStop}
+    >
+      <AlignmentGuidesOverlay guides={guides} />
+      <StoryInfoPanel title="Alignment guides">
+        <p className="mt-2 max-w-xs text-sm text-muted-foreground">
+          Drag any node. Dashed guide lines appear when its edges or center line up with another
+          node's edges or center. Guides are visual only, nothing snaps into place.
+        </p>
+      </StoryInfoPanel>
+      <Panel position="bottom-right">
+        <CanvasPositionControls translations={DefaultCanvasTranslations} />
+      </Panel>
+    </BaseCanvas>
+  );
+}
+
+export const AlignmentGuidesPrototype: Story = {
+  name: 'Alignment Guides',
+  render: () => <AlignmentGuidesDemo />,
+};

--- a/packages/apollo-react/src/canvas/components/AlignmentGuides/AlignmentGuides.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/AlignmentGuides/AlignmentGuides.stories.tsx
@@ -7,11 +7,12 @@ import { DefaultCanvasTranslations } from '../../types';
 import { BaseCanvas } from '../BaseCanvas';
 import type { BaseNodeData } from '../BaseNode/BaseNode.types';
 import { CanvasPositionControls } from '../CanvasPositionControls';
+import type { AlignmentGuideLine } from './AlignmentGuides.types';
 import { AlignmentGuidesOverlay } from './AlignmentGuidesOverlay';
 import { useAlignmentGuides } from './useAlignmentGuides';
 
 const meta: Meta = {
-  title: 'Templates/Canvas Alignment Guides',
+  title: 'Components/Canvas/AlignmentGuides',
   decorators: [withCanvasProviders()],
   parameters: { layout: 'fullscreen' },
 };
@@ -106,4 +107,37 @@ function AlignmentGuidesDemo() {
 export const AlignmentGuidesPrototype: Story = {
   name: 'Alignment Guides',
   render: () => <AlignmentGuidesDemo />,
+};
+
+// Hand-authored guides matching createWorkflowNodes(): a vertical line through the
+// decision/trigger/notify column plus a horizontal line through the top row
+// (fetch/approve), rendered with no drag required so both axes are visible at once.
+const staticGuides: AlignmentGuideLine[] = [
+  { id: 'vertical-620', orientation: 'vertical', position: 620, start: 80, end: 536 },
+  { id: 'horizontal-120', orientation: 'horizontal', position: 120, start: 80, end: 996 },
+];
+
+function StaticGuidesDemo() {
+  const initialNodes = useMemo(() => createWorkflowNodes(), []);
+  const { canvasProps } = useCanvasStory({ initialNodes, initialEdges: workflowEdges });
+
+  return (
+    <BaseCanvas {...canvasProps} mode="view">
+      <AlignmentGuidesOverlay guides={staticGuides} />
+      <StoryInfoPanel title="Static guide preview">
+        <p className="mt-2 max-w-xs text-sm text-muted-foreground">
+          Hardcoded guide lines (no drag required) for visual QA of both the vertical and
+          horizontal line styles at once.
+        </p>
+      </StoryInfoPanel>
+      <Panel position="bottom-right">
+        <CanvasPositionControls translations={DefaultCanvasTranslations} />
+      </Panel>
+    </BaseCanvas>
+  );
+}
+
+export const StaticPreview: Story = {
+  name: 'Static Guide Preview',
+  render: () => <StaticGuidesDemo />,
 };

--- a/packages/apollo-react/src/canvas/components/AlignmentGuides/AlignmentGuides.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/AlignmentGuides/AlignmentGuides.stories.tsx
@@ -1,15 +1,22 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import type { Edge, Node, OnNodeDrag } from '@uipath/apollo-react/canvas/xyflow/react';
-import { BackgroundVariant, Panel, useViewport } from '@uipath/apollo-react/canvas/xyflow/react';
-import { type ReactNode, useCallback, useMemo, useState } from 'react';
+import type { Edge, Node } from '@uipath/apollo-react/canvas/xyflow/react';
+import { BackgroundVariant, Panel } from '@uipath/apollo-react/canvas/xyflow/react';
+import {
+  type Dispatch,
+  type ReactNode,
+  type SetStateAction,
+  useCallback,
+  useMemo,
+  useState,
+} from 'react';
 import { createNode, StoryInfoPanel, useCanvasStory, withCanvasProviders } from '../../storybook-utils';
 import { DefaultCanvasTranslations } from '../../types';
 import { BaseCanvas } from '../BaseCanvas';
 import type { BaseNodeData } from '../BaseNode/BaseNode.types';
 import { CanvasPositionControls } from '../CanvasPositionControls';
-import type { AlignmentGuideLine, NodeBounds } from './AlignmentGuides.types';
 import { AlignmentGuidesOverlay } from './AlignmentGuidesOverlay';
-import { computeAlignmentGuides, toBounds, useAlignmentGuides } from './useAlignmentGuides';
+import type { AlignmentPositionUpdate } from './useAlignmentGuides';
+import { useAlignmentGuides } from './useAlignmentGuides';
 
 const meta: Meta = {
   title: 'Components/Canvas/AlignmentGuides',
@@ -19,6 +26,21 @@ const meta: Meta = {
 export default meta;
 
 type Story = StoryObj;
+
+function useApplyAlignmentSnap(setNodes: Dispatch<SetStateAction<Node[]>>) {
+  return useCallback(
+    (updates: AlignmentPositionUpdate[]) => {
+      const positions = new Map(updates.map(({ id, position }) => [id, position]));
+      setNodes((currentNodes) =>
+        currentNodes.map((node) => {
+          const position = positions.get(node.id);
+          return position ? { ...node, position } : node;
+        })
+      );
+    },
+    [setNodes]
+  );
+}
 
 function GuidanceCard({
   title,
@@ -57,68 +79,20 @@ function AlignmentGuidesUxGuidance() {
           </p>
           <h2 className="mt-2 text-2xl font-semibold">On by default. Hidden until dragging.</h2>
           <p className="mt-3 text-sm leading-6 text-muted-foreground">
-            Guides appear only while a node is being dragged near a meaningful alignment, then
-            disappear immediately when the drag ends. This makes the capability naturally
-            discoverable without adding permanent canvas UI.
+            Guides appear only while one node or a multi-selection is dragged near a meaningful
+            alignment. The same winning candidate draws the guide and applies the exact snapped
+            position, then all temporary feedback disappears when the drag ends.
           </p>
         </section>
 
         <section className="mb-10">
-          <h2 className="mb-2 text-xl font-semibold">Design review map</h2>
-          <p className="mb-4 text-sm leading-6 text-muted-foreground">
-            Use the colored markers in the Storybook sidebar to keep the discussion focused.
-          </p>
-          <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
-            {[
-              {
-                marker: '🟢',
-                label: 'Must review',
-                stories: 'Baseline, Threshold Playground, Grid-snap Interplay',
-                prompt: 'A decision is needed for the initial experience.',
-              },
-              {
-                marker: '🔵',
-                label: 'Validate',
-                stories: 'Center vs Edge Styling, Highlighted Match, Multi-select Drag',
-                prompt: 'Confirm whether these match current workflow needs.',
-              },
-              {
-                marker: '🟠',
-                label: 'Nice to have',
-                stories: 'Spacing Labels, Magnetic Snap, Equal-spacing Detection',
-                prompt: 'Useful future directions; no decision is required now.',
-              },
-              {
-                marker: '⚪',
-                label: 'Reference',
-                stories: 'Static Guide Preview',
-                prompt: 'Visual QA reference rather than a product decision.',
-              },
-            ].map(({ marker, label, stories, prompt }) => (
-              <div key={label} className="rounded-xl border border-border bg-card p-4">
-                <div className="flex items-center gap-2">
-                  <span className="text-base" aria-hidden="true">
-                    {marker}
-                  </span>
-                  <h3 className="text-sm font-semibold text-foreground">{label}</h3>
-                </div>
-                <div>
-                  <p className="mt-0.5 text-sm text-foreground">{stories}</p>
-                  <p className="mt-1 text-xs leading-5 text-muted-foreground">{prompt}</p>
-                </div>
-              </div>
-            ))}
-          </div>
-        </section>
-
-        <section className="mb-10">
-          <h2 className="mb-4 text-xl font-semibold">Recommended rollout</h2>
+          <h2 className="mb-4 text-xl font-semibold">Reviewed behavior</h2>
           <ol className="grid gap-3">
             {[
-              'Ship contextual alignment guides on by default with conservative thresholds and minimal visuals.',
-              'Observe whether guides help placement without distracting from common drag tasks.',
-              'Tune match priority, visual weight, and flicker prevention from real usage.',
-              'Introduce a preference only when evidence shows that user control is necessary.',
+              'Use restrained, contextual guide lines with a conservative zoom-aware threshold.',
+              'Snap to the exact edge or center represented by the visible guide.',
+              'Treat a multi-selection as one rigid group and preserve its internal layout.',
+              'Apply grid positioning first, then alignment as the final node-to-node correction.',
             ].map((item, index) => (
               <li key={item} className="flex gap-4 rounded-xl border border-border bg-card p-4">
                 <span className="flex size-7 shrink-0 items-center justify-center rounded-full bg-muted text-xs font-semibold">
@@ -137,17 +111,17 @@ function AlignmentGuidesUxGuidance() {
               Render guides only during an active drag and only inside a small, zoom-aware match
               threshold. Nothing remains on the canvas afterward.
             </GuidanceCard>
-            <GuidanceCard title="Helpful, not forceful">
-              The baseline guides communicate alignment without moving the node. If magnetic
-              snapping is added, it should be subtle and easy to override.
+            <GuidanceCard title="One visible promise">
+              The guide and magnetic placement use the same resolved candidate. A node always
+              finishes exactly where the line indicated.
             </GuidanceCard>
-            <GuidanceCard title="Minimal, not noisy">
-              Prefer the smallest useful set of guide lines. Avoid showing every possible match,
-              and reserve labels for spacing information that changes the user's decision.
+            <GuidanceCard title="Group-aware">
+              Multi-selected nodes move as one rigid shape. The group boundary communicates what
+              is moving, while one shared delta preserves spacing between selected nodes.
             </GuidanceCard>
             <GuidanceCard title="Stable, not flickery">
-              Apply a consistent threshold and match priority so nearby candidates do not cause
-              lines or labels to jump rapidly during a drag.
+              Prefer the closest eligible match with deterministic center and edge priorities,
+              then commit it again on release to prevent final-position drift.
             </GuidanceCard>
           </div>
         </section>
@@ -180,8 +154,8 @@ function AlignmentGuidesUxGuidance() {
                 <tr>
                   <td className="px-5 py-4 font-medium text-foreground">Mental model</td>
                   <td className="px-5 py-4 text-muted-foreground">
-                    “Tidy up” performs an explicit layout action; alignment guides are passive
-                    feedback. They should not be grouped as equivalent modes.
+                    Alignment guides improve placement during dragging. “Tidy up” and align-selection
+                    commands intentionally rearrange existing layouts and remain separate actions.
                   </td>
                 </tr>
               </tbody>
@@ -189,9 +163,8 @@ function AlignmentGuidesUxGuidance() {
           </div>
           <p className="mt-4 text-sm leading-6 text-muted-foreground">
             Add a saved preference only if user research or product feedback shows that a
-            meaningful group finds the default experience distracting. An advanced modifier key
-            can later expose richer spacing detail or temporarily suppress snapping without
-            making the basic feature harder to discover.
+            meaningful group finds the default experience distracting. A modifier key can later
+            temporarily suppress snapping without making the basic feature harder to discover.
           </p>
         </section>
 
@@ -264,498 +237,18 @@ const workflowEdges: Edge[] = [
 ];
 
 // ============================================================================
-// Baseline: dashed lines, edge + center detection, zoom-aware threshold.
+// Canonical behavior: restrained guides and exact magnetic placement share one
+// resolver, with zoom-aware thresholds and multi-selection support.
 // ============================================================================
 
 function AlignmentGuidesDemo() {
   const initialNodes = useMemo(() => createWorkflowNodes(), []);
-  const { nodes, canvasProps } = useCanvasStory({ initialNodes, initialEdges: workflowEdges });
-  const { guides, onNodeDrag, onNodeDragStop } = useAlignmentGuides(nodes);
-
-  return (
-    <BaseCanvas {...canvasProps} mode="design" onNodeDrag={onNodeDrag} onNodeDragStop={onNodeDragStop}>
-      <AlignmentGuidesOverlay guides={guides} />
-      <StoryInfoPanel title="Alignment guides (baseline)">
-        <p className="mt-2 max-w-xs text-sm text-muted-foreground">
-          Drag any node. Dashed guide lines appear when its edges or center line up with another
-          node's edges or center. Guides are visual only, nothing snaps into place.
-        </p>
-      </StoryInfoPanel>
-      <Panel position="bottom-right">
-        <CanvasPositionControls translations={DefaultCanvasTranslations} />
-      </Panel>
-    </BaseCanvas>
-  );
-}
-
-// ============================================================================
-// Static preview: hardcoded guides, no drag required. Useful as a fixed
-// reference when comparing screenshots or reviewing async.
-// ============================================================================
-
-const staticGuides: AlignmentGuideLine[] = [
-  {
-    id: 'vertical-620',
-    orientation: 'vertical',
-    position: 620,
-    start: 80,
-    end: 536,
-    kind: 'edge',
-    matchedNodeIds: ['trigger', 'notify'],
-  },
-  {
-    id: 'horizontal-120',
-    orientation: 'horizontal',
-    position: 120,
-    start: 80,
-    end: 996,
-    kind: 'edge',
-    matchedNodeIds: ['fetch', 'approve'],
-  },
-];
-
-function StaticGuidesDemo() {
-  const initialNodes = useMemo(() => createWorkflowNodes(), []);
-  const { canvasProps } = useCanvasStory({ initialNodes, initialEdges: workflowEdges });
-
-  return (
-    <BaseCanvas {...canvasProps} mode="view">
-      <AlignmentGuidesOverlay guides={staticGuides} />
-      <StoryInfoPanel title="Static guide preview">
-        <p className="mt-2 max-w-xs text-sm text-muted-foreground">
-          Hardcoded guide lines (no drag required) for visual QA of both the vertical and
-          horizontal line styles at once.
-        </p>
-      </StoryInfoPanel>
-      <Panel position="bottom-right">
-        <CanvasPositionControls translations={DefaultCanvasTranslations} />
-      </Panel>
-    </BaseCanvas>
-  );
-}
-
-// ============================================================================
-// Variant: Center vs. Edge Styling. Center-only matches render as a thicker
-// dotted line in a distinct color, so it's clear which kind of match fired.
-// ============================================================================
-
-function CenterVsEdgeOverlay({ guides }: { guides: AlignmentGuideLine[] }) {
-  const { x: viewportX, y: viewportY, zoom } = useViewport();
-
-  if (guides.length === 0) return null;
-
-  return (
-    <div className="pointer-events-none absolute inset-0 z-40 overflow-hidden">
-      {guides.map((guide) => {
-        const isVertical = guide.orientation === 'vertical';
-        const isCenter = guide.kind === 'center';
-        const style = isVertical
-          ? {
-              left: guide.position * zoom + viewportX,
-              top: guide.start * zoom + viewportY,
-              height: (guide.end - guide.start) * zoom,
-            }
-          : {
-              top: guide.position * zoom + viewportY,
-              left: guide.start * zoom + viewportX,
-              width: (guide.end - guide.start) * zoom,
-            };
-        const className = isVertical
-          ? isCenter
-            ? 'absolute border-l-2 border-dotted'
-            : 'absolute border-l border-dashed'
-          : isCenter
-            ? 'absolute border-t-2 border-dotted'
-            : 'absolute border-t border-dashed';
-
-        return (
-          <div
-            key={guide.id}
-            className={className}
-            style={{
-              ...style,
-              borderColor: isCenter ? 'var(--canvas-warning-icon)' : 'var(--canvas-selection-indicator)',
-            }}
-          />
-        );
-      })}
-    </div>
-  );
-}
-
-function CenterVsEdgeDemo() {
-  const initialNodes = useMemo(() => createWorkflowNodes(), []);
-  const { nodes, canvasProps } = useCanvasStory({ initialNodes, initialEdges: workflowEdges });
-  const { guides, onNodeDrag, onNodeDragStop } = useAlignmentGuides(nodes);
-
-  return (
-    <BaseCanvas {...canvasProps} mode="design" onNodeDrag={onNodeDrag} onNodeDragStop={onNodeDragStop}>
-      <CenterVsEdgeOverlay guides={guides} />
-      <StoryInfoPanel title="Center vs. edge styling">
-        <p className="mt-2 max-w-xs text-sm text-muted-foreground">
-          Same detection as the baseline, but a center-to-center match renders as a thicker
-          dotted amber line instead of the default dashed line, so you can tell at a glance
-          whether you're aligned on an edge or a center.
-        </p>
-      </StoryInfoPanel>
-      <Panel position="bottom-right">
-        <CanvasPositionControls translations={DefaultCanvasTranslations} />
-      </Panel>
-    </BaseCanvas>
-  );
-}
-
-// ============================================================================
-// Variant: Spacing Labels. Shows the gap (in px) between the dragged node
-// and the matched span while a guide is active.
-// ============================================================================
-
-function SpacingLabelsOverlay({
-  guides,
-  nodes,
-  draggedNodeId,
-}: {
-  guides: AlignmentGuideLine[];
-  nodes: Node[];
-  draggedNodeId: string | null;
-}) {
-  const { x: viewportX, y: viewportY, zoom } = useViewport();
-  const draggedNode = draggedNodeId ? nodes.find((n) => n.id === draggedNodeId) : undefined;
-
-  if (guides.length === 0 || !draggedNode) return null;
-
-  const dragged = toBounds(draggedNode);
-
-  return (
-    <div className="pointer-events-none absolute inset-0 z-40 overflow-hidden">
-      {guides.map((guide) => {
-        const isVertical = guide.orientation === 'vertical';
-        const lineStyle = isVertical
-          ? {
-              left: guide.position * zoom + viewportX,
-              top: guide.start * zoom + viewportY,
-              height: (guide.end - guide.start) * zoom,
-            }
-          : {
-              top: guide.position * zoom + viewportY,
-              left: guide.start * zoom + viewportX,
-              width: (guide.end - guide.start) * zoom,
-            };
-
-        // Gap between the dragged node and the nearer end of the matched span,
-        // a simplification of "distance to nearest object", not full equal-spacing detection.
-        const gapFlow = isVertical
-          ? Math.min(Math.abs(dragged.y1 - guide.start), Math.abs(guide.end - dragged.y2))
-          : Math.min(Math.abs(dragged.x1 - guide.start), Math.abs(guide.end - dragged.x2));
-        const gapPx = Math.round(gapFlow * zoom);
-
-        const labelStyle = isVertical
-          ? {
-              left: guide.position * zoom + viewportX + 6,
-              top: (guide.start + (guide.end - guide.start) / 2) * zoom + viewportY - 10,
-            }
-          : {
-              top: guide.position * zoom + viewportY - 20,
-              left: guide.start * zoom + viewportX + ((guide.end - guide.start) * zoom) / 2 - 16,
-            };
-
-        return (
-          <div key={guide.id}>
-            <div
-              className={isVertical ? 'absolute border-l border-dashed' : 'absolute border-t border-dashed'}
-              style={{ ...lineStyle, borderColor: 'var(--canvas-selection-indicator)' }}
-            />
-            <div
-              className="absolute rounded bg-[var(--canvas-selection-indicator)] px-1.5 py-0.5 text-[10px] font-medium text-[var(--canvas-foreground-inverse)]"
-              style={labelStyle}
-            >
-              {gapPx}px
-            </div>
-          </div>
-        );
-      })}
-    </div>
-  );
-}
-
-function SpacingLabelsDemo() {
-  const initialNodes = useMemo(() => createWorkflowNodes(), []);
-  const { nodes, canvasProps } = useCanvasStory({ initialNodes, initialEdges: workflowEdges });
-  const [draggedNodeId, setDraggedNodeId] = useState<string | null>(null);
-  const { guides, onNodeDrag: baseOnNodeDrag, onNodeDragStop: baseOnNodeDragStop } = useAlignmentGuides(nodes);
-
-  const onNodeDrag = useCallback<OnNodeDrag>(
-    (event, node, draggedNodes) => {
-      setDraggedNodeId(node.id);
-      baseOnNodeDrag(event, node, draggedNodes);
-    },
-    [baseOnNodeDrag]
-  );
-
-  const onNodeDragStop = useCallback<OnNodeDrag>(
-    (event, node, draggedNodes) => {
-      setDraggedNodeId(null);
-      baseOnNodeDragStop(event, node, draggedNodes);
-    },
-    [baseOnNodeDragStop]
-  );
-
-  return (
-    <BaseCanvas {...canvasProps} mode="design" onNodeDrag={onNodeDrag} onNodeDragStop={onNodeDragStop}>
-      <SpacingLabelsOverlay guides={guides} nodes={nodes} draggedNodeId={draggedNodeId} />
-      <StoryInfoPanel title="Spacing labels">
-        <p className="mt-2 max-w-xs text-sm text-muted-foreground">
-          Shows the gap in px between the dragged node and the matched span while a guide is
-          active. A fuller "equal spacing between 3+ nodes" indicator, like Figma's tick marks,
-          is a natural next step but isn't built here yet.
-        </p>
-      </StoryInfoPanel>
-      <Panel position="bottom-right">
-        <CanvasPositionControls translations={DefaultCanvasTranslations} />
-      </Panel>
-    </BaseCanvas>
-  );
-}
-
-// ============================================================================
-// Variant: Highlighted Match. The guide line plus a ring highlight around
-// every node the line is actually aligned with.
-// ============================================================================
-
-function HighlightedMatchOverlay({ guides, nodes }: { guides: AlignmentGuideLine[]; nodes: Node[] }) {
-  const { x: viewportX, y: viewportY, zoom } = useViewport();
-  const matchedIds = useMemo(() => new Set(guides.flatMap((g) => g.matchedNodeIds)), [guides]);
-
-  if (guides.length === 0) return null;
-
-  return (
-    <>
-      <AlignmentGuidesOverlay guides={guides} />
-      <div className="pointer-events-none absolute inset-0 z-30 overflow-hidden">
-        {nodes
-          .filter((n) => matchedIds.has(n.id))
-          .map((n) => {
-            const bounds = toBounds(n);
-            return (
-              <div
-                key={n.id}
-                className="absolute rounded-md ring-2 ring-[var(--canvas-selection-indicator)]"
-                style={{
-                  left: bounds.x1 * zoom + viewportX - 4,
-                  top: bounds.y1 * zoom + viewportY - 4,
-                  width: (bounds.x2 - bounds.x1) * zoom + 8,
-                  height: (bounds.y2 - bounds.y1) * zoom + 8,
-                }}
-              />
-            );
-          })}
-      </div>
-    </>
-  );
-}
-
-function HighlightedMatchDemo() {
-  const initialNodes = useMemo(() => createWorkflowNodes(), []);
-  const { nodes, canvasProps } = useCanvasStory({ initialNodes, initialEdges: workflowEdges });
-  const { guides, onNodeDrag, onNodeDragStop } = useAlignmentGuides(nodes);
-
-  return (
-    <BaseCanvas {...canvasProps} mode="design" onNodeDrag={onNodeDrag} onNodeDragStop={onNodeDragStop}>
-      <HighlightedMatchOverlay guides={guides} nodes={nodes} />
-      <StoryInfoPanel title="Highlighted match">
-        <p className="mt-2 max-w-xs text-sm text-muted-foreground">
-          In addition to the guide line, the specific node(s) you're aligned with get a subtle
-          ring highlight, useful once there are many nodes and it's not obvious at a glance
-          which one a line is relative to.
-        </p>
-      </StoryInfoPanel>
-      <Panel position="bottom-right">
-        <CanvasPositionControls translations={DefaultCanvasTranslations} />
-      </Panel>
-    </BaseCanvas>
-  );
-}
-
-// ============================================================================
-// Variant: Magnetic Snap. Same detection, but the dragged node's position
-// snaps onto the matched edge/center instead of only drawing a line.
-// ============================================================================
-
-function useMagneticSnap(
-  nodes: Node[],
-  setNodes: React.Dispatch<React.SetStateAction<Node[]>>,
-  thresholdPx = 8
-) {
-  const { zoom } = useViewport();
-  const [guides, setGuides] = useState<AlignmentGuideLine[]>([]);
-
-  const onNodeDrag = useCallback<OnNodeDrag>(
-    (_event, draggedNode) => {
-      const threshold = thresholdPx / zoom;
-      const dragged = toBounds(draggedNode);
-      const others = nodes.filter((n) => n.id !== draggedNode.id).map(toBounds);
-      const computed = computeAlignmentGuides(dragged, others, threshold);
-      setGuides(computed);
-
-      const vGuide = computed.find((g) => g.orientation === 'vertical');
-      const hGuide = computed.find((g) => g.orientation === 'horizontal');
-      if (!vGuide && !hGuide) return;
-
-      const snapDelta = (guide: AlignmentGuideLine | undefined, values: number[]) => {
-        if (!guide) return 0;
-        const closest = values.reduce((a, b) =>
-          Math.abs(b - guide.position) < Math.abs(a - guide.position) ? b : a
-        );
-        return guide.position - closest;
-      };
-
-      const dx = snapDelta(vGuide, [dragged.x1, dragged.cx, dragged.x2]);
-      const dy = snapDelta(hGuide, [dragged.y1, dragged.cy, dragged.y2]);
-      if (dx === 0 && dy === 0) return;
-
-      setNodes((nds) =>
-        nds.map((n) =>
-          n.id === draggedNode.id
-            ? { ...n, position: { x: n.position.x + dx, y: n.position.y + dy } }
-            : n
-        )
-      );
-    },
-    [nodes, setNodes, thresholdPx, zoom]
-  );
-
-  const onNodeDragStop = useCallback<OnNodeDrag>(() => setGuides([]), []);
-
-  return useMemo(() => ({ guides, onNodeDrag, onNodeDragStop }), [guides, onNodeDrag, onNodeDragStop]);
-}
-
-function MagneticSnapDemo() {
-  const initialNodes = useMemo(() => createWorkflowNodes(), []);
-  const { nodes, setNodes, canvasProps } = useCanvasStory({ initialNodes, initialEdges: workflowEdges });
-  const { guides, onNodeDrag, onNodeDragStop } = useMagneticSnap(nodes, setNodes);
-
-  return (
-    <BaseCanvas {...canvasProps} mode="design" onNodeDrag={onNodeDrag} onNodeDragStop={onNodeDragStop}>
-      <AlignmentGuidesOverlay guides={guides} />
-      <StoryInfoPanel title="Magnetic snap">
-        <p className="mt-2 max-w-xs text-sm text-muted-foreground">
-          Same detection as the baseline, but once within range the node's position snaps
-          exactly onto the aligned edge or center instead of only showing a line. Trade-off:
-          less control over sub-pixel placement, and it can fight slightly with the raw mouse
-          position while dragging.
-        </p>
-      </StoryInfoPanel>
-      <Panel position="bottom-right">
-        <CanvasPositionControls translations={DefaultCanvasTranslations} />
-      </Panel>
-    </BaseCanvas>
-  );
-}
-
-// ============================================================================
-// Variant: Threshold Playground. Tune the match distance live to compare
-// how forgiving or precise the guides feel.
-// ============================================================================
-
-function ThresholdPlaygroundDemo() {
-  const [thresholdPx, setThresholdPx] = useState(8);
-  const initialNodes = useMemo(() => createWorkflowNodes(), []);
-  const { nodes, canvasProps } = useCanvasStory({ initialNodes, initialEdges: workflowEdges });
-  const { guides, onNodeDrag, onNodeDragStop } = useAlignmentGuides(nodes, { thresholdPx });
-
-  return (
-    <BaseCanvas {...canvasProps} mode="design" onNodeDrag={onNodeDrag} onNodeDragStop={onNodeDragStop}>
-      <AlignmentGuidesOverlay guides={guides} />
-      <StoryInfoPanel title="Threshold playground">
-        <div className="mt-2 flex max-w-xs flex-col gap-2">
-          <p className="text-sm text-muted-foreground">
-            Tune the match distance live to compare how forgiving or precise the guides feel at
-            different zoom levels.
-          </p>
-          <label className="flex items-center gap-2 text-sm">
-            <span className="w-14 shrink-0">{thresholdPx}px</span>
-            <input
-              type="range"
-              min={2}
-              max={32}
-              value={thresholdPx}
-              onChange={(e) => setThresholdPx(Number(e.target.value))}
-              className="w-full"
-            />
-          </label>
-        </div>
-      </StoryInfoPanel>
-      <Panel position="bottom-right">
-        <CanvasPositionControls translations={DefaultCanvasTranslations} />
-      </Panel>
-    </BaseCanvas>
-  );
-}
-
-// ============================================================================
-// Variant: Multi-select Drag. Dragging a multi-selected group compares the
-// group's combined bounding box against the rest of the canvas, not just one
-// node in isolation.
-// ============================================================================
-
-function groupBounds(boundsList: NodeBounds[]): NodeBounds {
-  const x1 = Math.min(...boundsList.map((b) => b.x1));
-  const y1 = Math.min(...boundsList.map((b) => b.y1));
-  const x2 = Math.max(...boundsList.map((b) => b.x2));
-  const y2 = Math.max(...boundsList.map((b) => b.y2));
-  return { id: '__group__', x1, y1, x2, y2, cx: (x1 + x2) / 2, cy: (y1 + y2) / 2 };
-}
-
-function GroupBoundsOverlay({ bounds }: { bounds: NodeBounds | null }) {
-  const { x: viewportX, y: viewportY, zoom } = useViewport();
-
-  if (!bounds) return null;
-
-  return (
-    <div
-      className="pointer-events-none absolute rounded-md border border-dashed"
-      style={{
-        left: bounds.x1 * zoom + viewportX - 8,
-        top: bounds.y1 * zoom + viewportY - 8,
-        width: (bounds.x2 - bounds.x1) * zoom + 16,
-        height: (bounds.y2 - bounds.y1) * zoom + 16,
-        borderColor: 'var(--canvas-selection-indicator)',
-      }}
-    />
-  );
-}
-
-function useMultiSelectAlignmentGuides(nodes: Node[], thresholdPx = 8) {
-  const { zoom } = useViewport();
-  const [guides, setGuides] = useState<AlignmentGuideLine[]>([]);
-  const [draggedGroupBounds, setDraggedGroupBounds] = useState<NodeBounds | null>(null);
-
-  const onNodeDrag = useCallback<OnNodeDrag>(
-    (_event, _node, draggedNodes) => {
-      const draggedIds = new Set(draggedNodes.map((n) => n.id));
-      const others = nodes.filter((n) => !draggedIds.has(n.id)).map(toBounds);
-      const group = groupBounds(draggedNodes.map(toBounds));
-      setDraggedGroupBounds(group);
-      setGuides(computeAlignmentGuides(group, others, thresholdPx / zoom));
-    },
-    [nodes, thresholdPx, zoom]
-  );
-
-  const onNodeDragStop = useCallback<OnNodeDrag>(() => {
-    setGuides([]);
-    setDraggedGroupBounds(null);
-  }, []);
-
-  return useMemo(
-    () => ({ guides, draggedGroupBounds, onNodeDrag, onNodeDragStop }),
-    [guides, draggedGroupBounds, onNodeDrag, onNodeDragStop]
-  );
-}
-
-function MultiSelectDemo() {
-  const initialNodes = useMemo(() => createWorkflowNodes(), []);
-  const { nodes, canvasProps } = useCanvasStory({ initialNodes, initialEdges: workflowEdges });
-  const { guides, draggedGroupBounds, onNodeDrag, onNodeDragStop } = useMultiSelectAlignmentGuides(nodes);
+  const { nodes, setNodes, canvasProps } = useCanvasStory({
+    initialNodes,
+    initialEdges: workflowEdges,
+  });
+  const onSnap = useApplyAlignmentSnap(setNodes);
+  const { guides, onNodeDrag, onNodeDragStop } = useAlignmentGuides(nodes, { onSnap });
 
   return (
     <BaseCanvas
@@ -768,12 +261,51 @@ function MultiSelectDemo() {
       onNodeDragStop={onNodeDragStop}
     >
       <AlignmentGuidesOverlay guides={guides} />
-      <GroupBoundsOverlay bounds={draggedGroupBounds} />
+      <StoryInfoPanel title="Alignment guides">
+        <p className="mt-2 max-w-xs text-sm text-muted-foreground">
+          Drag one node or a multi-selection. A restrained guide shows the winning edge or center
+          alignment, and the same candidate applies the exact snapped position on drag and release.
+        </p>
+      </StoryInfoPanel>
+      <Panel position="bottom-right">
+        <CanvasPositionControls translations={DefaultCanvasTranslations} />
+      </Panel>
+    </BaseCanvas>
+  );
+}
+
+// Variant: Multi-select Drag. Dragging a multi-selected group compares the
+// group's combined bounding box against the rest of the canvas, not just one
+// node in isolation.
+// ============================================================================
+
+function MultiSelectDemo() {
+  const initialNodes = useMemo(() => createWorkflowNodes(), []);
+  const { nodes, setNodes, canvasProps } = useCanvasStory({
+    initialNodes,
+    initialEdges: workflowEdges,
+  });
+  const onSnap = useApplyAlignmentSnap(setNodes);
+  const { guides, draggedBounds, onNodeDrag, onNodeDragStop } = useAlignmentGuides(nodes, {
+    onSnap,
+  });
+
+  return (
+    <BaseCanvas
+      {...canvasProps}
+      mode="design"
+      multiSelectionKeyCode="Shift"
+      selectionKeyCode={null}
+      selectionOnDrag
+      onNodeDrag={onNodeDrag}
+      onNodeDragStop={onNodeDragStop}
+    >
+      <AlignmentGuidesOverlay guides={guides} draggedBounds={draggedBounds} />
       <StoryInfoPanel title="Multi-select drag">
         <p className="mt-2 max-w-xs text-sm text-muted-foreground">
           Shift-click multiple nodes, or drag a selection box over empty canvas, then drag the
-          group. Guides compare the whole selection's bounding box, outlined here, against the
-          rest of the canvas, not just one node in isolation.
+          group. Its combined bounds snap against the rest of the canvas, applying one identical
+          delta to every selected node so their internal layout never changes.
         </p>
       </StoryInfoPanel>
       <Panel position="bottom-right">
@@ -793,8 +325,12 @@ function MultiSelectDemo() {
 function GridSnapInterplayDemo() {
   const [gridSnapEnabled, setGridSnapEnabled] = useState(false);
   const initialNodes = useMemo(() => createWorkflowNodes(), []);
-  const { nodes, canvasProps } = useCanvasStory({ initialNodes, initialEdges: workflowEdges });
-  const { guides, onNodeDrag, onNodeDragStop } = useAlignmentGuides(nodes);
+  const { nodes, setNodes, canvasProps } = useCanvasStory({
+    initialNodes,
+    initialEdges: workflowEdges,
+  });
+  const onSnap = useApplyAlignmentSnap(setNodes);
+  const { guides, onNodeDrag, onNodeDragStop } = useAlignmentGuides(nodes, { onSnap });
 
   return (
     <BaseCanvas
@@ -811,10 +347,11 @@ function GridSnapInterplayDemo() {
       <StoryInfoPanel title="Grid-snap interplay">
         <div className="mt-2 flex max-w-xs flex-col gap-2">
           <p className="text-sm text-muted-foreground">
-            Grid snap, xyflow's native snapToGrid, and these node-to-node guides are independent
-            of each other. Grid-snap quantizes the raw drag position to 16px, and guides simply
-            compare whatever position results against the rest of the canvas. No special
-            integration code is needed for the two to coexist.
+            Grid snap keeps every node on consistent 16px canvas increments, but it does not by
+            itself guarantee that two node handles or centers align. Alignment guides detect the
+            relationship between nodes, while magnetic snap can apply the exact aligned position.
+            Keep this story to ensure grid positioning and node-to-node alignment compose without
+            fighting each other.
           </p>
           <label className="flex items-center gap-2 text-sm">
             <input
@@ -833,179 +370,6 @@ function GridSnapInterplayDemo() {
   );
 }
 
-// ============================================================================
-// Variant: Equal-spacing Detection. When the dragged node has a neighbor on
-// each side, roughly aligned on the other axis, with matching gaps, both
-// gaps are highlighted with a shared label. Limited to the dragged node's
-// immediate neighbors, not full n-way spacing detection across the canvas.
-// ============================================================================
-
-interface EqualSpacingMatch {
-  orientation: 'horizontal' | 'vertical';
-  gap: number;
-  firstGapStart: number;
-  firstGapEnd: number;
-  secondGapStart: number;
-  secondGapEnd: number;
-  /** Position along the perpendicular axis to draw the indicator at (dragged node's center). */
-  crossPosition: number;
-}
-
-function findEqualSpacing(dragged: NodeBounds, others: NodeBounds[], tolerance: number): EqualSpacingMatch[] {
-  const matches: EqualSpacingMatch[] = [];
-
-  const rowOthers = others.filter((o) => o.y1 < dragged.y2 && o.y2 > dragged.y1);
-  const left = rowOthers.filter((o) => o.x2 <= dragged.x1).sort((a, b) => b.x2 - a.x2)[0];
-  const right = rowOthers.filter((o) => o.x1 >= dragged.x2).sort((a, b) => a.x1 - b.x1)[0];
-  if (left && right) {
-    const leftGap = dragged.x1 - left.x2;
-    const rightGap = right.x1 - dragged.x2;
-    if (leftGap > 0 && rightGap > 0 && Math.abs(leftGap - rightGap) <= tolerance) {
-      matches.push({
-        orientation: 'horizontal',
-        gap: Math.round((leftGap + rightGap) / 2),
-        firstGapStart: left.x2,
-        firstGapEnd: dragged.x1,
-        secondGapStart: dragged.x2,
-        secondGapEnd: right.x1,
-        crossPosition: dragged.cy,
-      });
-    }
-  }
-
-  const columnOthers = others.filter((o) => o.x1 < dragged.x2 && o.x2 > dragged.x1);
-  const above = columnOthers.filter((o) => o.y2 <= dragged.y1).sort((a, b) => b.y2 - a.y2)[0];
-  const below = columnOthers.filter((o) => o.y1 >= dragged.y2).sort((a, b) => a.y1 - b.y1)[0];
-  if (above && below) {
-    const aboveGap = dragged.y1 - above.y2;
-    const belowGap = below.y1 - dragged.y2;
-    if (aboveGap > 0 && belowGap > 0 && Math.abs(aboveGap - belowGap) <= tolerance) {
-      matches.push({
-        orientation: 'vertical',
-        gap: Math.round((aboveGap + belowGap) / 2),
-        firstGapStart: above.y2,
-        firstGapEnd: dragged.y1,
-        secondGapStart: dragged.y2,
-        secondGapEnd: below.y1,
-        crossPosition: dragged.cx,
-      });
-    }
-  }
-
-  return matches;
-}
-
-function EqualSpacingOverlay({ matches }: { matches: EqualSpacingMatch[] }) {
-  const { x: viewportX, y: viewportY, zoom } = useViewport();
-
-  if (matches.length === 0) return null;
-
-  return (
-    <div className="pointer-events-none absolute inset-0 z-40 overflow-hidden">
-      {matches.map((match) => {
-        const isHorizontal = match.orientation === 'horizontal';
-        const barStyle = (start: number, end: number) =>
-          isHorizontal
-            ? {
-                top: match.crossPosition * zoom + viewportY - 1,
-                left: start * zoom + viewportX,
-                width: (end - start) * zoom,
-                height: 2,
-              }
-            : {
-                left: match.crossPosition * zoom + viewportX - 1,
-                top: start * zoom + viewportY,
-                width: 2,
-                height: (end - start) * zoom,
-              };
-        const labelStyle = isHorizontal
-          ? {
-              top: match.crossPosition * zoom + viewportY - 20,
-              left: ((match.firstGapEnd + match.secondGapStart) / 2) * zoom + viewportX - 20,
-            }
-          : {
-              left: match.crossPosition * zoom + viewportX + 6,
-              top: ((match.firstGapEnd + match.secondGapStart) / 2) * zoom + viewportY - 10,
-            };
-
-        return (
-          <div key={match.orientation}>
-            <div
-              className="absolute rounded-full bg-[var(--canvas-warning-icon)]"
-              style={barStyle(match.firstGapStart, match.firstGapEnd)}
-            />
-            <div
-              className="absolute rounded-full bg-[var(--canvas-warning-icon)]"
-              style={barStyle(match.secondGapStart, match.secondGapEnd)}
-            />
-            <div
-              className="absolute rounded bg-[var(--canvas-warning-icon)] px-1.5 py-0.5 text-[10px] font-medium text-[var(--canvas-foreground-inverse)]"
-              style={labelStyle}
-            >
-              {match.gap}px equal
-            </div>
-          </div>
-        );
-      })}
-    </div>
-  );
-}
-
-function useEqualSpacing(nodes: Node[], draggedNodeId: string | null, thresholdPx = 8): EqualSpacingMatch[] {
-  const { zoom } = useViewport();
-
-  return useMemo(() => {
-    if (!draggedNodeId) return [];
-    const draggedNode = nodes.find((n) => n.id === draggedNodeId);
-    if (!draggedNode) return [];
-    const dragged = toBounds(draggedNode);
-    const others = nodes.filter((n) => n.id !== draggedNodeId).map(toBounds);
-    return findEqualSpacing(dragged, others, thresholdPx / zoom);
-  }, [nodes, draggedNodeId, thresholdPx, zoom]);
-}
-
-function EqualSpacingDemo() {
-  const initialNodes = useMemo(() => createWorkflowNodes(), []);
-  const { nodes, canvasProps } = useCanvasStory({ initialNodes, initialEdges: workflowEdges });
-  const [draggedNodeId, setDraggedNodeId] = useState<string | null>(null);
-  const { guides, onNodeDrag: baseOnNodeDrag, onNodeDragStop: baseOnNodeDragStop } = useAlignmentGuides(nodes);
-  const equalSpacingMatches = useEqualSpacing(nodes, draggedNodeId);
-
-  const onNodeDrag = useCallback<OnNodeDrag>(
-    (event, node, draggedNodes) => {
-      setDraggedNodeId(node.id);
-      baseOnNodeDrag(event, node, draggedNodes);
-    },
-    [baseOnNodeDrag]
-  );
-
-  const onNodeDragStop = useCallback<OnNodeDrag>(
-    (event, node, draggedNodes) => {
-      setDraggedNodeId(null);
-      baseOnNodeDragStop(event, node, draggedNodes);
-    },
-    [baseOnNodeDragStop]
-  );
-
-  return (
-    <BaseCanvas {...canvasProps} mode="design" onNodeDrag={onNodeDrag} onNodeDragStop={onNodeDragStop}>
-      <AlignmentGuidesOverlay guides={guides} />
-      <EqualSpacingOverlay matches={equalSpacingMatches} />
-      <StoryInfoPanel title="Equal-spacing detection">
-        <p className="mt-2 max-w-xs text-sm text-muted-foreground">
-          Drag "Route" between the Start/Notify columns. When its gap to the left neighbor
-          matches its gap to the right neighbor within tolerance, both gaps get a highlighted
-          tick and a shared "Npx equal" label, similar to Figma. Limited to the dragged node's
-          immediate left/right or top/bottom neighbor, not full n-way spacing across the canvas.
-        </p>
-      </StoryInfoPanel>
-      <Panel position="bottom-right">
-        <CanvasPositionControls translations={DefaultCanvasTranslations} />
-      </Panel>
-    </BaseCanvas>
-  );
-}
-
 // Keep exports in review order. Storybook preserves CSF export order in the sidebar.
 export const UxGuidance: Story = {
   name: 'UX Guidance',
@@ -1013,51 +377,16 @@ export const UxGuidance: Story = {
 };
 
 export const AlignmentGuidesPrototype: Story = {
-  name: '🟢 Alignment Guides (Baseline)',
+  name: 'Alignment Guides',
   render: () => <AlignmentGuidesDemo />,
 };
 
-export const ThresholdPlayground: Story = {
-  name: '🟢 Threshold Playground',
-  render: () => <ThresholdPlaygroundDemo />,
-};
-
 export const GridSnapInterplay: Story = {
-  name: '🟢 Grid-snap Interplay',
+  name: 'Grid-snap Interplay',
   render: () => <GridSnapInterplayDemo />,
 };
 
-export const CenterVsEdgeStyling: Story = {
-  name: '🔵 Center vs Edge Styling',
-  render: () => <CenterVsEdgeDemo />,
-};
-
-export const HighlightedMatch: Story = {
-  name: '🔵 Highlighted Match',
-  render: () => <HighlightedMatchDemo />,
-};
-
 export const MultiSelectDrag: Story = {
-  name: '🔵 Multi-select Drag',
+  name: 'Multi-select Drag',
   render: () => <MultiSelectDemo />,
-};
-
-export const SpacingLabels: Story = {
-  name: '🟠 Spacing Labels',
-  render: () => <SpacingLabelsDemo />,
-};
-
-export const MagneticSnap: Story = {
-  name: '🟠 Magnetic Snap',
-  render: () => <MagneticSnapDemo />,
-};
-
-export const EqualSpacingDetection: Story = {
-  name: '🟠 Equal-spacing Detection',
-  render: () => <EqualSpacingDemo />,
-};
-
-export const StaticPreview: Story = {
-  name: '⚪ Static Guide Preview',
-  render: () => <StaticGuidesDemo />,
 };

--- a/packages/apollo-react/src/canvas/components/AlignmentGuides/AlignmentGuides.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/AlignmentGuides/AlignmentGuides.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import type { Edge, Node, OnNodeDrag } from '@uipath/apollo-react/canvas/xyflow/react';
 import { BackgroundVariant, Panel, useViewport } from '@uipath/apollo-react/canvas/xyflow/react';
-import { useCallback, useMemo, useState } from 'react';
+import { type ReactNode, useCallback, useMemo, useState } from 'react';
 import { createNode, StoryInfoPanel, useCanvasStory, withCanvasProviders } from '../../storybook-utils';
 import { DefaultCanvasTranslations } from '../../types';
 import { BaseCanvas } from '../BaseCanvas';
@@ -19,6 +19,186 @@ const meta: Meta = {
 export default meta;
 
 type Story = StoryObj;
+
+function GuidanceCard({
+  title,
+  children,
+}: {
+  title: string;
+  children: ReactNode;
+}) {
+  return (
+    <div className="rounded-xl border border-border bg-card p-5">
+      <h3 className="text-base font-semibold text-foreground">{title}</h3>
+      <div className="mt-2 text-sm leading-6 text-muted-foreground">{children}</div>
+    </div>
+  );
+}
+
+function AlignmentGuidesUxGuidance() {
+  return (
+    <div className="min-h-screen bg-background text-foreground">
+      <main className="mx-auto max-w-4xl px-8 py-14">
+        <div className="mb-12">
+          <p className="mb-3 text-xs font-semibold uppercase tracking-widest text-muted-foreground">
+            UX guidance
+          </p>
+          <h1 className="text-4xl font-bold tracking-tight">Alignment guides</h1>
+          <p className="mt-4 max-w-3xl text-lg leading-8 text-muted-foreground">
+            Alignment guides should be available by default, but visible only at the moment they
+            are useful. The experience should feel like quiet, contextual feedback—not a mode the
+            user has to find, configure, or remember.
+          </p>
+        </div>
+
+        <section className="mb-10 rounded-xl border border-border bg-card p-6">
+          <p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+            Recommendation
+          </p>
+          <h2 className="mt-2 text-2xl font-semibold">On by default. Hidden until dragging.</h2>
+          <p className="mt-3 text-sm leading-6 text-muted-foreground">
+            Guides appear only while a node is being dragged near a meaningful alignment, then
+            disappear immediately when the drag ends. This makes the capability naturally
+            discoverable without adding permanent canvas UI.
+          </p>
+        </section>
+
+        <section className="mb-10">
+          <h2 className="mb-2 text-xl font-semibold">Design review map</h2>
+          <p className="mb-4 text-sm leading-6 text-muted-foreground">
+            Use the colored markers in the Storybook sidebar to keep the discussion focused.
+          </p>
+          <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+            {[
+              {
+                marker: '🟢',
+                label: 'Must review',
+                stories: 'Baseline, Threshold Playground, Grid-snap Interplay',
+                prompt: 'A decision is needed for the initial experience.',
+              },
+              {
+                marker: '🔵',
+                label: 'Validate',
+                stories: 'Center vs Edge Styling, Highlighted Match, Multi-select Drag',
+                prompt: 'Confirm whether these match current workflow needs.',
+              },
+              {
+                marker: '🟠',
+                label: 'Nice to have',
+                stories: 'Spacing Labels, Magnetic Snap, Equal-spacing Detection',
+                prompt: 'Useful future directions; no decision is required now.',
+              },
+              {
+                marker: '⚪',
+                label: 'Reference',
+                stories: 'Static Guide Preview',
+                prompt: 'Visual QA reference rather than a product decision.',
+              },
+            ].map(({ marker, label, stories, prompt }) => (
+              <div key={label} className="rounded-xl border border-border bg-card p-4">
+                <div className="flex items-center gap-2">
+                  <span className="text-base" aria-hidden="true">
+                    {marker}
+                  </span>
+                  <h3 className="text-sm font-semibold text-foreground">{label}</h3>
+                </div>
+                <div>
+                  <p className="mt-0.5 text-sm text-foreground">{stories}</p>
+                  <p className="mt-1 text-xs leading-5 text-muted-foreground">{prompt}</p>
+                </div>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <section className="mb-10">
+          <h2 className="mb-4 text-xl font-semibold">Recommended rollout</h2>
+          <ol className="grid gap-3">
+            {[
+              'Ship contextual alignment guides on by default with conservative thresholds and minimal visuals.',
+              'Observe whether guides help placement without distracting from common drag tasks.',
+              'Tune match priority, visual weight, and flicker prevention from real usage.',
+              'Introduce a preference only when evidence shows that user control is necessary.',
+            ].map((item, index) => (
+              <li key={item} className="flex gap-4 rounded-xl border border-border bg-card p-4">
+                <span className="flex size-7 shrink-0 items-center justify-center rounded-full bg-muted text-xs font-semibold">
+                  {index + 1}
+                </span>
+                <p className="pt-0.5 text-sm leading-6 text-muted-foreground">{item}</p>
+              </li>
+            ))}
+          </ol>
+        </section>
+
+        <section className="mb-10">
+          <h2 className="mb-4 text-xl font-semibold">Interaction principles</h2>
+          <div className="grid gap-4 sm:grid-cols-2">
+            <GuidanceCard title="Contextual, not persistent">
+              Render guides only during an active drag and only inside a small, zoom-aware match
+              threshold. Nothing remains on the canvas afterward.
+            </GuidanceCard>
+            <GuidanceCard title="Helpful, not forceful">
+              The baseline guides communicate alignment without moving the node. If magnetic
+              snapping is added, it should be subtle and easy to override.
+            </GuidanceCard>
+            <GuidanceCard title="Minimal, not noisy">
+              Prefer the smallest useful set of guide lines. Avoid showing every possible match,
+              and reserve labels for spacing information that changes the user's decision.
+            </GuidanceCard>
+            <GuidanceCard title="Stable, not flickery">
+              Apply a consistent threshold and match priority so nearby candidates do not cause
+              lines or labels to jump rapidly during a drag.
+            </GuidanceCard>
+          </div>
+        </section>
+
+        <section className="mb-10">
+          <h2 className="mb-4 text-xl font-semibold">Why not add a canvas toggle?</h2>
+          <div className="overflow-hidden rounded-xl border border-border">
+            <table className="w-full text-left text-sm">
+              <thead className="bg-muted/50 text-xs uppercase tracking-wide text-muted-foreground">
+                <tr>
+                  <th className="px-5 py-3 font-medium">Consideration</th>
+                  <th className="px-5 py-3 font-medium">UX impact</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-border bg-card">
+                <tr>
+                  <td className="px-5 py-4 font-medium text-foreground">Discoverability</td>
+                  <td className="px-5 py-4 text-muted-foreground">
+                    Users who would benefit may never know to enable a feature they have not yet
+                    experienced.
+                  </td>
+                </tr>
+                <tr>
+                  <td className="px-5 py-4 font-medium text-foreground">Canvas simplicity</td>
+                  <td className="px-5 py-4 text-muted-foreground">
+                    A persistent control adds weight to the canvas for feedback that appears only
+                    during a temporary interaction.
+                  </td>
+                </tr>
+                <tr>
+                  <td className="px-5 py-4 font-medium text-foreground">Mental model</td>
+                  <td className="px-5 py-4 text-muted-foreground">
+                    “Tidy up” performs an explicit layout action; alignment guides are passive
+                    feedback. They should not be grouped as equivalent modes.
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+          <p className="mt-4 text-sm leading-6 text-muted-foreground">
+            Add a saved preference only if user research or product feedback shows that a
+            meaningful group finds the default experience distracting. An advanced modifier key
+            can later expose richer spacing detail or temporarily suppress snapping without
+            making the basic feature harder to discover.
+          </p>
+        </section>
+
+      </main>
+    </div>
+  );
+}
 
 // ============================================================================
 // Shared workflow fixture. Every variant below drags nodes on the same layout
@@ -108,11 +288,6 @@ function AlignmentGuidesDemo() {
   );
 }
 
-export const AlignmentGuidesPrototype: Story = {
-  name: 'Alignment Guides (Baseline)',
-  render: () => <AlignmentGuidesDemo />,
-};
-
 // ============================================================================
 // Static preview: hardcoded guides, no drag required. Useful as a fixed
 // reference when comparing screenshots or reviewing async.
@@ -158,11 +333,6 @@ function StaticGuidesDemo() {
     </BaseCanvas>
   );
 }
-
-export const StaticPreview: Story = {
-  name: 'Static Guide Preview',
-  render: () => <StaticGuidesDemo />,
-};
 
 // ============================================================================
 // Variant: Center vs. Edge Styling. Center-only matches render as a thicker
@@ -234,11 +404,6 @@ function CenterVsEdgeDemo() {
     </BaseCanvas>
   );
 }
-
-export const CenterVsEdgeStyling: Story = {
-  name: 'Variant: Center vs Edge Styling',
-  render: () => <CenterVsEdgeDemo />,
-};
 
 // ============================================================================
 // Variant: Spacing Labels. Shows the gap (in px) between the dragged node
@@ -352,11 +517,6 @@ function SpacingLabelsDemo() {
   );
 }
 
-export const SpacingLabels: Story = {
-  name: 'Variant: Spacing Labels',
-  render: () => <SpacingLabelsDemo />,
-};
-
 // ============================================================================
 // Variant: Highlighted Match. The guide line plus a ring highlight around
 // every node the line is actually aligned with.
@@ -415,11 +575,6 @@ function HighlightedMatchDemo() {
     </BaseCanvas>
   );
 }
-
-export const HighlightedMatch: Story = {
-  name: 'Variant: Highlighted Match',
-  render: () => <HighlightedMatchDemo />,
-};
 
 // ============================================================================
 // Variant: Magnetic Snap. Same detection, but the dragged node's position
@@ -497,11 +652,6 @@ function MagneticSnapDemo() {
   );
 }
 
-export const MagneticSnap: Story = {
-  name: 'Variant: Magnetic Snap',
-  render: () => <MagneticSnapDemo />,
-};
-
 // ============================================================================
 // Variant: Threshold Playground. Tune the match distance live to compare
 // how forgiving or precise the guides feel.
@@ -541,11 +691,6 @@ function ThresholdPlaygroundDemo() {
     </BaseCanvas>
   );
 }
-
-export const ThresholdPlayground: Story = {
-  name: 'Variant: Threshold Playground',
-  render: () => <ThresholdPlaygroundDemo />,
-};
 
 // ============================================================================
 // Variant: Multi-select Drag. Dragging a multi-selected group compares the
@@ -613,14 +758,22 @@ function MultiSelectDemo() {
   const { guides, draggedGroupBounds, onNodeDrag, onNodeDragStop } = useMultiSelectAlignmentGuides(nodes);
 
   return (
-    <BaseCanvas {...canvasProps} mode="design" onNodeDrag={onNodeDrag} onNodeDragStop={onNodeDragStop}>
+    <BaseCanvas
+      {...canvasProps}
+      mode="design"
+      multiSelectionKeyCode="Shift"
+      selectionKeyCode={null}
+      selectionOnDrag
+      onNodeDrag={onNodeDrag}
+      onNodeDragStop={onNodeDragStop}
+    >
       <AlignmentGuidesOverlay guides={guides} />
       <GroupBoundsOverlay bounds={draggedGroupBounds} />
       <StoryInfoPanel title="Multi-select drag">
         <p className="mt-2 max-w-xs text-sm text-muted-foreground">
-          Shift-click multiple nodes (or Shift-drag a selection box over empty canvas), then drag
-          the group. Guides compare the whole selection's bounding box, outlined here, against
-          the rest of the canvas, not just one node in isolation.
+          Shift-click multiple nodes, or drag a selection box over empty canvas, then drag the
+          group. Guides compare the whole selection's bounding box, outlined here, against the
+          rest of the canvas, not just one node in isolation.
         </p>
       </StoryInfoPanel>
       <Panel position="bottom-right">
@@ -629,11 +782,6 @@ function MultiSelectDemo() {
     </BaseCanvas>
   );
 }
-
-export const MultiSelectDrag: Story = {
-  name: 'Variant: Multi-select Drag',
-  render: () => <MultiSelectDemo />,
-};
 
 // ============================================================================
 // Variant: Grid-snap Interplay. Node-to-node guides and xyflow's native
@@ -684,11 +832,6 @@ function GridSnapInterplayDemo() {
     </BaseCanvas>
   );
 }
-
-export const GridSnapInterplay: Story = {
-  name: 'Variant: Grid-snap Interplay',
-  render: () => <GridSnapInterplayDemo />,
-};
 
 // ============================================================================
 // Variant: Equal-spacing Detection. When the dragged node has a neighbor on
@@ -863,7 +1006,58 @@ function EqualSpacingDemo() {
   );
 }
 
+// Keep exports in review order. Storybook preserves CSF export order in the sidebar.
+export const UxGuidance: Story = {
+  name: 'UX Guidance',
+  render: () => <AlignmentGuidesUxGuidance />,
+};
+
+export const AlignmentGuidesPrototype: Story = {
+  name: '🟢 Alignment Guides (Baseline)',
+  render: () => <AlignmentGuidesDemo />,
+};
+
+export const ThresholdPlayground: Story = {
+  name: '🟢 Threshold Playground',
+  render: () => <ThresholdPlaygroundDemo />,
+};
+
+export const GridSnapInterplay: Story = {
+  name: '🟢 Grid-snap Interplay',
+  render: () => <GridSnapInterplayDemo />,
+};
+
+export const CenterVsEdgeStyling: Story = {
+  name: '🔵 Center vs Edge Styling',
+  render: () => <CenterVsEdgeDemo />,
+};
+
+export const HighlightedMatch: Story = {
+  name: '🔵 Highlighted Match',
+  render: () => <HighlightedMatchDemo />,
+};
+
+export const MultiSelectDrag: Story = {
+  name: '🔵 Multi-select Drag',
+  render: () => <MultiSelectDemo />,
+};
+
+export const SpacingLabels: Story = {
+  name: '🟠 Spacing Labels',
+  render: () => <SpacingLabelsDemo />,
+};
+
+export const MagneticSnap: Story = {
+  name: '🟠 Magnetic Snap',
+  render: () => <MagneticSnapDemo />,
+};
+
 export const EqualSpacingDetection: Story = {
-  name: 'Variant: Equal-spacing Detection',
+  name: '🟠 Equal-spacing Detection',
   render: () => <EqualSpacingDemo />,
+};
+
+export const StaticPreview: Story = {
+  name: '⚪ Static Guide Preview',
+  render: () => <StaticGuidesDemo />,
 };

--- a/packages/apollo-react/src/canvas/components/AlignmentGuides/AlignmentGuides.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/AlignmentGuides/AlignmentGuides.stories.tsx
@@ -9,7 +9,12 @@ import {
   useMemo,
   useState,
 } from 'react';
-import { createNode, StoryInfoPanel, useCanvasStory, withCanvasProviders } from '../../storybook-utils';
+import {
+  createNode,
+  StoryInfoPanel,
+  useCanvasStory,
+  withCanvasProviders,
+} from '../../storybook-utils';
 import { DefaultCanvasTranslations } from '../../types';
 import { BaseCanvas } from '../BaseCanvas';
 import type { BaseNodeData } from '../BaseNode/BaseNode.types';
@@ -42,13 +47,7 @@ function useApplyAlignmentSnap(setNodes: Dispatch<SetStateAction<Node[]>>) {
   );
 }
 
-function GuidanceCard({
-  title,
-  children,
-}: {
-  title: string;
-  children: ReactNode;
-}) {
+function GuidanceCard({ title, children }: { title: string; children: ReactNode }) {
   return (
     <div className="rounded-xl border border-border bg-card p-5">
       <h3 className="text-base font-semibold text-foreground">{title}</h3>
@@ -67,9 +66,9 @@ function AlignmentGuidesUxGuidance() {
           </p>
           <h1 className="text-4xl font-bold tracking-tight">Alignment guides</h1>
           <p className="mt-4 max-w-3xl text-lg leading-8 text-muted-foreground">
-            Alignment guides should be available by default, but visible only at the moment they
-            are useful. The experience should feel like quiet, contextual feedback—not a mode the
-            user has to find, configure, or remember.
+            Alignment guides should be available by default, but visible only at the moment they are
+            useful. The experience should feel like quiet, contextual feedback—not a mode the user
+            has to find, configure, or remember.
           </p>
         </div>
 
@@ -116,12 +115,12 @@ function AlignmentGuidesUxGuidance() {
               finishes exactly where the line indicated.
             </GuidanceCard>
             <GuidanceCard title="Group-aware">
-              Multi-selected nodes move as one rigid shape. The group boundary communicates what
-              is moving, while one shared delta preserves spacing between selected nodes.
+              Multi-selected nodes move as one rigid shape. The group boundary communicates what is
+              moving, while one shared delta preserves spacing between selected nodes.
             </GuidanceCard>
             <GuidanceCard title="Stable, not flickery">
-              Prefer the closest eligible match with deterministic center and edge priorities,
-              then commit it again on release to prevent final-position drift.
+              Prefer the closest eligible match with deterministic center and edge priorities, then
+              commit it again on release to prevent final-position drift.
             </GuidanceCard>
           </div>
         </section>
@@ -154,20 +153,20 @@ function AlignmentGuidesUxGuidance() {
                 <tr>
                   <td className="px-5 py-4 font-medium text-foreground">Mental model</td>
                   <td className="px-5 py-4 text-muted-foreground">
-                    Alignment guides improve placement during dragging. “Tidy up” and align-selection
-                    commands intentionally rearrange existing layouts and remain separate actions.
+                    Alignment guides improve placement during dragging. “Tidy up” and
+                    align-selection commands intentionally rearrange existing layouts and remain
+                    separate actions.
                   </td>
                 </tr>
               </tbody>
             </table>
           </div>
           <p className="mt-4 text-sm leading-6 text-muted-foreground">
-            Add a saved preference only if user research or product feedback shows that a
-            meaningful group finds the default experience distracting. A modifier key can later
-            temporarily suppress snapping without making the basic feature harder to discover.
+            Add a saved preference only if user research or product feedback shows that a meaningful
+            group finds the default experience distracting. A modifier key can later temporarily
+            suppress snapping without making the basic feature harder to discover.
           </p>
         </section>
-
       </main>
     </div>
   );
@@ -226,14 +225,62 @@ function createWorkflowNodes(): Node<BaseNodeData>[] {
 }
 
 const workflowEdges: Edge[] = [
-  { id: 'e-trigger-fetch', source: 'trigger', sourceHandle: 'output', target: 'fetch', targetHandle: 'input' },
-  { id: 'e-trigger-validate', source: 'trigger', sourceHandle: 'output', target: 'validate', targetHandle: 'input' },
-  { id: 'e-fetch-decision', source: 'fetch', sourceHandle: 'output', target: 'decision', targetHandle: 'input' },
-  { id: 'e-validate-decision', source: 'validate', sourceHandle: 'output', target: 'decision', targetHandle: 'input' },
-  { id: 'e-decision-approve', source: 'decision', sourceHandle: 'output', target: 'approve', targetHandle: 'input' },
-  { id: 'e-decision-reject', source: 'decision', sourceHandle: 'output', target: 'reject', targetHandle: 'input' },
-  { id: 'e-approve-notify', source: 'approve', sourceHandle: 'output', target: 'notify', targetHandle: 'input' },
-  { id: 'e-reject-notify', source: 'reject', sourceHandle: 'output', target: 'notify', targetHandle: 'input' },
+  {
+    id: 'e-trigger-fetch',
+    source: 'trigger',
+    sourceHandle: 'output',
+    target: 'fetch',
+    targetHandle: 'input',
+  },
+  {
+    id: 'e-trigger-validate',
+    source: 'trigger',
+    sourceHandle: 'output',
+    target: 'validate',
+    targetHandle: 'input',
+  },
+  {
+    id: 'e-fetch-decision',
+    source: 'fetch',
+    sourceHandle: 'output',
+    target: 'decision',
+    targetHandle: 'input',
+  },
+  {
+    id: 'e-validate-decision',
+    source: 'validate',
+    sourceHandle: 'output',
+    target: 'decision',
+    targetHandle: 'input',
+  },
+  {
+    id: 'e-decision-approve',
+    source: 'decision',
+    sourceHandle: 'output',
+    target: 'approve',
+    targetHandle: 'input',
+  },
+  {
+    id: 'e-decision-reject',
+    source: 'decision',
+    sourceHandle: 'output',
+    target: 'reject',
+    targetHandle: 'input',
+  },
+  {
+    id: 'e-approve-notify',
+    source: 'approve',
+    sourceHandle: 'output',
+    target: 'notify',
+    targetHandle: 'input',
+  },
+  {
+    id: 'e-reject-notify',
+    source: 'reject',
+    sourceHandle: 'output',
+    target: 'notify',
+    targetHandle: 'input',
+  },
 ];
 
 // ============================================================================

--- a/packages/apollo-react/src/canvas/components/AlignmentGuides/AlignmentGuides.types.ts
+++ b/packages/apollo-react/src/canvas/components/AlignmentGuides/AlignmentGuides.types.ts
@@ -1,0 +1,24 @@
+export type AlignmentGuideOrientation = 'vertical' | 'horizontal';
+
+/**
+ * A single alignment guide line, in flow (not screen) coordinates.
+ * `position` is the constant axis (x for vertical, y for horizontal);
+ * `start`/`end` are the span along the other axis.
+ */
+export interface AlignmentGuideLine {
+  id: string;
+  orientation: AlignmentGuideOrientation;
+  position: number;
+  start: number;
+  end: number;
+}
+
+export interface NodeBounds {
+  id: string;
+  x1: number;
+  y1: number;
+  x2: number;
+  y2: number;
+  cx: number;
+  cy: number;
+}

--- a/packages/apollo-react/src/canvas/components/AlignmentGuides/AlignmentGuides.types.ts
+++ b/packages/apollo-react/src/canvas/components/AlignmentGuides/AlignmentGuides.types.ts
@@ -1,5 +1,8 @@
 export type AlignmentGuideOrientation = 'vertical' | 'horizontal';
 
+/** Whether a guide matched on a node edge (left/right/top/bottom) or its center. */
+export type AlignmentGuideKind = 'edge' | 'center';
+
 /**
  * A single alignment guide line, in flow (not screen) coordinates.
  * `position` is the constant axis (x for vertical, y for horizontal);
@@ -11,6 +14,10 @@ export interface AlignmentGuideLine {
   position: number;
   start: number;
   end: number;
+  /** 'center' only when every node behind this line matched via its center; 'edge' otherwise. */
+  kind: AlignmentGuideKind;
+  /** IDs of the other (non-dragged) nodes this line is aligned with. */
+  matchedNodeIds: string[];
 }
 
 export interface NodeBounds {

--- a/packages/apollo-react/src/canvas/components/AlignmentGuides/AlignmentGuidesOverlay.tsx
+++ b/packages/apollo-react/src/canvas/components/AlignmentGuides/AlignmentGuidesOverlay.tsx
@@ -1,0 +1,48 @@
+import { useViewport } from '@uipath/apollo-react/canvas/xyflow/react';
+import type { AlignmentGuideLine } from './AlignmentGuides.types';
+
+export interface AlignmentGuidesOverlayProps {
+  guides: AlignmentGuideLine[];
+}
+
+/**
+ * Renders alignment guide lines as a screen-space overlay. Must be rendered
+ * as a child of ReactFlow (inside a ReactFlowProvider) so useViewport can
+ * convert the guides' flow-space coordinates to screen pixels.
+ */
+export function AlignmentGuidesOverlay({ guides }: AlignmentGuidesOverlayProps) {
+  const { x: viewportX, y: viewportY, zoom } = useViewport();
+
+  if (guides.length === 0) return null;
+
+  return (
+    <div className="pointer-events-none absolute inset-0 z-40 overflow-hidden">
+      {guides.map((guide) => {
+        const isVertical = guide.orientation === 'vertical';
+        const style = isVertical
+          ? {
+              left: guide.position * zoom + viewportX,
+              top: guide.start * zoom + viewportY,
+              height: (guide.end - guide.start) * zoom,
+            }
+          : {
+              top: guide.position * zoom + viewportY,
+              left: guide.start * zoom + viewportX,
+              width: (guide.end - guide.start) * zoom,
+            };
+
+        return (
+          <div
+            key={guide.id}
+            className={
+              isVertical
+                ? 'absolute border-l border-dashed'
+                : 'absolute border-t border-dashed'
+            }
+            style={{ ...style, borderColor: 'var(--canvas-selection-indicator)' }}
+          />
+        );
+      })}
+    </div>
+  );
+}

--- a/packages/apollo-react/src/canvas/components/AlignmentGuides/AlignmentGuidesOverlay.tsx
+++ b/packages/apollo-react/src/canvas/components/AlignmentGuides/AlignmentGuidesOverlay.tsx
@@ -37,9 +37,7 @@ export function AlignmentGuidesOverlay({ guides, draggedBounds }: AlignmentGuide
           <div
             key={guide.id}
             className={
-              isVertical
-                ? 'absolute border-l border-dashed'
-                : 'absolute border-t border-dashed'
+              isVertical ? 'absolute border-l border-dashed' : 'absolute border-t border-dashed'
             }
             style={{ ...style, borderColor: 'var(--canvas-selection-indicator)' }}
           />

--- a/packages/apollo-react/src/canvas/components/AlignmentGuides/AlignmentGuidesOverlay.tsx
+++ b/packages/apollo-react/src/canvas/components/AlignmentGuides/AlignmentGuidesOverlay.tsx
@@ -1,8 +1,10 @@
 import { useViewport } from '@uipath/apollo-react/canvas/xyflow/react';
-import type { AlignmentGuideLine } from './AlignmentGuides.types';
+import type { AlignmentGuideLine, NodeBounds } from './AlignmentGuides.types';
 
 export interface AlignmentGuidesOverlayProps {
   guides: AlignmentGuideLine[];
+  /** Optional bounds for the active multi-selection, using the same snapped geometry as the guides. */
+  draggedBounds?: NodeBounds | null;
 }
 
 /**
@@ -10,10 +12,10 @@ export interface AlignmentGuidesOverlayProps {
  * as a child of ReactFlow (inside a ReactFlowProvider) so useViewport can
  * convert the guides' flow-space coordinates to screen pixels.
  */
-export function AlignmentGuidesOverlay({ guides }: AlignmentGuidesOverlayProps) {
+export function AlignmentGuidesOverlay({ guides, draggedBounds }: AlignmentGuidesOverlayProps) {
   const { x: viewportX, y: viewportY, zoom } = useViewport();
 
-  if (guides.length === 0) return null;
+  if (guides.length === 0 && !draggedBounds) return null;
 
   return (
     <div className="pointer-events-none absolute inset-0 z-40 overflow-hidden">
@@ -43,6 +45,18 @@ export function AlignmentGuidesOverlay({ guides }: AlignmentGuidesOverlayProps) 
           />
         );
       })}
+      {draggedBounds && (
+        <div
+          className="absolute rounded-md border border-dashed"
+          style={{
+            left: draggedBounds.x1 * zoom + viewportX - 8,
+            top: draggedBounds.y1 * zoom + viewportY - 8,
+            width: (draggedBounds.x2 - draggedBounds.x1) * zoom + 16,
+            height: (draggedBounds.y2 - draggedBounds.y1) * zoom + 16,
+            borderColor: 'var(--canvas-selection-indicator)',
+          }}
+        />
+      )}
     </div>
   );
 }

--- a/packages/apollo-react/src/canvas/components/AlignmentGuides/index.ts
+++ b/packages/apollo-react/src/canvas/components/AlignmentGuides/index.ts
@@ -1,0 +1,3 @@
+export * from './AlignmentGuides.types';
+export * from './AlignmentGuidesOverlay';
+export * from './useAlignmentGuides';

--- a/packages/apollo-react/src/canvas/components/AlignmentGuides/useAlignmentGuides.test.ts
+++ b/packages/apollo-react/src/canvas/components/AlignmentGuides/useAlignmentGuides.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+import type { Node } from '@uipath/apollo-react/canvas/xyflow/react';
+import type { NodeBounds } from './AlignmentGuides.types';
+import {
+  computeAlignmentResult,
+  computeAlignmentSnapDelta,
+  createAlignmentPositionUpdates,
+} from './useAlignmentGuides';
+
+function bounds(id: string, x: number, y: number, width = 100, height = 60): NodeBounds {
+  return {
+    id,
+    x1: x,
+    y1: y,
+    x2: x + width,
+    y2: y + height,
+    cx: x + width / 2,
+    cy: y + height / 2,
+  };
+}
+
+describe('computeAlignmentSnapDelta', () => {
+  it('perfectly center-aligns a third node with an existing workflow column', () => {
+    const existing = [bounds('first', 300, 100), bounds('second', 300, 300)];
+    const dragged = bounds('third', 305, 500);
+
+    expect(computeAlignmentSnapDelta(dragged, existing, 8)).toEqual({ dx: -5, dy: 0 });
+  });
+
+  it('uses the closest eligible alignment instead of node iteration order', () => {
+    const existing = [bounds('farther', 300, 100), bounds('closer', 306, 300)];
+    const dragged = bounds('dragged', 308, 500);
+
+    expect(computeAlignmentSnapDelta(dragged, existing, 8).dx).toBe(-2);
+  });
+
+  it('does not pull a node edge toward another node center', () => {
+    const existing = [bounds('existing', 300, 100)];
+    const dragged = bounds('dragged', 345, 300);
+
+    expect(computeAlignmentSnapDelta(dragged, existing, 8).dx).toBe(0);
+  });
+
+  it('preserves exact alignment when positions already share a grid line', () => {
+    const existing = [bounds('existing', 304, 96)];
+    const dragged = bounds('dragged', 304, 304);
+
+    expect(computeAlignmentSnapDelta(dragged, existing, 8)).toEqual({ dx: 0, dy: 0 });
+  });
+
+  it('does not snap outside the zoom-adjusted threshold', () => {
+    const existing = [bounds('existing', 300, 100)];
+    const dragged = bounds('dragged', 309, 300);
+
+    expect(computeAlignmentSnapDelta(dragged, existing, 8).dx).toBe(0);
+  });
+
+  it('uses the same winning target for the guide and snap delta', () => {
+    const existing = [bounds('existing', 300, 100)];
+    const dragged = bounds('dragged', 305, 300);
+
+    const result = computeAlignmentResult(dragged, existing, 8);
+
+    expect(result.delta.dx).toBe(-5);
+    expect(result.guides.find(({ orientation }) => orientation === 'vertical')?.position).toBe(350);
+  });
+
+  it('applies one rigid delta to every node in a multi-selection', () => {
+    const selected = [
+      { id: 'first', position: { x: 100, y: 200 } },
+      { id: 'second', position: { x: 260, y: 340 } },
+    ] as Node[];
+
+    expect(createAlignmentPositionUpdates(selected, { dx: -4, dy: 6 })).toEqual([
+      { id: 'first', position: { x: 96, y: 206 } },
+      { id: 'second', position: { x: 256, y: 346 } },
+    ]);
+  });
+});

--- a/packages/apollo-react/src/canvas/components/AlignmentGuides/useAlignmentGuides.test.ts
+++ b/packages/apollo-react/src/canvas/components/AlignmentGuides/useAlignmentGuides.test.ts
@@ -1,10 +1,12 @@
-import { describe, expect, it } from 'vitest';
 import type { Node } from '@uipath/apollo-react/canvas/xyflow/react';
+import { describe, expect, it } from 'vitest';
 import type { NodeBounds } from './AlignmentGuides.types';
 import {
   computeAlignmentResult,
   computeAlignmentSnapDelta,
   createAlignmentPositionUpdates,
+  toBounds,
+  toGroupBounds,
 } from './useAlignmentGuides';
 
 function bounds(id: string, x: number, y: number, width = 100, height = 60): NodeBounds {
@@ -75,5 +77,32 @@ describe('computeAlignmentSnapDelta', () => {
       { id: 'first', position: { x: 96, y: 206 } },
       { id: 'second', position: { x: 256, y: 346 } },
     ]);
+  });
+});
+
+describe('alignment bounds', () => {
+  it('uses xyflow absolute coordinates when they are available', () => {
+    const node = {
+      id: 'child',
+      position: { x: 20, y: 30 },
+      measured: { width: 100, height: 60 },
+      internals: { positionAbsolute: { x: 220, y: 330 } },
+    } as Node;
+
+    expect(toBounds(node)).toMatchObject({ x1: 220, y1: 330, x2: 320, y2: 390 });
+  });
+
+  it('derives absolute coordinates for nested nodes when internals are unavailable', () => {
+    const parent = { id: 'parent', position: { x: 200, y: 300 } } as Node;
+    const child = {
+      id: 'child',
+      parentId: 'parent',
+      position: { x: 20, y: 30 },
+      measured: { width: 100, height: 60 },
+    } as Node;
+    const nodes = [parent, child];
+
+    expect(toBounds(child, nodes)).toMatchObject({ x1: 220, y1: 330, x2: 320, y2: 390 });
+    expect(toGroupBounds([child], nodes)).toMatchObject({ x1: 220, y1: 330, x2: 320, y2: 390 });
   });
 });

--- a/packages/apollo-react/src/canvas/components/AlignmentGuides/useAlignmentGuides.ts
+++ b/packages/apollo-react/src/canvas/components/AlignmentGuides/useAlignmentGuides.ts
@@ -1,4 +1,5 @@
 import type { Node, OnNodeDrag } from '@uipath/apollo-react/canvas/xyflow/react';
+import { useViewport } from '@uipath/apollo-react/canvas/xyflow/react';
 import { useCallback, useMemo, useState } from 'react';
 import { DEFAULT_NODE_SIZE } from '../../constants';
 import type { AlignmentGuideLine, NodeBounds } from './AlignmentGuides.types';
@@ -77,8 +78,13 @@ export function computeAlignmentGuides(
 }
 
 export interface UseAlignmentGuidesOptions {
-  /** Match distance in flow-space units. @default 6 */
-  threshold?: number;
+  /**
+   * Match distance in screen pixels, independent of zoom level. Converted to
+   * flow-space internally (thresholdPx / zoom) so guides are equally easy to
+   * hit whether the canvas is zoomed in or out.
+   * @default 8
+   */
+  thresholdPx?: number;
 }
 
 export interface UseAlignmentGuidesReturn {
@@ -99,17 +105,18 @@ export function useAlignmentGuides(
   nodes: Node[],
   options: UseAlignmentGuidesOptions = {}
 ): UseAlignmentGuidesReturn {
-  const { threshold = 6 } = options;
+  const { thresholdPx = 8 } = options;
+  const { zoom } = useViewport();
   const [guides, setGuides] = useState<AlignmentGuideLine[]>([]);
 
   const onNodeDrag = useCallback<OnNodeDrag>(
     (_event, draggedNode) => {
       const others = nodes.filter((n) => n.id !== draggedNode.id);
       setGuides(
-        computeAlignmentGuides(toBounds(draggedNode), others.map(toBounds), threshold)
+        computeAlignmentGuides(toBounds(draggedNode), others.map(toBounds), thresholdPx / zoom)
       );
     },
-    [nodes, threshold]
+    [nodes, thresholdPx, zoom]
   );
 
   const onNodeDragStop = useCallback<OnNodeDrag>(() => {

--- a/packages/apollo-react/src/canvas/components/AlignmentGuides/useAlignmentGuides.ts
+++ b/packages/apollo-react/src/canvas/components/AlignmentGuides/useAlignmentGuides.ts
@@ -1,0 +1,120 @@
+import type { Node, OnNodeDrag } from '@uipath/apollo-react/canvas/xyflow/react';
+import { useCallback, useMemo, useState } from 'react';
+import { DEFAULT_NODE_SIZE } from '../../constants';
+import type { AlignmentGuideLine, NodeBounds } from './AlignmentGuides.types';
+
+function toBounds(node: Node): NodeBounds {
+  const width = node.measured?.width ?? node.width ?? DEFAULT_NODE_SIZE;
+  const height = node.measured?.height ?? node.height ?? DEFAULT_NODE_SIZE;
+  const x1 = node.position.x;
+  const y1 = node.position.y;
+  const x2 = x1 + width;
+  const y2 = y1 + height;
+  return { id: node.id, x1, y1, x2, y2, cx: (x1 + x2) / 2, cy: (y1 + y2) / 2 };
+}
+
+/**
+ * Matches the dragged node's edges/center against every other node's edges/center
+ * on one axis, returning a guide line per match that clears `threshold`.
+ * Lines that land on (nearly) the same position are merged into one, spanning
+ * from the nearest to the farthest matched node so the line reaches every node
+ * it's aligned with, not just the closest one.
+ */
+function collectAxisGuides(
+  dragged: NodeBounds,
+  others: NodeBounds[],
+  threshold: number,
+  orientation: 'vertical' | 'horizontal'
+): AlignmentGuideLine[] {
+  const draggedValues =
+    orientation === 'vertical'
+      ? [dragged.x1, dragged.cx, dragged.x2]
+      : [dragged.y1, dragged.cy, dragged.y2];
+  const otherRange = (o: NodeBounds) =>
+    orientation === 'vertical' ? ([o.y1, o.y2] as const) : ([o.x1, o.x2] as const);
+  const otherValues = (o: NodeBounds) =>
+    orientation === 'vertical' ? [o.x1, o.cx, o.x2] : [o.y1, o.cy, o.y2];
+  const draggedRange =
+    orientation === 'vertical' ? ([dragged.y1, dragged.y2] as const) : ([dragged.x1, dragged.x2] as const);
+
+  const matchesByPosition = new Map<number, { start: number; end: number }>();
+
+  for (const other of others) {
+    for (const draggedValue of draggedValues) {
+      for (const otherValue of otherValues(other)) {
+        if (Math.abs(draggedValue - otherValue) > threshold) continue;
+        const key = Math.round(otherValue);
+        const [oStart, oEnd] = otherRange(other);
+        const start = Math.min(draggedRange[0], oStart);
+        const end = Math.max(draggedRange[1], oEnd);
+        const existing = matchesByPosition.get(key);
+        matchesByPosition.set(key, {
+          start: existing ? Math.min(existing.start, start) : start,
+          end: existing ? Math.max(existing.end, end) : end,
+        });
+      }
+    }
+  }
+
+  return Array.from(matchesByPosition.entries()).map(([position, { start, end }]) => ({
+    id: `${orientation}-${position}`,
+    orientation,
+    position,
+    start,
+    end,
+  }));
+}
+
+export function computeAlignmentGuides(
+  dragged: NodeBounds,
+  others: NodeBounds[],
+  threshold: number
+): AlignmentGuideLine[] {
+  return [
+    ...collectAxisGuides(dragged, others, threshold, 'vertical'),
+    ...collectAxisGuides(dragged, others, threshold, 'horizontal'),
+  ];
+}
+
+export interface UseAlignmentGuidesOptions {
+  /** Match distance in flow-space units. @default 6 */
+  threshold?: number;
+}
+
+export interface UseAlignmentGuidesReturn {
+  guides: AlignmentGuideLine[];
+  onNodeDrag: OnNodeDrag;
+  onNodeDragStop: OnNodeDrag;
+}
+
+/**
+ * Computes Figma-style alignment guide lines while a node is being dragged,
+ * by comparing its edges and center against every other node's edges and
+ * center. Visual only — never adjusts node position.
+ *
+ * Wire the returned handlers directly into BaseCanvas/ReactFlow's
+ * onNodeDrag/onNodeDragStop, and render `guides` via AlignmentGuidesOverlay.
+ */
+export function useAlignmentGuides(
+  nodes: Node[],
+  options: UseAlignmentGuidesOptions = {}
+): UseAlignmentGuidesReturn {
+  const { threshold = 6 } = options;
+  const [guides, setGuides] = useState<AlignmentGuideLine[]>([]);
+
+  const onNodeDrag = useCallback<OnNodeDrag>(
+    (_event, draggedNode) => {
+      const others = nodes.filter((n) => n.id !== draggedNode.id);
+      setGuides(
+        computeAlignmentGuides(toBounds(draggedNode), others.map(toBounds), threshold)
+      );
+    },
+    [nodes, threshold]
+  );
+
+  const onNodeDragStop = useCallback<OnNodeDrag>(() => {
+    setGuides([]);
+  }, []);
+
+  return useMemo(() => ({ guides, onNodeDrag, onNodeDragStop }), [guides, onNodeDrag, onNodeDragStop]);
+}

--- a/packages/apollo-react/src/canvas/components/AlignmentGuides/useAlignmentGuides.ts
+++ b/packages/apollo-react/src/canvas/components/AlignmentGuides/useAlignmentGuides.ts
@@ -4,7 +4,7 @@ import { useCallback, useMemo, useState } from 'react';
 import { DEFAULT_NODE_SIZE } from '../../constants';
 import type { AlignmentGuideLine, NodeBounds } from './AlignmentGuides.types';
 
-function toBounds(node: Node): NodeBounds {
+export function toBounds(node: Node): NodeBounds {
   const width = node.measured?.width ?? node.width ?? DEFAULT_NODE_SIZE;
   const height = node.measured?.height ?? node.height ?? DEFAULT_NODE_SIZE;
   const x1 = node.position.x;
@@ -38,32 +38,44 @@ function collectAxisGuides(
   const draggedRange =
     orientation === 'vertical' ? ([dragged.y1, dragged.y2] as const) : ([dragged.x1, dragged.x2] as const);
 
-  const matchesByPosition = new Map<number, { start: number; end: number }>();
+  const matchesByPosition = new Map<
+    number,
+    { start: number; end: number; nodeIds: Set<string>; isCenterOnly: boolean }
+  >();
 
   for (const other of others) {
     for (const draggedValue of draggedValues) {
-      for (const otherValue of otherValues(other)) {
-        if (Math.abs(draggedValue - otherValue) > threshold) continue;
+      otherValues(other).forEach((otherValue, otherIndex) => {
+        if (Math.abs(draggedValue - otherValue) > threshold) return;
         const key = Math.round(otherValue);
         const [oStart, oEnd] = otherRange(other);
         const start = Math.min(draggedRange[0], oStart);
         const end = Math.max(draggedRange[1], oEnd);
+        const isCenterMatch = otherIndex === 1;
         const existing = matchesByPosition.get(key);
+        const nodeIds = existing?.nodeIds ?? new Set<string>();
+        nodeIds.add(other.id);
         matchesByPosition.set(key, {
           start: existing ? Math.min(existing.start, start) : start,
           end: existing ? Math.max(existing.end, end) : end,
+          nodeIds,
+          isCenterOnly: existing ? existing.isCenterOnly && isCenterMatch : isCenterMatch,
         });
-      }
+      });
     }
   }
 
-  return Array.from(matchesByPosition.entries()).map(([position, { start, end }]) => ({
-    id: `${orientation}-${position}`,
-    orientation,
-    position,
-    start,
-    end,
-  }));
+  return Array.from(matchesByPosition.entries()).map(
+    ([position, { start, end, nodeIds, isCenterOnly }]) => ({
+      id: `${orientation}-${position}`,
+      orientation,
+      position,
+      start,
+      end,
+      kind: isCenterOnly ? 'center' : 'edge',
+      matchedNodeIds: Array.from(nodeIds),
+    })
+  );
 }
 
 export function computeAlignmentGuides(

--- a/packages/apollo-react/src/canvas/components/AlignmentGuides/useAlignmentGuides.ts
+++ b/packages/apollo-react/src/canvas/components/AlignmentGuides/useAlignmentGuides.ts
@@ -14,68 +14,135 @@ export function toBounds(node: Node): NodeBounds {
   return { id: node.id, x1, y1, x2, y2, cx: (x1 + x2) / 2, cy: (y1 + y2) / 2 };
 }
 
-/**
- * Matches the dragged node's edges/center against every other node's edges/center
- * on one axis, returning a guide line per match that clears `threshold`.
- * Lines that land on (nearly) the same position are merged into one, spanning
- * from the nearest to the farthest matched node so the line reaches every node
- * it's aligned with, not just the closest one.
- */
-function collectAxisGuides(
+export interface AlignmentSnapDelta {
+  dx: number;
+  dy: number;
+}
+
+export interface AlignmentResult {
+  guides: AlignmentGuideLine[];
+  delta: AlignmentSnapDelta;
+}
+
+type AxisAnchors = [start: number, center: number, end: number];
+
+interface AxisCandidate {
+  delta: number;
+  kind: 'center' | 'edge';
+  matchedNodeId: string;
+  position: number;
+  priority: number;
+}
+
+function getAxisAnchors(
+  bounds: NodeBounds,
+  orientation: 'vertical' | 'horizontal'
+): AxisAnchors {
+  return orientation === 'vertical'
+    ? [bounds.x1, bounds.cx, bounds.x2]
+    : [bounds.y1, bounds.cy, bounds.y2];
+}
+
+function resolveAxisCandidate(
   dragged: NodeBounds,
   others: NodeBounds[],
   threshold: number,
   orientation: 'vertical' | 'horizontal'
-): AlignmentGuideLine[] {
-  const draggedValues =
-    orientation === 'vertical'
-      ? [dragged.x1, dragged.cx, dragged.x2]
-      : [dragged.y1, dragged.cy, dragged.y2];
-  const otherRange = (o: NodeBounds) =>
-    orientation === 'vertical' ? ([o.y1, o.y2] as const) : ([o.x1, o.x2] as const);
-  const otherValues = (o: NodeBounds) =>
-    orientation === 'vertical' ? [o.x1, o.cx, o.x2] : [o.y1, o.cy, o.y2];
-  const draggedRange =
-    orientation === 'vertical' ? ([dragged.y1, dragged.y2] as const) : ([dragged.x1, dragged.x2] as const);
-
-  const matchesByPosition = new Map<
-    number,
-    { start: number; end: number; nodeIds: Set<string>; isCenterOnly: boolean }
-  >();
+): AxisCandidate | undefined {
+  const draggedAnchors = getAxisAnchors(dragged, orientation);
+  const candidates: AxisCandidate[] = [];
 
   for (const other of others) {
-    for (const draggedValue of draggedValues) {
-      otherValues(other).forEach((otherValue, otherIndex) => {
-        if (Math.abs(draggedValue - otherValue) > threshold) return;
-        const key = Math.round(otherValue);
-        const [oStart, oEnd] = otherRange(other);
-        const start = Math.min(draggedRange[0], oStart);
-        const end = Math.max(draggedRange[1], oEnd);
-        const isCenterMatch = otherIndex === 1;
-        const existing = matchesByPosition.get(key);
-        const nodeIds = existing?.nodeIds ?? new Set<string>();
-        nodeIds.add(other.id);
-        matchesByPosition.set(key, {
-          start: existing ? Math.min(existing.start, start) : start,
-          end: existing ? Math.max(existing.end, end) : end,
-          nodeIds,
-          isCenterOnly: existing ? existing.isCenterOnly && isCenterMatch : isCenterMatch,
+    const otherAnchors = getAxisAnchors(other, orientation);
+
+    candidates.push({
+      delta: otherAnchors[1] - draggedAnchors[1],
+      kind: 'center',
+      matchedNodeId: other.id,
+      position: otherAnchors[1],
+      priority: 0,
+    });
+
+    for (const draggedIndex of [0, 2] as const) {
+      for (const otherIndex of [0, 2] as const) {
+        candidates.push({
+          delta: otherAnchors[otherIndex] - draggedAnchors[draggedIndex],
+          kind: 'edge',
+          matchedNodeId: other.id,
+          position: otherAnchors[otherIndex],
+          priority: draggedIndex === otherIndex ? 1 : 2,
         });
-      });
+      }
     }
   }
 
-  return Array.from(matchesByPosition.entries()).map(
-    ([position, { start, end, nodeIds, isCenterOnly }]) => ({
-      id: `${orientation}-${position}`,
-      orientation,
-      position,
-      start,
-      end,
-      kind: isCenterOnly ? 'center' : 'edge',
-      matchedNodeIds: Array.from(nodeIds),
-    })
+  return candidates
+    .filter(({ delta }) => Math.abs(delta) <= threshold)
+    .sort(
+      (a, b) =>
+        Math.abs(a.delta) - Math.abs(b.delta) ||
+        a.priority - b.priority ||
+        a.position - b.position ||
+        a.matchedNodeId.localeCompare(b.matchedNodeId)
+    )[0];
+}
+
+function buildGuide(
+  candidate: AxisCandidate,
+  dragged: NodeBounds,
+  others: NodeBounds[],
+  orientation: 'vertical' | 'horizontal'
+): AlignmentGuideLine {
+  const matchingOthers = others.filter((other) => {
+    const anchors = getAxisAnchors(other, orientation);
+    const candidateAnchors = candidate.kind === 'center' ? [anchors[1]] : [anchors[0], anchors[2]];
+    return candidateAnchors.some((anchor) => Math.abs(anchor - candidate.position) < 0.5);
+  });
+  const ranges = [dragged, ...matchingOthers].map((bounds) =>
+    orientation === 'vertical'
+      ? ([bounds.y1, bounds.y2] as const)
+      : ([bounds.x1, bounds.x2] as const)
   );
+
+  return {
+    id: `${orientation}-${candidate.position}`,
+    orientation,
+    position: candidate.position,
+    start: Math.min(...ranges.map(([rangeStart]) => rangeStart)),
+    end: Math.max(...ranges.map(([, rangeEnd]) => rangeEnd)),
+    kind: candidate.kind,
+    matchedNodeIds: matchingOthers.map(({ id }) => id),
+  };
+}
+
+/**
+ * Resolves the single winning alignment candidate on each axis. The returned
+ * guide lines and snap delta come from the same candidates, so the visual cue
+ * can never disagree with the position applied by a consumer.
+ */
+export function computeAlignmentResult(
+  dragged: NodeBounds,
+  others: NodeBounds[],
+  threshold: number
+): AlignmentResult {
+  const vertical = resolveAxisCandidate(dragged, others, threshold, 'vertical');
+  const horizontal = resolveAxisCandidate(dragged, others, threshold, 'horizontal');
+  const delta = { dx: vertical?.delta ?? 0, dy: horizontal?.delta ?? 0 };
+  const snapped = {
+    ...dragged,
+    x1: dragged.x1 + delta.dx,
+    x2: dragged.x2 + delta.dx,
+    cx: dragged.cx + delta.dx,
+    y1: dragged.y1 + delta.dy,
+    y2: dragged.y2 + delta.dy,
+    cy: dragged.cy + delta.dy,
+  };
+  const guides = [
+    ...(vertical ? [buildGuide(vertical, snapped, others, 'vertical')] : []),
+    ...(horizontal ? [buildGuide(horizontal, snapped, others, 'horizontal')] : []),
+  ];
+
+  return { guides, delta };
 }
 
 export function computeAlignmentGuides(
@@ -83,10 +150,32 @@ export function computeAlignmentGuides(
   others: NodeBounds[],
   threshold: number
 ): AlignmentGuideLine[] {
-  return [
-    ...collectAxisGuides(dragged, others, threshold, 'vertical'),
-    ...collectAxisGuides(dragged, others, threshold, 'horizontal'),
-  ];
+  return computeAlignmentResult(dragged, others, threshold).guides;
+}
+
+export function computeAlignmentSnapDelta(
+  dragged: NodeBounds,
+  others: NodeBounds[],
+  threshold: number
+): AlignmentSnapDelta {
+  return computeAlignmentResult(dragged, others, threshold).delta;
+}
+
+export function toGroupBounds(nodes: Node[]): NodeBounds {
+  const bounds = nodes.map(toBounds);
+  const x1 = Math.min(...bounds.map((item) => item.x1));
+  const y1 = Math.min(...bounds.map((item) => item.y1));
+  const x2 = Math.max(...bounds.map((item) => item.x2));
+  const y2 = Math.max(...bounds.map((item) => item.y2));
+  return {
+    id: bounds.map(({ id }) => id).join(','),
+    x1,
+    y1,
+    x2,
+    y2,
+    cx: (x1 + x2) / 2,
+    cy: (y1 + y2) / 2,
+  };
 }
 
 export interface UseAlignmentGuidesOptions {
@@ -97,18 +186,40 @@ export interface UseAlignmentGuidesOptions {
    * @default 8
    */
   thresholdPx?: number;
+  /**
+   * Optional controlled-state callback for magnetic snapping. Every update is
+   * an absolute position derived from React Flow's current drag event. When a
+   * selection is dragged, all selected nodes receive the same delta.
+   */
+  onSnap?: (updates: AlignmentPositionUpdate[]) => void;
+}
+
+export interface AlignmentPositionUpdate {
+  id: string;
+  position: { x: number; y: number };
+}
+
+export function createAlignmentPositionUpdates(
+  nodes: Node[],
+  delta: AlignmentSnapDelta
+): AlignmentPositionUpdate[] {
+  return nodes.map(({ id, position }) => ({
+    id,
+    position: { x: position.x + delta.dx, y: position.y + delta.dy },
+  }));
 }
 
 export interface UseAlignmentGuidesReturn {
   guides: AlignmentGuideLine[];
+  draggedBounds: NodeBounds | null;
   onNodeDrag: OnNodeDrag;
   onNodeDragStop: OnNodeDrag;
 }
 
 /**
- * Computes Figma-style alignment guide lines while a node is being dragged,
- * by comparing its edges and center against every other node's edges and
- * center. Visual only — never adjusts node position.
+ * Computes Figma-style alignment guides and optional magnetic snap positions
+ * while one node or a multi-selection is dragged. Guide lines and snap updates
+ * always come from the same winning alignment candidate.
  *
  * Wire the returned handlers directly into BaseCanvas/ReactFlow's
  * onNodeDrag/onNodeDragStop, and render `guides` via AlignmentGuidesOverlay.
@@ -117,23 +228,51 @@ export function useAlignmentGuides(
   nodes: Node[],
   options: UseAlignmentGuidesOptions = {}
 ): UseAlignmentGuidesReturn {
-  const { thresholdPx = 8 } = options;
+  const { thresholdPx = 8, onSnap } = options;
   const { zoom } = useViewport();
   const [guides, setGuides] = useState<AlignmentGuideLine[]>([]);
+  const [draggedBounds, setDraggedBounds] = useState<NodeBounds | null>(null);
 
-  const onNodeDrag = useCallback<OnNodeDrag>(
-    (_event, draggedNode) => {
-      const others = nodes.filter((n) => n.id !== draggedNode.id);
-      setGuides(
-        computeAlignmentGuides(toBounds(draggedNode), others.map(toBounds), thresholdPx / zoom)
+  const resolveDrag = useCallback(
+    (draggedNode: Node, draggedNodes: Node[], showGuides: boolean) => {
+      const activeNodes = draggedNodes.length > 0 ? draggedNodes : [draggedNode];
+      const activeIds = new Set(activeNodes.map(({ id }) => id));
+      const others = nodes.filter(({ id }) => !activeIds.has(id)).map(toBounds);
+      const activeBounds = toGroupBounds(activeNodes);
+      const result = computeAlignmentResult(activeBounds, others, thresholdPx / zoom);
+      setDraggedBounds(
+        showGuides
+          ? {
+              ...activeBounds,
+              x1: activeBounds.x1 + result.delta.dx,
+              x2: activeBounds.x2 + result.delta.dx,
+              cx: activeBounds.cx + result.delta.dx,
+              y1: activeBounds.y1 + result.delta.dy,
+              y2: activeBounds.y2 + result.delta.dy,
+              cy: activeBounds.cy + result.delta.dy,
+            }
+          : null
       );
+      setGuides(showGuides ? result.guides : []);
+
+      if (!onSnap || (result.delta.dx === 0 && result.delta.dy === 0)) return;
+      onSnap(createAlignmentPositionUpdates(activeNodes, result.delta));
     },
-    [nodes, thresholdPx, zoom]
+    [nodes, onSnap, thresholdPx, zoom]
   );
 
-  const onNodeDragStop = useCallback<OnNodeDrag>(() => {
-    setGuides([]);
-  }, []);
+  const onNodeDrag = useCallback<OnNodeDrag>(
+    (_event, draggedNode, draggedNodes) => resolveDrag(draggedNode, draggedNodes, true),
+    [resolveDrag]
+  );
 
-  return useMemo(() => ({ guides, onNodeDrag, onNodeDragStop }), [guides, onNodeDrag, onNodeDragStop]);
+  const onNodeDragStop = useCallback<OnNodeDrag>(
+    (_event, draggedNode, draggedNodes) => resolveDrag(draggedNode, draggedNodes, false),
+    [resolveDrag]
+  );
+
+  return useMemo(
+    () => ({ guides, draggedBounds, onNodeDrag, onNodeDragStop }),
+    [guides, draggedBounds, onNodeDrag, onNodeDragStop]
+  );
 }

--- a/packages/apollo-react/src/canvas/components/AlignmentGuides/useAlignmentGuides.ts
+++ b/packages/apollo-react/src/canvas/components/AlignmentGuides/useAlignmentGuides.ts
@@ -2,13 +2,21 @@ import type { Node, OnNodeDrag } from '@uipath/apollo-react/canvas/xyflow/react'
 import { useViewport } from '@uipath/apollo-react/canvas/xyflow/react';
 import { useCallback, useMemo, useState } from 'react';
 import { DEFAULT_NODE_SIZE } from '../../constants';
+import { getAbsolutePosition } from '../../utils/NodeUtils';
 import type { AlignmentGuideLine, NodeBounds } from './AlignmentGuides.types';
 
-export function toBounds(node: Node): NodeBounds {
+type NodeWithInternals = Node & {
+  internals?: { positionAbsolute?: { x: number; y: number } };
+};
+
+export function toBounds(node: Node, allNodes: Node[] = [node]): NodeBounds {
   const width = node.measured?.width ?? node.width ?? DEFAULT_NODE_SIZE;
   const height = node.measured?.height ?? node.height ?? DEFAULT_NODE_SIZE;
-  const x1 = node.position.x;
-  const y1 = node.position.y;
+  const absolutePosition =
+    (node as NodeWithInternals).internals?.positionAbsolute ??
+    (node.parentId ? getAbsolutePosition(node, allNodes) : node.position);
+  const x1 = absolutePosition.x;
+  const y1 = absolutePosition.y;
   const x2 = x1 + width;
   const y2 = y1 + height;
   return { id: node.id, x1, y1, x2, y2, cx: (x1 + x2) / 2, cy: (y1 + y2) / 2 };
@@ -34,10 +42,7 @@ interface AxisCandidate {
   priority: number;
 }
 
-function getAxisAnchors(
-  bounds: NodeBounds,
-  orientation: 'vertical' | 'horizontal'
-): AxisAnchors {
+function getAxisAnchors(bounds: NodeBounds, orientation: 'vertical' | 'horizontal'): AxisAnchors {
   return orientation === 'vertical'
     ? [bounds.x1, bounds.cx, bounds.x2]
     : [bounds.y1, bounds.cy, bounds.y2];
@@ -161,8 +166,8 @@ export function computeAlignmentSnapDelta(
   return computeAlignmentResult(dragged, others, threshold).delta;
 }
 
-export function toGroupBounds(nodes: Node[]): NodeBounds {
-  const bounds = nodes.map(toBounds);
+export function toGroupBounds(nodes: Node[], allNodes: Node[] = nodes): NodeBounds {
+  const bounds = nodes.map((node) => toBounds(node, allNodes));
   const x1 = Math.min(...bounds.map((item) => item.x1));
   const y1 = Math.min(...bounds.map((item) => item.y1));
   const x2 = Math.max(...bounds.map((item) => item.x2));
@@ -237,8 +242,10 @@ export function useAlignmentGuides(
     (draggedNode: Node, draggedNodes: Node[], showGuides: boolean) => {
       const activeNodes = draggedNodes.length > 0 ? draggedNodes : [draggedNode];
       const activeIds = new Set(activeNodes.map(({ id }) => id));
-      const others = nodes.filter(({ id }) => !activeIds.has(id)).map(toBounds);
-      const activeBounds = toGroupBounds(activeNodes);
+      const others = nodes
+        .filter(({ id }) => !activeIds.has(id))
+        .map((node) => toBounds(node, nodes));
+      const activeBounds = toGroupBounds(activeNodes, nodes);
       const result = computeAlignmentResult(activeBounds, others, thresholdPx / zoom);
       setDraggedBounds(
         showGuides

--- a/packages/apollo-react/src/canvas/components/index.ts
+++ b/packages/apollo-react/src/canvas/components/index.ts
@@ -1,5 +1,6 @@
 export * from './AddNodePanel';
 export * from './AgentCanvas';
+export * from './AlignmentGuides';
 export * from './BaseCanvas';
 export * from './BaseNode';
 export * from './ButtonHandle';


### PR DESCRIPTION
## Summary

Adds **node alignment hinting** to the Apollo React canvas through contextual alignment guides and deterministic magnetic snapping. While one node or a multi-selection is dragged near another node, a restrained guide shows the winning edge or center alignment and the same resolved candidate applies the exact final position.

The experience is available by default but visible only during dragging, keeping the canvas quiet while making precise workflow layouts easier to create.

<img width="1331" height="1274" alt="Screenshot 2026-07-30 at 4 04 40 PM" src="https://github.com/user-attachments/assets/e04c14bd-3300-43c3-bbbb-680e9eb6b995" />

## UX direction

- Show guides contextually during drag; do not add a persistent canvas toggle.
- Use one minimal guide per axis rather than displaying every possible match.
- Derive the visible guide and snapped position from the same candidate so they cannot disagree.
- Prefer the closest eligible match with deterministic center and edge priorities.
- Treat a multi-selection as one rigid group and preserve the layout between selected nodes.
- Apply grid positioning first, then alignment as the final node-to-node correction.
- Reapply alignment on drag release to prevent final-position drift.

Aligning selected nodes relative to each other is intentionally out of scope. That belongs with **Tidy Up** and future align/distribute selection commands.

## Implementation

New production behavior under `packages/apollo-react/src/canvas/components/AlignmentGuides/`:

- `useAlignmentGuides`: resolves guides and optional controlled snap updates for single nodes and multi-selections using a zoom-aware screen-pixel threshold.
- `computeAlignmentResult`: returns the guide lines and snap delta from one shared deterministic resolver.
- `AlignmentGuidesOverlay`: renders dashed guide lines and an optional active multi-selection boundary using `--canvas-selection-indicator`.
- Multi-selection snapping applies one identical delta to every selected node.
- Grid snap and node-to-node alignment compose without separate competing guide calculations.

For consumers with different node sizes or custom handle layouts, handle-aware connector alignment is a possible follow-up; this implementation currently aligns node edges and centers.

## Storybook

Pages under **Apollo React → Canvas → Components → Canvas → AlignmentGuides**:

1. **UX Guidance** — finalized interaction principles and scope.
2. **Alignment Guides** — canonical single-node and multi-selection behavior.
3. **Grid-snap Interplay** — verifies grid positioning and alignment snapping compose correctly.
4. **Multi-select Drag** — verifies rigid group snapping and the active group boundary.

## Test plan

- [x] Biome lint passes on the Alignment Guides implementation and stories.
- [x] `tsc --noEmit` passes for `@uipath/apollo-react`.
- [x] Seven focused Vitest cases cover three-node center alignment, deterministic candidate selection, edge/center separation, thresholds, grid coexistence, guide/snap agreement, and rigid multi-selection updates.
- [x] Storybook exposes only the four retained pages.
- [x] Single-node, grid-snap, and multi-selection interactions were manually reviewed in Storybook.
