### PR TITLE
chore(repo): bump uip-go to 0.3.1 (relative-root-assets fix)

### DIFF
--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -13,7 +13,7 @@ permissions: {}
 env:
   TURBO_TELEMETRY_DISABLED: 1
   DO_NOT_TRACK: 1
-  UIP_GO_VERSION: 0.3.0
+  UIP_GO_VERSION: 0.3.1
 
 concurrency:
   group: coded-app-preview-pr-${{ github.event.pull_request.number }}

--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -16,7 +16,7 @@ concurrency:
 env:
   TURBO_TELEMETRY_DISABLED: 1
   DO_NOT_TRACK: 1
-  UIP_GO_VERSION: 0.3.0
+  UIP_GO_VERSION: 0.3.1
 
 jobs:
   deploy:


### PR DESCRIPTION
Bumps `UIP_GO_VERSION` `0.3.0 → 0.3.1` in `preview-deploy.yml` and `production-deploy.yml`.

## Why

0.3.1 gates the `relative-root-assets` postprocess on files that actually exist in the output, so it stops corrupting bundled library string literals such as `@monaco-editor/loader`'s `"/loader.js"` (which had become `"./loader.js"` → `.../vs./loader.js` → 404). This fixes the Monaco code-editor stories on the apollo-design Coded App.

## Rollout

- uip-go fix: [UiPath/uip-go#1](https://github.com/UiPath/uip-go/pull/1) — merged, published as **v0.3.1** to GitHub Packages.
- This PR picks it up; the next apollo-design deploy runs the fixed postprocess.