### PR TITLE
fix(repo): self-host Monaco on apollo-design instead of the jsdelivr CDN

### DIFF
--- a/apps/storybook/.storybook/main.ts
+++ b/apps/storybook/.storybook/main.ts
@@ -1,12 +1,26 @@
 import { readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import type { StorybookConfig } from '@storybook/react-vite';
-import { mergeAlias } from 'vite';
 import type { PluginOption } from 'vite';
+import { mergeAlias } from 'vite';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
+
+// Self-host Monaco's `vs` assets (served at /monaco/vs via staticDirs) instead
+// of the @monaco-editor default jsdelivr CDN, which is blocked on the Coded App
+// host. monaco-editor is a direct dep of apollo-wind, so resolve from there.
+const require = createRequire(import.meta.url);
+const monacoVsDir = resolve(
+  dirname(
+    require.resolve('monaco-editor/package.json', {
+      paths: [resolve(__dirname, '../../../packages/apollo-wind')],
+    })
+  ),
+  'min/vs'
+);
 
 // react-scan must install its devtools hook before React initializes.
 // Two Storybook behaviors interfere with this:
@@ -69,6 +83,7 @@ const config: StorybookConfig = {
       from: '../../../packages/apollo-core/src/icons/svg/third-party',
       to: '/brand',
     },
+    { from: monacoVsDir, to: '/monaco/vs' },
   ],
   framework: {
     name: '@storybook/react-vite',

--- a/apps/storybook/.storybook/preview.tsx
+++ b/apps/storybook/.storybook/preview.tsx
@@ -1,3 +1,4 @@
+import { loader } from '@monaco-editor/react';
 import CssBaseline from '@mui/material/CssBaseline';
 import { ThemeProvider } from '@mui/material/styles';
 import type { Preview } from '@storybook/react';
@@ -15,6 +16,14 @@ import React, { useEffect } from 'react';
 import { ApolloDocsContainer } from './DocsContainer';
 import { GlobalStyles } from './GlobalStyles';
 import { ALL_THEMES, clampThemeForMaterial, DEFAULT_THEME, type ThemeMode } from './themes';
+
+// Load Monaco from the app's own origin (/monaco/vs, copied via staticDirs in
+// main.ts) instead of the default jsdelivr CDN, which is blocked on the Coded
+// App host. Resolve against document.baseURI so it is correct under the Coded
+// App sub-path and in dev.
+if (typeof document !== 'undefined') {
+  loader.config({ paths: { vs: new URL('monaco/vs', document.baseURI).href } });
+}
 
 // The react-scan devtools hook is installed via previewBody in main.ts
 // (must happen before React initializes). Here we configure the overlay/canvas


### PR DESCRIPTION
## Problem

The Monaco code-editor stories (Apollo Wind → Patterns → Code Editors) stopped loading after apollo-design moved to Coded App hosting. Console shows `Monaco initialization: error` with a `<script>` load-error event.

## Root cause

`@monaco-editor/react` is used with no `loader.config`, so Monaco loads from its default **jsdelivr CDN** (`https://cdn.jsdelivr.net/npm/monaco-editor@0.55.1/min/vs`). That external CDN script fails to load on the Coded App host, so the editor never initializes. An enterprise platform app shouldn't depend on a public CDN at runtime.

## Fix

Self-host Monaco from the app's own origin:
- `main.ts`: copy `monaco-editor/min/vs` into the Storybook build via `staticDirs` → `/monaco/vs`.
- `preview.tsx`: `loader.config({ paths: { vs } })`, with `vs` resolved against `document.baseURI` so it is correct under the Coded App sub-path (`/apollo-design/monaco/vs`) and in dev. No external CDN at runtime.

## Verification

- `pnpm turbo run storybook:build --filter=storybook-app` succeeds.
- Build output contains `/monaco/vs` (121 files: `loader.js`, `editor/editor.main.js`/`.css`, the 0.55.1 `workers-*.js` and `nls.messages-*` chunks, all languages).
- The `/monaco/vs` loader path is bundled into the preview iframe.
- Final check: load the Monaco story on the deployed Coded App and confirm the editor renders (needs a browser in the platform session).

Only `.storybook/main.ts` and `.storybook/preview.tsx` change; build output is gitignored.