### PR TITLE
Add LockableValueField component and HITL panel

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -8,6 +8,14 @@ on:
 
 env:
   BASE_REF: ${{ github.event.pull_request.base.ref }}
+  # Turbo's own GitHub Actions event auto-detection for `--affected` doesn't
+  # reliably resolve the base ref in this repo (falls back to treating every
+  # package as affected, silently running Format/Lint/etc. against the whole
+  # monorepo instead of just what the PR touched). Giving it a concrete SHA
+  # sidesteps the ambiguity entirely -- verified locally that `--affected`
+  # correctly narrows to just the changed packages (+ their dependents) once
+  # this is set, versus all 9 packages without it.
+  TURBO_SCM_BASE: ${{ github.event.pull_request.base.sha }}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/apps/storybook/.storybook/preview.tsx
+++ b/apps/storybook/.storybook/preview.tsx
@@ -169,6 +169,9 @@ const preview: Preview = {
               [
                 'UiPath',
                 [
+                  'Lockable Value Field',
+                  'Prompt Editor',
+                  'Canvas',
                   'Canvas Toolbar',
                   'Chat Composer',
                   'Chat Message',

--- a/packages/apollo-core/biome.json
+++ b/packages/apollo-core/biome.json
@@ -1,4 +1,5 @@
 {
+  "root": false,
   "$schema": "https://biomejs.dev/schemas/2.3.6/schema.json",
   "vcs": {
     "enabled": true,

--- a/packages/apollo-react/biome.json
+++ b/packages/apollo-react/biome.json
@@ -1,4 +1,5 @@
 {
+  "root": false,
   "$schema": "https://biomejs.dev/schemas/2.3.6/schema.json",
   "vcs": {
     "enabled": true,

--- a/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.stories.tsx
@@ -1,16 +1,48 @@
+import {
+  closestCenter,
+  DndContext,
+  type DragEndEvent,
+  type DragOverEvent,
+  DragOverlay,
+  type DragStartEvent,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+} from '@dnd-kit/core';
+import {
+  arrayMove,
+  SortableContext,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
 import type { EditorProps } from '@monaco-editor/react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import type { FormSchema } from '@uipath/apollo-wind';
+import type { FormSchema, LockableFieldType, LockableValueFieldMode } from '@uipath/apollo-wind';
 import {
   Badge,
   Button,
+  Card,
+  CardContent,
   cn,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
+  FIELD_TYPE_META,
+  HoverCard,
+  HoverCardContent,
+  HoverCardTrigger,
+  Input,
+  Label,
+  LockableValueField,
   MetadataForm,
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
   ResizableHandle,
   ResizablePanel,
   ResizablePanelGroup,
@@ -20,6 +52,13 @@ import {
   TabsContent,
   TabsList,
   TabsTrigger,
+  Textarea,
+  ToggleGroup,
+  ToggleGroupItem,
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
 } from '@uipath/apollo-wind';
 import {
   apolloCoreDarkHCMonaco,
@@ -31,27 +70,37 @@ import {
 } from '@uipath/apollo-wind/editor-themes';
 import {
   ChevronDown,
+  ChevronsDownUp,
+  ChevronsUpDown,
   CircleAlert,
   CircleCheck,
+  CircleDot,
+  CircleOff,
   Code2,
+  Copy,
   Eye,
   File,
+  FileBracesCorner,
   GitFork,
   Globe,
   GripVertical,
   HardDrive,
+  Pencil,
   Play,
   Plus,
   ScanText,
+  Search,
   Sparkles,
   Trash2,
   Type,
   Upload,
+  UserRoundCheck,
   X,
   Zap,
 } from 'lucide-react';
 import type { CSSProperties, ReactNode } from 'react';
-import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { lazy, Suspense, useCallback, useEffect, useId, useMemo, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 import { NodeOutputModeSelect } from '../../controls';
 import type {
   DeriveTypeIcon,
@@ -639,6 +688,34 @@ const COMPACT_EDITOR_OPTIONS = {
   scrollbar: { vertical: 'auto', horizontal: 'hidden', alwaysConsumeMouseWheel: false },
   automaticLayout: true,
 } as const;
+
+const JSON_VIEWER_OPTIONS = {
+  readOnly: true,
+  fontSize: 12,
+  lineHeight: 18,
+  minimap: { enabled: false },
+  scrollBeyondLastLine: false,
+  wordWrap: 'off',
+  fontFamily:
+    'ui-monospace, SFMono-Regular, "SF Mono", Consolas, "Liberation Mono", Menlo, monospace',
+  padding: { top: 8, bottom: 8 },
+  lineNumbers: 'off' as const,
+  lineDecorationsWidth: 0,
+  glyphMargin: false,
+  folding: true,
+  renderLineHighlight: 'none' as const,
+  hideCursorInOverviewRuler: true,
+  overviewRulerBorder: false,
+  overviewRulerLanes: 0,
+  scrollbar: {
+    vertical: 'auto' as const,
+    horizontal: 'auto' as const,
+    alwaysConsumeMouseWheel: false,
+  },
+  automaticLayout: true,
+} as const;
+
+const JSON_EDITOR_OPTIONS = { ...JSON_VIEWER_OPTIONS, readOnly: false } as const;
 
 const INLINE_EDITOR_OPTIONS = {
   fontSize: 13,
@@ -1673,6 +1750,1776 @@ export const InputEditor: Story = {
 };
 
 // ============================================================================
+// Output Panel helpers
+// ============================================================================
+
+type OutputNode = {
+  key: string;
+  type: 'string' | 'number' | 'boolean' | 'object' | 'array' | 'null';
+  value?: string | number | boolean | null;
+  children?: OutputNode[];
+  path: string;
+};
+
+function TypeBadge({ type }: { type: OutputNode['type'] }) {
+  const labels: Record<OutputNode['type'], string> = {
+    string: 'T',
+    number: '#',
+    boolean: '?',
+    object: '{}',
+    array: '[]',
+    null: '∅',
+  };
+  const label = labels[type];
+  const cls = 'border-border bg-surface-overlay text-foreground-muted';
+  return (
+    <span
+      className={cn(
+        'inline-flex h-[18px] min-w-[18px] shrink-0 items-center justify-center rounded border px-0.5 font-mono text-[9px] font-semibold leading-none',
+        cls
+      )}
+    >
+      {label}
+    </span>
+  );
+}
+
+function outputValueColorClass(type: OutputNode['type'], value: unknown): string {
+  if (type === 'string') return 'text-success';
+  if (type === 'number') return 'text-info';
+  if (type === 'boolean') return value ? 'text-success' : 'text-error';
+  if (type === 'null') return 'text-foreground-subtle';
+  return 'text-foreground';
+}
+
+function formatOutputValue(
+  type: OutputNode['type'],
+  value: string | number | boolean | null | undefined
+): string {
+  if (type === 'null' || value === null || value === undefined) return 'null';
+  if (type === 'string') return `"${value}"`;
+  return String(value);
+}
+
+function nodeMatchesQuery(node: OutputNode, q: string): boolean {
+  if (!q) return true;
+  if (node.key.toLowerCase().includes(q)) return true;
+  if (
+    node.value !== undefined &&
+    node.value !== null &&
+    String(node.value).toLowerCase().includes(q)
+  )
+    return true;
+  return node.children?.some((c) => nodeMatchesQuery(c, q)) ?? false;
+}
+
+function collectContainerPaths(nodes: OutputNode[]): string[] {
+  const paths: string[] = [];
+  for (const n of nodes) {
+    if (n.children) {
+      paths.push(n.path);
+      paths.push(...collectContainerPaths(n.children));
+    }
+  }
+  return paths;
+}
+
+type FlatRow = { node: OutputNode; depth: number };
+
+function flattenOutputTree(
+  nodes: OutputNode[],
+  collapsed: Record<string, boolean>,
+  query: string,
+  depth = 0
+): FlatRow[] {
+  const rows: FlatRow[] = [];
+  for (const n of nodes) {
+    if (query && !nodeMatchesQuery(n, query)) continue;
+    rows.push({ node: n, depth });
+    if (n.children && !collapsed[n.path]) {
+      rows.push(...flattenOutputTree(n.children, collapsed, query, depth + 1));
+    }
+  }
+  return rows;
+}
+
+const PANEL_NODE_ID = 'httpRequest1';
+const PANEL_NODE_LABEL = 'HTTP Request';
+
+// ============================================================================
+
+const REFERENCED_OUTPUTS = [
+  { name: 'responseBody', type: 'object' },
+  { name: 'statusCode', type: 'number' },
+  { name: 'headers', type: 'object' },
+  { name: 'errorMessage', type: 'string' },
+  { name: 'duration', type: 'number' },
+  { name: 'requestId', type: 'string' },
+  { name: 'token', type: 'string' },
+];
+
+const REFERENCED_INPUTS = [
+  { name: 'responseBody', type: 'object' },
+  { name: 'statusCode', type: 'number' },
+  { name: 'headers', type: 'object' },
+  { name: 'condition', type: 'string' },
+  { name: 'result', type: 'boolean' },
+  { name: 'prompt', type: 'string' },
+  { name: 'response', type: 'string' },
+  { name: 'assignee', type: 'string' },
+  { name: 'message', type: 'string' },
+];
+
+const HTTP_REQUEST_CHILDREN: OutputNode[] = [
+  { key: 'statusCode', type: 'number', value: 200, path: `${PANEL_NODE_ID}.statusCode` },
+  {
+    key: 'responseBody',
+    type: 'object',
+    path: `${PANEL_NODE_ID}.responseBody`,
+    children: [
+      { key: 'id', type: 'string', value: 'inv-001', path: `${PANEL_NODE_ID}.responseBody.id` },
+      {
+        key: 'amount',
+        type: 'number',
+        value: 1500,
+        path: `${PANEL_NODE_ID}.responseBody.amount`,
+      },
+      {
+        key: 'currency',
+        type: 'string',
+        value: 'USD',
+        path: `${PANEL_NODE_ID}.responseBody.currency`,
+      },
+      {
+        key: 'status',
+        type: 'string',
+        value: 'paid',
+        path: `${PANEL_NODE_ID}.responseBody.status`,
+      },
+    ],
+  },
+  {
+    key: 'headers',
+    type: 'object',
+    path: `${PANEL_NODE_ID}.headers`,
+    children: [
+      {
+        key: 'content-type',
+        type: 'string',
+        value: 'application/json',
+        path: `${PANEL_NODE_ID}.headers.content-type`,
+      },
+      {
+        key: 'x-request-id',
+        type: 'string',
+        value: 'abc-123',
+        path: `${PANEL_NODE_ID}.headers.x-request-id`,
+      },
+    ],
+  },
+  { key: 'errorMessage', type: 'string', value: null, path: `${PANEL_NODE_ID}.errorMessage` },
+  { key: 'duration', type: 'number', value: 342, path: `${PANEL_NODE_ID}.duration` },
+  { key: 'requestId', type: 'string', value: 'req-abc-123', path: `${PANEL_NODE_ID}.requestId` },
+  {
+    key: 'token',
+    type: 'string',
+    value: 'eyJhbGciOiJSUzI1NiJ9',
+    path: `${PANEL_NODE_ID}.token`,
+  },
+  { key: 'retryCount', type: 'number', value: 0, path: `${PANEL_NODE_ID}.retryCount` },
+  { key: 'cached', type: 'boolean', value: false, path: `${PANEL_NODE_ID}.cached` },
+];
+
+const INPUT_TREE_DATA: OutputNode[] = [
+  { key: PANEL_NODE_ID, type: 'object', path: PANEL_NODE_ID, children: HTTP_REQUEST_CHILDREN },
+  {
+    key: 'decision1',
+    type: 'object',
+    path: 'decision1',
+    children: [
+      {
+        key: 'condition',
+        type: 'string',
+        value: 'invoice.amount > 1000',
+        path: 'decision1.condition',
+      },
+      { key: 'result', type: 'boolean', value: true, path: 'decision1.result' },
+      { key: 'branch', type: 'string', value: 'approve', path: 'decision1.branch' },
+    ],
+  },
+  {
+    key: 'agent1',
+    type: 'object',
+    path: 'agent1',
+    children: [
+      {
+        key: 'prompt',
+        type: 'string',
+        value: 'Summarize the invoice details',
+        path: 'agent1.prompt',
+      },
+      { key: 'model', type: 'string', value: 'gpt-4o-mini', path: 'agent1.model' },
+      {
+        key: 'response',
+        type: 'string',
+        value: 'Invoice inv-001 for $1,500 USD is paid.',
+        path: 'agent1.response',
+      },
+      { key: 'tokens', type: 'number', value: 342, path: 'agent1.tokens' },
+    ],
+  },
+  {
+    key: 'approval1',
+    type: 'object',
+    path: 'approval1',
+    children: [
+      { key: 'assignee', type: 'string', value: 'finance-team', path: 'approval1.assignee' },
+      {
+        key: 'message',
+        type: 'string',
+        value: 'Please review this invoice',
+        path: 'approval1.message',
+      },
+      { key: 'dueDate', type: 'string', value: '2025-01-15', path: 'approval1.dueDate' },
+    ],
+  },
+];
+
+const HTTP_REQUEST_JSON = JSON.stringify(
+  {
+    statusCode: 200,
+    responseBody: {
+      id: 'inv-001',
+      amount: 1500.0,
+      currency: 'USD',
+      status: 'paid',
+    },
+    headers: {
+      'content-type': 'application/json',
+      'x-request-id': 'abc-123',
+    },
+    errorMessage: null,
+    duration: 342,
+    requestId: 'req-abc-123',
+    token: 'eyJhbGciOiJSUzI1NiJ9',
+    retryCount: 0,
+    cached: false,
+  },
+  null,
+  2
+);
+
+const OUTPUT_TREE_DATA: OutputNode[] = [
+  { key: PANEL_NODE_ID, type: 'object', path: PANEL_NODE_ID, children: HTTP_REQUEST_CHILDREN },
+];
+
+const INPUT_JSON = HTTP_REQUEST_JSON;
+const OUTPUT_JSON = HTTP_REQUEST_JSON;
+
+// ============================================================================
+// Concept 2 — Expression Reference Panel
+// Flat list of all leaf output paths as copyable expression references.
+// ============================================================================
+
+function Concept2PanelStory({
+  mode,
+  context = 'flow',
+}: {
+  mode: 'input' | 'output';
+  context?: 'studio' | 'flow';
+}) {
+  const monacoTheme = useMonacoTheme();
+  const [search, setSearch] = useState('');
+  const [filter, setFilter] = useState<'default' | 'referenced' | 'all'>('default');
+  const [collapsed, setCollapsed] = useState<Record<string, boolean>>(() =>
+    Object.fromEntries(
+      [...collectContainerPaths(OUTPUT_TREE_DATA), ...collectContainerPaths(INPUT_TREE_DATA)]
+        .filter((p) => p !== PANEL_NODE_ID)
+        .map((p) => [p, true])
+    )
+  );
+  const [copiedPath, setCopiedPath] = useState<string | null>(null);
+  const [searchOpen, setSearchOpen] = useState(false);
+  const [editingPath, setEditingPath] = useState<string | null>(null);
+  const [editedValues, setEditedValues] = useState<
+    Record<string, string | number | boolean | null>
+  >({});
+  const [nodeMode, setNodeMode] = useState<'live' | 'static' | 'simulated' | 'disabled'>('live');
+
+  const NODE_MODES = [
+    {
+      value: 'live',
+      label: 'Live',
+      description: 'Use the real response from this node',
+      icon: CircleDot,
+    },
+    {
+      value: 'static',
+      label: 'Static mock',
+      description: 'Always return a value you define',
+      icon: FileBracesCorner,
+    },
+    {
+      value: 'simulated',
+      label: 'Simulated',
+      description: 'Generate a response dynamically using an LLM',
+      icon: Sparkles,
+    },
+    {
+      value: 'disabled',
+      label: 'Skip node',
+      description: "Don't execute this node",
+      icon: CircleOff,
+    },
+  ] as const;
+  const currentNodeMode = NODE_MODES.find((m) => m.value === nodeMode) ?? NODE_MODES[0];
+  const CurrentModeIcon = currentNodeMode.icon;
+
+  const isOutput = mode === 'output';
+  const currentTreeData = isOutput ? OUTPUT_TREE_DATA : INPUT_TREE_DATA;
+  const currentReferenced = isOutput ? REFERENCED_OUTPUTS : REFERENCED_INPUTS;
+  const currentJson = isOutput ? OUTPUT_JSON : INPUT_JSON;
+  const referencedKeys = new Set(currentReferenced.map((r) => r.name));
+
+  const activeTreeData =
+    filter !== 'referenced'
+      ? currentTreeData
+      : currentTreeData
+          .map((root) => ({
+            ...root,
+            children: root.children?.filter((n) => referencedKeys.has(n.key)),
+          }))
+          .filter((root) => (root.children?.length ?? 0) > 0);
+
+  const rows = flattenOutputTree(activeTreeData, collapsed, search.toLowerCase());
+
+  const toggleCollapsed = (path: string) =>
+    setCollapsed((prev) => ({ ...prev, [path]: !prev[path] }));
+
+  const allContainerPaths = collectContainerPaths(activeTreeData);
+  const allCollapsed = allContainerPaths.length > 0 && allContainerPaths.every((p) => collapsed[p]);
+  const toggleAll = () => {
+    if (allCollapsed) {
+      setCollapsed({});
+    } else {
+      setCollapsed(Object.fromEntries(allContainerPaths.map((p) => [p, true])));
+    }
+  };
+
+  const escapeRef = useRef(false);
+
+  const saveEdit = (node: OutputNode, raw: string) => {
+    const val =
+      node.type === 'boolean' ? raw === 'true' : node.type === 'number' ? Number(raw) || 0 : raw;
+    setEditedValues((prev) => ({ ...prev, [node.path]: val }));
+    setEditingPath(null);
+  };
+
+  const copyExpr = (path: string) => {
+    navigator.clipboard
+      ?.writeText(`{{${path}}}`)
+      ?.then(() => {
+        setCopiedPath(path);
+        setTimeout(() => setCopiedPath(null), 1500);
+      })
+      ?.catch(() => {});
+  };
+
+  return (
+    <PanelFrame>
+      <NodePropertyPanel
+        panelTitle={isOutput ? 'Output' : 'Input'}
+        contentInset="0.875rem"
+        onClose={() => {}}
+        className="h-[640px]"
+      >
+        <div className="flex h-full min-h-0 flex-col">
+          {/* Node identity bar — hidden in Studio context */}
+          {context === 'flow' && (
+            <div className="shrink-0 flex items-center justify-between gap-2 [padding-inline:var(--mf-content-inset,0.875rem)] pb-3 pt-4">
+              <div className="flex min-w-0 items-center gap-2">
+                <Globe size={13} className="shrink-0 text-foreground-subtle" />
+                <span className="text-xs font-medium text-foreground">{PANEL_NODE_LABEL}</span>
+                <span className="font-mono text-[10px] text-foreground-muted">{PANEL_NODE_ID}</span>
+              </div>
+              {isOutput && (
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <button
+                      type="button"
+                      className="flex cursor-pointer items-center gap-1.5 rounded-full border border-border px-2 py-0.5 text-[11px] font-medium text-foreground-muted transition hover:bg-surface-overlay hover:text-foreground"
+                    >
+                      <CurrentModeIcon size={10} className="text-foreground-subtle" />
+                      <span>{currentNodeMode.label}</span>
+                      <ChevronDown size={10} className="text-foreground-subtle" />
+                    </button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align="end" className="w-64">
+                    {NODE_MODES.map((m) => {
+                      const Icon = m.icon;
+                      return (
+                        <DropdownMenuItem
+                          key={m.value}
+                          onClick={() => setNodeMode(m.value)}
+                          className={cn(
+                            'flex items-start gap-2',
+                            nodeMode === m.value && 'text-foreground'
+                          )}
+                        >
+                          <Icon size={13} className="mt-[2px] shrink-0 text-foreground-subtle" />
+                          <div className="flex flex-col gap-0.5">
+                            <span className="text-xs font-medium">{m.label}</span>
+                            <span className="text-[10px] leading-tight text-foreground-muted">
+                              {m.description}
+                            </span>
+                          </div>
+                        </DropdownMenuItem>
+                      );
+                    })}
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              )}
+            </div>
+          )}
+
+          <Tabs defaultValue="schema" className="flex min-h-0 flex-1 flex-col">
+            {/* Tab strip — status badge moves here in Studio context */}
+            <div
+              className={cn(
+                'shrink-0 flex items-center gap-2 [padding-inline:var(--mf-content-inset,0.875rem)] pb-1.5',
+                context === 'studio' && 'pt-3'
+              )}
+            >
+              <TabsList className={TAB_LIST_CLASS}>
+                <TabsTrigger value="schema" className={TAB_TRIGGER_CLASS}>
+                  Schema
+                </TabsTrigger>
+                <TabsTrigger value="json" className={TAB_TRIGGER_CLASS}>
+                  JSON
+                </TabsTrigger>
+              </TabsList>
+              {context === 'studio' && isOutput && (
+                <>
+                  <div className="flex-1" />
+                  <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                      <button
+                        type="button"
+                        className="flex cursor-pointer items-center gap-1.5 rounded-full border border-border px-2 py-0.5 text-[11px] font-medium text-foreground-muted transition hover:bg-surface-overlay hover:text-foreground"
+                      >
+                        <CurrentModeIcon size={10} className="text-foreground-subtle" />
+                        <span>{currentNodeMode.label}</span>
+                        <ChevronDown size={10} className="text-foreground-subtle" />
+                      </button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent align="end" className="w-64">
+                      {NODE_MODES.map((m) => {
+                        const Icon = m.icon;
+                        return (
+                          <DropdownMenuItem
+                            key={m.value}
+                            onClick={() => setNodeMode(m.value)}
+                            className={cn(
+                              'flex items-start gap-2',
+                              nodeMode === m.value && 'text-foreground'
+                            )}
+                          >
+                            <Icon size={13} className="mt-[2px] shrink-0 text-foreground-subtle" />
+                            <div className="flex flex-col gap-0.5">
+                              <span className="text-xs font-medium">{m.label}</span>
+                              <span className="text-[10px] leading-tight text-foreground-muted">
+                                {m.description}
+                              </span>
+                            </div>
+                          </DropdownMenuItem>
+                        );
+                      })}
+                    </DropdownMenuContent>
+                  </DropdownMenu>
+                </>
+              )}
+            </div>
+
+            {/* Schema tab */}
+            <TabsContent value="schema" className="mt-0 flex min-h-0 flex-1 flex-col">
+              {/* Header: filter dropdown on left, search + collapse on right */}
+              <div className="shrink-0 flex items-center gap-1.5 [padding-inline:var(--mf-content-inset,0.875rem)] pb-1 pt-2">
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <button
+                      type="button"
+                      className="flex cursor-pointer shrink-0 items-center gap-1.5 rounded-md px-2 py-1 text-xs font-medium text-foreground-muted transition hover:bg-surface-overlay hover:text-foreground"
+                    >
+                      <span>
+                        {filter === 'referenced'
+                          ? 'Filter: Referenced in this node'
+                          : filter === 'all'
+                            ? 'Filter: All'
+                            : 'Filter'}
+                      </span>
+                      {filter === 'referenced' && (
+                        <span className="rounded-sm bg-surface-raised px-1.5 py-0.5 font-mono text-[10px] font-medium leading-none text-foreground">
+                          {currentReferenced.length}
+                        </span>
+                      )}
+                      <ChevronDown size={10} className="text-foreground-subtle" />
+                    </button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align="start" className="w-52">
+                    <DropdownMenuItem
+                      onClick={() => setFilter('referenced')}
+                      className={cn(
+                        'flex items-center justify-between',
+                        filter === 'referenced' && 'text-foreground'
+                      )}
+                    >
+                      <span className="text-[11px]">Referenced in this node</span>
+                      <span className="ml-3 rounded bg-surface-overlay px-1.5 py-0.5 font-mono text-[10px] font-medium leading-none text-foreground-muted">
+                        {currentReferenced.length}
+                      </span>
+                    </DropdownMenuItem>
+                    <DropdownMenuItem
+                      onClick={() => setFilter('all')}
+                      className={cn('text-[11px]', filter === 'all' && 'text-foreground')}
+                    >
+                      All
+                    </DropdownMenuItem>
+                  </DropdownMenuContent>
+                </DropdownMenu>
+                <div className="flex-1" />
+                {searchOpen ? (
+                  <div className="relative flex items-center">
+                    <Search
+                      size={12}
+                      className="pointer-events-none absolute left-2 text-foreground-subtle"
+                    />
+                    <Input
+                      autoFocus
+                      type="text"
+                      variant="ghost"
+                      size="xs"
+                      value={search}
+                      onChange={(e) => setSearch(e.target.value)}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Escape') {
+                          setSearch('');
+                          setSearchOpen(false);
+                        }
+                      }}
+                      aria-label={isOutput ? 'Search outputs' : 'Search inputs'}
+                      placeholder={isOutput ? 'Search outputs...' : 'Search inputs...'}
+                      className="w-36 pl-6 pr-6 text-foreground placeholder:text-foreground-subtle focus-visible:ring-0"
+                    />
+                    <button
+                      type="button"
+                      onClick={() => {
+                        setSearch('');
+                        setSearchOpen(false);
+                      }}
+                      aria-label="Clear search"
+                      className="absolute right-1.5 grid size-4 place-items-center text-foreground-subtle transition hover:text-foreground"
+                    >
+                      <X size={11} />
+                    </button>
+                  </div>
+                ) : (
+                  <Button
+                    variant="ghost"
+                    size="4xs"
+                    icon
+                    onClick={() => setSearchOpen(true)}
+                    title="Search fields"
+                    aria-label="Search fields"
+                    className="rounded text-foreground-subtle hover:bg-surface-overlay hover:text-foreground"
+                  >
+                    <Search size={12} />
+                  </Button>
+                )}
+                {allContainerPaths.length > 0 && (
+                  <Button
+                    variant="ghost"
+                    size="4xs"
+                    icon
+                    onClick={toggleAll}
+                    title={allCollapsed ? 'Expand all' : 'Collapse all'}
+                    aria-label={allCollapsed ? 'Expand all' : 'Collapse all'}
+                    className="rounded text-foreground-subtle hover:bg-surface-overlay hover:text-foreground"
+                  >
+                    {allCollapsed ? <ChevronsUpDown size={12} /> : <ChevronsDownUp size={12} />}
+                  </Button>
+                )}
+              </div>
+
+              {/* Tree list */}
+              <div className="min-h-0 flex-1 overflow-hidden rounded-xl border border-surface-overlay bg-surface-overlay/40 pb-0 [margin-inline:var(--mf-content-inset,0.875rem)] mb-4 mt-1">
+                <div className="h-full overflow-y-auto pt-1.5">
+                  {rows.map(({ node, depth }) =>
+                    node.children !== undefined ? (
+                      <div
+                        key={node.path}
+                        className="group flex cursor-default items-center gap-2 py-1 transition hover:bg-surface-overlay"
+                        style={{ paddingLeft: `${8 + depth * 16}px`, paddingRight: '14px' }}
+                      >
+                        <button
+                          type="button"
+                          onClick={() => toggleCollapsed(node.path)}
+                          aria-label={
+                            collapsed[node.path] ? `Expand ${node.key}` : `Collapse ${node.key}`
+                          }
+                          className="cursor-pointer grid size-3 shrink-0 place-items-center text-foreground-subtle transition hover:text-foreground"
+                        >
+                          <ChevronDown
+                            size={10}
+                            className={cn(
+                              'transition-transform duration-100',
+                              collapsed[node.path] && '-rotate-90'
+                            )}
+                          />
+                        </button>
+                        <TypeBadge type={node.type} />
+                        <span className="flex-1 truncate font-mono text-xs text-foreground">
+                          {node.key}
+                        </span>
+                        <span className="shrink-0 font-mono text-[10px] text-foreground-muted">
+                          {node.type === 'array'
+                            ? `${node.children.length} ${node.children.length === 1 ? 'item' : 'items'}`
+                            : `${node.children.length} ${node.children.length === 1 ? 'key' : 'keys'}`}
+                        </span>
+                      </div>
+                    ) : (
+                      <div
+                        key={node.path}
+                        className="group flex cursor-default items-center gap-2 py-1 transition hover:bg-surface-overlay"
+                        style={{ paddingLeft: `${8 + depth * 16}px`, paddingRight: '14px' }}
+                      >
+                        <div className="size-3 shrink-0" />
+                        <TypeBadge type={node.type} />
+                        <span className="shrink-0 font-mono text-xs text-foreground">
+                          {node.key}
+                        </span>
+                        <span className="shrink-0 font-mono text-xs text-foreground-subtle">=</span>
+                        {editingPath === node.path ? (
+                          <input
+                            autoFocus
+                            type="text"
+                            defaultValue={String(editedValues[node.path] ?? node.value ?? '')}
+                            onBlur={(e) => {
+                              if (!escapeRef.current) saveEdit(node, e.target.value);
+                              escapeRef.current = false;
+                            }}
+                            onKeyDown={(e) => {
+                              if (e.key === 'Enter') saveEdit(node, e.currentTarget.value);
+                              if (e.key === 'Escape') {
+                                escapeRef.current = true;
+                                setEditingPath(null);
+                              }
+                            }}
+                            className={cn(
+                              'min-w-0 flex-1 rounded bg-transparent px-1 font-mono text-xs outline-none ring-1 ring-brand',
+                              outputValueColorClass(
+                                node.type,
+                                editedValues[node.path] ?? node.value
+                              )
+                            )}
+                          />
+                        ) : (
+                          <>
+                            <button
+                              type="button"
+                              onClick={() => node.type !== 'null' && setEditingPath(node.path)}
+                              className={cn(
+                                'max-w-[55%] shrink-0 truncate font-mono text-xs',
+                                node.type !== 'null' ? 'cursor-text' : 'cursor-default',
+                                outputValueColorClass(
+                                  node.type,
+                                  editedValues[node.path] ?? node.value
+                                )
+                              )}
+                            >
+                              {formatOutputValue(
+                                node.type,
+                                (editedValues[node.path] ?? node.value) as
+                                  | string
+                                  | number
+                                  | boolean
+                                  | null
+                              )}
+                            </button>
+                            <div className="flex-1" />
+                            <Button
+                              variant="ghost"
+                              size="4xs"
+                              icon
+                              onClick={() => copyExpr(node.path)}
+                              title={`Copy {{${node.path}}}`}
+                              aria-label={`Copy expression for ${node.path}`}
+                              className="shrink-0 rounded text-foreground-subtle opacity-0 hover:bg-surface-raised hover:text-foreground group-hover:opacity-100 focus-visible:opacity-100"
+                            >
+                              {copiedPath === node.path ? (
+                                <CircleCheck size={11} className="text-brand" />
+                              ) : (
+                                <Copy size={11} />
+                              )}
+                            </Button>
+                          </>
+                        )}
+                      </div>
+                    )
+                  )}
+                  {rows.length === 0 && (
+                    <p className="py-4 text-center text-xs text-foreground-subtle">
+                      No references match your search.
+                    </p>
+                  )}
+                </div>
+              </div>
+            </TabsContent>
+
+            {/* JSON tab */}
+            <TabsContent
+              value="json"
+              className="mt-0 flex min-h-0 flex-1 flex-col pb-4 pt-1 [padding-inline:var(--mf-content-inset,0.875rem)]"
+            >
+              <div className="min-h-0 flex-1 overflow-hidden rounded-xl border border-surface-overlay">
+                <MonacoEditor
+                  height="100%"
+                  language="json"
+                  value={currentJson}
+                  theme={monacoTheme}
+                  beforeMount={registerMonacoThemes}
+                  options={JSON_VIEWER_OPTIONS}
+                />
+              </div>
+            </TabsContent>
+          </Tabs>
+        </div>
+      </NodePropertyPanel>
+    </PanelFrame>
+  );
+}
+
+// ============================================================================
+// In Studio / In Flow layout
+// ============================================================================
+
+function InputOutputStory() {
+  const [context, setContext] = useState<'studio' | 'flow'>('flow');
+  return (
+    <div className="flex flex-col items-center gap-6 p-8">
+      <div className="flex items-center overflow-hidden rounded border border-border">
+        {(['flow', 'studio'] as const).map((c, i) => (
+          <span key={c} className="contents">
+            {i > 0 && <div className="h-3 w-px bg-border" />}
+            <button
+              type="button"
+              onClick={() => setContext(c)}
+              className={cn(
+                'cursor-pointer px-3 py-1 text-xs font-medium transition',
+                context === c
+                  ? 'bg-surface-overlay text-foreground'
+                  : 'text-foreground-muted hover:text-foreground'
+              )}
+            >
+              {c === 'studio' ? 'In Studio' : 'In Flow'}
+            </button>
+          </span>
+        ))}
+      </div>
+      <div className="flex items-start gap-[50px]">
+        <div className="w-[380px]">
+          <Concept2PanelStory mode="input" context={context} />
+        </div>
+        <div className="w-[380px]">
+          <Concept2PanelStory mode="output" context={context} />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ============================================================================
+// Prototype — LockableValueField
+// ============================================================================
+
+interface LockableCase {
+  id: number;
+  title: string;
+  required: boolean;
+  value: string;
+  locked: boolean;
+  mode: LockableValueFieldMode;
+  fieldType: LockableFieldType;
+}
+
+/** Guards against malformed JSON (e.g. from hand-editing the schema view) reaching setCases -- a
+ *  missing/wrong-typed id would break Sortable, and an unknown fieldType would break rendering. */
+function isValidLockableCase(item: unknown): item is LockableCase {
+  if (typeof item !== 'object' || item === null) return false;
+  const c = item as Record<string, unknown>;
+  return (
+    typeof c.id === 'number' &&
+    Number.isSafeInteger(c.id) &&
+    c.id > 0 &&
+    typeof c.title === 'string' &&
+    typeof c.required === 'boolean' &&
+    typeof c.value === 'string' &&
+    typeof c.locked === 'boolean' &&
+    (c.mode === 'fixed' || c.mode === 'expression') &&
+    typeof c.fieldType === 'string' &&
+    Object.hasOwn(FIELD_TYPE_META, c.fieldType)
+  );
+}
+
+const DEFAULT_LOCKABLE_CASES: LockableCase[] = [
+  {
+    id: 1,
+    title: 'Invoice Number',
+    required: true,
+    value: '',
+    locked: true,
+    mode: 'fixed',
+    fieldType: 'string',
+  },
+  {
+    id: 2,
+    title: 'Submission Date',
+    required: true,
+    value: '',
+    locked: true,
+    mode: 'fixed',
+    fieldType: 'date',
+  },
+  {
+    id: 3,
+    title: 'Approved Amount',
+    required: true,
+    value: '',
+    locked: true,
+    mode: 'fixed',
+    fieldType: 'integer',
+  },
+];
+
+function LockableCaseRow({
+  id,
+  caseTitle,
+  onTitleChange,
+  required,
+  onRequiredChange,
+  onDelete,
+  value,
+  onValueChange,
+  locked,
+  onLockedChange,
+  mode,
+  onModeChange,
+  fieldType,
+  onFieldTypeChange,
+  compact,
+  controlsVisibility,
+  monacoTheme,
+  insertBefore,
+  insertAfter,
+}: {
+  id: number;
+  caseTitle: string;
+  onTitleChange: (title: string) => void;
+  required: boolean;
+  onRequiredChange: (required: boolean) => void;
+  onDelete: () => void;
+  value: string;
+  onValueChange: (value: string) => void;
+  locked: boolean;
+  onLockedChange: (locked: boolean) => void;
+  mode: LockableValueFieldMode;
+  onModeChange: (mode: LockableValueFieldMode) => void;
+  fieldType: LockableFieldType;
+  onFieldTypeChange: (fieldType: LockableFieldType) => void;
+  compact?: boolean;
+  controlsVisibility?: 'visible' | 'hover';
+  monacoTheme: string;
+  /** Shows the insertion line above this row (the dragged item would land here). */
+  insertBefore?: boolean;
+  /** Shows the insertion line below this row (the dragged item would land here). */
+  insertAfter?: boolean;
+}) {
+  const [editingTitle, setEditingTitle] = useState(false);
+  const titleRef = useRef<HTMLInputElement>(null);
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id,
+  });
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={{ transform: CSS.Transform.toString(transform), transition }}
+      className="group relative"
+    >
+      {/* Rendered as a child of this row's own transformed wrapper (not an
+          outer sibling) so it moves in lockstep with the row during the
+          sortable reflow animation instead of drifting out of sync. */}
+      {insertBefore && (
+        <div
+          aria-hidden
+          className="pointer-events-none absolute inset-x-0 -top-2 z-10 h-0.5 rounded-full bg-brand"
+        />
+      )}
+      <div
+        className={cn(isDragging && 'rounded-lg border-2 border-dashed border-brand/50 opacity-50')}
+      >
+        <LockableValueField
+          id={`return-value-${id}`}
+          label={
+            <div className="flex min-w-0 flex-1 items-center gap-1">
+              <button
+                type="button"
+                {...attributes}
+                {...listeners}
+                aria-label="Drag to reorder"
+                title="Drag to reorder"
+                className="grid size-5 shrink-0 touch-none place-items-center rounded text-foreground-subtle transition hover:bg-surface-overlay hover:text-foreground [cursor:grab]"
+              >
+                <GripVertical size={12} />
+              </button>
+              {editingTitle ? (
+                <input
+                  ref={titleRef}
+                  value={caseTitle}
+                  onChange={(e) => onTitleChange(e.target.value)}
+                  onBlur={() => setEditingTitle(false)}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter' || e.key === 'Escape') setEditingTitle(false);
+                  }}
+                  className="min-w-0 flex-1 rounded bg-surface-overlay px-1 py-0.5 text-xs font-medium text-foreground outline-none ring-1 ring-brand"
+                  autoFocus
+                />
+              ) : (
+                <button
+                  type="button"
+                  onClick={() => {
+                    setEditingTitle(true);
+                    setTimeout(() => titleRef.current?.select(), 0);
+                  }}
+                  className="truncate rounded px-1 py-0.5 text-left text-xs font-medium text-foreground-muted transition hover:bg-surface-overlay hover:text-foreground"
+                >
+                  {caseTitle}
+                  {required && <span className="ml-0.5 text-destructive">*</span>}
+                </button>
+              )}
+            </div>
+          }
+          headerActions={
+            <button
+              type="button"
+              onClick={onDelete}
+              aria-label="Delete field"
+              title="Delete field"
+              className={cn(
+                'grid size-6 shrink-0 place-items-center rounded text-foreground-subtle transition hover:bg-surface-overlay hover:text-foreground',
+                controlsVisibility === 'hover' &&
+                  'opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 has-[[aria-expanded=true]]:opacity-100'
+              )}
+            >
+              <X size={12} />
+            </button>
+          }
+          value={value}
+          onValueChange={onValueChange}
+          locked={locked}
+          onLockedChange={onLockedChange}
+          mode={mode}
+          onModeChange={onModeChange}
+          renderExpressionEditor={({ id, value, onValueChange, onBlur, readOnly, placeholder }) => (
+            <div className="relative h-10 min-w-0 flex-1 overflow-visible" onBlur={onBlur}>
+              <MonacoEditor
+                height="40px"
+                language="javascript"
+                value={value}
+                onChange={(nextValue) => onValueChange?.(nextValue ?? '')}
+                theme={monacoTheme}
+                beforeMount={registerMonacoThemes}
+                options={{ ...INLINE_EDITOR_OPTIONS, readOnly, fixedOverflowWidgets: true }}
+              />
+              {value === '' && (
+                <label
+                  htmlFor={id}
+                  className="pointer-events-none absolute left-[14px] top-1/2 -translate-y-1/2 font-mono text-[13px] text-foreground-subtle"
+                >
+                  {placeholder}
+                </label>
+              )}
+            </div>
+          )}
+          fieldType={fieldType}
+          onFieldTypeChange={onFieldTypeChange}
+          required={required}
+          onRequiredChange={onRequiredChange}
+          compact={compact}
+          controlsVisibility={controlsVisibility}
+        />
+      </div>
+      {insertAfter && (
+        <div
+          aria-hidden
+          className="pointer-events-none absolute inset-x-0 -bottom-2 z-10 h-0.5 rounded-full bg-brand"
+        />
+      )}
+    </div>
+  );
+}
+
+interface FormButtonItem {
+  id: number;
+  label: string;
+  variant: 'default' | 'outline';
+}
+
+const DEFAULT_FORM_BUTTONS: FormButtonItem[] = [
+  { id: 1, label: 'Approve', variant: 'default' },
+  { id: 2, label: 'Cancel', variant: 'outline' },
+];
+
+function FormButtonChip({
+  label,
+  onLabelChange,
+  variant,
+  onVariantChange,
+  onDelete,
+}: {
+  label: string;
+  onLabelChange: (label: string) => void;
+  variant: 'default' | 'outline';
+  onVariantChange: (variant: 'default' | 'outline') => void;
+  onDelete: () => void;
+}) {
+  const [editing, setEditing] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  return (
+    <div
+      className={cn(
+        'group/button flex h-10 items-stretch overflow-hidden rounded-lg text-sm font-semibold transition',
+        variant === 'default'
+          ? 'bg-brand text-foreground-on-accent'
+          : 'border border-input bg-background text-foreground future:border-border-subtle future:text-muted-foreground'
+      )}
+    >
+      {editing ? (
+        <input
+          ref={inputRef}
+          value={label}
+          onChange={(e) => onLabelChange(e.target.value)}
+          onBlur={() => setEditing(false)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' || e.key === 'Escape') setEditing(false);
+          }}
+          autoFocus
+          size={Math.max(label.length, 4)}
+          className="bg-transparent px-3 outline-none"
+        />
+      ) : (
+        <button
+          type="button"
+          onClick={() => {
+            setEditing(true);
+            setTimeout(() => inputRef.current?.select(), 0);
+          }}
+          className={cn(
+            'px-4 transition',
+            variant === 'default'
+              ? 'hover:bg-brand-hover'
+              : 'hover:bg-accent hover:text-accent-foreground future:hover:text-foreground'
+          )}
+        >
+          {label}
+        </button>
+      )}
+      <Popover>
+        <TooltipProvider delayDuration={300}>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <PopoverTrigger asChild>
+                <button
+                  type="button"
+                  aria-label="Edit button"
+                  className={cn(
+                    'grid w-0 shrink-0 place-items-center overflow-hidden px-0 opacity-0 transition-all duration-200 group-hover/button:w-8 group-hover/button:px-2 group-hover/button:opacity-100 aria-expanded:w-8 aria-expanded:px-2 aria-expanded:opacity-100',
+                    variant === 'default'
+                      ? 'hover:bg-brand-hover'
+                      : 'hover:bg-accent hover:text-accent-foreground future:hover:text-foreground'
+                  )}
+                >
+                  <Pencil size={12} className="shrink-0" />
+                </button>
+              </PopoverTrigger>
+            </TooltipTrigger>
+            <TooltipContent>Edit button</TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+        <PopoverContent align="start" className="w-48 space-y-3">
+          <div className="space-y-1.5">
+            <span className="text-xs font-medium text-foreground-muted">Type</span>
+            <ToggleGroup
+              type="single"
+              value={variant}
+              onValueChange={(value) => {
+                if (value) onVariantChange(value as 'default' | 'outline');
+              }}
+              className="w-full"
+            >
+              <ToggleGroupItem value="default" className="flex-1 text-xs">
+                Primary
+              </ToggleGroupItem>
+              <ToggleGroupItem value="outline" className="flex-1 text-xs">
+                Secondary
+              </ToggleGroupItem>
+            </ToggleGroup>
+          </div>
+          <div className="h-px bg-border-subtle" />
+          <button
+            type="button"
+            onClick={onDelete}
+            className="flex w-full items-center gap-1.5 rounded-lg px-1.5 py-1 text-xs text-destructive transition hover:bg-destructive/10"
+          >
+            <X size={12} />
+            Delete button
+          </button>
+        </PopoverContent>
+      </Popover>
+    </div>
+  );
+}
+
+function FieldDragOverlay({ caseItem }: { caseItem: LockableCase }) {
+  const meta = FIELD_TYPE_META[caseItem.fieldType];
+  return (
+    <div
+      className="flex items-center gap-2 rounded-lg border border-border-subtle bg-surface-raised px-3 py-2 shadow-lg"
+      style={{ cursor: 'grabbing' }}
+    >
+      <GripVertical size={12} className="shrink-0 text-foreground-subtle" />
+      <meta.icon size={12} className="shrink-0 text-foreground-subtle" />
+      <span className="truncate text-xs font-medium text-foreground">
+        {caseItem.title}
+        {caseItem.required && <span className="ml-0.5 text-destructive">*</span>}
+      </span>
+    </div>
+  );
+}
+
+function LockableValueFieldShowcase({
+  controlsVisibility,
+  onControlsVisibilityChange,
+}: {
+  controlsVisibility: 'visible' | 'hover';
+  onControlsVisibilityChange: (visibility: 'visible' | 'hover') => void;
+}) {
+  const fullViewId = useId();
+  const compactViewId = useId();
+  const [showcaseValue, setShowcaseValue] = useState('');
+  const [showcaseLocked, setShowcaseLocked] = useState(true);
+  const [showcaseMode, setShowcaseMode] = useState<LockableValueFieldMode>('fixed');
+  const [showcaseFieldType, setShowcaseFieldType] = useState<LockableFieldType>('string');
+  const [showcaseRequired, setShowcaseRequired] = useState(true);
+
+  const handleShowcaseFieldTypeChange = (type: LockableFieldType) => {
+    setShowcaseFieldType(type);
+    setShowcaseValue('');
+    if (!FIELD_TYPE_META[type].supportsExpression) {
+      setShowcaseMode('fixed');
+    }
+  };
+
+  return (
+    <div className="flex w-[380px] shrink-0 flex-col gap-4 rounded-2xl border border-border-subtle bg-surface-raised p-5">
+      <div className="flex flex-col gap-1">
+        <span className="text-sm font-semibold text-foreground">Demo controls</span>
+        <p className="text-xs leading-4 text-foreground-muted">
+          Toggle Show/Hide to preview how field controls behave in the panel on the left. Uses
+          component →{' '}
+          <a
+            href="/?path=/docs/apollo-wind-components-uipath-lockable-value-field--docs"
+            target="_top"
+            className="font-medium text-brand transition hover:text-brand-hover"
+          >
+            Lockable Value Field
+          </a>
+        </p>
+      </div>
+      <div className="flex items-center justify-between border-t border-border-subtle pt-4">
+        <span className="text-[11px] font-medium uppercase tracking-wide text-foreground-subtle">
+          Controls
+        </span>
+        <ToggleGroup
+          type="single"
+          size="xs"
+          value={controlsVisibility}
+          onValueChange={(v) => v && onControlsVisibilityChange(v as 'visible' | 'hover')}
+        >
+          <ToggleGroupItem value="visible" className="!px-2.5 !text-xs">
+            Show
+          </ToggleGroupItem>
+          <ToggleGroupItem value="hover" className="!px-2.5 !text-xs">
+            Hide
+          </ToggleGroupItem>
+        </ToggleGroup>
+      </div>
+      <div className="flex flex-col gap-2">
+        <span className="text-[11px] font-medium uppercase tracking-wide text-foreground-subtle">
+          Full view
+        </span>
+        <LockableValueField
+          id={fullViewId}
+          label={
+            <Label htmlFor={fullViewId} className="text-xs font-medium text-foreground-muted">
+              Label
+              {showcaseRequired && <span className="ml-0.5 text-destructive">*</span>}
+            </Label>
+          }
+          headerActions={
+            <button
+              type="button"
+              aria-label="Close field"
+              className={cn(
+                'grid size-7 shrink-0 place-items-center rounded-lg text-foreground-subtle transition hover:bg-surface-overlay hover:text-foreground',
+                controlsVisibility === 'hover' &&
+                  'opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100 has-[[aria-expanded=true]]:opacity-100'
+              )}
+            >
+              <X size={14} />
+            </button>
+          }
+          value={showcaseValue}
+          onValueChange={setShowcaseValue}
+          locked={showcaseLocked}
+          onLockedChange={setShowcaseLocked}
+          mode={showcaseMode}
+          onModeChange={setShowcaseMode}
+          fieldType={showcaseFieldType}
+          onFieldTypeChange={handleShowcaseFieldTypeChange}
+          required={showcaseRequired}
+          onRequiredChange={setShowcaseRequired}
+          controlsVisibility={controlsVisibility}
+        />
+      </div>
+      <div className="flex flex-col gap-2 border-t border-border-subtle pt-4">
+        <span className="text-[11px] font-medium uppercase tracking-wide text-foreground-subtle">
+          Compact view (narrow container)
+        </span>
+        <div className="w-[200px]">
+          <LockableValueField
+            id={compactViewId}
+            label={
+              <Label htmlFor={compactViewId} className="text-xs font-medium text-foreground-muted">
+                Label
+                {showcaseRequired && <span className="ml-0.5 text-destructive">*</span>}
+              </Label>
+            }
+            headerActions={
+              <button
+                type="button"
+                aria-label="Close field"
+                className={cn(
+                  'grid size-7 shrink-0 place-items-center rounded-lg text-foreground-subtle transition hover:bg-surface-overlay hover:text-foreground',
+                  controlsVisibility === 'hover' &&
+                    'opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100 has-[[aria-expanded=true]]:opacity-100'
+                )}
+              >
+                <X size={14} />
+              </button>
+            }
+            value={showcaseValue}
+            onValueChange={setShowcaseValue}
+            locked={showcaseLocked}
+            onLockedChange={setShowcaseLocked}
+            mode={showcaseMode}
+            onModeChange={setShowcaseMode}
+            fieldType={showcaseFieldType}
+            onFieldTypeChange={handleShowcaseFieldTypeChange}
+            required={showcaseRequired}
+            onRequiredChange={setShowcaseRequired}
+            controlsVisibility={controlsVisibility}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function QuickFormStory() {
+  const monacoTheme = useMonacoTheme();
+  const [cases, setCases] = useState<LockableCase[]>(DEFAULT_LOCKABLE_CASES);
+  const nextIdRef = useRef(4);
+  const [formView, setFormView] = useState<'edit' | 'json'>('edit');
+  const [formTitle, setFormTitle] = useState('Quick Approve');
+  const [formDescription, setFormDescription] = useState('Add a description');
+  const [editingFormTitle, setEditingFormTitle] = useState(false);
+  const [editingFormDescription, setEditingFormDescription] = useState(false);
+  const formTitleRef = useRef<HTMLInputElement>(null);
+  const formDescriptionRef = useRef<HTMLInputElement>(null);
+  const [jsonDraft, setJsonDraft] = useState(() => JSON.stringify(DEFAULT_LOCKABLE_CASES, null, 2));
+  const [jsonError, setJsonError] = useState<string | null>(null);
+  const [jsonCopied, setJsonCopied] = useState(false);
+  const [showcaseControlsVisibility, setShowcaseControlsVisibility] = useState<'visible' | 'hover'>(
+    'visible'
+  );
+  const [buttons, setButtons] = useState<FormButtonItem[]>(DEFAULT_FORM_BUTTONS);
+  const nextButtonIdRef = useRef(3);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (formView !== 'json') {
+      setJsonDraft(JSON.stringify(cases, null, 2));
+      setJsonError(null);
+    }
+  }, [cases, formView]);
+
+  const handleJsonChange = (value: string) => {
+    setJsonDraft(value);
+    try {
+      const parsed = JSON.parse(value);
+      if (!Array.isArray(parsed)) {
+        setJsonError('Expected a JSON array of fields.');
+        return;
+      }
+      if (!parsed.every(isValidLockableCase)) {
+        setJsonError('Each field needs id, title, required, value, locked, mode, and fieldType.');
+        return;
+      }
+      const fieldIds = parsed.map(({ id }) => id);
+      if (new Set(fieldIds).size !== fieldIds.length) {
+        setJsonError('Field IDs must be unique.');
+        return;
+      }
+      nextIdRef.current = Math.max(0, ...fieldIds) + 1;
+      setCases(parsed);
+      setJsonError(null);
+    } catch {
+      setJsonError('Invalid JSON.');
+    }
+  };
+
+  const handleCopyJson = () => {
+    navigator.clipboard
+      ?.writeText(jsonDraft)
+      ?.then(() => {
+        setJsonCopied(true);
+        setTimeout(() => setJsonCopied(false), 1500);
+      })
+      ?.catch(() => {});
+  };
+
+  const addCaseWithType = (fieldType: LockableFieldType) => {
+    const id = nextIdRef.current++;
+    setCases((prev) => [
+      ...prev,
+      {
+        id,
+        title: `Field ${id}`,
+        required: true,
+        value: '',
+        locked: true,
+        mode: 'fixed',
+        fieldType,
+      },
+    ]);
+  };
+  const deleteCase = (id: number) => setCases((prev) => prev.filter((c) => c.id !== id));
+  const updateCase = (id: number, patch: Partial<LockableCase>) =>
+    setCases((prev) => prev.map((c) => (c.id === id ? { ...c, ...patch } : c)));
+  const addButton = () => {
+    const id = nextButtonIdRef.current++;
+    setButtons((prev) => [...prev, { id, label: 'Button', variant: 'outline' }]);
+  };
+  const deleteButton = (id: number) => setButtons((prev) => prev.filter((b) => b.id !== id));
+  const updateButton = (id: number, patch: Partial<FormButtonItem>) =>
+    setButtons((prev) => prev.map((b) => (b.id === id ? { ...b, ...patch } : b)));
+  const updateCaseFieldType = (id: number, fieldType: LockableFieldType) =>
+    setCases((prev) =>
+      prev.map((c) =>
+        c.id === id
+          ? {
+              ...c,
+              fieldType,
+              value: '',
+              mode: FIELD_TYPE_META[fieldType].supportsExpression ? c.mode : 'fixed',
+            }
+          : c
+      )
+    );
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 3 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
+  );
+
+  const [activeDragId, setActiveDragId] = useState<number | null>(null);
+  const [overDragId, setOverDragId] = useState<number | null>(null);
+
+  const handleDragStart = (event: DragStartEvent) => {
+    setActiveDragId(event.active.id as number);
+  };
+
+  const handleDragOver = (event: DragOverEvent) => {
+    setOverDragId((event.over?.id as number) ?? null);
+  };
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+    if (over && active.id !== over.id) {
+      setCases((prev) => {
+        const oldIndex = prev.findIndex((c) => c.id === active.id);
+        const newIndex = prev.findIndex((c) => c.id === over.id);
+        return arrayMove(prev, oldIndex, newIndex);
+      });
+    }
+    setActiveDragId(null);
+    setOverDragId(null);
+  };
+
+  const handleDragCancel = () => {
+    setActiveDragId(null);
+    setOverDragId(null);
+  };
+
+  const activeCase = cases.find((c) => c.id === activeDragId);
+
+  return (
+    <div className="flex items-start gap-8">
+      <PanelFrame>
+        <NodePropertyPanel
+          panelTitle="Properties"
+          nodeIcon={<UserRoundCheck />}
+          nodeLabel="Quick Approve"
+          nodeCategory="Quick approve/reject decision for the extracted invoice."
+          action={<DebugButton />}
+          onClose={() => {}}
+          contentInset="0.875rem"
+          className="h-[760px]"
+        >
+          <Tabs defaultValue="parameters" className="flex min-h-0 flex-1 flex-col">
+            <div className="shrink-0 pt-3 [padding-inline:var(--mf-content-inset,0.875rem)]">
+              <TabsList className={TAB_LIST_CLASS}>
+                <TabsTrigger value="parameters" className={TAB_TRIGGER_CLASS}>
+                  Parameters
+                </TabsTrigger>
+                <TabsTrigger value="error-handling" className={TAB_TRIGGER_CLASS}>
+                  Branching
+                </TabsTrigger>
+                <TabsTrigger value="advanced" className={TAB_TRIGGER_CLASS}>
+                  Error handling
+                </TabsTrigger>
+              </TabsList>
+            </div>
+            <TabsContent
+              value="parameters"
+              className="mt-0 flex min-h-0 flex-1 flex-col gap-4 overflow-auto py-3 [padding-inline:var(--mf-content-inset,0.875rem)]"
+            >
+              {/* Quick form */}
+              <div className="flex flex-col gap-2">
+                <div className="flex items-center justify-between">
+                  <span className="text-xs font-medium text-foreground-muted">Quick form</span>
+                  <div className="flex items-center gap-2">
+                    <Popover>
+                      <TooltipProvider delayDuration={300}>
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <PopoverTrigger asChild>
+                              <button
+                                type="button"
+                                aria-label="Generate with AI"
+                                className="grid size-7 shrink-0 place-items-center rounded-lg text-foreground-subtle transition hover:bg-surface-overlay hover:text-foreground aria-expanded:bg-surface-overlay aria-expanded:text-foreground"
+                              >
+                                <Sparkles size={14} />
+                              </button>
+                            </PopoverTrigger>
+                          </TooltipTrigger>
+                          <TooltipContent>Generate with AI</TooltipContent>
+                        </Tooltip>
+                      </TooltipProvider>
+                      <PopoverContent align="end" className="w-64 space-y-1.5">
+                        <span className="flex items-center gap-1.5 text-xs font-medium text-foreground">
+                          <Sparkles size={12} className="text-brand" />
+                          Describe the form you want
+                        </span>
+                        <Textarea
+                          rows={3}
+                          placeholder="e.g. An invoice approval form with amount and due date"
+                          className="resize-none text-sm"
+                        />
+                        <Button size="sm" className="w-full">
+                          Generate
+                        </Button>
+                      </PopoverContent>
+                    </Popover>
+                    <ToggleGroup
+                      type="single"
+                      size="xs"
+                      value={formView}
+                      onValueChange={(v) => v && setFormView(v as 'edit' | 'json')}
+                    >
+                      <ToggleGroupItem value="edit" className="!px-2.5 !text-xs">
+                        UI
+                      </ToggleGroupItem>
+                      <ToggleGroupItem value="json" className="!px-2.5 !text-xs">
+                        JSON
+                      </ToggleGroupItem>
+                    </ToggleGroup>
+                  </div>
+                </div>
+                <Card>
+                  <CardContent className="flex flex-col gap-4 p-4">
+                    <div className="flex items-center gap-3.5">
+                      <input
+                        ref={fileInputRef}
+                        type="file"
+                        className="hidden"
+                        onChange={() => {}}
+                      />
+                      <HoverCard openDelay={300}>
+                        <HoverCardTrigger asChild>
+                          <button
+                            type="button"
+                            onClick={() => fileInputRef.current?.click()}
+                            aria-label="Upload a file"
+                            className="grid size-11 shrink-0 place-items-center rounded-xl bg-surface-overlay text-foreground-subtle transition hover:bg-surface-overlay/70 hover:text-foreground [&>svg]:size-5"
+                          >
+                            <Upload />
+                          </button>
+                        </HoverCardTrigger>
+                        <HoverCardContent align="start" className="w-56 space-y-1.5">
+                          <p className="text-xs font-semibold text-foreground">Upload form logo</p>
+                          <p className="text-xs text-foreground-muted">
+                            Images are automatically resized to fit the logo area.
+                          </p>
+                          <div className="space-y-0.5 text-[11px] text-foreground-subtle">
+                            <div>Type: PNG, JPG, SVG</div>
+                            <div>Size: 512 × 512 px</div>
+                          </div>
+                        </HoverCardContent>
+                      </HoverCard>
+                      <div className="flex min-w-0 flex-1 flex-col justify-center">
+                        {editingFormTitle ? (
+                          <input
+                            ref={formTitleRef}
+                            value={formTitle}
+                            onChange={(e) => setFormTitle(e.target.value)}
+                            onBlur={() => setEditingFormTitle(false)}
+                            onKeyDown={(e) => {
+                              if (e.key === 'Enter' || e.key === 'Escape')
+                                setEditingFormTitle(false);
+                            }}
+                            className="rounded bg-surface-overlay px-1 text-base font-semibold leading-5 tracking-[-0.3px] text-foreground outline-none ring-1 ring-brand"
+                            autoFocus
+                          />
+                        ) : (
+                          <button
+                            type="button"
+                            onClick={() => {
+                              setEditingFormTitle(true);
+                              setTimeout(() => formTitleRef.current?.select(), 0);
+                            }}
+                            className="truncate rounded px-1 text-left text-base font-semibold leading-5 tracking-[-0.3px] text-foreground transition hover:bg-surface-overlay"
+                          >
+                            {formTitle}
+                          </button>
+                        )}
+                        {editingFormDescription ? (
+                          <input
+                            ref={formDescriptionRef}
+                            value={formDescription}
+                            onChange={(e) => setFormDescription(e.target.value)}
+                            onBlur={() => setEditingFormDescription(false)}
+                            onKeyDown={(e) => {
+                              if (e.key === 'Enter' || e.key === 'Escape')
+                                setEditingFormDescription(false);
+                            }}
+                            className="rounded bg-surface-overlay px-1 text-xs leading-4 text-foreground outline-none ring-1 ring-brand"
+                            autoFocus
+                          />
+                        ) : (
+                          <button
+                            type="button"
+                            onClick={() => {
+                              setEditingFormDescription(true);
+                              setTimeout(() => formDescriptionRef.current?.select(), 0);
+                            }}
+                            className="truncate rounded px-1 text-left text-xs leading-4 text-foreground-muted transition hover:bg-surface-overlay hover:text-foreground"
+                          >
+                            {formDescription}
+                          </button>
+                        )}
+                      </div>
+                    </div>
+                    {formView === 'edit' && (
+                      <>
+                        <DndContext
+                          sensors={sensors}
+                          collisionDetection={closestCenter}
+                          onDragStart={handleDragStart}
+                          onDragOver={handleDragOver}
+                          onDragEnd={handleDragEnd}
+                          onDragCancel={handleDragCancel}
+                        >
+                          <SortableContext
+                            items={cases.map((c) => c.id)}
+                            strategy={verticalListSortingStrategy}
+                          >
+                            <div className="flex flex-col gap-4">
+                              {cases.map((c, index) => {
+                                const activeIndex = cases.findIndex((x) => x.id === activeDragId);
+                                const isOver =
+                                  activeDragId != null &&
+                                  overDragId === c.id &&
+                                  c.id !== activeDragId;
+                                return (
+                                  <LockableCaseRow
+                                    key={c.id}
+                                    id={c.id}
+                                    caseTitle={c.title}
+                                    onTitleChange={(title) => updateCase(c.id, { title })}
+                                    required={c.required}
+                                    onRequiredChange={(required) => updateCase(c.id, { required })}
+                                    onDelete={() => deleteCase(c.id)}
+                                    value={c.value}
+                                    onValueChange={(value) => updateCase(c.id, { value })}
+                                    locked={c.locked}
+                                    onLockedChange={(locked) => updateCase(c.id, { locked })}
+                                    mode={c.mode}
+                                    onModeChange={(mode) => updateCase(c.id, { mode })}
+                                    fieldType={c.fieldType}
+                                    compact
+                                    onFieldTypeChange={(fieldType) =>
+                                      updateCaseFieldType(c.id, fieldType)
+                                    }
+                                    controlsVisibility={showcaseControlsVisibility}
+                                    monacoTheme={monacoTheme}
+                                    insertBefore={isOver && activeIndex > index}
+                                    insertAfter={isOver && activeIndex < index}
+                                  />
+                                );
+                              })}
+                            </div>
+                          </SortableContext>
+                          {createPortal(
+                            <DragOverlay>
+                              {activeCase ? <FieldDragOverlay caseItem={activeCase} /> : null}
+                            </DragOverlay>,
+                            document.body
+                          )}
+                        </DndContext>
+                        <button
+                          type="button"
+                          onClick={() => addCaseWithType('string')}
+                          className="flex w-fit cursor-pointer items-center gap-1.5 text-xs text-brand transition hover:text-brand-hover"
+                        >
+                          <Plus size={12} />
+                          Add field
+                        </button>
+                        <div className="flex flex-wrap items-center gap-2">
+                          {buttons.map((b) => (
+                            <FormButtonChip
+                              key={b.id}
+                              label={b.label}
+                              onLabelChange={(label) => updateButton(b.id, { label })}
+                              variant={b.variant}
+                              onVariantChange={(variant) => updateButton(b.id, { variant })}
+                              onDelete={() => deleteButton(b.id)}
+                            />
+                          ))}
+                          <TooltipProvider delayDuration={300}>
+                            <Tooltip>
+                              <TooltipTrigger asChild>
+                                <button
+                                  type="button"
+                                  onClick={addButton}
+                                  aria-label="Add button"
+                                  className="grid size-10 shrink-0 place-items-center rounded-lg text-foreground-subtle transition hover:bg-surface-overlay hover:text-foreground"
+                                >
+                                  <Plus size={16} />
+                                </button>
+                              </TooltipTrigger>
+                              <TooltipContent>Add button</TooltipContent>
+                            </Tooltip>
+                          </TooltipProvider>
+                        </div>
+                      </>
+                    )}
+                    {formView === 'json' && (
+                      <div className="flex flex-col gap-1.5">
+                        <div className="flex items-center justify-between">
+                          <span className="text-xs font-medium text-foreground-muted">
+                            Form schema
+                          </span>
+                          <TooltipProvider delayDuration={300}>
+                            <Tooltip>
+                              <TooltipTrigger asChild>
+                                <button
+                                  type="button"
+                                  onClick={handleCopyJson}
+                                  aria-label="Copy JSON"
+                                  className="grid size-6 shrink-0 place-items-center rounded text-foreground-subtle transition hover:bg-surface-overlay hover:text-foreground"
+                                >
+                                  {jsonCopied ? (
+                                    <CircleCheck size={13} className="text-brand" />
+                                  ) : (
+                                    <Copy size={13} />
+                                  )}
+                                </button>
+                              </TooltipTrigger>
+                              <TooltipContent>{jsonCopied ? 'Copied' : 'Copy JSON'}</TooltipContent>
+                            </Tooltip>
+                          </TooltipProvider>
+                        </div>
+                        <div className="h-[320px] overflow-hidden rounded-xl border border-surface-overlay">
+                          <MonacoEditor
+                            height="100%"
+                            language="json"
+                            value={jsonDraft}
+                            onChange={(value) => handleJsonChange(value ?? '')}
+                            theme={monacoTheme}
+                            beforeMount={registerMonacoThemes}
+                            options={JSON_EDITOR_OPTIONS}
+                          />
+                        </div>
+                        {jsonError && <span className="text-xs text-destructive">{jsonError}</span>}
+                      </div>
+                    )}
+                  </CardContent>
+                </Card>
+              </div>
+            </TabsContent>
+            <TabsContent value="error-handling" className="mt-0" />
+            <TabsContent value="advanced" className="mt-0" />
+          </Tabs>
+        </NodePropertyPanel>
+      </PanelFrame>
+
+      <LockableValueFieldShowcase
+        controlsVisibility={showcaseControlsVisibility}
+        onControlsVisibilityChange={setShowcaseControlsVisibility}
+      />
+    </div>
+  );
+}
+
+export const InlineEditing: Story = {
+  name: 'Inline Editing',
+  render: () => <InlineEditingStory />,
+};
+
+export const Output: Story = {
+  name: 'Input / Output',
+  render: () => <InputOutputStory />,
+  parameters: { layout: 'fullscreen' },
+};
+
+export const QuickForm: Story = {
+  name: 'Form HITL',
+  render: () => <QuickFormStory />,
+};
+
+// ============================================================================
 // Inline Editing
 // Title and description in the node identity row are directly editable.
 // ============================================================================
@@ -1752,11 +3599,6 @@ function InlineEditingStory() {
     </PanelFrame>
   );
 }
-
-export const InlineEditing: Story = {
-  name: 'Inline Editing',
-  render: () => <InlineEditingStory />,
-};
 
 export const AlertsAndErrors: Story = {
   name: 'Alerts and Errors',
@@ -1863,32 +3705,6 @@ export const Responsive: Story = {
 // ============================================================================
 // Input / Output panels (NodeIOView)
 // ============================================================================
-
-const JSON_VIEWER_OPTIONS = {
-  readOnly: true,
-  fontSize: 12,
-  lineHeight: 18,
-  minimap: { enabled: false },
-  scrollBeyondLastLine: false,
-  wordWrap: 'off',
-  fontFamily:
-    'ui-monospace, SFMono-Regular, "SF Mono", Consolas, "Liberation Mono", Menlo, monospace',
-  padding: { top: 8, bottom: 8 },
-  lineNumbers: 'off' as const,
-  lineDecorationsWidth: 0,
-  glyphMargin: false,
-  folding: true,
-  renderLineHighlight: 'none' as const,
-  hideCursorInOverviewRuler: true,
-  overviewRulerBorder: false,
-  overviewRulerLanes: 0,
-  scrollbar: {
-    vertical: 'auto' as const,
-    horizontal: 'auto' as const,
-    alwaysConsumeMouseWheel: false,
-  },
-  automaticLayout: true,
-} as const;
 
 function MonacoJsonView({ value }: { value: JsonValue | undefined }) {
   const monacoTheme = useMonacoTheme();

--- a/packages/apollo-wind/.storybook/preview.tsx
+++ b/packages/apollo-wind/.storybook/preview.tsx
@@ -84,6 +84,9 @@ const preview: Preview = {
             [
               'UiPath',
               [
+                'Lockable Value Field',
+                'Prompt Editor',
+                'Canvas',
                 'Canvas Toolbar',
                 'Chat Composer',
                 'Chat Message',

--- a/packages/apollo-wind/biome.json
+++ b/packages/apollo-wind/biome.json
@@ -1,4 +1,5 @@
 {
+  "root": false,
   "$schema": "https://biomejs.dev/schemas/2.3.6/schema.json",
   "vcs": {
     "enabled": true,

--- a/packages/apollo-wind/src/components/custom/panel-flow.tsx
+++ b/packages/apollo-wind/src/components/custom/panel-flow.tsx
@@ -13,11 +13,11 @@ import {
   Workflow,
 } from 'lucide-react';
 import * as React from 'react';
+import { ChatComposer } from '@/components/custom/chat-composer';
 import { Avatar, AvatarFallback } from '@/components/ui/avatar';
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import { cn } from '@/lib';
-import { ChatComposer } from '@/components/custom/chat-composer';
 
 // ============================================================================
 // Types
@@ -30,6 +30,8 @@ export interface FlowPanelNavItem {
 }
 
 export interface FlowPanelToolItem {
+  /** Stable identifier used when rendering dynamic tool lists. */
+  id?: string;
   icon: 'search' | 'bot';
   title: string;
   description: string;
@@ -219,11 +221,13 @@ function ToolCard({ card }: { card: FlowPanelToolCard }) {
           <div className="flex flex-col gap-2 pb-4 pt-1">
             <p className="px-4 py-[5px] text-xs text-foreground-muted">Agents and tools used</p>
             <div className="flex flex-col gap-3">
-              {card.items.map((item, i) => {
+              {card.items.map((item, index) => {
                 const Icon = toolIconMap[item.icon];
                 return (
-                  // biome-ignore lint/suspicious/noArrayIndexKey: static display list
-                  <div key={i} className="flex items-start gap-2.5 pl-4 pr-9">
+                  <div
+                    key={item.id ?? `${item.icon}-${item.title}-${item.description}-${index}`}
+                    className="flex items-start gap-2.5 pl-4 pr-9"
+                  >
                     <div className="flex h-5 w-5 shrink-0 items-center justify-center">
                       <Icon className="h-4 w-4 text-foreground-secondary" />
                     </div>

--- a/packages/apollo-wind/src/components/ui/file-upload.test.tsx
+++ b/packages/apollo-wind/src/components/ui/file-upload.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { axe } from 'jest-axe';
 import { describe, expect, it, vi } from 'vitest';
@@ -35,9 +35,34 @@ describe('FileUpload', () => {
       expect(screen.getByText(/Max size: 5 MB/)).toBeInTheDocument();
     });
 
+    it('associates with an external label via id, so the label activates the file input', () => {
+      render(
+        <>
+          <label htmlFor="attachment">Attachment</label>
+          <FileUpload id="attachment" />
+        </>
+      );
+      expect(screen.getByLabelText('Attachment')).toBeInTheDocument();
+    });
+
     it('renders disabled state', () => {
       const { container } = render(<FileUpload disabled />);
       expect(container.querySelector('.opacity-50')).toBeInTheDocument();
+    });
+
+    it('makes the dropzone keyboard-focusable', () => {
+      render(<FileUpload />);
+      expect(screen.getByRole('button', { name: 'File upload area' })).toHaveAttribute(
+        'tabIndex',
+        '0'
+      );
+    });
+
+    it('removes the dropzone from tab order and marks it aria-disabled when disabled', () => {
+      render(<FileUpload disabled />);
+      const dropzone = screen.getByRole('button', { name: 'File upload area' });
+      expect(dropzone).toHaveAttribute('tabIndex', '-1');
+      expect(dropzone).toHaveAttribute('aria-disabled', 'true');
     });
   });
 
@@ -61,6 +86,31 @@ describe('FileUpload', () => {
 
       const results = await axe(container);
       expect(results).toHaveNoViolations();
+    });
+
+    it('calls onBlur only when focus leaves the entire file-upload widget', async () => {
+      const user = userEvent.setup();
+      const handleBlur = vi.fn();
+      const { container } = render(
+        <>
+          <FileUpload onBlur={handleBlur} />
+          <button type="button">Outside</button>
+        </>
+      );
+      const input = container.querySelector('input[type="file"]') as HTMLInputElement;
+      fireEvent.change(input, {
+        target: { files: [createMockFile('test.txt', 100, 'text/plain')] },
+      });
+
+      const dropzone = screen.getByRole('button', { name: 'File upload area' });
+      dropzone.focus();
+      await user.tab();
+      expect(screen.getByRole('button', { name: 'Remove test.txt' })).toHaveFocus();
+      expect(handleBlur).not.toHaveBeenCalled();
+
+      await user.tab();
+      expect(screen.getByRole('button', { name: 'Outside' })).toHaveFocus();
+      expect(handleBlur).toHaveBeenCalledOnce();
     });
   });
 

--- a/packages/apollo-wind/src/components/ui/file-upload.tsx
+++ b/packages/apollo-wind/src/components/ui/file-upload.tsx
@@ -6,6 +6,22 @@ import { Button } from '@/components/ui/button';
 import { cn } from '@/lib';
 
 export interface FileUploadProps {
+  /**
+   * Applied to the underlying `<input type="file">`, so an external
+   * `<label htmlFor>` can activate it (click-to-open) like any other labelable
+   * control. The dropzone itself is a `div[role=button]`, which isn't labelable,
+   * hence `ariaLabel` below for naming that part.
+   */
+  id?: string;
+  /**
+   * Names the dropzone (`div[role=button]`, not a labelable element, so a
+   * surrounding `<label htmlFor>` can't associate with it -- pass the field's
+   * visible label text here instead). Also names the `<input type="file">`
+   * itself when `id` is omitted; when `id` is provided, an external
+   * `<label htmlFor>` names the input instead (aria-label would otherwise
+   * override it in the accessible-name computation).
+   */
+  ariaLabel?: string;
   onFilesChange?: (files: File[]) => void;
   accept?: string;
   multiple?: boolean;
@@ -15,9 +31,12 @@ export interface FileUploadProps {
   showPreview?: boolean;
   /** External errors keyed by filename. Use this to set errors from outside (e.g., upload failures). */
   errors?: Record<string, string>;
+  onBlur?: React.FocusEventHandler<HTMLFieldSetElement>;
 }
 
 export function FileUpload({
+  id,
+  ariaLabel,
   onFilesChange,
   accept,
   multiple = false,
@@ -26,6 +45,7 @@ export function FileUpload({
   className,
   showPreview = false,
   errors,
+  onBlur,
 }: FileUploadProps) {
   const [files, setFiles] = React.useState<File[]>([]);
   const [isDragging, setIsDragging] = React.useState(false);
@@ -211,14 +231,38 @@ export function FileUpload({
   };
 
   return (
-    <div className={cn('w-full', className)}>
-      {/** biome-ignore lint/a11y/useSemanticElements: Intended */}
+    <fieldset
+      className={cn('m-0 min-w-0 w-full border-0 p-0', className)}
+      onBlur={(event) => {
+        if (!event.currentTarget.contains(event.relatedTarget as Node | null)) {
+          onBlur?.(event);
+        }
+      }}
+    >
+      <input
+        ref={inputRef}
+        id={id}
+        type="file"
+        className="hidden"
+        accept={accept}
+        multiple={multiple}
+        disabled={disabled}
+        onChange={handleInputChange}
+        // aria-label always wins over a `<label htmlFor>` association in the
+        // accessible-name computation, so only set it when there's no id for a
+        // consumer's label to target (same pattern as MultiSelect).
+        aria-label={id ? undefined : (ariaLabel ?? 'File upload')}
+      />
+      {/** biome-ignore lint/a11y/useSemanticElements: A div avoids invalid nested buttons when uploaded files have remove actions. */}
       <div
-        role="group"
-        aria-label="File upload area"
+        role="button"
+        aria-label={ariaLabel ?? 'File upload area'}
+        aria-disabled={disabled}
+        tabIndex={disabled ? -1 : 0}
         className={cn(
           // Base styles (all themes)
           'relative flex flex-col items-center justify-center w-full h-32 px-4 py-6 border-2 border-dashed rounded-lg cursor-pointer transition-colors',
+          'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background',
           // Future Dark / Future Light overrides
           'future:rounded-xl',
           isDragging
@@ -239,16 +283,6 @@ export function FileUpload({
           }
         }}
       >
-        <input
-          ref={inputRef}
-          type="file"
-          className="hidden"
-          accept={accept}
-          multiple={multiple}
-          disabled={disabled}
-          onChange={handleInputChange}
-          aria-label="File upload"
-        />
         <Upload className="w-8 h-8 mb-2 text-muted-foreground" />
         <p className="text-sm text-muted-foreground text-center">
           <span className="font-semibold">Click to upload</span> or drag and drop
@@ -311,6 +345,6 @@ export function FileUpload({
           })}
         </div>
       )}
-    </div>
+    </fieldset>
   );
 }

--- a/packages/apollo-wind/src/components/ui/lockable-value-field/components/field-header.tsx
+++ b/packages/apollo-wind/src/components/ui/lockable-value-field/components/field-header.tsx
@@ -1,0 +1,259 @@
+import { Asterisk, Braces, ChevronDown, Sparkles } from 'lucide-react';
+import type { ReactNode } from 'react';
+import { useId, useState } from 'react';
+import { Button } from '@/components/ui/button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { Label } from '@/components/ui/label';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import { Switch } from '@/components/ui/switch';
+import { Textarea } from '@/components/ui/textarea';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
+import { cn } from '@/lib';
+import type { LockableFieldType, LockableValueFieldOption } from '../types';
+import { FIELD_TYPE_META, FIELD_TYPE_ORDER } from '../types';
+
+export function FieldHeader({
+  label,
+  fieldId,
+  fieldLabel,
+  required,
+  fieldType,
+  onFieldTypeChange,
+  onRequiredChange,
+  controlsVisibility,
+  compact,
+  showFieldActions,
+  value,
+  onValueChange,
+  variables,
+  onGenerateWithAi,
+  headerActions,
+}: {
+  label?: ReactNode;
+  fieldId: string;
+  fieldLabel: string;
+  required?: boolean;
+  fieldType: LockableFieldType;
+  onFieldTypeChange?: (fieldType: LockableFieldType) => void;
+  onRequiredChange?: (required: boolean) => void;
+  controlsVisibility: 'visible' | 'hover';
+  compact?: boolean;
+  showFieldActions: boolean;
+  value: string;
+  onValueChange?: (value: string) => void;
+  variables: LockableValueFieldOption[];
+  onGenerateWithAi?: (prompt: string) => void;
+  headerActions?: ReactNode;
+}) {
+  const promptId = useId();
+  const [aiPrompt, setAiPrompt] = useState('');
+  const typeMeta = FIELD_TYPE_META[fieldType];
+  // 259px is the container width below which these controls no longer fit
+  // alongside their text labels, so they collapse to icon-only.
+  const collapsedTextClass = cn('@max-[259px]:hidden', compact && '!hidden');
+  const collapsedPaddingClass = cn('@max-[259px]:px-1.5', compact && '!px-1.5');
+  const compactOnlyClass = cn('hidden @max-[259px]:block', compact && '!block');
+
+  return (
+    <div className="flex items-center gap-1">
+      {label ?? (
+        <Label htmlFor={fieldId} className="text-xs font-medium text-foreground-muted">
+          {fieldLabel}
+          {required && <span className="ml-0.5 text-destructive">*</span>}
+        </Label>
+      )}
+      <TooltipProvider delayDuration={300}>
+        <div className="ml-auto flex items-center gap-0.5">
+          <div
+            className={cn(
+              'flex items-center gap-0.5',
+              controlsVisibility === 'hover' &&
+                'opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100 has-[[aria-expanded=true]]:opacity-100'
+            )}
+          >
+            {onFieldTypeChange && (
+              <DropdownMenu>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <DropdownMenuTrigger asChild>
+                      <button
+                        type="button"
+                        aria-label="Field type"
+                        className={cn(
+                          'flex h-7 items-center gap-1 rounded-lg px-2 text-[11px] text-foreground-subtle transition hover:bg-surface-overlay hover:text-foreground',
+                          collapsedPaddingClass
+                        )}
+                      >
+                        <typeMeta.icon size={12} />
+                        <span className={collapsedTextClass}>{typeMeta.label}</span>
+                        <ChevronDown size={9} className={collapsedTextClass} />
+                      </button>
+                    </DropdownMenuTrigger>
+                  </TooltipTrigger>
+                  <TooltipContent>Type</TooltipContent>
+                </Tooltip>
+                <DropdownMenuContent align="end" className="w-44">
+                  {FIELD_TYPE_ORDER.map((type) => {
+                    const meta = FIELD_TYPE_META[type];
+                    const isActive = type === fieldType;
+                    return (
+                      <DropdownMenuItem key={type} onClick={() => onFieldTypeChange(type)}>
+                        <meta.icon className={isActive ? 'text-brand' : 'text-foreground-muted'} />
+                        <span className={cn(isActive && 'font-medium text-brand')}>
+                          {meta.label}
+                        </span>
+                      </DropdownMenuItem>
+                    );
+                  })}
+                </DropdownMenuContent>
+              </DropdownMenu>
+            )}
+            {onRequiredChange && (
+              <>
+                <div className={collapsedTextClass}>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      {/* Wrapped in a span: TooltipTrigger's asChild merge otherwise
+                          overwrites the Switch's own data-state (checked/unchecked)
+                          with the tooltip's open/closed state, breaking its color classes. */}
+                      <span className="inline-flex">
+                        <Switch
+                          size="sm"
+                          checked={!!required}
+                          onCheckedChange={onRequiredChange}
+                          className="data-[state=checked]:bg-brand data-[state=unchecked]:bg-foreground-subtle"
+                          aria-label={required ? 'Required field' : 'Optional field'}
+                        />
+                      </span>
+                    </TooltipTrigger>
+                    <TooltipContent>Required</TooltipContent>
+                  </Tooltip>
+                </div>
+                <div className={compactOnlyClass}>
+                  <Popover>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <PopoverTrigger asChild>
+                          <button
+                            type="button"
+                            aria-label={required ? 'Required field' : 'Optional field'}
+                            className="grid size-7 place-items-center rounded-lg text-foreground-subtle transition hover:bg-surface-overlay hover:text-foreground"
+                          >
+                            <Asterisk size={12} />
+                          </button>
+                        </PopoverTrigger>
+                      </TooltipTrigger>
+                      <TooltipContent>Required</TooltipContent>
+                    </Tooltip>
+                    <PopoverContent align="end" className="w-48">
+                      <div className="flex items-center justify-between gap-3">
+                        <span className="text-xs font-medium text-foreground">Required</span>
+                        <Switch
+                          size="sm"
+                          checked={!!required}
+                          onCheckedChange={onRequiredChange}
+                          className="data-[state=checked]:bg-brand data-[state=unchecked]:bg-foreground-subtle"
+                          aria-label={required ? 'Required field' : 'Optional field'}
+                        />
+                      </div>
+                    </PopoverContent>
+                  </Popover>
+                </div>
+              </>
+            )}
+            {showFieldActions && (
+              <>
+                <Popover>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <PopoverTrigger asChild>
+                        <button
+                          type="button"
+                          aria-label="AI assist"
+                          className="grid size-7 place-items-center rounded-lg text-foreground-subtle transition hover:bg-surface-overlay hover:text-foreground"
+                        >
+                          <Sparkles size={12} />
+                        </button>
+                      </PopoverTrigger>
+                    </TooltipTrigger>
+                    <TooltipContent>Generate with AI</TooltipContent>
+                  </Tooltip>
+                  <PopoverContent align="end" className="space-y-3">
+                    <div className="space-y-1.5">
+                      <Label
+                        htmlFor={promptId}
+                        className="text-xs font-medium text-foreground-muted"
+                      >
+                        Describe what you want
+                      </Label>
+                      <Textarea
+                        id={promptId}
+                        rows={3}
+                        value={aiPrompt}
+                        onChange={(e) => setAiPrompt(e.target.value)}
+                        placeholder="Display a value from the previous step"
+                        className="resize-none text-sm"
+                      />
+                    </div>
+                    <span className="block text-[11px] text-foreground-subtle">
+                      Output: {typeMeta.label}
+                      {typeMeta.supportsExpression ? ' expression' : ' value'}
+                    </span>
+                    <Button
+                      size="sm"
+                      className="w-full"
+                      disabled={!onGenerateWithAi}
+                      onClick={() => onGenerateWithAi?.(aiPrompt)}
+                    >
+                      Generate
+                    </Button>
+                  </PopoverContent>
+                </Popover>
+                <DropdownMenu>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <DropdownMenuTrigger asChild>
+                        <button
+                          type="button"
+                          aria-label="Insert variable"
+                          disabled={variables.length === 0 || !onValueChange}
+                          className={cn(
+                            'flex h-7 items-center gap-1 rounded-lg px-2 text-[11px] text-foreground-subtle transition hover:bg-surface-overlay hover:text-foreground disabled:pointer-events-none disabled:opacity-50',
+                            collapsedPaddingClass
+                          )}
+                        >
+                          <Braces size={12} />
+                          <span className={collapsedTextClass}>Insert</span>
+                          <ChevronDown size={9} className={collapsedTextClass} />
+                        </button>
+                      </DropdownMenuTrigger>
+                    </TooltipTrigger>
+                    <TooltipContent>Insert variable</TooltipContent>
+                  </Tooltip>
+                  <DropdownMenuContent align="end" className="w-48">
+                    {variables.map((variable) => (
+                      <DropdownMenuItem
+                        key={variable.value}
+                        onClick={() =>
+                          onValueChange?.(value ? `${value} ${variable.value}` : variable.value)
+                        }
+                      >
+                        {variable.label}
+                      </DropdownMenuItem>
+                    ))}
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              </>
+            )}
+          </div>
+          {headerActions}
+        </div>
+      </TooltipProvider>
+    </div>
+  );
+}

--- a/packages/apollo-wind/src/components/ui/lockable-value-field/components/lock-toggle-button.tsx
+++ b/packages/apollo-wind/src/components/ui/lockable-value-field/components/lock-toggle-button.tsx
@@ -1,0 +1,44 @@
+import { LockKeyhole, LockKeyholeOpen } from 'lucide-react';
+import { InputGroupButton } from '@/components/ui/input-group';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
+
+/**
+ * The lock/unlock toggle shared by both the InputGroup and plain-Input
+ * layouts. Disabled (and its label adjusted) when onLockedChange isn't
+ * provided, since clicking it wouldn't do anything otherwise.
+ */
+export function LockToggleButton({
+  locked,
+  onLockedChange,
+}: {
+  locked: boolean;
+  onLockedChange?: (locked: boolean) => void;
+}) {
+  const interactive = !!onLockedChange;
+  return (
+    <TooltipProvider delayDuration={300}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <InputGroupButton
+            icon
+            size="3xs"
+            disabled={!interactive}
+            onClick={() => onLockedChange?.(!locked)}
+            aria-label={
+              interactive
+                ? locked
+                  ? 'Read-only. Click to make editable.'
+                  : 'Editable. Click to make read-only.'
+                : locked
+                  ? 'Read-only'
+                  : 'Editable'
+            }
+          >
+            {locked ? <LockKeyhole size={16} /> : <LockKeyholeOpen size={16} />}
+          </InputGroupButton>
+        </TooltipTrigger>
+        <TooltipContent>{locked ? 'Read-only' : 'Editable'}</TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}

--- a/packages/apollo-wind/src/components/ui/lockable-value-field/components/mode-menu-item.tsx
+++ b/packages/apollo-wind/src/components/ui/lockable-value-field/components/mode-menu-item.tsx
@@ -1,0 +1,30 @@
+import type { LucideIcon } from 'lucide-react';
+import { DropdownMenuItem } from '@/components/ui/dropdown-menu';
+import { cn } from '@/lib';
+
+/** One entry in the Fixed/Expression value-type dropdown. */
+export function ModeMenuItem({
+  icon: Icon,
+  label,
+  description,
+  active,
+  onClick,
+}: {
+  icon: LucideIcon;
+  label: string;
+  description: string;
+  active: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <DropdownMenuItem className="flex-col items-start gap-0.5 py-2" onClick={onClick}>
+      <div className="flex items-center gap-2">
+        <Icon size={13} className={active ? 'text-brand' : 'text-foreground-muted'} />
+        <span className={cn('text-xs font-medium', active ? 'text-brand' : 'text-foreground')}>
+          {label}
+        </span>
+      </div>
+      <span className="pl-6 text-[11px] leading-4 text-foreground-subtle">{description}</span>
+    </DropdownMenuItem>
+  );
+}

--- a/packages/apollo-wind/src/components/ui/lockable-value-field/index.ts
+++ b/packages/apollo-wind/src/components/ui/lockable-value-field/index.ts
@@ -1,0 +1,8 @@
+export { LockableValueField } from './lockable-value-field';
+export type {
+  LockableFieldType,
+  LockableValueFieldMode,
+  LockableValueFieldOption,
+  LockableValueFieldProps,
+} from './types';
+export { FIELD_TYPE_META, FIELD_TYPE_ORDER } from './types';

--- a/packages/apollo-wind/src/components/ui/lockable-value-field/lockable-value-field.stories.tsx
+++ b/packages/apollo-wind/src/components/ui/lockable-value-field/lockable-value-field.stories.tsx
@@ -1,0 +1,326 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { X } from 'lucide-react';
+import { useId, useRef, useState } from 'react';
+import { cn } from '@/lib';
+import { Label } from '../label';
+import { ToggleGroup, ToggleGroupItem } from '../toggle-group';
+import { LockableValueField } from './lockable-value-field';
+import { FIELD_TYPE_META, type LockableFieldType, type LockableValueFieldMode } from './types';
+
+const meta = {
+  title: 'Components/UiPath/Lockable Value Field',
+  component: LockableValueField,
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component: `
+A field that can be locked to read-only, typed as one of several data types,
+and (for scalar types) switched between a literal value and a JS expression.
+
+- Left lock icon toggles Editable / Read-only. Read-only fields show plain
+  text, not a disabled control.
+- Right value-mode icon switches between Fixed value and Expression,
+  updating the value styling. Only shown for types an expression can
+  produce.
+- Field type dropdown swaps the control itself: String, Integer, Date,
+  Boolean, Single select, Multi select, and File each render their own
+  matching input.
+- Required switch toggles the red asterisk on the label. Only shown when
+  \`onRequiredChange\` is provided.
+- Built-in AI-assist popover to describe and generate a value, and an
+  Insert-variable affordance for binding to upstream data. Both hidden via
+  \`showFieldActions={false}\` for read-only reviewer contexts.
+- \`label\` accepts any ReactNode, so a consumer can compose its own
+  inline-editable title in place of the default text -- see **Controls**
+  below.
+- \`controlsVisibility\` decides whether the type/required/AI/insert/header
+  actions are always shown or only on hover -- see **Controls** below.
+- Header row is responsive (container query): the type, required,
+  AI-assist, and insert-variable controls collapse to icon-only once the
+  field gets too narrow for their labels. See **Responsive** below.
+- Built on \`InputGroup\` for the scalar types that support expressions; see
+  Input Group's \`LockedFieldWithPopover\` story for a lighter-weight recipe
+  using only \`InputGroup\` primitives.
+        `,
+      },
+    },
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof LockableValueField>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+function CloseFieldButton({ controlsVisibility }: { controlsVisibility: 'visible' | 'hover' }) {
+  return (
+    <button
+      type="button"
+      aria-label="Close field"
+      className={cn(
+        'grid size-7 shrink-0 place-items-center rounded-lg text-foreground-subtle transition hover:bg-surface-overlay hover:text-foreground',
+        controlsVisibility === 'hover' &&
+          'opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100 has-[[aria-expanded=true]]:opacity-100'
+      )}
+    >
+      <X size={14} />
+    </button>
+  );
+}
+
+function DefaultDemo() {
+  const fieldId = useId();
+  const [value, setValue] = useState('');
+  const [locked, setLocked] = useState(true);
+  const [mode, setMode] = useState<LockableValueFieldMode>('fixed');
+  const [fieldType, setFieldType] = useState<LockableFieldType>('string');
+  const [required, setRequired] = useState(true);
+
+  const handleFieldTypeChange = (type: LockableFieldType) => {
+    setFieldType(type);
+    setValue('');
+    if (!FIELD_TYPE_META[type].supportsExpression) {
+      setMode('fixed');
+    }
+  };
+
+  return (
+    <div className="w-80">
+      <LockableValueField
+        id={fieldId}
+        label={
+          <Label htmlFor={fieldId} className="text-xs font-medium text-foreground-muted">
+            Label
+            {required && <span className="ml-0.5 text-destructive">*</span>}
+          </Label>
+        }
+        headerActions={<CloseFieldButton controlsVisibility="visible" />}
+        value={value}
+        onValueChange={setValue}
+        locked={locked}
+        onLockedChange={setLocked}
+        mode={mode}
+        onModeChange={setMode}
+        fieldType={fieldType}
+        onFieldTypeChange={handleFieldTypeChange}
+        required={required}
+        onRequiredChange={setRequired}
+      />
+    </div>
+  );
+}
+
+export const Default: Story = {
+  render: () => <DefaultDemo />,
+};
+
+/**
+ * Matches the inline-editable title pattern the Form HITL quick-form
+ * builder passes into `label`: click the text to edit it, blur or press
+ * Enter/Escape to commit.
+ */
+function InlineEditableLabel({
+  title,
+  onTitleChange,
+  required,
+}: {
+  title: string;
+  onTitleChange: (title: string) => void;
+  required: boolean;
+}) {
+  const [editing, setEditing] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  return editing ? (
+    <input
+      ref={inputRef}
+      value={title}
+      onChange={(e) => onTitleChange(e.target.value)}
+      onBlur={() => setEditing(false)}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === 'Escape') setEditing(false);
+      }}
+      className="min-w-0 flex-1 rounded bg-surface-overlay px-1 py-0.5 text-xs font-medium text-foreground outline-none ring-1 ring-brand"
+      // biome-ignore lint/a11y/noAutofocus: only mounts in response to the user's own click on the label, not on page load
+      autoFocus
+    />
+  ) : (
+    <button
+      type="button"
+      onClick={() => {
+        setEditing(true);
+        setTimeout(() => inputRef.current?.select(), 0);
+      }}
+      className="truncate rounded px-1 py-0.5 text-left text-xs font-medium text-foreground-muted transition hover:bg-surface-overlay hover:text-foreground"
+    >
+      {title}
+      {required && <span className="ml-0.5 text-destructive">*</span>}
+    </button>
+  );
+}
+
+function ControlsPlayground() {
+  const [title, setTitle] = useState('Label');
+  const [value, setValue] = useState('');
+  const [locked, setLocked] = useState(true);
+  const [mode, setMode] = useState<LockableValueFieldMode>('fixed');
+  const [fieldType, setFieldType] = useState<LockableFieldType>('string');
+  const [required, setRequired] = useState(true);
+  const [controlsVisibility, setControlsVisibility] = useState<'visible' | 'hover'>('visible');
+
+  const handleFieldTypeChange = (type: LockableFieldType) => {
+    setFieldType(type);
+    setValue('');
+    if (!FIELD_TYPE_META[type].supportsExpression) {
+      setMode('fixed');
+    }
+  };
+
+  return (
+    <div className="flex w-80 flex-col gap-4">
+      <div className="flex items-center justify-between">
+        <span className="text-[11px] font-medium uppercase tracking-wide text-foreground-subtle">
+          Controls
+        </span>
+        <ToggleGroup
+          type="single"
+          size="xs"
+          value={controlsVisibility}
+          onValueChange={(v) => v && setControlsVisibility(v as 'visible' | 'hover')}
+        >
+          <ToggleGroupItem value="visible" className="!px-2.5 !text-xs">
+            Show
+          </ToggleGroupItem>
+          <ToggleGroupItem value="hover" className="!px-2.5 !text-xs">
+            Hide
+          </ToggleGroupItem>
+        </ToggleGroup>
+      </div>
+      <LockableValueField
+        label={
+          <div className="flex min-w-0 flex-1 items-center gap-1">
+            <InlineEditableLabel title={title} onTitleChange={setTitle} required={required} />
+          </div>
+        }
+        headerActions={<CloseFieldButton controlsVisibility={controlsVisibility} />}
+        value={value}
+        onValueChange={setValue}
+        locked={locked}
+        onLockedChange={setLocked}
+        mode={mode}
+        onModeChange={setMode}
+        fieldType={fieldType}
+        onFieldTypeChange={handleFieldTypeChange}
+        required={required}
+        onRequiredChange={setRequired}
+        controlsVisibility={controlsVisibility}
+      />
+    </div>
+  );
+}
+
+export const Controls: Story = {
+  render: () => <ControlsPlayground />,
+};
+
+function ResponsiveDemo() {
+  const fullWidthId = useId();
+  const narrowId = useId();
+  const compactId = useId();
+  const [value, setValue] = useState('');
+  const [locked, setLocked] = useState(true);
+  const [mode, setMode] = useState<LockableValueFieldMode>('fixed');
+  const [fieldType, setFieldType] = useState<LockableFieldType>('string');
+  const [required, setRequired] = useState(true);
+
+  const handleFieldTypeChange = (type: LockableFieldType) => {
+    setFieldType(type);
+    setValue('');
+    if (!FIELD_TYPE_META[type].supportsExpression) {
+      setMode('fixed');
+    }
+  };
+
+  const label = (fieldId: string) => (
+    <Label htmlFor={fieldId} className="text-xs font-medium text-foreground-muted">
+      Label
+      {required && <span className="ml-0.5 text-destructive">*</span>}
+    </Label>
+  );
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="flex flex-col gap-2">
+        <span className="text-[11px] font-medium uppercase tracking-wide text-foreground-subtle">
+          Full width
+        </span>
+        <div className="w-80">
+          <LockableValueField
+            id={fullWidthId}
+            label={label(fullWidthId)}
+            headerActions={<CloseFieldButton controlsVisibility="visible" />}
+            value={value}
+            onValueChange={setValue}
+            locked={locked}
+            onLockedChange={setLocked}
+            mode={mode}
+            onModeChange={setMode}
+            fieldType={fieldType}
+            onFieldTypeChange={handleFieldTypeChange}
+            required={required}
+            onRequiredChange={setRequired}
+          />
+        </div>
+      </div>
+      <div className="flex flex-col gap-2">
+        <span className="text-[11px] font-medium uppercase tracking-wide text-foreground-subtle">
+          Narrow container (controls collapse to icon-only)
+        </span>
+        <div className="w-[200px]">
+          <LockableValueField
+            id={narrowId}
+            label={label(narrowId)}
+            headerActions={<CloseFieldButton controlsVisibility="visible" />}
+            value={value}
+            onValueChange={setValue}
+            locked={locked}
+            onLockedChange={setLocked}
+            mode={mode}
+            onModeChange={setMode}
+            fieldType={fieldType}
+            onFieldTypeChange={handleFieldTypeChange}
+            required={required}
+            onRequiredChange={setRequired}
+          />
+        </div>
+      </div>
+      <div className="flex flex-col gap-2">
+        <span className="text-[11px] font-medium uppercase tracking-wide text-foreground-subtle">
+          Forced compact (via the compact prop, regardless of width)
+        </span>
+        <div className="w-80">
+          <LockableValueField
+            compact
+            id={compactId}
+            label={label(compactId)}
+            headerActions={<CloseFieldButton controlsVisibility="visible" />}
+            value={value}
+            onValueChange={setValue}
+            locked={locked}
+            onLockedChange={setLocked}
+            mode={mode}
+            onModeChange={setMode}
+            fieldType={fieldType}
+            onFieldTypeChange={handleFieldTypeChange}
+            required={required}
+            onRequiredChange={setRequired}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export const Responsive: Story = {
+  render: () => <ResponsiveDemo />,
+};

--- a/packages/apollo-wind/src/components/ui/lockable-value-field/lockable-value-field.test.tsx
+++ b/packages/apollo-wind/src/components/ui/lockable-value-field/lockable-value-field.test.tsx
@@ -1,0 +1,513 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { axe } from 'jest-axe';
+import { describe, expect, it, vi } from 'vitest';
+import { LockableValueField } from './lockable-value-field';
+
+describe('LockableValueField', () => {
+  it('renders a read-only display value when locked', () => {
+    render(<LockableValueField value="INV-2024-0587" locked />);
+    expect(screen.getByPlaceholderText('String value')).toHaveValue('INV-2024-0587');
+    expect(screen.getByPlaceholderText('String value')).toHaveAttribute('readonly');
+  });
+
+  it('renders an editable input when unlocked and onValueChange is provided', () => {
+    render(<LockableValueField value="" locked={false} onValueChange={vi.fn()} />);
+    expect(screen.getByPlaceholderText('String value')).not.toHaveAttribute('readonly');
+  });
+
+  it('renders a read-only input when unlocked but onValueChange is not provided', () => {
+    render(<LockableValueField value="" locked={false} />);
+    expect(screen.getByPlaceholderText('String value')).toHaveAttribute('readonly');
+  });
+
+  it('forwards blur from the built-in value control', () => {
+    const handleBlur = vi.fn();
+    render(
+      <LockableValueField
+        value=""
+        locked={false}
+        onValueChange={vi.fn()}
+        onValueBlur={handleBlur}
+      />
+    );
+
+    fireEvent.blur(screen.getByPlaceholderText('String value'));
+    expect(handleBlur).toHaveBeenCalledOnce();
+  });
+
+  it('provides the consumer expression editor with blur and field context', () => {
+    const handleBlur = vi.fn();
+    const renderExpressionEditor = vi.fn(({ onBlur }: { onBlur?: () => void }) => (
+      <input aria-label="Custom editor" onBlur={onBlur} />
+    ));
+    render(
+      <LockableValueField
+        value=""
+        locked={false}
+        mode="expression"
+        fieldType="integer"
+        onValueChange={vi.fn()}
+        onValueBlur={handleBlur}
+        renderExpressionEditor={renderExpressionEditor}
+      />
+    );
+
+    expect(renderExpressionEditor).toHaveBeenCalledWith(
+      expect.objectContaining({
+        value: '',
+        readOnly: false,
+        fieldType: 'integer',
+        placeholder: 'Write an integer expression',
+        onBlur: handleBlur,
+      })
+    );
+    fireEvent.blur(screen.getByRole('textbox', { name: 'Custom editor' }));
+    expect(handleBlur).toHaveBeenCalledOnce();
+  });
+
+  it('withholds value changes from a consumer expression editor while locked', () => {
+    const renderExpressionEditor = vi.fn(() => <div>Custom editor</div>);
+    render(
+      <LockableValueField
+        value="item.id"
+        locked
+        mode="expression"
+        onValueChange={vi.fn()}
+        renderExpressionEditor={renderExpressionEditor}
+      />
+    );
+
+    expect(renderExpressionEditor).toHaveBeenCalledWith(
+      expect.objectContaining({
+        value: 'item.id',
+        readOnly: true,
+        onValueChange: undefined,
+      })
+    );
+  });
+
+  it('does not attach a value-change handler to the built-in expression input while locked', () => {
+    const handleChange = vi.fn();
+    render(
+      <LockableValueField value="item.id" locked mode="expression" onValueChange={handleChange} />
+    );
+
+    fireEvent.change(screen.getByDisplayValue('item.id'), { target: { value: 'other.id' } });
+    expect(handleChange).not.toHaveBeenCalled();
+  });
+
+  it('uses the correct article in the built-in integer expression placeholder', () => {
+    render(
+      <LockableValueField
+        value=""
+        locked={false}
+        mode="expression"
+        fieldType="integer"
+        onValueChange={vi.fn()}
+      />
+    );
+    expect(screen.getByPlaceholderText('Write an integer expression')).toBeInTheDocument();
+  });
+
+  it('toggles locked state when the lock button is clicked', async () => {
+    const user = userEvent.setup();
+    const handleLockedChange = vi.fn();
+    render(<LockableValueField locked onLockedChange={handleLockedChange} />);
+
+    await user.click(screen.getByRole('button', { name: 'Read-only. Click to make editable.' }));
+    expect(handleLockedChange).toHaveBeenCalledWith(false);
+  });
+
+  it('does not open a menu when the lock button is clicked', async () => {
+    const user = userEvent.setup();
+    render(<LockableValueField locked onLockedChange={vi.fn()} />);
+
+    await user.click(screen.getByRole('button', { name: 'Read-only. Click to make editable.' }));
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+  });
+
+  it('only shows the Required switch when onRequiredChange is provided', () => {
+    const { rerender } = render(<LockableValueField locked={false} />);
+    expect(screen.queryByRole('switch')).not.toBeInTheDocument();
+
+    rerender(<LockableValueField locked={false} required onRequiredChange={vi.fn()} />);
+    expect(screen.getByRole('switch')).toBeInTheDocument();
+  });
+
+  it('only shows the field-type dropdown when onFieldTypeChange is provided', () => {
+    const { rerender } = render(<LockableValueField locked={false} />);
+    expect(screen.queryByRole('button', { name: 'Field type' })).not.toBeInTheDocument();
+
+    rerender(<LockableValueField locked={false} onFieldTypeChange={vi.fn()} />);
+    expect(screen.getByRole('button', { name: 'Field type' })).toBeInTheDocument();
+  });
+
+  it('hides AI-assist and Insert-variable actions when showFieldActions is false', () => {
+    render(<LockableValueField locked={false} showFieldActions={false} />);
+    expect(screen.queryByRole('button', { name: 'AI assist' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Insert variable' })).not.toBeInTheDocument();
+  });
+
+  it('shows AI-assist and Insert-variable actions by default', () => {
+    render(<LockableValueField locked={false} />);
+    expect(screen.getByRole('button', { name: 'AI assist' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Insert variable' })).toBeInTheDocument();
+  });
+
+  it('only shows the Fixed/Expression mode dropdown for types that support expressions', () => {
+    const { rerender } = render(<LockableValueField locked={false} fieldType="single-select" />);
+    expect(screen.queryByRole('button', { name: 'Choose value type' })).not.toBeInTheDocument();
+
+    rerender(<LockableValueField locked={false} fieldType="string" />);
+    expect(screen.getByRole('button', { name: 'Choose value type' })).toBeInTheDocument();
+  });
+
+  it('renders headerActions content after the built-in controls', () => {
+    render(
+      <LockableValueField
+        locked={false}
+        headerActions={<button type="button">Delete field</button>}
+      />
+    );
+    expect(screen.getByRole('button', { name: 'Delete field' })).toBeInTheDocument();
+  });
+
+  it('renders a Switch control for boolean fields when unlocked', () => {
+    render(<LockableValueField locked={false} fieldType="boolean" value="true" />);
+    expect(screen.getByRole('switch')).toBeChecked();
+  });
+
+  it('disables the boolean Switch when unlocked but onValueChange is not provided', () => {
+    render(<LockableValueField locked={false} fieldType="boolean" value="true" />);
+    expect(screen.getByRole('switch')).toBeDisabled();
+  });
+
+  it('disables the date-picker trigger when unlocked but onValueChange is not provided', () => {
+    render(<LockableValueField locked={false} fieldType="date" />);
+    expect(screen.getByText('Pick a date').closest('button')).toBeDisabled();
+  });
+
+  it('calls onValueBlur when the date picker closes, not when focus enters its calendar', async () => {
+    const user = userEvent.setup();
+    const handleBlur = vi.fn();
+    render(
+      <LockableValueField
+        locked={false}
+        fieldType="date"
+        onValueChange={vi.fn()}
+        onValueBlur={handleBlur}
+      />
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Date value' }));
+    expect(handleBlur).not.toHaveBeenCalled();
+
+    await user.keyboard('{Escape}');
+    expect(handleBlur).toHaveBeenCalledOnce();
+  });
+
+  it('disables the single-select trigger when unlocked but onValueChange is not provided', () => {
+    render(<LockableValueField locked={false} fieldType="single-select" />);
+    expect(screen.getByRole('combobox')).toBeDisabled();
+  });
+
+  it('calls onValueBlur when the single-select closes, not when focus enters its menu', async () => {
+    const user = userEvent.setup();
+    const handleBlur = vi.fn();
+    render(
+      <LockableValueField
+        locked={false}
+        fieldType="single-select"
+        onValueChange={vi.fn()}
+        onValueBlur={handleBlur}
+      />
+    );
+
+    await user.click(screen.getByRole('combobox'));
+    expect(handleBlur).not.toHaveBeenCalled();
+
+    await user.keyboard('{Escape}');
+    expect(handleBlur).toHaveBeenCalledOnce();
+  });
+
+  it('disables the multi-select trigger when unlocked but onValueChange is not provided', () => {
+    render(<LockableValueField locked={false} fieldType="multi-select" />);
+    expect(screen.getByRole('combobox')).toBeDisabled();
+  });
+
+  it('renders a file upload control for file fields when unlocked', () => {
+    render(<LockableValueField locked={false} fieldType="file" />);
+    expect(screen.getByText(/drag/i, { exact: false })).toBeInTheDocument();
+  });
+
+  it('disables the file upload control when unlocked but onValueChange is not provided', () => {
+    const { container } = render(<LockableValueField locked={false} fieldType="file" />);
+    expect(container.querySelector('input[type="file"]')).toBeDisabled();
+  });
+
+  it('associates the multi-select control with a custom label via the generated id', () => {
+    render(
+      <LockableValueField
+        locked={false}
+        fieldType="multi-select"
+        label={<label htmlFor="tags-field">Tags</label>}
+        id="tags-field"
+      />
+    );
+    expect(screen.getByLabelText('Tags')).toBeInTheDocument();
+  });
+
+  it("uses the field's computed label as the file upload area's accessible name", () => {
+    render(<LockableValueField locked={false} fieldType="file" />);
+    expect(screen.getByRole('button', { name: 'File value' })).toBeInTheDocument();
+  });
+
+  it('associates the file upload control with a custom label via the generated id', () => {
+    render(
+      <LockableValueField
+        locked={false}
+        fieldType="file"
+        label={<label htmlFor="attachment-field">Attachment</label>}
+        id="attachment-field"
+      />
+    );
+    expect(screen.getByLabelText('Attachment')).toBeInTheDocument();
+  });
+
+  it('uses an explicit accessible name for a custom file field label', () => {
+    render(
+      <LockableValueField
+        locked={false}
+        fieldType="file"
+        label={<span>Supporting document</span>}
+        fileUploadAriaLabel="Supporting document"
+      />
+    );
+    expect(screen.getByRole('button', { name: 'Supporting document' })).toBeInTheDocument();
+  });
+
+  it('ignores non-string entries when parsing a locked multi-select value', () => {
+    const options = [{ label: 'Alpha', value: 'alpha' }];
+    render(
+      <LockableValueField
+        locked
+        fieldType="multi-select"
+        value={JSON.stringify(['alpha', 42, null])}
+        options={options}
+      />
+    );
+    expect(screen.getByPlaceholderText('Multi select value')).toHaveValue('Alpha');
+  });
+
+  it('falls back to the raw value for a locked multi-select value that parses to no entries', () => {
+    render(<LockableValueField locked fieldType="multi-select" value="not-json" />);
+    expect(screen.getByPlaceholderText('Multi select value')).toHaveValue('not-json');
+  });
+
+  it('shows an empty display for a locked multi-select value that is an explicit empty array', () => {
+    render(<LockableValueField locked fieldType="multi-select" value="[]" />);
+    expect(screen.getByPlaceholderText('Multi select value')).toHaveValue('');
+  });
+
+  it('falls back to the raw value instead of throwing on an invalid date string', () => {
+    expect(() =>
+      render(<LockableValueField locked fieldType="date" value="not-a-date" />)
+    ).not.toThrow();
+    expect(screen.getByPlaceholderText('Date value')).toHaveValue('not-a-date');
+  });
+
+  it('shows the raw value instead of throwing when unlocked with an invalid date', () => {
+    const { container } = render(
+      <LockableValueField locked={false} fieldType="date" value="not-a-date" />
+    );
+    expect(container).toHaveTextContent('not-a-date');
+  });
+
+  it('rejects an out-of-range date-only value instead of silently normalizing it', () => {
+    render(<LockableValueField locked fieldType="date" value="2024-13-40" />);
+    expect(screen.getByPlaceholderText('Date value')).toHaveValue('2024-13-40');
+  });
+
+  it('formats a date-only value using the local calendar day, not UTC', () => {
+    const originalTz = process.env.TZ;
+    process.env.TZ = 'America/Los_Angeles';
+    try {
+      render(<LockableValueField locked fieldType="date" value="2024-01-15" />);
+      const expected = new Date(2024, 0, 15).toLocaleDateString(undefined, {
+        year: 'numeric',
+        month: 'long',
+        day: 'numeric',
+      });
+      expect(screen.getByPlaceholderText('Date value')).toHaveValue(expected);
+    } finally {
+      if (originalTz === undefined) {
+        delete process.env.TZ;
+      } else {
+        process.env.TZ = originalTz;
+      }
+    }
+  });
+
+  it('associates the default label with the field via a generated id when none is provided', () => {
+    render(<LockableValueField locked={false} />);
+    expect(screen.getByLabelText('String value')).toBeInTheDocument();
+  });
+
+  it('disables the lock button when onLockedChange is not provided', () => {
+    render(<LockableValueField locked />);
+    expect(screen.getByRole('button', { name: 'Read-only' })).toBeDisabled();
+  });
+
+  it('enables the lock button and uses the click-to-toggle label when onLockedChange is provided', () => {
+    render(<LockableValueField locked onLockedChange={vi.fn()} />);
+    expect(
+      screen.getByRole('button', { name: 'Read-only. Click to make editable.' })
+    ).not.toBeDisabled();
+  });
+
+  it('renders consumer-supplied options for single-select instead of the demo defaults', () => {
+    const options = [{ label: 'Custom option', value: 'custom' }];
+    render(
+      <LockableValueField
+        locked={false}
+        fieldType="single-select"
+        value="custom"
+        options={options}
+      />
+    );
+    expect(screen.getByRole('combobox')).toHaveTextContent('Custom option');
+    expect(screen.queryByText('Option 1')).not.toBeInTheDocument();
+  });
+
+  it('shows a consumer-supplied option label for a locked single-select value', () => {
+    const options = [{ label: 'Custom option', value: 'custom' }];
+    render(
+      <LockableValueField locked fieldType="single-select" value="custom" options={options} />
+    );
+    expect(screen.getByPlaceholderText('Single select value')).toHaveValue('Custom option');
+  });
+
+  it('falls back to the raw value for a locked single-select value not present in options', () => {
+    render(
+      <LockableValueField
+        locked
+        fieldType="single-select"
+        value="stale-option"
+        options={[{ label: 'Option 1', value: 'option-1' }]}
+      />
+    );
+    expect(screen.getByPlaceholderText('Single select value')).toHaveValue('stale-option');
+  });
+
+  it('disables Generate and does not call onGenerateWithAi when not provided', async () => {
+    const user = userEvent.setup();
+    render(<LockableValueField locked={false} />);
+    await user.click(screen.getByRole('button', { name: 'AI assist' }));
+    expect(screen.getByRole('button', { name: 'Generate' })).toBeDisabled();
+  });
+
+  it('calls onGenerateWithAi with the entered prompt when Generate is clicked', async () => {
+    const user = userEvent.setup();
+    const handleGenerate = vi.fn();
+    render(<LockableValueField locked={false} onGenerateWithAi={handleGenerate} />);
+
+    await user.click(screen.getByRole('button', { name: 'AI assist' }));
+    await user.type(screen.getByLabelText('Describe what you want'), 'a random number');
+    await user.click(screen.getByRole('button', { name: 'Generate' }));
+
+    expect(handleGenerate).toHaveBeenCalledWith('a random number');
+  });
+
+  it('shows an empty display instead of "False" for an unset boolean value when locked', () => {
+    const { container } = render(<LockableValueField locked fieldType="boolean" value="" />);
+    expect(screen.getByPlaceholderText('Boolean value')).toHaveValue('');
+    expect(container).not.toHaveTextContent('False');
+  });
+
+  it('disables the Fixed/Expression dropdown trigger when onModeChange is not provided', () => {
+    render(<LockableValueField locked={false} fieldType="string" />);
+    expect(screen.getByRole('button', { name: 'Choose value type' })).toBeDisabled();
+  });
+
+  it('enables the Fixed/Expression dropdown trigger when onModeChange is provided', () => {
+    render(<LockableValueField locked={false} fieldType="string" onModeChange={vi.fn()} />);
+    expect(screen.getByRole('button', { name: 'Choose value type' })).not.toBeDisabled();
+  });
+
+  it('reflects the current field type in the AI-assist output hint', async () => {
+    const user = userEvent.setup();
+    render(<LockableValueField locked={false} fieldType="date" />);
+    await user.click(screen.getByRole('button', { name: 'AI assist' }));
+    expect(screen.getByText('Output: Date expression')).toBeInTheDocument();
+  });
+
+  it('shows a value (not expression) output hint for types that do not support expressions', async () => {
+    const user = userEvent.setup();
+    render(<LockableValueField locked={false} fieldType="single-select" />);
+    await user.click(screen.getByRole('button', { name: 'AI assist' }));
+    expect(screen.getByText('Output: Single select value')).toBeInTheDocument();
+  });
+
+  it('reflects the field type and mode in the default label', () => {
+    const { rerender } = render(<LockableValueField locked={false} fieldType="integer" />);
+    expect(screen.getByPlaceholderText('Integer value')).toBeInTheDocument();
+
+    rerender(<LockableValueField locked={false} fieldType="date" mode="expression" />);
+    expect(screen.getByPlaceholderText('Write a date expression')).toBeInTheDocument();
+  });
+
+  it('disables Insert variable when no variables are provided', () => {
+    render(<LockableValueField locked={false} />);
+    expect(screen.getByRole('button', { name: 'Insert variable' })).toBeDisabled();
+  });
+
+  it('disables Insert variable when variables are provided but onValueChange is not', () => {
+    render(
+      <LockableValueField locked={false} variables={[{ label: 'Item ID', value: 'item.id' }]} />
+    );
+    expect(screen.getByRole('button', { name: 'Insert variable' })).toBeDisabled();
+  });
+
+  it('disables Insert variable while the field is locked', () => {
+    render(
+      <LockableValueField
+        locked
+        onValueChange={vi.fn()}
+        variables={[{ label: 'Item ID', value: 'item.id' }]}
+      />
+    );
+    expect(screen.getByRole('button', { name: 'Insert variable' })).toBeDisabled();
+  });
+
+  it('appends the selected variable to the current value when Insert variable is used', async () => {
+    const user = userEvent.setup();
+    const handleValueChange = vi.fn();
+    render(
+      <LockableValueField
+        locked={false}
+        value="hello"
+        onValueChange={handleValueChange}
+        variables={[{ label: 'Item ID', value: 'item.id' }]}
+      />
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Insert variable' }));
+    await user.click(screen.getByRole('menuitem', { name: 'Item ID' }));
+
+    expect(handleValueChange).toHaveBeenCalledWith('hello item.id');
+  });
+
+  it('has no accessibility violations', async () => {
+    const { container } = render(
+      <LockableValueField
+        locked={false}
+        required
+        onRequiredChange={vi.fn()}
+        onFieldTypeChange={vi.fn()}
+      />
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/packages/apollo-wind/src/components/ui/lockable-value-field/lockable-value-field.tsx
+++ b/packages/apollo-wind/src/components/ui/lockable-value-field/lockable-value-field.tsx
@@ -1,0 +1,301 @@
+import { Code2, Type } from 'lucide-react';
+import { useId, useState } from 'react';
+import { Calendar } from '@/components/ui/calendar';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { FileUpload } from '@/components/ui/file-upload';
+import { Input } from '@/components/ui/input';
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupButton,
+  InputGroupInput,
+} from '@/components/ui/input-group';
+import { MultiSelect } from '@/components/ui/multi-select';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Switch } from '@/components/ui/switch';
+import { cn } from '@/lib';
+import { FieldHeader } from './components/field-header';
+import { LockToggleButton } from './components/lock-toggle-button';
+import { ModeMenuItem } from './components/mode-menu-item';
+import type { LockableValueFieldProps } from './types';
+import { FIELD_TYPE_META } from './types';
+import {
+  DEFAULT_SELECT_OPTIONS,
+  formatDateValue,
+  getLockedDisplayValue,
+  parseDateValue,
+  parseListValue,
+  toDateOnlyString,
+} from './utils';
+
+/**
+ * LockableValueField — a field that can be locked to read-only, typed as one
+ * of several data types, and (for scalar types) switched between a literal
+ * value and a JS expression.
+ *
+ * The expression mode is styled as code (monospace) but does not carry real
+ * syntax highlighting or evaluation. Select/multiselect options default to a
+ * small demo set unless `options` is provided. The built-in AI-assist
+ * "Generate" button is a no-op unless `onGenerateWithAi` is provided; the
+ * Insert-variable menu is empty (and disabled) unless `variables` is
+ * provided; file uploads aren't persisted anywhere.
+ */
+export function LockableValueField({
+  value = '',
+  onValueChange,
+  onValueBlur,
+  locked = true,
+  onLockedChange,
+  mode = 'fixed',
+  onModeChange,
+  renderExpressionEditor,
+  fieldType = 'string',
+  onFieldTypeChange,
+  required,
+  onRequiredChange,
+  label,
+  fileUploadAriaLabel,
+  headerActions,
+  compact,
+  controlsVisibility = 'visible',
+  showFieldActions = true,
+  options = DEFAULT_SELECT_OPTIONS,
+  onGenerateWithAi,
+  variables = [],
+  id,
+  className,
+}: LockableValueFieldProps) {
+  const generatedId = useId();
+  const [datePopoverOpen, setDatePopoverOpen] = useState(false);
+  const [selectOpen, setSelectOpen] = useState(false);
+  const fieldId = id ?? generatedId;
+  const typeMeta = FIELD_TYPE_META[fieldType];
+  const effectiveMode = typeMeta.supportsExpression ? mode : 'fixed';
+  const editableOnValueChange = locked ? undefined : onValueChange;
+  const fieldTypeLabel = typeMeta.label.toLowerCase();
+  const expressionArticle = /^[aeiou]/.test(fieldTypeLabel) ? 'an' : 'a';
+  const fieldLabel =
+    effectiveMode === 'expression'
+      ? `Write ${expressionArticle} ${fieldTypeLabel} expression`
+      : `${typeMeta.label} value`;
+
+  // Locked fields are read-only, not disabled — the raw control (switch, date
+  // picker, select) has nothing left to do once editing is blocked, so it's
+  // replaced with plain, selectable text showing the same value.
+  const lockedDisplayValue = getLockedDisplayValue(fieldType, value, options);
+
+  return (
+    <div className={cn('@container group flex flex-col gap-1.5', className)}>
+      <FieldHeader
+        label={label}
+        fieldId={fieldId}
+        fieldLabel={fieldLabel}
+        required={required}
+        fieldType={fieldType}
+        onFieldTypeChange={onFieldTypeChange}
+        onRequiredChange={onRequiredChange}
+        controlsVisibility={controlsVisibility}
+        compact={compact}
+        showFieldActions={showFieldActions}
+        value={value}
+        onValueChange={editableOnValueChange}
+        variables={variables}
+        onGenerateWithAi={onGenerateWithAi}
+        headerActions={headerActions}
+      />
+
+      {typeMeta.supportsExpression ? (
+        <InputGroup>
+          <InputGroupAddon align="inline-start">
+            <LockToggleButton locked={locked} onLockedChange={onLockedChange} />
+          </InputGroupAddon>
+
+          {effectiveMode === 'expression' ? (
+            renderExpressionEditor ? (
+              renderExpressionEditor({
+                id: fieldId,
+                value,
+                onValueChange: editableOnValueChange,
+                onBlur: onValueBlur,
+                readOnly: !editableOnValueChange,
+                placeholder: fieldLabel,
+                fieldType,
+              })
+            ) : (
+              <InputGroupInput
+                id={fieldId}
+                readOnly={!editableOnValueChange}
+                value={value}
+                onChange={(e) => editableOnValueChange?.(e.target.value)}
+                onBlur={onValueBlur}
+                placeholder={fieldLabel}
+                className="font-mono"
+              />
+            )
+          ) : locked ? (
+            <InputGroupInput
+              id={fieldId}
+              readOnly
+              value={lockedDisplayValue}
+              placeholder={fieldLabel}
+              onBlur={onValueBlur}
+            />
+          ) : fieldType === 'boolean' ? (
+            <div className="flex h-full flex-1 items-center px-3">
+              <Switch
+                id={fieldId}
+                checked={value === 'true'}
+                onCheckedChange={(checked) => onValueChange?.(String(checked))}
+                onBlur={onValueBlur}
+                disabled={!onValueChange}
+              />
+            </div>
+          ) : fieldType === 'date' ? (
+            <Popover
+              open={datePopoverOpen}
+              onOpenChange={(open) => {
+                setDatePopoverOpen(open);
+                if (!open) onValueBlur?.();
+              }}
+            >
+              <PopoverTrigger asChild>
+                <button
+                  type="button"
+                  id={fieldId}
+                  data-slot="input-group-control"
+                  disabled={!onValueChange}
+                  className="flex h-full flex-1 items-center text-left text-sm text-foreground outline-none disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                  {value ? (
+                    formatDateValue(value)
+                  ) : (
+                    <span className="text-muted-foreground">Pick a date</span>
+                  )}
+                </button>
+              </PopoverTrigger>
+              <PopoverContent align="start" className="w-auto p-0">
+                <Calendar
+                  mode="single"
+                  selected={parseDateValue(value)}
+                  onSelect={(date) => onValueChange?.(date ? toDateOnlyString(date) : '')}
+                  initialFocus
+                />
+              </PopoverContent>
+            </Popover>
+          ) : (
+            <InputGroupInput
+              id={fieldId}
+              type={fieldType === 'integer' ? 'number' : 'text'}
+              readOnly={!onValueChange}
+              value={value}
+              onChange={(e) => onValueChange?.(e.target.value)}
+              onBlur={onValueBlur}
+              placeholder={fieldLabel}
+            />
+          )}
+
+          <InputGroupAddon align="inline-end">
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <InputGroupButton
+                  icon
+                  size="3xs"
+                  disabled={!onModeChange}
+                  aria-label="Choose value type"
+                >
+                  {effectiveMode === 'expression' ? <Code2 /> : <Type />}
+                </InputGroupButton>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end" className="w-56">
+                <ModeMenuItem
+                  icon={Type}
+                  label={typeMeta.fixedLabel}
+                  description={typeMeta.fixedDescription}
+                  active={effectiveMode === 'fixed'}
+                  onClick={() => onModeChange?.('fixed')}
+                />
+                <ModeMenuItem
+                  icon={Code2}
+                  label="Expression"
+                  description="Use a JS expression"
+                  active={effectiveMode === 'expression'}
+                  onClick={() => onModeChange?.('expression')}
+                />
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </InputGroupAddon>
+        </InputGroup>
+      ) : (
+        <div className="flex items-center gap-2">
+          <LockToggleButton locked={locked} onLockedChange={onLockedChange} />
+
+          {locked ? (
+            <Input
+              id={fieldId}
+              readOnly
+              value={lockedDisplayValue}
+              placeholder={fieldLabel}
+              className="flex-1"
+              onBlur={onValueBlur}
+            />
+          ) : fieldType === 'single-select' ? (
+            <Select
+              open={selectOpen}
+              onOpenChange={(open) => {
+                setSelectOpen(open);
+                if (!open && selectOpen) onValueBlur?.();
+              }}
+              value={value || undefined}
+              onValueChange={onValueChange}
+              disabled={!onValueChange}
+            >
+              <SelectTrigger id={fieldId} className="flex-1">
+                <SelectValue placeholder="Select an option" />
+              </SelectTrigger>
+              <SelectContent>
+                {options.map((option) => (
+                  <SelectItem key={option.value} value={option.value}>
+                    {option.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          ) : fieldType === 'multi-select' ? (
+            <MultiSelect
+              id={fieldId}
+              className="flex-1"
+              options={options}
+              selected={parseListValue(value)}
+              onChange={(selected) => onValueChange?.(JSON.stringify(selected))}
+              placeholder="Select options..."
+              disabled={!onValueChange}
+              onBlur={onValueBlur}
+            />
+          ) : (
+            fieldType === 'file' && (
+              <FileUpload
+                id={fieldId}
+                ariaLabel={fileUploadAriaLabel ?? (typeof label === 'string' ? label : fieldLabel)}
+                className="flex-1"
+                onFilesChange={(files) => onValueChange?.(files.map((f) => f.name).join(', '))}
+                disabled={!onValueChange}
+                onBlur={onValueBlur}
+              />
+            )
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/apollo-wind/src/components/ui/lockable-value-field/types.ts
+++ b/packages/apollo-wind/src/components/ui/lockable-value-field/types.ts
@@ -1,0 +1,158 @@
+import {
+  ALargeSmall,
+  Calendar as CalendarIcon,
+  File as FileIcon,
+  Hash,
+  List,
+  ListChecks,
+  type LucideIcon,
+  ToggleLeft,
+} from 'lucide-react';
+import type { ReactNode } from 'react';
+
+export type LockableValueFieldMode = 'fixed' | 'expression';
+
+export type LockableFieldType =
+  | 'string'
+  | 'integer'
+  | 'date'
+  | 'boolean'
+  | 'single-select'
+  | 'multi-select'
+  | 'file';
+
+interface FieldTypeMeta {
+  label: string;
+  icon: LucideIcon;
+  supportsExpression: boolean;
+  fixedLabel: string;
+  fixedDescription: string;
+}
+
+export const FIELD_TYPE_META: Record<LockableFieldType, FieldTypeMeta> = {
+  string: {
+    label: 'String',
+    icon: ALargeSmall,
+    supportsExpression: true,
+    fixedLabel: 'Fixed value',
+    fixedDescription: 'Use a literal string value',
+  },
+  integer: {
+    label: 'Integer',
+    icon: Hash,
+    supportsExpression: true,
+    fixedLabel: 'Fixed value',
+    fixedDescription: 'Use a literal number value',
+  },
+  date: {
+    label: 'Date',
+    icon: CalendarIcon,
+    supportsExpression: true,
+    fixedLabel: 'Fixed date',
+    fixedDescription: 'Use a literal date value',
+  },
+  boolean: {
+    label: 'Boolean',
+    icon: ToggleLeft,
+    supportsExpression: true,
+    fixedLabel: 'Fixed value',
+    fixedDescription: 'Use a literal true or false value',
+  },
+  'single-select': {
+    label: 'Single select',
+    icon: List,
+    supportsExpression: false,
+    fixedLabel: 'Fixed value',
+    fixedDescription: 'Choose one option',
+  },
+  'multi-select': {
+    label: 'Multi select',
+    icon: ListChecks,
+    supportsExpression: false,
+    fixedLabel: 'Fixed value',
+    fixedDescription: 'Choose one or more options',
+  },
+  file: {
+    label: 'File',
+    icon: FileIcon,
+    supportsExpression: false,
+    fixedLabel: 'Fixed value',
+    fixedDescription: 'Upload a file',
+  },
+};
+
+export const FIELD_TYPE_ORDER: LockableFieldType[] = [
+  'string',
+  'integer',
+  'date',
+  'boolean',
+  'single-select',
+  'multi-select',
+  'file',
+];
+
+export interface LockableValueFieldOption {
+  label: string;
+  value: string;
+}
+
+export interface LockableValueFieldProps {
+  /** Current field value. Encoding depends on fieldType (e.g. multi-select is a JSON array string). */
+  value?: string;
+  /** Called when the user edits the value (only fires while unlocked). */
+  onValueChange?: (value: string) => void;
+  /** Called when the active value control loses focus. */
+  onValueBlur?: () => void;
+  /** Whether the field is read-only. Defaults to true. */
+  locked?: boolean;
+  /** Called when the user toggles the lock. */
+  onLockedChange?: (locked: boolean) => void;
+  /** Fixed value vs. JS expression. Defaults to 'fixed'. Ignored for types that don't support expressions. */
+  mode?: LockableValueFieldMode;
+  /** Called when the user switches modes. */
+  onModeChange?: (mode: LockableValueFieldMode) => void;
+  /**
+   * Optional expression editor used in place of the built-in monospace input.
+   * Consumers can use this to supply a syntax-aware editor such as Monaco.
+   */
+  renderExpressionEditor?: (props: {
+    id: string;
+    value: string;
+    onValueChange?: (value: string) => void;
+    onBlur?: () => void;
+    readOnly: boolean;
+    placeholder: string;
+    fieldType: LockableFieldType;
+  }) => ReactNode;
+  /** The field's data type. Defaults to 'string'. Determines which control renders the value. */
+  fieldType?: LockableFieldType;
+  /** Called when the user switches the field type. */
+  onFieldTypeChange?: (fieldType: LockableFieldType) => void;
+  /** Shows a required-field asterisk next to the default label. Ignored when `label` is provided. */
+  required?: boolean;
+  /** Called when the user toggles required/optional. Renders the Required switch when provided. */
+  onRequiredChange?: (required: boolean) => void;
+  /** Overrides the default mode-based label (e.g. a field name instead of "String value"). */
+  label?: ReactNode;
+  /** Accessible name for the file-upload dropzone. Defaults to a string `label`, then the computed field label. */
+  fileUploadAriaLabel?: string;
+  /** Extra content rendered after the built-in AI assist / Insert variable buttons (e.g. a delete button). */
+  headerActions?: ReactNode;
+  /** Forces the header row into its narrow-container icon-only layout, regardless of actual width. For demos/comparisons. */
+  compact?: boolean;
+  /** Whether the field-type, AI-assist, and insert-variable controls are always shown or only on hover. Defaults to 'visible'. */
+  controlsVisibility?: 'visible' | 'hover';
+  /** Whether the AI-assist and Insert-variable actions render at all. Set to false for read-only reviewer contexts where field configuration isn't editable. Defaults to true. */
+  showFieldActions?: boolean;
+  /** Options for 'single-select' / 'multi-select' field types. Defaults to a small set of demo options. */
+  options?: LockableValueFieldOption[];
+  /** Called with the entered prompt when the user clicks Generate in the AI-assist popover. */
+  onGenerateWithAi?: (prompt: string) => void;
+  /**
+   * Variables offered by the "Insert variable" popover; clicking one appends its value to the
+   * current value. The button is disabled when this is empty (the default).
+   */
+  variables?: LockableValueFieldOption[];
+  id?: string;
+  className?: string;
+}

--- a/packages/apollo-wind/src/components/ui/lockable-value-field/utils.ts
+++ b/packages/apollo-wind/src/components/ui/lockable-value-field/utils.ts
@@ -1,0 +1,96 @@
+import type { LockableFieldType, LockableValueFieldOption } from './types';
+
+export const DEFAULT_SELECT_OPTIONS: LockableValueFieldOption[] = [
+  { label: 'Option 1', value: 'option-1' },
+  { label: 'Option 2', value: 'option-2' },
+  { label: 'Option 3', value: 'option-3' },
+];
+
+export function parseListValue(value: string): string[] {
+  try {
+    const parsed = JSON.parse(value);
+    return Array.isArray(parsed) ? parsed.filter((v): v is string => typeof v === 'string') : [];
+  } catch {
+    return [];
+  }
+}
+
+const DATE_ONLY_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+
+/**
+ * Parses a date field's stored value, returning undefined for empty or invalid input.
+ *
+ * Date-only strings (`YYYY-MM-DD`) are parsed as a local date instead of going through
+ * `new Date(string)` directly -- the latter treats date-only strings as UTC midnight,
+ * which rolls over to the previous day once formatted in a negative-UTC-offset
+ * timezone. Full ISO timestamps (which already carry explicit time/zone info) go
+ * through `new Date` as-is.
+ */
+export function parseDateValue(value: string): Date | undefined {
+  if (DATE_ONLY_PATTERN.test(value)) {
+    const [year, month, day] = value.split('-').map(Number);
+    const date = new Date(year, month - 1, day);
+    // new Date() normalizes out-of-range components (e.g. month 13, day 40)
+    // into a different valid date instead of rejecting them -- reject
+    // anything that didn't round-trip back to the requested year/month/day.
+    const isValid =
+      !Number.isNaN(date.getTime()) &&
+      date.getFullYear() === year &&
+      date.getMonth() === month - 1 &&
+      date.getDate() === day;
+    return isValid ? date : undefined;
+  }
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? undefined : date;
+}
+
+/** Formats a Date as a local `YYYY-MM-DD` string, the inverse of parseDateValue's date-only path. */
+export function toDateOnlyString(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+/** Formats a date field's value for display, falling back to the raw value if it isn't a valid date. */
+export function formatDateValue(value: string): string {
+  const date = parseDateValue(value);
+  return date
+    ? date.toLocaleDateString(undefined, { year: 'numeric', month: 'long', day: 'numeric' })
+    : value;
+}
+
+/**
+ * Computes the plain-text shown in place of the real control once a field is locked.
+ * Boolean/single-select/multi-select resolve their stored value to a display label;
+ * everything else (including an invalid date, so the component never throws on
+ * external input) falls back to the raw value.
+ */
+export function getLockedDisplayValue(
+  fieldType: LockableFieldType,
+  value: string,
+  options: LockableValueFieldOption[]
+): string {
+  switch (fieldType) {
+    case 'boolean':
+      if (value === 'true') return 'True';
+      if (value === 'false') return 'False';
+      return '';
+    case 'date':
+      return value ? formatDateValue(value) : '';
+    case 'single-select':
+      return options.find((option) => option.value === value)?.label ?? value;
+    case 'multi-select': {
+      const parsed = parseListValue(value);
+      // A malformed value (not JSON, or an array with no string entries) also
+      // parses to an empty list -- fall back to the raw value so it's still
+      // visible, rather than rendering as if the field were genuinely empty.
+      if (parsed.length === 0 && value && value !== '[]') {
+        return value;
+      }
+      return parsed.map((v) => options.find((option) => option.value === v)?.label ?? v).join(', ');
+    }
+    default:
+      return value;
+  }
+}

--- a/packages/apollo-wind/src/components/ui/multi-select.test.tsx
+++ b/packages/apollo-wind/src/components/ui/multi-select.test.tsx
@@ -35,6 +35,34 @@ describe('MultiSelect', () => {
     expect(results).toHaveNoViolations();
   });
 
+  it('uses aria-label for its accessible name when no id is provided', () => {
+    const onChange = vi.fn();
+    render(<MultiSelect options={mockOptions} selected={['react']} onChange={onChange} />);
+    expect(screen.getByRole('combobox', { name: '1 item selected' })).toBeInTheDocument();
+  });
+
+  it('pluralizes the aria-label when more than one item is selected', () => {
+    const onChange = vi.fn();
+    render(<MultiSelect options={mockOptions} selected={['react', 'vue']} onChange={onChange} />);
+    expect(screen.getByRole('combobox', { name: '2 items selected' })).toBeInTheDocument();
+  });
+
+  it('lets an associated label name the field instead of the aria-label when an id is provided', () => {
+    const onChange = vi.fn();
+    render(
+      <>
+        <label htmlFor="frameworks">Frameworks</label>
+        <MultiSelect
+          id="frameworks"
+          options={mockOptions}
+          selected={['react']}
+          onChange={onChange}
+        />
+      </>
+    );
+    expect(screen.getByRole('combobox', { name: 'Frameworks' })).toBeInTheDocument();
+  });
+
   it('renders with default placeholder when none provided', () => {
     const onChange = vi.fn();
     render(<MultiSelect options={mockOptions} selected={[]} onChange={onChange} />);
@@ -58,6 +86,18 @@ describe('MultiSelect', () => {
 
     // Command input should be visible when popover is open
     expect(screen.getByPlaceholderText('Search...')).toBeInTheDocument();
+  });
+
+  it('calls onBlur when the popover closes, not when focus enters it', async () => {
+    const user = userEvent.setup();
+    const onBlur = vi.fn();
+    render(<MultiSelect options={mockOptions} selected={[]} onChange={vi.fn()} onBlur={onBlur} />);
+
+    await user.click(screen.getByRole('combobox'));
+    expect(onBlur).not.toHaveBeenCalled();
+
+    await user.keyboard('{Escape}');
+    expect(onBlur).toHaveBeenCalledOnce();
   });
 
   it('allows selecting items', async () => {

--- a/packages/apollo-wind/src/components/ui/multi-select.tsx
+++ b/packages/apollo-wind/src/components/ui/multi-select.tsx
@@ -15,6 +15,8 @@ import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover
 import { cn } from '@/lib/index';
 
 export interface MultiSelectProps {
+  /** Applied to the trigger button, so a `<label htmlFor>` pointing at it associates correctly. */
+  id?: string;
   options: { label: string; value: string }[];
   selected: string[];
   onChange: (selected: string[]) => void;
@@ -25,11 +27,14 @@ export interface MultiSelectProps {
   disabled?: boolean;
   searchPlaceholder?: string;
   clearAllText?: string | ((count: number) => string);
+  /** Called when the multi-select popover closes after being opened. */
+  onBlur?: () => void;
 }
 
 const MultiSelect = React.forwardRef<HTMLDivElement, MultiSelectProps>(
   (
     {
+      id,
       options,
       selected,
       onChange,
@@ -40,6 +45,7 @@ const MultiSelect = React.forwardRef<HTMLDivElement, MultiSelectProps>(
       disabled = false,
       searchPlaceholder = 'Search...',
       clearAllText,
+      onBlur,
     },
     ref
   ) => {
@@ -66,13 +72,30 @@ const MultiSelect = React.forwardRef<HTMLDivElement, MultiSelectProps>(
 
     return (
       <div ref={ref} className={cn('relative', className)}>
-        <Popover open={open} onOpenChange={setOpen}>
+        <Popover
+          open={open}
+          onOpenChange={(nextOpen) => {
+            setOpen(nextOpen);
+            if (!nextOpen && open) onBlur?.();
+          }}
+        >
           <PopoverTrigger asChild>
             <Button
+              id={id}
               variant="outline"
               role="combobox"
               aria-expanded={open}
-              aria-label={selected.length > 0 ? `${selected.length} items selected` : placeholder}
+              // aria-label always wins over a `<label htmlFor>` association in the
+              // accessible-name computation, so only set it when there's no id for a
+              // consumer's label to target -- otherwise the label's own text names
+              // the field, same as any other labelable control (Input, Select, ...).
+              aria-label={
+                id
+                  ? undefined
+                  : selected.length > 0
+                    ? `${selected.length} ${selected.length === 1 ? 'item' : 'items'} selected`
+                    : placeholder
+              }
               className={cn(
                 'w-full justify-between future:rounded-xl future:border-0 future:bg-surface-overlay future:hover:bg-surface-hover future:font-normal future:text-muted-foreground',
                 selected.length > 0 ? 'h-auto min-h-10' : 'h-10'

--- a/packages/apollo-wind/src/components/ui/prompt-editor/prompt-editor.stories.tsx
+++ b/packages/apollo-wind/src/components/ui/prompt-editor/prompt-editor.stories.tsx
@@ -5,7 +5,7 @@ import { PromptEditor } from './prompt-editor';
 import type { PromptEditorAutoCompleteOption, PromptEditorMode, PromptEditorToken } from './types';
 
 const meta = {
-  title: 'Components/PromptEditor',
+  title: 'Components/UiPath/Prompt Editor',
   component: PromptEditor,
   parameters: {
     layout: 'centered',

--- a/packages/apollo-wind/src/index.ts
+++ b/packages/apollo-wind/src/index.ts
@@ -58,6 +58,18 @@ export type {
   InputGroupTextareaProps,
 } from './components/ui/input-group';
 
+export {
+  FIELD_TYPE_META,
+  FIELD_TYPE_ORDER,
+  LockableValueField,
+} from './components/ui/lockable-value-field';
+export type {
+  LockableValueFieldProps,
+  LockableValueFieldMode,
+  LockableFieldType,
+  LockableValueFieldOption,
+} from './components/ui/lockable-value-field';
+
 export { Textarea } from './components/ui/textarea';
 export type { TextareaProps } from './components/ui/textarea';
 


### PR DESCRIPTION
## Overview

Promotes `LockableValueField` from a one-off prototype into a documented, tested Apollo Wind component and updates the Apollo React Form HITL panel to consume it.

The Form HITL story now uses its standard typed control in Fixed value mode and a syntax-aware inline JavaScript editor in Expression mode. The Monaco suggestions overlay is configured to escape the compact field boundary instead of being clipped.

## Consumer integration

The API is now aligned with Flow Workbench’s adapter pattern.

Apollo Wind owns the field shell, locking, field-type selection, fixed/expression mode, and common value lifecycle. Consumers can supply their production editor through `renderExpressionEditor`, which receives the current value, `onValueChange`, `onBlur`, `readOnly`, placeholder, field ID, and field type.

This keeps Flow Workbench’s application-specific concerns in Flow Workbench—its `ExpressionValue` storage model, scoped `$vars` / `$metadata` / `$self` declarations, diagnostics, theming, variable insertion, and Monaco configuration—without coupling Apollo Wind to those services. The built-in value controls also forward the same blur contract for consistent touched-state, validation, and deferred-commit behavior.

## Apollo Wind — what to review

- `LockableValueField`: lockable read-only/editable states, typed fixed-value controls, and fixed/expression switching.
- Public API: `renderExpressionEditor` supports consumer-owned rich editors; `onValueBlur` and `fieldType` complete the adapter contract.
- Storybook organization: Lockable Value Field and Prompt Editor now live under `Components → UiPath`, with Lockable Value Field and Prompt Editor ordered above Canvas.
- Tests: coverage includes built-in value behavior, expression-editor context, blur forwarding, accessibility, invalid dates, options, and field actions.
- Date and effective-mode safeguards prevent invalid dates from throwing and prevent expression labels from appearing for types that cannot use expressions.

<img width="1025" height="931" alt="Screenshot 2026-07-27 at 2 34 22 PM" src="https://github.com/user-attachments/assets/cdad5a5f-eb0b-4af2-b916-362949ddac40" />

## Apollo React — what to review

- Form HITL consumes `LockableValueField` from `@uipath/apollo-wind` instead of a local prototype.
- Expression mode injects the inline Monaco editor while Fixed value mode retains the standard typed field.
- The suggestions widget uses fixed overflow positioning so variables and completions are not masked by the compact field row.
- The demo panel links to the canonical Lockable Value Field documentation under its new UiPath location.
- JSON schema edits are validated before applying them, preventing malformed hand edits from breaking the field list.

<img width="1259" height="1194" alt="Form HITL" src="https://github.com/user-attachments/assets/71c84afc-48eb-42a5-8bf7-b079cd5d9f65" />

## Also fixed

Two pre-existing CI issues reproduced on `main` are included:

- Apollo Core, Apollo React, and Apollo Wind Biome configs now declare `"root": false` for Biome 2.x.
- PR checks set `TURBO_SCM_BASE` explicitly so affected-package detection resolves the PR base reliably.

## Test plan

- [x] Apollo Wind Vitest suite: 62 files, 1,062 tests passed
- [x] Filtered Apollo Wind / Apollo React type and build checks passed
- [x] Biome formatting passed on the updated files
- [x] Verified Form HITL Fixed value and Expression modes in Storybook
- [x] Verified Monaco suggestions render outside the compact field boundary
- [x] Verified Lockable Value Field and Prompt Editor navigation under `Components → UiPath`

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
