### PR TITLE
ci(apollo-vertex): restore production registry deployment

### DIFF
--- a/.github/workflows/apollo-vertex-registry-deploy.yml
+++ b/.github/workflows/apollo-vertex-registry-deploy.yml
@@ -1,0 +1,89 @@
+name: Apollo Vertex Registry Production Deployment
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '.github/actions/install-node-deps/**'
+      - '.github/workflows/apollo-vertex-registry-deploy.yml'
+      - 'apps/apollo-vertex/**'
+      - 'package.json'
+      - 'pnpm-lock.yaml'
+      - 'pnpm-workspace.yaml'
+      - 'turbo.json'
+
+permissions: {}
+
+concurrency:
+  group: apollo-vertex-registry-production
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    name: Deploy Apollo Vertex Registry
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+
+      - name: Install Node dependencies
+        uses: ./.github/actions/install-node-deps
+        env:
+          GH_NPM_REGISTRY_TOKEN: ${{ github.token }}
+
+      - name: Install Vercel CLI
+        run: npm install -g vercel@53.4.0
+
+      - name: Build Apollo Vertex
+        run: pnpm turbo build --filter=apollo-vertex
+
+      - name: Build Vercel output
+        env:
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID_VERTEX }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+        run: vercel build --yes --prod
+
+      - name: Deploy to Vercel
+        env:
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID_VERTEX }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+        run: vercel deploy --prebuilt --archive=tgz --yes --prod
+
+      - name: Verify canonical registry
+        env:
+          REGISTRY_URL: https://apollo-vertex.vercel.app/r/registry.json
+        run: |
+          set -euo pipefail
+
+          expected_file="apps/apollo-vertex/public/r/registry.json"
+          expected_sha="$(sha256sum "$expected_file" | awk '{print $1}')"
+          response_file="$(mktemp)"
+          trap 'rm -f "$response_file"' EXIT
+
+          for attempt in {1..12}; do
+            if curl --fail --silent --show-error --location \
+              --header 'Cache-Control: no-cache' \
+              "${REGISTRY_URL}?sha=${GITHUB_SHA}" \
+              --output "$response_file"; then
+              actual_sha="$(sha256sum "$response_file" | awk '{print $1}')"
+              if [ "$actual_sha" = "$expected_sha" ]; then
+                echo "Canonical registry matches the generated artifact."
+                exit 0
+              fi
+            fi
+
+            if [ "$attempt" -lt 12 ]; then
+              sleep 10
+            fi
+          done
+
+          echo "::error::Canonical registry does not match the generated artifact."
+          exit 1


### PR DESCRIPTION
## Why

PR #896 moved the production sites from Vercel to Coded Apps. Apollo Vertex also hosts the public registry, and our registry URLs still point to apollo-vertex.vercel.app. This meant registry changes like PR #952 were no longer published there.

## What changed

- deploy Apollo Vertex to Vercel when relevant changes reach main
- build the registry before deployment
- check that the live registry matches the build

## Validation

- actionlint
- registry build with all 84 items
- freshness check against the current Vercel and Coded App registries