### PR TITLE
Add Node Property Panel UI inventory

### DIFF
--- a/packages/apollo-react/src/canvas/components/NodePropertyPanel/ExpressionField.tsx
+++ b/packages/apollo-react/src/canvas/components/NodePropertyPanel/ExpressionField.tsx
@@ -1,5 +1,4 @@
 import { ChevronDown, Maximize2, Redo2, Sparkles, Undo2 } from 'lucide-react';
-import { PanelFieldLabel } from './PanelField';
 
 export type ExpressionMode = 'expr' | 'json';
 
@@ -40,7 +39,7 @@ export function ExpressionField({
       {/* Label row */}
       {label && (
         <div className="flex items-center justify-between">
-          <PanelFieldLabel className="leading-4">{label}</PanelFieldLabel>
+          <span className="text-xs font-medium leading-4 text-foreground">{label}</span>
           <div className="flex items-center gap-0.5">
             <button
               type="button"

--- a/packages/apollo-react/src/canvas/components/NodePropertyPanel/ExpressionField.tsx
+++ b/packages/apollo-react/src/canvas/components/NodePropertyPanel/ExpressionField.tsx
@@ -35,11 +35,11 @@ export function ExpressionField({
   const activeMode = mode;
 
   return (
-    <div className="flex flex-col gap-2">
+    <div className="flex flex-col gap-1.5">
       {/* Label row */}
       {label && (
         <div className="flex items-center justify-between">
-          <span className="text-xs font-medium text-foreground-muted">{label}</span>
+          <span className="text-xs font-medium leading-4 text-foreground">{label}</span>
           <div className="flex items-center gap-0.5">
             <button
               type="button"

--- a/packages/apollo-react/src/canvas/components/NodePropertyPanel/ExpressionField.tsx
+++ b/packages/apollo-react/src/canvas/components/NodePropertyPanel/ExpressionField.tsx
@@ -1,4 +1,5 @@
 import { ChevronDown, Maximize2, Redo2, Sparkles, Undo2 } from 'lucide-react';
+import { PanelFieldLabel } from './PanelField';
 
 export type ExpressionMode = 'expr' | 'json';
 
@@ -39,7 +40,7 @@ export function ExpressionField({
       {/* Label row */}
       {label && (
         <div className="flex items-center justify-between">
-          <span className="text-xs font-medium leading-4 text-foreground">{label}</span>
+          <PanelFieldLabel className="leading-4">{label}</PanelFieldLabel>
           <div className="flex items-center gap-0.5">
             <button
               type="button"

--- a/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.stories.tsx
@@ -75,6 +75,8 @@ import {
   TooltipContent,
   TooltipProvider,
   TooltipTrigger,
+  toast,
+  Toaster,
 } from '@uipath/apollo-wind';
 import {
   apolloCoreDarkHCMonaco,
@@ -106,6 +108,7 @@ import {
   Plus,
   ScanText,
   Search,
+  RefreshCw,
   Sparkles,
   Trash2,
   Type,
@@ -133,6 +136,7 @@ import type {
 } from '../JsonTree';
 import { isJsonObject } from '../JsonTree';
 import { NodeIOView, type NodeIOViewTab } from '../NodeIOView';
+import { CanvasTooltip } from '../CanvasTooltip';
 import { NodePropertyPanel } from './NodePropertyPanel';
 
 // @monaco-editor/react uses a CJS build without an `exports` field, which
@@ -3639,11 +3643,6 @@ function InlineEditingStory() {
   );
 }
 
-export const InlineEditing: Story = {
-  name: 'Inline Editing',
-  render: () => <InlineEditingStory />,
-};
-
 // ============================================================================
 // Panel UI Inventory
 // Interactive reference of common controls and layout patterns used in panels.
@@ -3667,7 +3666,15 @@ function InventoryField({
   );
 }
 
-function PatternNote({ title, children }: { title: string; children: ReactNode }) {
+function PatternNote({
+  title,
+  eyebrow = 'Layout pattern',
+  children,
+}: {
+  title: string;
+  eyebrow?: string;
+  children: ReactNode;
+}) {
   const [dismissed, setDismissed] = useState(false);
 
   if (dismissed) return null;
@@ -3676,7 +3683,7 @@ function PatternNote({ title, children }: { title: string; children: ReactNode }
     <aside className="rounded-lg border border-border-subtle bg-surface-overlay p-3">
       <div className="flex items-start justify-between gap-3">
         <p className="pt-0.5 text-[10px] font-semibold uppercase tracking-[0.08em] text-brand">
-          Layout pattern
+          {eyebrow}
         </p>
         <Button
           variant="ghost"
@@ -3895,8 +3902,9 @@ function PanelUIInventoryStory() {
   };
 
   return (
-    <PanelFrame>
-      <NodePropertyPanel
+    <>
+      <PanelFrame>
+        <NodePropertyPanel
         panelTitle="Properties"
         nodeIcon={<Sparkles />}
         nodeLabel="UI element inventory"
@@ -4096,61 +4104,182 @@ function PanelUIInventoryStory() {
           </TabsContent>
 
           <TabsContent value="states" className="mt-0 min-h-0 flex-1 overflow-y-auto p-3.5">
-            <div className="grid gap-4">
-              <div className="flex flex-wrap gap-2">
-                <Badge>Default</Badge>
-                <Badge variant="secondary">Optional</Badge>
-                <Badge variant="outline">Read only</Badge>
-              </div>
-              <SuccessFieldBlock
-                title="Configuration is valid"
-                message="All required fields have been completed."
-                action="This node is ready to run."
-              />
-              <ErrorFieldBlock
-                title="Connection required"
-                message="No valid connection is configured for this node."
-                action="Select a connection before running this node."
-              />
-              <InventoryField label="Field with validation" description="Use a unique node name.">
-                <div>
-                  <Input
-                    defaultValue="Existing node"
-                    aria-invalid="true"
-                    className="border-destructive"
-                  />
-                  <InlineValidationMessage
-                    message="This node name is already in use."
-                    action="Enter a unique name before saving."
-                  />
+            <div className="grid gap-5">
+              <section className="grid gap-3">
+                <PatternNote title="Status labels" eyebrow="State pattern">
+                  Short labels communicate a field or setting state without interrupting the task.
+                </PatternNote>
+                <div className="flex flex-wrap gap-2">
+                  <Badge>Default</Badge>
+                  <Badge variant="secondary">Optional</Badge>
+                  <Badge variant="outline">Read only</Badge>
                 </div>
-              </InventoryField>
+              </section>
+
+              <section className="grid gap-3 border-t border-border-subtle pt-5">
+                <PatternNote title="Section messages" eyebrow="State pattern">
+                  Persistent feedback summarizes a panel-level result and provides the next action
+                  when one is needed.
+                </PatternNote>
+                <SuccessFieldBlock
+                  title="Configuration is valid"
+                  message="All required fields have been completed."
+                  action="This node is ready to run."
+                />
+                <ErrorFieldBlock
+                  title="Connection required"
+                  message="No valid connection is configured for this node."
+                  action="Select a connection before running this node."
+                />
+              </section>
+
+              <section className="grid gap-3 border-t border-border-subtle pt-5">
+                <PatternNote title="Inline validation" eyebrow="State pattern">
+                  Field-specific feedback stays beside the control so the issue and resolution are
+                  clear in context.
+                </PatternNote>
+                <InventoryField
+                  label="Field with validation"
+                  description="Use a unique node name."
+                >
+                  <div>
+                    <Input
+                      defaultValue="Existing node"
+                      aria-invalid="true"
+                      className="border-destructive"
+                    />
+                    <InlineValidationMessage
+                      message="This node name is already in use."
+                      action="Enter a unique name before saving."
+                    />
+                  </div>
+                </InventoryField>
+              </section>
+
+              <section className="grid gap-3 border-t border-border-subtle pt-5">
+                <PatternNote title="Transient feedback" eyebrow="State pattern">
+                  Toasts confirm the result of a user action without interrupting the task. Keep
+                  actionable errors visible in the panel instead.
+                </PatternNote>
+                <div className="grid grid-cols-2 gap-2">
+                  <Button
+                    variant="outline"
+                    onClick={() =>
+                      toast.info('Background sync complete', {
+                        description: 'The latest panel data is available.',
+                      })
+                    }
+                  >
+                    Info
+                  </Button>
+                  <Button
+                    variant="outline"
+                    onClick={() =>
+                      toast.success('Changes saved', {
+                        description: 'Panel settings are up to date.',
+                      })
+                    }
+                  >
+                    Success
+                  </Button>
+                  <Button
+                    variant="outline"
+                    onClick={() =>
+                      toast.warning('Review recommended', {
+                        description: 'Some optional settings still use defaults.',
+                      })
+                    }
+                  >
+                    Warning
+                  </Button>
+                  <Button
+                    variant="outline"
+                    onClick={() =>
+                      toast.error('Update failed', {
+                        description: 'Your changes were not saved. Try again.',
+                      })
+                    }
+                  >
+                    Error
+                  </Button>
+                </div>
+              </section>
             </div>
           </TabsContent>
 
           <TabsContent value="actions" className="mt-0 min-h-0 flex-1 overflow-y-auto p-3.5">
             <div className="grid gap-5">
-              <div className="grid gap-2">
-                <Label className="text-xs">Button hierarchy</Label>
+              <section className="grid gap-3">
+                <PatternNote title="Button hierarchy" eyebrow="Action pattern">
+                  Use one primary action per context, with secondary, tertiary, and destructive
+                  styles reflecting lower emphasis or greater consequence.
+                </PatternNote>
                 <div className="flex flex-wrap gap-2">
                   <Button>Primary</Button>
                   <Button variant="outline">Secondary</Button>
                   <Button variant="ghost">Tertiary</Button>
                   <Button variant="destructive">Delete</Button>
                 </div>
-              </div>
-              <div className="grid gap-2">
-                <Label className="text-xs">Footer pattern</Label>
+              </section>
+
+              <section className="grid gap-3 border-t border-border-subtle pt-5">
+                <PatternNote title="Header actions" eyebrow="Action pattern">
+                  Reserve the panel header for high-frequency node-level commands such as running
+                  or debugging. Keep the set small so the primary task remains clear.
+                </PatternNote>
+                <div className="flex flex-wrap items-center gap-2">
+                  <RunButton />
+                  <DebugButton />
+                </div>
+              </section>
+
+              <section className="grid gap-3 border-t border-border-subtle pt-5">
+                <PatternNote title="Footer actions" eyebrow="Action pattern">
+                  Place panel-level actions at the end of the content, with the primary action last
+                  and the cancel action immediately before it.
+                </PatternNote>
                 <div className="flex justify-end gap-2 border-t border-border-subtle pt-4">
                   <Button variant="ghost">Cancel</Button>
                   <Button>Save changes</Button>
                 </div>
-              </div>
+              </section>
+
+              <section className="grid gap-3 border-t border-border-subtle pt-5">
+                <PatternNote title="Icon-only utilities" eyebrow="Action pattern">
+                  Use compact icon actions for familiar utilities when space is limited. Always
+                  provide a tooltip and accessible name.
+                </PatternNote>
+                <div className="flex items-center gap-1">
+                  <CanvasTooltip content="Refresh data">
+                    <Button variant="ghost" size="4xs" icon aria-label="Refresh data">
+                      <RefreshCw size={14} />
+                    </Button>
+                  </CanvasTooltip>
+                  <CanvasTooltip content="Duplicate node">
+                    <Button variant="ghost" size="4xs" icon aria-label="Duplicate node">
+                      <Copy size={14} />
+                    </Button>
+                  </CanvasTooltip>
+                  <CanvasTooltip content="Delete node">
+                    <Button
+                      variant="ghost"
+                      size="4xs"
+                      icon
+                      aria-label="Delete node"
+                      className="text-error hover:text-error"
+                    >
+                      <Trash2 size={14} />
+                    </Button>
+                  </CanvasTooltip>
+                </div>
+              </section>
             </div>
           </TabsContent>
-        </Tabs>
-      </NodePropertyPanel>
-    </PanelFrame>
+          </Tabs>
+        </NodePropertyPanel>
+      </PanelFrame>
+      <Toaster className="[&_[data-description]]:!text-foreground-muted [&_[data-icon]]:!mt-0.5 [&_[data-icon]]:!self-start" />
+    </>
   );
 }
 

--- a/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.stories.tsx
@@ -111,7 +111,6 @@ import {
   RefreshCw,
   Sparkles,
   Trash2,
-  Type,
   Upload,
   UserRoundCheck,
   X,
@@ -458,6 +457,7 @@ const TAB_TRIGGER_CLASS =
 // ============================================================================
 
 export const Default: Story = {
+  name: 'Form Default',
   render: () => (
     <PanelFrame>
       <NodePropertyPanel
@@ -475,7 +475,13 @@ export const Default: Story = {
   ),
 };
 
+export const QuickForm: Story = {
+  name: 'Form HITL',
+  render: () => <QuickFormStory />,
+};
+
 export const EmbeddedNoTitleBar: Story = {
+  name: 'Form Embedded',
   render: () => (
     <PanelFrame>
       <NodePropertyPanel
@@ -491,6 +497,7 @@ export const EmbeddedNoTitleBar: Story = {
 };
 
 export const NoParametersTab: Story = {
+  name: 'Form No Parameters',
   render: () => (
     <PanelFrame>
       <NodePropertyPanel
@@ -610,7 +617,7 @@ function FullEditorStory() {
             </div>
             <TabsContent value="parameters" className="mt-0 flex min-h-0 flex-1 flex-col">
               <div className="flex shrink-0 items-center justify-between py-2 [padding-inline:var(--mf-content-inset,0.875rem)]">
-                <span className="text-xs font-medium text-foreground-muted">Path</span>
+                <span className="text-xs font-medium leading-4 text-foreground">Path</span>
                 <div className="flex items-center gap-0.5">
                   <button
                     type="button"
@@ -849,7 +856,7 @@ function CasePanel({
         <>
           {/* Condition label + buttons */}
           <div className="flex items-center justify-between border-t border-border-subtle px-3 py-2">
-            <span className="text-xs font-medium text-foreground-muted">Condition</span>
+            <span className="text-xs font-medium leading-4 text-foreground">Condition</span>
             <div className="flex items-center gap-0.5">
               <button
                 type="button"
@@ -1163,7 +1170,7 @@ function CompactEditorStory() {
             <TabsContent value="parameters" className="mt-0 min-h-0 flex-1 overflow-auto">
               {/* Cases field label row */}
               <div className="py-2 [padding-inline:var(--mf-content-inset,0.875rem)]">
-                <span className="text-sm font-medium text-foreground-muted">Cases</span>
+                <span className="text-xs font-medium leading-4 text-foreground">Cases</span>
               </div>
 
               {/* Case accordion panels — inset cards with gap */}
@@ -1335,7 +1342,7 @@ function AlertsAndErrorsStory() {
 
               <TabsContent value="parameters" className="mt-0 min-h-0 flex-1 overflow-auto">
                 <div className="py-2 [padding-inline:var(--mf-content-inset,0.875rem)]">
-                  <span className="text-sm font-medium text-foreground-muted">Cases</span>
+                  <span className="text-xs font-medium leading-4 text-foreground">Cases</span>
                 </div>
                 <div className="flex flex-col gap-2 pb-1 [padding-inline:var(--mf-content-inset,0.875rem)]">
                   {cases.map((c, i) => (
@@ -1369,7 +1376,7 @@ function AlertsAndErrorsStory() {
               <TabsContent value="error-handling" className="mt-0 min-h-0 flex-1 overflow-auto">
                 <div className="flex flex-col gap-3 py-3 [padding-inline:var(--mf-content-inset,0.875rem)]">
                   <div className="flex flex-col gap-2">
-                    <span className="text-sm font-medium text-foreground-muted">
+                    <span className="text-xs font-medium leading-4 text-foreground">
                       Failure behavior
                     </span>
                     <ErrorFieldBlock
@@ -1384,7 +1391,7 @@ function AlertsAndErrorsStory() {
               <TabsContent value="advanced" className="mt-0 min-h-0 flex-1 overflow-auto">
                 <div className="flex flex-col gap-3 py-3 [padding-inline:var(--mf-content-inset,0.875rem)]">
                   <div className="flex flex-col gap-2">
-                    <span className="text-sm font-medium text-foreground-muted">
+                    <span className="text-xs font-medium leading-4 text-foreground">
                       Execution limits
                     </span>
                     <ErrorFieldBlock
@@ -1422,229 +1429,67 @@ const INSERT_SNIPPETS = [
 function InlineCaseRow({
   caseTitle,
   onTitleChange,
-  onDelete,
-  monacoTheme,
   defaultValue = '',
 }: {
   caseTitle: string;
   onTitleChange: (title: string) => void;
-  onDelete: () => void;
-  monacoTheme: string;
   defaultValue?: string;
 }) {
+  const fieldId = useId();
   const [editingTitle, setEditingTitle] = useState(false);
   const titleRef = useRef<HTMLInputElement>(null);
   const [value, setValue] = useState(defaultValue);
-  const [mode, setMode] = useState<'fixed' | 'expression'>('fixed');
-  const [insertOpen, setInsertOpen] = useState(false);
-  const insertRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    if (!insertOpen) return;
-    const handler = (e: MouseEvent) => {
-      if (insertRef.current && !insertRef.current.contains(e.target as Node)) {
-        setInsertOpen(false);
-      }
-    };
-    document.addEventListener('mousedown', handler);
-    return () => document.removeEventListener('mousedown', handler);
-  }, [insertOpen]);
-
-  const insertSnippet = (code: string) => {
-    setValue((v) => (v ? `${v} ${code}` : code));
-    setInsertOpen(false);
-  };
+  const [locked, setLocked] = useState(false);
+  const [mode, setMode] = useState<LockableValueFieldMode>('fixed');
 
   return (
-    <div className="flex flex-col gap-1.5">
-      {/* Case title row */}
-      <div className="group flex items-center">
-        {editingTitle ? (
-          <input
-            ref={titleRef}
-            value={caseTitle}
-            onChange={(e) => onTitleChange(e.target.value)}
-            onBlur={() => setEditingTitle(false)}
-            onKeyDown={(e) => {
-              if (e.key === 'Enter' || e.key === 'Escape') setEditingTitle(false);
-            }}
-            className="flex-1 rounded bg-surface-overlay px-1 py-0.5 text-xs font-medium text-foreground outline-none ring-1 ring-brand"
-            autoFocus
-          />
-        ) : (
-          <button
-            type="button"
-            onClick={() => {
-              setEditingTitle(true);
-              setTimeout(() => titleRef.current?.select(), 0);
-            }}
-            className="flex-1 truncate rounded px-1 py-0.5 text-left text-xs font-medium text-foreground-muted transition hover:bg-surface-overlay hover:text-foreground"
-          >
-            {caseTitle}
-          </button>
-        )}
-        <div className="flex shrink-0 items-center gap-0.5">
-          <button
-            type="button"
-            onClick={onDelete}
-            aria-label="Delete case"
-            title="Delete case"
-            className="grid size-7 shrink-0 place-items-center rounded-lg text-foreground-subtle opacity-0 transition hover:bg-surface-overlay hover:text-foreground group-hover:opacity-100"
-          >
-            <X size={12} />
-          </button>
-          <button
-            type="button"
-            aria-label="AI assist"
-            title="AI assist"
-            className="grid size-7 place-items-center rounded-lg text-foreground-subtle transition hover:bg-surface-overlay hover:text-foreground"
-          >
-            <Sparkles size={12} />
-          </button>
-          {/* Insert popover */}
-          <div ref={insertRef} className="relative">
+    <LockableValueField
+      id={fieldId}
+      label={
+        <div className="flex min-w-0 flex-1 items-center">
+          {editingTitle ? (
+            <input
+              ref={titleRef}
+              value={caseTitle}
+              onChange={(event) => onTitleChange(event.target.value)}
+              onBlur={() => setEditingTitle(false)}
+              onKeyDown={(event) => {
+                if (event.key === 'Enter' || event.key === 'Escape') setEditingTitle(false);
+              }}
+              className="min-w-0 flex-1 rounded bg-surface-overlay px-1 py-0.5 text-xs font-medium leading-4 text-foreground outline-none ring-1 ring-brand"
+              autoFocus
+            />
+          ) : (
             <button
               type="button"
-              aria-label="Insert snippet"
-              title="Insert snippet"
-              onClick={() => setInsertOpen((v) => !v)}
-              className={cn(
-                'flex h-7 items-center gap-1 rounded-lg px-2 text-[11px] transition',
-                insertOpen
-                  ? 'bg-surface-overlay text-foreground'
-                  : 'text-foreground-subtle hover:bg-surface-overlay hover:text-foreground'
-              )}
+              onClick={() => {
+                setEditingTitle(true);
+                setTimeout(() => titleRef.current?.select(), 0);
+              }}
+              className="min-w-0 flex-1 truncate rounded px-1 py-0.5 text-left text-xs font-medium leading-4 text-foreground transition hover:bg-surface-overlay"
             >
-              <span className="font-mono text-[10px]">{'{x}'}</span>
-              <span>Insert</span>
-              <ChevronDown size={9} />
+              {caseTitle}
             </button>
-            {insertOpen && (
-              <div className="absolute right-0 top-full z-50 mt-1 min-w-[192px] overflow-hidden rounded-xl border border-border-subtle bg-surface-overlay py-1 shadow-lg">
-                {INSERT_SNIPPETS.map((s) => (
-                  <button
-                    key={s.code}
-                    type="button"
-                    onClick={() => insertSnippet(s.code)}
-                    className="flex w-full items-center justify-between gap-3 px-3 py-1.5 text-left hover:bg-surface-raised"
-                  >
-                    <span className="text-xs text-foreground">{s.label}</span>
-                    <span className="font-mono text-[10px] text-foreground-muted">{s.code}</span>
-                  </button>
-                ))}
-              </div>
-            )}
-          </div>
+          )}
         </div>
-      </div>
-
-      {/* Monaco editor with mode toggle on the right.
-          Outer wrapper is NOT overflow-hidden so the popover can escape. */}
-      <div className="relative">
-        <div className="overflow-hidden rounded-xl border border-border-subtle">
-          <div className="relative h-10">
-            <MonacoEditor
-              height="40px"
-              language={mode === 'expression' ? 'javascript' : 'plaintext'}
-              value={value}
-              onChange={(val) => setValue(val ?? '')}
-              theme={monacoTheme}
-              beforeMount={registerMonacoThemes}
-              options={INLINE_EDITOR_OPTIONS}
-            />
-            {value === '' && (
-              <div className="pointer-events-none absolute left-[14px] top-1/2 -translate-y-1/2 font-mono text-[13px] text-foreground-subtle">
-                {mode === 'fixed' ? 'Enter a value' : 'Enter an expression'}
-              </div>
-            )}
-          </div>
-        </div>
-        {/* Mode toggle — DropdownMenu picker */}
-        <div className="absolute right-2 top-1/2 z-10 flex -translate-y-1/2 items-center gap-1.5">
-          <div className="h-3.5 w-px bg-border" />
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <button
-                type="button"
-                aria-label="Select expression mode"
-                className={cn(
-                  'flex h-6 items-center rounded border px-1.5 text-[10px] font-medium transition',
-                  mode === 'expression'
-                    ? 'border-brand/40 bg-brand/15 text-brand'
-                    : 'border-border bg-surface text-foreground-muted hover:text-foreground'
-                )}
-              >
-                {mode === 'fixed' ? 'PT' : 'JS'}
-              </button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end" className="w-56 p-1">
-              <DropdownMenuItem
-                onClick={() => setMode('fixed')}
-                className={cn(
-                  'flex flex-col items-start gap-0.5 py-2.5 focus:bg-surface-overlay',
-                  mode === 'fixed' && 'bg-surface-raised'
-                )}
-              >
-                <div className="flex items-center gap-2">
-                  <Type
-                    size={13}
-                    className={cn(
-                      'shrink-0',
-                      mode === 'fixed' ? 'text-brand' : 'text-foreground-muted'
-                    )}
-                  />
-                  <span
-                    className={cn(
-                      'text-xs font-medium',
-                      mode === 'fixed' ? 'text-brand' : 'text-foreground'
-                    )}
-                  >
-                    Plain text
-                  </span>
-                </div>
-                <span className="pl-[21px] text-[11px] leading-4 text-foreground-subtle">
-                  Enter static values like "hello" or 42
-                </span>
-              </DropdownMenuItem>
-              <DropdownMenuSeparator />
-              <DropdownMenuItem
-                onClick={() => setMode('expression')}
-                className={cn(
-                  'flex flex-col items-start gap-0.5 py-2.5 focus:bg-surface-overlay',
-                  mode === 'expression' && 'bg-surface-raised'
-                )}
-              >
-                <div className="flex items-center gap-2">
-                  <Code2
-                    size={13}
-                    className={cn(
-                      'shrink-0',
-                      mode === 'expression' ? 'text-brand' : 'text-foreground-muted'
-                    )}
-                  />
-                  <span
-                    className={cn(
-                      'text-xs font-medium',
-                      mode === 'expression' ? 'text-brand' : 'text-foreground'
-                    )}
-                  >
-                    Javascript expression
-                  </span>
-                </div>
-                <span className="pl-[21px] text-[11px] leading-4 text-foreground-subtle">
-                  Compute the return value dynamically with JS
-                </span>
-              </DropdownMenuItem>
-            </DropdownMenuContent>
-          </DropdownMenu>
-        </div>
-      </div>
-    </div>
+      }
+      value={value}
+      onValueChange={setValue}
+      locked={locked}
+      onLockedChange={setLocked}
+      mode={mode}
+      onModeChange={setMode}
+      fieldType="string"
+      variables={INSERT_SNIPPETS.map((snippet) => ({
+        label: snippet.label,
+        value: snippet.code,
+      }))}
+      controlsVisibility="visible"
+    />
   );
 }
 
 function InputEditorStory() {
-  const monacoTheme = useMonacoTheme();
   const [cases, setCases] = useState([{ id: 1, title: 'Return value' }]);
   const nextIdRef = useRef(2);
   const [defaultBranch, setDefaultBranch] = useState(false);
@@ -1659,7 +1504,6 @@ function InputEditorStory() {
     const id = nextIdRef.current++;
     setCases((prev) => [...prev, { id, title: `Output variable ${id}` }]);
   };
-  const deleteCase = (id: number) => setCases((prev) => prev.filter((c) => c.id !== id));
   const updateCaseTitle = (id: number, title: string) =>
     setCases((prev) => prev.map((c) => (c.id === id ? { ...c, title } : c)));
 
@@ -1751,7 +1595,7 @@ function InputEditorStory() {
             </div>
             <TabsContent value="parameters" className="mt-0 min-h-0 flex-1 overflow-auto">
               <div className="py-2 [padding-inline:var(--mf-content-inset,0.875rem)]">
-                <span className="text-sm font-medium text-foreground-muted">Output messaging</span>
+                <span className="text-xs font-medium leading-4 text-foreground">Output messaging</span>
               </div>
               <div className="flex flex-col gap-3 pb-1 [padding-inline:var(--mf-content-inset,0.875rem)]">
                 {cases.map((c) => (
@@ -1759,8 +1603,6 @@ function InputEditorStory() {
                     key={c.id}
                     caseTitle={c.title}
                     onTitleChange={(title) => updateCaseTitle(c.id, title)}
-                    onDelete={() => deleteCase(c.id)}
-                    monacoTheme={monacoTheme}
                     defaultValue=""
                   />
                 ))}
@@ -1790,6 +1632,12 @@ function InputEditorStory() {
 export const InputEditor: Story = {
   name: 'Editor Inline',
   render: () => <InputEditorStory />,
+};
+
+export const Output: Story = {
+  name: 'Input / Output',
+  render: () => <InputOutputStory />,
+  parameters: { layout: 'fullscreen' },
 };
 
 // ============================================================================
@@ -2743,7 +2591,7 @@ function LockableCaseRow({
                     setEditingTitle(true);
                     setTimeout(() => titleRef.current?.select(), 0);
                   }}
-                  className="truncate rounded px-1 py-0.5 text-left text-xs font-medium text-foreground-muted transition hover:bg-surface-overlay hover:text-foreground"
+                  className="truncate rounded px-1 py-0.5 text-left text-xs font-medium text-foreground transition hover:bg-surface-overlay"
                 >
                   {caseTitle}
                   {required && <span className="ml-0.5 text-destructive">*</span>}
@@ -2901,7 +2749,7 @@ function FormButtonChip({
         </TooltipProvider>
         <PopoverContent align="start" className="w-48 space-y-3">
           <div className="space-y-1.5">
-            <span className="text-xs font-medium text-foreground-muted">Type</span>
+            <span className="text-xs font-medium leading-4 text-foreground">Type</span>
             <ToggleGroup
               type="single"
               value={variant}
@@ -3014,7 +2862,7 @@ function LockableValueFieldShowcase({
         <LockableValueField
           id={fullViewId}
           label={
-            <Label htmlFor={fullViewId} className="text-xs font-medium text-foreground-muted">
+            <Label htmlFor={fullViewId} className="text-xs font-medium leading-4 text-foreground">
               Label
               {showcaseRequired && <span className="ml-0.5 text-destructive">*</span>}
             </Label>
@@ -3053,7 +2901,7 @@ function LockableValueFieldShowcase({
           <LockableValueField
             id={compactViewId}
             label={
-              <Label htmlFor={compactViewId} className="text-xs font-medium text-foreground-muted">
+              <Label htmlFor={compactViewId} className="text-xs font-medium leading-4 text-foreground">
                 Label
                 {showcaseRequired && <span className="ml-0.5 text-destructive">*</span>}
               </Label>
@@ -3546,22 +3394,6 @@ function QuickFormStory() {
   );
 }
 
-export const InlineEditing: Story = {
-  name: 'Inline Editing',
-  render: () => <InlineEditingStory />,
-};
-
-export const Output: Story = {
-  name: 'Input / Output',
-  render: () => <InputOutputStory />,
-  parameters: { layout: 'fullscreen' },
-};
-
-export const QuickForm: Story = {
-  name: 'Form HITL',
-  render: () => <QuickFormStory />,
-};
-
 // ============================================================================
 // Inline Editing
 // Title and description in the node identity row are directly editable.
@@ -3882,6 +3714,18 @@ function InventorySubContainer({
 function PanelUIInventoryStory() {
   const [enabled, setEnabled] = useState(true);
   const [checked, setChecked] = useState(true);
+  const compositionFieldId = useId();
+  const [compositionValue, setCompositionValue] = useState('invoice.total');
+  const [compositionLocked, setCompositionLocked] = useState(true);
+  const [compositionMode, setCompositionMode] = useState<LockableValueFieldMode>('fixed');
+  const [compositionFieldType, setCompositionFieldType] =
+    useState<LockableFieldType>('string');
+  const [compositionRequired, setCompositionRequired] = useState(true);
+  const [compositionEditor, setCompositionEditor] = useState('ui');
+  const [compositionFields, setCompositionFields] = useState([
+    { id: 1, label: 'Invoice number' },
+    { id: 2, label: 'Approved amount' },
+  ]);
   const allInventorySections = ['text-fields', 'choices', 'collapsed'];
   const allSubContainerSections = ['text-fields', 'choices', 'advanced'];
   const [expandedSections, setExpandedSections] = useState<string[]>([]);
@@ -3901,6 +3745,12 @@ function PanelUIInventoryStory() {
     setExpandedSubContainerSections(allSubContainerSections);
   };
 
+  const updateCompositionFieldType = (fieldType: LockableFieldType) => {
+    setCompositionFieldType(fieldType);
+    setCompositionValue('');
+    if (!FIELD_TYPE_META[fieldType].supportsExpression) setCompositionMode('fixed');
+  };
+
   return (
     <>
       <PanelFrame>
@@ -3914,14 +3764,14 @@ function PanelUIInventoryStory() {
         onClose={() => {}}
         className="h-[720px]"
       >
-        <Tabs defaultValue="fields" className="flex h-full min-h-0 flex-col">
+        <Tabs defaultValue="layout" className="flex h-full min-h-0 flex-col">
           <div className="flex shrink-0 items-center gap-2 border-b border-border-subtle px-3.5 py-3">
             <ScrollableTabsList
               className={cn(TAB_LIST_CLASS, 'min-w-0 flex-1')}
               scrollButtonClassName="size-6 hover:bg-surface-overlay"
             >
-              <TabsTrigger value="fields" className={TAB_TRIGGER_CLASS}>
-                Form fields
+              <TabsTrigger value="layout" className={TAB_TRIGGER_CLASS}>
+                Layout
               </TabsTrigger>
               <TabsTrigger value="states" className={TAB_TRIGGER_CLASS}>
                 States
@@ -3943,7 +3793,7 @@ function PanelUIInventoryStory() {
             </Button>
           </div>
 
-          <TabsContent value="fields" className="mt-0 min-h-0 flex-1 overflow-y-auto">
+          <TabsContent value="layout" className="mt-0 min-h-0 flex-1 overflow-y-auto">
             <div className="grid gap-4 px-3.5 py-5">
               <PatternNote title="Flat content">
                 A simple, always-visible layout for short configurations that do not need
@@ -4100,6 +3950,134 @@ function PanelUIInventoryStory() {
                 expandedSections={expandedSubContainerSections}
                 onExpandedSectionsChange={setExpandedSubContainerSections}
               />
+            </div>
+            <div className="grid gap-5 border-t border-border-subtle px-3.5 py-5">
+              <section className="grid gap-3">
+                <PatternNote title="Lockable value field" eyebrow="Composition pattern">
+                  Combines field type, required state, AI assistance, variable insertion, and
+                  fixed or expression values in one reusable Flow control.
+                </PatternNote>
+                <LockableValueField
+                  id={compositionFieldId}
+                  label={
+                    <Label
+                      htmlFor={compositionFieldId}
+                      className="text-xs font-medium leading-4 text-foreground"
+                    >
+                      Invoice value
+                      {compositionRequired && <span className="ml-0.5 text-destructive">*</span>}
+                    </Label>
+                  }
+                  headerActions={
+                    <CanvasTooltip content="Remove field">
+                      <Button variant="ghost" size="4xs" icon aria-label="Remove field">
+                        <X size={14} />
+                      </Button>
+                    </CanvasTooltip>
+                  }
+                  value={compositionValue}
+                  onValueChange={setCompositionValue}
+                  locked={compositionLocked}
+                  onLockedChange={setCompositionLocked}
+                  mode={compositionMode}
+                  onModeChange={setCompositionMode}
+                  fieldType={compositionFieldType}
+                  onFieldTypeChange={updateCompositionFieldType}
+                  required={compositionRequired}
+                  onRequiredChange={setCompositionRequired}
+                  controlsVisibility="visible"
+                />
+              </section>
+
+              <section className="grid gap-3 border-t border-border-subtle pt-5">
+                <PatternNote title="Repeatable field list" eyebrow="Composition pattern">
+                  Use reorder, add, and remove controls when users build a variable-length set of
+                  related fields.
+                </PatternNote>
+                <div className="grid gap-2">
+                  {compositionFields.map((field) => (
+                    <div
+                      key={field.id}
+                      className="flex items-center gap-2 rounded-lg border border-border-subtle bg-surface-raised p-2"
+                    >
+                      <button
+                        type="button"
+                        aria-label={`Drag ${field.label} to reorder`}
+                        title="Drag to reorder"
+                        className="grid size-6 shrink-0 place-items-center rounded text-foreground-subtle transition hover:bg-surface-overlay hover:text-foreground [cursor:grab]"
+                      >
+                        <GripVertical size={13} />
+                      </button>
+                      <span className="min-w-0 flex-1 truncate text-xs font-medium text-foreground">
+                        {field.label}
+                      </span>
+                      <CanvasTooltip content={`Delete ${field.label}`}>
+                        <Button
+                          variant="ghost"
+                          size="4xs"
+                          icon
+                          aria-label={`Delete ${field.label}`}
+                          onClick={() =>
+                            setCompositionFields((fields) =>
+                              fields.filter((item) => item.id !== field.id)
+                            )
+                          }
+                        >
+                          <Trash2 size={13} />
+                        </Button>
+                      </CanvasTooltip>
+                    </div>
+                  ))}
+                  <Button
+                    variant="ghost"
+                    className="justify-start text-brand hover:text-brand-hover"
+                    onClick={() =>
+                      setCompositionFields((fields) => [
+                        ...fields,
+                        {
+                          id: Math.max(0, ...fields.map((field) => field.id)) + 1,
+                          label: `New field ${fields.length + 1}`,
+                        },
+                      ])
+                    }
+                  >
+                    <Plus size={13} />
+                    Add field
+                  </Button>
+                </div>
+              </section>
+
+              <section className="grid gap-3 border-t border-border-subtle pt-5">
+                <PatternNote title="Editing modes" eyebrow="Composition pattern">
+                  Switch between a guided interface and a source representation without changing
+                  the underlying configuration.
+                </PatternNote>
+                <ToggleGroup
+                  type="single"
+                  value={compositionEditor}
+                  onValueChange={(value) => value && setCompositionEditor(value)}
+                  className="w-fit"
+                >
+                  <ToggleGroupItem value="ui" className="px-3 text-xs">
+                    UI
+                  </ToggleGroupItem>
+                  <ToggleGroupItem value="json" className="px-3 text-xs">
+                    JSON
+                  </ToggleGroupItem>
+                </ToggleGroup>
+                {compositionEditor === 'ui' ? (
+                  <InventoryField label="Form title">
+                    <Input defaultValue="Quick approve" />
+                  </InventoryField>
+                ) : (
+                  <Textarea
+                    aria-label="JSON configuration"
+                    defaultValue={'{\n  "title": "Quick approve"\n}'}
+                    rows={4}
+                    className="font-mono text-xs"
+                  />
+                )}
+              </section>
             </div>
           </TabsContent>
 
@@ -4283,13 +4261,99 @@ function PanelUIInventoryStory() {
   );
 }
 
+export const InputOutput: IOStory = {
+  name: 'Input / Output 3 Column',
+  args: {
+    showExtractionTab: true,
+    readOnly: false,
+    inputData: 'schema-and-value',
+  },
+  argTypes: {
+    showExtractionTab: {
+      control: 'boolean',
+      description: 'Show the custom Extraction table tab on the Output panel.',
+    },
+    readOnly: {
+      control: 'boolean',
+      description: 'Force the Input and Output panels read-only.',
+    },
+    inputData: {
+      control: 'select',
+      options: ['schema-and-value', 'schema-only', 'value-only'],
+      description:
+        'Input panel data: schema and value, schema only (all rows unset), or value only (no schema).',
+    },
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: `
+\`NodeIOView\` is the composed node input/output panel body used in the flow
+builder: a schema-aware value tree with Schema / JSON tabs, inline editing,
+custom value cells, and consumer-provided extra tabs. It is a panel *body*,
+composed inside \`NodePropertyPanel\`, which owns the chrome.
+
+This story pieces together the three panels a user sees while working a
+**Document Extraction** node (**Input**, **Properties**, **Output**) to show
+how they read as a set. Input is driven by upstream execution data; Properties
+is a standard \`MetadataForm\` (with a file field); Output is a believable
+extraction result with an optional custom **Extraction** table tab (toggle it
+with the control below). Switch the Output mode to **Static** to edit the
+mocked output inline.
+
+File rows (e.g. the source **document**) surface their affordances as custom
+**row actions** via \`nodeActions\`: **Upload** is always offered, while
+**Preview** and **Delete** appear only once a file is present, with the
+built-in copy/wrap actions omitted for those rows. Preview opens a banner atop
+the panel; Upload mock-populates a file.
+
+Use the controls to force read-only mode or swap the Input panel's data:
+schema only renders every row as unset, value only drops the schema. The
+Input toolbar's filter narrows the tree to fields referenced by this node.
+
+The three panels sit in a resizable split: drag a handle between them to grow
+one panel and shrink its neighbor, testing how the tree rows behave at
+different widths (truncation, action-button visibility).
+        `,
+      },
+    },
+  },
+  render: (args) => (
+    <div className="h-180 w-full max-w-350">
+      {/* Split-pane docked panels: drag a handle to grow one panel and shrink
+            its neighbor in tandem, exercising the width-sensitive tree layout. */}
+      <ResizablePanelGroup
+        orientation="horizontal"
+        className="overflow-hidden rounded-2xl border border-border-subtle shadow-lg"
+      >
+        <ResizablePanel defaultSize="33%" minSize="15%">
+          {/* Keyed so switching the data variant remounts with fresh edit state. */}
+          <InputPanel
+            key={args.inputData}
+            readOnly={args.readOnly}
+            {...INPUT_DATA[args.inputData]}
+          />
+        </ResizablePanel>
+        <ResizableHandle withHandle />
+        <ResizablePanel defaultSize="34%" minSize="15%">
+          <PropertiesPanel />
+        </ResizablePanel>
+        <ResizableHandle withHandle />
+        <ResizablePanel defaultSize="33%" minSize="15%">
+          <OutputPanel showExtractionTab={args.showExtractionTab} readOnly={args.readOnly} />
+        </ResizablePanel>
+      </ResizablePanelGroup>
+    </div>
+  ),
+};
+
 export const PanelUIInventory: Story = {
-  name: 'Panel UI Inventory',
+  name: 'UI Inventory',
   render: () => <PanelUIInventoryStory />,
 };
 
 export const AlertsAndErrors: Story = {
-  name: 'Alerts and Errors',
+  name: 'UI Alerts and Errors',
   render: () => <AlertsAndErrorsStory />,
 };
 
@@ -4340,7 +4404,7 @@ function CompactResponsivePanelStory() {
             <TabsContent
               key={step.id}
               value={step.id}
-              className="mt-0 min-h-0 flex-1 overflow-y-auto [&_label]:text-foreground-muted"
+              className="mt-0 min-h-0 flex-1 overflow-y-auto [&_[data-slot=form-description]]:text-xs [&_[data-slot=form-description]]:leading-4 [&_[data-slot=form-description]]:text-foreground-muted [&_[data-slot=form-label]]:text-xs [&_[data-slot=form-label]]:font-medium [&_[data-slot=form-label]]:leading-4 [&_[data-slot=form-label]]:text-foreground"
             >
               <MetadataForm
                 schema={flatSchema}
@@ -4355,7 +4419,7 @@ function CompactResponsivePanelStory() {
 }
 
 export const Responsive: Story = {
-  name: 'Responsive',
+  name: 'UI Responsive',
   render: () => (
     <div className="flex items-start gap-[80px]">
       <div className="flex flex-col gap-3">
@@ -5096,89 +5160,3 @@ interface StoryArgs {
 }
 
 type IOStory = StoryObj<StoryArgs>;
-
-export const InputOutput: IOStory = {
-  name: 'Input / Output',
-  args: {
-    showExtractionTab: true,
-    readOnly: false,
-    inputData: 'schema-and-value',
-  },
-  argTypes: {
-    showExtractionTab: {
-      control: 'boolean',
-      description: 'Show the custom Extraction table tab on the Output panel.',
-    },
-    readOnly: {
-      control: 'boolean',
-      description: 'Force the Input and Output panels read-only.',
-    },
-    inputData: {
-      control: 'select',
-      options: Object.keys(INPUT_DATA),
-      description:
-        'Input panel data: schema and value, schema only (all rows unset), or value only (no schema).',
-    },
-  },
-  parameters: {
-    docs: {
-      description: {
-        story: `
-\`NodeIOView\` is the composed node input/output panel body used in the flow
-builder: a schema-aware value tree with Schema / JSON tabs, inline editing,
-custom value cells, and consumer-provided extra tabs. It is a panel *body*,
-composed inside \`NodePropertyPanel\`, which owns the chrome.
-
-This story pieces together the three panels a user sees while working a
-**Document Extraction** node (**Input**, **Properties**, **Output**) to show
-how they read as a set. Input is driven by upstream execution data; Properties
-is a standard \`MetadataForm\` (with a file field); Output is a believable
-extraction result with an optional custom **Extraction** table tab (toggle it
-with the control below). Switch the Output mode to **Static** to edit the
-mocked output inline.
-
-File rows (e.g. the source **document**) surface their affordances as custom
-**row actions** via \`nodeActions\`: **Upload** is always offered, while
-**Preview** and **Delete** appear only once a file is present, with the
-built-in copy/wrap actions omitted for those rows. Preview opens a banner atop
-the panel; Upload mock-populates a file.
-
-Use the controls to force read-only mode or swap the Input panel's data:
-schema only renders every row as unset, value only drops the schema. The
-Input toolbar's filter narrows the tree to fields referenced by this node.
-
-The three panels sit in a resizable split: drag a handle between them to grow
-one panel and shrink its neighbor, testing how the tree rows behave at
-different widths (truncation, action-button visibility).
-        `,
-      },
-    },
-  },
-  render: (args) => (
-    <div className="h-180 w-full max-w-350">
-      {/* Split-pane docked panels: drag a handle to grow one panel and shrink
-            its neighbor in tandem, exercising the width-sensitive tree layout. */}
-      <ResizablePanelGroup
-        orientation="horizontal"
-        className="overflow-hidden rounded-2xl border border-border-subtle shadow-lg"
-      >
-        <ResizablePanel defaultSize="33%" minSize="15%">
-          {/* Keyed so switching the data variant remounts with fresh edit state. */}
-          <InputPanel
-            key={args.inputData}
-            readOnly={args.readOnly}
-            {...INPUT_DATA[args.inputData]}
-          />
-        </ResizablePanel>
-        <ResizableHandle withHandle />
-        <ResizablePanel defaultSize="34%" minSize="15%">
-          <PropertiesPanel />
-        </ResizablePanel>
-        <ResizableHandle withHandle />
-        <ResizablePanel defaultSize="33%" minSize="15%">
-          <OutputPanel showExtractionTab={args.showExtractionTab} readOnly={args.readOnly} />
-        </ResizablePanel>
-      </ResizablePanelGroup>
-    </div>
-  ),
-};

--- a/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.stories.tsx
@@ -22,10 +22,18 @@ import type { EditorProps } from '@monaco-editor/react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import type { FormSchema, LockableFieldType, LockableValueFieldMode } from '@uipath/apollo-wind';
 import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+  Alert,
+  AlertDescription,
+  AlertTitle,
   Badge,
   Button,
   Card,
   CardContent,
+  Checkbox,
   cn,
   DropdownMenu,
   DropdownMenuContent,
@@ -46,7 +54,15 @@ import {
   ResizableHandle,
   ResizablePanel,
   ResizablePanelGroup,
+  RadioGroup,
+  RadioGroupItem,
   ScrollableTabsList,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Slider,
   Switch,
   Tabs,
   TabsContent,
@@ -3599,6 +3615,510 @@ function InlineEditingStory() {
     </PanelFrame>
   );
 }
+
+export const InlineEditing: Story = {
+  name: 'Inline Editing',
+  render: () => <InlineEditingStory />,
+};
+
+// ============================================================================
+// Panel UI Inventory
+// Interactive reference of common controls and layout patterns used in panels.
+// ============================================================================
+
+function InventoryField({
+  label,
+  description,
+  children,
+}: {
+  label: string;
+  description?: string;
+  children: ReactNode;
+}) {
+  return (
+    <div className="grid gap-1.5">
+      <Label className="text-xs font-medium text-foreground">{label}</Label>
+      {children}
+      {description && <p className="text-xs leading-4 text-foreground-muted">{description}</p>}
+    </div>
+  );
+}
+
+function PatternNote({ title, children }: { title: string; children: ReactNode }) {
+  const [dismissed, setDismissed] = useState(false);
+
+  if (dismissed) return null;
+
+  return (
+    <aside className="rounded-lg border border-border-subtle bg-surface-overlay p-3">
+      <div className="flex items-start justify-between gap-3">
+        <p className="pt-0.5 text-[10px] font-semibold uppercase tracking-[0.08em] text-brand">
+          Layout pattern
+        </p>
+        <Button
+          variant="ghost"
+          size="4xs"
+          icon
+          onClick={() => setDismissed(true)}
+          aria-label={`Dismiss ${title} note`}
+          title="Dismiss note"
+          className="-mr-1 -mt-1 shrink-0 text-foreground-subtle hover:bg-surface-raised hover:text-foreground"
+        >
+          <X size={12} />
+        </Button>
+      </div>
+      <h3 className="mt-1 text-sm font-semibold text-foreground">{title}</h3>
+      <p className="mt-1 text-xs leading-4 text-foreground-muted">{children}</p>
+    </aside>
+  );
+}
+
+function InventorySubContainer({
+  expandedSections,
+  onExpandedSectionsChange,
+}: {
+  expandedSections: string[];
+  onExpandedSectionsChange: (sections: string[]) => void;
+}) {
+  const [enabled, setEnabled] = useState(true);
+  const [checked, setChecked] = useState(true);
+  const toggleSection = (section: string) => {
+    onExpandedSectionsChange(
+      expandedSections.includes(section)
+        ? expandedSections.filter((value) => value !== section)
+        : [...expandedSections, section]
+    );
+  };
+
+  return (
+    <div className="grid gap-3">
+      <div className="overflow-hidden rounded-xl border border-border-subtle">
+        <button
+          type="button"
+          onClick={() => toggleSection('text-fields')}
+          aria-expanded={expandedSections.includes('text-fields')}
+          className="flex w-full items-center gap-2 px-3 py-2.5 text-left transition hover:bg-surface-overlay"
+        >
+          <ChevronDown
+            size={12}
+            className={cn(
+              'shrink-0 text-foreground-subtle transition-transform duration-150',
+              !expandedSections.includes('text-fields') && '-rotate-90'
+            )}
+          />
+          <span className="min-w-0 flex-1 text-xs font-medium text-foreground">
+            Text and numeric fields
+          </span>
+        </button>
+
+        {expandedSections.includes('text-fields') && (
+          <div className="border-t border-border-subtle">
+            <section className="grid gap-4 px-3 py-4">
+              <InventoryField label="Display name">
+                <Input defaultValue="Invoice extraction" />
+              </InventoryField>
+              <InventoryField label="Instructions">
+                <Textarea defaultValue="Extract the invoice number and total." rows={3} />
+              </InventoryField>
+              <InventoryField label="Retries">
+                <Input type="number" defaultValue="3" min="0" />
+              </InventoryField>
+              <InventoryField label="System identifier">
+                <Input value="invoice-extraction-01" readOnly disabled />
+              </InventoryField>
+            </section>
+          </div>
+        )}
+      </div>
+
+      <div className="overflow-hidden rounded-xl border border-border-subtle">
+        <button
+          type="button"
+          onClick={() => toggleSection('choices')}
+          aria-expanded={expandedSections.includes('choices')}
+          className="flex w-full items-center gap-2 px-3 py-2.5 text-left transition hover:bg-surface-overlay"
+        >
+          <ChevronDown
+            size={12}
+            className={cn(
+              'shrink-0 text-foreground-subtle transition-transform duration-150',
+              !expandedSections.includes('choices') && '-rotate-90'
+            )}
+          />
+          <span className="min-w-0 flex-1 text-xs font-medium text-foreground">
+            Selection controls
+          </span>
+        </button>
+        {expandedSections.includes('choices') && (
+          <section className="grid gap-5 border-t border-border-subtle px-3 py-4">
+            <InventoryField label="Connection">
+              <Select defaultValue="production">
+                <SelectTrigger className="w-full">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="production">Production</SelectItem>
+                  <SelectItem value="staging">Staging</SelectItem>
+                </SelectContent>
+              </Select>
+            </InventoryField>
+            <InventoryField label="Processing mode">
+              <RadioGroup defaultValue="automatic" className="grid gap-2">
+                <Label className="flex items-center gap-2 font-normal">
+                  <RadioGroupItem value="automatic" />
+                  Automatic
+                </Label>
+                <Label className="flex items-center gap-2 font-normal">
+                  <RadioGroupItem value="manual" />
+                  Manual review
+                </Label>
+              </RadioGroup>
+            </InventoryField>
+            <div className="flex items-start gap-2">
+              <Checkbox
+                id="sub-container-save-output"
+                checked={checked}
+                onCheckedChange={(value) => setChecked(value === true)}
+              />
+              <Label htmlFor="sub-container-save-output" className="text-xs">
+                Save output for later steps
+              </Label>
+            </div>
+            <div className="flex items-center justify-between gap-4">
+              <Label htmlFor="sub-container-enabled" className="text-xs">
+                Enabled
+              </Label>
+              <Switch
+                id="sub-container-enabled"
+                checked={enabled}
+                onCheckedChange={setEnabled}
+              />
+            </div>
+            <InventoryField label="Confidence threshold" description="Current value: 75%">
+              <Slider defaultValue={[75]} max={100} step={5} />
+            </InventoryField>
+          </section>
+        )}
+      </div>
+
+      <div className="overflow-hidden rounded-xl border border-border-subtle">
+        <button
+          type="button"
+          onClick={() => toggleSection('advanced')}
+          aria-expanded={expandedSections.includes('advanced')}
+          className="flex w-full items-center gap-2 px-3 py-2.5 text-left transition hover:bg-surface-overlay"
+        >
+          <ChevronDown
+            size={12}
+            className={cn(
+              'shrink-0 text-foreground-subtle transition-transform duration-150',
+              !expandedSections.includes('advanced') && '-rotate-90'
+            )}
+          />
+          <span className="min-w-0 flex-1 text-xs font-medium text-foreground">
+            Advanced options
+          </span>
+        </button>
+        {expandedSections.includes('advanced') && (
+          <section className="grid gap-4 border-t border-border-subtle px-3 py-4">
+            <Alert>
+              <CircleCheck />
+              <AlertTitle>Configuration is valid</AlertTitle>
+              <AlertDescription>All required values are ready.</AlertDescription>
+            </Alert>
+            <InventoryField label="Field with validation" description="Use a unique name.">
+              <Input
+                defaultValue="Existing configuration"
+                aria-invalid="true"
+                className="border-destructive"
+              />
+            </InventoryField>
+            <div className="flex flex-wrap gap-2">
+              <Badge>Active</Badge>
+              <Badge variant="outline">Optional</Badge>
+            </div>
+            <div className="flex justify-end gap-2 border-t border-border-subtle pt-4">
+              <Button variant="ghost">Cancel</Button>
+              <Button variant="outline">Test</Button>
+              <Button>Save</Button>
+            </div>
+          </section>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function PanelUIInventoryStory() {
+  const [enabled, setEnabled] = useState(true);
+  const [checked, setChecked] = useState(true);
+  const allInventorySections = ['text-fields', 'choices', 'collapsed'];
+  const allSubContainerSections = ['text-fields', 'choices', 'advanced'];
+  const [expandedSections, setExpandedSections] = useState(allInventorySections);
+  const [expandedSubContainerSections, setExpandedSubContainerSections] = useState(
+    allSubContainerSections
+  );
+  const allSectionsExpanded =
+    expandedSections.length === allInventorySections.length &&
+    expandedSubContainerSections.length === allSubContainerSections.length;
+
+  const toggleAllSections = () => {
+    if (allSectionsExpanded) {
+      setExpandedSections([]);
+      setExpandedSubContainerSections([]);
+      return;
+    }
+
+    setExpandedSections(allInventorySections);
+    setExpandedSubContainerSections(allSubContainerSections);
+  };
+
+  return (
+    <PanelFrame>
+      <NodePropertyPanel
+        panelTitle="Properties"
+        nodeIcon={<Sparkles />}
+        nodeLabel="UI element inventory"
+        nodeCategory="Panel reference"
+        action={<RunButton />}
+        contentInset="0.875rem"
+        onClose={() => {}}
+        className="h-[720px]"
+      >
+        <Tabs defaultValue="fields" className="flex h-full min-h-0 flex-col">
+          <div className="flex shrink-0 items-center gap-2 border-b border-border-subtle px-3.5 py-3">
+            <ScrollableTabsList
+              className={cn(TAB_LIST_CLASS, 'min-w-0 flex-1')}
+              scrollButtonClassName="size-6 hover:bg-surface-overlay"
+            >
+              <TabsTrigger value="fields" className={TAB_TRIGGER_CLASS}>
+                Form fields
+              </TabsTrigger>
+              <TabsTrigger value="states" className={TAB_TRIGGER_CLASS}>
+                States
+              </TabsTrigger>
+              <TabsTrigger value="actions" className={TAB_TRIGGER_CLASS}>
+                Actions
+              </TabsTrigger>
+            </ScrollableTabsList>
+            <Button
+              variant="ghost"
+              size="4xs"
+              icon
+              onClick={toggleAllSections}
+              aria-label={allSectionsExpanded ? 'Collapse all sections' : 'Expand all sections'}
+              title={allSectionsExpanded ? 'Collapse all sections' : 'Expand all sections'}
+              className="shrink-0 text-foreground-subtle hover:bg-surface-overlay hover:text-foreground"
+            >
+              <ChevronsUpDown size={13} />
+            </Button>
+          </div>
+
+          <TabsContent value="fields" className="mt-0 min-h-0 flex-1 overflow-y-auto">
+            <div className="px-3.5 pt-5">
+              <PatternNote title="Expandable sections">
+                Full-width sections that reveal or hide related fields without adding nested
+                container chrome.
+              </PatternNote>
+            </div>
+            <Accordion
+              type="multiple"
+              value={expandedSections}
+              onValueChange={setExpandedSections}
+            >
+              <AccordionItem value="text-fields" className="border-border-subtle px-3.5">
+                <AccordionTrigger className="py-4 text-sm">Text and numeric fields</AccordionTrigger>
+                <AccordionContent className="grid gap-4 pb-5">
+                  <InventoryField label="Name" description="Short, single-line text input.">
+                    <Input defaultValue="Extract invoice data" />
+                  </InventoryField>
+                  <InventoryField label="Description">
+                    <Textarea
+                      defaultValue="Extract structured fields from incoming invoices."
+                      rows={3}
+                    />
+                  </InventoryField>
+                  <InventoryField label="Retry count">
+                    <Input type="number" defaultValue="3" min="0" />
+                  </InventoryField>
+                  <InventoryField label="Read-only value">
+                    <Input value="Generated by the system" readOnly disabled />
+                  </InventoryField>
+                </AccordionContent>
+              </AccordionItem>
+
+              <AccordionItem value="choices" className="border-border-subtle px-3.5">
+                <AccordionTrigger className="py-4 text-sm">Selection controls</AccordionTrigger>
+                <AccordionContent className="grid gap-5 pb-5">
+                  <InventoryField label="Connection">
+                    <Select defaultValue="production">
+                      <SelectTrigger className="w-full">
+                        <SelectValue placeholder="Choose a connection" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="production">Production</SelectItem>
+                        <SelectItem value="staging">Staging</SelectItem>
+                        <SelectItem value="development">Development</SelectItem>
+                      </SelectContent>
+                    </Select>
+                  </InventoryField>
+                  <InventoryField label="Processing mode">
+                    <RadioGroup defaultValue="automatic" className="grid gap-2">
+                      <Label className="flex items-center gap-2 font-normal">
+                        <RadioGroupItem value="automatic" />
+                        Automatic
+                      </Label>
+                      <Label className="flex items-center gap-2 font-normal">
+                        <RadioGroupItem value="manual" />
+                        Manual review
+                      </Label>
+                    </RadioGroup>
+                  </InventoryField>
+                  <div className="flex items-start gap-2">
+                    <Checkbox
+                      id="save-output"
+                      checked={checked}
+                      onCheckedChange={(value) => setChecked(value === true)}
+                    />
+                    <div className="grid gap-0.5">
+                      <Label htmlFor="save-output" className="text-xs">
+                        Save output to storage
+                      </Label>
+                      <p className="text-xs text-foreground-muted">
+                        Makes the result available to later steps.
+                      </p>
+                    </div>
+                  </div>
+                  <div className="flex items-center justify-between gap-4">
+                    <div>
+                      <Label htmlFor="enabled-switch" className="text-xs">
+                        Enabled
+                      </Label>
+                      <p className="text-xs text-foreground-muted">Run this node in the workflow.</p>
+                    </div>
+                    <Switch
+                      id="enabled-switch"
+                      checked={enabled}
+                      onCheckedChange={setEnabled}
+                    />
+                  </div>
+                  <InventoryField label="Confidence threshold" description="Current value: 75%">
+                    <Slider defaultValue={[75]} max={100} step={5} />
+                  </InventoryField>
+                </AccordionContent>
+              </AccordionItem>
+
+              <AccordionItem value="collapsed" className="border-border-subtle px-3.5">
+                <AccordionTrigger className="py-4 text-sm">Advanced options</AccordionTrigger>
+                <AccordionContent className="grid gap-4 pb-5">
+                  <InventoryField label="Internal identifier">
+                    <Input defaultValue="invoice-extractor-01" />
+                  </InventoryField>
+                </AccordionContent>
+              </AccordionItem>
+            </Accordion>
+            <div className="grid gap-3 border-t border-border-subtle px-3.5 py-5">
+              <PatternNote title="Sub-containers">
+                Dense, collapsible cards for related configuration when stronger visual grouping is
+                useful.
+              </PatternNote>
+              <InventorySubContainer
+                expandedSections={expandedSubContainerSections}
+                onExpandedSectionsChange={setExpandedSubContainerSections}
+              />
+            </div>
+            <div className="grid gap-4 border-t border-border-subtle px-3.5 py-5">
+              <PatternNote title="Flat content">
+                A simple, always-visible layout for short configurations that do not need
+                collapsible sections or nested containers.
+              </PatternNote>
+              <div className="grid gap-4">
+                <InventoryField label="Name" description="A field placed directly in the panel.">
+                  <Input defaultValue="Extract invoice data" />
+                </InventoryField>
+                <InventoryField label="Connection">
+                  <Select defaultValue="production">
+                    <SelectTrigger className="w-full">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="production">Production</SelectItem>
+                      <SelectItem value="staging">Staging</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </InventoryField>
+                <div className="flex items-center justify-between gap-4">
+                  <div>
+                    <Label htmlFor="flat-pattern-enabled" className="text-xs">
+                      Enabled
+                    </Label>
+                    <p className="text-xs text-foreground-muted">
+                      Run this node in the workflow.
+                    </p>
+                  </div>
+                  <Switch id="flat-pattern-enabled" defaultChecked />
+                </div>
+              </div>
+            </div>
+          </TabsContent>
+
+          <TabsContent value="states" className="mt-0 min-h-0 flex-1 overflow-y-auto p-3.5">
+            <div className="grid gap-4">
+              <div className="flex flex-wrap gap-2">
+                <Badge>Default</Badge>
+                <Badge variant="secondary">Optional</Badge>
+                <Badge variant="outline">Read only</Badge>
+              </div>
+              <Alert>
+                <CircleCheck />
+                <AlertTitle>Configuration is valid</AlertTitle>
+                <AlertDescription>All required fields have been completed.</AlertDescription>
+              </Alert>
+              <Alert variant="destructive">
+                <CircleAlert />
+                <AlertTitle>Connection required</AlertTitle>
+                <AlertDescription>Select a valid connection before running this node.</AlertDescription>
+              </Alert>
+              <InventoryField label="Field with validation" description="Use a unique node name.">
+                <Input
+                  defaultValue="Existing node"
+                  aria-invalid="true"
+                  className="border-destructive"
+                />
+              </InventoryField>
+            </div>
+          </TabsContent>
+
+          <TabsContent value="actions" className="mt-0 min-h-0 flex-1 overflow-y-auto p-3.5">
+            <div className="grid gap-5">
+              <div className="grid gap-2">
+                <Label className="text-xs">Button hierarchy</Label>
+                <div className="flex flex-wrap gap-2">
+                  <Button>Primary</Button>
+                  <Button variant="outline">Secondary</Button>
+                  <Button variant="ghost">Tertiary</Button>
+                  <Button variant="destructive">Delete</Button>
+                </div>
+              </div>
+              <div className="grid gap-2">
+                <Label className="text-xs">Footer pattern</Label>
+                <div className="flex justify-end gap-2 border-t border-border-subtle pt-4">
+                  <Button variant="ghost">Cancel</Button>
+                  <Button>Save changes</Button>
+                </div>
+              </div>
+            </div>
+          </TabsContent>
+        </Tabs>
+      </NodePropertyPanel>
+    </PanelFrame>
+  );
+}
+
+export const PanelUIInventory: Story = {
+  name: 'Panel UI Inventory',
+  render: () => <PanelUIInventoryStory />,
+};
 
 export const AlertsAndErrors: Story = {
   name: 'Alerts and Errors',

--- a/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.stories.tsx
@@ -38,7 +38,6 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
-  DropdownMenuSeparator,
   DropdownMenuTrigger,
   FIELD_TYPE_META,
   HoverCard,
@@ -97,12 +96,14 @@ import {
   Code2,
   Copy,
   Eye,
+  EyeOff,
   File,
   FileBracesCorner,
   GitFork,
   Globe,
   GripVertical,
   HardDrive,
+  Info,
   Pencil,
   Play,
   Plus,
@@ -111,13 +112,25 @@ import {
   RefreshCw,
   Sparkles,
   Trash2,
+  TriangleAlert,
   Upload,
   UserRoundCheck,
   X,
   Zap,
 } from 'lucide-react';
 import type { CSSProperties, ReactNode } from 'react';
-import { lazy, Suspense, useCallback, useEffect, useId, useMemo, useRef, useState } from 'react';
+import {
+  createContext,
+  lazy,
+  Suspense,
+  useCallback,
+  useContext,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import { createPortal } from 'react-dom';
 import { NodeOutputModeSelect } from '../../controls';
 import type {
@@ -456,6 +469,16 @@ const TAB_TRIGGER_CLASS =
 // ============================================================================
 // Stories — NodePropertyPanel
 // ============================================================================
+
+export const PanelUIInventory: Story = {
+  name: 'UI Inventory',
+  render: () => <PanelUIInventoryStory />,
+};
+
+export const Responsive: Story = {
+  name: 'UI Responsive',
+  render: () => <ResponsiveStory />,
+};
 
 export const Default: Story = {
   name: 'Form Default',
@@ -906,51 +929,6 @@ function CasePanel({
   );
 }
 
-type CompactTabId = 'parameters' | 'error-handling' | 'advanced';
-
-const ALERT_ISSUES: Array<{
-  id: string;
-  tab: CompactTabId;
-  tabLabel: string;
-  field: string;
-  message: string;
-  action: string;
-}> = [
-  {
-    id: 'condition',
-    tab: 'parameters',
-    tabLabel: 'Parameters',
-    field: 'Case 1 condition',
-    message: 'Condition cannot be evaluated because the expression returns text.',
-    action: 'Return a boolean expression, for example input.status === "active".',
-  },
-  {
-    id: 'fallback',
-    tab: 'error-handling',
-    tabLabel: 'Error handling',
-    field: 'Fallback path',
-    message: 'No fallback path is configured for failed case evaluation.',
-    action: 'Choose a fallback branch or enable Default branch.',
-  },
-  {
-    id: 'timeout',
-    tab: 'advanced',
-    tabLabel: 'Advanced',
-    field: 'Timeout',
-    message: 'Retry duration exceeds the node timeout.',
-    action: 'Increase timeout to 60 seconds or reduce retries to 1.',
-  },
-];
-
-const ALERT_ISSUE_COUNT_BY_TAB = ALERT_ISSUES.reduce<Record<CompactTabId, number>>(
-  (acc, issue) => ({ ...acc, [issue.tab]: acc[issue.tab] + 1 }),
-  {
-    parameters: 0,
-    'error-handling': 0,
-    advanced: 0,
-  }
-);
-
 function TabLabelWithError({ label, count }: { label: string; count: number }) {
   return (
     <span className="inline-flex items-center gap-1.5">
@@ -997,6 +975,52 @@ function ErrorFieldBlock({
   );
 }
 
+function InfoFieldBlock({
+  title,
+  message,
+  action,
+}: {
+  title: string;
+  message: string;
+  action: string;
+}) {
+  return (
+    <div className="rounded-xl border border-info/30 bg-info-background/10 p-3">
+      <div className="flex items-start gap-2">
+        <Info size={14} className="mt-0.5 shrink-0 text-info" />
+        <div className="min-w-0 flex-1">
+          <p className="text-xs font-semibold text-foreground">{title}</p>
+          <p className="mt-1 text-xs leading-4 text-foreground-muted">{message}</p>
+          <p className="mt-1 text-xs leading-4 text-foreground-muted">{action}</p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function WarningFieldBlock({
+  title,
+  message,
+  action,
+}: {
+  title: string;
+  message: string;
+  action: string;
+}) {
+  return (
+    <div className="rounded-xl border border-warning/50 bg-warning-background/25 p-3">
+      <div className="flex items-start gap-2">
+        <TriangleAlert size={14} className="mt-0.5 shrink-0 text-warning" />
+        <div className="min-w-0 flex-1">
+          <p className="text-xs font-semibold text-foreground">{title}</p>
+          <p className="mt-1 text-xs leading-4 text-warning">{message}</p>
+          <p className="mt-1 text-xs leading-4 text-foreground-muted">{action}</p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 function SuccessFieldBlock({
   title,
   message,
@@ -1015,48 +1039,6 @@ function SuccessFieldBlock({
           <p className="mt-1 text-xs leading-4 text-success">{message}</p>
           <p className="mt-1 text-xs leading-4 text-foreground-muted">{action}</p>
         </div>
-      </div>
-    </div>
-  );
-}
-
-const ALERT_PATTERN_NOTES = [
-  {
-    title: 'Tab error count',
-    description: 'Marks each tab with the number of issues inside that section.',
-  },
-  {
-    title: 'Inline field error',
-    description: 'Places the message and next action directly under the invalid code editor.',
-  },
-  {
-    title: 'Section error block',
-    description:
-      'Explains tab-specific configuration problems when the field is not currently visible.',
-  },
-];
-
-function AlertPatternNoteCard() {
-  return (
-    <div className="w-[320px] rounded-xl border border-border-subtle bg-surface-overlay p-4 shadow-sm">
-      <div className="flex items-start gap-2">
-        <CircleAlert size={15} className="mt-0.5 shrink-0 text-error" />
-        <div className="min-w-0">
-          <h3 className="text-sm font-semibold text-foreground">Alert and error types included</h3>
-          <p className="mt-1 text-xs leading-4 text-foreground-muted">
-            The story combines tab-level cues with local, action-oriented messages.
-          </p>
-        </div>
-      </div>
-      <div className="mt-3 flex flex-col gap-2">
-        {ALERT_PATTERN_NOTES.map((note) => (
-          <div key={note.title} className="flex gap-2">
-            <span className="mt-1.5 size-1.5 shrink-0 rounded-full bg-error" />
-            <p className="text-xs leading-4 text-foreground-muted">
-              <span className="font-medium text-foreground">{note.title}:</span> {note.description}
-            </p>
-          </div>
-        ))}
       </div>
     </div>
   );
@@ -1219,197 +1201,6 @@ export const CompactEditor: Story = {
   name: 'Editor Compact',
   render: () => <CompactEditorStory />,
 };
-
-function AlertsAndErrorsStory() {
-  const monacoTheme = useMonacoTheme();
-  const [activeTab, setActiveTab] = useState<CompactTabId>('parameters');
-  const [cases, setCases] = useState([{ id: 1, title: 'Case 1' }]);
-  const nextIdRef = useRef(2);
-  const [defaultBranch, setDefaultBranch] = useState(false);
-  const [label, setLabel] = useState('Switch');
-  const [category, setCategory] = useState('Control');
-  const [editingLabel, setEditingLabel] = useState(false);
-  const [editingCategory, setEditingCategory] = useState(false);
-  const labelRef = useRef<HTMLInputElement>(null);
-  const categoryRef = useRef<HTMLInputElement>(null);
-
-  const addCase = () => {
-    const id = nextIdRef.current++;
-    setCases((prev) => [...prev, { id, title: `Case ${id}` }]);
-  };
-  const deleteCase = (id: number) => setCases((prev) => prev.filter((c) => c.id !== id));
-  const updateCaseTitle = (id: number, title: string) =>
-    setCases((prev) => prev.map((c) => (c.id === id ? { ...c, title } : c)));
-  const conditionIssue = ALERT_ISSUES.find((issue) => issue.id === 'condition');
-
-  return (
-    <div className="flex items-start gap-8">
-      <div className="flex w-[320px] shrink-0 flex-col gap-4">
-        <AlertPatternNoteCard />
-      </div>
-      <PanelFrame>
-        <NodePropertyPanel
-          panelTitle="Properties"
-          onClose={() => {}}
-          contentInset="0.875rem"
-          className="h-[760px]"
-        >
-          <div className="flex h-full flex-col">
-            <div className="flex shrink-0 items-center justify-between gap-4 py-4 [padding-inline:var(--mf-content-inset,0.875rem)]">
-              <div className="flex min-w-0 flex-1 items-center gap-3.5">
-                <div className="grid size-11 shrink-0 place-items-center rounded-xl bg-surface-overlay text-foreground-subtle [&>svg]:size-5">
-                  <GitFork />
-                </div>
-                <div className="flex min-w-0 flex-1 flex-col justify-center">
-                  {editingLabel ? (
-                    <input
-                      ref={labelRef}
-                      value={label}
-                      onChange={(e) => setLabel(e.target.value)}
-                      onBlur={() => setEditingLabel(false)}
-                      onKeyDown={(e) => {
-                        if (e.key === 'Enter' || e.key === 'Escape') setEditingLabel(false);
-                      }}
-                      className="w-full rounded bg-surface-overlay px-1.5 py-0.5 text-base font-semibold leading-5 tracking-[-0.3px] text-foreground outline-none ring-1 ring-brand"
-                      autoFocus
-                    />
-                  ) : (
-                    <button
-                      type="button"
-                      onClick={() => {
-                        setEditingLabel(true);
-                        setTimeout(() => labelRef.current?.select(), 0);
-                      }}
-                      className="truncate rounded px-1.5 py-0.5 text-left text-base font-semibold leading-5 tracking-[-0.3px] text-foreground transition hover:bg-surface-overlay"
-                    >
-                      {label}
-                    </button>
-                  )}
-                  {editingCategory ? (
-                    <input
-                      ref={categoryRef}
-                      value={category}
-                      onChange={(e) => setCategory(e.target.value)}
-                      onBlur={() => setEditingCategory(false)}
-                      onKeyDown={(e) => {
-                        if (e.key === 'Enter' || e.key === 'Escape') setEditingCategory(false);
-                      }}
-                      className="w-full rounded bg-surface-overlay px-1.5 py-0.5 text-xs leading-4 text-foreground outline-none ring-1 ring-brand"
-                      autoFocus
-                    />
-                  ) : (
-                    <button
-                      type="button"
-                      onClick={() => {
-                        setEditingCategory(true);
-                        setTimeout(() => categoryRef.current?.select(), 0);
-                      }}
-                      className="truncate rounded px-1.5 py-0.5 text-left text-xs leading-4 text-foreground-muted transition hover:bg-surface-overlay"
-                    >
-                      {category}
-                    </button>
-                  )}
-                </div>
-              </div>
-              <div className="shrink-0">
-                <DebugButton />
-              </div>
-            </div>
-
-            <Tabs
-              value={activeTab}
-              onValueChange={(value) => setActiveTab(value as CompactTabId)}
-              className="flex min-h-0 flex-1 flex-col"
-            >
-              <div className="shrink-0 pt-3 [padding-inline:var(--mf-content-inset,0.875rem)]">
-                <TabsList className={TAB_LIST_CLASS}>
-                  <TabsTrigger value="parameters" className={TAB_TRIGGER_CLASS}>
-                    <TabLabelWithError
-                      label="Parameters"
-                      count={ALERT_ISSUE_COUNT_BY_TAB.parameters}
-                    />
-                  </TabsTrigger>
-                  <TabsTrigger value="error-handling" className={TAB_TRIGGER_CLASS}>
-                    <TabLabelWithError
-                      label="Error handling"
-                      count={ALERT_ISSUE_COUNT_BY_TAB['error-handling']}
-                    />
-                  </TabsTrigger>
-                  <TabsTrigger value="advanced" className={TAB_TRIGGER_CLASS}>
-                    <TabLabelWithError label="Advanced" count={ALERT_ISSUE_COUNT_BY_TAB.advanced} />
-                  </TabsTrigger>
-                </TabsList>
-              </div>
-
-              <TabsContent value="parameters" className="mt-0 min-h-0 flex-1 overflow-auto">
-                <div className="py-2 [padding-inline:var(--mf-content-inset,0.875rem)]">
-                  <span className="text-xs font-medium leading-4 text-foreground">Cases</span>
-                </div>
-                <div className="flex flex-col gap-2 pb-1 [padding-inline:var(--mf-content-inset,0.875rem)]">
-                  {cases.map((c, i) => (
-                    <CasePanel
-                      key={c.id}
-                      caseTitle={c.title}
-                      onTitleChange={(title) => updateCaseTitle(c.id, title)}
-                      onDelete={() => deleteCase(c.id)}
-                      monacoTheme={monacoTheme}
-                      defaultExpanded={i === 0}
-                      defaultValue={i === 0 ? 'input.status' : ''}
-                      errorMessage={i === 0 ? conditionIssue?.message : undefined}
-                      errorAction={i === 0 ? conditionIssue?.action : undefined}
-                    />
-                  ))}
-                </div>
-                <button
-                  type="button"
-                  onClick={addCase}
-                  className="flex items-center gap-1.5 py-3 text-xs text-brand transition hover:text-brand-hover [padding-inline:var(--mf-content-inset,0.875rem)]"
-                >
-                  <Plus size={12} />
-                  Add case
-                </button>
-                <div className="flex items-center gap-2 py-3 [padding-inline:var(--mf-content-inset,0.875rem)]">
-                  <Switch size="sm" checked={defaultBranch} onCheckedChange={setDefaultBranch} />
-                  <span className="text-xs text-foreground-muted">Default branch</span>
-                </div>
-              </TabsContent>
-
-              <TabsContent value="error-handling" className="mt-0 min-h-0 flex-1 overflow-auto">
-                <div className="flex flex-col gap-3 py-3 [padding-inline:var(--mf-content-inset,0.875rem)]">
-                  <div className="flex flex-col gap-2">
-                    <span className="text-xs font-medium leading-4 text-foreground">
-                      Failure behavior
-                    </span>
-                    <ErrorFieldBlock
-                      title="Fallback path"
-                      message="No fallback path is configured for failed case evaluation."
-                      action="Choose a fallback branch or enable Default branch before running this node."
-                    />
-                  </div>
-                </div>
-              </TabsContent>
-
-              <TabsContent value="advanced" className="mt-0 min-h-0 flex-1 overflow-auto">
-                <div className="flex flex-col gap-3 py-3 [padding-inline:var(--mf-content-inset,0.875rem)]">
-                  <div className="flex flex-col gap-2">
-                    <span className="text-xs font-medium leading-4 text-foreground">
-                      Execution limits
-                    </span>
-                    <ErrorFieldBlock
-                      title="Timeout"
-                      message="Retry duration exceeds the node timeout."
-                      action="Increase timeout to 60 seconds or reduce retries to 1."
-                    />
-                  </div>
-                </div>
-              </TabsContent>
-            </Tabs>
-          </div>
-        </NodePropertyPanel>
-      </PanelFrame>
-    </div>
-  );
-}
 
 // ============================================================================
 // Input Editor
@@ -3402,87 +3193,6 @@ function QuickFormStory() {
 }
 
 // ============================================================================
-// Inline Editing
-// Title and description in the node identity row are directly editable.
-// ============================================================================
-
-function InlineEditingStory() {
-  const [name, setName] = useState('Policy check');
-  const [type, setType] = useState('AI Agent');
-  const [editingName, setEditingName] = useState(false);
-  const [editingType, setEditingType] = useState(false);
-  const nameRef = useRef<HTMLInputElement>(null);
-  const typeRef = useRef<HTMLInputElement>(null);
-
-  return (
-    <PanelFrame>
-      <NodePropertyPanel panelTitle="Properties" onClose={() => {}} contentInset="0.875rem">
-        {/* Node identity row — inline editable */}
-        <div className="flex shrink-0 items-center gap-3 py-4 [padding-inline:var(--mf-content-inset,0.875rem)]">
-          <div className="flex min-w-0 flex-1 flex-col gap-0.5">
-            {editingName ? (
-              <input
-                ref={nameRef}
-                value={name}
-                onChange={(e) => setName(e.target.value)}
-                onBlur={() => setEditingName(false)}
-                onKeyDown={(e) => {
-                  if (e.key === 'Enter' || e.key === 'Escape') setEditingName(false);
-                }}
-                className="w-full rounded bg-surface-overlay px-1.5 py-0.5 text-base font-semibold leading-5 tracking-[-0.4px] text-foreground outline-none ring-1 ring-brand"
-                autoFocus
-              />
-            ) : (
-              <button
-                type="button"
-                onClick={() => {
-                  setEditingName(true);
-                  setTimeout(() => nameRef.current?.select(), 0);
-                }}
-                className="truncate rounded px-1.5 py-0.5 text-left text-base font-semibold leading-5 tracking-[-0.4px] text-foreground transition hover:bg-surface-overlay"
-              >
-                {name}
-              </button>
-            )}
-            {editingType ? (
-              <input
-                ref={typeRef}
-                value={type}
-                onChange={(e) => setType(e.target.value)}
-                onBlur={() => setEditingType(false)}
-                onKeyDown={(e) => {
-                  if (e.key === 'Enter' || e.key === 'Escape') setEditingType(false);
-                }}
-                className="w-full rounded bg-surface-overlay px-1.5 py-0.5 text-sm leading-5 text-foreground outline-none ring-1 ring-brand"
-                autoFocus
-              />
-            ) : (
-              <button
-                type="button"
-                onClick={() => {
-                  setEditingType(true);
-                  setTimeout(() => typeRef.current?.select(), 0);
-                }}
-                className="truncate rounded px-1.5 py-0.5 text-left text-sm leading-5 text-foreground-muted transition hover:bg-surface-overlay"
-              >
-                {type}
-              </button>
-            )}
-          </div>
-          <button
-            type="button"
-            className="flex h-8 items-center gap-2 rounded-lg bg-brand px-4 text-sm font-semibold text-foreground-on-accent transition hover:bg-brand-hover"
-          >
-            <Play size={14} />
-            Run
-          </button>
-        </div>
-      </NodePropertyPanel>
-    </PanelFrame>
-  );
-}
-
-// ============================================================================
 // Panel UI Inventory
 // Interactive reference of common controls and layout patterns used in panels.
 // ============================================================================
@@ -3503,6 +3213,8 @@ function InventoryField({
   );
 }
 
+const PatternNotesVisibilityContext = createContext(true);
+
 function PatternNote({
   title,
   eyebrow = 'Layout pattern',
@@ -3513,8 +3225,9 @@ function PatternNote({
   children: ReactNode;
 }) {
   const [dismissed, setDismissed] = useState(false);
+  const notesVisible = useContext(PatternNotesVisibilityContext);
 
-  if (dismissed) return null;
+  if (dismissed || !notesVisible) return null;
 
   return (
     <aside className="rounded-lg border border-border-subtle bg-surface-overlay p-3">
@@ -3716,9 +3429,71 @@ function InventorySubContainer({
   );
 }
 
+type CompositionFieldItem = { id: number; label: string };
+
+function SortableCompositionField({
+  field,
+  onDelete,
+}: {
+  field: CompositionFieldItem;
+  onDelete: () => void;
+}) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: field.id,
+  });
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={{ transform: CSS.Transform.toString(transform), transition }}
+      className={cn(
+        'flex items-center gap-2 rounded-lg border border-border-subtle bg-surface-raised p-2',
+        isDragging && 'opacity-30'
+      )}
+    >
+      <button
+        type="button"
+        aria-label={`Drag ${field.label} to reorder`}
+        title="Drag to reorder"
+        className="grid size-6 shrink-0 place-items-center rounded text-foreground-subtle transition hover:bg-surface-overlay hover:text-foreground [cursor:grab] active:[cursor:grabbing]"
+        {...attributes}
+        {...listeners}
+      >
+        <GripVertical size={13} />
+      </button>
+      <span className="min-w-0 flex-1 truncate text-xs font-medium text-foreground">
+        {field.label}
+      </span>
+      <CanvasTooltip content={`Delete ${field.label}`}>
+        <Button
+          variant="ghost"
+          size="4xs"
+          icon
+          aria-label={`Delete ${field.label}`}
+          onClick={onDelete}
+        >
+          <Trash2 size={13} />
+        </Button>
+      </CanvasTooltip>
+    </div>
+  );
+}
+
+function CompositionFieldDragOverlay({ field }: { field: CompositionFieldItem }) {
+  return (
+    <div className="flex items-center gap-2 rounded-lg border border-border-subtle bg-surface-raised p-2 shadow-lg [cursor:grabbing]">
+      <GripVertical size={13} className="shrink-0 text-foreground-subtle" />
+      <span className="min-w-0 flex-1 truncate text-xs font-medium text-foreground">
+        {field.label}
+      </span>
+    </div>
+  );
+}
+
 function PanelUIInventoryStory() {
   const [enabled, setEnabled] = useState(true);
   const [checked, setChecked] = useState(true);
+  const [notesVisible, setNotesVisible] = useState(true);
   const compositionFieldId = useId();
   const [compositionValue, setCompositionValue] = useState('invoice.total');
   const [compositionLocked, setCompositionLocked] = useState(true);
@@ -3731,6 +3506,14 @@ function PanelUIInventoryStory() {
     { id: 1, label: 'Invoice number' },
     { id: 2, label: 'Approved amount' },
   ]);
+  const compositionSensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 3 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
+  );
+  const [activeCompositionFieldId, setActiveCompositionFieldId] = useState<number | null>(null);
+  const activeCompositionField = compositionFields.find(
+    (field) => field.id === activeCompositionFieldId
+  );
   const allInventorySections = ['text-fields', 'choices', 'collapsed'];
   const allSubContainerSections = ['text-fields', 'choices', 'advanced'];
   const [expandedSections, setExpandedSections] = useState<string[]>([]);
@@ -3769,6 +3552,7 @@ function PanelUIInventoryStory() {
         onClose={() => {}}
         className="h-[720px]"
       >
+        <PatternNotesVisibilityContext.Provider value={notesVisible}>
         <Tabs defaultValue="layout" className="flex h-full min-h-0 flex-col">
           <div className="flex shrink-0 items-center gap-2 border-b border-border-subtle px-3.5 py-3">
             <ScrollableTabsList
@@ -3784,7 +3568,21 @@ function PanelUIInventoryStory() {
               <TabsTrigger value="actions" className={TAB_TRIGGER_CLASS}>
                 Actions
               </TabsTrigger>
+              <TabsTrigger value="composition" className={TAB_TRIGGER_CLASS}>
+                Composition
+              </TabsTrigger>
             </ScrollableTabsList>
+            <Button
+              variant="ghost"
+              size="4xs"
+              icon
+              onClick={() => setNotesVisible((visible) => !visible)}
+              aria-label={notesVisible ? 'Hide notes' : 'Show notes'}
+              title={notesVisible ? 'Hide notes' : 'Show notes'}
+              className="shrink-0 text-foreground-subtle hover:bg-surface-overlay hover:text-foreground"
+            >
+              {notesVisible ? <EyeOff size={13} /> : <Eye size={13} />}
+            </Button>
             <Button
               variant="ghost"
               size="4xs"
@@ -3832,7 +3630,7 @@ function PanelUIInventoryStory() {
                 </div>
               </div>
             </div>
-            <div className="border-t border-border-subtle px-3.5 pt-5">
+            <div className="border-t border-border-subtle px-3.5 has-[aside]:pt-5">
               <PatternNote title="Expandable sections">
                 Full-width sections that reveal or hide related fields without adding nested
                 container chrome.
@@ -3956,164 +3754,58 @@ function PanelUIInventoryStory() {
                 onExpandedSectionsChange={setExpandedSubContainerSections}
               />
             </div>
-            <div className="grid gap-5 border-t border-border-subtle px-3.5 py-5">
-              <section className="grid gap-3">
-                <PatternNote title="Lockable value field" eyebrow="Composition pattern">
-                  Combines field type, required state, AI assistance, variable insertion, and
-                  fixed or expression values in one reusable Flow control.
-                </PatternNote>
-                <LockableValueField
-                  id={compositionFieldId}
-                  label={
-                    <PanelFieldLabel
-                      htmlFor={compositionFieldId}
-                      required={compositionRequired}
-                      className="leading-4"
-                    >
-                      Invoice value
-                    </PanelFieldLabel>
-                  }
-                  headerActions={
-                    <CanvasTooltip content="Remove field">
-                      <Button variant="ghost" size="4xs" icon aria-label="Remove field">
-                        <X size={14} />
-                      </Button>
-                    </CanvasTooltip>
-                  }
-                  value={compositionValue}
-                  onValueChange={setCompositionValue}
-                  locked={compositionLocked}
-                  onLockedChange={setCompositionLocked}
-                  mode={compositionMode}
-                  onModeChange={setCompositionMode}
-                  fieldType={compositionFieldType}
-                  onFieldTypeChange={updateCompositionFieldType}
-                  required={compositionRequired}
-                  onRequiredChange={setCompositionRequired}
-                  controlsVisibility="visible"
-                />
-              </section>
-
-              <section className="grid gap-3 border-t border-border-subtle pt-5">
-                <PatternNote title="Repeatable field list" eyebrow="Composition pattern">
-                  Use reorder, add, and remove controls when users build a variable-length set of
-                  related fields.
-                </PatternNote>
-                <div className="grid gap-2">
-                  {compositionFields.map((field) => (
-                    <div
-                      key={field.id}
-                      className="flex items-center gap-2 rounded-lg border border-border-subtle bg-surface-raised p-2"
-                    >
-                      <button
-                        type="button"
-                        aria-label={`Drag ${field.label} to reorder`}
-                        title="Drag to reorder"
-                        className="grid size-6 shrink-0 place-items-center rounded text-foreground-subtle transition hover:bg-surface-overlay hover:text-foreground [cursor:grab]"
-                      >
-                        <GripVertical size={13} />
-                      </button>
-                      <span className="min-w-0 flex-1 truncate text-xs font-medium text-foreground">
-                        {field.label}
-                      </span>
-                      <CanvasTooltip content={`Delete ${field.label}`}>
-                        <Button
-                          variant="ghost"
-                          size="4xs"
-                          icon
-                          aria-label={`Delete ${field.label}`}
-                          onClick={() =>
-                            setCompositionFields((fields) =>
-                              fields.filter((item) => item.id !== field.id)
-                            )
-                          }
-                        >
-                          <Trash2 size={13} />
-                        </Button>
-                      </CanvasTooltip>
-                    </div>
-                  ))}
-                  <Button
-                    variant="ghost"
-                    className="justify-start text-brand hover:text-brand-hover"
-                    onClick={() =>
-                      setCompositionFields((fields) => [
-                        ...fields,
-                        {
-                          id: Math.max(0, ...fields.map((field) => field.id)) + 1,
-                          label: `New field ${fields.length + 1}`,
-                        },
-                      ])
-                    }
-                  >
-                    <Plus size={13} />
-                    Add field
-                  </Button>
-                </div>
-              </section>
-
-              <section className="grid gap-3 border-t border-border-subtle pt-5">
-                <PatternNote title="Editing modes" eyebrow="Composition pattern">
-                  Switch between a guided interface and a source representation without changing
-                  the underlying configuration.
-                </PatternNote>
-                <ToggleGroup
-                  type="single"
-                  value={compositionEditor}
-                  onValueChange={(value) => value && setCompositionEditor(value)}
-                  className="w-fit"
-                >
-                  <ToggleGroupItem value="ui" className="px-3 text-xs">
-                    UI
-                  </ToggleGroupItem>
-                  <ToggleGroupItem value="json" className="px-3 text-xs">
-                    JSON
-                  </ToggleGroupItem>
-                </ToggleGroup>
-                {compositionEditor === 'ui' ? (
-                  <InventoryField label="Form title">
-                    <Input defaultValue="Quick approve" />
-                  </InventoryField>
-                ) : (
-                  <Textarea
-                    aria-label="JSON configuration"
-                    defaultValue={'{\n  "title": "Quick approve"\n}'}
-                    rows={4}
-                    className="font-mono text-xs"
-                  />
-                )}
-              </section>
-            </div>
           </TabsContent>
 
           <TabsContent value="states" className="mt-0 min-h-0 flex-1 overflow-y-auto p-3.5">
             <div className="grid gap-5">
               <section className="grid gap-3">
-                <PatternNote title="Status labels" eyebrow="State pattern">
-                  Short labels communicate a field or setting state without interrupting the task.
-                </PatternNote>
-                <div className="flex flex-wrap gap-2">
-                  <Badge>Default</Badge>
-                  <Badge variant="secondary">Optional</Badge>
-                  <Badge variant="outline">Read only</Badge>
-                </div>
-              </section>
-
-              <section className="grid gap-3 border-t border-border-subtle pt-5">
                 <PatternNote title="Section messages" eyebrow="State pattern">
                   Persistent feedback summarizes a panel-level result and provides the next action
                   when one is needed.
                 </PatternNote>
+                <InfoFieldBlock
+                  title="Configuration guidance"
+                  message="This node uses the connection selected for the current folder."
+                  action="Change the folder context to use a different connection."
+                />
                 <SuccessFieldBlock
                   title="Configuration is valid"
                   message="All required fields have been completed."
                   action="This node is ready to run."
+                />
+                <WarningFieldBlock
+                  title="Review recommended"
+                  message="The request timeout is higher than the recommended value."
+                  action="Review the timeout before publishing this workflow."
                 />
                 <ErrorFieldBlock
                   title="Connection required"
                   message="No valid connection is configured for this node."
                   action="Select a connection before running this node."
                 />
+              </section>
+
+              <section className="grid gap-3 border-t border-border-subtle pt-5">
+                <PatternNote title="Navigation validation" eyebrow="State pattern">
+                  Error counts on tabs reveal where unresolved issues live, including problems in
+                  sections that are not currently visible.
+                </PatternNote>
+                <Tabs defaultValue="parameters">
+                  <ScrollableTabsList
+                    className={cn(TAB_LIST_CLASS, 'w-full')}
+                    scrollButtonClassName="size-6 hover:bg-surface-overlay"
+                  >
+                    <TabsTrigger value="parameters" className={TAB_TRIGGER_CLASS}>
+                      <TabLabelWithError label="Parameters" count={1} />
+                    </TabsTrigger>
+                    <TabsTrigger value="error-handling" className={TAB_TRIGGER_CLASS}>
+                      <TabLabelWithError label="Error handling" count={2} />
+                    </TabsTrigger>
+                    <TabsTrigger value="advanced" className={TAB_TRIGGER_CLASS}>
+                      Advanced
+                    </TabsTrigger>
+                  </ScrollableTabsList>
+                </Tabs>
               </section>
 
               <section className="grid gap-3 border-t border-border-subtle pt-5">
@@ -4129,7 +3821,7 @@ function PanelUIInventoryStory() {
                     <Input
                       defaultValue="Existing node"
                       aria-invalid="true"
-                      className="border-destructive"
+                      className="!border !border-error"
                     />
                     <InlineValidationMessage
                       message="This node name is already in use."
@@ -4185,6 +3877,18 @@ function PanelUIInventoryStory() {
                   >
                     Error
                   </Button>
+                </div>
+              </section>
+
+              <section className="grid gap-3 border-t border-border-subtle pt-5">
+                <PatternNote title="Status labels" eyebrow="State pattern">
+                  Short labels communicate passive field or setting states without interrupting
+                  the task.
+                </PatternNote>
+                <div className="flex flex-wrap gap-2">
+                  <Badge>Default</Badge>
+                  <Badge variant="secondary">Optional</Badge>
+                  <Badge variant="outline">Read only</Badge>
                 </div>
               </section>
             </div>
@@ -4258,7 +3962,150 @@ function PanelUIInventoryStory() {
               </section>
             </div>
           </TabsContent>
+
+          <TabsContent value="composition" className="mt-0 min-h-0 flex-1 overflow-y-auto p-3.5">
+            <div className="grid gap-5">
+              <section className="grid gap-3">
+                <PatternNote title="Repeatable field list" eyebrow="Composition pattern">
+                  Use reorder, add, and remove controls when users build a variable-length set of
+                  related fields.
+                </PatternNote>
+                <div className="grid gap-2">
+                  <DndContext
+                    sensors={compositionSensors}
+                    collisionDetection={closestCenter}
+                    onDragStart={(event) => setActiveCompositionFieldId(event.active.id as number)}
+                    onDragEnd={({ active, over }) => {
+                      if (over && active.id !== over.id) {
+                        setCompositionFields((fields) => {
+                          const oldIndex = fields.findIndex((field) => field.id === active.id);
+                          const newIndex = fields.findIndex((field) => field.id === over.id);
+                          return arrayMove(fields, oldIndex, newIndex);
+                        });
+                      }
+                      setActiveCompositionFieldId(null);
+                    }}
+                    onDragCancel={() => setActiveCompositionFieldId(null)}
+                  >
+                    <SortableContext
+                      items={compositionFields.map((field) => field.id)}
+                      strategy={verticalListSortingStrategy}
+                    >
+                      <div className="grid gap-2">
+                        {compositionFields.map((field) => (
+                          <SortableCompositionField
+                            key={field.id}
+                            field={field}
+                            onDelete={() =>
+                              setCompositionFields((fields) =>
+                                fields.filter((item) => item.id !== field.id)
+                              )
+                            }
+                          />
+                        ))}
+                      </div>
+                    </SortableContext>
+                    {createPortal(
+                      <DragOverlay>
+                        {activeCompositionField ? (
+                          <CompositionFieldDragOverlay field={activeCompositionField} />
+                        ) : null}
+                      </DragOverlay>,
+                      document.body
+                    )}
+                  </DndContext>
+                  <button
+                    type="button"
+                    className="flex w-fit cursor-pointer items-center gap-1.5 text-xs text-brand transition hover:text-brand-hover"
+                    onClick={() =>
+                      setCompositionFields((fields) => [
+                        ...fields,
+                        {
+                          id: Math.max(0, ...fields.map((field) => field.id)) + 1,
+                          label: `New field ${fields.length + 1}`,
+                        },
+                      ])
+                    }
+                  >
+                    <Plus size={12} />
+                    Add field
+                  </button>
+                </div>
+              </section>
+
+              <section className="grid gap-3 border-t border-border-subtle pt-5">
+                <PatternNote title="Editing modes" eyebrow="Composition pattern">
+                  Switch between a guided interface and a source representation without changing
+                  the underlying configuration.
+                </PatternNote>
+                <ToggleGroup
+                  type="single"
+                  size="xs"
+                  value={compositionEditor}
+                  onValueChange={(value) => value && setCompositionEditor(value)}
+                  className="w-fit"
+                >
+                  <ToggleGroupItem value="ui" className="!px-2.5 !text-xs">
+                    UI
+                  </ToggleGroupItem>
+                  <ToggleGroupItem value="json" className="!px-2.5 !text-xs">
+                    JSON
+                  </ToggleGroupItem>
+                </ToggleGroup>
+                {compositionEditor === 'ui' ? (
+                  <InventoryField label="Form title">
+                    <Input defaultValue="Quick approve" />
+                  </InventoryField>
+                ) : (
+                  <Textarea
+                    aria-label="JSON configuration"
+                    defaultValue={'{\n  "title": "Quick approve"\n}'}
+                    rows={4}
+                    className="font-mono text-xs"
+                  />
+                )}
+              </section>
+
+              <section className="grid gap-3 border-t border-border-subtle pt-5">
+                <PatternNote title="Lockable value field" eyebrow="Composition pattern">
+                  Combines field type, required state, AI assistance, variable insertion, and
+                  fixed or expression values in one reusable Flow control.
+                </PatternNote>
+                <LockableValueField
+                  id={compositionFieldId}
+                  label={
+                    <PanelFieldLabel
+                      htmlFor={compositionFieldId}
+                      required={compositionRequired}
+                      className="leading-4"
+                    >
+                      Invoice value
+                    </PanelFieldLabel>
+                  }
+                  headerActions={
+                    <CanvasTooltip content="Remove field">
+                      <Button variant="ghost" size="4xs" icon aria-label="Remove field">
+                        <X size={14} />
+                      </Button>
+                    </CanvasTooltip>
+                  }
+                  value={compositionValue}
+                  onValueChange={setCompositionValue}
+                  locked={compositionLocked}
+                  onLockedChange={setCompositionLocked}
+                  mode={compositionMode}
+                  onModeChange={setCompositionMode}
+                  fieldType={compositionFieldType}
+                  onFieldTypeChange={updateCompositionFieldType}
+                  required={compositionRequired}
+                  onRequiredChange={setCompositionRequired}
+                  controlsVisibility="visible"
+                />
+              </section>
+            </div>
+          </TabsContent>
           </Tabs>
+        </PatternNotesVisibilityContext.Provider>
         </NodePropertyPanel>
       </PanelFrame>
       <Toaster className="[&_[data-description]]:!text-foreground-muted [&_[data-icon]]:!mt-0.5 [&_[data-icon]]:!self-start" />
@@ -4352,16 +4199,6 @@ different widths (truncation, action-button visibility).
   ),
 };
 
-export const PanelUIInventory: Story = {
-  name: 'UI Inventory',
-  render: () => <PanelUIInventoryStory />,
-};
-
-export const AlertsAndErrors: Story = {
-  name: 'UI Alerts and Errors',
-  render: () => <AlertsAndErrorsStory />,
-};
-
 const SURFACE_REMAP = { '--surface-raised': 'var(--surface-overlay)' } as CSSProperties;
 
 function CompactResponsivePanelStory() {
@@ -4423,15 +4260,11 @@ function CompactResponsivePanelStory() {
   );
 }
 
-export const Responsive: Story = {
-  name: 'UI Responsive',
-  render: () => (
-    <div className="flex items-start gap-[80px]">
+function ResponsiveStory() {
+  return (
+    <div className="flex items-start gap-[30px]">
       <div className="flex flex-col gap-3">
-        <div className="flex flex-col gap-0.5">
-          <span className="text-xs font-medium text-foreground">Fixed Size</span>
-          <span className="text-xs text-foreground-muted">Example Spacious</span>
-        </div>
+        <span className="text-xs font-medium text-foreground">Example Spacious</span>
         <PanelFrame>
           <NodePropertyPanel
             panelTitle="Properties"
@@ -4447,17 +4280,14 @@ export const Responsive: Story = {
         </PanelFrame>
       </div>
       <div className="flex flex-col gap-3">
-        <div className="flex flex-col gap-0.5">
-          <span className="text-xs font-medium text-foreground">Fixed Size</span>
-          <span className="text-xs text-foreground-muted">Example Compact</span>
-        </div>
+        <span className="text-xs font-medium text-foreground">Example Compact</span>
         <PanelFrame width="w-[280px]">
           <CompactResponsivePanelStory />
         </PanelFrame>
       </div>
     </div>
-  ),
-};
+  );
+}
 
 // ============================================================================
 // Input / Output panels (NodeIOView)

--- a/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.stories.tsx
@@ -3915,7 +3915,40 @@ function PanelUIInventoryStory() {
           </div>
 
           <TabsContent value="fields" className="mt-0 min-h-0 flex-1 overflow-y-auto">
-            <div className="px-3.5 pt-5">
+            <div className="grid gap-4 px-3.5 py-5">
+              <PatternNote title="Flat content">
+                A simple, always-visible layout for short configurations that do not need
+                collapsible sections or nested containers.
+              </PatternNote>
+              <div className="grid gap-4">
+                <InventoryField label="Name" description="A field placed directly in the panel.">
+                  <Input defaultValue="Extract invoice data" />
+                </InventoryField>
+                <InventoryField label="Connection">
+                  <Select defaultValue="production">
+                    <SelectTrigger className="w-full">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="production">Production</SelectItem>
+                      <SelectItem value="staging">Staging</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </InventoryField>
+                <div className="flex items-center justify-between gap-4">
+                  <div>
+                    <Label htmlFor="flat-pattern-enabled" className="text-xs">
+                      Enabled
+                    </Label>
+                    <p className="text-xs text-foreground-muted">
+                      Run this node in the workflow.
+                    </p>
+                  </div>
+                  <Switch id="flat-pattern-enabled" defaultChecked />
+                </div>
+              </div>
+            </div>
+            <div className="border-t border-border-subtle px-3.5 pt-5">
               <PatternNote title="Expandable sections">
                 Full-width sections that reveal or hide related fields without adding nested
                 container chrome.
@@ -4026,39 +4059,6 @@ function PanelUIInventoryStory() {
                 expandedSections={expandedSubContainerSections}
                 onExpandedSectionsChange={setExpandedSubContainerSections}
               />
-            </div>
-            <div className="grid gap-4 border-t border-border-subtle px-3.5 py-5">
-              <PatternNote title="Flat content">
-                A simple, always-visible layout for short configurations that do not need
-                collapsible sections or nested containers.
-              </PatternNote>
-              <div className="grid gap-4">
-                <InventoryField label="Name" description="A field placed directly in the panel.">
-                  <Input defaultValue="Extract invoice data" />
-                </InventoryField>
-                <InventoryField label="Connection">
-                  <Select defaultValue="production">
-                    <SelectTrigger className="w-full">
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="production">Production</SelectItem>
-                      <SelectItem value="staging">Staging</SelectItem>
-                    </SelectContent>
-                  </Select>
-                </InventoryField>
-                <div className="flex items-center justify-between gap-4">
-                  <div>
-                    <Label htmlFor="flat-pattern-enabled" className="text-xs">
-                      Enabled
-                    </Label>
-                    <p className="text-xs text-foreground-muted">
-                      Run this node in the workflow.
-                    </p>
-                  </div>
-                  <Switch id="flat-pattern-enabled" defaultChecked />
-                </div>
-              </div>
             </div>
           </TabsContent>
 

--- a/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.stories.tsx
@@ -1387,7 +1387,9 @@ function InputEditorStory() {
             </div>
             <TabsContent value="parameters" className="mt-0 min-h-0 flex-1 overflow-auto">
               <div className="py-2 [padding-inline:var(--mf-content-inset,0.875rem)]">
-                <span className="text-xs font-medium leading-4 text-foreground">Output messaging</span>
+                <span className="text-xs font-medium leading-4 text-foreground">
+                  Output messaging
+                </span>
               </div>
               <div className="flex flex-col gap-3 pb-1 [padding-inline:var(--mf-content-inset,0.875rem)]">
                 {cases.map((c) => (
@@ -2654,11 +2656,7 @@ function LockableValueFieldShowcase({
         <LockableValueField
           id={fullViewId}
           label={
-            <PanelFieldLabel
-              htmlFor={fullViewId}
-              required={showcaseRequired}
-              className="leading-4"
-            >
+            <PanelFieldLabel htmlFor={fullViewId} required={showcaseRequired} className="leading-4">
               Label
             </PanelFieldLabel>
           }
@@ -3368,11 +3366,7 @@ function InventorySubContainer({
               <Label htmlFor="sub-container-enabled" className="text-xs">
                 Enabled
               </Label>
-              <Switch
-                id="sub-container-enabled"
-                checked={enabled}
-                onCheckedChange={setEnabled}
-              />
+              <Switch id="sub-container-enabled" checked={enabled} onCheckedChange={setEnabled} />
             </div>
             <InventoryField label="Confidence threshold" description="Current value: 75%">
               <Slider defaultValue={[75]} max={100} step={5} />
@@ -3498,8 +3492,7 @@ function PanelUIInventoryStory() {
   const [compositionValue, setCompositionValue] = useState('invoice.total');
   const [compositionLocked, setCompositionLocked] = useState(true);
   const [compositionMode, setCompositionMode] = useState<LockableValueFieldMode>('fixed');
-  const [compositionFieldType, setCompositionFieldType] =
-    useState<LockableFieldType>('string');
+  const [compositionFieldType, setCompositionFieldType] = useState<LockableFieldType>('string');
   const [compositionRequired, setCompositionRequired] = useState(true);
   const [compositionEditor, setCompositionEditor] = useState('ui');
   const [compositionFields, setCompositionFields] = useState([
@@ -3543,569 +3536,579 @@ function PanelUIInventoryStory() {
     <>
       <PanelFrame>
         <NodePropertyPanel
-        panelTitle="Properties"
-        nodeIcon={<Sparkles />}
-        nodeLabel="UI element inventory"
-        nodeCategory="Panel reference"
-        action={<RunButton />}
-        contentInset="0.875rem"
-        onClose={() => {}}
-        className="h-[720px]"
-      >
-        <PatternNotesVisibilityContext.Provider value={notesVisible}>
-        <Tabs defaultValue="layout" className="flex h-full min-h-0 flex-col">
-          <div className="flex shrink-0 items-center gap-2 border-b border-border-subtle px-3.5 py-3">
-            <ScrollableTabsList
-              className={cn(TAB_LIST_CLASS, 'min-w-0 flex-1')}
-              scrollButtonClassName="size-6 hover:bg-surface-overlay"
-            >
-              <TabsTrigger value="layout" className={TAB_TRIGGER_CLASS}>
-                Layout
-              </TabsTrigger>
-              <TabsTrigger value="states" className={TAB_TRIGGER_CLASS}>
-                States
-              </TabsTrigger>
-              <TabsTrigger value="actions" className={TAB_TRIGGER_CLASS}>
-                Actions
-              </TabsTrigger>
-              <TabsTrigger value="composition" className={TAB_TRIGGER_CLASS}>
-                Composition
-              </TabsTrigger>
-            </ScrollableTabsList>
-            <Button
-              variant="ghost"
-              size="4xs"
-              icon
-              onClick={() => setNotesVisible((visible) => !visible)}
-              aria-label={notesVisible ? 'Hide notes' : 'Show notes'}
-              title={notesVisible ? 'Hide notes' : 'Show notes'}
-              className="shrink-0 text-foreground-subtle hover:bg-surface-overlay hover:text-foreground"
-            >
-              {notesVisible ? <EyeOff size={13} /> : <Eye size={13} />}
-            </Button>
-            <Button
-              variant="ghost"
-              size="4xs"
-              icon
-              onClick={toggleAllSections}
-              aria-label={allSectionsExpanded ? 'Collapse all sections' : 'Expand all sections'}
-              title={allSectionsExpanded ? 'Collapse all sections' : 'Expand all sections'}
-              className="shrink-0 text-foreground-subtle hover:bg-surface-overlay hover:text-foreground"
-            >
-              <ChevronsUpDown size={13} />
-            </Button>
-          </div>
-
-          <TabsContent value="layout" className="mt-0 min-h-0 flex-1 overflow-y-auto">
-            <div className="grid gap-4 px-3.5 py-5">
-              <PatternNote title="Flat content">
-                A simple, always-visible layout for short configurations that do not need
-                collapsible sections or nested containers.
-              </PatternNote>
-              <div className="grid gap-4">
-                <InventoryField label="Name" description="A field placed directly in the panel.">
-                  <Input defaultValue="Extract invoice data" />
-                </InventoryField>
-                <InventoryField label="Connection">
-                  <Select defaultValue="production">
-                    <SelectTrigger className="w-full">
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="production">Production</SelectItem>
-                      <SelectItem value="staging">Staging</SelectItem>
-                    </SelectContent>
-                  </Select>
-                </InventoryField>
-                <div className="flex items-center justify-between gap-4">
-                  <div>
-                    <Label htmlFor="flat-pattern-enabled" className="text-xs">
-                      Enabled
-                    </Label>
-                    <p className="text-xs text-foreground-muted">
-                      Run this node in the workflow.
-                    </p>
-                  </div>
-                  <Switch id="flat-pattern-enabled" defaultChecked />
-                </div>
+          panelTitle="Properties"
+          nodeIcon={<Sparkles />}
+          nodeLabel="UI element inventory"
+          nodeCategory="Panel reference"
+          action={<RunButton />}
+          contentInset="0.875rem"
+          onClose={() => {}}
+          className="h-[720px]"
+        >
+          <PatternNotesVisibilityContext.Provider value={notesVisible}>
+            <Tabs defaultValue="layout" className="flex h-full min-h-0 flex-col">
+              <div className="flex shrink-0 items-center gap-2 border-b border-border-subtle px-3.5 py-3">
+                <ScrollableTabsList
+                  className={cn(TAB_LIST_CLASS, 'min-w-0 flex-1')}
+                  scrollButtonClassName="size-6 hover:bg-surface-overlay"
+                >
+                  <TabsTrigger value="layout" className={TAB_TRIGGER_CLASS}>
+                    Layout
+                  </TabsTrigger>
+                  <TabsTrigger value="states" className={TAB_TRIGGER_CLASS}>
+                    States
+                  </TabsTrigger>
+                  <TabsTrigger value="actions" className={TAB_TRIGGER_CLASS}>
+                    Actions
+                  </TabsTrigger>
+                  <TabsTrigger value="composition" className={TAB_TRIGGER_CLASS}>
+                    Composition
+                  </TabsTrigger>
+                </ScrollableTabsList>
+                <Button
+                  variant="ghost"
+                  size="4xs"
+                  icon
+                  onClick={() => setNotesVisible((visible) => !visible)}
+                  aria-label={notesVisible ? 'Hide notes' : 'Show notes'}
+                  title={notesVisible ? 'Hide notes' : 'Show notes'}
+                  className="shrink-0 text-foreground-subtle hover:bg-surface-overlay hover:text-foreground"
+                >
+                  {notesVisible ? <EyeOff size={13} /> : <Eye size={13} />}
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="4xs"
+                  icon
+                  onClick={toggleAllSections}
+                  aria-label={allSectionsExpanded ? 'Collapse all sections' : 'Expand all sections'}
+                  title={allSectionsExpanded ? 'Collapse all sections' : 'Expand all sections'}
+                  className="shrink-0 text-foreground-subtle hover:bg-surface-overlay hover:text-foreground"
+                >
+                  <ChevronsUpDown size={13} />
+                </Button>
               </div>
-            </div>
-            <div className="border-t border-border-subtle px-3.5 has-[aside]:pt-5">
-              <PatternNote title="Expandable sections">
-                Full-width sections that reveal or hide related fields without adding nested
-                container chrome.
-              </PatternNote>
-            </div>
-            <Accordion
-              type="multiple"
-              value={expandedSections}
-              onValueChange={setExpandedSections}
-            >
-              <AccordionItem value="text-fields" className="border-border-subtle px-3.5">
-                <AccordionTrigger className="group py-4 text-sm hover:no-underline">
-                  <span className="text-foreground transition-colors group-hover:text-foreground-muted">
-                    Text and numeric fields
-                  </span>
-                </AccordionTrigger>
-                <AccordionContent className="grid gap-4 pb-5">
-                  <InventoryField label="Name" description="Short, single-line text input.">
-                    <Input defaultValue="Extract invoice data" />
-                  </InventoryField>
-                  <InventoryField label="Description">
-                    <Textarea
-                      defaultValue="Extract structured fields from incoming invoices."
-                      rows={3}
-                    />
-                  </InventoryField>
-                  <InventoryField label="Retry count">
-                    <Input type="number" defaultValue="3" min="0" />
-                  </InventoryField>
-                  <InventoryField label="Read-only value">
-                    <Input value="Generated by the system" readOnly disabled />
-                  </InventoryField>
-                </AccordionContent>
-              </AccordionItem>
 
-              <AccordionItem value="choices" className="border-border-subtle px-3.5">
-                <AccordionTrigger className="group py-4 text-sm hover:no-underline">
-                  <span className="text-foreground transition-colors group-hover:text-foreground-muted">
-                    Selection controls
-                  </span>
-                </AccordionTrigger>
-                <AccordionContent className="grid gap-5 pb-5">
-                  <InventoryField label="Connection">
-                    <Select defaultValue="production">
-                      <SelectTrigger className="w-full">
-                        <SelectValue placeholder="Choose a connection" />
-                      </SelectTrigger>
-                      <SelectContent>
-                        <SelectItem value="production">Production</SelectItem>
-                        <SelectItem value="staging">Staging</SelectItem>
-                        <SelectItem value="development">Development</SelectItem>
-                      </SelectContent>
-                    </Select>
-                  </InventoryField>
-                  <InventoryField label="Processing mode">
-                    <RadioGroup defaultValue="automatic" className="grid gap-2">
-                      <Label className="flex items-center gap-2 font-normal">
-                        <RadioGroupItem value="automatic" />
-                        Automatic
-                      </Label>
-                      <Label className="flex items-center gap-2 font-normal">
-                        <RadioGroupItem value="manual" />
-                        Manual review
-                      </Label>
-                    </RadioGroup>
-                  </InventoryField>
-                  <div className="flex items-start gap-2">
-                    <Checkbox
-                      id="save-output"
-                      checked={checked}
-                      onCheckedChange={(value) => setChecked(value === true)}
-                    />
-                    <div className="grid gap-0.5">
-                      <Label htmlFor="save-output" className="text-xs">
-                        Save output to storage
-                      </Label>
-                      <p className="text-xs text-foreground-muted">
-                        Makes the result available to later steps.
-                      </p>
-                    </div>
-                  </div>
-                  <div className="flex items-center justify-between gap-4">
-                    <div>
-                      <Label htmlFor="enabled-switch" className="text-xs">
-                        Enabled
-                      </Label>
-                      <p className="text-xs text-foreground-muted">Run this node in the workflow.</p>
-                    </div>
-                    <Switch
-                      id="enabled-switch"
-                      checked={enabled}
-                      onCheckedChange={setEnabled}
-                    />
-                  </div>
-                  <InventoryField label="Confidence threshold" description="Current value: 75%">
-                    <Slider defaultValue={[75]} max={100} step={5} />
-                  </InventoryField>
-                </AccordionContent>
-              </AccordionItem>
-
-              <AccordionItem value="collapsed" className="border-border-subtle px-3.5">
-                <AccordionTrigger className="group py-4 text-sm hover:no-underline">
-                  <span className="text-foreground transition-colors group-hover:text-foreground-muted">
-                    Advanced options
-                  </span>
-                </AccordionTrigger>
-                <AccordionContent className="grid gap-4 pb-5">
-                  <InventoryField label="Internal identifier">
-                    <Input defaultValue="invoice-extractor-01" />
-                  </InventoryField>
-                </AccordionContent>
-              </AccordionItem>
-            </Accordion>
-            <div className="grid gap-3 border-t border-border-subtle px-3.5 py-5">
-              <PatternNote title="Sub-containers">
-                Dense, collapsible cards for related configuration when stronger visual grouping is
-                useful.
-              </PatternNote>
-              <InventorySubContainer
-                expandedSections={expandedSubContainerSections}
-                onExpandedSectionsChange={setExpandedSubContainerSections}
-              />
-            </div>
-          </TabsContent>
-
-          <TabsContent value="states" className="mt-0 min-h-0 flex-1 overflow-y-auto p-3.5">
-            <div className="grid gap-5">
-              <section className="grid gap-3">
-                <PatternNote title="Section messages" eyebrow="State pattern">
-                  Persistent feedback summarizes a panel-level result and provides the next action
-                  when one is needed.
-                </PatternNote>
-                <InfoFieldBlock
-                  title="Configuration guidance"
-                  message="This node uses the connection selected for the current folder."
-                  action="Change the folder context to use a different connection."
-                />
-                <SuccessFieldBlock
-                  title="Configuration is valid"
-                  message="All required fields have been completed."
-                  action="This node is ready to run."
-                />
-                <WarningFieldBlock
-                  title="Review recommended"
-                  message="The request timeout is higher than the recommended value."
-                  action="Review the timeout before publishing this workflow."
-                />
-                <ErrorFieldBlock
-                  title="Connection required"
-                  message="No valid connection is configured for this node."
-                  action="Select a connection before running this node."
-                />
-              </section>
-
-              <section className="grid gap-3 border-t border-border-subtle pt-5">
-                <PatternNote title="Navigation validation" eyebrow="State pattern">
-                  Error counts on tabs reveal where unresolved issues live, including problems in
-                  sections that are not currently visible.
-                </PatternNote>
-                <Tabs defaultValue="parameters">
-                  <ScrollableTabsList
-                    className={cn(TAB_LIST_CLASS, 'w-full')}
-                    scrollButtonClassName="size-6 hover:bg-surface-overlay"
-                  >
-                    <TabsTrigger value="parameters" className={TAB_TRIGGER_CLASS}>
-                      <TabLabelWithError label="Parameters" count={1} />
-                    </TabsTrigger>
-                    <TabsTrigger value="error-handling" className={TAB_TRIGGER_CLASS}>
-                      <TabLabelWithError label="Error handling" count={2} />
-                    </TabsTrigger>
-                    <TabsTrigger value="advanced" className={TAB_TRIGGER_CLASS}>
-                      Advanced
-                    </TabsTrigger>
-                  </ScrollableTabsList>
-                </Tabs>
-              </section>
-
-              <section className="grid gap-3 border-t border-border-subtle pt-5">
-                <PatternNote title="Inline validation" eyebrow="State pattern">
-                  Field-specific feedback stays beside the control so the issue and resolution are
-                  clear in context.
-                </PatternNote>
-                <InventoryField
-                  label="Field with validation"
-                  description="Use a unique node name."
-                >
-                  <div>
-                    <Input
-                      defaultValue="Existing node"
-                      aria-invalid="true"
-                      className="!border !border-error"
-                    />
-                    <InlineValidationMessage
-                      message="This node name is already in use."
-                      action="Enter a unique name before saving."
-                    />
-                  </div>
-                </InventoryField>
-              </section>
-
-              <section className="grid gap-3 border-t border-border-subtle pt-5">
-                <PatternNote title="Transient feedback" eyebrow="State pattern">
-                  Toasts confirm the result of a user action without interrupting the task. Keep
-                  actionable errors visible in the panel instead.
-                </PatternNote>
-                <div className="grid grid-cols-2 gap-2">
-                  <Button
-                    variant="outline"
-                    onClick={() =>
-                      toast.info('Background sync complete', {
-                        description: 'The latest panel data is available.',
-                      })
-                    }
-                  >
-                    Info
-                  </Button>
-                  <Button
-                    variant="outline"
-                    onClick={() =>
-                      toast.success('Changes saved', {
-                        description: 'Panel settings are up to date.',
-                      })
-                    }
-                  >
-                    Success
-                  </Button>
-                  <Button
-                    variant="outline"
-                    onClick={() =>
-                      toast.warning('Review recommended', {
-                        description: 'Some optional settings still use defaults.',
-                      })
-                    }
-                  >
-                    Warning
-                  </Button>
-                  <Button
-                    variant="outline"
-                    onClick={() =>
-                      toast.error('Update failed', {
-                        description: 'Your changes were not saved. Try again.',
-                      })
-                    }
-                  >
-                    Error
-                  </Button>
-                </div>
-              </section>
-
-              <section className="grid gap-3 border-t border-border-subtle pt-5">
-                <PatternNote title="Status labels" eyebrow="State pattern">
-                  Short labels communicate passive field or setting states without interrupting
-                  the task.
-                </PatternNote>
-                <div className="flex flex-wrap gap-2">
-                  <Badge>Default</Badge>
-                  <Badge variant="secondary">Optional</Badge>
-                  <Badge variant="outline">Read only</Badge>
-                </div>
-              </section>
-            </div>
-          </TabsContent>
-
-          <TabsContent value="actions" className="mt-0 min-h-0 flex-1 overflow-y-auto p-3.5">
-            <div className="grid gap-5">
-              <section className="grid gap-3">
-                <PatternNote title="Button hierarchy" eyebrow="Action pattern">
-                  Use one primary action per context, with secondary, tertiary, and destructive
-                  styles reflecting lower emphasis or greater consequence.
-                </PatternNote>
-                <div className="flex flex-wrap gap-2">
-                  <Button>Primary</Button>
-                  <Button variant="outline">Secondary</Button>
-                  <Button variant="ghost">Tertiary</Button>
-                  <Button variant="destructive">Delete</Button>
-                </div>
-              </section>
-
-              <section className="grid gap-3 border-t border-border-subtle pt-5">
-                <PatternNote title="Header actions" eyebrow="Action pattern">
-                  Reserve the panel header for high-frequency node-level commands such as running
-                  or debugging. Keep the set small so the primary task remains clear.
-                </PatternNote>
-                <div className="flex flex-wrap items-center gap-2">
-                  <RunButton />
-                  <DebugButton />
-                </div>
-              </section>
-
-              <section className="grid gap-3 border-t border-border-subtle pt-5">
-                <PatternNote title="Footer actions" eyebrow="Action pattern">
-                  Place panel-level actions at the end of the content, with the primary action last
-                  and the cancel action immediately before it.
-                </PatternNote>
-                <div className="flex justify-end gap-2 border-t border-border-subtle pt-4">
-                  <Button variant="ghost">Cancel</Button>
-                  <Button>Save changes</Button>
-                </div>
-              </section>
-
-              <section className="grid gap-3 border-t border-border-subtle pt-5">
-                <PatternNote title="Icon-only utilities" eyebrow="Action pattern">
-                  Use compact icon actions for familiar utilities when space is limited. Always
-                  provide a tooltip and accessible name.
-                </PatternNote>
-                <div className="flex items-center gap-1">
-                  <CanvasTooltip content="Refresh data">
-                    <Button variant="ghost" size="4xs" icon aria-label="Refresh data">
-                      <RefreshCw size={14} />
-                    </Button>
-                  </CanvasTooltip>
-                  <CanvasTooltip content="Duplicate node">
-                    <Button variant="ghost" size="4xs" icon aria-label="Duplicate node">
-                      <Copy size={14} />
-                    </Button>
-                  </CanvasTooltip>
-                  <CanvasTooltip content="Delete node">
-                    <Button
-                      variant="ghost"
-                      size="4xs"
-                      icon
-                      aria-label="Delete node"
-                      className="text-error hover:text-error"
+              <TabsContent value="layout" className="mt-0 min-h-0 flex-1 overflow-y-auto">
+                <div className="grid gap-4 px-3.5 py-5">
+                  <PatternNote title="Flat content">
+                    A simple, always-visible layout for short configurations that do not need
+                    collapsible sections or nested containers.
+                  </PatternNote>
+                  <div className="grid gap-4">
+                    <InventoryField
+                      label="Name"
+                      description="A field placed directly in the panel."
                     >
-                      <Trash2 size={14} />
-                    </Button>
-                  </CanvasTooltip>
-                </div>
-              </section>
-            </div>
-          </TabsContent>
-
-          <TabsContent value="composition" className="mt-0 min-h-0 flex-1 overflow-y-auto p-3.5">
-            <div className="grid gap-5">
-              <section className="grid gap-3">
-                <PatternNote title="Repeatable field list" eyebrow="Composition pattern">
-                  Use reorder, add, and remove controls when users build a variable-length set of
-                  related fields.
-                </PatternNote>
-                <div className="grid gap-2">
-                  <DndContext
-                    sensors={compositionSensors}
-                    collisionDetection={closestCenter}
-                    onDragStart={(event) => setActiveCompositionFieldId(event.active.id as number)}
-                    onDragEnd={({ active, over }) => {
-                      if (over && active.id !== over.id) {
-                        setCompositionFields((fields) => {
-                          const oldIndex = fields.findIndex((field) => field.id === active.id);
-                          const newIndex = fields.findIndex((field) => field.id === over.id);
-                          return arrayMove(fields, oldIndex, newIndex);
-                        });
-                      }
-                      setActiveCompositionFieldId(null);
-                    }}
-                    onDragCancel={() => setActiveCompositionFieldId(null)}
-                  >
-                    <SortableContext
-                      items={compositionFields.map((field) => field.id)}
-                      strategy={verticalListSortingStrategy}
-                    >
-                      <div className="grid gap-2">
-                        {compositionFields.map((field) => (
-                          <SortableCompositionField
-                            key={field.id}
-                            field={field}
-                            onDelete={() =>
-                              setCompositionFields((fields) =>
-                                fields.filter((item) => item.id !== field.id)
-                              )
-                            }
-                          />
-                        ))}
+                      <Input defaultValue="Extract invoice data" />
+                    </InventoryField>
+                    <InventoryField label="Connection">
+                      <Select defaultValue="production">
+                        <SelectTrigger className="w-full">
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="production">Production</SelectItem>
+                          <SelectItem value="staging">Staging</SelectItem>
+                        </SelectContent>
+                      </Select>
+                    </InventoryField>
+                    <div className="flex items-center justify-between gap-4">
+                      <div>
+                        <Label htmlFor="flat-pattern-enabled" className="text-xs">
+                          Enabled
+                        </Label>
+                        <p className="text-xs text-foreground-muted">
+                          Run this node in the workflow.
+                        </p>
                       </div>
-                    </SortableContext>
-                    {createPortal(
-                      <DragOverlay>
-                        {activeCompositionField ? (
-                          <CompositionFieldDragOverlay field={activeCompositionField} />
-                        ) : null}
-                      </DragOverlay>,
-                      document.body
-                    )}
-                  </DndContext>
-                  <button
-                    type="button"
-                    className="flex w-fit cursor-pointer items-center gap-1.5 text-xs text-brand transition hover:text-brand-hover"
-                    onClick={() =>
-                      setCompositionFields((fields) => [
-                        ...fields,
-                        {
-                          id: Math.max(0, ...fields.map((field) => field.id)) + 1,
-                          label: `New field ${fields.length + 1}`,
-                        },
-                      ])
-                    }
-                  >
-                    <Plus size={12} />
-                    Add field
-                  </button>
+                      <Switch id="flat-pattern-enabled" defaultChecked />
+                    </div>
+                  </div>
                 </div>
-              </section>
-
-              <section className="grid gap-3 border-t border-border-subtle pt-5">
-                <PatternNote title="Editing modes" eyebrow="Composition pattern">
-                  Switch between a guided interface and a source representation without changing
-                  the underlying configuration.
-                </PatternNote>
-                <ToggleGroup
-                  type="single"
-                  size="xs"
-                  value={compositionEditor}
-                  onValueChange={(value) => value && setCompositionEditor(value)}
-                  className="w-fit"
+                <div className="border-t border-border-subtle px-3.5 has-[aside]:pt-5">
+                  <PatternNote title="Expandable sections">
+                    Full-width sections that reveal or hide related fields without adding nested
+                    container chrome.
+                  </PatternNote>
+                </div>
+                <Accordion
+                  type="multiple"
+                  value={expandedSections}
+                  onValueChange={setExpandedSections}
                 >
-                  <ToggleGroupItem value="ui" className="!px-2.5 !text-xs">
-                    UI
-                  </ToggleGroupItem>
-                  <ToggleGroupItem value="json" className="!px-2.5 !text-xs">
-                    JSON
-                  </ToggleGroupItem>
-                </ToggleGroup>
-                {compositionEditor === 'ui' ? (
-                  <InventoryField label="Form title">
-                    <Input defaultValue="Quick approve" />
-                  </InventoryField>
-                ) : (
-                  <Textarea
-                    aria-label="JSON configuration"
-                    defaultValue={'{\n  "title": "Quick approve"\n}'}
-                    rows={4}
-                    className="font-mono text-xs"
-                  />
-                )}
-              </section>
+                  <AccordionItem value="text-fields" className="border-border-subtle px-3.5">
+                    <AccordionTrigger className="group py-4 text-sm hover:no-underline">
+                      <span className="text-foreground transition-colors group-hover:text-foreground-muted">
+                        Text and numeric fields
+                      </span>
+                    </AccordionTrigger>
+                    <AccordionContent className="grid gap-4 pb-5">
+                      <InventoryField label="Name" description="Short, single-line text input.">
+                        <Input defaultValue="Extract invoice data" />
+                      </InventoryField>
+                      <InventoryField label="Description">
+                        <Textarea
+                          defaultValue="Extract structured fields from incoming invoices."
+                          rows={3}
+                        />
+                      </InventoryField>
+                      <InventoryField label="Retry count">
+                        <Input type="number" defaultValue="3" min="0" />
+                      </InventoryField>
+                      <InventoryField label="Read-only value">
+                        <Input value="Generated by the system" readOnly disabled />
+                      </InventoryField>
+                    </AccordionContent>
+                  </AccordionItem>
 
-              <section className="grid gap-3 border-t border-border-subtle pt-5">
-                <PatternNote title="Lockable value field" eyebrow="Composition pattern">
-                  Combines field type, required state, AI assistance, variable insertion, and
-                  fixed or expression values in one reusable Flow control.
-                </PatternNote>
-                <LockableValueField
-                  id={compositionFieldId}
-                  label={
-                    <PanelFieldLabel
-                      htmlFor={compositionFieldId}
-                      required={compositionRequired}
-                      className="leading-4"
+                  <AccordionItem value="choices" className="border-border-subtle px-3.5">
+                    <AccordionTrigger className="group py-4 text-sm hover:no-underline">
+                      <span className="text-foreground transition-colors group-hover:text-foreground-muted">
+                        Selection controls
+                      </span>
+                    </AccordionTrigger>
+                    <AccordionContent className="grid gap-5 pb-5">
+                      <InventoryField label="Connection">
+                        <Select defaultValue="production">
+                          <SelectTrigger className="w-full">
+                            <SelectValue placeholder="Choose a connection" />
+                          </SelectTrigger>
+                          <SelectContent>
+                            <SelectItem value="production">Production</SelectItem>
+                            <SelectItem value="staging">Staging</SelectItem>
+                            <SelectItem value="development">Development</SelectItem>
+                          </SelectContent>
+                        </Select>
+                      </InventoryField>
+                      <InventoryField label="Processing mode">
+                        <RadioGroup defaultValue="automatic" className="grid gap-2">
+                          <Label className="flex items-center gap-2 font-normal">
+                            <RadioGroupItem value="automatic" />
+                            Automatic
+                          </Label>
+                          <Label className="flex items-center gap-2 font-normal">
+                            <RadioGroupItem value="manual" />
+                            Manual review
+                          </Label>
+                        </RadioGroup>
+                      </InventoryField>
+                      <div className="flex items-start gap-2">
+                        <Checkbox
+                          id="save-output"
+                          checked={checked}
+                          onCheckedChange={(value) => setChecked(value === true)}
+                        />
+                        <div className="grid gap-0.5">
+                          <Label htmlFor="save-output" className="text-xs">
+                            Save output to storage
+                          </Label>
+                          <p className="text-xs text-foreground-muted">
+                            Makes the result available to later steps.
+                          </p>
+                        </div>
+                      </div>
+                      <div className="flex items-center justify-between gap-4">
+                        <div>
+                          <Label htmlFor="enabled-switch" className="text-xs">
+                            Enabled
+                          </Label>
+                          <p className="text-xs text-foreground-muted">
+                            Run this node in the workflow.
+                          </p>
+                        </div>
+                        <Switch
+                          id="enabled-switch"
+                          checked={enabled}
+                          onCheckedChange={setEnabled}
+                        />
+                      </div>
+                      <InventoryField label="Confidence threshold" description="Current value: 75%">
+                        <Slider defaultValue={[75]} max={100} step={5} />
+                      </InventoryField>
+                    </AccordionContent>
+                  </AccordionItem>
+
+                  <AccordionItem value="collapsed" className="border-border-subtle px-3.5">
+                    <AccordionTrigger className="group py-4 text-sm hover:no-underline">
+                      <span className="text-foreground transition-colors group-hover:text-foreground-muted">
+                        Advanced options
+                      </span>
+                    </AccordionTrigger>
+                    <AccordionContent className="grid gap-4 pb-5">
+                      <InventoryField label="Internal identifier">
+                        <Input defaultValue="invoice-extractor-01" />
+                      </InventoryField>
+                    </AccordionContent>
+                  </AccordionItem>
+                </Accordion>
+                <div className="grid gap-3 border-t border-border-subtle px-3.5 py-5">
+                  <PatternNote title="Sub-containers">
+                    Dense, collapsible cards for related configuration when stronger visual grouping
+                    is useful.
+                  </PatternNote>
+                  <InventorySubContainer
+                    expandedSections={expandedSubContainerSections}
+                    onExpandedSectionsChange={setExpandedSubContainerSections}
+                  />
+                </div>
+              </TabsContent>
+
+              <TabsContent value="states" className="mt-0 min-h-0 flex-1 overflow-y-auto p-3.5">
+                <div className="grid gap-5">
+                  <section className="grid gap-3">
+                    <PatternNote title="Section messages" eyebrow="State pattern">
+                      Persistent feedback summarizes a panel-level result and provides the next
+                      action when one is needed.
+                    </PatternNote>
+                    <InfoFieldBlock
+                      title="Configuration guidance"
+                      message="This node uses the connection selected for the current folder."
+                      action="Change the folder context to use a different connection."
+                    />
+                    <SuccessFieldBlock
+                      title="Configuration is valid"
+                      message="All required fields have been completed."
+                      action="This node is ready to run."
+                    />
+                    <WarningFieldBlock
+                      title="Review recommended"
+                      message="The request timeout is higher than the recommended value."
+                      action="Review the timeout before publishing this workflow."
+                    />
+                    <ErrorFieldBlock
+                      title="Connection required"
+                      message="No valid connection is configured for this node."
+                      action="Select a connection before running this node."
+                    />
+                  </section>
+
+                  <section className="grid gap-3 border-t border-border-subtle pt-5">
+                    <PatternNote title="Navigation validation" eyebrow="State pattern">
+                      Error counts on tabs reveal where unresolved issues live, including problems
+                      in sections that are not currently visible.
+                    </PatternNote>
+                    <Tabs defaultValue="parameters">
+                      <ScrollableTabsList
+                        className={cn(TAB_LIST_CLASS, 'w-full')}
+                        scrollButtonClassName="size-6 hover:bg-surface-overlay"
+                      >
+                        <TabsTrigger value="parameters" className={TAB_TRIGGER_CLASS}>
+                          <TabLabelWithError label="Parameters" count={1} />
+                        </TabsTrigger>
+                        <TabsTrigger value="error-handling" className={TAB_TRIGGER_CLASS}>
+                          <TabLabelWithError label="Error handling" count={2} />
+                        </TabsTrigger>
+                        <TabsTrigger value="advanced" className={TAB_TRIGGER_CLASS}>
+                          Advanced
+                        </TabsTrigger>
+                      </ScrollableTabsList>
+                    </Tabs>
+                  </section>
+
+                  <section className="grid gap-3 border-t border-border-subtle pt-5">
+                    <PatternNote title="Inline validation" eyebrow="State pattern">
+                      Field-specific feedback stays beside the control so the issue and resolution
+                      are clear in context.
+                    </PatternNote>
+                    <InventoryField
+                      label="Field with validation"
+                      description="Use a unique node name."
                     >
-                      Invoice value
-                    </PanelFieldLabel>
-                  }
-                  headerActions={
-                    <CanvasTooltip content="Remove field">
-                      <Button variant="ghost" size="4xs" icon aria-label="Remove field">
-                        <X size={14} />
+                      <div>
+                        <Input
+                          defaultValue="Existing node"
+                          aria-invalid="true"
+                          className="!border !border-error"
+                        />
+                        <InlineValidationMessage
+                          message="This node name is already in use."
+                          action="Enter a unique name before saving."
+                        />
+                      </div>
+                    </InventoryField>
+                  </section>
+
+                  <section className="grid gap-3 border-t border-border-subtle pt-5">
+                    <PatternNote title="Transient feedback" eyebrow="State pattern">
+                      Toasts confirm the result of a user action without interrupting the task. Keep
+                      actionable errors visible in the panel instead.
+                    </PatternNote>
+                    <div className="grid grid-cols-2 gap-2">
+                      <Button
+                        variant="outline"
+                        onClick={() =>
+                          toast.info('Background sync complete', {
+                            description: 'The latest panel data is available.',
+                          })
+                        }
+                      >
+                        Info
                       </Button>
-                    </CanvasTooltip>
-                  }
-                  value={compositionValue}
-                  onValueChange={setCompositionValue}
-                  locked={compositionLocked}
-                  onLockedChange={setCompositionLocked}
-                  mode={compositionMode}
-                  onModeChange={setCompositionMode}
-                  fieldType={compositionFieldType}
-                  onFieldTypeChange={updateCompositionFieldType}
-                  required={compositionRequired}
-                  onRequiredChange={setCompositionRequired}
-                  controlsVisibility="visible"
-                />
-              </section>
-            </div>
-          </TabsContent>
-          </Tabs>
-        </PatternNotesVisibilityContext.Provider>
+                      <Button
+                        variant="outline"
+                        onClick={() =>
+                          toast.success('Changes saved', {
+                            description: 'Panel settings are up to date.',
+                          })
+                        }
+                      >
+                        Success
+                      </Button>
+                      <Button
+                        variant="outline"
+                        onClick={() =>
+                          toast.warning('Review recommended', {
+                            description: 'Some optional settings still use defaults.',
+                          })
+                        }
+                      >
+                        Warning
+                      </Button>
+                      <Button
+                        variant="outline"
+                        onClick={() =>
+                          toast.error('Update failed', {
+                            description: 'Your changes were not saved. Try again.',
+                          })
+                        }
+                      >
+                        Error
+                      </Button>
+                    </div>
+                  </section>
+
+                  <section className="grid gap-3 border-t border-border-subtle pt-5">
+                    <PatternNote title="Status labels" eyebrow="State pattern">
+                      Short labels communicate passive field or setting states without interrupting
+                      the task.
+                    </PatternNote>
+                    <div className="flex flex-wrap gap-2">
+                      <Badge>Default</Badge>
+                      <Badge variant="secondary">Optional</Badge>
+                      <Badge variant="outline">Read only</Badge>
+                    </div>
+                  </section>
+                </div>
+              </TabsContent>
+
+              <TabsContent value="actions" className="mt-0 min-h-0 flex-1 overflow-y-auto p-3.5">
+                <div className="grid gap-5">
+                  <section className="grid gap-3">
+                    <PatternNote title="Button hierarchy" eyebrow="Action pattern">
+                      Use one primary action per context, with secondary, tertiary, and destructive
+                      styles reflecting lower emphasis or greater consequence.
+                    </PatternNote>
+                    <div className="flex flex-wrap gap-2">
+                      <Button>Primary</Button>
+                      <Button variant="outline">Secondary</Button>
+                      <Button variant="ghost">Tertiary</Button>
+                      <Button variant="destructive">Delete</Button>
+                    </div>
+                  </section>
+
+                  <section className="grid gap-3 border-t border-border-subtle pt-5">
+                    <PatternNote title="Header actions" eyebrow="Action pattern">
+                      Reserve the panel header for high-frequency node-level commands such as
+                      running or debugging. Keep the set small so the primary task remains clear.
+                    </PatternNote>
+                    <div className="flex flex-wrap items-center gap-2">
+                      <RunButton />
+                      <DebugButton />
+                    </div>
+                  </section>
+
+                  <section className="grid gap-3 border-t border-border-subtle pt-5">
+                    <PatternNote title="Footer actions" eyebrow="Action pattern">
+                      Place panel-level actions at the end of the content, with the primary action
+                      last and the cancel action immediately before it.
+                    </PatternNote>
+                    <div className="flex justify-end gap-2 border-t border-border-subtle pt-4">
+                      <Button variant="ghost">Cancel</Button>
+                      <Button>Save changes</Button>
+                    </div>
+                  </section>
+
+                  <section className="grid gap-3 border-t border-border-subtle pt-5">
+                    <PatternNote title="Icon-only utilities" eyebrow="Action pattern">
+                      Use compact icon actions for familiar utilities when space is limited. Always
+                      provide a tooltip and accessible name.
+                    </PatternNote>
+                    <div className="flex items-center gap-1">
+                      <CanvasTooltip content="Refresh data">
+                        <Button variant="ghost" size="4xs" icon aria-label="Refresh data">
+                          <RefreshCw size={14} />
+                        </Button>
+                      </CanvasTooltip>
+                      <CanvasTooltip content="Duplicate node">
+                        <Button variant="ghost" size="4xs" icon aria-label="Duplicate node">
+                          <Copy size={14} />
+                        </Button>
+                      </CanvasTooltip>
+                      <CanvasTooltip content="Delete node">
+                        <Button
+                          variant="ghost"
+                          size="4xs"
+                          icon
+                          aria-label="Delete node"
+                          className="text-error hover:text-error"
+                        >
+                          <Trash2 size={14} />
+                        </Button>
+                      </CanvasTooltip>
+                    </div>
+                  </section>
+                </div>
+              </TabsContent>
+
+              <TabsContent
+                value="composition"
+                className="mt-0 min-h-0 flex-1 overflow-y-auto p-3.5"
+              >
+                <div className="grid gap-5">
+                  <section className="grid gap-3">
+                    <PatternNote title="Repeatable field list" eyebrow="Composition pattern">
+                      Use reorder, add, and remove controls when users build a variable-length set
+                      of related fields.
+                    </PatternNote>
+                    <div className="grid gap-2">
+                      <DndContext
+                        sensors={compositionSensors}
+                        collisionDetection={closestCenter}
+                        onDragStart={(event) =>
+                          setActiveCompositionFieldId(event.active.id as number)
+                        }
+                        onDragEnd={({ active, over }) => {
+                          if (over && active.id !== over.id) {
+                            setCompositionFields((fields) => {
+                              const oldIndex = fields.findIndex((field) => field.id === active.id);
+                              const newIndex = fields.findIndex((field) => field.id === over.id);
+                              return arrayMove(fields, oldIndex, newIndex);
+                            });
+                          }
+                          setActiveCompositionFieldId(null);
+                        }}
+                        onDragCancel={() => setActiveCompositionFieldId(null)}
+                      >
+                        <SortableContext
+                          items={compositionFields.map((field) => field.id)}
+                          strategy={verticalListSortingStrategy}
+                        >
+                          <div className="grid gap-2">
+                            {compositionFields.map((field) => (
+                              <SortableCompositionField
+                                key={field.id}
+                                field={field}
+                                onDelete={() =>
+                                  setCompositionFields((fields) =>
+                                    fields.filter((item) => item.id !== field.id)
+                                  )
+                                }
+                              />
+                            ))}
+                          </div>
+                        </SortableContext>
+                        {createPortal(
+                          <DragOverlay>
+                            {activeCompositionField ? (
+                              <CompositionFieldDragOverlay field={activeCompositionField} />
+                            ) : null}
+                          </DragOverlay>,
+                          document.body
+                        )}
+                      </DndContext>
+                      <button
+                        type="button"
+                        className="flex w-fit cursor-pointer items-center gap-1.5 text-xs text-brand transition hover:text-brand-hover"
+                        onClick={() =>
+                          setCompositionFields((fields) => [
+                            ...fields,
+                            {
+                              id: Math.max(0, ...fields.map((field) => field.id)) + 1,
+                              label: `New field ${fields.length + 1}`,
+                            },
+                          ])
+                        }
+                      >
+                        <Plus size={12} />
+                        Add field
+                      </button>
+                    </div>
+                  </section>
+
+                  <section className="grid gap-3 border-t border-border-subtle pt-5">
+                    <PatternNote title="Editing modes" eyebrow="Composition pattern">
+                      Switch between a guided interface and a source representation without changing
+                      the underlying configuration.
+                    </PatternNote>
+                    <ToggleGroup
+                      type="single"
+                      size="xs"
+                      value={compositionEditor}
+                      onValueChange={(value) => value && setCompositionEditor(value)}
+                      className="w-fit"
+                    >
+                      <ToggleGroupItem value="ui" className="!px-2.5 !text-xs">
+                        UI
+                      </ToggleGroupItem>
+                      <ToggleGroupItem value="json" className="!px-2.5 !text-xs">
+                        JSON
+                      </ToggleGroupItem>
+                    </ToggleGroup>
+                    {compositionEditor === 'ui' ? (
+                      <InventoryField label="Form title">
+                        <Input defaultValue="Quick approve" />
+                      </InventoryField>
+                    ) : (
+                      <Textarea
+                        aria-label="JSON configuration"
+                        defaultValue={'{\n  "title": "Quick approve"\n}'}
+                        rows={4}
+                        className="font-mono text-xs"
+                      />
+                    )}
+                  </section>
+
+                  <section className="grid gap-3 border-t border-border-subtle pt-5">
+                    <PatternNote title="Lockable value field" eyebrow="Composition pattern">
+                      Combines field type, required state, AI assistance, variable insertion, and
+                      fixed or expression values in one reusable Flow control.
+                    </PatternNote>
+                    <LockableValueField
+                      id={compositionFieldId}
+                      label={
+                        <PanelFieldLabel
+                          htmlFor={compositionFieldId}
+                          required={compositionRequired}
+                          className="leading-4"
+                        >
+                          Invoice value
+                        </PanelFieldLabel>
+                      }
+                      headerActions={
+                        <CanvasTooltip content="Remove field">
+                          <Button variant="ghost" size="4xs" icon aria-label="Remove field">
+                            <X size={14} />
+                          </Button>
+                        </CanvasTooltip>
+                      }
+                      value={compositionValue}
+                      onValueChange={setCompositionValue}
+                      locked={compositionLocked}
+                      onLockedChange={setCompositionLocked}
+                      mode={compositionMode}
+                      onModeChange={setCompositionMode}
+                      fieldType={compositionFieldType}
+                      onFieldTypeChange={updateCompositionFieldType}
+                      required={compositionRequired}
+                      onRequiredChange={setCompositionRequired}
+                      controlsVisibility="visible"
+                    />
+                  </section>
+                </div>
+              </TabsContent>
+            </Tabs>
+          </PatternNotesVisibilityContext.Provider>
         </NodePropertyPanel>
       </PanelFrame>
       <Toaster className="[&_[data-description]]:!text-foreground-muted [&_[data-icon]]:!mt-0.5 [&_[data-icon]]:!self-start" />

--- a/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.stories.tsx
@@ -137,6 +137,7 @@ import { isJsonObject } from '../JsonTree';
 import { NodeIOView, type NodeIOViewTab } from '../NodeIOView';
 import { CanvasTooltip } from '../CanvasTooltip';
 import { NodePropertyPanel } from './NodePropertyPanel';
+import { PanelField, PanelFieldLabel } from './PanelField';
 
 // @monaco-editor/react uses a CJS build without an `exports` field, which
 // causes Rolldown (Vite 8 production bundler) to resolve the default import as
@@ -617,7 +618,7 @@ function FullEditorStory() {
             </div>
             <TabsContent value="parameters" className="mt-0 flex min-h-0 flex-1 flex-col">
               <div className="flex shrink-0 items-center justify-between py-2 [padding-inline:var(--mf-content-inset,0.875rem)]">
-                <span className="text-xs font-medium leading-4 text-foreground">Path</span>
+                <PanelFieldLabel className="leading-4">Path</PanelFieldLabel>
                 <div className="flex items-center gap-0.5">
                   <button
                     type="button"
@@ -856,7 +857,7 @@ function CasePanel({
         <>
           {/* Condition label + buttons */}
           <div className="flex items-center justify-between border-t border-border-subtle px-3 py-2">
-            <span className="text-xs font-medium leading-4 text-foreground">Condition</span>
+            <PanelFieldLabel className="leading-4">Condition</PanelFieldLabel>
             <div className="flex items-center gap-0.5">
               <button
                 type="button"
@@ -2862,10 +2863,13 @@ function LockableValueFieldShowcase({
         <LockableValueField
           id={fullViewId}
           label={
-            <Label htmlFor={fullViewId} className="text-xs font-medium leading-4 text-foreground">
+            <PanelFieldLabel
+              htmlFor={fullViewId}
+              required={showcaseRequired}
+              className="leading-4"
+            >
               Label
-              {showcaseRequired && <span className="ml-0.5 text-destructive">*</span>}
-            </Label>
+            </PanelFieldLabel>
           }
           headerActions={
             <button
@@ -2901,10 +2905,13 @@ function LockableValueFieldShowcase({
           <LockableValueField
             id={compactViewId}
             label={
-              <Label htmlFor={compactViewId} className="text-xs font-medium leading-4 text-foreground">
+              <PanelFieldLabel
+                htmlFor={compactViewId}
+                required={showcaseRequired}
+                className="leading-4"
+              >
                 Label
-                {showcaseRequired && <span className="ml-0.5 text-destructive">*</span>}
-              </Label>
+              </PanelFieldLabel>
             }
             headerActions={
               <button
@@ -3490,11 +3497,9 @@ function InventoryField({
   children: ReactNode;
 }) {
   return (
-    <div className="grid gap-1.5">
-      <Label className="text-xs font-medium text-foreground">{label}</Label>
+    <PanelField label={label} description={description}>
       {children}
-      {description && <p className="text-xs leading-4 text-foreground-muted">{description}</p>}
-    </div>
+    </PanelField>
   );
 }
 
@@ -3960,13 +3965,13 @@ function PanelUIInventoryStory() {
                 <LockableValueField
                   id={compositionFieldId}
                   label={
-                    <Label
+                    <PanelFieldLabel
                       htmlFor={compositionFieldId}
-                      className="text-xs font-medium leading-4 text-foreground"
+                      required={compositionRequired}
+                      className="leading-4"
                     >
                       Invoice value
-                      {compositionRequired && <span className="ml-0.5 text-destructive">*</span>}
-                    </Label>
+                    </PanelFieldLabel>
                   }
                   headerActions={
                     <CanvasTooltip content="Remove field">

--- a/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.stories.tsx
@@ -118,7 +118,7 @@ import {
   X,
   Zap,
 } from 'lucide-react';
-import type { CSSProperties, ReactNode } from 'react';
+import type { CSSProperties, ReactElement, ReactNode } from 'react';
 import {
   createContext,
   lazy,
@@ -3202,7 +3202,7 @@ function InventoryField({
 }: {
   label: string;
   description?: string;
-  children: ReactNode;
+  children: ReactElement;
 }) {
   return (
     <PanelField label={label} description={description}>
@@ -3507,7 +3507,7 @@ function PanelUIInventoryStory() {
   const activeCompositionField = compositionFields.find(
     (field) => field.id === activeCompositionFieldId
   );
-  const allInventorySections = ['text-fields', 'choices', 'collapsed'];
+  const allInventorySections = ['text-fields', 'choices', 'advanced'];
   const allSubContainerSections = ['text-fields', 'choices', 'advanced'];
   const [expandedSections, setExpandedSections] = useState<string[]>([]);
   const [expandedSubContainerSections, setExpandedSubContainerSections] = useState<string[]>([]);
@@ -3729,7 +3729,7 @@ function PanelUIInventoryStory() {
                     </AccordionContent>
                   </AccordionItem>
 
-                  <AccordionItem value="collapsed" className="border-border-subtle px-3.5">
+                  <AccordionItem value="advanced" className="border-border-subtle px-3.5">
                     <AccordionTrigger className="group py-4 text-sm hover:no-underline">
                       <span className="text-foreground transition-colors group-hover:text-foreground-muted">
                         Advanced options

--- a/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.stories.tsx
@@ -985,6 +985,29 @@ function ErrorFieldBlock({
   );
 }
 
+function SuccessFieldBlock({
+  title,
+  message,
+  action,
+}: {
+  title: string;
+  message: string;
+  action: string;
+}) {
+  return (
+    <div className="rounded-xl border border-success/50 bg-success-background/25 p-3">
+      <div className="flex items-start gap-2">
+        <CircleCheck size={14} className="mt-0.5 shrink-0 text-success" />
+        <div className="min-w-0 flex-1">
+          <p className="text-xs font-semibold text-foreground">{title}</p>
+          <p className="mt-1 text-xs leading-4 text-success">{message}</p>
+          <p className="mt-1 text-xs leading-4 text-foreground-muted">{action}</p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 const ALERT_PATTERN_NOTES = [
   {
     title: 'Tab error count',
@@ -3854,10 +3877,8 @@ function PanelUIInventoryStory() {
   const [checked, setChecked] = useState(true);
   const allInventorySections = ['text-fields', 'choices', 'collapsed'];
   const allSubContainerSections = ['text-fields', 'choices', 'advanced'];
-  const [expandedSections, setExpandedSections] = useState(allInventorySections);
-  const [expandedSubContainerSections, setExpandedSubContainerSections] = useState(
-    allSubContainerSections
-  );
+  const [expandedSections, setExpandedSections] = useState<string[]>([]);
+  const [expandedSubContainerSections, setExpandedSubContainerSections] = useState<string[]>([]);
   const allSectionsExpanded =
     expandedSections.length === allInventorySections.length &&
     expandedSubContainerSections.length === allSubContainerSections.length;
@@ -3960,7 +3981,11 @@ function PanelUIInventoryStory() {
               onValueChange={setExpandedSections}
             >
               <AccordionItem value="text-fields" className="border-border-subtle px-3.5">
-                <AccordionTrigger className="py-4 text-sm">Text and numeric fields</AccordionTrigger>
+                <AccordionTrigger className="group py-4 text-sm hover:no-underline">
+                  <span className="text-foreground transition-colors group-hover:text-foreground-muted">
+                    Text and numeric fields
+                  </span>
+                </AccordionTrigger>
                 <AccordionContent className="grid gap-4 pb-5">
                   <InventoryField label="Name" description="Short, single-line text input.">
                     <Input defaultValue="Extract invoice data" />
@@ -3981,7 +4006,11 @@ function PanelUIInventoryStory() {
               </AccordionItem>
 
               <AccordionItem value="choices" className="border-border-subtle px-3.5">
-                <AccordionTrigger className="py-4 text-sm">Selection controls</AccordionTrigger>
+                <AccordionTrigger className="group py-4 text-sm hover:no-underline">
+                  <span className="text-foreground transition-colors group-hover:text-foreground-muted">
+                    Selection controls
+                  </span>
+                </AccordionTrigger>
                 <AccordionContent className="grid gap-5 pb-5">
                   <InventoryField label="Connection">
                     <Select defaultValue="production">
@@ -4042,7 +4071,11 @@ function PanelUIInventoryStory() {
               </AccordionItem>
 
               <AccordionItem value="collapsed" className="border-border-subtle px-3.5">
-                <AccordionTrigger className="py-4 text-sm">Advanced options</AccordionTrigger>
+                <AccordionTrigger className="group py-4 text-sm hover:no-underline">
+                  <span className="text-foreground transition-colors group-hover:text-foreground-muted">
+                    Advanced options
+                  </span>
+                </AccordionTrigger>
                 <AccordionContent className="grid gap-4 pb-5">
                   <InventoryField label="Internal identifier">
                     <Input defaultValue="invoice-extractor-01" />
@@ -4069,22 +4102,28 @@ function PanelUIInventoryStory() {
                 <Badge variant="secondary">Optional</Badge>
                 <Badge variant="outline">Read only</Badge>
               </div>
-              <Alert>
-                <CircleCheck />
-                <AlertTitle>Configuration is valid</AlertTitle>
-                <AlertDescription>All required fields have been completed.</AlertDescription>
-              </Alert>
-              <Alert variant="destructive">
-                <CircleAlert />
-                <AlertTitle>Connection required</AlertTitle>
-                <AlertDescription>Select a valid connection before running this node.</AlertDescription>
-              </Alert>
+              <SuccessFieldBlock
+                title="Configuration is valid"
+                message="All required fields have been completed."
+                action="This node is ready to run."
+              />
+              <ErrorFieldBlock
+                title="Connection required"
+                message="No valid connection is configured for this node."
+                action="Select a connection before running this node."
+              />
               <InventoryField label="Field with validation" description="Use a unique node name.">
-                <Input
-                  defaultValue="Existing node"
-                  aria-invalid="true"
-                  className="border-destructive"
-                />
+                <div>
+                  <Input
+                    defaultValue="Existing node"
+                    aria-invalid="true"
+                    className="border-destructive"
+                  />
+                  <InlineValidationMessage
+                    message="This node name is already in use."
+                    action="Enter a unique name before saving."
+                  />
+                </div>
               </InventoryField>
             </div>
           </TabsContent>

--- a/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.tsx
+++ b/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.tsx
@@ -140,7 +140,7 @@ export function NodePropertyPanel({
         <div className="flex min-h-0 flex-1 flex-col">
           <div
             className={cn(
-              'flex min-h-0 flex-1 flex-col [&_label]:text-foreground-muted',
+              'flex min-h-0 flex-1 flex-col [&_[data-slot=form-description]]:text-xs [&_[data-slot=form-description]]:leading-4 [&_[data-slot=form-description]]:text-foreground-muted [&_[data-slot=form-label]]:text-xs [&_[data-slot=form-label]]:font-medium [&_[data-slot=form-label]]:leading-4 [&_[data-slot=form-label]]:text-foreground',
               SURFACE_REMAP
             )}
           >
@@ -163,7 +163,12 @@ export function NodePropertyPanel({
         // Single-page schema: classic behavior — this wrapper scrolls the whole
         // form. No stepVariant: it only applies to step-based schemas.
         <div className="min-h-0 flex-1 overflow-auto">
-          <div className={cn('[&_label]:text-foreground-muted', SURFACE_REMAP)}>
+          <div
+            className={cn(
+              '[&_[data-slot=form-description]]:text-xs [&_[data-slot=form-description]]:leading-4 [&_[data-slot=form-description]]:text-foreground-muted [&_[data-slot=form-label]]:text-xs [&_[data-slot=form-label]]:font-medium [&_[data-slot=form-label]]:leading-4 [&_[data-slot=form-label]]:text-foreground',
+              SURFACE_REMAP
+            )}
+          >
             <MetadataForm
               key={resetKey}
               schema={formSchema}

--- a/packages/apollo-react/src/canvas/components/NodePropertyPanel/PanelField.test.tsx
+++ b/packages/apollo-react/src/canvas/components/NodePropertyPanel/PanelField.test.tsx
@@ -1,0 +1,42 @@
+import { Input } from '@uipath/apollo-wind';
+import { render, screen } from '../../utils/testing';
+import { PanelField, PanelFieldLabel } from './PanelField';
+
+describe('PanelField', () => {
+  it('labels a panel control and renders supporting text', () => {
+    render(
+      <PanelField htmlFor="endpoint" label="Endpoint" description="The URL to call.">
+        <Input id="endpoint" />
+      </PanelField>
+    );
+
+    expect(screen.getByLabelText('Endpoint')).toHaveAttribute(
+      'aria-describedby',
+      'endpoint-description'
+    );
+    expect(screen.getByText('The URL to call.')).toBeInTheDocument();
+  });
+
+  it('renders required and error states without changing the control', () => {
+    render(
+      <PanelField htmlFor="name" label="Name" required error="Name is required.">
+        <Input id="name" />
+      </PanelField>
+    );
+
+    expect(screen.getByText('*')).toBeInTheDocument();
+    expect(screen.getByLabelText(/Name/)).toHaveAttribute('aria-invalid', 'true');
+    expect(screen.getByText('Name is required.')).toHaveAttribute('id', 'name-error');
+  });
+
+  it('provides the same label treatment to controls that own their layout', () => {
+    render(
+      <PanelFieldLabel htmlFor="expression" required>
+        Expression
+      </PanelFieldLabel>
+    );
+
+    expect(screen.getByText('Expression')).toHaveAttribute('for', 'expression');
+    expect(screen.getByText('*')).toBeInTheDocument();
+  });
+});

--- a/packages/apollo-react/src/canvas/components/NodePropertyPanel/PanelField.test.tsx
+++ b/packages/apollo-react/src/canvas/components/NodePropertyPanel/PanelField.test.tsx
@@ -29,6 +29,17 @@ describe('PanelField', () => {
     expect(screen.getByText('Name is required.')).toHaveAttribute('id', 'name-error');
   });
 
+  it('keeps an explicit htmlFor aligned with the rendered control id', () => {
+    render(
+      <PanelField htmlFor="panel-name" label="Name">
+        <Input id="legacy-name" />
+      </PanelField>
+    );
+
+    expect(screen.getByLabelText('Name')).toHaveAttribute('id', 'panel-name');
+    expect(screen.queryByRole('textbox', { name: 'Name' })).toBeInTheDocument();
+  });
+
   it('provides the same label treatment to controls that own their layout', () => {
     render(
       <PanelFieldLabel htmlFor="expression" required>

--- a/packages/apollo-react/src/canvas/components/NodePropertyPanel/PanelField.tsx
+++ b/packages/apollo-react/src/canvas/components/NodePropertyPanel/PanelField.tsx
@@ -75,7 +75,7 @@ export function PanelField({
     .join(' ');
   const control = isValidElement(children)
     ? cloneElement(children, {
-        id: children.props.id ?? controlId,
+        id: controlId,
         'aria-describedby': describedBy || undefined,
         'aria-invalid': error ? true : children.props['aria-invalid'],
       })

--- a/packages/apollo-react/src/canvas/components/NodePropertyPanel/PanelField.tsx
+++ b/packages/apollo-react/src/canvas/components/NodePropertyPanel/PanelField.tsx
@@ -1,0 +1,110 @@
+import { cn, Label, type LabelProps } from '@uipath/apollo-wind';
+import {
+  cloneElement,
+  forwardRef,
+  isValidElement,
+  type ReactElement,
+  type ReactNode,
+  useId,
+} from 'react';
+
+type PanelControlProps = {
+  id?: string;
+  'aria-describedby'?: string;
+  'aria-invalid'?: boolean;
+};
+
+export interface PanelFieldProps {
+  /** Label displayed above the panel control. */
+  label: ReactNode;
+  /** ID of the control labelled by this field. */
+  htmlFor?: string;
+  /** Supporting guidance displayed below the control. */
+  description?: ReactNode;
+  /** Validation message displayed below the supporting guidance. */
+  error?: ReactNode;
+  /** Displays the panel-standard required indicator after the label. */
+  required?: boolean;
+  /** Input, select, editor, or other panel control. */
+  children: ReactElement<PanelControlProps>;
+  className?: string;
+}
+
+export interface PanelFieldLabelProps extends LabelProps {
+  /** Displays the panel-standard required indicator after the label. */
+  required?: boolean;
+}
+
+/** Panel-scoped label treatment for controls that own their field layout. */
+export const PanelFieldLabel = forwardRef<HTMLLabelElement, PanelFieldLabelProps>(
+  ({ children, className, required = false, ...props }, ref) => (
+    <Label
+      ref={ref}
+      data-slot="panel-field-label"
+      className={cn('text-xs font-medium text-foreground', className)}
+      {...props}
+    >
+      {children}
+      {required && <span className="ml-0.5 text-destructive">*</span>}
+    </Label>
+  )
+);
+
+PanelFieldLabel.displayName = 'PanelFieldLabel';
+
+/**
+ * PanelField standardizes the label, spacing, supporting text, and validation
+ * treatment used by inputs inside a NodePropertyPanel. It composes existing
+ * controls without changing their own size, styling, or behavior.
+ */
+export function PanelField({
+  label,
+  htmlFor,
+  description,
+  error,
+  required = false,
+  children,
+  className,
+}: PanelFieldProps) {
+  const generatedId = useId();
+  const controlId = htmlFor ?? children.props.id ?? generatedId;
+  const descriptionId = description ? `${controlId}-description` : undefined;
+  const errorId = error ? `${controlId}-error` : undefined;
+  const describedBy = [children.props['aria-describedby'], descriptionId, errorId]
+    .filter(Boolean)
+    .join(' ');
+  const control = isValidElement(children)
+    ? cloneElement(children, {
+        id: children.props.id ?? controlId,
+        'aria-describedby': describedBy || undefined,
+        'aria-invalid': error ? true : children.props['aria-invalid'],
+      })
+    : children;
+
+  return (
+    <div className={cn('grid gap-1.5', className)} data-slot="panel-field">
+      <PanelFieldLabel htmlFor={controlId} required={required}>
+        {label}
+      </PanelFieldLabel>
+      {control}
+      {description && (
+        <p
+          id={descriptionId}
+          data-slot="panel-field-description"
+          className="text-xs leading-4 text-foreground-muted"
+        >
+          {description}
+        </p>
+      )}
+      {error && (
+        <p
+          id={errorId}
+          data-slot="panel-field-error"
+          className="text-xs leading-4 text-destructive"
+        >
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/packages/apollo-react/src/canvas/components/NodePropertyPanel/index.ts
+++ b/packages/apollo-react/src/canvas/components/NodePropertyPanel/index.ts
@@ -2,3 +2,5 @@ export type { ExpressionFieldProps, ExpressionMode } from './ExpressionField';
 export { ExpressionField } from './ExpressionField';
 export { NodePropertyPanel } from './NodePropertyPanel';
 export type { NodePropertyPanelProps } from './NodePropertyPanel.types';
+export type { PanelFieldLabelProps, PanelFieldProps } from './PanelField';
+export { PanelField, PanelFieldLabel } from './PanelField';

--- a/packages/apollo-wind/src/components/forms/field-renderer.tsx
+++ b/packages/apollo-wind/src/components/forms/field-renderer.tsx
@@ -578,7 +578,11 @@ function FormField({
   children: React.ReactNode;
   className?: string;
 }) {
-  return <div className={cn('space-y-2', className)}>{children}</div>;
+  return (
+    <div data-slot="form-field" className={cn('grid gap-1.5', className)}>
+      {children}
+    </div>
+  );
 }
 
 function FormLabel({
@@ -593,7 +597,7 @@ function FormLabel({
   className?: string;
 }) {
   return (
-    <Label htmlFor={htmlFor} className={className}>
+    <Label data-slot="form-label" htmlFor={htmlFor} className={className}>
       {children}
       {required && <span className="text-destructive ml-1">*</span>}
     </Label>
@@ -602,7 +606,11 @@ function FormLabel({
 
 function FormDescription({ children }: { children?: React.ReactNode }) {
   if (!children) return null;
-  return <p className="text-sm text-muted-foreground">{children}</p>;
+  return (
+    <p data-slot="form-description" className="text-sm text-muted-foreground">
+      {children}
+    </p>
+  );
 }
 
 function FormError({ children }: { children?: React.ReactNode }) {


### PR DESCRIPTION
## Overview

Improves the Node Property Panel Storybook examples by consolidating UX patterns, standardizing panel fields, and making the sidebar easier to navigate.

## Key changes

https://github.com/user-attachments/assets/1cc559f1-4c4f-4bf7-bdfd-41273504021a

### 1. Added UI Inventory

- Added one interactive reference for panel **Layout**, **States**, **Actions**, and **Composition** patterns.
- Includes common fields, expandable sections, sub-containers, validation, toasts, actions, repeatable lists, and editing modes.
- Added controls to expand/collapse examples and show/hide guidance notes.

### 2. Consolidated Alerts and Errors

- Moved section messages, validation, transient feedback, and status examples into UI Inventory.
- Removed the redundant **UI Alerts and Errors** story.

### 3. Improved sidebar organization

- Moved **UI Inventory** and **UI Responsive** below Docs.
- Grouped Form, Editor, and Input / Output examples more consistently.
- Removed the redundant Inline Editing story and clarified **Input / Output 3 Column**.

### 4. Standardized panel fields

- Added an exported `PanelField` pattern for panel-specific labels, descriptions, errors, and spacing.
- Applied the pattern across relevant panel examples without changing their layouts.
- Added focused tests for the reusable field behavior.

### 5. Refined supporting examples

- Aligned repeatable-list, editing-mode, toast, and lockable-field examples with established panel patterns.
- Simplified the responsive comparison to **Example Spacious** and **Example Compact**.

## Validation

Formatting, commit lint, lint, typecheck, focused tests, build, and GitHub PR checks.
