### PR TITLE
feat(apollo-react): add data-testids to stage/task node components

### DIFF
--- a/packages/apollo-react/src/canvas/components/StageNode/StageNodeAdhocTaskGroups.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNodeAdhocTaskGroups.tsx
@@ -32,6 +32,7 @@ const StageNodeAdhocTaskGroupsInner = ({
   generateDeleteTaskMenuItemForTask: (taskId: string) => NodeMenuItem | undefined;
 }) => {
   const {
+    id,
     execution,
     onTaskGroupModification,
     onReplaceTaskFromToolbox,
@@ -73,9 +74,14 @@ const StageNodeAdhocTaskGroupsInner = ({
   return (
     <StageAdditionalTasksSection style={{ marginTop }}>
       <StageAdditionalTasksHeaderSection>
-        <span className="text-xs font-bold text-foreground-muted">{labels.adhocTasks}</span>
+        <span
+          data-testid={`adhoc-tasks-header-${id}`}
+          className="text-xs font-bold text-foreground-muted"
+        >
+          {labels.adhocTasks}
+        </span>
       </StageAdditionalTasksHeaderSection>
-      <StageTaskList>
+      <StageTaskList data-testid={`adhoc-tasks-list-${id}`}>
         {adhocTasks.map(({ task }) => {
           const taskExecution = execution?.taskStatus?.[task.id];
           // Consumer items (e.g. breakpoints) are allowed even in read-only/Debug view;

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNodeAllTaskGroups.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNodeAllTaskGroups.tsx
@@ -157,11 +157,15 @@ const StageNodeAllTaskGroupsInner = ({
               size="sm"
               onClick={handleTaskAddClick}
               style={{ maxWidth: 'fit-content', padding: 0 }}
+              data-testid={`add-task-body-button-${id}`}
             >
               {defaultContent}
             </Button>
           ) : (
-            <span className="inline-flex items-center h-9 text-sm font-medium text-foreground-muted">
+            <span
+              data-testid={`no-tasks-body-${id}`}
+              className="inline-flex items-center h-9 text-sm font-medium text-foreground-muted"
+            >
               {defaultContent}
             </span>
           )}

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNodeEventDrivenTaskGroups.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNodeEventDrivenTaskGroups.tsx
@@ -32,6 +32,7 @@ const StageNodeEventDrivenTaskGroupsInner = ({
   generateDeleteTaskMenuItemForTask: (taskId: string) => NodeMenuItem | undefined;
 }) => {
   const {
+    id,
     execution,
     onTaskGroupModification,
     onReplaceTaskFromToolbox,
@@ -72,9 +73,14 @@ const StageNodeEventDrivenTaskGroupsInner = ({
   return (
     <StageAdditionalTasksSection style={{ marginTop }}>
       <StageAdditionalTasksHeaderSection>
-        <span className="text-xs font-bold text-foreground-muted">{labels.eventDrivenTasks}</span>
+        <span
+          data-testid={`event-driven-tasks-header-${id}`}
+          className="text-xs font-bold text-foreground-muted"
+        >
+          {labels.eventDrivenTasks}
+        </span>
       </StageAdditionalTasksHeaderSection>
-      <StageTaskList>
+      <StageTaskList data-testid={`event-driven-tasks-list-${id}`}>
         {eventDrivenTasks.map(({ task }) => {
           const taskExecution = execution?.taskStatus?.[task.id];
           // Consumer items (e.g. breakpoints) are allowed even in read-only/Debug view;

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNodeHeader.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNodeHeader.tsx
@@ -201,6 +201,7 @@ const StageNodeHeaderInner = ({
                 onClick={handleTaskAddClick}
                 aria-label={labels.addTask}
                 disabled={isAddTaskDisabled}
+                data-testid={`add-task-button-${id}`}
               >
                 <CanvasIcon icon="plus" size={20} />
               </Button>
@@ -243,6 +244,7 @@ const StageNodeHeaderInner = ({
                 const button = (
                   <StageChip
                     key={chip.type}
+                    data-testid={`stage-${chip.type}-chip-${id}`}
                     type="button"
                     aria-label={typeof chip.tooltip === 'string' ? chip.tooltip : chip.type}
                     onClick={(e) => {
@@ -268,7 +270,10 @@ const StageNodeHeaderInner = ({
         </div>
       )}
       {stageDuration && (
-        <span className="flex min-h-8 items-center text-xs text-foreground-muted">
+        <span
+          className="flex min-h-8 items-center text-xs text-foreground-muted"
+          data-testid={`stage-duration-${id}`}
+        >
           {stageDuration}
         </span>
       )}

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNodeSequentialTaskGroups.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNodeSequentialTaskGroups.tsx
@@ -62,6 +62,7 @@ export const StageNodeSequentialTaskGroups = ({
   ) => NodeMenuItem | undefined;
 }) => {
   const {
+    id,
     execution,
     onTaskGroupModification,
     onReplaceTaskFromToolbox,
@@ -202,7 +203,12 @@ export const StageNodeSequentialTaskGroups = ({
   return (
     <StageAdditionalTasksSection>
       <StageAdditionalTasksHeaderSection>
-        <span className="text-xs font-bold text-foreground-muted">{labels.sequentialTasks}</span>
+        <span
+          data-testid={`sequential-tasks-header-${id}`}
+          className="text-xs font-bold text-foreground-muted"
+        >
+          {labels.sequentialTasks}
+        </span>
       </StageAdditionalTasksHeaderSection>
       <DndContext
         collisionDetection={closestCenter}
@@ -215,7 +221,7 @@ export const StageNodeSequentialTaskGroups = ({
       >
         <SortableContext items={sequentialTaskIds} strategy={verticalListSortingStrategy}>
           {/* Disable dragging and panning the canvas when dragging a task */}
-          <StageTaskList className="nodrag nopan">
+          <StageTaskList data-testid={`sequential-tasks-list-${id}`} className="nodrag nopan">
             {sequentialTaskGroups.map((taskGroup, groupIndex) => {
               const isParallel = taskGroup.length > 1;
               return (

--- a/packages/apollo-react/src/canvas/components/StageNode/StageTaskEntryConditionIcon.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageTaskEntryConditionIcon.tsx
@@ -15,6 +15,7 @@ export const StageTaskEntryConditionIcon = ({
   return (
     <CanvasTooltip content="Entry condition" placement="top">
       <span
+        data-testid={`task-entry-condition-icon-${task.id}`}
         style={{
           display: 'flex',
           alignItems: 'center',

--- a/packages/apollo-react/src/canvas/components/StageNode/StageTitleInput.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageTitleInput.tsx
@@ -62,7 +62,10 @@ export const StageTitleInput = ({
   );
 
   return (
-    <div className={cn('py-0.5 text-sm', !isEditing && 'font-bold', className)}>
+    <div
+      className={cn('py-0.5 text-sm', !isEditing && 'font-bold', className)}
+      data-testid={`stage-title-input-${stageId}`}
+    >
       <CanvasTooltip content={label} placement="top" hide={isEditing} delay>
         <div
           className={cn(

--- a/packages/apollo-react/src/canvas/components/StageNode/TaskContent.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/TaskContent.tsx
@@ -118,7 +118,12 @@ export const TaskContent = memo(
     // Ad hoc tasks are by definition not required, so never show the "*" marker on them.
     const showRequiredMarker = task.isRequired && !task.isAdhoc && task.taskGroupType !== 'adhoc';
     const durationLabel = taskExecution?.duration ? (
-      <span className="text-xs text-foreground-muted">{taskExecution.duration}</span>
+      <span
+        data-testid={`stage-task-duration-${task.id}`}
+        className="text-xs text-foreground-muted"
+      >
+        {taskExecution.duration}
+      </span>
     ) : null;
 
     return (
@@ -135,7 +140,9 @@ export const TaskContent = memo(
           align="center"
           style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
         >
-          <StageTaskIcon>{task.icon ?? <ProcessCanvasIcon />}</StageTaskIcon>
+          <StageTaskIcon data-testid={`stage-task-icon-${task.id}`}>
+            {task.icon ?? <ProcessCanvasIcon />}
+          </StageTaskIcon>
           <CanvasTooltip
             content={task.label}
             placement="top"
@@ -151,11 +158,19 @@ export const TaskContent = memo(
                 whiteSpace: 'nowrap',
               }}
             >
-              <span className="text-sm truncate" style={{ minWidth: 0 }}>
+              <span
+                data-testid={`stage-task-label-${task.id}`}
+                className="text-sm truncate"
+                style={{ minWidth: 0 }}
+              >
                 {task.label}
               </span>
               {showRequiredMarker && (
-                <span className="text-sm" style={{ flexShrink: 0 }}>
+                <span
+                  data-testid={`stage-task-required-marker-${task.id}`}
+                  className="text-sm"
+                  style={{ flexShrink: 0 }}
+                >
                   {'*'}
                 </span>
               )}
@@ -182,6 +197,7 @@ export const TaskContent = memo(
                 role="img"
                 aria-label={runsTooltip}
                 className="h-[14px] gap-px rounded-full px-1 py-0 text-[11px] leading-none [&>svg]:size-3"
+                data-testid={`stage-task-runs-${task.id}`}
               >
                 <Redo2 aria-hidden />
                 {totalRuns}
@@ -195,6 +211,7 @@ export const TaskContent = memo(
                 role="img"
                 aria-label={reworkTooltip}
                 className="h-[14px] rounded-full px-1 py-0 [&>svg]:size-3"
+                data-testid={`stage-task-rework-${task.id}`}
               >
                 <RotateCcw aria-hidden />
               </Badge>
@@ -208,6 +225,7 @@ export const TaskContent = memo(
                 size="icon"
                 className="h-4 w-4 rounded-sm"
                 aria-label={taskStatusTooltip}
+                data-testid={`stage-task-status-${task.id}`}
               >
                 <ExecutionStatusIcon status={taskExecution.status} />
               </Button>


### PR DESCRIPTION
Adding data-testids to various components in the Stage node component. When writing e2e tests it can be hard to get the specific element since a lot of it is just icons with a lot of repeated elements