### PR TITLE
feat(apollo-react): add CanvasBottomPanel

### DIFF
--- a/packages/apollo-react/src/canvas/components/CanvasBottomPanel/CanvasBottomPanel.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/CanvasBottomPanel/CanvasBottomPanel.stories.tsx
@@ -1,0 +1,210 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Button, Separator, TooltipProvider } from '@uipath/apollo-wind';
+import {
+  Bug,
+  ChevronDown,
+  ChevronUp,
+  FlaskConical,
+  Play,
+  RotateCcw,
+  Sparkles,
+  Square,
+} from 'lucide-react';
+import { useState } from 'react';
+import { useCanvasStory, withCanvasProviders } from '../../storybook-utils';
+import { Panel } from '../../xyflow/react';
+import { BaseCanvas } from '../BaseCanvas';
+import {
+  CanvasModeToolbar,
+  TOOLBAR_ICON_BUTTON_CLASS,
+} from '../CanvasModeToolbar/CanvasModeToolbar';
+import { CanvasZoomControls } from '../CanvasZoomControls';
+import { ToolbarButton } from '../ToolbarButton';
+import { CanvasBottomPanel } from './CanvasBottomPanel';
+import type { CanvasBottomPanelTab } from './CanvasBottomPanel.types';
+
+const meta: Meta<typeof CanvasBottomPanel> = {
+  title: 'Components/Controls/CanvasBottomPanel',
+  component: CanvasBottomPanel,
+  parameters: {
+    layout: 'fullscreen',
+  },
+  decorators: [
+    (Story) => (
+      <TooltipProvider>
+        <Story />
+      </TooltipProvider>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof CanvasBottomPanel>;
+
+function DebugContent() {
+  return (
+    <div className="grid h-full grid-cols-[220px_1fr]">
+      <div className="border-r border-border-subtle p-3">
+        <p className="mb-2 text-xs font-semibold text-foreground">Run history</p>
+        <button type="button" className="w-full rounded-lg bg-surface-overlay p-3 text-left">
+          <span className="block text-xs font-medium text-foreground">Flow run</span>
+          <span className="mt-1 block text-[11px] text-foreground-muted">Completed in 2.4s</span>
+        </button>
+      </div>
+      <div className="p-4">
+        <div className="mb-3 flex items-center gap-2 text-sm font-medium">
+          <span className="size-2 rounded-full bg-success" />
+          Execution completed
+        </div>
+        <div className="rounded-xl border border-border-subtle bg-surface p-4 text-xs text-foreground-muted">
+          Select an execution step to inspect its input, output, logs, and metrics.
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function EvaluateContent() {
+  return (
+    <div className="flex h-full items-center justify-center p-6">
+      <div className="max-w-md text-center">
+        <Sparkles className="mx-auto mb-3 size-6 text-foreground-accent" />
+        <p className="text-sm font-medium text-foreground">Evaluate your flow</p>
+        <p className="mt-1 text-xs text-foreground-muted">
+          Connect a dataset and evaluators in your product, then render that experience here.
+        </p>
+        <Button className="mt-4" size="sm">
+          Start evaluation
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function usePanelState(initialCollapsed = false) {
+  const [activeTabId, setActiveTabId] = useState('debug');
+  const [isCollapsed, setIsCollapsed] = useState(initialCollapsed);
+  const tabs: CanvasBottomPanelTab[] = [
+    {
+      id: 'debug',
+      label: (
+        <>
+          <Bug className="size-3" />
+          Debug
+        </>
+      ),
+      ariaLabel: 'Debug',
+      content: <DebugContent />,
+    },
+    {
+      id: 'evaluate',
+      label: (
+        <>
+          <FlaskConical className="size-3" />
+          Evaluate
+        </>
+      ),
+      ariaLabel: 'Evaluate',
+      content: <EvaluateContent />,
+    },
+  ];
+
+  return {
+    activeTabId,
+    setActiveTabId,
+    isCollapsed,
+    setIsCollapsed,
+    tabs,
+  };
+}
+
+function PanelExample({ initialCollapsed = false }: { initialCollapsed?: boolean }) {
+  const state = usePanelState(initialCollapsed);
+
+  return (
+    <div className="h-[380px] bg-surface p-4">
+      <CanvasBottomPanel
+        className="h-full"
+        tabs={state.tabs}
+        activeTabId={state.activeTabId}
+        onTabChange={state.setActiveTabId}
+        isCollapsed={state.isCollapsed}
+        onCollapsedChange={state.setIsCollapsed}
+        headerActions={
+          <>
+            <Button size="xs" variant="ghost">
+              Clear
+            </Button>
+            <ToolbarButton
+              label={state.isCollapsed ? 'Expand panel' : 'Collapse panel'}
+              onClick={() => state.setIsCollapsed(!state.isCollapsed)}
+            >
+              {state.isCollapsed ? <ChevronUp /> : <ChevronDown />}
+            </ToolbarButton>
+          </>
+        }
+      />
+    </div>
+  );
+}
+
+export const Collapsed: Story = {
+  render: () => <PanelExample initialCollapsed />,
+};
+
+export const Expanded: Story = {
+  render: () => <PanelExample />,
+};
+
+function CanvasCompositionStory() {
+  const { canvasProps } = useCanvasStory({ initialNodes: [], initialEdges: [] });
+  const state = usePanelState();
+
+  return (
+    <div className="h-screen">
+      <BaseCanvas {...canvasProps} mode="design">
+        <Panel position="top-center">
+          <CanvasModeToolbar>
+            <ToolbarButton label="Run debug" className={TOOLBAR_ICON_BUTTON_CLASS}>
+              <Play />
+            </ToolbarButton>
+            <ToolbarButton label="Stop" disabled className={TOOLBAR_ICON_BUTTON_CLASS}>
+              <Square />
+            </ToolbarButton>
+            <Separator orientation="vertical" className="h-5" />
+            <ToolbarButton label="Restart" disabled className={TOOLBAR_ICON_BUTTON_CLASS}>
+              <RotateCcw />
+            </ToolbarButton>
+          </CanvasModeToolbar>
+        </Panel>
+        <Panel position="bottom-right" className="mb-16">
+          <CanvasZoomControls />
+        </Panel>
+        <div className="pointer-events-none absolute inset-x-4 bottom-4 z-10">
+          <CanvasBottomPanel
+            className="pointer-events-auto h-72"
+            tabs={state.tabs}
+            activeTabId={state.activeTabId}
+            onTabChange={state.setActiveTabId}
+            isCollapsed={state.isCollapsed}
+            onCollapsedChange={state.setIsCollapsed}
+            headerActions={
+              <ToolbarButton
+                label={state.isCollapsed ? 'Expand panel' : 'Collapse panel'}
+                onClick={() => state.setIsCollapsed(!state.isCollapsed)}
+              >
+                {state.isCollapsed ? <ChevronUp /> : <ChevronDown />}
+              </ToolbarButton>
+            }
+          />
+        </div>
+      </BaseCanvas>
+    </div>
+  );
+}
+
+export const CanvasComposition: Story = {
+  name: 'Debug / Evaluate Canvas Composition',
+  decorators: [withCanvasProviders()],
+  render: () => <CanvasCompositionStory />,
+};

--- a/packages/apollo-react/src/canvas/components/CanvasBottomPanel/CanvasBottomPanel.test.tsx
+++ b/packages/apollo-react/src/canvas/components/CanvasBottomPanel/CanvasBottomPanel.test.tsx
@@ -1,0 +1,98 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import type { ComponentProps } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { CanvasBottomPanel } from './CanvasBottomPanel';
+import type { CanvasBottomPanelTab } from './CanvasBottomPanel.types';
+
+const tabs: CanvasBottomPanelTab[] = [
+  { id: 'debug', label: 'Debug', content: <div data-testid="debug-content">Debug view</div> },
+  {
+    id: 'evaluate',
+    label: 'Evaluate',
+    content: <div data-testid="evaluate-content">Evaluate view</div>,
+  },
+];
+
+function renderPanel(overrides: Partial<ComponentProps<typeof CanvasBottomPanel>> = {}) {
+  const props: ComponentProps<typeof CanvasBottomPanel> = {
+    tabs,
+    activeTabId: 'debug',
+    onTabChange: vi.fn(),
+    isCollapsed: false,
+    onCollapsedChange: vi.fn(),
+    ...overrides,
+  };
+  return { ...render(<CanvasBottomPanel {...props} />), props };
+}
+
+describe('CanvasBottomPanel', () => {
+  it('renders consumer-provided tabs and only displays the active content', () => {
+    renderPanel();
+
+    expect(screen.getByRole('tab', { name: 'Debug' })).toHaveAttribute('aria-selected', 'true');
+    expect(screen.getByRole('tab', { name: 'Evaluate' })).toHaveAttribute('aria-selected', 'false');
+    expect(screen.getByTestId('debug-content').parentElement).toHaveStyle({ display: 'block' });
+    expect(screen.getByTestId('evaluate-content').parentElement).toHaveStyle({
+      display: 'none',
+    });
+  });
+
+  it('reports tab changes without owning active state', () => {
+    const onTabChange = vi.fn();
+    renderPanel({ onTabChange });
+
+    fireEvent.click(screen.getByRole('tab', { name: 'Evaluate' }));
+
+    expect(onTabChange).toHaveBeenCalledWith('evaluate');
+    expect(screen.getByRole('tab', { name: 'Debug' })).toHaveAttribute('aria-selected', 'true');
+  });
+
+  it('keeps tab content mounted when inactive or collapsed', () => {
+    renderPanel({ isCollapsed: true });
+
+    expect(screen.getByTestId('canvas-bottom-panel-content')).toHaveStyle({ display: 'none' });
+    expect(screen.getByTestId('debug-content')).toBeInTheDocument();
+    expect(screen.getByTestId('evaluate-content')).toBeInTheDocument();
+  });
+
+  it('expands when a tab is selected while collapsed', () => {
+    const onCollapsedChange = vi.fn();
+    renderPanel({ isCollapsed: true, onCollapsedChange });
+
+    fireEvent.click(screen.getByRole('tab', { name: 'Evaluate' }));
+
+    expect(onCollapsedChange).toHaveBeenCalledWith(false);
+  });
+
+  it('renders optional consumer-owned header actions', () => {
+    renderPanel({ headerActions: <button type="button">Collapse panel</button> });
+
+    expect(screen.getByRole('button', { name: 'Collapse panel' })).toBeInTheDocument();
+  });
+
+  it('associates each tab with its panel and applies roving tab index', () => {
+    renderPanel();
+
+    const debugTab = screen.getByRole('tab', { name: 'Debug' });
+    const evaluateTab = screen.getByRole('tab', { name: 'Evaluate' });
+    const debugPanel = document.getElementById(debugTab.getAttribute('aria-controls') ?? '');
+
+    expect(debugTab).toHaveAttribute('tabindex', '0');
+    expect(evaluateTab).toHaveAttribute('tabindex', '-1');
+    expect(debugPanel).toHaveAttribute('aria-labelledby', debugTab.id);
+  });
+
+  it.each([
+    ['ArrowRight', 'evaluate'],
+    ['ArrowLeft', 'evaluate'],
+    ['End', 'evaluate'],
+    ['Home', 'debug'],
+  ])('supports %s keyboard navigation', (key, expectedTab) => {
+    const onTabChange = vi.fn();
+    renderPanel({ onTabChange });
+
+    fireEvent.keyDown(screen.getByRole('tab', { name: 'Debug' }), { key });
+
+    expect(onTabChange).toHaveBeenLastCalledWith(expectedTab);
+  });
+});

--- a/packages/apollo-react/src/canvas/components/CanvasBottomPanel/CanvasBottomPanel.tsx
+++ b/packages/apollo-react/src/canvas/components/CanvasBottomPanel/CanvasBottomPanel.tsx
@@ -1,0 +1,147 @@
+import { Fragment, memo, useCallback, type KeyboardEvent as ReactKeyboardEvent } from 'react';
+import { cn } from '@uipath/apollo-wind';
+import type { CanvasBottomPanelProps } from './CanvasBottomPanel.types';
+
+export const CANVAS_BOTTOM_PANEL_COLLAPSED_HEIGHT = 48;
+
+function clearNativeSelection() {
+  if (typeof window === 'undefined' || typeof window.getSelection !== 'function') return;
+  window.getSelection()?.removeAllRanges();
+}
+
+export const CanvasBottomPanel = memo(function CanvasBottomPanel({
+  tabs,
+  activeTabId,
+  onTabChange,
+  isCollapsed,
+  onCollapsedChange,
+  headerActions,
+  idPrefix = 'canvas-bottom-panel',
+  className,
+}: CanvasBottomPanelProps) {
+  const focusTab = useCallback(
+    (tabId: string) => {
+      requestAnimationFrame(() => {
+        document.getElementById(`${idPrefix}-tab-${tabId}`)?.focus();
+      });
+    },
+    [idPrefix]
+  );
+
+  const activateTab = useCallback(
+    (tabId: string) => {
+      clearNativeSelection();
+      onTabChange(tabId);
+      if (isCollapsed) onCollapsedChange(false);
+    },
+    [isCollapsed, onCollapsedChange, onTabChange]
+  );
+
+  const handleKeyDown = useCallback(
+    (event: ReactKeyboardEvent<HTMLButtonElement>, index: number) => {
+      if (tabs.length === 0) return;
+
+      let nextIndex: number;
+      switch (event.key) {
+        case 'ArrowRight':
+          nextIndex = (index + 1) % tabs.length;
+          break;
+        case 'ArrowLeft':
+          nextIndex = (index - 1 + tabs.length) % tabs.length;
+          break;
+        case 'Home':
+          nextIndex = 0;
+          break;
+        case 'End':
+          nextIndex = tabs.length - 1;
+          break;
+        default:
+          return;
+      }
+
+      event.preventDefault();
+      const nextTab = tabs[nextIndex];
+      if (!nextTab) return;
+      activateTab(nextTab.id);
+      focusTab(nextTab.id);
+    },
+    [activateTab, focusTab, tabs]
+  );
+
+  return (
+    <section
+      data-testid="canvas-bottom-panel"
+      className={cn(
+        'flex min-h-0 flex-col overflow-hidden rounded-2xl border border-border-subtle bg-surface-raised text-foreground shadow-lg',
+        className
+      )}
+      style={isCollapsed ? { height: CANVAS_BOTTOM_PANEL_COLLAPSED_HEIGHT } : undefined}
+    >
+      <header
+        className="flex shrink-0 items-center justify-between gap-3 px-3"
+        style={{ height: CANVAS_BOTTOM_PANEL_COLLAPSED_HEIGHT }}
+      >
+        <div
+          role="tablist"
+          aria-orientation="horizontal"
+          className="flex min-w-0 items-center gap-1 overflow-x-auto"
+        >
+          {tabs.map((tab, index) => {
+            const isActive = tab.id === activeTabId;
+            return (
+              <Fragment key={tab.id}>
+                <button
+                  id={`${idPrefix}-tab-${tab.id}`}
+                  type="button"
+                  role="tab"
+                  aria-label={tab.ariaLabel}
+                  aria-selected={isActive}
+                  aria-controls={`${idPrefix}-tabpanel-${tab.id}`}
+                  tabIndex={isActive ? 0 : -1}
+                  data-state={isActive ? 'active' : 'inactive'}
+                  className="inline-flex h-7 shrink-0 cursor-pointer select-none items-center justify-center gap-1.5 whitespace-nowrap rounded-lg px-2.5 text-xs font-medium text-foreground-muted transition-colors hover:bg-surface-hover hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring data-[state=active]:bg-surface-overlay data-[state=active]:text-foreground"
+                  onClick={() => activateTab(tab.id)}
+                  onKeyDown={(event) => handleKeyDown(event, index)}
+                >
+                  {tab.label}
+                </button>
+              </Fragment>
+            );
+          })}
+        </div>
+
+        {headerActions && (
+          <div
+            className="flex shrink-0 items-center gap-1"
+            data-testid="canvas-bottom-panel-actions"
+          >
+            {headerActions}
+          </div>
+        )}
+      </header>
+
+      <div
+        className="min-h-0 flex-1 border-t border-border-subtle"
+        style={{ display: isCollapsed ? 'none' : 'block' }}
+        data-testid="canvas-bottom-panel-content"
+      >
+        {tabs.map((tab) => {
+          const isActive = tab.id === activeTabId;
+          return (
+            <div
+              key={tab.id}
+              id={`${idPrefix}-tabpanel-${tab.id}`}
+              role="tabpanel"
+              aria-labelledby={`${idPrefix}-tab-${tab.id}`}
+              hidden={!isActive}
+              className="h-full w-full"
+              style={{ display: isActive ? 'block' : 'none' }}
+            >
+              {tab.content}
+            </div>
+          );
+        })}
+      </div>
+    </section>
+  );
+});

--- a/packages/apollo-react/src/canvas/components/CanvasBottomPanel/CanvasBottomPanel.types.ts
+++ b/packages/apollo-react/src/canvas/components/CanvasBottomPanel/CanvasBottomPanel.types.ts
@@ -1,0 +1,25 @@
+import type { ReactNode } from 'react';
+
+export interface CanvasBottomPanelTab {
+  /** Stable identifier used for controlled selection and ARIA relationships. */
+  id: string;
+  /** Visible tab label. */
+  label: ReactNode;
+  /** Accessible label when the visible label is not plain text. */
+  ariaLabel?: string;
+  /** Content remains mounted while inactive or collapsed so consumer state is preserved. */
+  content: ReactNode;
+}
+
+export interface CanvasBottomPanelProps {
+  tabs: CanvasBottomPanelTab[];
+  activeTabId: string;
+  onTabChange: (tabId: string) => void;
+  isCollapsed: boolean;
+  onCollapsedChange: (isCollapsed: boolean) => void;
+  /** Consumer-owned controls rendered at the end of the panel header. */
+  headerActions?: ReactNode;
+  /** Unique prefix for tab and panel IDs when multiple instances share a page. */
+  idPrefix?: string;
+  className?: string;
+}

--- a/packages/apollo-react/src/canvas/components/CanvasBottomPanel/index.ts
+++ b/packages/apollo-react/src/canvas/components/CanvasBottomPanel/index.ts
@@ -1,0 +1,5 @@
+export { CANVAS_BOTTOM_PANEL_COLLAPSED_HEIGHT, CanvasBottomPanel } from './CanvasBottomPanel';
+export type {
+  CanvasBottomPanelProps,
+  CanvasBottomPanelTab,
+} from './CanvasBottomPanel.types';

--- a/packages/apollo-react/src/canvas/components/index.ts
+++ b/packages/apollo-react/src/canvas/components/index.ts
@@ -4,6 +4,7 @@ export * from './BaseCanvas';
 export * from './BaseNode';
 export * from './ButtonHandle';
 export * from './CanvasModeToolbar';
+export * from './CanvasBottomPanel';
 export * from './CanvasPositionControls';
 export * from './CanvasZoomControls';
 export * from './CaseFlow';


### PR DESCRIPTION
## Overview

Adds a reusable, product-neutral `CanvasBottomPanel` to Apollo React for canvas experiences that need a collapsible tabbed panel.

## What changed

- Added a controlled `CanvasBottomPanel` API with consumer-provided tabs and content.
- Added controlled active-tab and collapsed-state behavior.
- Added optional consumer-owned header actions.
- Preserved mounted tab content across tab switches and collapsed state so consumer state is retained.
- Implemented WAI-ARIA tab relationships, roving tab index, and Arrow Left/Right, Home, and End keyboard navigation.
- Added public exports from the Apollo React canvas component barrel.
- Added Storybook examples for collapsed, expanded, Debug/Evaluate switching, header actions, and composition with `CanvasModeToolbar` and `CanvasZoomControls`.
- Added focused component tests for rendering, controlled behavior, mounted-content preservation, actions, ARIA relationships, and keyboard navigation.

## Why

Flow products currently need a reusable canvas-level bottom panel shell without coupling Apollo to product-specific debug sessions, evaluation stores, datasets, or execution history. This provides the shared presentation and accessibility layer while keeping product logic in consuming applications.

## Validation

- `CanvasBottomPanel.test.tsx`: 10 tests passing
- Apollo React package build: passing
- Full Storybook production build: passing
- Biome lint/format checks: passing
- `git diff --check`: passing
