### PR TITLE
feat(apollo-vertex): Roadmap Status page with live Jira data

### DIFF
--- a/apps/apollo-vertex/app/_meta.ts
+++ b/apps/apollo-vertex/app/_meta.ts
@@ -1,5 +1,6 @@
 export default {
   index: "Introduction",
+  "design-system-status": "Roadmap status",
   foundation: "Foundation",
   components: "Components",
   patterns: "Patterns",

--- a/apps/apollo-vertex/app/api/jira/route.ts
+++ b/apps/apollo-vertex/app/api/jira/route.ts
@@ -1,0 +1,22 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { fetchJiraIssues } from "@/lib/jira";
+import { processIssues } from "@/lib/jira-resolve";
+
+// Intentionally public — this endpoint surfaces cross-team design system status.
+// No auth guard is by design; confirmed with @ruudandriessen.
+export async function GET(_req: NextRequest) {
+  try {
+    const issues = await fetchJiraIssues();
+    const jiraBaseUrl =
+      process.env.JIRA_BASE_URL ?? "https://uipath.atlassian.net";
+    const data = processIssues(issues, jiraBaseUrl);
+    return NextResponse.json(data, {
+      headers: {
+        "Cache-Control": "public, s-maxage=300, stale-while-revalidate=60",
+      },
+    });
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e);
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/apps/apollo-vertex/app/design-system-status/_components/status-board.tsx
+++ b/apps/apollo-vertex/app/design-system-status/_components/status-board.tsx
@@ -1,0 +1,235 @@
+import {
+  ArrowUpRight,
+  CheckCircle2,
+  Clock,
+  Inbox,
+  TriangleAlert,
+} from "lucide-react";
+import Link from "next/link";
+import type { ReactNode } from "react";
+import { fetchJiraIssues } from "@/lib/jira";
+import {
+  type BadgeLabel,
+  type BoardData,
+  type ProcessedCard,
+  processIssues,
+} from "@/lib/jira-resolve";
+import { Badge } from "@/registry/badge/badge";
+
+// ─── status tag ──────────────────────────────────────────────────────────────
+
+function StatusTag({ status }: { status: string }) {
+  const s = status.toLowerCase();
+
+  if (s === "in review" || s === "review") {
+    return (
+      <Badge variant="default" status="info">
+        In Review
+      </Badge>
+    );
+  }
+  if (s === "in progress") {
+    return <Badge variant="secondary">In Progress</Badge>;
+  }
+  if (s === "closed" || s === "done") {
+    return (
+      <Badge variant="secondary" status="success">
+        Delivered
+      </Badge>
+    );
+  }
+  return <Badge variant="secondary">{status}</Badge>;
+}
+
+// ─── label badge ─────────────────────────────────────────────────────────────
+
+function LegalBadge({ label }: { label: BadgeLabel }) {
+  if (label === "required") {
+    return (
+      <Badge variant="secondary" status="error">
+        Required
+      </Badge>
+    );
+  }
+  if (label === "best-practice") {
+    return (
+      <Badge variant="secondary" status="warning">
+        Best practice
+      </Badge>
+    );
+  }
+  return null;
+}
+
+// ─── card ────────────────────────────────────────────────────────────────────
+
+function StatusCard({ card }: { card: ProcessedCard }) {
+  const isExternal = card.link.startsWith("http");
+
+  return (
+    <Link
+      href={card.link}
+      {...(isExternal ? { target: "_blank", rel: "noopener noreferrer" } : {})}
+      className="group flex flex-col gap-3 rounded-lg border border-border bg-card p-4 transition-colors hover:border-primary hover:bg-accent"
+    >
+      <div className="flex items-start justify-between gap-2">
+        <div className="flex flex-wrap gap-1.5">
+          <StatusTag status={card.status} />
+          {card.badge && <LegalBadge label={card.badge} />}
+        </div>
+        <ArrowUpRight className="size-4 shrink-0 text-muted-foreground opacity-0 transition-opacity group-hover:opacity-100" />
+      </div>
+
+      <p className="text-sm font-medium leading-snug text-card-foreground">
+        {card.summary}
+      </p>
+
+      <div className="flex flex-col gap-0.5">
+        {card.epicName && (
+          <p className="text-xs text-muted-foreground/70">{card.epicName}</p>
+        )}
+        <p className="text-xs text-muted-foreground">{card.key}</p>
+      </div>
+    </Link>
+  );
+}
+
+// ─── section ─────────────────────────────────────────────────────────────────
+
+function Section({
+  title,
+  description,
+  icon,
+  cards,
+  empty,
+}: {
+  title: string;
+  description: string;
+  icon: ReactNode;
+  cards: ProcessedCard[];
+  empty: string;
+}) {
+  return (
+    <section>
+      <div className="mb-4 flex items-center gap-2">
+        {icon}
+        <div>
+          <h2 className="text-lg font-semibold text-foreground">{title}</h2>
+          <p className="text-sm text-muted-foreground">{description}</p>
+        </div>
+        <span className="ml-auto rounded-full bg-muted px-2.5 py-0.5 text-xs font-medium text-muted-foreground">
+          {cards.length}
+        </span>
+      </div>
+
+      {cards.length === 0 ? (
+        <p className="rounded-lg border border-dashed border-border py-10 text-center text-sm text-muted-foreground">
+          {empty}
+        </p>
+      ) : (
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {cards.map((card) => (
+            <StatusCard key={card.key} card={card} />
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}
+
+// ─── error state ─────────────────────────────────────────────────────────────
+
+function SetupError({ message }: { message: string }) {
+  const isMissingConfig = message.includes("Missing Jira configuration");
+  return (
+    <div className="rounded-lg border border-border bg-card p-6">
+      <div className="mb-3 flex items-center gap-2 text-warning-foreground">
+        <TriangleAlert className="size-5" />
+        <span className="font-semibold">
+          {isMissingConfig
+            ? "Jira credentials not configured"
+            : "Could not load Jira data"}
+        </span>
+      </div>
+      {isMissingConfig ? (
+        <div className="space-y-2 text-sm text-muted-foreground">
+          <p>
+            Add{" "}
+            <code className="rounded bg-muted px-1 font-mono text-xs">
+              JIRA_BASE_URL
+            </code>
+            ,{" "}
+            <code className="rounded bg-muted px-1 font-mono text-xs">
+              JIRA_EMAIL
+            </code>
+            , and{" "}
+            <code className="rounded bg-muted px-1 font-mono text-xs">
+              JIRA_API_TOKEN
+            </code>{" "}
+            to{" "}
+            <code className="rounded bg-muted px-1 font-mono text-xs">
+              apps/apollo-vertex/.env.local
+            </code>
+            , then restart the dev server.
+          </p>
+        </div>
+      ) : (
+        <p className="text-sm text-muted-foreground">{message}</p>
+      )}
+    </div>
+  );
+}
+
+// ─── board ───────────────────────────────────────────────────────────────────
+
+export async function StatusBoard() {
+  let data: BoardData | null = null;
+  let error: string | null = null;
+
+  try {
+    const issues = await fetchJiraIssues();
+    const jiraBaseUrl =
+      process.env.JIRA_BASE_URL ?? "https://uipath.atlassian.net";
+    data = processIssues(issues, jiraBaseUrl);
+  } catch (e) {
+    error = e instanceof Error ? e.message : String(e);
+  }
+
+  if (error) {
+    return (
+      <div className="not-prose mt-6">
+        <SetupError message={error} />
+      </div>
+    );
+  }
+
+  if (!data) return null;
+
+  return (
+    <div className="not-prose mt-6 space-y-10">
+      <Section
+        title="Recently Delivered"
+        description="Curated list of shipped work. Links go to the Vertex doc page when available."
+        icon={<CheckCircle2 className="size-5 shrink-0 text-success" />}
+        cards={data.delivered}
+        empty="No delivered items yet."
+      />
+
+      <Section
+        title="Coming Soon"
+        description="In Review is closest to landing and sorted first."
+        icon={<Clock className="size-5 shrink-0 text-info" />}
+        cards={data.comingSoon}
+        empty="Nothing in progress right now."
+      />
+
+      <Section
+        title="Backlog"
+        description="Planned work not yet started."
+        icon={<Inbox className="size-5 shrink-0 text-muted-foreground" />}
+        cards={data.backlog}
+        empty="Backlog is empty."
+      />
+    </div>
+  );
+}

--- a/apps/apollo-vertex/app/design-system-status/page.mdx
+++ b/apps/apollo-vertex/app/design-system-status/page.mdx
@@ -1,0 +1,11 @@
+---
+title: Roadmap status
+---
+
+import { StatusBoard } from './_components/status-board';
+
+# Roadmap status
+
+Live view of design system work for developers building on Vertex. Jira is the single source of truth. [View the VS Horizontal UX board →](https://uipath.atlassian.net/jira/software/projects/DESIGN/boards)
+
+<StatusBoard />

--- a/apps/apollo-vertex/lib/jira-resolve.ts
+++ b/apps/apollo-vertex/lib/jira-resolve.ts
@@ -1,0 +1,259 @@
+import { extractAdfText, type JiraIssue } from "./jira";
+
+// All known routable slugs per section, derived from the site's _meta.ts files
+const SLUGS_BY_SECTION: Record<string, string[]> = {
+  components: [
+    "accordion",
+    "alert",
+    "alert-dialog",
+    "aspect-ratio",
+    "avatar",
+    "badge",
+    "breadcrumb",
+    "button",
+    "button-group",
+    "calendar",
+    "card",
+    "carousel",
+    "chart",
+    "line-chart",
+    "multi-line-chart",
+    "bar-chart",
+    "distribution-chart",
+    "kpi-chart",
+    "table-chart",
+    "checkbox",
+    "collapsible",
+    "combobox",
+    "command",
+    "context-menu",
+    "data-table",
+    "date-picker",
+    "dialog",
+    "drawer",
+    "dropdown-menu",
+    "empty",
+    "field",
+    "feature-flags",
+    "filter-dropdown",
+    "form",
+    "form-wizard",
+    "hover-card",
+    "input",
+    "input-group",
+    "input-otp",
+    "item",
+    "kbd",
+    "label",
+    "menubar",
+    "navigation-menu",
+    "pagination",
+    "popover",
+    "progress",
+    "radio-group",
+    "resizable",
+    "scroll-area",
+    "select",
+    "separator",
+    "sheet",
+    "sidebar",
+    "skeleton",
+    "slider",
+    "sonner",
+    "spinner",
+    "switch",
+    "table",
+    "tabs",
+    "textarea",
+    "toggle",
+    "toggle-group",
+    "tooltip",
+  ],
+  patterns: [
+    "ai-chat",
+    "feedback-vote-widget",
+    "metric-card",
+    "page-header",
+    "shell",
+  ],
+  templates: ["list-page", "settings", "solution-tests"],
+  guidelines: ["ai-toolkit", "notifications"],
+  foundation: ["colors", "spacing", "grid", "typography", "icons", "logos"],
+};
+
+// Flat map: slug → absolute path
+const SLUG_PATH_MAP = new Map<string, string>();
+for (const [section, slugs] of Object.entries(SLUGS_BY_SECTION)) {
+  for (const slug of slugs) {
+    SLUG_PATH_MAP.set(slug, `/${section}/${slug}`);
+  }
+}
+
+export type LinkSource = "explicit" | "convention" | "jira";
+export type Section = "delivered" | "coming-soon" | "backlog";
+export type BadgeLabel = "required" | "best-practice" | null;
+
+export interface ProcessedCard {
+  key: string;
+  summary: string;
+  status: string;
+  section: Section;
+  badge: BadgeLabel;
+  link: string;
+  linkSource: LinkSource;
+  jiraUrl: string;
+  updated: string;
+  epicName: string | null;
+  epicKey: string | null;
+}
+
+export interface BoardData {
+  delivered: ProcessedCard[];
+  comingSoon: ProcessedCard[];
+  backlog: ProcessedCard[];
+  linkStats: { explicit: number; convention: number; jiraFallback: number };
+}
+
+const SECTION_BY_STATUS = {
+  closed: "delivered",
+  done: "delivered",
+  "in progress": "coming-soon",
+  "in review": "coming-soon",
+  review: "coming-soon",
+} satisfies Record<string, Section>;
+
+function toSection(statusName: string): Section {
+  const key = statusName.trim().toLowerCase();
+  return (
+    (SECTION_BY_STATUS as Record<string, Section | undefined>)[key] ?? "backlog"
+  );
+}
+
+const BADGE_BY_LABEL = {
+  "ai-legal-required": "required",
+  "ai-legal-best-practice": "best-practice",
+} as const satisfies Record<string, Exclude<BadgeLabel, null>>;
+
+const BADGE_LABEL_PRIORITY = [
+  "ai-legal-required",
+  "ai-legal-best-practice",
+] as const;
+
+function toBadge(labels: readonly string[]): BadgeLabel {
+  const label = BADGE_LABEL_PRIORITY.find((candidate) =>
+    labels.includes(candidate),
+  );
+  return label ? BADGE_BY_LABEL[label] : null;
+}
+
+function resolveDeliveredLink(
+  issue: JiraIssue,
+  jiraUrl: string,
+): { url: string; source: LinkSource } {
+  const descText = extractAdfText(issue.fields.description);
+
+  // Priority 1: explicit "Vertex: https://..." or "Vertex URL: https://..." in description
+  const vertexMatch = descText.match(
+    /Vertex(?:\s+URL)?:\s*(https?:\/\/[^\s\n)]+)/i,
+  );
+  if (vertexMatch) {
+    return { url: vertexMatch[1].trim(), source: "explicit" };
+  }
+
+  // Priority 2: "Component: <name>" convention — slugify and look up known paths
+  const componentMatch = descText.match(/^Component:\s*(.+)$/im);
+  if (componentMatch) {
+    const rawSlug = componentMatch[1].match(/^([^\s(,]+)/)?.[1];
+    if (rawSlug) {
+      const slug = rawSlug
+        .toLowerCase()
+        .replaceAll(/[^a-z0-9]+/g, "-")
+        .replaceAll(/(^-|-$)/g, "");
+      const path = SLUG_PATH_MAP.get(slug);
+      if (path) return { url: path, source: "convention" };
+    }
+  }
+
+  // Priority 3: fall back to Jira ticket
+  return { url: jiraUrl, source: "jira" };
+}
+
+function buildCard(issue: JiraIssue, jiraBaseUrl: string): ProcessedCard {
+  const statusName = issue.fields.status.name;
+  const section = toSection(statusName);
+  const jiraUrl = `${jiraBaseUrl}/browse/${issue.key}`;
+
+  const { url: link, source: linkSource } =
+    section === "delivered"
+      ? resolveDeliveredLink(issue, jiraUrl)
+      : { url: jiraUrl, source: "jira" as LinkSource };
+
+  const parentIsEpic =
+    issue.fields.parent?.fields.issuetype.name === "Epic" ||
+    issue.fields.parent?.fields.issuetype.hierarchyLevel === 1;
+
+  return {
+    key: issue.key,
+    summary: issue.fields.summary,
+    status: statusName,
+    section,
+    badge: toBadge(issue.fields.labels),
+    link,
+    linkSource,
+    jiraUrl,
+    updated: issue.fields.updated,
+    epicName: parentIsEpic
+      ? (issue.fields.parent?.fields.summary ?? null)
+      : null,
+    epicKey: parentIsEpic ? (issue.fields.parent?.key ?? null) : null,
+  };
+}
+
+function isReviewStatus(s: string): boolean {
+  const sl = s.toLowerCase();
+  return sl === "review" || sl === "in review";
+}
+
+function sortComingSoon(cards: ProcessedCard[]): ProcessedCard[] {
+  return cards.toSorted((a, b) => {
+    const aReview = isReviewStatus(a.status);
+    const bReview = isReviewStatus(b.status);
+    if (aReview !== bReview) return aReview ? -1 : 1;
+    return 0;
+  });
+}
+
+function countLinkStats(cards: ProcessedCard[]): BoardData["linkStats"] {
+  return cards.reduce(
+    (acc, c) => {
+      if (c.linkSource === "explicit") acc.explicit++;
+      else if (c.linkSource === "convention") acc.convention++;
+      else acc.jiraFallback++;
+      return acc;
+    },
+    { explicit: 0, convention: 0, jiraFallback: 0 },
+  );
+}
+
+export function processIssues(
+  issues: JiraIssue[],
+  jiraBaseUrl: string,
+): BoardData {
+  const delivered: ProcessedCard[] = [];
+  const comingSoon: ProcessedCard[] = [];
+  const backlog: ProcessedCard[] = [];
+
+  for (const issue of issues) {
+    const card = buildCard(issue, jiraBaseUrl);
+    if (card.section === "delivered") delivered.push(card);
+    else if (card.section === "coming-soon") comingSoon.push(card);
+    else backlog.push(card);
+  }
+
+  return {
+    delivered,
+    comingSoon: sortComingSoon(comingSoon),
+    backlog,
+    linkStats: countLinkStats(delivered),
+  };
+}

--- a/apps/apollo-vertex/lib/jira.ts
+++ b/apps/apollo-vertex/lib/jira.ts
@@ -1,0 +1,104 @@
+const JQL =
+  'project = DESIGN AND labels = "horizontal-ux" AND status != "On hold" AND (statusCategory != Done OR labels = "ds-delivered") ORDER BY updated DESC';
+
+const FIELDS = [
+  "summary",
+  "status",
+  "labels",
+  "updated",
+  "resolutiondate",
+  "description",
+  "parent",
+];
+
+interface AdfNode {
+  type: string;
+  text?: string;
+  content?: AdfNode[];
+  attrs?: Record<string, string>;
+}
+
+export interface JiraIssue {
+  key: string;
+  fields: {
+    summary: string;
+    status: { name: string };
+    labels: string[];
+    updated: string;
+    resolutiondate: string | null;
+    description: AdfNode | null;
+    parent?: {
+      key: string;
+      fields: {
+        summary: string;
+        issuetype: { name: string; hierarchyLevel: number };
+      };
+    } | null;
+  };
+}
+
+export function extractAdfText(node: AdfNode | null | undefined): string {
+  if (!node) return "";
+  if (node.type === "text") return node.text ?? "";
+  if (node.type === "inlineCard") return node.attrs?.url ?? "";
+  if (!node.content) return "";
+  const parts = node.content.map(extractAdfText);
+  const isBlock =
+    node.type === "paragraph" ||
+    node.type === "heading" ||
+    node.type === "listItem" ||
+    node.type === "bulletList" ||
+    node.type === "orderedList";
+  return isBlock ? `${parts.join("")}\n` : parts.join("");
+}
+
+export async function fetchJiraIssues(): Promise<JiraIssue[]> {
+  const base = process.env.JIRA_BASE_URL;
+  const email = process.env.JIRA_EMAIL;
+  const token = process.env.JIRA_API_TOKEN;
+
+  if (!base || !email || !token) {
+    throw new Error(
+      "Missing Jira configuration. Add JIRA_BASE_URL, JIRA_EMAIL, and JIRA_API_TOKEN to .env.local",
+    );
+  }
+
+  const auth = Buffer.from(`${email}:${token}`).toString("base64");
+  const issues: JiraIssue[] = [];
+  let nextPageToken: string | undefined;
+
+  do {
+    const body: Record<string, unknown> = {
+      jql: JQL,
+      fields: FIELDS,
+      maxResults: 50,
+    };
+    if (nextPageToken) body["nextPageToken"] = nextPageToken;
+
+    // eslint-disable-next-line no-await-in-loop -- cursor pagination is inherently sequential
+    const res = await fetch(`${base}/rest/api/3/search/jql`, {
+      method: "POST",
+      headers: {
+        Authorization: `Basic ${auth}`,
+        "Content-Type": "application/json",
+        Accept: "application/json",
+      },
+      body: JSON.stringify(body),
+      next: { revalidate: 300 },
+    });
+
+    if (!res.ok) {
+      throw new Error(`Jira API error: ${res.status} ${res.statusText}`);
+    }
+
+    // eslint-disable-next-line no-await-in-loop, @typescript-eslint/no-unsafe-type-assertion -- cursor pagination is inherently sequential; res.json() is untyped, shape is dictated by Jira REST v3 contract
+    const data = (await res.json()) as {
+      issues?: JiraIssue[];
+      nextPageToken?: string;
+    };
+    issues.push(...(data.issues ?? []));
+    nextPageToken = data.nextPageToken;
+  } while (nextPageToken);
+
+  return issues;
+}


### PR DESCRIPTION
## Summary
- Adds a `/design-system-status` page surfaced as **"Roadmap status"** in the sidebar, positioned directly under Introduction
- Reads live from the VS Horizontal UX Jira board (`label = "horizontal-ux"`) and displays three sections: Recently Delivered, Coming Soon, and Backlog
- Coming Soon cards are sorted with In Review first, In Progress after
- Delivered section is curated: only tickets with the `ds-delivered` Jira label appear
- Epic name shown on cards when the ticket has a parent Epic
- Link resolution for delivered tickets: explicit `Vertex: <url>` in description (supports both plain text and Jira smartlinks) → convention slug lookup → Jira URL fallback

## Environment variables required
Add to `.env.local` locally and to the Vercel project for production:
```
JIRA_BASE_URL=https://uipath.atlassian.net
JIRA_EMAIL=<your-email>
JIRA_API_TOKEN=<your-api-token>
```

## How to add tickets to the Delivered section
Add the `ds-delivered` label to the Jira ticket. No code change needed.

## How to set the Vertex link on a delivered card
Add `Vertex: https://...` as a line in the Jira ticket description.

## Test plan
- [ ] Visit `/design-system-status` and confirm three sections render with live data
- [ ] Confirm "In Review" cards appear at the top of Coming Soon
- [ ] Confirm the Delivered section shows only the `ds-delivered`-labelled ticket(s)
- [ ] Confirm epic names appear on cards that have a parent Epic
- [ ] Confirm clicking a delivered card with a `Vertex:` URL navigates to the Vertex page (not Jira)
- [ ] Confirm page loads gracefully without env vars (shows setup error state)

🤖 Generated with [Claude Code](https://claude.com/claude-code)