### PR TITLE
feat(apollo-react): NodePropertyPanel autoComplete prop + theme-scoped surface

### DIFF
--- a/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.test.tsx
+++ b/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.test.tsx
@@ -87,4 +87,24 @@ describe('NodePropertyPanel', () => {
     );
     expect(screen.getByTestId('header-extra')).toBeInTheDocument();
   });
+
+  it('forwards autoComplete to the form for a multi-step schema', () => {
+    const { container } = render(<NodePropertyPanel schema={MULTI_STEP} autoComplete="off" />);
+    expect(container.querySelector('form')).toHaveAttribute('autocomplete', 'off');
+  });
+
+  it('forwards autoComplete to the form for a single-page schema', () => {
+    const SINGLE_PAGE: FormSchema = {
+      id: 'http',
+      title: 'HTTP',
+      sections: [{ id: 'p', fields: [{ id: 'url', name: 'url', type: 'text', label: 'URL' }] }],
+    };
+    const { container } = render(<NodePropertyPanel schema={SINGLE_PAGE} autoComplete="off" />);
+    expect(container.querySelector('form')).toHaveAttribute('autocomplete', 'off');
+  });
+
+  it('renders the form without an autocomplete attribute when autoComplete is omitted', () => {
+    const { container } = render(<NodePropertyPanel schema={MULTI_STEP} />);
+    expect(container.querySelector('form')).not.toHaveAttribute('autocomplete');
+  });
 });

--- a/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.tsx
+++ b/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.tsx
@@ -3,8 +3,10 @@ import { GripVertical, X } from 'lucide-react';
 import { type CSSProperties, useMemo } from 'react';
 import type { NodePropertyPanelProps } from './NodePropertyPanel.types';
 
-// Remap surface-raised -> surface-overlay so inputs read lighter than the panel.
-const SURFACE_REMAP = { '--surface-raised': 'var(--surface-overlay)' } as CSSProperties;
+// Future themes raise the panel surface, so inputs remap surface-raised ->
+// surface-overlay to read lighter than the panel. Current themes keep the
+// classic bg-surface panel and stock input surfaces (no remap).
+const SURFACE_REMAP = 'future:[--surface-raised:var(--surface-overlay)]';
 
 /**
  * NodePropertyPanel — a presentational, docked properties panel for canvas nodes.
@@ -67,7 +69,7 @@ export function NodePropertyPanel({
 
   return (
     <div
-      className={cn('flex min-h-0 flex-col bg-surface-raised', className)}
+      className={cn('flex min-h-0 flex-col bg-surface future:bg-surface-raised', className)}
       style={{ '--mf-content-inset': contentInset } as CSSProperties}
     >
       {/* ── Title bar (optional; host panel system may own it) ── */}
@@ -126,9 +128,7 @@ export function NodePropertyPanel({
 
       {/* ── Content (children) or Form ── */}
       {children ? (
-        <div className="min-h-0 flex-1 overflow-auto" style={SURFACE_REMAP}>
-          {children}
-        </div>
+        <div className={cn('min-h-0 flex-1 overflow-auto', SURFACE_REMAP)}>{children}</div>
       ) : !formSchema ? (
         <div className="py-4 text-xs text-foreground-subtle [padding-inline:var(--mf-content-inset,1.5rem)]">
           No form schema defined for this node.
@@ -139,8 +139,10 @@ export function NodePropertyPanel({
         // scroll container — the form's inset/padding move inside TabbedStepForm.
         <div className="flex min-h-0 flex-1 flex-col">
           <div
-            style={SURFACE_REMAP}
-            className="flex min-h-0 flex-1 flex-col [&_label]:text-foreground-muted"
+            className={cn(
+              'flex min-h-0 flex-1 flex-col [&_label]:text-foreground-muted',
+              SURFACE_REMAP
+            )}
           >
             <MetadataForm
               key={resetKey}
@@ -161,7 +163,7 @@ export function NodePropertyPanel({
         // Single-page schema: classic behavior — this wrapper scrolls the whole
         // form. No stepVariant: it only applies to step-based schemas.
         <div className="min-h-0 flex-1 overflow-auto">
-          <div style={SURFACE_REMAP} className="[&_label]:text-foreground-muted">
+          <div className={cn('[&_label]:text-foreground-muted', SURFACE_REMAP)}>
             <MetadataForm
               key={resetKey}
               schema={formSchema}

--- a/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.tsx
+++ b/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.tsx
@@ -45,6 +45,7 @@ export function NodePropertyPanel({
   plugins,
   onSubmit,
   disabled,
+  autoComplete,
   resetKey,
   className,
   contentInset = '1.5rem',
@@ -151,6 +152,7 @@ export function NodePropertyPanel({
               onActiveStepChange={onActiveStepChange}
               onSubmit={onSubmit}
               disabled={disabled}
+              autoComplete={autoComplete}
               className="flex min-h-0 flex-1 flex-col"
             />
           </div>
@@ -167,6 +169,7 @@ export function NodePropertyPanel({
               sectionVariant={sectionVariant}
               onSubmit={onSubmit}
               disabled={disabled}
+              autoComplete={autoComplete}
               className="flex flex-col gap-4 pb-6 pt-3 [padding-inline:var(--mf-content-inset)]"
             />
           </div>

--- a/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.types.ts
+++ b/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.types.ts
@@ -52,6 +52,12 @@ export interface NodePropertyPanelProps {
   /** Disables all fields (e.g. read-only nodes). */
   disabled?: boolean;
   /**
+   * Forwarded to the underlying `MetadataForm`'s `<form>` element. Set `'off'`
+   * to keep browser autofill dropdowns from covering fields whose names match
+   * common autofill categories (e.g. `label`, `url`, `description`).
+   */
+  autoComplete?: 'off' | 'on';
+  /**
    * Change this (e.g. to the selected node id) to remount the form with fresh
    * initial data. The form reads `schema.initialData` once per mount, so a
    * stable identity per selected node prevents stale values across selections.


### PR DESCRIPTION
## Summary

Two host-parity fixes for `NodePropertyPanel`, both driven by flow-workbench's adoption of the panel for its node properties redesign.

### 1. Forward `autoComplete` to the form

`MetadataForm` already accepts `autoComplete` and applies it to its `<form>` element, but `NodePropertyPanel` doesn't expose it — so hosts embedding the panel cannot disable browser autofill. Autofill dropdowns cover fields whose names match common autofill categories (`label`, `url`, `description`), which flow-workbench hits in its docked node properties panel and edge panel (its expanded dialog uses `MetadataForm` directly and already passes `autoComplete="off"`).

- Add `autoComplete?: 'off' | 'on'` to `NodePropertyPanelProps` (same type `MetadataForm` accepts), forwarded verbatim to the underlying `MetadataForm` in both the tabbed (multi-step) and single-page branches.

### 2. Theme-scoped panel surface

The panel hardcoded `bg-surface-raised`, which diverges from the classic flat properties panel (`bg-surface`) on the six current themes. Following the established `future` variant precedent (pagination, input-group, NodeToolbar):

- Root: `bg-surface future:bg-surface-raised` — current themes keep the classic surface; only `.future-light` / `.future-dark` get the raised panel.
- The `--surface-raised → --surface-overlay` input remap only makes sense when the panel itself is raised, so it moves from an unconditional inline `style` to a future-scoped arbitrary-property class: `future:[--surface-raised:var(--surface-overlay)]`.

## Testing

- Tests: `autoComplete` reaches the `<form>` in both branches; no attribute emitted when omitted (12/12 pass).
- `biome format:check` clean; lint unchanged.

Both changes are additive/backwards-compatible for current-theme hosts: omitted `autoComplete` renders exactly as before, and the surface change restores the classic panel background on current themes while preserving the raised look under future themes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)