### PR TITLE
fix(ci): grant pull-requests write to Coded App preview comment jobs

### DIFF
--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -25,7 +25,7 @@ jobs:
     if: github.event.action != 'closed' && github.event.pull_request.head.repo.fork == false
     runs-on: ubuntu-latest
     permissions:
-      issues: write
+      pull-requests: write
 
     steps:
       - name: Initialize PR comment
@@ -278,7 +278,7 @@ jobs:
     if: ${{ always() && github.event.action != 'closed' && github.event.pull_request.head.repo.fork == false && needs.initialize-comment.result != 'skipped' }}
     runs-on: ubuntu-latest
     permissions:
-      issues: write
+      pull-requests: write
 
     steps:
       - name: Download deploy results


### PR DESCRIPTION
## Problem
The **Initialize / Update Apollo Coded App Preview Comment** jobs in `preview-deploy.yml` fail on **every** PR with:

```
RequestError [HttpError]: Resource not accessible by integration  (403)
POST /repos/UiPath/apollo-ui/issues/{n}/comments
x-accepted-github-permissions: issues=write; pull_requests=write
```

Both jobs declared `permissions: issues: write`, which is not effective for posting PR comments in this org.

## Fix
Switch both comment jobs to `permissions: pull-requests: write`.

The identical `github.rest.issues.createComment(...)` call worked under the previous Vercel workflow with `pull-requests: write`, and that scope is the repo-wide convention for commenting jobs (`pr-labeler`, `pr-size`, `close-stale-prs`, `apollo-vertex-auto-merge`).

## Impact
Unblocks the preview-deployment PR comment (the status/links table) on all open PRs. No change to deploy logic, permissions footprint stays minimal (only the two comment jobs, `pull-requests: write`).