### PR TITLE
test(apollo-react): cover StageNode rules and shared subcomponents

### DIFF
--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.test.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.test.tsx
@@ -106,7 +106,7 @@ vi.mock('../Toolbox', () => ({
 }));
 
 // Mock DraggableTask
-vi.mock('./DraggableTask', () => ({
+vi.mock('./tasks/DraggableTask', () => ({
   DraggableTask: ({
     task,
     isDragDisabled,
@@ -1364,5 +1364,99 @@ describe('StageNode - Breakpoints on adhoc and event-driven tasks', () => {
     });
 
     expect(screen.queryByTestId('stage-task-breakpoint-adhoc-1')).not.toBeInTheDocument();
+  });
+});
+
+describe('StageNode - Entry, exit and completion rules', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('does not render any rule sections when no rules are provided', () => {
+    renderStageNode();
+
+    expect(screen.queryByTestId('entry-rules-container-stage-1')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('exit-rules-container-stage-1')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('completion-rules-container-stage-1')).not.toBeInTheDocument();
+  });
+
+  it('renders the entry rules section with a pill per rule', () => {
+    renderStageNode({
+      stageDetails: {
+        ...defaultProps.stageDetails,
+        entryRules: [
+          { id: 'entry-1', label: 'Amount > 1000' },
+          { id: 'entry-2', label: 'Region is EU' },
+        ],
+      },
+    });
+
+    expect(screen.getByTestId('entry-rules-container-stage-1')).toBeInTheDocument();
+    expect(screen.getByTestId('stage-rule-entry-1')).toHaveTextContent('Amount > 1000');
+    expect(screen.getByTestId('stage-rule-entry-2')).toHaveTextContent('Region is EU');
+  });
+
+  it('renders the exit rules section with a pill per rule', () => {
+    renderStageNode({
+      stageDetails: {
+        ...defaultProps.stageDetails,
+        exitRules: [{ id: 'exit-1', label: 'Approved' }],
+      },
+    });
+
+    expect(screen.getByTestId('exit-rules-container-stage-1')).toBeInTheDocument();
+    expect(screen.getByTestId('stage-rule-exit-1')).toHaveTextContent('Approved');
+  });
+
+  it('renders the completion rules section with a pill per rule', () => {
+    renderStageNode({
+      stageDetails: {
+        ...defaultProps.stageDetails,
+        completionRules: [{ id: 'completion-1', label: 'All tasks done' }],
+      },
+    });
+
+    expect(screen.getByTestId('completion-rules-container-stage-1')).toBeInTheDocument();
+    expect(screen.getByTestId('stage-rule-completion-1')).toHaveTextContent('All tasks done');
+  });
+
+  it('invokes a rule onClick when the rule pill is clicked', async () => {
+    const user = userEvent.setup();
+    const onClick = vi.fn();
+    renderStageNode({
+      stageDetails: {
+        ...defaultProps.stageDetails,
+        entryRules: [{ id: 'entry-1', label: 'Amount > 1000', onClick }],
+      },
+    });
+
+    await user.click(screen.getByTestId('stage-rule-entry-1'));
+
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders a collapsible entry rules header when a section state is provided', () => {
+    renderStageNode({
+      stageDetails: {
+        ...defaultProps.stageDetails,
+        entryRules: [{ id: 'entry-1', label: 'Amount > 1000' }],
+        sectionStates: { entryRules: { isCollapsed: false, onCollapsedToggle: vi.fn() } },
+      },
+    });
+
+    expect(screen.getByTestId('entry-rules-header-stage-1-accordion-button')).toBeInTheDocument();
+    expect(screen.getByTestId('stage-rule-entry-1')).toBeInTheDocument();
+  });
+
+  it('collapses the entry rules body when the section state is collapsed', () => {
+    renderStageNode({
+      stageDetails: {
+        ...defaultProps.stageDetails,
+        entryRules: [{ id: 'entry-1', label: 'Amount > 1000' }],
+        sectionStates: { entryRules: { isCollapsed: true, onCollapsedToggle: vi.fn() } },
+      },
+    });
+
+    expect(screen.queryByTestId('stage-rule-entry-1')).not.toBeInTheDocument();
   });
 });

--- a/packages/apollo-react/src/canvas/components/StageNode/rules/CompletionRulesContainer.test.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/rules/CompletionRulesContainer.test.tsx
@@ -1,0 +1,81 @@
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, userEvent } from '../../../utils/testing';
+import type { StageNodeProps, StageRule } from '../StageNode.types';
+import { CompletionRulesContainer } from './CompletionRulesContainer';
+
+vi.mock('../../CanvasTooltip', () => ({
+  CanvasTooltip: ({ children }: { content: ReactNode; children: ReactNode }) => <>{children}</>,
+}));
+
+const completionRules: StageRule[] = [
+  { id: 'rule-1', label: 'Rule 1' },
+  { id: 'rule-2', label: 'Rule 2' },
+];
+
+const makeProps = (stageDetails: Partial<StageNodeProps['stageDetails']>): StageNodeProps =>
+  ({
+    id: 'stage-1',
+    selected: false,
+    dragging: false,
+    width: 300,
+    stageDetails: { label: 'Test Stage', tasks: [], ...stageDetails },
+  }) as StageNodeProps;
+
+describe('CompletionRulesContainer', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders nothing when there are no completion rules', () => {
+    render(<CompletionRulesContainer props={makeProps({})} isReadOnly={false} />);
+
+    expect(screen.queryByTestId('completion-rules-container-stage-1')).not.toBeInTheDocument();
+  });
+
+  it('renders a static header and a pill per rule when no section state is provided', () => {
+    render(<CompletionRulesContainer props={makeProps({ completionRules })} isReadOnly={false} />);
+
+    expect(screen.getByTestId('completion-rules-container-stage-1')).toBeInTheDocument();
+    expect(screen.getByTestId('completion-rules-header-stage-1')).toHaveTextContent(
+      'Completion rules'
+    );
+    expect(screen.getByTestId('stage-rule-rule-1')).toBeInTheDocument();
+    expect(screen.getByTestId('stage-rule-rule-2')).toBeInTheDocument();
+    expect(
+      screen.queryByTestId('completion-rules-header-stage-1-accordion-button')
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders a collapsible header and toggles via onCollapsedToggle', async () => {
+    const user = userEvent.setup();
+    const onCollapsedToggle = vi.fn();
+    render(
+      <CompletionRulesContainer
+        props={makeProps({
+          completionRules,
+          sectionStates: { completionRules: { isCollapsed: false, onCollapsedToggle } },
+        })}
+        isReadOnly={false}
+      />
+    );
+
+    expect(screen.getByTestId('stage-rule-rule-1')).toBeInTheDocument();
+    await user.click(screen.getByTestId('completion-rules-header-stage-1-accordion-button'));
+    expect(onCollapsedToggle).toHaveBeenCalledTimes(1);
+  });
+
+  it('hides the rules when the collapsible section is collapsed', () => {
+    render(
+      <CompletionRulesContainer
+        props={makeProps({
+          completionRules,
+          sectionStates: { completionRules: { isCollapsed: true, onCollapsedToggle: vi.fn() } },
+        })}
+        isReadOnly={false}
+      />
+    );
+
+    expect(screen.queryByTestId('stage-rule-rule-1')).not.toBeInTheDocument();
+  });
+});

--- a/packages/apollo-react/src/canvas/components/StageNode/rules/EntryRulesContainer.test.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/rules/EntryRulesContainer.test.tsx
@@ -1,0 +1,111 @@
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, userEvent } from '../../../utils/testing';
+import type { StageNodeProps, StageRule } from '../StageNode.types';
+import { EntryRulesContainer } from './EntryRulesContainer';
+
+vi.mock('../../CanvasTooltip', () => ({
+  CanvasTooltip: ({ children }: { content: ReactNode; children: ReactNode }) => <>{children}</>,
+}));
+
+const entryRules: StageRule[] = [
+  { id: 'rule-1', label: 'Rule 1' },
+  { id: 'rule-2', label: 'Rule 2' },
+];
+
+const makeProps = (stageDetails: Partial<StageNodeProps['stageDetails']>): StageNodeProps =>
+  ({
+    id: 'stage-1',
+    selected: false,
+    dragging: false,
+    width: 300,
+    stageDetails: { label: 'Test Stage', tasks: [], ...stageDetails },
+  }) as StageNodeProps;
+
+describe('EntryRulesContainer', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders nothing when there are no entry rules', () => {
+    render(<EntryRulesContainer props={makeProps({})} isReadOnly={false} />);
+
+    expect(screen.queryByTestId('entry-rules-container-stage-1')).not.toBeInTheDocument();
+  });
+
+  it('renders nothing when the entry rules array is empty', () => {
+    render(<EntryRulesContainer props={makeProps({ entryRules: [] })} isReadOnly={false} />);
+
+    expect(screen.queryByTestId('entry-rules-container-stage-1')).not.toBeInTheDocument();
+  });
+
+  describe('without section state (static header)', () => {
+    it('renders the container, a static header and a pill per rule', () => {
+      render(<EntryRulesContainer props={makeProps({ entryRules })} isReadOnly={false} />);
+
+      expect(screen.getByTestId('entry-rules-container-stage-1')).toBeInTheDocument();
+      expect(screen.getByTestId('entry-rules-header-stage-1')).toHaveTextContent('Entry rules');
+      expect(screen.getByTestId('stage-rule-rule-1')).toBeInTheDocument();
+      expect(screen.getByTestId('stage-rule-rule-2')).toBeInTheDocument();
+    });
+
+    it('does not render a collapsible accordion button', () => {
+      render(<EntryRulesContainer props={makeProps({ entryRules })} isReadOnly={false} />);
+
+      expect(
+        screen.queryByTestId('entry-rules-header-stage-1-accordion-button')
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe('with section state (collapsible header)', () => {
+    it('renders a collapsible header and shows the rules when expanded', () => {
+      const onCollapsedToggle = vi.fn();
+      render(
+        <EntryRulesContainer
+          props={makeProps({
+            entryRules,
+            sectionStates: { entryRules: { isCollapsed: false, onCollapsedToggle } },
+          })}
+          isReadOnly={false}
+        />
+      );
+
+      expect(screen.getByTestId('entry-rules-header-stage-1-accordion-button')).toBeInTheDocument();
+      expect(screen.getByTestId('stage-rule-rule-1')).toBeInTheDocument();
+    });
+
+    it('hides the rules when collapsed', () => {
+      const onCollapsedToggle = vi.fn();
+      render(
+        <EntryRulesContainer
+          props={makeProps({
+            entryRules,
+            sectionStates: { entryRules: { isCollapsed: true, onCollapsedToggle } },
+          })}
+          isReadOnly={false}
+        />
+      );
+
+      expect(screen.queryByTestId('stage-rule-rule-1')).not.toBeInTheDocument();
+    });
+
+    it('calls onCollapsedToggle when the header is clicked', async () => {
+      const user = userEvent.setup();
+      const onCollapsedToggle = vi.fn();
+      render(
+        <EntryRulesContainer
+          props={makeProps({
+            entryRules,
+            sectionStates: { entryRules: { isCollapsed: false, onCollapsedToggle } },
+          })}
+          isReadOnly={false}
+        />
+      );
+
+      await user.click(screen.getByTestId('entry-rules-header-stage-1-accordion-button'));
+
+      expect(onCollapsedToggle).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/packages/apollo-react/src/canvas/components/StageNode/rules/ExitRulesContainer.test.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/rules/ExitRulesContainer.test.tsx
@@ -1,0 +1,79 @@
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, userEvent } from '../../../utils/testing';
+import type { StageNodeProps, StageRule } from '../StageNode.types';
+import { ExitRulesContainer } from './ExitRulesContainer';
+
+vi.mock('../../CanvasTooltip', () => ({
+  CanvasTooltip: ({ children }: { content: ReactNode; children: ReactNode }) => <>{children}</>,
+}));
+
+const exitRules: StageRule[] = [
+  { id: 'rule-1', label: 'Rule 1' },
+  { id: 'rule-2', label: 'Rule 2' },
+];
+
+const makeProps = (stageDetails: Partial<StageNodeProps['stageDetails']>): StageNodeProps =>
+  ({
+    id: 'stage-1',
+    selected: false,
+    dragging: false,
+    width: 300,
+    stageDetails: { label: 'Test Stage', tasks: [], ...stageDetails },
+  }) as StageNodeProps;
+
+describe('ExitRulesContainer', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders nothing when there are no exit rules', () => {
+    render(<ExitRulesContainer props={makeProps({})} isReadOnly={false} />);
+
+    expect(screen.queryByTestId('exit-rules-container-stage-1')).not.toBeInTheDocument();
+  });
+
+  it('renders a static header and a pill per rule when no section state is provided', () => {
+    render(<ExitRulesContainer props={makeProps({ exitRules })} isReadOnly={false} />);
+
+    expect(screen.getByTestId('exit-rules-container-stage-1')).toBeInTheDocument();
+    expect(screen.getByTestId('exit-rules-header-stage-1')).toHaveTextContent('Exit rules');
+    expect(screen.getByTestId('stage-rule-rule-1')).toBeInTheDocument();
+    expect(screen.getByTestId('stage-rule-rule-2')).toBeInTheDocument();
+    expect(
+      screen.queryByTestId('exit-rules-header-stage-1-accordion-button')
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders a collapsible header and toggles via onCollapsedToggle', async () => {
+    const user = userEvent.setup();
+    const onCollapsedToggle = vi.fn();
+    render(
+      <ExitRulesContainer
+        props={makeProps({
+          exitRules,
+          sectionStates: { exitRules: { isCollapsed: false, onCollapsedToggle } },
+        })}
+        isReadOnly={false}
+      />
+    );
+
+    expect(screen.getByTestId('stage-rule-rule-1')).toBeInTheDocument();
+    await user.click(screen.getByTestId('exit-rules-header-stage-1-accordion-button'));
+    expect(onCollapsedToggle).toHaveBeenCalledTimes(1);
+  });
+
+  it('hides the rules when the collapsible section is collapsed', () => {
+    render(
+      <ExitRulesContainer
+        props={makeProps({
+          exitRules,
+          sectionStates: { exitRules: { isCollapsed: true, onCollapsedToggle: vi.fn() } },
+        })}
+        isReadOnly={false}
+      />
+    );
+
+    expect(screen.queryByTestId('stage-rule-rule-1')).not.toBeInTheDocument();
+  });
+});

--- a/packages/apollo-react/src/canvas/components/StageNode/rules/StageRuleContent.test.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/rules/StageRuleContent.test.tsx
@@ -1,0 +1,58 @@
+import type { ReactNode } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '../../../utils/testing';
+import type { StageRule } from '../StageNode.types';
+import { StageRuleContent } from './StageRuleContent';
+
+// Surface CanvasTooltip content into the DOM so the label copy can be asserted
+// without relying on Radix's hover-driven open/close (unreliable in happy-dom).
+vi.mock('../../CanvasTooltip', () => ({
+  CanvasTooltip: ({ content, children }: { content: ReactNode; children: ReactNode }) => (
+    <span
+      data-testid="canvas-tooltip"
+      data-tooltip-content={typeof content === 'string' ? content : ''}
+    >
+      {children}
+    </span>
+  ),
+}));
+
+const rule: StageRule = { id: 'rule-1', label: 'Amount > 1000' };
+
+describe('StageRuleContent', () => {
+  it('renders the rule label under a rule-scoped test id', () => {
+    render(<StageRuleContent rule={rule} ruleType="entry" />);
+
+    const label = screen.getByTestId('stage-rule-label-rule-1');
+    expect(label).toHaveTextContent('Amount > 1000');
+  });
+
+  it('wraps the label in a tooltip showing the rule label', () => {
+    const { container } = render(<StageRuleContent rule={rule} ruleType="entry" />);
+
+    expect(container.querySelector('[data-tooltip-content="Amount > 1000"]')).not.toBeNull();
+  });
+
+  it('renders the entry-condition icon for an entry rule', () => {
+    render(<StageRuleContent rule={rule} ruleType="entry" />);
+
+    expect(screen.getByTestId('stage-rule-icon-rule-1')).toBeInTheDocument();
+    expect(screen.getByTestId('entry-condition-icon')).toBeInTheDocument();
+    expect(screen.queryByTestId('exit-condition-icon')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('completion-condition-icon')).not.toBeInTheDocument();
+  });
+
+  it('renders the exit-condition icon for an exit rule', () => {
+    render(<StageRuleContent rule={rule} ruleType="exit" />);
+
+    expect(screen.getByTestId('exit-condition-icon')).toBeInTheDocument();
+    expect(screen.queryByTestId('entry-condition-icon')).not.toBeInTheDocument();
+  });
+
+  it('renders the completion-condition icon for a completion rule', () => {
+    render(<StageRuleContent rule={rule} ruleType="completion" />);
+
+    expect(screen.getByTestId('completion-condition-icon')).toBeInTheDocument();
+    expect(screen.queryByTestId('entry-condition-icon')).not.toBeInTheDocument();
+  });
+});

--- a/packages/apollo-react/src/canvas/components/StageNode/rules/StageRuleItemPill.test.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/rules/StageRuleItemPill.test.tsx
@@ -1,0 +1,49 @@
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, userEvent } from '../../../utils/testing';
+import type { StageRule } from '../StageNode.types';
+import { StageRuleItemPill } from './StageRuleItemPill';
+
+vi.mock('../../CanvasTooltip', () => ({
+  CanvasTooltip: ({ children }: { content: ReactNode; children: ReactNode }) => <>{children}</>,
+}));
+
+const createRule = (onClick?: () => void): StageRule => ({
+  id: 'rule-1',
+  label: 'Amount > 1000',
+  onClick,
+});
+
+describe('StageRuleItemPill', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders the pill with a rule-scoped test id and its label', () => {
+    render(<StageRuleItemPill rule={createRule()} ruleType="entry" isReadOnly={false} />);
+
+    const pill = screen.getByTestId('stage-rule-rule-1');
+    expect(pill).toBeInTheDocument();
+    expect(pill).toHaveTextContent('Amount > 1000');
+  });
+
+  it('invokes the rule onClick when clicked and not read-only', async () => {
+    const user = userEvent.setup();
+    const onClick = vi.fn();
+    render(<StageRuleItemPill rule={createRule(onClick)} ruleType="entry" isReadOnly={false} />);
+
+    await user.click(screen.getByTestId('stage-rule-rule-1'));
+
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not invoke the rule onClick when read-only', async () => {
+    const user = userEvent.setup();
+    const onClick = vi.fn();
+    render(<StageRuleItemPill rule={createRule(onClick)} ruleType="entry" isReadOnly={true} />);
+
+    await user.click(screen.getByTestId('stage-rule-rule-1'));
+
+    expect(onClick).not.toHaveBeenCalled();
+  });
+});

--- a/packages/apollo-react/src/canvas/components/StageNode/rules/StageRulesContainer.test.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/rules/StageRulesContainer.test.tsx
@@ -1,0 +1,42 @@
+import type { ReactNode } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '../../../utils/testing';
+import type { StageRule } from '../StageNode.types';
+import { StageRulesContainer } from './StageRulesContainer';
+
+vi.mock('../../CanvasTooltip', () => ({
+  CanvasTooltip: ({ children }: { content: ReactNode; children: ReactNode }) => <>{children}</>,
+}));
+
+const rules: StageRule[] = [
+  { id: 'rule-1', label: 'Rule 1' },
+  { id: 'rule-2', label: 'Rule 2' },
+  { id: 'rule-3', label: 'Rule 3' },
+];
+
+describe('StageRulesContainer', () => {
+  it('renders nothing when there are no rules', () => {
+    const { container } = render(
+      <StageRulesContainer rules={[]} ruleType="entry" isReadOnly={false} />
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders one pill per rule', () => {
+    render(<StageRulesContainer rules={rules} ruleType="entry" isReadOnly={false} />);
+
+    expect(screen.getByTestId('stage-rule-rule-1')).toBeInTheDocument();
+    expect(screen.getByTestId('stage-rule-rule-2')).toBeInTheDocument();
+    expect(screen.getByTestId('stage-rule-rule-3')).toBeInTheDocument();
+  });
+
+  it('renders the pills in the order they are supplied', () => {
+    render(<StageRulesContainer rules={rules} ruleType="entry" isReadOnly={false} />);
+
+    const rendered = screen
+      .getAllByTestId(/^stage-rule-rule-/)
+      .map((el) => el.getAttribute('data-testid'));
+    expect(rendered).toEqual(['stage-rule-rule-1', 'stage-rule-rule-2', 'stage-rule-rule-3']);
+  });
+});

--- a/packages/apollo-react/src/canvas/components/StageNode/shared/CollapsibleStageHeader.test.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/shared/CollapsibleStageHeader.test.tsx
@@ -1,0 +1,117 @@
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, userEvent } from '../../../utils/testing';
+import { CollapsibleStageHeader } from './CollapsibleStageHeader';
+
+// Surface CanvasTooltip content into the DOM so the label copy can be asserted
+// without relying on Radix's hover-driven open/close (unreliable in happy-dom).
+vi.mock('../../CanvasTooltip', () => ({
+  CanvasTooltip: ({ content, children }: { content: ReactNode; children: ReactNode }) => (
+    <span
+      data-testid="canvas-tooltip"
+      data-tooltip-content={typeof content === 'string' ? content : ''}
+    >
+      {children}
+    </span>
+  ),
+}));
+
+const renderHeader = (
+  overrides: Partial<React.ComponentProps<typeof CollapsibleStageHeader>> = {}
+) =>
+  render(
+    <CollapsibleStageHeader
+      isOpen={true}
+      label="Entry rules"
+      testId="entry-rules-header-stage-1"
+      onToggle={vi.fn()}
+      {...overrides}
+    >
+      <div data-testid="section-body">Body</div>
+    </CollapsibleStageHeader>
+  );
+
+describe('CollapsibleStageHeader', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders the wrapper, accordion button and label with derived test ids', () => {
+    renderHeader();
+
+    expect(screen.getByTestId('entry-rules-header-stage-1')).toBeInTheDocument();
+    expect(screen.getByTestId('entry-rules-header-stage-1-accordion-button')).toBeInTheDocument();
+    expect(screen.getByTestId('entry-rules-header-stage-1-label')).toHaveTextContent('Entry rules');
+  });
+
+  it('renders the children while open', () => {
+    renderHeader({ isOpen: true });
+
+    expect(screen.getByTestId('section-body')).toBeInTheDocument();
+  });
+
+  it('does not render the children while collapsed', () => {
+    renderHeader({ isOpen: false });
+
+    expect(screen.queryByTestId('section-body')).not.toBeInTheDocument();
+  });
+
+  it('exposes an expanded accordion button with a "Collapse" label when open', () => {
+    renderHeader({ isOpen: true });
+
+    const button = screen.getByTestId('entry-rules-header-stage-1-accordion-button');
+    expect(button).toHaveAttribute('aria-expanded', 'true');
+    expect(button).toHaveAttribute('aria-label', 'Collapse Entry rules');
+  });
+
+  it('exposes a collapsed accordion button with an "Expand" label when closed', () => {
+    renderHeader({ isOpen: false });
+
+    const button = screen.getByTestId('entry-rules-header-stage-1-accordion-button');
+    expect(button).toHaveAttribute('aria-expanded', 'false');
+    expect(button).toHaveAttribute('aria-label', 'Expand Entry rules');
+  });
+
+  it('invokes onToggle when the header is clicked', async () => {
+    const user = userEvent.setup();
+    const onToggle = vi.fn();
+    renderHeader({ onToggle });
+
+    await user.click(screen.getByTestId('entry-rules-header-stage-1-accordion-button'));
+
+    expect(onToggle).toHaveBeenCalledTimes(1);
+  });
+
+  it('invokes onToggle when Enter is pressed on the focused header', async () => {
+    const user = userEvent.setup();
+    const onToggle = vi.fn();
+    renderHeader({ onToggle });
+
+    screen.getByTestId('entry-rules-header-stage-1-accordion-button').focus();
+    await user.keyboard('{Enter}');
+
+    expect(onToggle).toHaveBeenCalledTimes(1);
+  });
+
+  it('invokes onToggle when Space is pressed on the focused header', async () => {
+    const user = userEvent.setup();
+    const onToggle = vi.fn();
+    renderHeader({ onToggle });
+
+    screen.getByTestId('entry-rules-header-stage-1-accordion-button').focus();
+    await user.keyboard('{ }');
+
+    expect(onToggle).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not toggle on unrelated keys', async () => {
+    const user = userEvent.setup();
+    const onToggle = vi.fn();
+    renderHeader({ onToggle });
+
+    screen.getByTestId('entry-rules-header-stage-1-accordion-button').focus();
+    await user.keyboard('{ArrowDown}');
+
+    expect(onToggle).not.toHaveBeenCalled();
+  });
+});

--- a/packages/apollo-react/src/canvas/components/StageNode/shared/StageCompletionConditionIcon.test.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/shared/StageCompletionConditionIcon.test.tsx
@@ -1,0 +1,58 @@
+import type { ReactNode } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '../../../utils/testing';
+import { StageCompletionConditionIcon } from './StageCompletionConditionIcon';
+
+// Surface CanvasTooltip content into the DOM so the tooltip copy can be
+// asserted without relying on Radix's hover-driven open/close (unreliable in
+// happy-dom). Mirrors the pattern used in tasks/TaskContent.test.tsx.
+vi.mock('../../CanvasTooltip', () => ({
+  CanvasTooltip: ({ content, children }: { content: ReactNode; children: ReactNode }) => (
+    <span
+      data-testid="canvas-tooltip"
+      data-tooltip-content={typeof content === 'string' ? content : ''}
+    >
+      {children}
+    </span>
+  ),
+}));
+
+describe('StageCompletionConditionIcon', () => {
+  it('renders under the default test id when none is supplied', () => {
+    render(<StageCompletionConditionIcon />);
+
+    expect(screen.getByTestId('completion-condition-icon')).toBeInTheDocument();
+  });
+
+  it('uses a caller-supplied test id instead of the default', () => {
+    render(<StageCompletionConditionIcon dataTestId="completion-icon-stage-1" />);
+
+    expect(screen.getByTestId('completion-icon-stage-1')).toBeInTheDocument();
+    expect(screen.queryByTestId('completion-condition-icon')).not.toBeInTheDocument();
+  });
+
+  it('wraps the glyph in a "Completion condition" tooltip', () => {
+    render(<StageCompletionConditionIcon />);
+
+    expect(screen.getByTestId('canvas-tooltip')).toHaveAttribute(
+      'data-tooltip-content',
+      'Completion condition'
+    );
+  });
+
+  it('renders a 20px checklist at the default size', () => {
+    const { container } = render(<StageCompletionConditionIcon />);
+
+    const svg = container.querySelector('svg');
+    expect(svg).toHaveAttribute('width', '20');
+    expect(svg).toHaveAttribute('height', '20');
+  });
+
+  it('renders a 16px checklist when small', () => {
+    const { container } = render(<StageCompletionConditionIcon small />);
+
+    const svg = container.querySelector('svg');
+    expect(svg).toHaveAttribute('width', '16');
+    expect(svg).toHaveAttribute('height', '16');
+  });
+});

--- a/packages/apollo-react/src/canvas/components/StageNode/shared/StageEntryConditionIcon.test.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/shared/StageEntryConditionIcon.test.tsx
@@ -1,0 +1,58 @@
+import type { ReactNode } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '../../../utils/testing';
+import { StageEntryConditionIcon } from './StageEntryConditionIcon';
+
+// Surface CanvasTooltip content into the DOM so the tooltip copy can be
+// asserted without relying on Radix's hover-driven open/close (unreliable in
+// happy-dom). Mirrors the pattern used in tasks/TaskContent.test.tsx.
+vi.mock('../../CanvasTooltip', () => ({
+  CanvasTooltip: ({ content, children }: { content: ReactNode; children: ReactNode }) => (
+    <span
+      data-testid="canvas-tooltip"
+      data-tooltip-content={typeof content === 'string' ? content : ''}
+    >
+      {children}
+    </span>
+  ),
+}));
+
+describe('StageEntryConditionIcon', () => {
+  it('renders under the default test id when none is supplied', () => {
+    render(<StageEntryConditionIcon />);
+
+    expect(screen.getByTestId('entry-condition-icon')).toBeInTheDocument();
+  });
+
+  it('uses a caller-supplied test id instead of the default', () => {
+    render(<StageEntryConditionIcon dataTestId="task-entry-condition-icon-task-1" />);
+
+    expect(screen.getByTestId('task-entry-condition-icon-task-1')).toBeInTheDocument();
+    expect(screen.queryByTestId('entry-condition-icon')).not.toBeInTheDocument();
+  });
+
+  it('wraps the glyph in an "Entry condition" tooltip', () => {
+    render(<StageEntryConditionIcon />);
+
+    expect(screen.getByTestId('canvas-tooltip')).toHaveAttribute(
+      'data-tooltip-content',
+      'Entry condition'
+    );
+  });
+
+  it('renders a 20px diamond at the default size', () => {
+    const { container } = render(<StageEntryConditionIcon />);
+
+    const svg = container.querySelector('svg');
+    expect(svg).toHaveAttribute('width', '20');
+    expect(svg).toHaveAttribute('height', '20');
+  });
+
+  it('renders a 16px diamond when small', () => {
+    const { container } = render(<StageEntryConditionIcon small />);
+
+    const svg = container.querySelector('svg');
+    expect(svg).toHaveAttribute('width', '16');
+    expect(svg).toHaveAttribute('height', '16');
+  });
+});

--- a/packages/apollo-react/src/canvas/components/StageNode/shared/StageExitConditionIcon.test.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/shared/StageExitConditionIcon.test.tsx
@@ -1,0 +1,58 @@
+import type { ReactNode } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '../../../utils/testing';
+import { StageExitConditionIcon } from './StageExitConditionIcon';
+
+// Surface CanvasTooltip content into the DOM so the tooltip copy can be
+// asserted without relying on Radix's hover-driven open/close (unreliable in
+// happy-dom). Mirrors the pattern used in tasks/TaskContent.test.tsx.
+vi.mock('../../CanvasTooltip', () => ({
+  CanvasTooltip: ({ content, children }: { content: ReactNode; children: ReactNode }) => (
+    <span
+      data-testid="canvas-tooltip"
+      data-tooltip-content={typeof content === 'string' ? content : ''}
+    >
+      {children}
+    </span>
+  ),
+}));
+
+describe('StageExitConditionIcon', () => {
+  it('renders under the default test id when none is supplied', () => {
+    render(<StageExitConditionIcon />);
+
+    expect(screen.getByTestId('exit-condition-icon')).toBeInTheDocument();
+  });
+
+  it('uses a caller-supplied test id instead of the default', () => {
+    render(<StageExitConditionIcon dataTestId="exit-icon-stage-1" />);
+
+    expect(screen.getByTestId('exit-icon-stage-1')).toBeInTheDocument();
+    expect(screen.queryByTestId('exit-condition-icon')).not.toBeInTheDocument();
+  });
+
+  it('wraps the glyph in an "Exit condition" tooltip', () => {
+    render(<StageExitConditionIcon />);
+
+    expect(screen.getByTestId('canvas-tooltip')).toHaveAttribute(
+      'data-tooltip-content',
+      'Exit condition'
+    );
+  });
+
+  it('renders a 20px diamond at the default size', () => {
+    const { container } = render(<StageExitConditionIcon />);
+
+    const svg = container.querySelector('svg');
+    expect(svg).toHaveAttribute('width', '20');
+    expect(svg).toHaveAttribute('height', '20');
+  });
+
+  it('renders a 16px diamond when small', () => {
+    const { container } = render(<StageExitConditionIcon small />);
+
+    const svg = container.querySelector('svg');
+    expect(svg).toHaveAttribute('width', '16');
+    expect(svg).toHaveAttribute('height', '16');
+  });
+});

--- a/packages/apollo-react/src/canvas/components/StageNode/shared/StageItemsHeaderTitle.test.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/shared/StageItemsHeaderTitle.test.tsx
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '../../../utils/testing';
+import { StageItemsHeaderTitle } from './StageItemsHeaderTitle';
+
+describe('StageItemsHeaderTitle', () => {
+  it('renders the title text under the provided test id', () => {
+    render(<StageItemsHeaderTitle title="Entry rules" testId="entry-rules-header-stage-1" />);
+
+    const header = screen.getByTestId('entry-rules-header-stage-1');
+    expect(header).toBeInTheDocument();
+    expect(header).toHaveTextContent('Entry rules');
+  });
+
+  it('applies the muted heading styling classes', () => {
+    render(<StageItemsHeaderTitle title="Tasks" testId="tasks-header-stage-1" />);
+
+    const header = screen.getByTestId('tasks-header-stage-1');
+    expect(header).toHaveClass('text-xs', 'font-bold', 'text-foreground-muted');
+  });
+});

--- a/packages/apollo-react/src/canvas/components/StageNode/tasks/StageTaskEntryConditionIcon.test.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/tasks/StageTaskEntryConditionIcon.test.tsx
@@ -1,0 +1,56 @@
+import type { ReactNode } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '../../../utils/testing';
+import type { StageTaskItem } from '../StageNode.types';
+import { StageTaskEntryConditionIcon } from './StageTaskEntryConditionIcon';
+
+vi.mock('../../CanvasTooltip', () => ({
+  CanvasTooltip: ({ content, children }: { content: ReactNode; children: ReactNode }) => (
+    <span
+      data-testid="canvas-tooltip"
+      data-tooltip-content={typeof content === 'string' ? content : ''}
+    >
+      {children}
+    </span>
+  ),
+}));
+
+const createTask = (overrides: Partial<StageTaskItem> = {}): StageTaskItem => ({
+  id: 'task-1',
+  label: 'Task 1',
+  ...overrides,
+});
+
+describe('StageTaskEntryConditionIcon', () => {
+  it('renders nothing when the task has no entry condition', () => {
+    render(<StageTaskEntryConditionIcon task={createTask()} />);
+
+    expect(screen.queryByTestId('task-entry-condition-icon-task-1')).not.toBeInTheDocument();
+  });
+
+  it('renders a task-scoped entry-condition icon when the task has an entry condition', () => {
+    render(<StageTaskEntryConditionIcon task={createTask({ hasEntryCondition: true })} />);
+
+    expect(screen.getByTestId('task-entry-condition-icon-task-1')).toBeInTheDocument();
+  });
+
+  it('renders a 20px diamond by default', () => {
+    const { container } = render(
+      <StageTaskEntryConditionIcon task={createTask({ hasEntryCondition: true })} />
+    );
+
+    const svg = container.querySelector('svg');
+    expect(svg).toHaveAttribute('width', '20');
+    expect(svg).toHaveAttribute('height', '20');
+  });
+
+  it('renders a 16px diamond when small', () => {
+    const { container } = render(
+      <StageTaskEntryConditionIcon task={createTask({ hasEntryCondition: true })} small />
+    );
+
+    const svg = container.querySelector('svg');
+    expect(svg).toHaveAttribute('width', '16');
+    expect(svg).toHaveAttribute('height', '16');
+  });
+});


### PR DESCRIPTION
## What

Adds unit test coverage for the new files introduced in #986 (entry/exit/completion stage rules and collapsible sections), plus integration coverage for the rule sections in `StageNode` itself. Targets `feat/stage-node-rules-sections` so the coverage lands with that PR.

Scope follows the request: new files and genuinely-changed existing files only. Files that were merely moved into `tasks/` or had their imports updated are intentionally not given new tests (their existing tests moved with them).

## Tests added

**`rules/`**
- `StageRuleContent` — icon selection per rule type (entry/exit/completion), label + tooltip rendering
- `StageRuleItemPill` — click invokes `rule.onClick`, suppressed in read-only
- `StageRulesContainer` — one pill per rule, ordering, empty-state renders nothing
- `EntryRulesContainer` / `ExitRulesContainer` / `CompletionRulesContainer` — empty-state, static header vs collapsible header, expand/collapse visibility and `onCollapsedToggle`

**`shared/`**
- `CollapsibleStageHeader` — click/Enter/Space toggle (and no-op on other keys), `aria-expanded` / `aria-label` state, children visibility
- `StageEntryConditionIcon` / `StageExitConditionIcon` / `StageCompletionConditionIcon` — default vs custom test id, tooltip copy, default (20px) and `small` (16px) sizing
- `StageItemsHeaderTitle` — title text and styling

**`tasks/`**
- `StageTaskEntryConditionIcon` — renders only when the task has an entry condition; sizing

**`StageNode.test.tsx`**
- New describe block asserting the entry/exit/completion rule sections render (pills, rule `onClick`, collapsible vs collapsed) via the real containers
- Fixes the stale `./DraggableTask` mock path (now `./tasks/DraggableTask`) that broke after the task components moved into `tasks/`

## Verification

- `vitest --run src/canvas/components/StageNode` → 19 files, 255 tests passing (was 192)
- Biome check clean on all touched files
- `tsc --noEmit` reports no new errors in the added files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013sSQSFZqbWNANFrWnDBdhZ

---
_Generated by [Claude Code](https://claude.ai/code/session_013sSQSFZqbWNANFrWnDBdhZ)_