### PR TITLE
fix(apollo-vertex): return AI Chat sign-out to the coded app, not the platform portal

### DIFF
--- a/apps/apollo-vertex/app/auth_callback/page.tsx
+++ b/apps/apollo-vertex/app/auth_callback/page.tsx
@@ -1,23 +1,19 @@
 "use client";
 
 import { useEffect } from "react";
-import { STORAGE_KEYS } from "@/lib/auth";
-
-const FALLBACK_PATH = "/";
+import { resolveReturnPath, STORAGE_KEYS } from "@/lib/auth";
 
 export default function AuthCallback() {
   useEffect(() => {
-    const returnTo =
-      sessionStorage.getItem(STORAGE_KEYS.AUTH_RETURN_TO) ?? FALLBACK_PATH;
+    const stored = sessionStorage.getItem(STORAGE_KEYS.AUTH_RETURN_TO);
     sessionStorage.removeItem(STORAGE_KEYS.AUTH_RETURN_TO);
 
-    // returnTo is an absolute path already including the Coded App base path
-    // (captured from window.location.pathname at sign-in), so navigate with
-    // window.location rather than Next's router, which would prepend basePath
-    // again and double it. Carries the ?code/?state through to the page that
-    // completes the token exchange.
+    // resolveReturnPath guards origin, falls back to the app root, and resolves
+    // to the real file on Coded App builds. window.location avoids Next's router
+    // doubling the basePath. Carries ?code/?state through to complete the token
+    // exchange.
     const search = window.location.search;
-    window.location.replace(`${returnTo}${search}`);
+    window.location.replace(`${resolveReturnPath(stored)}${search}`);
   }, []);
 
   return null;

--- a/apps/apollo-vertex/app/portal_/cloudrpa/page.tsx
+++ b/apps/apollo-vertex/app/portal_/cloudrpa/page.tsx
@@ -9,21 +9,19 @@
  * reads the stored return path and navigates the user back to where they were.
  */
 
-import { useRouter } from "next/navigation";
 import { useEffect } from "react";
-import { STORAGE_KEYS } from "@/lib/auth";
-
-const FALLBACK_PATH = "/";
+import { resolveReturnPath, STORAGE_KEYS } from "@/lib/auth";
 
 export default function PostLogoutRedirect() {
-  const router = useRouter();
-
   useEffect(() => {
-    const returnTo =
-      sessionStorage.getItem(STORAGE_KEYS.LOGOUT_RETURN_TO) ?? FALLBACK_PATH;
+    const stored = sessionStorage.getItem(STORAGE_KEYS.LOGOUT_RETURN_TO);
     sessionStorage.removeItem(STORAGE_KEYS.LOGOUT_RETURN_TO);
-    router.replace(returnTo);
-  }, [router]);
+
+    // resolveReturnPath guards origin, falls back to the app root, and resolves
+    // to the real file on Coded App builds. window.location avoids Next's router
+    // doubling the basePath already present in the stored path.
+    window.location.replace(resolveReturnPath(stored));
+  }, []);
 
   return null;
 }

--- a/apps/apollo-vertex/lib/auth.ts
+++ b/apps/apollo-vertex/lib/auth.ts
@@ -23,6 +23,37 @@ export const STORAGE_KEYS = {
   LOGOUT_RETURN_TO: "logout_return_to",
 } as const;
 
+// The Coded App host serves the root shell for any path that is not an explicit
+// file, so a hard navigation to a bare route path renders the docs home. Map it
+// to its "/index.html" form on Coded App builds; no-op in dev.
+export function toCodedAppFilePath(path: string): string {
+  if (process.env.NEXT_PUBLIC_APOLLO_CODED_APP !== "1") return path;
+  const trimmed = path.replace(/\/+$/, "");
+  const lastSegment = trimmed.slice(trimmed.lastIndexOf("/") + 1);
+  // Already an explicit file (e.g. ".../index.html"); leave it alone.
+  if (lastSegment.includes(".")) return path;
+  return `${trimmed}/index.html`;
+}
+
+// Same-origin absolute path only; rejects protocol-relative ("//") and
+// backslash ("/\\") forms that window.location resolves off-origin.
+function isSafeReturnPath(value: string): boolean {
+  return (
+    value.startsWith("/") && !value.startsWith("//") && !value.startsWith("/\\")
+  );
+}
+
+// Resolve a stored return path (from sessionStorage) into a safe navigation
+// target: reject off-origin values, falling back to the app root (which honors
+// the Coded App basePath, not the host root), then map to the "/index.html"
+// file form for Coded App builds.
+export function resolveReturnPath(stored: string | null): string {
+  const codedAppPath = process.env.NEXT_PUBLIC_APOLLO_CODED_APP_PATH;
+  const fallback = codedAppPath ? `/${codedAppPath}` : "/";
+  const path = stored && isSafeReturnPath(stored) ? stored : fallback;
+  return toCodedAppFilePath(path);
+}
+
 const TokenResponseSchema = z.object({
   access_token: z.string(),
   id_token: z.string(),

--- a/apps/apollo-vertex/templates/ai-chat/AiChatLoginGate.tsx
+++ b/apps/apollo-vertex/templates/ai-chat/AiChatLoginGate.tsx
@@ -7,7 +7,7 @@ import { ChevronRight, LogIn, LogOut } from "lucide-react";
 import type { ReactNode } from "react";
 import { z } from "zod";
 import { Button } from "@/components/ui/button";
-import { STORAGE_KEYS } from "@/lib/auth";
+import { STORAGE_KEYS, toCodedAppFilePath } from "@/lib/auth";
 import { STALE_TIME_MS } from "@/lib/constants";
 import {
   Select,
@@ -18,6 +18,7 @@ import {
 } from "@/registry/select/select";
 import { useAuth } from "@/registry/shell/shell-auth-provider";
 import {
+  AICHAT_CODED_APP_PATH,
   AICHAT_DIRECT_BASE_URL,
   AICHAT_IS_CODED_APP,
   AICHAT_PORTAL_API_BASE,
@@ -204,9 +205,15 @@ export function AiChatLoginGate({ children }: AiChatLoginGateProps) {
     if (idToken) {
       endSessionUrl.searchParams.set("id_token_hint", idToken);
     }
+    // Return to THIS app's bounce page, not the platform portal: identity lives
+    // on identityOrigin, but the target is the app's own host + base path.
+    // toCodedAppFilePath resolves the bounce path to a real file on Coded App
+    // builds (no-op in dev).
+    const basePath = AICHAT_CODED_APP_PATH ? `/${AICHAT_CODED_APP_PATH}` : "";
+    const bouncePath = toCodedAppFilePath("/portal_/cloudrpa");
     endSessionUrl.searchParams.set(
       "post_logout_redirect_uri",
-      `${identityOrigin}/portal_/cloudrpa`,
+      `${window.location.origin}${basePath}${bouncePath}`,
     );
     window.location.href = endSessionUrl.toString();
   }

--- a/apps/apollo-vertex/templates/ai-chat/ai-chat-example-utils.ts
+++ b/apps/apollo-vertex/templates/ai-chat/ai-chat-example-utils.ts
@@ -22,6 +22,12 @@ export const AICHAT_SCOPE = "openid profile offline_access";
 export const AICHAT_IS_CODED_APP =
   process.env.NEXT_PUBLIC_APOLLO_CODED_APP === "1";
 
+// The Coded App base path (e.g. "apollo-vertex"), baked by next.config. Empty
+// in dev / regular builds. Used to build same-app absolute URLs such as the
+// post-logout return target.
+export const AICHAT_CODED_APP_PATH =
+  process.env.NEXT_PUBLIC_APOLLO_CODED_APP_PATH ?? "";
+
 // Two modes, chosen at build time:
 //   - Coded App export: there is no server, so the browser calls the platform
 //     host directly. uip-go bakes the platform context (base URL, redirect


### PR DESCRIPTION
## Problem

Signing out of the AI Chat demo in a Coded App build did **not** return the user to the app. It landed them on the real UiPath portal instead.

## Root cause

`handleLogout` built `post_logout_redirect_uri` from `identityOrigin`, which for a Coded App is the **platform host** (e.g. `staging.uipath.com`). So identity redirected to `staging.uipath.com/portal_/cloudrpa` (the platform portal), never reaching the app's own `/portal_/cloudrpa` bounce page that restores the pre-logout path.

## Fix

- Point `post_logout_redirect_uri` at the **app's own** host + base path (`window.location.origin` + `/<coded-app-path>/portal_/cloudrpa`). The endsession endpoint still correctly uses `identityOrigin`.
- New `AICHAT_CODED_APP_PATH` const exposes the baked base path.
- Bounce page (`app/portal_/cloudrpa/page.tsx`): switched `router.replace` → `window.location.replace`. The stored return path already includes the Coded App base path, so Next's router would prepend `basePath` again and double it. This matches the sibling `auth_callback` page. The bug was latent because the bounce page was never reached before this fix.

## Deploy sequencing (important)

Identity will reject the new `post_logout_redirect_uri` until the coded-app host's post-logout URI is registered on Uber.Client (stg). That registration (`https://engdogfood.staging.uipath.host/*/portal_/cloudrpa`) is folded into the open **first-party-service-metadata** Coded App callback PR. **That metadata change must deploy before this merges to production.** Until then, sign-out behaves as it does today.

## Testing

- Biome check + `tsc --noEmit` pass.
- Full sign-out round-trip to be verified in a real browser on the engdogfood staging deploy once the metadata registration is live.