### PR TITLE
fix(apollo-wind): suppress native search clear button to avoid duplicate

### DIFF
--- a/packages/apollo-wind/src/components/ui/search.test.tsx
+++ b/packages/apollo-wind/src/components/ui/search.test.tsx
@@ -97,6 +97,13 @@ describe('Search', () => {
     expect(input).toHaveClass('custom-search');
   });
 
+  it('suppresses the native search clear button to avoid a duplicate', () => {
+    render(<Search value="test" onChange={vi.fn()} />);
+    const input = screen.getByRole('searchbox');
+    expect(input).toHaveClass('[&::-webkit-search-cancel-button]:appearance-none');
+    expect(input).toHaveClass('[&::-webkit-search-decoration]:appearance-none');
+  });
+
   it('forwards ref correctly', () => {
     const ref = { current: null };
     render(<Search ref={ref} />);

--- a/packages/apollo-wind/src/components/ui/search.tsx
+++ b/packages/apollo-wind/src/components/ui/search.tsx
@@ -45,7 +45,10 @@ const Search = React.forwardRef<HTMLInputElement, SearchProps>(
         <InputGroupInput
           ref={ref}
           type="search"
-          className={className}
+          className={cn(
+            '[&::-webkit-search-cancel-button]:appearance-none [&::-webkit-search-decoration]:appearance-none',
+            className
+          )}
           value={value}
           onChange={(e) => onChange?.(e.target.value)}
           {...props}


### PR DESCRIPTION
## Summary

`<Search>` renders **two** clear buttons whenever the field has a value: the small native one and the component's own styled one.

Root cause: the component sets `type="search"` on the inner `InputGroupInput`, so Chromium/WebKit (Chrome, Edge, Safari — and therefore any Chromium webview) automatically renders a native `::-webkit-search-cancel-button`. The component **also** renders its own clear control (`InputGroupButton` with `<X/>`, gated on `showClearButton && value`, default on). Nothing suppresses the native pseudo-element, so both appear.

## Before
<img width="753" height="197" alt="2026-07-24 10 54 07" src="https://github.com/user-attachments/assets/195a1562-dad6-4b32-a9d1-c33f0fcc5851" />

## After
<img width="753" height="197" alt="2026-07-24 10 53 06" src="https://github.com/user-attachments/assets/13f788cd-f44e-4db8-9d91-d604717b70ca" />

## Notes

- Chromium/WebKit-only symptom (Firefox never renders a native search-cancel button), but the suppression is harmless everywhere.
- Behavior is otherwise unchanged: the styled clear button, `onClear`, `showClearButton`, and `onChange` all work as before.
- `biome check` passes on the changed file (lint + format clean).

## Testing

- [x] `biome check` clean on the changed file
- [x] Visual: type into a `<Search>` in a Chromium browser → exactly one (styled) clear button
