### PR TITLE
feat(apollo-react): add Patterns TaskIcon type with stacked-cards glyph

### DIFF
--- a/packages/apollo-react/src/canvas/components/TaskIcon/TaskIcon.styles.ts
+++ b/packages/apollo-react/src/canvas/components/TaskIcon/TaskIcon.styles.ts
@@ -22,6 +22,7 @@ export const TASK_ICON_GRADIENTS: Record<TaskItemTypeValues, string> = {
   [TaskItemTypeValues.Tools]: CategoryColor.Grey,
   [TaskItemTypeValues.MoreElements]: CategoryColor.Grey,
   [TaskItemTypeValues.CreateNew]: CategoryColor.Grey,
+  [TaskItemTypeValues.Patterns]: CategoryColor.Grey,
 };
 
 interface TaskIconContainerProps {

--- a/packages/apollo-react/src/canvas/components/TaskIcon/TaskIcon.test.tsx
+++ b/packages/apollo-react/src/canvas/components/TaskIcon/TaskIcon.test.tsx
@@ -66,4 +66,18 @@ describe('TaskIcon', () => {
       }
     });
   });
+
+  describe('Patterns type', () => {
+    it('renders with SVG icon', () => {
+      const { container } = render(<TaskIcon type={TaskItemTypeValues.Patterns} />);
+      expect(container.querySelector('svg')).toBeInTheDocument();
+    });
+
+    it('renders at all sizes', () => {
+      for (const size of ['sm', 'md', 'lg'] as const) {
+        const { container } = render(<TaskIcon type={TaskItemTypeValues.Patterns} size={size} />);
+        expect(container.firstChild).toBeInTheDocument();
+      }
+    });
+  });
 });

--- a/packages/apollo-react/src/canvas/components/TaskIcon/TaskIcon.tsx
+++ b/packages/apollo-react/src/canvas/components/TaskIcon/TaskIcon.tsx
@@ -5,6 +5,7 @@ import {
   CaseManagementProject,
   ConnectorBuilderProject,
   HumanIcon,
+  PatternsIcon,
   RpaProject,
 } from '@uipath/apollo-react/canvas/icons';
 import {
@@ -53,6 +54,8 @@ const getIconForType = (type: TaskItemTypeValues, iconSize: number): React.React
       return <MoreIcon size={iconSize} />;
     case TaskItemTypeValues.CreateNew:
       return <CreateIcon size={iconSize} />;
+    case TaskItemTypeValues.Patterns:
+      return <PatternsIcon w={iconSize} h={iconSize} />;
   }
 };
 

--- a/packages/apollo-react/src/canvas/components/TaskIcon/TaskIcon.types.ts
+++ b/packages/apollo-react/src/canvas/components/TaskIcon/TaskIcon.types.ts
@@ -12,6 +12,7 @@ export enum TaskItemTypeValues {
   Tools = 'tools',
   MoreElements = 'more_elements',
   CreateNew = 'create_new',
+  Patterns = 'patterns',
 }
 
 export type TaskIconSize = 'sm' | 'md' | 'lg';

--- a/packages/apollo-react/src/canvas/icons/PatternsIcon.tsx
+++ b/packages/apollo-react/src/canvas/icons/PatternsIcon.tsx
@@ -1,0 +1,26 @@
+export const PatternsIcon = ({ w = 24, h = 24 }: { w?: number | string; h?: number | string }) => (
+  <svg xmlns="http://www.w3.org/2000/svg" width={w} height={h} viewBox="0 0 24 24" fill="none">
+    <rect x="6" y="3" width="14" height="10" rx="2" stroke="currentColor" strokeWidth="1.5" />
+    {/* Background fill lets each card occlude the one behind it. */}
+    <rect
+      x="4"
+      y="6"
+      width="14"
+      height="10"
+      rx="2"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      fill="var(--color-background, transparent)"
+    />
+    <rect
+      x="2"
+      y="9"
+      width="14"
+      height="10"
+      rx="2"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      fill="var(--color-background, transparent)"
+    />
+  </svg>
+);

--- a/packages/apollo-react/src/canvas/icons/index.ts
+++ b/packages/apollo-react/src/canvas/icons/index.ts
@@ -36,6 +36,7 @@ export { McpIcon } from './McpIcon';
 export { MemoryIcon } from './MemoryIcon';
 export { OpenAIIcon } from './OpenAIIcon';
 export { OrganizeIcon } from './OrganizeIcon';
+export { PatternsIcon } from './PatternsIcon';
 export { ReturnToOriginIcon } from './ReturnToOriginIcon';
 export { RpaProject } from './RpaProject';
 export { ScriptTaskIcon } from './ScriptTaskIcon';


### PR DESCRIPTION
## What

Adds a `Patterns` task-icon type to the canvas `TaskIcon` component:

- `TaskItemTypeValues.Patterns` (`'patterns'`)
- New `PatternsIcon` stacked-cards glyph in `canvas/icons` (exported from the barrel, so it also shows up in the icon gallery stories)
- Wired into `getIconForType` and `TASK_ICON_GRADIENTS` with the Grey gradient, same as `Queues`/`Tools`/`MoreElements`
- Unit test coverage mirroring the existing `MoreElements`/`CreateNew` blocks (the enum-driven `it.each` and gradient-mapping tests pick the new type up automatically)

The glyph uses `currentColor` strokes on a 24x24 viewBox; the front cards occlude the ones behind via `fill: var(--color-background, transparent)`, the same occlusion approach `SwitchIcon` already uses.

## Why

Canvas quick-add toolboxes render every category entry through `TaskIcon`, but a "Patterns" entry has no matching type, so consumers currently hand-replicate `TaskIconContainer` (size config, border radius, gradient, foreground color) to make the entry sit flush with its siblings. Shipping the type in `TaskIcon` keeps the tile theme-correct in both themes and reusable across consumers.

## Follow-up

Once this releases, the consumer-side copy of the container/glyph in PO.Frontend will be removed in favor of `<TaskIcon type={TaskItemTypeValues.Patterns} />`.

## Validation

- `biome check` clean on the touched files
- `vitest --run src/canvas/components/TaskIcon`: 24/24 passing
- `turbo build --filter=@uipath/apollo-react` succeeds; `dist` output contains the new type and icon export
