### PR TITLE
feat(apollo-vertex): solution-tests telemetry seam + routed run details [AGVSOL-4914]

### DIFF
--- a/apps/apollo-vertex/app/templates/solution-tests/page.mdx
+++ b/apps/apollo-vertex/app/templates/solution-tests/page.mdx
@@ -79,6 +79,10 @@ interface SolutionTestsConfig {
   subjectColumns?: ColumnDef<SolutionTest>[];
   /** Turns the test name into a link to its subject. */
   getSubjectHref?: (test: SolutionTest) => string | undefined;
+  /** Opens a run's details page. The host owns the route and navigation: on that
+   * route, render the exported smart `RunDetails` (it's `runId`-driven). Without
+   * this callback the Details action is inert, so run details can't be opened. */
+  onOpenRun?: (run: SolutionTestRun) => void;
   /** Subject noun for labels, e.g. `{ singular: "Loan", plural: "Loans" }`. */
   subjectNoun?: { singular: string; plural: string };
   /** Score at/above which a result passes (drives pass color + KPI trend line). Defaults to 0.9. */

--- a/apps/apollo-vertex/app/templates/solution-tests/page.mdx
+++ b/apps/apollo-vertex/app/templates/solution-tests/page.mdx
@@ -85,6 +85,8 @@ interface SolutionTestsConfig {
   passThreshold?: number;
   /** Show the Expected/Actual input panels in run-result details. Defaults to false (outputs only). */
   showInputs?: boolean;
+  /** Typed telemetry callback. Fires a named event when each action is triggered; a no-op unless supplied. */
+  track?: TrackSolutionTestEvent;
 }
 ```
 
@@ -109,6 +111,62 @@ via `config.passThreshold`. Consumers who want to supply their own data plumbing
 render the dumb `SolutionTestsView`, which takes all data and callbacks via
 props. It must still be wrapped in `SolutionTestsProvider` (the view reads
 `config` from context via `useSolutionTestsConfig`), as the preview above does.
+
+## Telemetry
+
+The template emits typed telemetry events for both user *actions* (run, create,
+delete, force-stop, adopt / update / remove baseline) and *UI interactions*
+(switching tabs, expanding rows, opening run details, inspecting a result or its
+raw output). The template only *names* the events. It never ships an analytics
+backend. Pass a `track` callback through `config` to route them wherever you
+collect analytics. Omit it and tracking is a no-op.
+
+```tsx
+const config: SolutionTestsConfig = {
+  subjectColumns,
+  track: (event, properties) => analytics.track(event, properties),
+};
+```
+
+Action events fire on intent (the mutation's `onMutate`, not on success), so they
+report only when writes go through the action hooks (`useRunTests`,
+`useCreateTest`, and friends) in the smart container. UI-interaction events fire
+straight from the view components, so they emit whenever the view renders inside a
+`SolutionTestsProvider` that carries a `track`, including the bare
+`SolutionTestsView`.
+
+`SolutionTestEventMap` is the single source of truth for the event contract, so
+the callback is fully typed: `properties` is narrowed to the payload of the
+`event` you pass. Compose the map into your own app's event map to keep the
+wiring type-safe end to end.
+
+**Actions**
+
+| Event                               | Payload                                              | Fired when                          |
+| ----------------------------------- | ---------------------------------------------------- | ----------------------------------- |
+| `VS.SolutionTest.Run`               | `{ mode: "all" \| "test" \| "selected", testCount }` | A test run is started               |
+| `VS.SolutionTest.Created`           | `{ subjectId }`                                      | A test is created from a subject    |
+| `VS.SolutionTest.ActiveToggled`     | `{ testId, isActive }`                               | A test is enabled or disabled       |
+| `VS.SolutionTest.Deleted`           | `{ testId }`                                         | A test is deleted                   |
+| `VS.SolutionTest.BatchForceStopped` | `{ batchId }`                                        | A batch run is force-stopped        |
+| `VS.SolutionTest.RunForceStopped`   | `{ runId }`                                          | A single run is force-stopped       |
+| `VS.SolutionTest.JobAdopted`        | `{ resultId }`                                       | A run result is adopted as baseline |
+| `VS.SolutionTest.BaselineUpdated`   | `{ resultId }`                                       | A baseline is updated from a result |
+| `VS.SolutionTest.BaselineRemoved`   | `{ baselineId }`                                     | A baseline is removed               |
+
+**UI interactions**
+
+| Event                              | Payload                       | Fired when                                    |
+| ---------------------------------- | ----------------------------- | --------------------------------------------- |
+| `VS.SolutionTest.TabViewed`        | `{ tab: "cases" \| "runs" }`  | The Test cases / Test runs tab is switched    |
+| `VS.SolutionTest.TestExpanded`     | `{ testId }`                  | A test case row is expanded                   |
+| `VS.SolutionTest.BatchExpanded`    | `{ batchId }`                 | A batch run row is expanded                   |
+| `VS.SolutionTest.RunDetailsOpened` | `{ runId }`                   | A run's details page is opened                |
+| `VS.SolutionTest.ResultViewed`     | `{ resultId }`                | A different agent result is selected          |
+| `VS.SolutionTest.RawOutputViewed`  | `{ processName }`             | An agent's raw expected output is opened      |
+
+`SolutionTestEventMap`, `SolutionTestEventName`, and `TrackSolutionTestEvent`
+are all exported from the package barrel.
 
 ## Saving a subject as a test
 
@@ -227,6 +285,9 @@ you prefer to supply your own data plumbing or render the view against a mock
 - **Fixed setup** — evaluator labels, status labels, and the poll interval are
   hard-coded in `constants.ts`; edit there to retarget a deployment. The pass
   threshold defaults to `0.9` but is overridable via `config.passThreshold`.
+- **Telemetry** — `config.track` receives a typed event when each action is
+  triggered; wire it to your analytics backend (see [Telemetry](#telemetry)).
+  Omit it for no tracking.
 - **i18n** — framework strings use `react-i18next`; wrap your app in
   `ApolloShell` (which initializes i18n via `LocaleProvider`) or provide your
   own `I18nextProvider`.

--- a/apps/apollo-vertex/locales/en.json
+++ b/apps/apollo-vertex/locales/en.json
@@ -214,6 +214,8 @@
   "run_results": "Run results",
   "run_results_description": "Agent-level results for this test run",
   "run_selected": "Run selected ({{count}})",
+  "run_unavailable": "Run unavailable",
+  "run_unavailable_description": "This run doesn't exist or hasn't finished running.",
   "runs_in_progress": "Runs in progress",
   "russian": "Russian",
   "save_and_rerun": "Save & re-run",

--- a/apps/apollo-vertex/registry/solution-tests/config.ts
+++ b/apps/apollo-vertex/registry/solution-tests/config.ts
@@ -2,7 +2,7 @@ import type { ColumnDef } from "@tanstack/react-table";
 import { DEFAULT_PASS_THRESHOLD } from "./constants";
 import type { EvaluatorRenderers } from "./evaluators/registry";
 import type { ProcessOutputRenderers } from "./outputs/registry";
-import type { SolutionTest } from "./types";
+import type { SolutionTest, SolutionTestRun } from "./types";
 
 /**
  * Telemetry events the Solution Tests actions emit, with payloads. The template
@@ -63,6 +63,9 @@ export interface SolutionTestsConfig {
   subjectColumns?: ColumnDef<SolutionTest>[];
   /** When set, the test name links to its subject. */
   getSubjectHref?: (test: SolutionTest) => string | undefined;
+  /** Opens a run's details. The host owns the route + navigation; the view
+   *  calls this when a run row is opened. Run details can't open without it. */
+  onOpenRun?: (run: SolutionTestRun) => void;
   subjectNoun?: { singular: string; plural: string };
   /** Score at/above which a result passes (drives pass color + KPI trend line). Defaults to 0.9. */
   passThreshold?: number;
@@ -80,6 +83,7 @@ export interface SolutionTestsConfig {
 export interface ResolvedSolutionTestsConfig {
   subjectColumns: ColumnDef<SolutionTest>[];
   getSubjectHref?: (test: SolutionTest) => string | undefined;
+  onOpenRun?: (run: SolutionTestRun) => void;
   subjectNoun?: { singular: string; plural: string };
   passThreshold: number;
   showDebug: boolean;
@@ -95,6 +99,7 @@ export function resolveConfig(
   return {
     subjectColumns: config.subjectColumns ?? [],
     getSubjectHref: config.getSubjectHref,
+    onOpenRun: config.onOpenRun,
     subjectNoun: config.subjectNoun,
     passThreshold: config.passThreshold ?? DEFAULT_PASS_THRESHOLD,
     showDebug: config.showDebug ?? false,

--- a/apps/apollo-vertex/registry/solution-tests/config.ts
+++ b/apps/apollo-vertex/registry/solution-tests/config.ts
@@ -4,6 +4,59 @@ import type { EvaluatorRenderers } from "./evaluators/registry";
 import type { ProcessOutputRenderers } from "./outputs/registry";
 import type { SolutionTest } from "./types";
 
+/**
+ * Telemetry events the Solution Tests actions emit, with payloads. The template
+ * names the events; the host supplies `track` (below) to route them. Compose
+ * into a host event map with `interface … extends SolutionTestEventMap {}` (not
+ * an intersection) so a generic tracker's `Map[K]` indexing keeps working.
+ */
+export interface SolutionTestEventMap {
+  "VS.SolutionTest.Run": {
+    mode: "all" | "test" | "selected";
+    testCount: number;
+  };
+  "VS.SolutionTest.Created": { subjectId: string };
+  "VS.SolutionTest.ActiveToggled": { testId: string; isActive: boolean };
+  "VS.SolutionTest.Deleted": { testId: string };
+  "VS.SolutionTest.BatchForceStopped": { batchId: string };
+  "VS.SolutionTest.RunForceStopped": { runId: string };
+  "VS.SolutionTest.JobAdopted": { resultId: string };
+  "VS.SolutionTest.BaselineUpdated": { resultId: string };
+  "VS.SolutionTest.BaselineRemoved": { baselineId: string };
+
+  // UI interactions (no server request) — user navigation and output inspection.
+  "VS.SolutionTest.TabViewed": { tab: "cases" | "runs" };
+  "VS.SolutionTest.TestExpanded": { testId: string };
+  "VS.SolutionTest.BatchExpanded": { batchId: string };
+  "VS.SolutionTest.RunDetailsOpened": { runId: string };
+  "VS.SolutionTest.ResultViewed": { resultId: string };
+  "VS.SolutionTest.RawOutputViewed": { processName: string };
+}
+
+export type SolutionTestEventName = keyof SolutionTestEventMap;
+
+type UnionToIntersection<U> = (
+  U extends unknown
+    ? (arg: U) => void
+    : never
+) extends (arg: infer I) => void
+  ? I
+  : never;
+
+/**
+ * Typed telemetry callback the host injects via config. An intersection of
+ * per-event signatures (not one generic signature) so a host tracker generic
+ * over a wider event map assigns to it cast-free.
+ */
+export type TrackSolutionTestEvent = UnionToIntersection<
+  {
+    [K in SolutionTestEventName]: (
+      event: K,
+      properties: SolutionTestEventMap[K],
+    ) => void;
+  }[SolutionTestEventName]
+>;
+
 /** Per-vertical presentation config; everything else is hard-coded in `constants`. */
 export interface SolutionTestsConfig {
   /** Columns inserted between the Test Name and Version columns. */
@@ -19,6 +72,8 @@ export interface SolutionTestsConfig {
   evaluatorRenderers?: EvaluatorRenderers;
   /** Keyed by stable agent id and/or process name; unmatched outputs render as raw JSON. */
   outputRenderers?: ProcessOutputRenderers;
+  /** Emit a telemetry event for each action. No-op unless the host supplies it. */
+  track?: TrackSolutionTestEvent;
 }
 
 /** Config with defaults applied — what components read from context. */
@@ -30,6 +85,8 @@ export interface ResolvedSolutionTestsConfig {
   showDebug: boolean;
   evaluatorRenderers: EvaluatorRenderers;
   outputRenderers: ProcessOutputRenderers;
+  /** Optional — call sites use `track?.(…)`, so no tracking happens if absent. */
+  track?: TrackSolutionTestEvent;
 }
 
 export function resolveConfig(
@@ -43,5 +100,6 @@ export function resolveConfig(
     showDebug: config.showDebug ?? false,
     evaluatorRenderers: config.evaluatorRenderers ?? {},
     outputRenderers: config.outputRenderers ?? {},
+    track: config.track,
   };
 }

--- a/apps/apollo-vertex/registry/solution-tests/expanded-agents.tsx
+++ b/apps/apollo-vertex/registry/solution-tests/expanded-agents.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import type { SolutionTest, SolutionTestJob } from "./types";
+import { useSolutionTestsConfig } from "./context";
 import { useBaselineJobs, useJobExpectedOutput } from "./hooks";
 import { ExpandedAgentsView } from "./expanded-agents-view";
 
@@ -17,6 +18,7 @@ interface ExpandedAgentsProps {
 export const ExpandedAgents = ({ test }: ExpandedAgentsProps) => {
   const { jobs: baselines, isLoading } = useBaselineJobs(test.Id);
   const expectedOutput = useJobExpectedOutput();
+  const { track } = useSolutionTestsConfig();
 
   const [openJob, setOpenJob] = useState<SolutionTestJob | null>(null);
 
@@ -42,7 +44,12 @@ export const ExpandedAgents = ({ test }: ExpandedAgentsProps) => {
       isLoading={isLoading}
       noOutputJobIds={noOutputJobIds}
       viewing={viewing}
-      onViewExpected={(job) => setOpenJob(job)}
+      onViewExpected={(job) => {
+        track?.("VS.SolutionTest.RawOutputViewed", {
+          processName: job.ProcessName,
+        });
+        setOpenJob(job);
+      }}
       onCloseViewer={() => setOpenJob(null)}
     />
   );

--- a/apps/apollo-vertex/registry/solution-tests/expanded-run-tests.tsx
+++ b/apps/apollo-vertex/registry/solution-tests/expanded-run-tests.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useNavigate } from "@tanstack/react-router";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 import type { SolutionTest, SolutionTestRun } from "./types";
@@ -13,11 +12,11 @@ interface ExpandedRunTestsProps {
   tests: SolutionTest[];
 }
 
-/** Smart wrapper: force-stop action + navigation to the run-details page. */
+/** Smart wrapper: force-stop action + opening the run-details route (the host
+ *  owns navigation via `config.onOpenRun`). */
 export const ExpandedRunTests = ({ runs, tests }: ExpandedRunTestsProps) => {
   const { t } = useTranslation();
-  const navigate = useNavigate();
-  const { track } = useSolutionTestsConfig();
+  const { track, onOpenRun } = useSolutionTestsConfig();
   const forceStopRun = useForceStopRun();
 
   const stoppingRunId = forceStopRun.isPending
@@ -30,14 +29,10 @@ export const ExpandedRunTests = ({ runs, tests }: ExpandedRunTestsProps) => {
       tests={tests}
       stoppingRunId={stoppingRunId}
       onOpenDetails={(run) => {
+        // No host navigation wired up — don't track an open that can't happen.
+        if (!onOpenRun) return;
         track?.("VS.SolutionTest.RunDetailsOpened", { runId: run.Id });
-        void navigate({
-          to: ".",
-          search: (prev: Record<string, unknown>) => ({
-            ...prev,
-            run: run.Id,
-          }),
-        });
+        onOpenRun(run);
       }}
       onForceStop={(runId) =>
         forceStopRun.mutate(runId, {

--- a/apps/apollo-vertex/registry/solution-tests/expanded-run-tests.tsx
+++ b/apps/apollo-vertex/registry/solution-tests/expanded-run-tests.tsx
@@ -4,6 +4,7 @@ import { useNavigate } from "@tanstack/react-router";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 import type { SolutionTest, SolutionTestRun } from "./types";
+import { useSolutionTestsConfig } from "./context";
 import { useForceStopRun } from "./hooks";
 import { ExpandedRunTestsView } from "./expanded-run-tests-view";
 
@@ -16,6 +17,7 @@ interface ExpandedRunTestsProps {
 export const ExpandedRunTests = ({ runs, tests }: ExpandedRunTestsProps) => {
   const { t } = useTranslation();
   const navigate = useNavigate();
+  const { track } = useSolutionTestsConfig();
   const forceStopRun = useForceStopRun();
 
   const stoppingRunId = forceStopRun.isPending
@@ -27,15 +29,16 @@ export const ExpandedRunTests = ({ runs, tests }: ExpandedRunTestsProps) => {
       runs={runs}
       tests={tests}
       stoppingRunId={stoppingRunId}
-      onOpenDetails={(run) =>
+      onOpenDetails={(run) => {
+        track?.("VS.SolutionTest.RunDetailsOpened", { runId: run.Id });
         void navigate({
           to: ".",
           search: (prev: Record<string, unknown>) => ({
             ...prev,
             run: run.Id,
           }),
-        })
-      }
+        });
+      }}
       onForceStop={(runId) =>
         forceStopRun.mutate(runId, {
           onSuccess: () => toast.success(t("force_stop_initiated")),

--- a/apps/apollo-vertex/registry/solution-tests/index.ts
+++ b/apps/apollo-vertex/registry/solution-tests/index.ts
@@ -30,6 +30,9 @@ export {
 export type {
   SolutionTestsConfig,
   ResolvedSolutionTestsConfig,
+  SolutionTestEventMap,
+  SolutionTestEventName,
+  TrackSolutionTestEvent,
 } from "./config";
 export {
   makeRenderer,

--- a/apps/apollo-vertex/registry/solution-tests/index.ts
+++ b/apps/apollo-vertex/registry/solution-tests/index.ts
@@ -17,6 +17,7 @@
  */
 
 export { SolutionTests } from "./solution-tests";
+export { RunDetails } from "./run-details";
 export { SolutionTestsView } from "./solution-tests-view";
 export type { SolutionTestsViewProps } from "./solution-tests-view";
 export { SaveAsTestButton } from "./save-as-test-button";

--- a/apps/apollo-vertex/registry/solution-tests/run-details-view.tsx
+++ b/apps/apollo-vertex/registry/solution-tests/run-details-view.tsx
@@ -200,14 +200,14 @@ const RunDetailsPane = ({
     status === RunResultStatus.Passed || status === RunResultStatus.Failed;
 
   // Directional triangle indicating the tested version moved up or down from
-  // the baseline (not a warning — just a signal that it changed).
+  // the baseline (not a warning — just a signal that it changed). Versions that
+  // are numerically equal ("1.0" vs "1.0.0") or non-numeric get no glyph.
+  const versionComparison = compareVersions(
+    result.ProcessVersion ?? "",
+    result.BaselineProcessVersion ?? "",
+  );
   const versionGlyph =
-    compareVersions(
-      result.ProcessVersion ?? "",
-      result.BaselineProcessVersion ?? "",
-    ) < 0
-      ? "▼"
-      : "▲";
+    versionComparison < 0 ? "▼" : versionComparison > 0 ? "▲" : null;
 
   const baselineInfo = baselineJobMap.get(result.ProcessName);
   const inBaseline = !!baselineInfo;
@@ -245,7 +245,7 @@ const RunDetailsPane = ({
             <span className="inline-flex items-center gap-1">
               {`${t("tested_agent_version")}: `}
               {showActualVersion ? (result.ProcessVersion ?? "-") : "—"}
-              {showActualVersion && versionChanged && (
+              {showActualVersion && versionChanged && versionGlyph && (
                 <Tooltip>
                   <TooltipTrigger asChild>
                     <span

--- a/apps/apollo-vertex/registry/solution-tests/run-details.tsx
+++ b/apps/apollo-vertex/registry/solution-tests/run-details.tsx
@@ -4,6 +4,14 @@ import { useQuery } from "@tanstack/react-query";
 import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import {
+  Empty,
+  EmptyContent,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyTitle,
+} from "@/components/ui/empty";
 import { useSolutionTestsConfig } from "./context";
 import {
   useAdoptJob,
@@ -11,15 +19,14 @@ import {
   useRemoveJobBaseline,
   useResultAttachment,
   useRunResults,
+  useSolutionTestRuns,
+  useSolutionTests,
   useUpdateBaseline,
 } from "./hooks";
 import type { ExpandedRowData } from "./result-expanded-content";
 import { RunDetailsView, type BaselineJobMap } from "./run-details-view";
-import {
-  RunResultStatus,
-  type SolutionTestRun,
-  type SolutionTestRunResult,
-} from "./types";
+import { RunResultStatus, type SolutionTestRunResult } from "./types";
+import { isRunDone } from "./utils";
 
 type ResultAttachments = Omit<ExpandedRowData, "loading">;
 
@@ -81,18 +88,28 @@ async function fetchResultAttachments(
 }
 
 interface RunDetailsProps {
-  run: SolutionTestRun;
-  subjectId: string;
+  /** Run id from the route param. Resolved to a run via the live collections. */
+  runId: string;
   onBack: () => void;
 }
 
-/** Smart wrapper: live run results + baseline jobs, selected-agent attachment
- *  fetch + baseline write actions, driving the full-page run-details view. */
-export const RunDetails = ({ run, subjectId, onBack }: RunDetailsProps) => {
+/** Smart wrapper: resolves the run from the route id, loads its live results +
+ *  baseline jobs, fetches the selected-agent attachments, and drives the
+ *  full-page run-details view. A route id that doesn't resolve to a completed
+ *  run (stale/shared link, or a still-running run) renders an empty state with a
+ *  Back button rather than auto-navigating. */
+export const RunDetails = ({ runId, onBack }: RunDetailsProps) => {
   const { t } = useTranslation();
   const { showDebug, track } = useSolutionTestsConfig();
-  const { results, isLoading } = useRunResults(run.Id);
-  const { jobs: baselines } = useBaselineJobs(run.SolutionTestId);
+  const { runs, isLoading: runsLoading } = useSolutionTestRuns();
+  const { tests } = useSolutionTests();
+
+  const run = runs.find((r) => r.Id === runId);
+  const test = run && tests.find((x) => x.Id === run.SolutionTestId);
+  const subjectId = test?.SubjectId ?? run?.SolutionTestId ?? "";
+
+  const { results, isLoading } = useRunResults(runId);
+  const { jobs: baselines } = useBaselineJobs(run?.SolutionTestId ?? "");
 
   const attachment = useResultAttachment();
   const adopt = useAdoptJob();
@@ -152,6 +169,28 @@ export const RunDetails = ({ run, subjectId, onBack }: RunDetailsProps) => {
       setSelectedResultId(results[0].Id);
     }
   }, [results, selectedResultId]);
+
+  // A route id that isn't a completed run has nothing to show (a stale or shared
+  // deep-link). Wait for the runs collection to resolve so a valid link isn't
+  // judged early, then render an empty state — never navigate away on the user.
+  if (!run || !isRunDone(run.Status)) {
+    if (runsLoading) return null;
+    return (
+      <Empty className="h-full min-h-[600px]">
+        <EmptyHeader>
+          <EmptyTitle>{t("run_unavailable")}</EmptyTitle>
+          <EmptyDescription>
+            {t("run_unavailable_description")}
+          </EmptyDescription>
+        </EmptyHeader>
+        <EmptyContent>
+          <Button variant="outline" onClick={onBack}>
+            {t("back")}
+          </Button>
+        </EmptyContent>
+      </Empty>
+    );
+  }
 
   return (
     <RunDetailsView

--- a/apps/apollo-vertex/registry/solution-tests/run-details.tsx
+++ b/apps/apollo-vertex/registry/solution-tests/run-details.tsx
@@ -90,7 +90,7 @@ interface RunDetailsProps {
  *  fetch + baseline write actions, driving the full-page run-details view. */
 export const RunDetails = ({ run, subjectId, onBack }: RunDetailsProps) => {
   const { t } = useTranslation();
-  const { showDebug } = useSolutionTestsConfig();
+  const { showDebug, track } = useSolutionTestsConfig();
   const { results, isLoading } = useRunResults(run.Id);
   const { jobs: baselines } = useBaselineJobs(run.SolutionTestId);
 
@@ -166,7 +166,14 @@ export const RunDetails = ({ run, subjectId, onBack }: RunDetailsProps) => {
       updatingResultId={updatingResultId}
       removingBaselineId={removingBaselineId}
       onBack={onBack}
-      onSelect={setSelectedResultId}
+      onSelect={(id) => {
+        // Only a genuine selection change is a "view" — re-clicking the shown
+        // agent should not re-emit.
+        if (id !== selectedResult?.Id) {
+          track?.("VS.SolutionTest.ResultViewed", { resultId: id });
+        }
+        setSelectedResultId(id);
+      }}
       onAdopt={(id) =>
         adopt.mutate(id, {
           onSuccess: () => toast.success(t("agent_adopted_successfully")),

--- a/apps/apollo-vertex/registry/solution-tests/solution-tests-view.tsx
+++ b/apps/apollo-vertex/registry/solution-tests/solution-tests-view.tsx
@@ -163,6 +163,7 @@ export const SolutionTestsView = ({
   const activeTab = activeTabProp ?? internalTab;
   const handleTabChange = (tab: TabValue) => {
     // When controlled, `activeTab` resolves to the prop so this is ignored.
+    config.track?.("VS.SolutionTest.TabViewed", { tab });
     setInternalTab(tab);
     onTabChange?.(tab);
   };
@@ -215,6 +216,10 @@ export const SolutionTestsView = ({
           aria-label={row.getIsExpanded() ? t("collapse") : t("expand")}
           onClick={(e) => {
             e.stopPropagation();
+            if (!row.getIsExpanded())
+              config.track?.("VS.SolutionTest.TestExpanded", {
+                testId: row.original.Id,
+              });
             row.toggleExpanded();
           }}
         >
@@ -379,6 +384,10 @@ export const SolutionTestsView = ({
           aria-label={row.getIsExpanded() ? t("collapse") : t("expand")}
           onClick={(e) => {
             e.stopPropagation();
+            if (!row.getIsExpanded())
+              config.track?.("VS.SolutionTest.BatchExpanded", {
+                batchId: row.original.Id,
+              });
             row.toggleExpanded();
           }}
         >

--- a/apps/apollo-vertex/registry/solution-tests/solution-tests-view.tsx
+++ b/apps/apollo-vertex/registry/solution-tests/solution-tests-view.tsx
@@ -171,8 +171,11 @@ export const SolutionTestsView = ({
   // Runs default to newest-first by run date; the user can re-sort.
   const runsTable = useControlledTable([{ id: "StartedAt", desc: true }]);
   // `getRowId` is the test `Id`, so selection keys are test ids directly.
+  // Prune ids whose test no longer exists (e.g. deleted while selected) so the
+  // Run-selected count and payload never reference a stale test.
+  const existingTestIds = new Set(tests.map((test) => test.Id));
   const selectedTestIds = Object.keys(casesTable.rowSelection).filter(
-    (id) => casesTable.rowSelection[id],
+    (id) => casesTable.rowSelection[id] && existingTestIds.has(id),
   );
 
   const testCasesColumns: ColumnDef<SolutionTest>[] = [

--- a/apps/apollo-vertex/registry/solution-tests/solution-tests.tsx
+++ b/apps/apollo-vertex/registry/solution-tests/solution-tests.tsx
@@ -30,8 +30,6 @@ import {
 } from "./solution-tests-view";
 import { ExpandedAgents } from "./expanded-agents";
 import { ExpandedRunTests } from "./expanded-run-tests";
-import { RunDetails } from "./run-details";
-import { isRunDone } from "./utils";
 
 function getRunsForBatch(
   batchId: string,
@@ -86,41 +84,9 @@ export const SolutionTests = () => {
     });
   };
 
-  // The selected run drives the full-page run-details view. It's synced to the
-  // `?run=` search param so it survives reloads and is shareable.
-  const selectedRunId = useSearch({
-    strict: false,
-    select: (search: Record<string, unknown>) =>
-      typeof search.run === "string" ? search.run : "",
-  });
-  // Only completed runs have results to show. A stale or shared
-  // `?run=<pending-id>` falls through to the table instead of an empty page.
-  const selectedRun = allRuns.find(
-    (r) => r.Id === selectedRunId && isRunDone(r.Status),
-  );
-
   const hasActiveRuns = batchRuns.some(
     (r) => r.Status === RunStatus.Pending || r.Status === RunStatus.Running,
   );
-
-  if (selectedRun) {
-    const test = tests.find((x) => x.Id === selectedRun.SolutionTestId);
-    // The test's display label (e.g. "Loan LOAN-…") — the run-details title subject.
-    const subjectId =
-      test?.TestName ?? test?.SubjectId ?? selectedRun.SolutionTestId;
-    return (
-      <RunDetails
-        run={selectedRun}
-        subjectId={subjectId}
-        onBack={() =>
-          void navigate({
-            to: ".",
-            search: ({ run: _run, ...rest }: Record<string, unknown>) => rest,
-          })
-        }
-      />
-    );
-  }
 
   return (
     <SolutionTestsView

--- a/apps/apollo-vertex/registry/solution-tests/use-baseline-jobs.ts
+++ b/apps/apollo-vertex/registry/solution-tests/use-baseline-jobs.ts
@@ -12,7 +12,11 @@ import { useMutation } from "@tanstack/react-query";
 import { useSolution } from "@uipath/vs-core";
 import { fetchAttachment } from "./attachments";
 import { ENTITY } from "./constants";
-import { useSolutionTestsActions, useSolutionTestsContext } from "./context";
+import {
+  useSolutionTestsActions,
+  useSolutionTestsConfig,
+  useSolutionTestsContext,
+} from "./context";
 import type { AttachmentFetcher, MutationHook } from "./mutations";
 import { JobRole } from "./types";
 import type { SolutionTestJob } from "./types";
@@ -39,12 +43,15 @@ export function useBaselineJobs(testId: string): UseBaselineJobsResult {
 /** Remove a job from the test's expected (baseline) results. */
 export function useRemoveJobBaseline(): MutationHook<string> {
   const actions = useSolutionTestsActions();
+  const { track } = useSolutionTestsConfig();
   const jobsCollection = useSolutionTestCollection(ENTITY.jobs);
   return useMutation({
     mutationFn: async (baselineId: string) => {
       await actions.removeJobBaseline(baselineId);
       await jobsCollection.utils.refetch();
     },
+    onMutate: (baselineId) =>
+      track?.("VS.SolutionTest.BaselineRemoved", { baselineId }),
   });
 }
 

--- a/apps/apollo-vertex/registry/solution-tests/use-force-stop.ts
+++ b/apps/apollo-vertex/registry/solution-tests/use-force-stop.ts
@@ -7,21 +7,26 @@
  */
 
 import { useMutation } from "@tanstack/react-query";
-import { useSolutionTestsActions } from "./context";
+import { useSolutionTestsActions, useSolutionTestsConfig } from "./context";
 import type { MutationHook } from "./mutations";
 
 /** Force-stop a whole batch run. */
 export function useForceStopBatch(): MutationHook<string> {
   const actions = useSolutionTestsActions();
+  const { track } = useSolutionTestsConfig();
   return useMutation({
     mutationFn: (batchId: string) => actions.forceStopBatch(batchId),
+    onMutate: (batchId) =>
+      track?.("VS.SolutionTest.BatchForceStopped", { batchId }),
   });
 }
 
 /** Force-stop a single run. */
 export function useForceStopRun(): MutationHook<string> {
   const actions = useSolutionTestsActions();
+  const { track } = useSolutionTestsConfig();
   return useMutation({
     mutationFn: (runId: string) => actions.forceStopRun(runId),
+    onMutate: (runId) => track?.("VS.SolutionTest.RunForceStopped", { runId }),
   });
 }

--- a/apps/apollo-vertex/registry/solution-tests/use-run-results.ts
+++ b/apps/apollo-vertex/registry/solution-tests/use-run-results.ts
@@ -12,7 +12,11 @@ import { useMutation } from "@tanstack/react-query";
 import { useSolution } from "@uipath/vs-core";
 import { fetchAttachment } from "./attachments";
 import { ENTITY } from "./constants";
-import { useSolutionTestsActions, useSolutionTestsContext } from "./context";
+import {
+  useSolutionTestsActions,
+  useSolutionTestsConfig,
+  useSolutionTestsContext,
+} from "./context";
 import type { AttachmentFetcher, MutationHook } from "./mutations";
 import { JobRole } from "./types";
 import type {
@@ -70,16 +74,21 @@ export function useRunResults(runId: string): UseRunResultsResult {
 /** Adopt a run result's job as the test baseline. */
 export function useAdoptJob(): MutationHook<string> {
   const actions = useSolutionTestsActions();
+  const { track } = useSolutionTestsConfig();
   return useMutation({
     mutationFn: (resultId: string) => actions.adoptJob(resultId),
+    onMutate: (resultId) => track?.("VS.SolutionTest.JobAdopted", { resultId }),
   });
 }
 
 /** Update the test baseline from a run result. */
 export function useUpdateBaseline(): MutationHook<string> {
   const actions = useSolutionTestsActions();
+  const { track } = useSolutionTestsConfig();
   return useMutation({
     mutationFn: (resultId: string) => actions.updateBaseline(resultId),
+    onMutate: (resultId) =>
+      track?.("VS.SolutionTest.BaselineUpdated", { resultId }),
   });
 }
 

--- a/apps/apollo-vertex/registry/solution-tests/use-solution-tests.ts
+++ b/apps/apollo-vertex/registry/solution-tests/use-solution-tests.ts
@@ -10,7 +10,7 @@ import { useLiveQuery } from "@tanstack/react-db";
 import { useMutation } from "@tanstack/react-query";
 import { useSolution } from "@uipath/vs-core";
 import { ENTITY } from "./constants";
-import { useSolutionTestsActions } from "./context";
+import { useSolutionTestsActions, useSolutionTestsConfig } from "./context";
 import type { MutationHook } from "./mutations";
 import type { SolutionTest } from "./types";
 import { useSolutionTestCollection } from "./use-solution-test-collection";
@@ -40,21 +40,27 @@ export function useRunTests(): MutationHook<{
   mode: RunTestsMode;
 }> {
   const actions = useSolutionTestsActions();
+  const { track } = useSolutionTestsConfig();
   return useMutation({
     mutationFn: ({ testIds }: { testIds?: string[]; mode: RunTestsMode }) =>
       actions.runTests(testIds),
+    // Track the user action on trigger (not success) — we want intent, not outcome.
+    onMutate: ({ testIds, mode }) =>
+      track?.("VS.SolutionTest.Run", { mode, testCount: testIds?.length ?? 0 }),
   });
 }
 
 /** Create a solution test from a subject id (e.g. a loan). */
 export function useCreateTest(): MutationHook<string> {
   const actions = useSolutionTestsActions();
+  const { track } = useSolutionTestsConfig();
   const testsCollection = useSolutionTestCollection(ENTITY.tests);
   return useMutation({
     mutationFn: async (subjectId: string) => {
       await actions.createTest(subjectId);
       await testsCollection.utils.refetch();
     },
+    onMutate: (subjectId) => track?.("VS.SolutionTest.Created", { subjectId }),
   });
 }
 
@@ -69,6 +75,7 @@ export function useToggleTestActive(): MutationHook<{
   isActive: boolean;
 }> {
   const solution = useSolution();
+  const { track } = useSolutionTestsConfig();
   return useMutation({
     mutationFn: async ({
       testId,
@@ -86,12 +93,15 @@ export function useToggleTestActive(): MutationHook<{
       });
       await transaction.isPersisted.promise;
     },
+    onMutate: ({ testId, isActive }) =>
+      track?.("VS.SolutionTest.ActiveToggled", { testId, isActive }),
   });
 }
 
 /** Delete a test. */
 export function useDeleteTest(): MutationHook<string> {
   const actions = useSolutionTestsActions();
+  const { track } = useSolutionTestsConfig();
   const testsCollection = useSolutionTestCollection(ENTITY.tests);
   const jobsCollection = useSolutionTestCollection(ENTITY.jobs);
   return useMutation({
@@ -102,5 +112,6 @@ export function useDeleteTest(): MutationHook<string> {
         jobsCollection.utils.refetch(),
       ]);
     },
+    onMutate: (testId) => track?.("VS.SolutionTest.Deleted", { testId }),
   });
 }

--- a/apps/apollo-vertex/registry/solution-tests/utils.ts
+++ b/apps/apollo-vertex/registry/solution-tests/utils.ts
@@ -4,14 +4,16 @@ export function isRunDone(status: number): boolean {
   return status !== RunStatus.Pending && status !== RunStatus.Running;
 }
 
-/** Compare dot-separated versions by numeric segment: 1 if a>b, -1 if a<b, else 0. */
+/** Compare dot-separated versions by numeric segment: 1 if a>b, -1 if a<b, else
+ *  0. Segments that aren't strictly numeric (e.g. "1-beta") are skipped, so
+ *  annotated/pre-release versions compare equal and show no glyph. */
 export function compareVersions(a: string, b: string): number {
   const pa = a.split(".");
   const pb = b.split(".");
   const len = Math.max(pa.length, pb.length);
   for (let i = 0; i < len; i++) {
-    const na = Number.parseInt(pa[i] ?? "0", 10);
-    const nb = Number.parseInt(pb[i] ?? "0", 10);
+    const na = Number(pa[i] ?? "0");
+    const nb = Number(pb[i] ?? "0");
     if (Number.isNaN(na) || Number.isNaN(nb) || na === nb) continue;
     return na > nb ? 1 : -1;
   }


### PR DESCRIPTION
Adds an optional, fully-typed `track` telemetry callback to `SolutionTestsConfig` so a host can route Solution Tests events to its own analytics backend, a no-op when omitted; each action hook (run, create, toggle-active, delete, force-stop, adopt/update/remove baseline) plus UI interactions (tab/expand/details/inspect) fire a named event, with `SolutionTestEventMap` as the single typed source of truth exported from the barrel. Opening a batch run's details now drives a `runId`-based child route via an `onOpenRun` seam, so run details survive reloads and are shareable. Also includes review fixes (pruning stale run-result selection and suppressing the version glyph when unchanged) and a docs Telemetry section covering the callback and event contract.

👨 Generated with Kluijt Code