### PR TITLE
feat(apollo-react): multi-strategy Tidy up menu for CanvasZoomControls

### DIFF
--- a/packages/apollo-react/src/canvas/components/CanvasZoomControls/CanvasZoomControls.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/CanvasZoomControls/CanvasZoomControls.stories.tsx
@@ -1,18 +1,51 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import type { Edge, Node } from '@uipath/apollo-react/canvas/xyflow/react';
-import { Panel, useReactFlow } from '@uipath/apollo-react/canvas/xyflow/react';
+import { Panel, Position, useReactFlow } from '@uipath/apollo-react/canvas/xyflow/react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   createNode,
-  HandleConfigs,
   StoryInfoPanel,
   useCanvasStory,
   withCanvasProviders,
 } from '../../storybook-utils';
+import { CanvasIcon } from '../../utils/icon-registry';
 import { compactAlignNodes, subtleAlignNodes, TIDY_UP_STRATEGIES } from '../../utils/tidy-up';
 import { BaseCanvas } from '../BaseCanvas';
+import { BaseNodeOverrideConfigProvider } from '../BaseNode';
 import type { BaseNodeData } from '../BaseNode/BaseNode.types';
+import type { NodeToolbarConfig } from '../Toolbar';
 import { CanvasZoomControls, type TidyUpMenuOption } from './CanvasZoomControls';
+
+// Handle presets for "Horizontal layout"/"Vertical layout", scoped to this
+// story only. Deliberately label-less (unlike storybook-utils' HandleConfigs
+// presets): at compact spacing, an "Input"/"Output" caption overlaps the
+// neighboring node's own label/subLabel text. Only the handle *position*
+// (left/right vs top/bottom) matters for keeping edges straight.
+const LEFT_RIGHT_HANDLES = [
+  {
+    position: Position.Left,
+    handles: [{ id: 'input', type: 'target' as const, handleType: 'input' as const }],
+  },
+  {
+    position: Position.Right,
+    handles: [{ id: 'output', type: 'source' as const, handleType: 'output' as const }],
+  },
+];
+const TOP_BOTTOM_HANDLES = [
+  {
+    position: Position.Top,
+    handles: [{ id: 'input', type: 'target' as const, handleType: 'input' as const }],
+  },
+  {
+    position: Position.Bottom,
+    handles: [{ id: 'output', type: 'source' as const, handleType: 'output' as const }],
+  },
+];
+
+// Wider than compactAlignNodes' own default spacing -- used only by
+// "Horizontal layout"/"Vertical layout" for a less cramped feel. Compact
+// layout keeps its own default untouched.
+const SPACIOUS_LAYOUT_SPACING: [number, number] = [80, 96];
 
 // ============================================================================
 // Meta Configuration
@@ -34,17 +67,35 @@ type Story = StoryObj<typeof CanvasZoomControls>;
 // Story Components
 // ============================================================================
 
+// A component consumer can pass onOrganize, tidyUpOptions, both, or neither --
+// the "Tidy up" icon only renders when one of those is provided. Shown here so
+// Vertical/Horizontal double as the canonical full-toolbar reference for each
+// orientation, not just zoom/fit.
+const REFERENCE_TIDY_UP_OPTIONS: TidyUpMenuOption[] = [
+  ...TIDY_UP_STRATEGIES,
+  {
+    id: 'reset',
+    label: 'Reset to original',
+    icon: 'rotate-ccw',
+    separatorBefore: true,
+  },
+];
+
 function VerticalStory() {
   const { canvasProps } = useCanvasStory({ initialNodes: [], initialEdges: [] });
+  const [lastSelected, setLastSelected] = useState<string | null>(null);
 
   return (
     <BaseCanvas {...canvasProps} mode="design">
       <Panel position="bottom-right">
-        <CanvasZoomControls />
+        <CanvasZoomControls
+          tidyUpOptions={REFERENCE_TIDY_UP_OPTIONS}
+          onTidyUpSelect={setLastSelected}
+        />
       </Panel>
       <StoryInfoPanel
         title="Zoom controls — vertical"
-        description="Default vertical orientation. Zoom in, zoom out, and fit to screen buttons are stacked vertically."
+        description={`Default vertical orientation. Zoom in, zoom out, fit to screen, and Tidy up are stacked vertically. Last selected: ${lastSelected ?? 'none'}.`}
       />
     </BaseCanvas>
   );
@@ -52,15 +103,20 @@ function VerticalStory() {
 
 function HorizontalStory() {
   const { canvasProps } = useCanvasStory({ initialNodes: [], initialEdges: [] });
+  const [lastSelected, setLastSelected] = useState<string | null>(null);
 
   return (
     <BaseCanvas {...canvasProps} mode="design">
       <Panel position="bottom-center">
-        <CanvasZoomControls orientation="horizontal" />
+        <CanvasZoomControls
+          orientation="horizontal"
+          tidyUpOptions={REFERENCE_TIDY_UP_OPTIONS}
+          onTidyUpSelect={setLastSelected}
+        />
       </Panel>
       <StoryInfoPanel
         title="Zoom controls — horizontal"
-        description="Horizontal orientation. Buttons are laid out in a row."
+        description={`Horizontal orientation. Buttons, including Tidy up, are laid out in a row. Last selected: ${lastSelected ?? 'none'}.`}
       />
     </BaseCanvas>
   );
@@ -80,35 +136,7 @@ function WithOrganizeStory() {
       </Panel>
       <StoryInfoPanel
         title="Zoom controls — with organize"
-        description={`Includes the optional "Tidy up" button. Organize pressed: ${organizeCount} time${organizeCount === 1 ? '' : 's'}.`}
-      />
-    </BaseCanvas>
-  );
-}
-
-function WithTidyUpMenuStory() {
-  const { canvasProps } = useCanvasStory({ initialNodes: [], initialEdges: [] });
-  const [lastSelected, setLastSelected] = useState<string | null>(null);
-
-  return (
-    <BaseCanvas {...canvasProps} mode="design">
-      <Panel position="bottom-right">
-        <CanvasZoomControls
-          orientation="vertical"
-          tidyUpOptions={[
-            ...TIDY_UP_STRATEGIES,
-            {
-              id: 'reset',
-              label: 'Reset to original',
-              separatorBefore: true,
-            },
-          ]}
-          onTidyUpSelect={setLastSelected}
-        />
-      </Panel>
-      <StoryInfoPanel
-        title="Zoom controls: with tidy up menu"
-        description={`The "Tidy up" button opens a menu of strategies instead of running one hardcoded action -- a destructive/reset-style option can be set apart with "separatorBefore". Last selected: ${lastSelected ?? 'none'}. See "With Tidy Up Menu and Interaction" below for the strategies actually applied to a real workflow.`}
+        description={`Uses "onOrganize" -- a single hardcoded action on click, no menu. This is what AgentCanvas uses in production today. Compare to Vertical/Horizontal, which use "tidyUpOptions" for a menu of strategies instead. Organize pressed: ${organizeCount} time${organizeCount === 1 ? '' : 's'}.`}
       />
     </BaseCanvas>
   );
@@ -244,8 +272,8 @@ function WithTidyUpMenuAndInteractionStory() {
         // otherwise every edge still has to bend around the node to reach a
         // side handle, defeating the point of re-flowing top-to-bottom.
         const handleConfigurations =
-          optionId === 'horizontal' ? HandleConfigs.inputOutput : HandleConfigs.topBottom;
-        compactAlignNodes(canvasProps.nodes, messyEdges, undefined, direction)
+          optionId === 'horizontal' ? LEFT_RIGHT_HANDLES : TOP_BOTTOM_HANDLES;
+        compactAlignNodes(canvasProps.nodes, messyEdges, SPACIOUS_LAYOUT_SPACING, direction)
           .then((laidOut) => {
             setNodes(
               laidOut.map((node) => ({ ...node, data: { ...node.data, handleConfigurations } }))
@@ -278,16 +306,17 @@ function WithTidyUpMenuAndInteractionStory() {
       {
         id: 'horizontal',
         label: 'Horizontal layout',
-        description: 'Re-flows left-to-right.',
+        icon: 'move-horizontal',
       },
       {
         id: 'vertical',
         label: 'Vertical layout',
-        description: 'Re-flows top-to-bottom.',
+        icon: 'move-vertical',
       },
       {
         id: 'reset',
         label: 'Reset to original',
+        icon: 'rotate-ccw',
         disabled: isTidying,
         separatorBefore: true,
       },
@@ -295,24 +324,93 @@ function WithTidyUpMenuAndInteractionStory() {
     [isTidying]
   );
 
+  // Story-scoped only: overrides every node's toolbar to add the same tidy-up
+  // strategies to its "more options" overflow menu, so a user can trigger
+  // them from a node's own toolbar as well as the corner control. Uses
+  // BaseNodeOverrideConfigProvider rather than extending the real
+  // uipath.blank-node/uipath.manual-trigger manifests, so this has no effect
+  // outside this one story.
+  const nodeToolbarConfig: NodeToolbarConfig = useMemo(
+    () => ({
+      actions: [
+        {
+          id: 'delete',
+          icon: <CanvasIcon icon="trash" size={14} />,
+          label: 'Delete',
+          onAction: () => {},
+        },
+        {
+          id: 'duplicate',
+          icon: <CanvasIcon icon="copy" size={14} />,
+          label: 'Duplicate',
+          onAction: () => {},
+        },
+        {
+          id: 'breakpoint',
+          icon: <CanvasIcon icon="circle" size={14} />,
+          label: 'Toggle breakpoint',
+          onAction: () => {},
+        },
+      ],
+      overflowLabel: 'Tidy up',
+      overflowActions: [
+        {
+          id: 'subtle',
+          icon: <CanvasIcon icon="grid-3x3" size={14} />,
+          label: 'Subtle align',
+          onAction: () => handleTidyUpSelect('subtle'),
+        },
+        {
+          id: 'compact',
+          icon: <CanvasIcon icon="shrink" size={14} />,
+          label: 'Compact layout',
+          onAction: () => handleTidyUpSelect('compact'),
+        },
+        {
+          id: 'horizontal',
+          icon: <CanvasIcon icon="move-horizontal" size={14} />,
+          label: 'Horizontal layout',
+          onAction: () => handleTidyUpSelect('horizontal'),
+        },
+        {
+          id: 'vertical',
+          icon: <CanvasIcon icon="move-vertical" size={14} />,
+          label: 'Vertical layout',
+          onAction: () => handleTidyUpSelect('vertical'),
+        },
+        { id: 'separator' },
+        {
+          id: 'reset',
+          icon: <CanvasIcon icon="rotate-ccw" size={14} />,
+          label: 'Reset to original',
+          disabled: isTidying,
+          onAction: () => handleTidyUpSelect('reset'),
+        },
+      ],
+    }),
+    [handleTidyUpSelect, isTidying]
+  );
+
   return (
-    <BaseCanvas {...canvasProps} mode="design">
-      <Panel position="bottom-right">
-        <CanvasZoomControls
-          orientation="vertical"
-          tidyUpOptions={tidyUpOptions}
-          onTidyUpSelect={handleTidyUpSelect}
+    <BaseNodeOverrideConfigProvider value={{ toolbarConfig: nodeToolbarConfig }}>
+      <BaseCanvas {...canvasProps} mode="design">
+        <Panel position="bottom-right">
+          <CanvasZoomControls
+            orientation="vertical"
+            tidyUpOptions={tidyUpOptions}
+            onTidyUpSelect={handleTidyUpSelect}
+          />
+        </Panel>
+        <StoryInfoPanel
+          title="Zoom controls: tidy up on a workflow"
+          description={
+            isTidying
+              ? 'Tidying up...'
+              : 'This workflow\'s nodes were placed carelessly. Trigger a strategy from the brush icon in the bottom-right toolbar, or from the "Tidy up" overflow menu above any node. Subtle align nudges nearly-aligned nodes onto a shared grid without changing the overall shape. Compact layout re-flows everything left-to-right. Horizontal layout does the same but also forces every handle back to left/right. Vertical layout re-flows top-to-bottom and flips handles to match. Reset to original restores the initial mess so you can try again.'
+          }
         />
-      </Panel>
-      <StoryInfoPanel
-        title="Zoom controls: with tidy up menu and interaction"
-        description={
-          isTidying
-            ? 'Tidying up...'
-            : "This workflow's nodes were placed carelessly. Click the brush icon in the bottom-right toolbar to pick a strategy: Subtle align nudges nearly-aligned nodes onto a shared grid without changing the overall shape. Compact layout re-flows everything left-to-right. Horizontal layout does the same but also forces every handle back to left/right. Vertical layout re-flows top-to-bottom and flips handles to match. Reset to original restores the initial mess so you can try again."
-        }
-      />
-    </BaseCanvas>
+      </BaseCanvas>
+    </BaseNodeOverrideConfigProvider>
   );
 }
 
@@ -335,12 +433,7 @@ export const WithOrganize: Story = {
   render: () => <WithOrganizeStory />,
 };
 
-export const WithTidyUpMenu: Story = {
-  name: 'Tidy up menu',
-  render: () => <WithTidyUpMenuStory />,
-};
-
 export const WithTidyUpMenuAndInteraction: Story = {
-  name: 'Tidy up interactions',
+  name: 'Tidy up: workflow',
   render: () => <WithTidyUpMenuAndInteractionStory />,
 };

--- a/packages/apollo-react/src/canvas/components/CanvasZoomControls/CanvasZoomControls.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/CanvasZoomControls/CanvasZoomControls.stories.tsx
@@ -1,9 +1,18 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { Panel } from '@uipath/apollo-react/canvas/xyflow/react';
-import { useState } from 'react';
-import { StoryInfoPanel, useCanvasStory, withCanvasProviders } from '../../storybook-utils';
+import type { Edge, Node } from '@uipath/apollo-react/canvas/xyflow/react';
+import { Panel, useReactFlow } from '@uipath/apollo-react/canvas/xyflow/react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  createNode,
+  HandleConfigs,
+  StoryInfoPanel,
+  useCanvasStory,
+  withCanvasProviders,
+} from '../../storybook-utils';
+import { compactAlignNodes, subtleAlignNodes, TIDY_UP_STRATEGIES } from '../../utils/tidy-up';
 import { BaseCanvas } from '../BaseCanvas';
-import { CanvasZoomControls } from './CanvasZoomControls';
+import type { BaseNodeData } from '../BaseNode/BaseNode.types';
+import { CanvasZoomControls, type TidyUpMenuOption } from './CanvasZoomControls';
 
 // ============================================================================
 // Meta Configuration
@@ -77,6 +86,236 @@ function WithOrganizeStory() {
   );
 }
 
+function WithTidyUpMenuStory() {
+  const { canvasProps } = useCanvasStory({ initialNodes: [], initialEdges: [] });
+  const [lastSelected, setLastSelected] = useState<string | null>(null);
+
+  return (
+    <BaseCanvas {...canvasProps} mode="design">
+      <Panel position="bottom-right">
+        <CanvasZoomControls
+          orientation="vertical"
+          tidyUpOptions={[
+            ...TIDY_UP_STRATEGIES,
+            {
+              id: 'reset',
+              label: 'Reset to original',
+              separatorBefore: true,
+            },
+          ]}
+          onTidyUpSelect={setLastSelected}
+        />
+      </Panel>
+      <StoryInfoPanel
+        title="Zoom controls: with tidy up menu"
+        description={`The "Tidy up" button opens a menu of strategies instead of running one hardcoded action -- a destructive/reset-style option can be set apart with "separatorBefore". Last selected: ${lastSelected ?? 'none'}. See "With Tidy Up Menu and Interaction" below for the strategies actually applied to a real workflow.`}
+      />
+    </BaseCanvas>
+  );
+}
+
+// ----------------------------------------------------------------------------
+// "With Tidy Up Menu and Interaction" -- a workflow whose nodes were dropped
+// carelessly (rows are almost-but-not-quite aligned, spacing is inconsistent)
+// so the tidy-up menu has something real to fix.
+// ----------------------------------------------------------------------------
+
+function createMessyNodes(): Node<BaseNodeData>[] {
+  return [
+    createNode({
+      id: 'trigger',
+      type: 'uipath.manual-trigger',
+      position: { x: 80, y: 210 },
+      display: { label: 'Manual trigger' },
+    }),
+    createNode({
+      id: 'fetch-data',
+      type: 'uipath.blank-node',
+      position: { x: 340, y: 40 },
+      display: { label: 'Fetch data', subLabel: 'HTTP request' },
+    }),
+    createNode({
+      id: 'validate',
+      type: 'uipath.blank-node',
+      position: { x: 345, y: 385 },
+      display: { label: 'Validate input', subLabel: 'Rules engine' },
+    }),
+    createNode({
+      id: 'transform',
+      type: 'uipath.blank-node',
+      position: { x: 625, y: 22 },
+      display: { label: 'Transform data', subLabel: 'Data mapper' },
+    }),
+    createNode({
+      id: 'enrich',
+      type: 'uipath.blank-node',
+      position: { x: 608, y: 412 },
+      display: { label: 'Enrich record', subLabel: 'AI agent' },
+    }),
+    createNode({
+      id: 'merge',
+      type: 'uipath.blank-node',
+      position: { x: 905, y: 195 },
+      display: { label: 'Merge results' },
+    }),
+    createNode({
+      id: 'notify',
+      type: 'uipath.blank-node',
+      position: { x: 1155, y: 168 },
+      display: { label: 'Send notification', subLabel: 'Slack integration' },
+    }),
+    createNode({
+      id: 'archive',
+      type: 'uipath.blank-node',
+      position: { x: 1162, y: 262 },
+      display: { label: 'Archive record', subLabel: 'Storage bucket' },
+    }),
+  ];
+}
+
+function messyEdge(id: string, source: string, target: string): Edge {
+  return { id, source, target, sourceHandle: 'output', targetHandle: 'input' };
+}
+
+// Keyed by node id so "Reset to original" can restore positions on the
+// existing node objects (preserving their measured dimensions) instead of
+// replacing them outright, which would force React Flow to re-measure
+// before fitView can compute correct bounds.
+const MESSY_POSITIONS: Record<string, { x: number; y: number }> = Object.fromEntries(
+  createMessyNodes().map((node) => [node.id, node.position])
+);
+
+const messyEdges: Edge[] = [
+  messyEdge('e-trigger-fetch', 'trigger', 'fetch-data'),
+  messyEdge('e-trigger-validate', 'trigger', 'validate'),
+  messyEdge('e-fetch-transform', 'fetch-data', 'transform'),
+  messyEdge('e-validate-enrich', 'validate', 'enrich'),
+  messyEdge('e-transform-merge', 'transform', 'merge'),
+  messyEdge('e-enrich-merge', 'enrich', 'merge'),
+  messyEdge('e-merge-notify', 'merge', 'notify'),
+  messyEdge('e-merge-archive', 'merge', 'archive'),
+];
+
+function WithTidyUpMenuAndInteractionStory() {
+  const initialNodes = useMemo(() => createMessyNodes(), []);
+  const { canvasProps, setNodes } = useCanvasStory({
+    initialNodes,
+    initialEdges: messyEdges,
+  });
+  const [isTidying, setIsTidying] = useState(false);
+  const [layoutVersion, setLayoutVersion] = useState(0);
+  const { fitView } = useReactFlow();
+
+  // Nodes can move well outside the current viewport (especially with
+  // "Compact layout"), so re-fit the camera after every layout change. This
+  // runs after BaseCanvas/xyflow's own effects have synced the new
+  // positions, since child effects commit before parent effects.
+  useEffect(() => {
+    if (layoutVersion === 0) {
+      return;
+    }
+    fitView({ duration: 400, padding: 0.2 });
+  }, [layoutVersion, fitView]);
+
+  const handleTidyUpSelect = useCallback(
+    (optionId: string) => {
+      if (optionId === 'subtle') {
+        setNodes((current) => subtleAlignNodes(current));
+        setLayoutVersion((v) => v + 1);
+        return;
+      }
+
+      if (optionId === 'compact') {
+        setIsTidying(true);
+        compactAlignNodes(canvasProps.nodes, messyEdges)
+          .then((laidOut) => {
+            setNodes(laidOut);
+            setLayoutVersion((v) => v + 1);
+          })
+          .finally(() => setIsTidying(false));
+        return;
+      }
+
+      if (optionId === 'horizontal' || optionId === 'vertical') {
+        setIsTidying(true);
+        const direction = optionId === 'horizontal' ? 'LR' : 'TD';
+        // Handles are side-mounted (left/right) by default, matching a
+        // horizontal flow. A vertical layout needs top/bottom handles too --
+        // otherwise every edge still has to bend around the node to reach a
+        // side handle, defeating the point of re-flowing top-to-bottom.
+        const handleConfigurations =
+          optionId === 'horizontal' ? HandleConfigs.inputOutput : HandleConfigs.topBottom;
+        compactAlignNodes(canvasProps.nodes, messyEdges, undefined, direction)
+          .then((laidOut) => {
+            setNodes(
+              laidOut.map((node) => ({ ...node, data: { ...node.data, handleConfigurations } }))
+            );
+            setLayoutVersion((v) => v + 1);
+          })
+          .finally(() => setIsTidying(false));
+        return;
+      }
+
+      if (optionId === 'reset') {
+        setNodes((current) =>
+          current.map((node) => ({
+            ...node,
+            position: MESSY_POSITIONS[node.id] ?? node.position,
+            // Clear the override so handles fall back to their manifest
+            // default (left/right), matching the original messy state.
+            data: { ...node.data, handleConfigurations: undefined },
+          }))
+        );
+        setLayoutVersion((v) => v + 1);
+      }
+    },
+    [canvasProps.nodes, setNodes]
+  );
+
+  const tidyUpOptions: TidyUpMenuOption[] = useMemo(
+    () => [
+      ...TIDY_UP_STRATEGIES,
+      {
+        id: 'horizontal',
+        label: 'Horizontal layout',
+        description: 'Re-flows left-to-right.',
+      },
+      {
+        id: 'vertical',
+        label: 'Vertical layout',
+        description: 'Re-flows top-to-bottom.',
+      },
+      {
+        id: 'reset',
+        label: 'Reset to original',
+        disabled: isTidying,
+        separatorBefore: true,
+      },
+    ],
+    [isTidying]
+  );
+
+  return (
+    <BaseCanvas {...canvasProps} mode="design">
+      <Panel position="bottom-right">
+        <CanvasZoomControls
+          orientation="vertical"
+          tidyUpOptions={tidyUpOptions}
+          onTidyUpSelect={handleTidyUpSelect}
+        />
+      </Panel>
+      <StoryInfoPanel
+        title="Zoom controls: with tidy up menu and interaction"
+        description={
+          isTidying
+            ? 'Tidying up...'
+            : "This workflow's nodes were placed carelessly. Click the brush icon in the bottom-right toolbar to pick a strategy: Subtle align nudges nearly-aligned nodes onto a shared grid without changing the overall shape. Compact layout re-flows everything left-to-right. Horizontal layout does the same but also forces every handle back to left/right. Vertical layout re-flows top-to-bottom and flips handles to match. Reset to original restores the initial mess so you can try again."
+        }
+      />
+    </BaseCanvas>
+  );
+}
+
 // ============================================================================
 // Exported Stories
 // ============================================================================
@@ -92,6 +331,16 @@ export const Horizontal: Story = {
 };
 
 export const WithOrganize: Story = {
-  name: 'With Organize',
+  name: 'Tidy up',
   render: () => <WithOrganizeStory />,
+};
+
+export const WithTidyUpMenu: Story = {
+  name: 'Tidy up menu',
+  render: () => <WithTidyUpMenuStory />,
+};
+
+export const WithTidyUpMenuAndInteraction: Story = {
+  name: 'Tidy up interactions',
+  render: () => <WithTidyUpMenuAndInteractionStory />,
 };

--- a/packages/apollo-react/src/canvas/components/CanvasZoomControls/CanvasZoomControls.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/CanvasZoomControls/CanvasZoomControls.stories.tsx
@@ -1,7 +1,8 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import type { Edge, Node } from '@uipath/apollo-react/canvas/xyflow/react';
 import { Panel, Position, useReactFlow } from '@uipath/apollo-react/canvas/xyflow/react';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Button } from '@uipath/apollo-wind';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   createNode,
   StoryInfoPanel,
@@ -15,6 +16,7 @@ import { BaseNodeOverrideConfigProvider } from '../BaseNode';
 import type { BaseNodeData } from '../BaseNode/BaseNode.types';
 import type { NodeToolbarConfig } from '../Toolbar';
 import { CanvasZoomControls, type TidyUpMenuOption } from './CanvasZoomControls';
+import { CanvasZoomControlsUXGuidance } from './CanvasZoomControlsUXGuidance';
 
 // Handle presets for "Horizontal layout"/"Vertical layout", scoped to this
 // story only. Deliberately label-less (unlike storybook-utils' HandleConfigs
@@ -74,9 +76,10 @@ type Story = StoryObj<typeof CanvasZoomControls>;
 const REFERENCE_TIDY_UP_OPTIONS: TidyUpMenuOption[] = [
   ...TIDY_UP_STRATEGIES,
   {
-    id: 'reset',
-    label: 'Reset to original',
-    icon: 'rotate-ccw',
+    id: 'undo',
+    label: 'Undo Tidy up',
+    icon: 'undo-2',
+    disabled: true,
     separatorBefore: true,
   },
 ];
@@ -205,7 +208,7 @@ function messyEdge(id: string, source: string, target: string): Edge {
   return { id, source, target, sourceHandle: 'output', targetHandle: 'input' };
 }
 
-// Keyed by node id so "Reset to original" can restore positions on the
+// Keyed by node id so the Storybook-only "Reset demo" control can restore positions on the
 // existing node objects (preserving their measured dimensions) instead of
 // replacing them outright, which would force React Flow to re-measure
 // before fitView can compute correct bounds.
@@ -232,6 +235,8 @@ function WithTidyUpMenuAndInteractionStory() {
   });
   const [isTidying, setIsTidying] = useState(false);
   const [layoutVersion, setLayoutVersion] = useState(0);
+  const [canUndo, setCanUndo] = useState(false);
+  const previousNodesRef = useRef<Node<BaseNodeData>[] | null>(null);
   const { fitView } = useReactFlow();
 
   // Nodes can move well outside the current viewport (especially with
@@ -245,15 +250,26 @@ function WithTidyUpMenuAndInteractionStory() {
     fitView({ duration: 400, padding: 0.2 });
   }, [layoutVersion, fitView]);
 
+  const rememberCurrentLayout = useCallback(() => {
+    previousNodesRef.current = canvasProps.nodes.map((node) => ({
+      ...node,
+      position: { ...node.position },
+      data: { ...node.data },
+    }));
+    setCanUndo(true);
+  }, [canvasProps.nodes]);
+
   const handleTidyUpSelect = useCallback(
     (optionId: string) => {
       if (optionId === 'subtle') {
+        rememberCurrentLayout();
         setNodes((current) => subtleAlignNodes(current));
         setLayoutVersion((v) => v + 1);
         return;
       }
 
       if (optionId === 'compact') {
+        rememberCurrentLayout();
         setIsTidying(true);
         compactAlignNodes(canvasProps.nodes, messyEdges)
           .then((laidOut) => {
@@ -265,6 +281,7 @@ function WithTidyUpMenuAndInteractionStory() {
       }
 
       if (optionId === 'horizontal' || optionId === 'vertical') {
+        rememberCurrentLayout();
         setIsTidying(true);
         const direction = optionId === 'horizontal' ? 'LR' : 'TD';
         // Handles are side-mounted (left/right) by default, matching a
@@ -284,21 +301,28 @@ function WithTidyUpMenuAndInteractionStory() {
         return;
       }
 
-      if (optionId === 'reset') {
-        setNodes((current) =>
-          current.map((node) => ({
-            ...node,
-            position: MESSY_POSITIONS[node.id] ?? node.position,
-            // Clear the override so handles fall back to their manifest
-            // default (left/right), matching the original messy state.
-            data: { ...node.data, handleConfigurations: undefined },
-          }))
-        );
+      if (optionId === 'undo' && previousNodesRef.current) {
+        setNodes(previousNodesRef.current);
+        previousNodesRef.current = null;
+        setCanUndo(false);
         setLayoutVersion((v) => v + 1);
       }
     },
-    [canvasProps.nodes, setNodes]
+    [canvasProps.nodes, rememberCurrentLayout, setNodes]
   );
+
+  const handleResetDemo = useCallback(() => {
+    setNodes((current) =>
+      current.map((node) => ({
+        ...node,
+        position: MESSY_POSITIONS[node.id] ?? node.position,
+        data: { ...node.data, handleConfigurations: undefined },
+      }))
+    );
+    previousNodesRef.current = null;
+    setCanUndo(false);
+    setLayoutVersion((v) => v + 1);
+  }, [setNodes]);
 
   const tidyUpOptions: TidyUpMenuOption[] = useMemo(
     () => [
@@ -314,14 +338,14 @@ function WithTidyUpMenuAndInteractionStory() {
         icon: 'move-vertical',
       },
       {
-        id: 'reset',
-        label: 'Reset to original',
-        icon: 'rotate-ccw',
-        disabled: isTidying,
+        id: 'undo',
+        label: 'Undo Tidy up',
+        icon: 'undo-2',
+        disabled: isTidying || !canUndo,
         separatorBefore: true,
       },
     ],
-    [isTidying]
+    [canUndo, isTidying]
   );
 
   // Story-scoped only: overrides every node's toolbar to add the same tidy-up
@@ -380,20 +404,25 @@ function WithTidyUpMenuAndInteractionStory() {
         },
         { id: 'separator' },
         {
-          id: 'reset',
-          icon: <CanvasIcon icon="rotate-ccw" size={14} />,
-          label: 'Reset to original',
-          disabled: isTidying,
-          onAction: () => handleTidyUpSelect('reset'),
+          id: 'undo',
+          icon: <CanvasIcon icon="undo-2" size={14} />,
+          label: 'Undo Tidy up',
+          disabled: isTidying || !canUndo,
+          onAction: () => handleTidyUpSelect('undo'),
         },
       ],
     }),
-    [handleTidyUpSelect, isTidying]
+    [canUndo, handleTidyUpSelect, isTidying]
   );
 
   return (
     <BaseNodeOverrideConfigProvider value={{ toolbarConfig: nodeToolbarConfig }}>
       <BaseCanvas {...canvasProps} mode="design">
+        <Panel position="top-right">
+          <Button variant="outline" size="sm" onClick={handleResetDemo}>
+            Reset demo
+          </Button>
+        </Panel>
         <Panel position="bottom-right">
           <CanvasZoomControls
             orientation="vertical"
@@ -406,7 +435,7 @@ function WithTidyUpMenuAndInteractionStory() {
           description={
             isTidying
               ? 'Tidying up...'
-              : 'This workflow\'s nodes were placed carelessly. Trigger a strategy from the brush icon in the bottom-right toolbar, or from the "Tidy up" overflow menu above any node. Subtle align nudges nearly-aligned nodes onto a shared grid without changing the overall shape. Compact layout re-flows everything left-to-right. Horizontal layout does the same but also forces every handle back to left/right. Vertical layout re-flows top-to-bottom and flips handles to match. Reset to original restores the initial mess so you can try again.'
+              : 'This workflow\'s nodes were placed carelessly. Trigger a strategy from the brush icon in the bottom-right toolbar, or from the "Tidy up" overflow menu above any node. Undo Tidy up restores the immediately previous layout. Reset demo restores the initial mess so you can try again.'
           }
         />
       </BaseCanvas>
@@ -417,6 +446,16 @@ function WithTidyUpMenuAndInteractionStory() {
 // ============================================================================
 // Exported Stories
 // ============================================================================
+
+export const UXGuidance: Story = {
+  name: 'UX Guidance',
+  parameters: {
+    layout: 'fullscreen',
+  },
+  render: (_, { globals }) => (
+    <CanvasZoomControlsUXGuidance globalTheme={globals.theme || 'future-dark'} />
+  ),
+};
 
 export const Vertical: Story = {
   name: 'Vertical',

--- a/packages/apollo-react/src/canvas/components/CanvasZoomControls/CanvasZoomControls.tsx
+++ b/packages/apollo-react/src/canvas/components/CanvasZoomControls/CanvasZoomControls.tsx
@@ -11,16 +11,23 @@ import {
   TooltipTrigger,
 } from '@uipath/apollo-wind';
 import { BrushCleaning, Scan, ZoomIn, ZoomOut } from 'lucide-react';
+import type { ReactNode } from 'react';
 import { Fragment, forwardRef, memo, useCallback } from 'react';
 import { useSafeLingui } from '../../../i18n';
+import { CanvasIcon } from '../../utils/icon-registry';
 import { ToolbarButton } from '../ToolbarButton';
 
 /** A single choice offered by the "Tidy up" menu, e.g. a layout strategy. */
 export interface TidyUpMenuOption {
   id: string;
   label: string;
-  description?: string;
   disabled?: boolean;
+  /**
+   * Icon shown next to the label, matching NodeToolbar's overflow-menu
+   * format. Pass a canvas icon id string (resolved via the icon registry,
+   * e.g. "grid-3x3") or a pre-rendered ReactNode.
+   */
+  icon?: ReactNode;
   /** Renders a separator above this option, e.g. to set a destructive/reset action apart. */
   separatorBefore?: boolean;
 }
@@ -142,7 +149,7 @@ export const CanvasZoomControls = memo(
                 {_({ id: 'canvas.zoom.tidy_up', message: 'Tidy up' })}
               </TooltipContent>
             </Tooltip>
-            <DropdownMenuContent align="end" side={tooltipSide} sideOffset={8} className="w-64">
+            <DropdownMenuContent align="end" side={tooltipSide} sideOffset={8} className="w-48">
               {tidyUpOptions.map((option) => (
                 <Fragment key={option.id}>
                   {option.separatorBefore && <DropdownMenuSeparator />}
@@ -151,14 +158,12 @@ export const CanvasZoomControls = memo(
                     disabled={option.disabled}
                     onSelect={() => onTidyUpSelect?.(option.id)}
                   >
-                    <div className="min-w-0">
-                      <p className="text-sm font-medium">{option.label}</p>
-                      {option.description && (
-                        <p className="text-xs text-foreground-muted truncate">
-                          {option.description}
-                        </p>
-                      )}
-                    </div>
+                    {typeof option.icon === 'string' ? (
+                      <CanvasIcon icon={option.icon} size={16} />
+                    ) : (
+                      option.icon
+                    )}
+                    <span>{option.label}</span>
                   </DropdownMenuItem>
                 </Fragment>
               ))}

--- a/packages/apollo-react/src/canvas/components/CanvasZoomControls/CanvasZoomControls.tsx
+++ b/packages/apollo-react/src/canvas/components/CanvasZoomControls/CanvasZoomControls.tsx
@@ -1,15 +1,47 @@
-import { forwardRef, memo, useCallback } from 'react';
-import { BrushCleaning, Scan, ZoomIn, ZoomOut } from 'lucide-react';
 import { useReactFlow } from '@uipath/apollo-react/canvas/xyflow/react';
-import { ToolbarButton } from '../ToolbarButton';
+import {
+  Button,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@uipath/apollo-wind';
+import { BrushCleaning, Scan, ZoomIn, ZoomOut } from 'lucide-react';
+import { Fragment, forwardRef, memo, useCallback } from 'react';
 import { useSafeLingui } from '../../../i18n';
+import { ToolbarButton } from '../ToolbarButton';
+
+/** A single choice offered by the "Tidy up" menu, e.g. a layout strategy. */
+export interface TidyUpMenuOption {
+  id: string;
+  label: string;
+  description?: string;
+  disabled?: boolean;
+  /** Renders a separator above this option, e.g. to set a destructive/reset action apart. */
+  separatorBefore?: boolean;
+}
 
 export interface CanvasZoomControlsProps {
   orientation?: 'vertical' | 'horizontal';
   fitViewOptions?: { duration?: number; padding?: number; maxZoom?: number };
   zoomInOptions?: { duration?: number };
   zoomOutOptions?: { duration?: number };
+  /**
+   * Runs a single "Tidy up" action immediately on click. Ignored when
+   * `tidyUpOptions` is provided -- pass that instead to offer a choice of
+   * strategies via a menu.
+   */
   onOrganize?: () => void;
+  /**
+   * When provided (with at least one option), the "Tidy up" button opens a
+   * menu of strategies instead of running a single hardcoded action.
+   */
+  tidyUpOptions?: TidyUpMenuOption[];
+  onTidyUpSelect?: (optionId: string) => void;
   onFitView?: () => void;
 }
 
@@ -24,6 +56,8 @@ export const CanvasZoomControls = memo(
       zoomInOptions,
       zoomOutOptions,
       onOrganize,
+      tidyUpOptions,
+      onTidyUpSelect,
       onFitView,
     },
     ref
@@ -87,16 +121,61 @@ export const CanvasZoomControls = memo(
           <Scan />
         </ToolbarButton>
 
-        {onOrganize && (
-          <ToolbarButton
-            testId="organize-button"
-            label={_({ id: 'canvas.zoom.tidy_up', message: 'Tidy up' })}
-            tooltipSide={tooltipSide}
-            onClick={onOrganize}
-            className={ZOOM_ICON_BUTTON_CLASS}
-          >
-            <BrushCleaning />
-          </ToolbarButton>
+        {tidyUpOptions && tidyUpOptions.length > 0 ? (
+          <DropdownMenu>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <DropdownMenuTrigger asChild>
+                  <Button
+                    data-testid="tidy-up-menu-button"
+                    aria-label={_({ id: 'canvas.zoom.tidy_up', message: 'Tidy up' })}
+                    variant="ghost"
+                    size="xs"
+                    icon
+                    className={ZOOM_ICON_BUTTON_CLASS}
+                  >
+                    <BrushCleaning />
+                  </Button>
+                </DropdownMenuTrigger>
+              </TooltipTrigger>
+              <TooltipContent side={tooltipSide}>
+                {_({ id: 'canvas.zoom.tidy_up', message: 'Tidy up' })}
+              </TooltipContent>
+            </Tooltip>
+            <DropdownMenuContent align="end" side={tooltipSide} sideOffset={8} className="w-64">
+              {tidyUpOptions.map((option) => (
+                <Fragment key={option.id}>
+                  {option.separatorBefore && <DropdownMenuSeparator />}
+                  <DropdownMenuItem
+                    data-testid={`tidy-up-option-${option.id}`}
+                    disabled={option.disabled}
+                    onSelect={() => onTidyUpSelect?.(option.id)}
+                  >
+                    <div className="min-w-0">
+                      <p className="text-sm font-medium">{option.label}</p>
+                      {option.description && (
+                        <p className="text-xs text-foreground-muted truncate">
+                          {option.description}
+                        </p>
+                      )}
+                    </div>
+                  </DropdownMenuItem>
+                </Fragment>
+              ))}
+            </DropdownMenuContent>
+          </DropdownMenu>
+        ) : (
+          onOrganize && (
+            <ToolbarButton
+              testId="organize-button"
+              label={_({ id: 'canvas.zoom.tidy_up', message: 'Tidy up' })}
+              tooltipSide={tooltipSide}
+              onClick={onOrganize}
+              className={ZOOM_ICON_BUTTON_CLASS}
+            >
+              <BrushCleaning />
+            </ToolbarButton>
+          )
         )}
       </div>
     );

--- a/packages/apollo-react/src/canvas/components/CanvasZoomControls/CanvasZoomControlsUXGuidance.tsx
+++ b/packages/apollo-react/src/canvas/components/CanvasZoomControls/CanvasZoomControlsUXGuidance.tsx
@@ -1,0 +1,314 @@
+import type { Edge, Node } from '@uipath/apollo-react/canvas/xyflow/react';
+import { Panel } from '@uipath/apollo-react/canvas/xyflow/react';
+import { Switch } from '@uipath/apollo-wind';
+import { BrushCleaning, Ellipsis } from 'lucide-react';
+import * as React from 'react';
+import { createNode, useCanvasStory } from '../../storybook-utils';
+import { CanvasIcon } from '../../utils/icon-registry';
+import { BaseCanvas } from '../BaseCanvas';
+import { CanvasZoomControls, type TidyUpMenuOption } from './CanvasZoomControls';
+
+const tidyUpOptions: TidyUpMenuOption[] = [
+  { id: 'subtle', label: 'Subtle align', icon: 'grid-3x3' },
+  { id: 'compact', label: 'Compact layout', icon: 'shrink' },
+  { id: 'horizontal', label: 'Horizontal layout', icon: 'move-horizontal' },
+  { id: 'vertical', label: 'Vertical layout', icon: 'move-vertical' },
+];
+
+const exampleNodes: Node[] = [
+  createNode({
+    id: 'trigger',
+    type: 'uipath.manual-trigger',
+    position: { x: 35, y: 115 },
+    display: { label: 'New request' },
+  }),
+  createNode({
+    id: 'review',
+    type: 'uipath.blank-node',
+    position: { x: 300, y: 55 },
+    display: { label: 'Review request' },
+  }),
+  createNode({
+    id: 'notify',
+    type: 'uipath.blank-node',
+    position: { x: 555, y: 150 },
+    display: { label: 'Notify owner' },
+  }),
+];
+
+const exampleEdges: Edge[] = [
+  {
+    id: 'trigger-review',
+    source: 'trigger',
+    target: 'review',
+    sourceHandle: 'output',
+    targetHandle: 'input',
+  },
+  {
+    id: 'review-notify',
+    source: 'review',
+    target: 'notify',
+    sourceHandle: 'output',
+    targetHandle: 'input',
+  },
+];
+
+function Eyebrow({ children }: { children: React.ReactNode }) {
+  return (
+    <p className="font-mono text-[11px] font-semibold uppercase tracking-[0.18em] text-primary">
+      {children}
+    </p>
+  );
+}
+
+function ScopeCard({
+  icon,
+  eyebrow,
+  title,
+  description,
+  affects,
+  availability,
+}: {
+  icon: React.ReactNode;
+  eyebrow: string;
+  title: string;
+  description: string;
+  affects: string;
+  availability: string;
+}) {
+  return (
+    <article className="flex min-h-[280px] flex-col rounded-2xl border border-border bg-card p-6 shadow-sm">
+      <div className="mb-8 flex items-start justify-between">
+        <span className="rounded-full border border-border bg-background px-3 py-1 font-mono text-[10px] font-medium uppercase tracking-[0.12em] text-muted-foreground">
+          {eyebrow}
+        </span>
+        <div className="flex size-10 items-center justify-center rounded-xl bg-primary/10 text-primary">
+          {icon}
+        </div>
+      </div>
+      <h3 className="text-xl font-semibold tracking-tight text-foreground">{title}</h3>
+      <p className="mt-2 max-w-lg text-sm leading-6 text-muted-foreground">{description}</p>
+      <dl className="mt-6 grid grid-cols-2 gap-4 border-t border-border pt-5 text-sm">
+        <div>
+          <dt className="text-xs font-medium text-muted-foreground">Affects</dt>
+          <dd className="mt-1 font-medium text-foreground">{affects}</dd>
+        </div>
+        <div>
+          <dt className="text-xs font-medium text-muted-foreground">Available</dt>
+          <dd className="mt-1 font-medium text-foreground">{availability}</dd>
+        </div>
+      </dl>
+    </article>
+  );
+}
+
+function LiveExample() {
+  const { canvasProps } = useCanvasStory({
+    initialNodes: exampleNodes,
+    initialEdges: exampleEdges,
+  });
+  const [lastAction, setLastAction] = React.useState('Choose a Tidy up strategy');
+
+  return (
+    <div className="overflow-hidden rounded-2xl border border-border bg-card shadow-sm">
+      <div className="flex items-center justify-between border-b border-border px-5 py-4">
+        <div>
+          <h3 className="text-sm font-semibold text-foreground">Core component use</h3>
+          <p className="mt-0.5 text-xs text-muted-foreground">
+            Keep the global control anchored to the canvas viewport.
+          </p>
+        </div>
+        <span className="hidden rounded-full bg-primary/10 px-3 py-1 text-xs font-medium text-primary sm:inline">
+          {lastAction}
+        </span>
+      </div>
+      <div className="h-[360px] bg-background">
+        <BaseCanvas {...canvasProps} mode="design">
+          <Panel position="bottom-right">
+            <CanvasZoomControls
+              tidyUpOptions={tidyUpOptions}
+              onTidyUpSelect={(id) => {
+                const option = tidyUpOptions.find((item) => item.id === id);
+                setLastAction(option?.label ?? id);
+              }}
+            />
+          </Panel>
+        </BaseCanvas>
+      </div>
+    </div>
+  );
+}
+
+function GuidanceRow({
+  strategy,
+  useWhen,
+  result,
+}: {
+  strategy: string;
+  useWhen: string;
+  result: string;
+}) {
+  return (
+    <div className="grid gap-2 border-t border-border py-4 first:border-t-0 sm:grid-cols-[150px_1fr_1fr] sm:gap-6">
+      <p className="text-sm font-semibold text-foreground">{strategy}</p>
+      <p className="text-sm leading-6 text-muted-foreground">{useWhen}</p>
+      <p className="text-sm leading-6 text-muted-foreground">{result}</p>
+    </div>
+  );
+}
+
+function AlignmentHintsConcept() {
+  const [enabled, setEnabled] = React.useState(true);
+
+  return (
+    <div className="flex min-h-72 items-center justify-center rounded-2xl border border-border bg-muted/20 p-8">
+      <div className="w-48 rounded-lg border border-border bg-popover p-1 shadow-xl">
+        <div className="flex items-center gap-2 rounded-md px-2 py-1.5 text-sm text-muted-foreground">
+          <CanvasIcon icon="undo-2" size={16} />
+          <span>Undo Tidy up</span>
+        </div>
+        <div className="my-1 h-px bg-border" />
+
+        {tidyUpOptions.map((option) => (
+          <div
+            key={option.id}
+            className="flex items-center gap-2 rounded-md px-2 py-1.5 text-sm text-foreground"
+          >
+            <CanvasIcon icon={option.icon as string} size={16} />
+            <span>{option.label}</span>
+          </div>
+        ))}
+
+        <div className="my-1 h-px bg-border" />
+        <div className="flex items-center justify-between gap-3 rounded-md px-2 py-1.5">
+          <span className="text-sm text-foreground">Alignment hints</span>
+          <Switch
+            size="sm"
+            checked={enabled}
+            aria-label="Toggle alignment hints concept"
+            onCheckedChange={setEnabled}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function CanvasZoomControlsUXGuidance({ globalTheme }: { globalTheme: string }) {
+  return (
+    <main className={`${globalTheme || 'future-dark'} min-h-screen bg-background text-foreground`}>
+      <div className="mx-auto max-w-5xl px-6 py-12 sm:px-8 sm:py-16">
+        <header className="max-w-3xl">
+          <Eyebrow>UX Guidance</Eyebrow>
+          <h1 className="mt-4 text-4xl font-semibold tracking-[-0.035em] text-foreground sm:text-5xl">
+            Tidy up without surprises
+          </h1>
+          <p className="mt-5 max-w-2xl text-lg leading-8 text-muted-foreground">
+            Tidy up helps people restore order without making them guess how much of their workflow
+            will move. The entry point communicates the scope.
+          </p>
+        </header>
+
+        <section className="mt-12">
+          <div className="mb-5 max-w-3xl">
+            <h2 className="text-2xl font-semibold tracking-tight text-foreground">
+              Location sets the expectation
+            </h2>
+            <p className="mt-3 text-sm leading-6 text-muted-foreground">
+              <strong className="font-semibold text-foreground">
+                Avoid duplicate global actions.
+              </strong>{' '}
+              If the hover-menu command moves the entire workflow, keep Tidy up in the bottom-right
+              control only. A contextual location promises a contextual result.
+            </p>
+          </div>
+
+          <div className="grid gap-5 md:grid-cols-2">
+            <ScopeCard
+              icon={<BrushCleaning size={19} />}
+              eyebrow="Global"
+              title="Bottom-right Tidy up"
+              description="Use the persistent canvas control when a layout strategy should reorganize the workflow as a whole."
+              affects="Entire workflow"
+              availability="Always visible"
+            />
+            <ScopeCard
+              icon={<Ellipsis size={20} />}
+              eyebrow="Contextual"
+              title="Hover-menu Tidy up"
+              description="Use the node overflow when the action is limited to the current node, selection, branch, or group."
+              affects="Current context"
+              availability="On hover or selection"
+            />
+          </div>
+        </section>
+
+        <section className="mt-16">
+          <h2 className="text-2xl font-semibold tracking-tight text-foreground">
+            Match the strategy to the intent
+          </h2>
+          <div className="mt-6 overflow-hidden rounded-2xl border border-border bg-card px-5 sm:px-6">
+            <div className="hidden grid-cols-[150px_1fr_1fr] gap-6 py-3 font-mono text-[10px] font-semibold uppercase tracking-[0.14em] text-muted-foreground sm:grid">
+              <span>Strategy</span>
+              <span>Use when</span>
+              <span>Expected result</span>
+            </div>
+            <GuidanceRow
+              strategy="Subtle align"
+              useWhen="The workflow is already understandable but spacing feels uneven."
+              result="Nudge nodes onto a shared rhythm while preserving the overall shape."
+            />
+            <GuidanceRow
+              strategy="Compact layout"
+              useWhen="The graph has grown organically and needs a clearer reading order."
+              result="Reflow the workflow and reduce unnecessary space."
+            />
+            <GuidanceRow
+              strategy="Horizontal layout"
+              useWhen="The process should read from left to right."
+              result="Reflow nodes horizontally and keep handles on the left and right."
+            />
+            <GuidanceRow
+              strategy="Vertical layout"
+              useWhen="The process should read from top to bottom."
+              result="Reflow nodes vertically and move handles to the top and bottom."
+            />
+          </div>
+        </section>
+
+        <section className="mt-16">
+          <div className="mb-5">
+            <h2 className="text-2xl font-semibold tracking-tight text-foreground">
+              Reference implementation
+            </h2>
+            <p className="mt-3 max-w-3xl text-sm leading-6 text-muted-foreground">
+              Let people choose the right degree of change. Use{' '}
+              <code className="rounded bg-muted px-1.5 py-0.5 text-foreground">tidyUpOptions</code>{' '}
+              when multiple layout strategies are available. Use{' '}
+              <code className="rounded bg-muted px-1.5 py-0.5 text-foreground">onOrganize</code>{' '}
+              only when one predictable action can run immediately.
+            </p>
+          </div>
+          <LiveExample />
+        </section>
+
+        <section className="mt-16">
+          <div className="mb-5 max-w-3xl">
+            <p className="font-mono text-[11px] font-semibold uppercase tracking-[0.18em] text-primary">
+              Open question
+            </p>
+            <h2 className="mt-2 text-2xl font-semibold tracking-tight text-foreground">
+              Should manual alignment hints be configurable?
+            </h2>
+            <p className="mt-3 text-sm leading-6 text-muted-foreground">
+              Alignment hints support precise manual placement and complement Tidy up without being
+              part of it. If optional, should the Tidy up menu also provide a persistent on or off
+              control?
+            </p>
+          </div>
+          <AlignmentHintsConcept />
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/packages/apollo-react/src/canvas/components/CanvasZoomControls/CanvasZoomControlsUXGuidance.tsx
+++ b/packages/apollo-react/src/canvas/components/CanvasZoomControls/CanvasZoomControlsUXGuidance.tsx
@@ -1,7 +1,25 @@
 import type { Edge, Node } from '@uipath/apollo-react/canvas/xyflow/react';
 import { Panel } from '@uipath/apollo-react/canvas/xyflow/react';
 import { Switch } from '@uipath/apollo-wind';
-import { BrushCleaning, Ellipsis } from 'lucide-react';
+import {
+  AlignHorizontalJustifyCenter,
+  AlignHorizontalJustifyEnd,
+  AlignHorizontalJustifyStart,
+  AlignHorizontalSpaceAround,
+  AlignStartHorizontal,
+  AlignVerticalJustifyCenter,
+  AlignVerticalJustifyEnd,
+  AlignVerticalJustifyStart,
+  AlignVerticalSpaceAround,
+  BrushCleaning,
+  ChevronRight,
+  Clipboard,
+  Copy,
+  Ellipsis,
+  Layers,
+  Scissors,
+  Trash2,
+} from 'lucide-react';
 import * as React from 'react';
 import { createNode, useCanvasStory } from '../../storybook-utils';
 import { CanvasIcon } from '../../utils/icon-registry';
@@ -9,10 +27,10 @@ import { BaseCanvas } from '../BaseCanvas';
 import { CanvasZoomControls, type TidyUpMenuOption } from './CanvasZoomControls';
 
 const tidyUpOptions: TidyUpMenuOption[] = [
-  { id: 'subtle', label: 'Subtle align', icon: 'grid-3x3' },
-  { id: 'compact', label: 'Compact layout', icon: 'shrink' },
-  { id: 'horizontal', label: 'Horizontal layout', icon: 'move-horizontal' },
-  { id: 'vertical', label: 'Vertical layout', icon: 'move-vertical' },
+  { id: 'subtle', label: 'Align subtly', icon: 'grid-3x3' },
+  { id: 'compact', label: 'Make compact', icon: 'shrink' },
+  { id: 'horizontal', label: 'Lay out horizontally', icon: 'move-horizontal' },
+  { id: 'vertical', label: 'Lay out vertically', icon: 'move-vertical' },
 ];
 
 const exampleNodes: Node[] = [
@@ -157,40 +175,393 @@ function GuidanceRow({
   );
 }
 
-function AlignmentHintsConcept() {
-  const [enabled, setEnabled] = React.useState(true);
+type MenuFlyout = 'tidy' | 'align' | 'distribute';
+
+function MenuCommand({
+  icon,
+  label,
+  shortcut,
+  active = false,
+  disabled = false,
+  flyout = false,
+  onSelect,
+}: {
+  icon: React.ReactNode;
+  label: string;
+  shortcut?: string;
+  active?: boolean;
+  disabled?: boolean;
+  flyout?: boolean;
+  onSelect: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      className={`flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-[13px] outline-none focus-visible:ring-2 focus-visible:ring-ring ${
+        disabled
+          ? 'cursor-not-allowed text-muted-foreground opacity-50'
+          : `text-foreground ${active ? 'bg-accent' : 'hover:bg-accent/60'}`
+      }`}
+      aria-expanded={flyout ? active : undefined}
+      disabled={disabled}
+      onClick={onSelect}
+      onMouseEnter={flyout ? onSelect : undefined}
+    >
+      {icon}
+      <span className="min-w-0 flex-1 truncate">{label}</span>
+      {shortcut && <span className="text-[11px] text-muted-foreground">{shortcut}</span>}
+      {flyout && <ChevronRight size={14} className="text-muted-foreground" />}
+    </button>
+  );
+}
+
+function MenuFlyoutPanel({
+  flyout,
+  hintsEnabled,
+  canUndo,
+  onHintsChange,
+  onAction,
+}: {
+  flyout: MenuFlyout;
+  hintsEnabled: boolean;
+  canUndo: boolean;
+  onHintsChange: (checked: boolean) => void;
+  onAction: (label: string) => void;
+}) {
+  if (flyout === 'tidy') {
+    return (
+      <>
+        <MenuCommand
+          icon={<CanvasIcon icon="undo-2" size={15} />}
+          label="Undo Tidy up"
+          disabled={!canUndo}
+          onSelect={() => onAction('Undo Tidy up')}
+        />
+        <div className="my-1 h-px bg-border" />
+        {tidyUpOptions.map((option) => (
+          <MenuCommand
+            key={option.id}
+            icon={<CanvasIcon icon={option.icon as string} size={15} />}
+            label={option.label}
+            onSelect={() => onAction(option.label)}
+          />
+        ))}
+      </>
+    );
+  }
+
+  const items =
+    flyout === 'align'
+      ? [
+          { label: 'Align left', icon: AlignHorizontalJustifyStart, separated: false },
+          { label: 'Align center', icon: AlignHorizontalJustifyCenter, separated: false },
+          { label: 'Align right', icon: AlignHorizontalJustifyEnd, separated: false },
+          { label: 'Align top', icon: AlignVerticalJustifyStart, separated: true },
+          { label: 'Align middle', icon: AlignVerticalJustifyCenter, separated: false },
+          { label: 'Align bottom', icon: AlignVerticalJustifyEnd, separated: false },
+        ]
+      : [
+          { label: 'Distribute horizontally', icon: AlignHorizontalSpaceAround, separated: false },
+          { label: 'Distribute vertically', icon: AlignVerticalSpaceAround, separated: false },
+        ];
 
   return (
-    <div className="flex min-h-72 items-center justify-center rounded-2xl border border-border bg-muted/20 p-8">
-      <div className="w-48 rounded-lg border border-border bg-popover p-1 shadow-xl">
-        <div className="flex items-center gap-2 rounded-md px-2 py-1.5 text-sm text-muted-foreground">
-          <CanvasIcon icon="undo-2" size={16} />
-          <span>Undo Tidy up</span>
-        </div>
-        <div className="my-1 h-px bg-border" />
+    <>
+      {items.map((item) => {
+        const Icon = item.icon;
 
-        {tidyUpOptions.map((option) => (
-          <div
-            key={option.id}
-            className="flex items-center gap-2 rounded-md px-2 py-1.5 text-sm text-foreground"
-          >
-            <CanvasIcon icon={option.icon as string} size={16} />
-            <span>{option.label}</span>
+        return (
+          <React.Fragment key={item.label}>
+            {item.separated && <div className="my-1 h-px bg-border" />}
+            <MenuCommand
+              icon={<Icon size={15} />}
+              label={item.label}
+              onSelect={() => onAction(item.label)}
+            />
+          </React.Fragment>
+        );
+      })}
+      {flyout === 'align' && (
+        <>
+          <div className="my-1 h-px bg-border" />
+          <div className="flex items-center justify-between gap-2 rounded-md px-2 py-1.5">
+            <span className="text-[13px] text-foreground">Alignment hints</span>
+            <Switch
+              size="sm"
+              checked={hintsEnabled}
+              aria-label="Toggle alignment hints concept"
+              onCheckedChange={onHintsChange}
+            />
           </div>
-        ))}
+        </>
+      )}
+    </>
+  );
+}
 
-        <div className="my-1 h-px bg-border" />
-        <div className="flex items-center justify-between gap-3 rounded-md px-2 py-1.5">
-          <span className="text-sm text-foreground">Alignment hints</span>
-          <Switch
-            size="sm"
-            checked={enabled}
-            aria-label="Toggle alignment hints concept"
-            onCheckedChange={setEnabled}
+function MenuStateExample({ selected }: { selected: boolean }) {
+  const [openFlyout, setOpenFlyout] = React.useState<MenuFlyout>('tidy');
+  const [hintsEnabled, setHintsEnabled] = React.useState(true);
+  const [canUndo, setCanUndo] = React.useState(false);
+  const [lastAction, setLastAction] = React.useState('Choose an action');
+
+  const handleAction = (label: string) => {
+    setLastAction(label);
+    if (label === 'Undo Tidy up') {
+      setCanUndo(false);
+    } else if (tidyUpOptions.some((option) => option.label === label)) {
+      setCanUndo(true);
+    }
+  };
+
+  return (
+    <article className="rounded-2xl border border-border bg-card p-5 shadow-sm">
+      <div className="mb-5 flex items-start justify-between gap-4">
+        <div>
+          <h3 className="text-base font-semibold text-foreground">
+            {selected ? 'Selection menu' : 'Canvas menu'}
+          </h3>
+          <p className="mt-1 text-xs leading-5 text-muted-foreground">
+            {selected ? 'Multiple nodes selected' : 'Nothing selected'}
+          </p>
+        </div>
+        <span className="max-w-36 truncate rounded-full bg-primary/10 px-2.5 py-1 text-[11px] font-medium text-primary">
+          {lastAction}
+        </span>
+      </div>
+
+      <div className="grid min-h-[320px] grid-cols-2 items-start gap-2 rounded-xl bg-muted/20 p-3">
+        <div className="rounded-lg border border-border bg-popover p-1 shadow-lg">
+          <MenuCommand
+            icon={<BrushCleaning size={15} />}
+            label={selected ? 'Tidy selected' : 'Tidy up'}
+            active={openFlyout === 'tidy'}
+            flyout
+            onSelect={() => setOpenFlyout('tidy')}
+          />
+
+          {selected ? (
+            <>
+              <MenuCommand
+                icon={<AlignStartHorizontal size={15} />}
+                label="Align"
+                active={openFlyout === 'align'}
+                flyout
+                onSelect={() => setOpenFlyout('align')}
+              />
+              <MenuCommand
+                icon={<AlignHorizontalSpaceAround size={15} />}
+                label="Distribute"
+                active={openFlyout === 'distribute'}
+                flyout
+                onSelect={() => setOpenFlyout('distribute')}
+              />
+              <div className="my-1 h-px bg-border" />
+              <MenuCommand
+                icon={<Copy size={15} />}
+                label="Copy"
+                shortcut="⌘C"
+                onSelect={() => handleAction('Copy')}
+              />
+              <MenuCommand
+                icon={<Scissors size={15} />}
+                label="Cut"
+                shortcut="⌘X"
+                onSelect={() => handleAction('Cut')}
+              />
+              <MenuCommand
+                icon={<Clipboard size={15} />}
+                label="Paste"
+                shortcut="⌘V"
+                onSelect={() => handleAction('Paste')}
+              />
+              <MenuCommand
+                icon={<Layers size={15} />}
+                label="Convert to subflow"
+                onSelect={() => handleAction('Convert to subflow')}
+              />
+              <div className="my-1 h-px bg-border" />
+              <MenuCommand
+                icon={<Trash2 size={15} />}
+                label="Delete"
+                shortcut="⌫"
+                onSelect={() => handleAction('Delete')}
+              />
+            </>
+          ) : null}
+        </div>
+
+        <div className="rounded-lg border border-border bg-popover p-1 shadow-lg">
+          <MenuFlyoutPanel
+            flyout={selected ? openFlyout : 'tidy'}
+            hintsEnabled={hintsEnabled}
+            canUndo={canUndo}
+            onHintsChange={(checked) => {
+              setHintsEnabled(checked);
+              handleAction(`Alignment hints ${checked ? 'on' : 'off'}`);
+            }}
+            onAction={handleAction}
           />
         </div>
       </div>
+    </article>
+  );
+}
+
+function ContextMenuSurface({ onAction }: { onAction: (label: string) => void }) {
+  return (
+    <div className="w-48 rounded-lg border border-border bg-popover p-1 shadow-xl">
+      <MenuCommand
+        icon={<BrushCleaning size={15} />}
+        label="Tidy selected"
+        flyout
+        onSelect={() => onAction('Tidy selected')}
+      />
+      <MenuCommand
+        icon={<AlignStartHorizontal size={15} />}
+        label="Align"
+        flyout
+        onSelect={() => onAction('Align')}
+      />
+      <MenuCommand
+        icon={<AlignHorizontalSpaceAround size={15} />}
+        label="Distribute"
+        flyout
+        onSelect={() => onAction('Distribute')}
+      />
+      <div className="my-1 h-px bg-border" />
+      <MenuCommand
+        icon={<Copy size={15} />}
+        label="Copy"
+        shortcut="⌘C"
+        onSelect={() => onAction('Copy')}
+      />
+      <MenuCommand
+        icon={<Scissors size={15} />}
+        label="Cut"
+        shortcut="⌘X"
+        onSelect={() => onAction('Cut')}
+      />
+      <MenuCommand
+        icon={<Clipboard size={15} />}
+        label="Paste"
+        shortcut="⌘V"
+        onSelect={() => onAction('Paste')}
+      />
+      <MenuCommand
+        icon={<Layers size={15} />}
+        label="Convert to subflow"
+        onSelect={() => onAction('Convert to subflow')}
+      />
+      <div className="my-1 h-px bg-border" />
+      <MenuCommand
+        icon={<Trash2 size={15} />}
+        label="Delete"
+        shortcut="⌫"
+        onSelect={() => onAction('Delete')}
+      />
     </div>
+  );
+}
+
+type WorkflowAccess = 'bottom-right' | 'hover' | 'right-click';
+
+function WorkflowAccessExample({ access }: { access: WorkflowAccess }) {
+  const contextual = access !== 'bottom-right';
+  const workflowNodes = React.useMemo(
+    () =>
+      exampleNodes.map((node) => ({
+        ...node,
+        selected: contextual && node.id === 'review',
+      })),
+    [contextual]
+  );
+  const { canvasProps } = useCanvasStory({
+    initialNodes: workflowNodes,
+    initialEdges: exampleEdges,
+  });
+  const [lastAction, setLastAction] = React.useState('Menu open');
+
+  const title =
+    access === 'bottom-right'
+      ? 'Bottom-right access'
+      : access === 'hover'
+        ? 'Node hover access'
+        : 'Right-click access';
+  const description =
+    access === 'bottom-right'
+      ? 'Open Tidy up from the persistent canvas control.'
+      : access === 'hover'
+        ? 'Hover over a node, then open More.'
+        : 'Right-click a node to open the same contextual menu.';
+
+  return (
+    <article className="overflow-hidden rounded-2xl border border-border bg-card shadow-sm">
+      <div className="flex items-start justify-between gap-4 border-b border-border px-5 py-4">
+        <div>
+          <p className="font-mono text-[10px] font-semibold uppercase tracking-[0.12em] text-primary">
+            Workflow experience
+          </p>
+          <h3 className="mt-1 text-sm font-semibold text-foreground">{title}</h3>
+          <p className="mt-1 text-xs leading-5 text-muted-foreground">{description}</p>
+        </div>
+        <span className="hidden max-w-40 truncate rounded-full bg-primary/10 px-2.5 py-1 text-[11px] font-medium text-primary sm:block">
+          {lastAction}
+        </span>
+      </div>
+      <div className="h-[300px] bg-background">
+        <BaseCanvas {...canvasProps} mode="design">
+          {access === 'bottom-right' ? (
+            <Panel position="bottom-right">
+              <div className="flex items-end gap-2">
+                <div className="w-48 rounded-lg border border-border bg-popover p-1 shadow-xl">
+                  <MenuFlyoutPanel
+                    flyout="tidy"
+                    hintsEnabled
+                    canUndo={false}
+                    onHintsChange={() => undefined}
+                    onAction={setLastAction}
+                  />
+                </div>
+                <CanvasZoomControls
+                  tidyUpOptions={tidyUpOptions}
+                  onTidyUpSelect={(id) => {
+                    const option = tidyUpOptions.find((item) => item.id === id);
+                    setLastAction(option?.label ?? id);
+                  }}
+                />
+              </div>
+            </Panel>
+          ) : access === 'hover' ? (
+            <Panel position="top-right">
+              <div className="flex items-start gap-2">
+                <div className="flex items-center rounded-lg border-2 border-primary bg-card p-1 pl-3 shadow-lg">
+                  <span className="text-xs font-medium text-foreground">Review request</span>
+                  <button
+                    type="button"
+                    className="ml-2 flex size-8 items-center justify-center rounded-md text-foreground outline-none hover:bg-accent focus-visible:ring-2 focus-visible:ring-ring"
+                    aria-label="Open node More menu"
+                    onClick={() => setLastAction('Opened from node More')}
+                  >
+                    <Ellipsis size={17} />
+                  </button>
+                </div>
+                <ContextMenuSurface onAction={setLastAction} />
+              </div>
+            </Panel>
+          ) : (
+            <Panel position="top-right">
+              <div className="flex items-start gap-2">
+                <div className="rounded-lg border border-dashed border-primary bg-primary/10 px-3 py-2 text-xs font-medium text-primary">
+                  Right-click node
+                </div>
+                <ContextMenuSurface onAction={setLastAction} />
+              </div>
+            </Panel>
+          )}
+        </BaseCanvas>
+      </div>
+    </article>
   );
 }
 
@@ -223,23 +594,32 @@ export function CanvasZoomControlsUXGuidance({ globalTheme }: { globalTheme: str
             </p>
           </div>
 
-          <div className="grid gap-5 md:grid-cols-2">
-            <ScopeCard
-              icon={<BrushCleaning size={19} />}
-              eyebrow="Global"
-              title="Bottom-right Tidy up"
-              description="Use the persistent canvas control when a layout strategy should reorganize the workflow as a whole."
-              affects="Entire workflow"
-              availability="Always visible"
-            />
-            <ScopeCard
-              icon={<Ellipsis size={20} />}
-              eyebrow="Contextual"
-              title="Hover-menu Tidy up"
-              description="Use the node overflow when the action is limited to the current node, selection, branch, or group."
-              affects="Current context"
-              availability="On hover or selection"
-            />
+          <div className="grid items-start gap-5 lg:grid-cols-2">
+            <div className="grid gap-5">
+              <ScopeCard
+                icon={<BrushCleaning size={19} />}
+                eyebrow="Global"
+                title="Bottom-right Tidy up"
+                description="Use the persistent canvas control when a layout strategy should reorganize the workflow as a whole."
+                affects="Entire workflow"
+                availability="Always visible"
+              />
+              <MenuStateExample selected={false} />
+              <WorkflowAccessExample access="bottom-right" />
+            </div>
+            <div className="grid gap-5">
+              <ScopeCard
+                icon={<Ellipsis size={20} />}
+                eyebrow="Contextual"
+                title="Hover-menu Tidy up"
+                description="Use the node overflow when the action is limited to the current node, selection, branch, or group."
+                affects="Current context"
+                availability="On hover or selection"
+              />
+              <MenuStateExample selected />
+              <WorkflowAccessExample access="hover" />
+              <WorkflowAccessExample access="right-click" />
+            </div>
           </div>
         </section>
 
@@ -254,22 +634,22 @@ export function CanvasZoomControlsUXGuidance({ globalTheme }: { globalTheme: str
               <span>Expected result</span>
             </div>
             <GuidanceRow
-              strategy="Subtle align"
+              strategy="Align subtly"
               useWhen="The workflow is already understandable but spacing feels uneven."
               result="Nudge nodes onto a shared rhythm while preserving the overall shape."
             />
             <GuidanceRow
-              strategy="Compact layout"
+              strategy="Make compact"
               useWhen="The graph has grown organically and needs a clearer reading order."
               result="Reflow the workflow and reduce unnecessary space."
             />
             <GuidanceRow
-              strategy="Horizontal layout"
+              strategy="Lay out horizontally"
               useWhen="The process should read from left to right."
               result="Reflow nodes horizontally and keep handles on the left and right."
             />
             <GuidanceRow
-              strategy="Vertical layout"
+              strategy="Lay out vertically"
               useWhen="The process should read from top to bottom."
               result="Reflow nodes vertically and move handles to the top and bottom."
             />
@@ -290,23 +670,6 @@ export function CanvasZoomControlsUXGuidance({ globalTheme }: { globalTheme: str
             </p>
           </div>
           <LiveExample />
-        </section>
-
-        <section className="mt-16">
-          <div className="mb-5 max-w-3xl">
-            <p className="font-mono text-[11px] font-semibold uppercase tracking-[0.18em] text-primary">
-              Open question
-            </p>
-            <h2 className="mt-2 text-2xl font-semibold tracking-tight text-foreground">
-              Should manual alignment hints be configurable?
-            </h2>
-            <p className="mt-3 text-sm leading-6 text-muted-foreground">
-              Alignment hints support precise manual placement and complement Tidy up without being
-              part of it. If optional, should the Tidy up menu also provide a persistent on or off
-              control?
-            </p>
-          </div>
-          <AlignmentHintsConcept />
         </section>
       </div>
     </main>

--- a/packages/apollo-react/src/canvas/components/CanvasZoomControls/index.ts
+++ b/packages/apollo-react/src/canvas/components/CanvasZoomControls/index.ts
@@ -1,2 +1,2 @@
+export type { CanvasZoomControlsProps, TidyUpMenuOption } from './CanvasZoomControls';
 export { CanvasZoomControls } from './CanvasZoomControls';
-export type { CanvasZoomControlsProps } from './CanvasZoomControls';

--- a/packages/apollo-react/src/canvas/storybook-utils/mocks/nodes.ts
+++ b/packages/apollo-react/src/canvas/storybook-utils/mocks/nodes.ts
@@ -250,6 +250,22 @@ export const HandleConfigs = {
     },
   ],
 
+  /** Input and output handles (top/bottom, for vertical/top-down flows) */
+  topBottom: [
+    {
+      position: Position.Top,
+      handles: [
+        { id: 'input', type: 'target' as const, handleType: 'input' as const, label: 'Input' },
+      ],
+    },
+    {
+      position: Position.Bottom,
+      handles: [
+        { id: 'output', type: 'source' as const, handleType: 'output' as const, label: 'Output' },
+      ],
+    },
+  ],
+
   /** Multiple bottom handles for artifacts */
   bottomArtifacts: (labels: string[]) => [
     {

--- a/packages/apollo-react/src/canvas/utils/tidy-up.test.ts
+++ b/packages/apollo-react/src/canvas/utils/tidy-up.test.ts
@@ -1,0 +1,94 @@
+import type { Edge, Node } from '@uipath/apollo-react/canvas/xyflow/react';
+import { describe, expect, it } from 'vitest';
+import { compactAlignNodes, subtleAlignNodes } from './tidy-up';
+
+describe('tidy-up', () => {
+  describe('subtleAlignNodes', () => {
+    it('returns the input unchanged for an empty list', () => {
+      expect(subtleAlignNodes([])).toEqual([]);
+    });
+
+    it('snaps nodes that are already close together onto a shared line', () => {
+      const nodes: Node[] = [
+        { id: 'a', type: 'generic', position: { x: 100, y: 0 }, data: {} },
+        { id: 'b', type: 'generic', position: { x: 108, y: 200 }, data: {} },
+        { id: 'c', type: 'generic', position: { x: 94, y: 400 }, data: {} },
+      ];
+
+      const result = subtleAlignNodes(nodes);
+      const xs = result.map((node) => node.position.x);
+
+      expect(xs[0]).toBe(xs[1]);
+      expect(xs[1]).toBe(xs[2]);
+    });
+
+    it('leaves nodes far from any neighbor untouched', () => {
+      const nodes: Node[] = [
+        { id: 'a', type: 'generic', position: { x: 0, y: 0 }, data: {} },
+        { id: 'b', type: 'generic', position: { x: 500, y: 500 }, data: {} },
+      ];
+
+      const result = subtleAlignNodes(nodes);
+
+      expect(result[0]?.position).toEqual({ x: 0, y: 0 });
+      expect(result[1]?.position).toEqual({ x: 500, y: 500 });
+    });
+
+    it('respects a custom snap threshold', () => {
+      const nodes: Node[] = [
+        { id: 'a', type: 'generic', position: { x: 0, y: 0 }, data: {} },
+        { id: 'b', type: 'generic', position: { x: 30, y: 0 }, data: {} },
+      ];
+
+      const snapped = subtleAlignNodes(nodes, 40);
+      const notSnapped = subtleAlignNodes(nodes, 10);
+
+      expect(snapped[0]?.position.x).toBe(snapped[1]?.position.x);
+      expect(notSnapped[0]?.position.x).not.toBe(notSnapped[1]?.position.x);
+    });
+
+    it('does not mutate the input nodes', () => {
+      const nodes: Node[] = [{ id: 'a', type: 'generic', position: { x: 0, y: 0 }, data: {} }];
+      const original = structuredClone(nodes);
+
+      subtleAlignNodes(nodes);
+
+      expect(nodes).toEqual(original);
+    });
+  });
+
+  describe('compactAlignNodes', () => {
+    it('lays out a simple chain left-to-right by default, matching handle-based edge routing', async () => {
+      const nodes: Node[] = [
+        { id: 'a', type: 'generic', position: { x: 300, y: 10 }, data: {} },
+        { id: 'b', type: 'generic', position: { x: -50, y: 900 }, data: {} },
+      ];
+      const edges: Edge[] = [{ id: 'a-b', source: 'a', target: 'b' }];
+
+      const result = await compactAlignNodes(nodes, edges);
+
+      const a = result.find((node) => node.id === 'a');
+      const b = result.find((node) => node.id === 'b');
+
+      expect(a).toBeDefined();
+      expect(b).toBeDefined();
+      // left-to-right layout: child sits to the right of its parent
+      expect(b?.position.x).toBeGreaterThan(a?.position.x ?? 0);
+    });
+
+    it('supports overriding the direction, e.g. back to top-down', async () => {
+      const nodes: Node[] = [
+        { id: 'a', type: 'generic', position: { x: 300, y: 10 }, data: {} },
+        { id: 'b', type: 'generic', position: { x: -50, y: 900 }, data: {} },
+      ];
+      const edges: Edge[] = [{ id: 'a-b', source: 'a', target: 'b' }];
+
+      const result = await compactAlignNodes(nodes, edges, undefined, 'TD');
+
+      const a = result.find((node) => node.id === 'a');
+      const b = result.find((node) => node.id === 'b');
+
+      expect(b?.position.y).toBeGreaterThan(a?.position.y ?? 0);
+    });
+  });
+});

--- a/packages/apollo-react/src/canvas/utils/tidy-up.ts
+++ b/packages/apollo-react/src/canvas/utils/tidy-up.ts
@@ -6,19 +6,20 @@ export type TidyUpStrategyId = 'subtle' | 'compact';
 export interface TidyUpStrategyOption {
   id: TidyUpStrategyId;
   label: string;
-  description: string;
+  /** Canvas icon id (resolved via the icon registry), matching NodeToolbar's overflow-menu format. */
+  icon: string;
 }
 
 export const TIDY_UP_STRATEGIES: TidyUpStrategyOption[] = [
   {
     id: 'subtle',
     label: 'Subtle align',
-    description: 'Snaps close nodes into a neat grid.',
+    icon: 'grid-3x3',
   },
   {
     id: 'compact',
     label: 'Compact layout',
-    description: 'Re-flows into a tight hierarchy.',
+    icon: 'shrink',
   },
 ];
 

--- a/packages/apollo-react/src/canvas/utils/tidy-up.ts
+++ b/packages/apollo-react/src/canvas/utils/tidy-up.ts
@@ -1,0 +1,110 @@
+import type { Edge, Node } from '@uipath/apollo-react/canvas/xyflow/react';
+import { d3HierarchyLayout } from './coded-agents/d3-layout';
+
+export type TidyUpStrategyId = 'subtle' | 'compact';
+
+export interface TidyUpStrategyOption {
+  id: TidyUpStrategyId;
+  label: string;
+  description: string;
+}
+
+export const TIDY_UP_STRATEGIES: TidyUpStrategyOption[] = [
+  {
+    id: 'subtle',
+    label: 'Subtle align',
+    description: 'Snaps close nodes into a neat grid.',
+  },
+  {
+    id: 'compact',
+    label: 'Compact layout',
+    description: 'Re-flows into a tight hierarchy.',
+  },
+];
+
+const DEFAULT_SNAP_THRESHOLD = 24;
+
+/**
+ * Clusters nearby values on a single axis and snaps every value in a cluster to
+ * the cluster's average. Values that aren't close to any neighbor are left as-is
+ * (each becomes its own single-value cluster).
+ */
+function snapAxis(values: number[], threshold: number): number[] {
+  const order = values.map((value, index) => ({ value, index })).sort((a, b) => a.value - b.value);
+  const clusters: Array<{ indices: number[]; sum: number }> = [];
+
+  for (const { value, index } of order) {
+    const current = clusters[clusters.length - 1];
+    const currentAverage = current ? current.sum / current.indices.length : undefined;
+    if (current && currentAverage !== undefined && value - currentAverage <= threshold) {
+      current.indices.push(index);
+      current.sum += value;
+    } else {
+      clusters.push({ indices: [index], sum: value });
+    }
+  }
+
+  const snapped = new Array<number>(values.length);
+  for (const cluster of clusters) {
+    const average = cluster.sum / cluster.indices.length;
+    for (const index of cluster.indices) {
+      snapped[index] = average;
+    }
+  }
+  return snapped;
+}
+
+/**
+ * "Subtle align" strategy: nudges nodes that are already close to being aligned
+ * onto a shared line, independently on the x and y axes. Nodes far from any
+ * neighbor are left untouched, so the overall shape of the workflow is
+ * preserved -- this is a cleanup pass, not a full re-layout.
+ */
+export function subtleAlignNodes<T extends Node>(
+  nodes: T[],
+  threshold = DEFAULT_SNAP_THRESHOLD
+): T[] {
+  if (nodes.length === 0) {
+    return nodes;
+  }
+
+  const xs = snapAxis(
+    nodes.map((node) => node.position.x),
+    threshold
+  );
+  const ys = snapAxis(
+    nodes.map((node) => node.position.y),
+    threshold
+  );
+
+  return nodes.map((node, index) => ({
+    ...node,
+    position: { x: xs[index] ?? node.position.x, y: ys[index] ?? node.position.y },
+  }));
+}
+
+const DEFAULT_COMPACT_SPACING: [number, number] = [48, 64];
+
+/**
+ * "Compact layout" strategy: re-flows the workflow into a tight hierarchy
+ * using the same d3-hierarchy layout CodedAgentFlow uses for its
+ * Mermaid-parsed graphs, with denser default spacing than that use case.
+ *
+ * Defaults to left-to-right because workflow nodes route edges by handle
+ * side (input on the left, output on the right, see `routing: 'handle'` on
+ * `CanvasEdge`) -- a top-down layout would still connect right-side outputs
+ * to left-side inputs below them, forcing every edge into an unnecessary
+ * zigzag. `LR` keeps a parent's output roughly level with its child's input.
+ */
+export async function compactAlignNodes<N extends Node, E extends Edge>(
+  nodes: N[],
+  edges: E[],
+  spacing: [number, number] = DEFAULT_COMPACT_SPACING,
+  direction: 'TD' | 'LR' | 'RL' | 'BT' = 'LR'
+): Promise<N[]> {
+  const { nodes: laidOut } = await d3HierarchyLayout(nodes, edges, {
+    direction,
+    spacing,
+  });
+  return laidOut as N[];
+}


### PR DESCRIPTION
## Summary
- Adds a "Tidy up" dropdown to `CanvasZoomControls` offering four layout strategies (Subtle align, Compact layout, Horizontal layout, Vertical layout) plus a Reset to original action, on top of the existing single-action `onOrganize` prop (unchanged, still used by `AgentCanvas`).
- New reusable `subtleAlignNodes` / `compactAlignNodes` utilities in `canvas/utils/tidy-up.ts`, with unit tests.
- Vertical layout also flips node handles to top/bottom (new `HandleConfigs`-style presets) so edges stay straight instead of zigzagging around side-mounted handles; Horizontal/Vertical also use wider node spacing than Compact for a less cramped look. Compact layout and Subtle align are untouched throughout.
- A second trigger point: the same tidy-up strategies are also available from a "Tidy up" overflow entry in each node's own `NodeToolbar`, scoped to the demo story only (via `BaseNodeOverrideConfigProvider`) — no effect on any other story or on production usage of these node types.
- Menu items render icon + label everywhere (corner control and NodeToolbar), matching format.
- Story pages under `Components/Controls/CanvasZoomControls`: **Vertical**, **Horizontal** (both now show the full toolbar including Tidy up), **Tidy up** (the single-action `onOrganize` demo, matching AgentCanvas's real production usage), and **Tidy up: workflow** (the full interactive demo — messy 8-node workflow, both entry points, real repositioning/handle-flipping).

## Test plan
- [x] `vitest run src/canvas/utils/tidy-up.test.ts` (7 passing)
- [x] `tsc --noEmit` clean
- [x] `biome check` clean on touched files
- [x] Manually verified all four strategies + reset from both entry points (corner control and NodeToolbar overflow) in Storybook
- [x] Confirmed `onOrganize` (AgentCanvas's existing single-action usage) still renders unchanged
- [x] Confirmed no overlap between handle captions and node labels on Horizontal/Vertical

🤖 Generated with [Claude Code](https://claude.com/claude-code)