### PR TITLE
ci(ci): storybook visual diff check + extract inline workflow scripts [PLT-108380]

### DIFF
--- a/.github/scripts/dependency-review-comment.mjs
+++ b/.github/scripts/dependency-review-comment.mjs
@@ -1,0 +1,23 @@
+/**
+ * The "Dependency License Review" PR comment (dependency-review.yml):
+ * publishes the report `scripts/check-licenses.ts` wrote, or a pointer to
+ * the logs when the check crashed before producing one.
+ *
+ * Inputs (env): REPORT_PATH — the license-report.md location.
+ */
+import { readFileSync } from 'node:fs';
+import { upsertComment } from './lib/pr-comments.mjs';
+
+const MARKER = '<!-- dependency-license-review -->';
+
+export async function licenseReviewComment({ github, context }) {
+  let report;
+  try {
+    report = readFileSync(process.env.REPORT_PATH, 'utf8');
+  } catch {
+    report =
+      '# Dependency License Review\n\n:x: License check script failed before generating a report. Check the workflow logs.';
+  }
+
+  await upsertComment({ github, context }, MARKER, `${MARKER}\n${report}`);
+}

--- a/.github/scripts/find-size-baseline.mjs
+++ b/.github/scripts/find-size-baseline.mjs
@@ -1,0 +1,30 @@
+/**
+ * Finds the latest successful main build that uploaded a `package-sizes`
+ * artifact and exposes its run id as the `run_id` step output — the "vs
+ * main" baseline for the PR size report (pr-checks.yml). Skip-ci
+ * version-bump commits skip release.yml, so the most recent run may have no
+ * artifact; walk back until one does.
+ */
+export async function findSizeBaseline({ github, context, core }) {
+  const runs = await github.rest.actions.listWorkflowRuns({
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+    workflow_id: 'release.yml',
+    branch: 'main',
+    status: 'success',
+    per_page: 10,
+  });
+  for (const run of runs.data.workflow_runs) {
+    const arts = await github.rest.actions.listWorkflowRunArtifacts({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      run_id: run.id,
+    });
+    if (arts.data.artifacts.some((a) => a.name === 'package-sizes' && !a.expired)) {
+      core.info(`Size baseline from main run ${run.id} (${(run.head_sha || '').slice(0, 7)})`);
+      core.setOutput('run_id', String(run.id));
+      return;
+    }
+  }
+  core.info('No main build with a package-sizes artifact found; "vs main" will show "—".');
+}

--- a/.github/scripts/lib/format.mjs
+++ b/.github/scripts/lib/format.mjs
@@ -1,0 +1,15 @@
+/** Shared formatting helpers for workflow-generated PR comments. */
+
+/** "Updated (PT)" timestamp used across the preview/visual-diff comments. */
+export function ptTimestamp() {
+  return new Date().toLocaleString('en-US', {
+    timeZone: 'America/Los_Angeles',
+    year: 'numeric',
+    month: 'short',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hour12: true,
+  });
+}

--- a/.github/scripts/lib/pr-comments.mjs
+++ b/.github/scripts/lib/pr-comments.mjs
@@ -1,0 +1,70 @@
+/**
+ * Shared helpers for the marker-comment pattern used by PR workflows: each
+ * workflow owns one PR comment identified by an HTML-comment marker (e.g.
+ * `<!-- apollo-coded-app-preview-comment -->`) and updates it in place
+ * instead of stacking new comments.
+ *
+ * Callers are `actions/github-script` steps; `github` is the authenticated
+ * Octokit instance and `context` the workflow run context.
+ */
+
+/**
+ * Finds the workflow's marker comment on the current PR. Only bot-authored
+ * comments count, so a user pasting the marker into their own comment cannot
+ * hijack (or leak data into) the slot the workflow updates.
+ */
+export async function findComment({ github, context }, marker) {
+  const comments = await github.paginate(github.rest.issues.listComments, {
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+    issue_number: context.issue.number,
+    per_page: 100,
+  });
+  return (
+    comments.find(
+      (comment) =>
+        comment.body?.includes(marker) &&
+        comment.user?.type === 'Bot' &&
+        ['github-actions[bot]', 'github-actions'].includes(comment.user?.login)
+    ) ?? null
+  );
+}
+
+/**
+ * Creates or updates the marker comment. `body` must itself contain the
+ * marker, or the next run will not find the comment and will create a
+ * duplicate.
+ */
+export async function upsertComment({ github, context }, marker, body) {
+  if (!body.includes(marker)) {
+    throw new Error(`comment body must contain its marker (${marker})`);
+  }
+  const existing = await findComment({ github, context }, marker);
+  if (existing) {
+    await github.rest.issues.updateComment({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      comment_id: existing.id,
+      body,
+    });
+  } else {
+    await github.rest.issues.createComment({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      issue_number: context.issue.number,
+      body,
+    });
+  }
+}
+
+/** Deletes the marker comment if present; a no-op otherwise. */
+export async function removeComment({ github, context }, marker) {
+  const existing = await findComment({ github, context }, marker);
+  if (existing) {
+    await github.rest.issues.deleteComment({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      comment_id: existing.id,
+    });
+  }
+}

--- a/.github/scripts/pr-size-labels.mjs
+++ b/.github/scripts/pr-size-labels.mjs
@@ -1,0 +1,114 @@
+/**
+ * PR size labels (pr-size.yml): the managed label set, definition sync, and
+ * per-PR label assignment. Both jobs import from here so the label
+ * definitions live in exactly one place.
+ */
+
+export const MANAGED_LABELS = [
+  { name: 'size:XS', color: '0e8a16', description: '0-9 changed lines.' },
+  { name: 'size:S', color: '5ebd3e', description: '10-29 changed lines.' },
+  { name: 'size:M', color: 'fbca04', description: '30-99 changed lines.' },
+  { name: 'size:L', color: 'fe7d37', description: '100-499 changed lines.' },
+  { name: 'size:XL', color: 'd93f0b', description: '500-999 changed lines.' },
+  { name: 'size:XXL', color: 'b60205', description: '1,000+ changed lines.' },
+];
+
+function resolveSizeLabel(totalChangedLines) {
+  if (totalChangedLines < 10) return 'size:XS';
+  if (totalChangedLines < 30) return 'size:S';
+  if (totalChangedLines < 100) return 'size:M';
+  if (totalChangedLines < 500) return 'size:L';
+  if (totalChangedLines < 1000) return 'size:XL';
+  return 'size:XXL';
+}
+
+/** Creates or updates the repo's size label definitions to match MANAGED_LABELS. */
+export async function ensureLabels({ github, context }) {
+  for (const label of MANAGED_LABELS) {
+    try {
+      const { data: existing } = await github.rest.issues.getLabel({
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        name: label.name,
+      });
+
+      if (existing.color !== label.color || (existing.description ?? '') !== label.description) {
+        await github.rest.issues.updateLabel({
+          owner: context.repo.owner,
+          repo: context.repo.repo,
+          name: label.name,
+          color: label.color,
+          description: label.description,
+        });
+      }
+    } catch (error) {
+      if (error.status !== 404) {
+        throw error;
+      }
+
+      try {
+        await github.rest.issues.createLabel({
+          owner: context.repo.owner,
+          repo: context.repo.repo,
+          name: label.name,
+          color: label.color,
+          description: label.description,
+        });
+      } catch (createError) {
+        // 422: another run created it between our 404 and this call.
+        if (createError.status !== 422) {
+          throw createError;
+        }
+      }
+    }
+  }
+}
+
+/** Puts the PR's single correct size label on, removing stale managed ones. */
+export async function syncLabel({ github, context, core }) {
+  const issueNumber = context.payload.pull_request.number;
+  const additions = context.payload.pull_request.additions ?? 0;
+  const deletions = context.payload.pull_request.deletions ?? 0;
+  const changedLines = additions + deletions;
+
+  const managedLabelNames = new Set(MANAGED_LABELS.map((label) => label.name));
+  const nextLabelName = resolveSizeLabel(changedLines);
+
+  const { data: currentLabels } = await github.rest.issues.listLabelsOnIssue({
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+    issue_number: issueNumber,
+    per_page: 100,
+  });
+
+  for (const label of currentLabels) {
+    if (!managedLabelNames.has(label.name) || label.name === nextLabelName) {
+      continue;
+    }
+
+    try {
+      await github.rest.issues.removeLabel({
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        issue_number: issueNumber,
+        name: label.name,
+      });
+    } catch (removeError) {
+      // 404: someone removed it between the list and this call.
+      if (removeError.status !== 404) {
+        throw removeError;
+      }
+    }
+  }
+
+  if (!currentLabels.some((label) => label.name === nextLabelName)) {
+    await github.rest.issues.addLabels({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      issue_number: issueNumber,
+      labels: [nextLabelName],
+    });
+  }
+
+  core.info(`PR #${issueNumber}: ${changedLines} changed lines -> ${nextLabelName}`);
+}

--- a/.github/scripts/preview-deploy/derive-app-url.mjs
+++ b/.github/scripts/preview-deploy/derive-app-url.mjs
@@ -1,0 +1,25 @@
+/**
+ * Prints the public URL of a Coded App deployed to uipath.host, derived from
+ * the tenant env (used when uip-go's output didn't include an "App URL:"
+ * line, and for the stable main apps that this run didn't deploy).
+ *
+ * Inputs (env): UIPATH_BASE_URL, UIPATH_ORG_NAME, APP_NAME.
+ * Output: the URL on stdout, e.g. https://org.env.uipath.host/app-name
+ */
+const baseUrl = process.env.UIPATH_BASE_URL || '';
+const orgName = process.env.UIPATH_ORG_NAME || '';
+const appName = process.env.APP_NAME || '';
+
+// staging.uipath.com → "staging" env infix; cloud/api hosts → none.
+let environment = '';
+try {
+  const hostname = new URL(baseUrl).hostname;
+  let inferred = hostname.replace(/\.uipath\.com$/, '');
+  inferred = inferred.replace(/^api\./, '').replace(/\.api$/, '');
+  environment = inferred && inferred !== 'api' && inferred !== 'cloud' ? inferred : '';
+} catch {
+  environment = '';
+}
+
+const suffix = environment ? `.${environment}` : '';
+console.log(`https://${orgName}${suffix}.uipath.host/${appName}`);

--- a/.github/scripts/preview-deploy/preview-comment.mjs
+++ b/.github/scripts/preview-deploy/preview-comment.mjs
@@ -1,0 +1,84 @@
+/**
+ * The "Apollo Coded App preview deployments" PR comment (preview-deploy.yml).
+ *
+ * `initComment` posts/updates the table with every project in a "Deploying…"
+ * state at the start of a run; `updateComment` rewrites it from the
+ * deploy-result artifacts once the deploy matrix finishes.
+ */
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { ptTimestamp } from '../lib/format.mjs';
+import { upsertComment } from '../lib/pr-comments.mjs';
+
+const MARKER = '<!-- apollo-coded-app-preview-comment -->';
+const PROJECTS = ['apollo-design', 'apollo-docs', 'apollo-landing', 'apollo-vertex'];
+
+const TABLE_HEADER = [
+  '| Project | Status | Preview | Updated (PT) |',
+  '|---------|--------|---------|--------------|',
+];
+
+function runUrl(context) {
+  return `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+}
+
+/** All projects "Deploying…", posted before the deploy matrix starts. */
+export async function initComment({ github, context }) {
+  const timestamp = ptTimestamp();
+  const deployingLink = `[Deploying...](${runUrl(context)})`;
+  const logsLink = `[Logs](${runUrl(context)})`;
+  const body = [
+    MARKER,
+    'Apollo Coded App preview deployments are running.',
+    '',
+    ...TABLE_HEADER,
+    ...PROJECTS.map((project) => `| ${project} | ${deployingLink} | ${logsLink} | ${timestamp} |`),
+  ].join('\n');
+
+  await upsertComment({ github, context }, MARKER, body);
+}
+
+/**
+ * Final per-project status table, read from the deploy-result artifacts the
+ * matrix legs uploaded (one `deploy-result-<project>` dir per leg under
+ * `RESULTS_DIR`, each holding `url` / `outcome` / `error` files).
+ */
+export async function updateComment({ github, context }) {
+  const resultsDir = process.env.RESULTS_DIR;
+  const logsLink = `[Logs](${runUrl(context)})`;
+  const timestamp = ptTimestamp();
+
+  const readResult = (project) => {
+    const dir = join(resultsDir, `deploy-result-${project}`);
+    const read = (name) => {
+      try {
+        return readFileSync(join(dir, name), 'utf8').trim();
+      } catch {
+        return '';
+      }
+    };
+    return { url: read('url'), outcome: read('outcome') || 'skipped' };
+  };
+
+  let anyFailed = false;
+  const rows = PROJECTS.map((project) => {
+    const { url, outcome } = readResult(project);
+    const ready = outcome === 'success' && Boolean(url);
+    if (outcome === 'failure') anyFailed = true;
+    const status = ready ? 'Ready' : outcome === 'failure' ? 'Failed' : 'Skipped';
+    const preview = ready ? `[Preview](${url}) · ${logsLink}` : logsLink;
+    return `| ${project} | ${status} | ${preview} | ${timestamp} |`;
+  });
+
+  const body = [
+    MARKER,
+    anyFailed
+      ? 'Apollo Coded App preview deployments finished with failures.'
+      : 'Apollo Coded App preview deployments are ready.',
+    '',
+    ...TABLE_HEADER,
+    ...rows,
+  ].join('\n');
+
+  await upsertComment({ github, context }, MARKER, body);
+}

--- a/.github/scripts/preview-deploy/visual-diff-comment.mjs
+++ b/.github/scripts/preview-deploy/visual-diff-comment.mjs
@@ -1,0 +1,50 @@
+/**
+ * The "Storybook visual diff" PR comment (preview-deploy.yml, visual-diff
+ * job). Reads the job's step outcomes/outputs from env and renders one of:
+ * skipped (preview deploy failed), run failure, no affected stories, clean
+ * pass, or changes detected with a link to the deployed report app.
+ */
+import { ptTimestamp } from '../lib/format.mjs';
+import { upsertComment } from '../lib/pr-comments.mjs';
+
+const MARKER = '<!-- apollo-visual-diff-comment -->';
+
+export async function visualDiffComment({ github, context }) {
+  const logsLink = `[Logs](https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId})`;
+  const n = (value) => Number(value) || 0;
+
+  const lines = [MARKER, '### Storybook visual diff', ''];
+  if (process.env.READY !== 'true') {
+    lines.push(
+      `⏭️ Skipped: the apollo-design preview deployment did not succeed, so no comparison ran. ${logsLink}`
+    );
+  } else if (process.env.SBDIFF_OUTCOME !== 'success') {
+    lines.push(`❌ The visual diff run failed before producing a result. ${logsLink}`);
+  } else if (process.env.NO_STORIES === 'true') {
+    lines.push(`✅ No stories are affected by this PR's changes; nothing to compare. ${logsLink}`);
+  } else if (process.env.HAS_DIFFS !== 'true') {
+    lines.push(
+      `✅ No visual changes. ${n(process.env.TOTAL)} stories affected by this PR were compared against the deployed main Storybook. ${logsLink}`
+    );
+  } else {
+    const parts = [];
+    if (n(process.env.CHANGED)) parts.push(`${n(process.env.CHANGED)} changed`);
+    if (n(process.env.ADDED)) parts.push(`${n(process.env.ADDED)} added`);
+    if (n(process.env.REMOVED)) parts.push(`${n(process.env.REMOVED)} removed`);
+    if (n(process.env.ERRORS)) parts.push(`${n(process.env.ERRORS)} errored`);
+    const report =
+      process.env.REPORT_OUTCOME === 'success' && process.env.REPORT_URL
+        ? `[View report](${process.env.REPORT_URL})`
+        : `report deployment failed, see ${logsLink}`;
+    lines.push(
+      `⚠️ Visual changes detected: ${parts.join(', ')} (of ${n(process.env.TOTAL)} compared, ${n(process.env.PASSED)} unchanged). ${report}`
+    );
+    lines.push('');
+    lines.push(
+      `Baseline is the deployed main Storybook, so changes merged to main after this branch was last updated can also appear here. ${logsLink}`
+    );
+  }
+  lines.push('', `_Updated (PT): ${ptTimestamp()}_`);
+
+  await upsertComment({ github, context }, MARKER, lines.join('\n'));
+}

--- a/.github/scripts/preview-deploy/visual-diff-counts.mjs
+++ b/.github/scripts/preview-deploy/visual-diff-counts.mjs
@@ -1,0 +1,25 @@
+/**
+ * Publishes an sbdiff run's record counts as step outputs (visual-diff job).
+ *
+ * Usage: node visual-diff-counts.mjs <path-to-summary.json>
+ * Reads the `counts` object sbdiff embeds in summary.json and appends
+ * total/changed/added/removed/errors/passed/has_diffs to $GITHUB_OUTPUT.
+ */
+import { appendFileSync, readFileSync } from 'node:fs';
+
+const summaryPath = process.argv[2];
+const counts = JSON.parse(readFileSync(summaryPath, 'utf8')).counts;
+
+appendFileSync(
+  process.env.GITHUB_OUTPUT,
+  [
+    `total=${counts.total}`,
+    `changed=${counts.changed}`,
+    `added=${counts.new}`,
+    `removed=${counts.removed}`,
+    `errors=${counts.error}`,
+    `passed=${counts.pass}`,
+    `has_diffs=${counts.diffs > 0}`,
+    '',
+  ].join('\n')
+);

--- a/.github/scripts/support-branch-scope-comment.mjs
+++ b/.github/scripts/support-branch-scope-comment.mjs
@@ -1,0 +1,43 @@
+/**
+ * The "Support Branch Scope" PR comment (support-branch-scope.yml): posted
+ * when a support-branch PR touches files outside its package directory,
+ * removed again once the PR is back in scope.
+ *
+ * Inputs (env): PACKAGE, PKG_DIR, OUT_OF_SCOPE_FILES, BASE_REF.
+ */
+import { removeComment, upsertComment } from './lib/pr-comments.mjs';
+
+const MARKER = '<!-- support-branch-scope-check -->';
+
+export async function postScopeComment({ github, context }) {
+  const pkgDir = process.env.PKG_DIR;
+  const outOfScope = (process.env.OUT_OF_SCOPE_FILES || '').trim();
+  const baseRef = process.env.BASE_REF;
+
+  let body = `${MARKER}\n`;
+  body += `## Support Branch Scope — \`${baseRef}\`\n\n`;
+  body += `> [!CAUTION]\n`;
+  body += `> This PR modifies files outside \`${pkgDir}/\`. Support branches should only contain changes scoped to their package.\n\n`;
+  body += `**Out-of-scope files:**\n`;
+  for (const f of outOfScope.split('\n').filter(Boolean)) {
+    body += `- \`${f}\`\n`;
+  }
+  body += `\n---\n\n`;
+
+  body += `### Need to update a workspace dependency (e.g. \`apollo-core\`)?\n\n`;
+  body += `This branch locks workspace deps to exact versions (e.g. \`5.9.0\` instead of \`workspace:*\`) `;
+  body += `and resolves them from the registry. `;
+  body += `Bumping the version in \`${pkgDir}/package.json\` and running \`pnpm install\` will fetch the new version.\n\n`;
+  body += `If your fix requires changes in a sibling package (e.g. \`apollo-core\`):\n\n`;
+  body += `1. **If the dependency is still on the same major on \`main\`** — land the fix on \`main\`, `;
+  body += `let it publish a new version, then bump the version in this branch's `;
+  body += `\`${pkgDir}/package.json\` and run \`pnpm install\` to update the lockfile.\n`;
+  body += `2. **If the dependency needs a support branch too** — cut a support branch for that package `;
+  body += `(e.g. \`support/apollo-core@5.x\`), publish the fix from there, then update the dependency version here.\n`;
+
+  await upsertComment({ github, context }, MARKER, body);
+}
+
+export async function removeScopeComment({ github, context }) {
+  await removeComment({ github, context }, MARKER);
+}

--- a/.github/scripts/test-registry/generate-matrix-batches.mjs
+++ b/.github/scripts/test-registry/generate-matrix-batches.mjs
@@ -1,0 +1,19 @@
+/**
+ * Prints the registry-check job matrix (apollo-vertex-registry-check.yml):
+ * every component in apps/apollo-vertex/registry.json, batched so each
+ * matrix leg installs a handful of components instead of one leg per
+ * component.
+ */
+import { readFileSync } from 'node:fs';
+
+const registry = JSON.parse(readFileSync('apps/apollo-vertex/registry.json', 'utf-8'));
+const names = registry.items.map((i) => i.name);
+const batchSize = 10;
+const batches = [];
+for (let i = 0; i < names.length; i += batchSize) {
+  batches.push({
+    batch_index: Math.floor(i / batchSize),
+    components: names.slice(i, i + batchSize).join(','),
+  });
+}
+console.log(JSON.stringify(batches));

--- a/.github/workflows/apollo-vertex-registry-check.yml
+++ b/.github/workflows/apollo-vertex-registry-check.yml
@@ -61,19 +61,7 @@ jobs:
       - name: Generate matrix batches
         id: matrix
         run: |
-          MATRIX=$(node -e '
-            const registry = JSON.parse(require("fs").readFileSync("apps/apollo-vertex/registry.json", "utf-8"));
-            const names = registry.items.map(i => i.name);
-            const batchSize = 10;
-            const batches = [];
-            for (let i = 0; i < names.length; i += batchSize) {
-              batches.push({
-                batch_index: Math.floor(i / batchSize),
-                components: names.slice(i, i + batchSize).join(",")
-              });
-            }
-            console.log(JSON.stringify(batches));
-          ')
+          MATRIX=$(node .github/scripts/test-registry/generate-matrix-batches.mjs)
           echo "result=${MATRIX}" >> "${GITHUB_OUTPUT}"
 
       - name: Create base shadcn app

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -51,44 +51,12 @@ jobs:
       - name: Post or update PR comment
         if: github.event.pull_request.head.repo.fork == false
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        env:
+          REPORT_PATH: ${{ runner.temp }}/license-report.md
         with:
           script: |
-            const fs = require('fs');
-            const reportPath = '${{ runner.temp }}/license-report.md';
-            const marker = '<!-- dependency-license-review -->';
-
-            let report;
-            try {
-              report = fs.readFileSync(reportPath, 'utf8');
-            } catch {
-              report = '# Dependency License Review\n\n:x: License check script failed before generating a report. Check the workflow logs.';
-            }
-
-            const body = `${marker}\n${report}`;
-
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-            });
-
-            const existing = comments.find(c => c.body.includes(marker));
-
-            if (existing) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: existing.id,
-                body,
-              });
-            } else {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                body,
-              });
-            }
+            const { licenseReviewComment } = await import(`${process.env.GITHUB_WORKSPACE}/.github/scripts/dependency-review-comment.mjs`);
+            await licenseReviewComment({ github, context });
 
       - name: Fail if license violations found
         if: steps.check.outcome == 'failure'

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -185,27 +185,8 @@ jobs:
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           script: |
-            const runs = await github.rest.actions.listWorkflowRuns({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              workflow_id: 'release.yml',
-              branch: 'main',
-              status: 'success',
-              per_page: 10,
-            });
-            for (const run of runs.data.workflow_runs) {
-              const arts = await github.rest.actions.listWorkflowRunArtifacts({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                run_id: run.id,
-              });
-              if (arts.data.artifacts.some((a) => a.name === 'package-sizes' && !a.expired)) {
-                core.info(`Size baseline from main run ${run.id} (${(run.head_sha || '').slice(0, 7)})`);
-                core.setOutput('run_id', String(run.id));
-                return;
-              }
-            }
-            core.info('No main build with a package-sizes artifact found; "vs main" will show "—".');
+            const { findSizeBaseline } = await import(`${process.env.GITHUB_WORKSPACE}/.github/scripts/find-size-baseline.mjs`);
+            await findSizeBaseline({ github, context, core });
 
       - name: Download main size baseline
         if: steps.baseline.outputs.run_id

--- a/.github/workflows/pr-size.yml
+++ b/.github/workflows/pr-size.yml
@@ -15,89 +15,33 @@ on:
 permissions:
   contents: read
 
+# The managed label set and the sizing logic live in
+# .github/scripts/pr-size-labels.mjs, shared by both jobs.
 jobs:
-  prepare-config:
-    name: Prepare PR size config
-    runs-on: ubuntu-24.04
-    outputs:
-      labels_json: ${{ steps.config.outputs.labels_json }}
-    steps:
-      - id: config
-        name: Build PR size label config
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
-        with:
-          result-encoding: string
-          script: |
-            const managedLabels = [
-              { name: "size:XS", color: "0e8a16", description: "0-9 changed lines." },
-              { name: "size:S", color: "5ebd3e", description: "10-29 changed lines." },
-              { name: "size:M", color: "fbca04", description: "30-99 changed lines." },
-              { name: "size:L", color: "fe7d37", description: "100-499 changed lines." },
-              { name: "size:XL", color: "d93f0b", description: "500-999 changed lines." },
-              { name: "size:XXL", color: "b60205", description: "1,000+ changed lines." },
-            ];
-
-            core.setOutput("labels_json", JSON.stringify(managedLabels));
   sync-label-definitions:
     name: Sync PR size label definitions
-    needs: prepare-config
     runs-on: ubuntu-24.04
     permissions:
       contents: read
       issues: write
       pull-requests: write
     steps:
+      - name: Checkout scripts
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          sparse-checkout: .github/scripts
+          persist-credentials: false
+
       - name: Ensure PR size labels exist
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
-        env:
-          PR_SIZE_LABELS_JSON: ${{ needs.prepare-config.outputs.labels_json }}
         with:
           script: |
-            const managedLabels = JSON.parse(process.env.PR_SIZE_LABELS_JSON ?? "[]");
+            const { ensureLabels } = await import(`${process.env.GITHUB_WORKSPACE}/.github/scripts/pr-size-labels.mjs`);
+            await ensureLabels({ github, context });
 
-            for (const label of managedLabels) {
-              try {
-                const { data: existing } = await github.rest.issues.getLabel({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  name: label.name,
-                });
-
-                if (
-                  existing.color !== label.color ||
-                  (existing.description ?? "") !== label.description
-                ) {
-                  await github.rest.issues.updateLabel({
-                    owner: context.repo.owner,
-                    repo: context.repo.repo,
-                    name: label.name,
-                    color: label.color,
-                    description: label.description,
-                  });
-                }
-              } catch (error) {
-                if (error.status !== 404) {
-                  throw error;
-                }
-
-                try {
-                  await github.rest.issues.createLabel({
-                    owner: context.repo.owner,
-                    repo: context.repo.repo,
-                    name: label.name,
-                    color: label.color,
-                    description: label.description,
-                  });
-                } catch (createError) {
-                  if (createError.status !== 422) {
-                    throw createError;
-                  }
-                }
-              }
-            }
   label:
     name: Label PR size
-    needs: [prepare-config, sync-label-definitions]
+    needs: sync-label-definitions
     runs-on: ubuntu-24.04
     permissions:
       contents: read
@@ -107,79 +51,15 @@ jobs:
       group: pr-size-${{ github.event.pull_request.number }}
       cancel-in-progress: true
     steps:
+      - name: Checkout scripts
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          sparse-checkout: .github/scripts
+          persist-credentials: false
+
       - name: Sync PR size label
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
-        env:
-          PR_SIZE_LABELS_JSON: ${{ needs.prepare-config.outputs.labels_json }}
         with:
           script: |
-            const issueNumber = context.payload.pull_request.number;
-            const additions = context.payload.pull_request.additions ?? 0;
-            const deletions = context.payload.pull_request.deletions ?? 0;
-            const changedLines = additions + deletions;
-            const managedLabels = JSON.parse(process.env.PR_SIZE_LABELS_JSON ?? "[]");
-
-            const managedLabelNames = new Set(managedLabels.map((label) => label.name));
-
-            const resolveSizeLabel = (totalChangedLines) => {
-              if (totalChangedLines < 10) {
-                return "size:XS";
-              }
-
-              if (totalChangedLines < 30) {
-                return "size:S";
-              }
-
-              if (totalChangedLines < 100) {
-                return "size:M";
-              }
-
-              if (totalChangedLines < 500) {
-                return "size:L";
-              }
-
-              if (totalChangedLines < 1000) {
-                return "size:XL";
-              }
-
-              return "size:XXL";
-            };
-
-            const nextLabelName = resolveSizeLabel(changedLines);
-
-            const { data: currentLabels } = await github.rest.issues.listLabelsOnIssue({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: issueNumber,
-              per_page: 100,
-            });
-
-            for (const label of currentLabels) {
-              if (!managedLabelNames.has(label.name) || label.name === nextLabelName) {
-                continue;
-              }
-
-              try {
-                await github.rest.issues.removeLabel({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  issue_number: issueNumber,
-                  name: label.name,
-                });
-              } catch (removeError) {
-                if (removeError.status !== 404) {
-                  throw removeError;
-                }
-              }
-            }
-
-            if (!currentLabels.some((label) => label.name === nextLabelName)) {
-              await github.rest.issues.addLabels({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: issueNumber,
-                labels: [nextLabelName],
-              });
-            }
-
-            core.info(`PR #${issueNumber}: ${changedLines} changed lines -> ${nextLabelName}`);
+            const { syncLabel } = await import(`${process.env.GITHUB_WORKSPACE}/.github/scripts/pr-size-labels.mjs`);
+            await syncLabel({ github, context, core });

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -371,6 +371,318 @@ jobs:
               });
             }
 
+  visual-diff:
+    name: Storybook Visual Diff
+    needs: deploy
+    # Informational check (never required for merge): compares the PR's
+    # apollo-design preview Storybook against the deployed main Storybook
+    # with @uipath/storybook-visual-diff and posts the result as a PR
+    # comment. Only PRs targeting main are compared (the deployed baseline
+    # tracks main). The apollo-design leg's outcome is read from its result
+    # artifact so a failure in another matrix leg doesn't skip this job.
+    if: ${{ !cancelled() && github.event.action != 'closed' && github.event.pull_request.head.repo.fork == false && github.event.pull_request.base.ref == 'main' && needs.deploy.result != 'skipped' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
+      pull-requests: write
+    env:
+      SBDIFF_VERSION: 1.1.1
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          # Full history: sbdiff scopes captured stories via
+          # git diff origin/main...HEAD plus a transitive import graph.
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Download apollo-design deploy result
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: deploy-result-apollo-design
+          path: ${{ runner.temp }}/apollo-design-result
+
+      - name: Resolve preview and baseline URLs
+        id: urls
+        env:
+          RESULT_DIR: ${{ runner.temp }}/apollo-design-result
+          UIPATH_BASE_URL: ${{ vars.UIPATH_BASE_URL || secrets.UIPATH_BASE_URL }}
+          UIPATH_ORG_NAME: ${{ vars.UIPATH_ORG_NAME || secrets.UIPATH_ORG_NAME }}
+        run: |
+          set -euo pipefail
+
+          outcome="$(cat "$RESULT_DIR/outcome" 2>/dev/null || echo skipped)"
+          preview_url="$(cat "$RESULT_DIR/url" 2>/dev/null || true)"
+          if [ "$outcome" != "success" ] || [ -z "$preview_url" ]; then
+            echo "apollo-design preview outcome: ${outcome} — skipping visual diff."
+            echo "ready=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Same URL derivation as the deploy job, for the stable main app.
+          baseline_url="$(APP_NAME=apollo-design node <<'NODE'
+          const baseUrl = process.env.UIPATH_BASE_URL || '';
+          const orgName = process.env.UIPATH_ORG_NAME || '';
+          const appName = process.env.APP_NAME || '';
+
+          let environment = '';
+          try {
+            const hostname = new URL(baseUrl).hostname;
+            let inferred = hostname.replace(/\.uipath\.com$/, '');
+            inferred = inferred.replace(/^api\./, '').replace(/\.api$/, '');
+            environment = inferred && inferred !== 'api' && inferred !== 'cloud' ? inferred : '';
+          } catch {
+            environment = '';
+          }
+
+          const suffix = environment ? `.${environment}` : '';
+          console.log(`https://${orgName}${suffix}.uipath.host/${appName}`);
+          NODE
+          )"
+
+          {
+            echo "ready=true"
+            echo "preview_url=${preview_url%/}"
+            echo "baseline_url=${baseline_url%/}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Set up Node 24
+        if: steps.urls.outputs.ready == 'true'
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          # sbdiff runs its TypeScript entry directly (requires Node >= 23.6).
+          node-version: 24
+
+      - name: Cache Playwright browsers
+        if: steps.urls.outputs.ready == 'true'
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-sbdiff-${{ env.SBDIFF_VERSION }}
+          restore-keys: |
+            ${{ runner.os }}-playwright-sbdiff-
+
+      - name: Install visual diff tools
+        if: steps.urls.outputs.ready == 'true'
+        env:
+          GH_NPM_REGISTRY_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          tools_npmrc="${RUNNER_TEMP}/sbdiff.npmrc"
+          tools_prefix="${RUNNER_TEMP}/sbdiff-tools"
+          {
+            printf '@uipath:registry=https://npm.pkg.github.com\n'
+            printf '//npm.pkg.github.com/:_authToken=%s\n' "$GH_NPM_REGISTRY_TOKEN"
+          } > "$tools_npmrc"
+          NPM_CONFIG_USERCONFIG="$tools_npmrc" npm install --prefix "$tools_prefix" \
+            "@uipath/storybook-visual-diff@${SBDIFF_VERSION}" \
+            "@uipath/uip-go@${UIP_GO_VERSION}"
+
+          "${tools_prefix}/node_modules/.bin/playwright" install --with-deps chromium
+
+      - name: Run storybook visual diff
+        if: steps.urls.outputs.ready == 'true'
+        id: sbdiff
+        env:
+          SBDIFF_CONFIG_DIR: ${{ runner.temp }}/sbdiff-config
+          BASELINE_URL: ${{ steps.urls.outputs.baseline_url }}
+          PREVIEW_URL: ${{ steps.urls.outputs.preview_url }}
+        run: |
+          set -euo pipefail
+
+          # Exit 0 = no visual changes, 1 = changes or story errors (both are
+          # valid outcomes for this informational check), >= 2 = broken run.
+          set +e
+          "${RUNNER_TEMP}/sbdiff-tools/node_modules/.bin/sbdiff" \
+            --baseline "$BASELINE_URL" \
+            --current "$PREVIEW_URL" \
+            --storybook-root apps/storybook \
+            --base origin/main \
+            --no-trunk-check \
+            --report-dir-file "${RUNNER_TEMP}/sbdiff-report-dir"
+          code=$?
+          set -e
+          if [ "$code" -ge 2 ]; then
+            echo "::error::storybook-visual-diff failed with exit code ${code}."
+            exit "$code"
+          fi
+
+          # The pointer file is written only when a report was produced; a
+          # clean exit without one means the PR's changed files affect no
+          # stories.
+          report_dir=""
+          if [ -f "${RUNNER_TEMP}/sbdiff-report-dir" ]; then
+            report_dir="$(cat "${RUNNER_TEMP}/sbdiff-report-dir")"
+          fi
+          if [ -z "$report_dir" ] || [ ! -f "${report_dir}/summary.json" ]; then
+            if [ "$code" -eq 0 ]; then
+              {
+                echo "no_stories=true"
+                echo "total=0"
+                echo "has_diffs=false"
+              } >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            echo "::error::sbdiff exited ${code} without producing a report."
+            exit 1
+          fi
+          echo "report_dir=${report_dir}" >> "$GITHUB_OUTPUT"
+          # Single-quoted on purpose: the ${...} below are JS template
+          # literals, not shell expansions.
+          # shellcheck disable=SC2016
+          node -e '
+          const fs = require("fs");
+          const c = JSON.parse(fs.readFileSync(process.argv[1], "utf8")).counts;
+          fs.appendFileSync(process.env.GITHUB_OUTPUT, [
+            `total=${c.total}`,
+            `changed=${c.changed}`,
+            `added=${c.new}`,
+            `removed=${c.removed}`,
+            `errors=${c.error}`,
+            `passed=${c.pass}`,
+            `has_diffs=${c.diffs > 0}`,
+            "",
+          ].join("\n"));
+          ' "${report_dir}/summary.json"
+
+      - name: Deploy visual diff report
+        if: steps.sbdiff.outputs.has_diffs == 'true'
+        id: report
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPORT_DIR: ${{ steps.sbdiff.outputs.report_dir }}
+          HEAD_REF: ${{ github.head_ref }}
+          UIPATH_BASE_URL: ${{ vars.UIPATH_BASE_URL || secrets.UIPATH_BASE_URL }}
+          UIPATH_CLIENT_ID: ${{ vars.UIPATH_CLIENT_ID || secrets.UIPATH_CLIENT_ID }}
+          UIPATH_CLIENT_SECRET: ${{ secrets.UIPATH_CLIENT_SECRET }}
+          UIPATH_FOLDER_KEY: ${{ vars.UIPATH_FOLDER_KEY || secrets.UIPATH_FOLDER_KEY }}
+          UIPATH_ORG_NAME: ${{ vars.UIPATH_ORG_NAME || secrets.UIPATH_ORG_NAME }}
+          UIPATH_TENANT_NAME: ${{ vars.UIPATH_TENANT_NAME || secrets.UIPATH_TENANT_NAME }}
+          UIPATH_CLIENT_SCOPE: ${{ vars.UIPATH_CLIENT_SCOPE || 'Apps Apps.Read Apps.Write OR.Folders.Read OR.Folders.Write OR.Execution' }}
+        run: |
+          set -euo pipefail
+
+          # Assemble the static report app: the sbdiff viewer plus this
+          # run's summary.json and referenced images. `sbdiff bundle` also
+          # injects the static-mode marker without which the viewer never
+          # loads summary.json.
+          "${RUNNER_TEMP}/sbdiff-tools/node_modules/.bin/sbdiff" bundle "$REPORT_DIR" \
+            --out .uipath-build/apollo-design-diff \
+            --branch "$HEAD_REF" \
+            --title "apollo-ui PR #${PR_NUMBER}"
+
+          short_sha="${GITHUB_SHA:0:7}"
+          version="0.1.0-pr${PR_NUMBER}.${short_sha}.${GITHUB_RUN_ATTEMPT}"
+          app_name="apollo-design-diff-pr-${PR_NUMBER}"
+          UIP_GO="${RUNNER_TEMP}/sbdiff-tools/node_modules/.bin/uip-go"
+
+          output_file="$(mktemp)"
+          echo "::group::uip-go apollo-design-diff"
+          "$UIP_GO" apollo-design-diff \
+              --name "$app_name" \
+              --path-name "$app_name" \
+              --tags "apollo,apollo-design-diff,preview" \
+              --version "$version" \
+              --folder-key "$UIPATH_FOLDER_KEY" \
+              --base-url "$UIPATH_BASE_URL" \
+              --org-name "$UIPATH_ORG_NAME" \
+              --tenant-name "$UIPATH_TENANT_NAME" \
+              --deploy-retries 3 \
+              --deploy-retry-delay-ms 10000 2>&1 | tee "$output_file"
+          echo "::endgroup::"
+
+          app_url="$(sed -nE 's/^[[:space:]]*App URL:[[:space:]]*//p' "$output_file" | tail -n 1)"
+          if [ -n "$app_url" ]; then
+            echo "url=${app_url%/}/" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Post visual diff comment
+        if: ${{ !cancelled() }}
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        env:
+          READY: ${{ steps.urls.outputs.ready }}
+          SBDIFF_OUTCOME: ${{ steps.sbdiff.outcome }}
+          NO_STORIES: ${{ steps.sbdiff.outputs.no_stories }}
+          HAS_DIFFS: ${{ steps.sbdiff.outputs.has_diffs }}
+          TOTAL: ${{ steps.sbdiff.outputs.total }}
+          CHANGED: ${{ steps.sbdiff.outputs.changed }}
+          ADDED: ${{ steps.sbdiff.outputs.added }}
+          REMOVED: ${{ steps.sbdiff.outputs.removed }}
+          ERRORS: ${{ steps.sbdiff.outputs.errors }}
+          PASSED: ${{ steps.sbdiff.outputs.passed }}
+          REPORT_OUTCOME: ${{ steps.report.outcome }}
+          REPORT_URL: ${{ steps.report.outputs.url }}
+        with:
+          script: |
+            const identifier = '<!-- apollo-visual-diff-comment -->';
+            const logsLink = `[Logs](https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId})`;
+            const timestamp = new Date().toLocaleString('en-US', {
+              timeZone: 'America/Los_Angeles',
+              year: 'numeric',
+              month: 'short',
+              day: '2-digit',
+              hour: '2-digit',
+              minute: '2-digit',
+              second: '2-digit',
+              hour12: true
+            });
+
+            const n = (v) => Number(v) || 0;
+            const lines = [identifier, '### Storybook visual diff', ''];
+            if (process.env.READY !== 'true') {
+              lines.push(`⏭️ Skipped: the apollo-design preview deployment did not succeed, so no comparison ran. ${logsLink}`);
+            } else if (process.env.SBDIFF_OUTCOME !== 'success') {
+              lines.push(`❌ The visual diff run failed before producing a result. ${logsLink}`);
+            } else if (process.env.NO_STORIES === 'true') {
+              lines.push(`✅ No stories are affected by this PR's changes; nothing to compare. ${logsLink}`);
+            } else if (process.env.HAS_DIFFS !== 'true') {
+              lines.push(`✅ No visual changes. ${n(process.env.TOTAL)} stories affected by this PR were compared against the deployed main Storybook. ${logsLink}`);
+            } else {
+              const parts = [];
+              if (n(process.env.CHANGED)) parts.push(`${n(process.env.CHANGED)} changed`);
+              if (n(process.env.ADDED)) parts.push(`${n(process.env.ADDED)} added`);
+              if (n(process.env.REMOVED)) parts.push(`${n(process.env.REMOVED)} removed`);
+              if (n(process.env.ERRORS)) parts.push(`${n(process.env.ERRORS)} errored`);
+              const report = process.env.REPORT_OUTCOME === 'success' && process.env.REPORT_URL
+                ? `[View report](${process.env.REPORT_URL})`
+                : `report deployment failed, see ${logsLink}`;
+              lines.push(`⚠️ Visual changes detected: ${parts.join(', ')} (of ${n(process.env.TOTAL)} compared, ${n(process.env.PASSED)} unchanged). ${report}`);
+              lines.push('');
+              lines.push(`Baseline is the deployed main Storybook, so changes merged to main after this branch was last updated can also appear here. ${logsLink}`);
+            }
+            lines.push('', `_Updated (PT): ${timestamp}_`);
+            const body = lines.join('\n');
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              per_page: 100,
+            });
+            const existing = comments.find(comment =>
+              comment.body?.includes(identifier) &&
+              comment.user?.type === 'Bot' &&
+              ['github-actions[bot]', 'github-actions'].includes(comment.user?.login)
+            );
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }
+
   cleanup-previews:
     name: Cleanup Apollo Coded App Previews
     if: github.event.action == 'closed' && github.event.pull_request.head.repo.fork == false
@@ -426,7 +738,7 @@ jobs:
 
           # No redirect-URI cleanup: previews reuse the first-party Uber.Client,
           # whose Coded App host is covered by a static wildcard registration.
-          for label in apollo-landing apollo-docs apollo-design apollo-vertex; do
+          for label in apollo-landing apollo-docs apollo-design apollo-vertex apollo-design-diff; do
             app_name="${label}-pr-${PR_NUMBER}"
             if ! "$UIP_GO" "$label" \
               --delete-app \

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -28,60 +28,19 @@ jobs:
       pull-requests: write
 
     steps:
+      # Comment scripts live in the repo, not inline (see .github/scripts/).
+      - name: Checkout scripts
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          sparse-checkout: .github/scripts
+          persist-credentials: false
+
       - name: Initialize PR comment
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           script: |
-            const identifier = '<!-- apollo-coded-app-preview-comment -->';
-            const timestamp = new Date().toLocaleString('en-US', {
-              timeZone: 'America/Los_Angeles',
-              year: 'numeric',
-              month: 'short',
-              day: '2-digit',
-              hour: '2-digit',
-              minute: '2-digit',
-              second: '2-digit',
-              hour12: true
-            });
-            const runUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
-            const deployingLink = `[Deploying...](${runUrl})`;
-            const logsLink = `[Logs](${runUrl})`;
-            const projects = ['apollo-design', 'apollo-docs', 'apollo-landing', 'apollo-vertex'];
-            const body = [
-              identifier,
-              'Apollo Coded App preview deployments are running.',
-              '',
-              '| Project | Status | Preview | Updated (PT) |',
-              '|---------|--------|---------|--------------|',
-              ...projects.map(project => `| ${project} | ${deployingLink} | ${logsLink} | ${timestamp} |`)
-            ].join('\n');
-
-            const comments = await github.paginate(github.rest.issues.listComments, {
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              per_page: 100,
-            });
-            const existing = comments.find(comment =>
-              comment.body?.includes(identifier) &&
-              comment.user?.type === 'Bot' &&
-              ['github-actions[bot]', 'github-actions'].includes(comment.user?.login)
-            );
-            if (existing) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: existing.id,
-                body,
-              });
-            } else {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                body,
-              });
-            }
+            const { initComment } = await import(`${process.env.GITHUB_WORKSPACE}/.github/scripts/preview-deploy/preview-comment.mjs`);
+            await initComment({ github, context });
 
   deploy:
     name: Deploy ${{ matrix.label }}
@@ -168,24 +127,7 @@ jobs:
           UIP_GO="${uip_go_prefix}/node_modules/.bin/uip-go"
 
           derive_app_url() {
-            APP_NAME="$1" node <<'NODE'
-          const baseUrl = process.env.UIPATH_BASE_URL || '';
-          const orgName = process.env.UIPATH_ORG_NAME || '';
-          const appName = process.env.APP_NAME || '';
-
-          let environment = '';
-          try {
-            const hostname = new URL(baseUrl).hostname;
-            let inferred = hostname.replace(/\.uipath\.com$/, '');
-            inferred = inferred.replace(/^api\./, '').replace(/\.api$/, '');
-            environment = inferred && inferred !== 'api' && inferred !== 'cloud' ? inferred : '';
-          } catch {
-            environment = '';
-          }
-
-          const suffix = environment ? `.${environment}` : '';
-          console.log(`https://${orgName}${suffix}.uipath.host/${appName}`);
-          NODE
+            APP_NAME="$1" node .github/scripts/preview-deploy/derive-app-url.mjs
           }
 
           # The platform-auth app (vertex) carries its client id in the recipe
@@ -281,6 +223,13 @@ jobs:
       pull-requests: write
 
     steps:
+      # Comment scripts live in the repo, not inline (see .github/scripts/).
+      - name: Checkout scripts
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          sparse-checkout: .github/scripts
+          persist-credentials: false
+
       - name: Download deploy results
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
@@ -293,83 +242,8 @@ jobs:
           RESULTS_DIR: ${{ runner.temp }}/results
         with:
           script: |
-            const fs = require('fs');
-            const path = require('path');
-
-            const identifier = '<!-- apollo-coded-app-preview-comment -->';
-            const projects = ['apollo-design', 'apollo-docs', 'apollo-landing', 'apollo-vertex'];
-            const resultsDir = process.env.RESULTS_DIR;
-            const logsLink = `[Logs](https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId})`;
-            const timestamp = new Date().toLocaleString('en-US', {
-              timeZone: 'America/Los_Angeles',
-              year: 'numeric',
-              month: 'short',
-              day: '2-digit',
-              hour: '2-digit',
-              minute: '2-digit',
-              second: '2-digit',
-              hour12: true
-            });
-
-            const readResult = (project) => {
-              const dir = path.join(resultsDir, `deploy-result-${project}`);
-              const read = (name) => {
-                try {
-                  return fs.readFileSync(path.join(dir, name), 'utf8').trim();
-                } catch {
-                  return '';
-                }
-              };
-              return { url: read('url'), outcome: read('outcome') || 'skipped' };
-            };
-
-            let anyFailed = false;
-            const rows = projects.map(project => {
-              const { url, outcome } = readResult(project);
-              const ready = outcome === 'success' && Boolean(url);
-              if (outcome === 'failure') anyFailed = true;
-              const status = ready ? 'Ready' : outcome === 'failure' ? 'Failed' : 'Skipped';
-              const preview = ready ? `[Preview](${url}) · ${logsLink}` : logsLink;
-              return `| ${project} | ${status} | ${preview} | ${timestamp} |`;
-            });
-
-            const body = [
-              identifier,
-              anyFailed
-                ? 'Apollo Coded App preview deployments finished with failures.'
-                : 'Apollo Coded App preview deployments are ready.',
-              '',
-              '| Project | Status | Preview | Updated (PT) |',
-              '|---------|--------|---------|--------------|',
-              ...rows
-            ].join('\n');
-
-            const comments = await github.paginate(github.rest.issues.listComments, {
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              per_page: 100,
-            });
-            const existing = comments.find(comment =>
-              comment.body?.includes(identifier) &&
-              comment.user?.type === 'Bot' &&
-              ['github-actions[bot]', 'github-actions'].includes(comment.user?.login)
-            );
-            if (existing) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: existing.id,
-                body,
-              });
-            } else {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                body,
-              });
-            }
+            const { updateComment } = await import(`${process.env.GITHUB_WORKSPACE}/.github/scripts/preview-deploy/preview-comment.mjs`);
+            await updateComment({ github, context });
 
   visual-diff:
     name: Storybook Visual Diff
@@ -422,25 +296,7 @@ jobs:
           fi
 
           # Same URL derivation as the deploy job, for the stable main app.
-          baseline_url="$(APP_NAME=apollo-design node <<'NODE'
-          const baseUrl = process.env.UIPATH_BASE_URL || '';
-          const orgName = process.env.UIPATH_ORG_NAME || '';
-          const appName = process.env.APP_NAME || '';
-
-          let environment = '';
-          try {
-            const hostname = new URL(baseUrl).hostname;
-            let inferred = hostname.replace(/\.uipath\.com$/, '');
-            inferred = inferred.replace(/^api\./, '').replace(/\.api$/, '');
-            environment = inferred && inferred !== 'api' && inferred !== 'cloud' ? inferred : '';
-          } catch {
-            environment = '';
-          }
-
-          const suffix = environment ? `.${environment}` : '';
-          console.log(`https://${orgName}${suffix}.uipath.host/${appName}`);
-          NODE
-          )"
+          baseline_url="$(APP_NAME=apollo-design node .github/scripts/preview-deploy/derive-app-url.mjs)"
 
           {
             echo "ready=true"
@@ -530,23 +386,7 @@ jobs:
             exit 1
           fi
           echo "report_dir=${report_dir}" >> "$GITHUB_OUTPUT"
-          # Single-quoted on purpose: the ${...} below are JS template
-          # literals, not shell expansions.
-          # shellcheck disable=SC2016
-          node -e '
-          const fs = require("fs");
-          const c = JSON.parse(fs.readFileSync(process.argv[1], "utf8")).counts;
-          fs.appendFileSync(process.env.GITHUB_OUTPUT, [
-            `total=${c.total}`,
-            `changed=${c.changed}`,
-            `added=${c.new}`,
-            `removed=${c.removed}`,
-            `errors=${c.error}`,
-            `passed=${c.pass}`,
-            `has_diffs=${c.diffs > 0}`,
-            "",
-          ].join("\n"));
-          ' "${report_dir}/summary.json"
+          node .github/scripts/preview-deploy/visual-diff-counts.mjs "${report_dir}/summary.json"
 
       - name: Deploy visual diff report
         if: steps.sbdiff.outputs.has_diffs == 'true'
@@ -617,71 +457,8 @@ jobs:
           REPORT_URL: ${{ steps.report.outputs.url }}
         with:
           script: |
-            const identifier = '<!-- apollo-visual-diff-comment -->';
-            const logsLink = `[Logs](https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId})`;
-            const timestamp = new Date().toLocaleString('en-US', {
-              timeZone: 'America/Los_Angeles',
-              year: 'numeric',
-              month: 'short',
-              day: '2-digit',
-              hour: '2-digit',
-              minute: '2-digit',
-              second: '2-digit',
-              hour12: true
-            });
-
-            const n = (v) => Number(v) || 0;
-            const lines = [identifier, '### Storybook visual diff', ''];
-            if (process.env.READY !== 'true') {
-              lines.push(`⏭️ Skipped: the apollo-design preview deployment did not succeed, so no comparison ran. ${logsLink}`);
-            } else if (process.env.SBDIFF_OUTCOME !== 'success') {
-              lines.push(`❌ The visual diff run failed before producing a result. ${logsLink}`);
-            } else if (process.env.NO_STORIES === 'true') {
-              lines.push(`✅ No stories are affected by this PR's changes; nothing to compare. ${logsLink}`);
-            } else if (process.env.HAS_DIFFS !== 'true') {
-              lines.push(`✅ No visual changes. ${n(process.env.TOTAL)} stories affected by this PR were compared against the deployed main Storybook. ${logsLink}`);
-            } else {
-              const parts = [];
-              if (n(process.env.CHANGED)) parts.push(`${n(process.env.CHANGED)} changed`);
-              if (n(process.env.ADDED)) parts.push(`${n(process.env.ADDED)} added`);
-              if (n(process.env.REMOVED)) parts.push(`${n(process.env.REMOVED)} removed`);
-              if (n(process.env.ERRORS)) parts.push(`${n(process.env.ERRORS)} errored`);
-              const report = process.env.REPORT_OUTCOME === 'success' && process.env.REPORT_URL
-                ? `[View report](${process.env.REPORT_URL})`
-                : `report deployment failed, see ${logsLink}`;
-              lines.push(`⚠️ Visual changes detected: ${parts.join(', ')} (of ${n(process.env.TOTAL)} compared, ${n(process.env.PASSED)} unchanged). ${report}`);
-              lines.push('');
-              lines.push(`Baseline is the deployed main Storybook, so changes merged to main after this branch was last updated can also appear here. ${logsLink}`);
-            }
-            lines.push('', `_Updated (PT): ${timestamp}_`);
-            const body = lines.join('\n');
-
-            const comments = await github.paginate(github.rest.issues.listComments, {
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              per_page: 100,
-            });
-            const existing = comments.find(comment =>
-              comment.body?.includes(identifier) &&
-              comment.user?.type === 'Bot' &&
-              ['github-actions[bot]', 'github-actions'].includes(comment.user?.login)
-            );
-            if (existing) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: existing.id,
-                body,
-              });
-            } else {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                body,
-              });
-            }
+            const { visualDiffComment } = await import(`${process.env.GITHUB_WORKSPACE}/.github/scripts/preview-deploy/visual-diff-comment.mjs`);
+            await visualDiffComment({ github, context });
 
   cleanup-previews:
     name: Cleanup Apollo Coded App Previews

--- a/.github/workflows/support-branch-scope.yml
+++ b/.github/workflows/support-branch-scope.yml
@@ -41,6 +41,7 @@ jobs:
           sparse-checkout: |
             packages
             web-packages
+            .github
           sparse-checkout-cone-mode: true
           fetch-depth: 1
           persist-credentials: false
@@ -115,77 +116,16 @@ jobs:
           BASE_REF: ${{ github.event.pull_request.base.ref }}
         with:
           script: |
-            const marker = '<!-- support-branch-scope-check -->';
-            const pkg = process.env.PACKAGE;
-            const pkgDir = process.env.PKG_DIR;
-            const status = process.env.SCOPE_STATUS;
-            const outOfScope = (process.env.OUT_OF_SCOPE_FILES || '').trim();
-            const baseRef = process.env.BASE_REF;
-
-            let body = `${marker}\n`;
-            body += `## Support Branch Scope — \`${baseRef}\`\n\n`;
-            body += `> [!CAUTION]\n`;
-            body += `> This PR modifies files outside \`${pkgDir}/\`. Support branches should only contain changes scoped to their package.\n\n`;
-            body += `**Out-of-scope files:**\n`;
-            for (const f of outOfScope.split('\n').filter(Boolean)) {
-              body += `- \`${f}\`\n`;
-            }
-            body += `\n---\n\n`;
-
-            body += `### Need to update a workspace dependency (e.g. \`apollo-core\`)?\n\n`;
-            body += `This branch locks workspace deps to exact versions (e.g. \`5.9.0\` instead of \`workspace:*\`) `;
-            body += `and resolves them from the registry. `;
-            body += `Bumping the version in \`${pkgDir}/package.json\` and running \`pnpm install\` will fetch the new version.\n\n`;
-            body += `If your fix requires changes in a sibling package (e.g. \`apollo-core\`):\n\n`;
-            body += `1. **If the dependency is still on the same major on \`main\`** — land the fix on \`main\`, `;
-            body += `let it publish a new version, then bump the version in this branch's `;
-            body += `\`${pkgDir}/package.json\` and run \`pnpm install\` to update the lockfile.\n`;
-            body += `2. **If the dependency needs a support branch too** — cut a support branch for that package `;
-            body += `(e.g. \`support/apollo-core@5.x\`), publish the fix from there, then update the dependency version here.\n`;
-
-            const comments = await github.paginate(github.rest.issues.listComments, {
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-            });
-
-            const existing = comments.find(c => c.body?.includes(marker));
-
-            if (existing) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: existing.id,
-                body,
-              });
-            } else {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                body,
-              });
-            }
+            const { postScopeComment } = await import(`${process.env.GITHUB_WORKSPACE}/.github/scripts/support-branch-scope-comment.mjs`);
+            await postScopeComment({ github, context });
 
       - name: Remove comment if scope is clean
         if: steps.scope.outputs.status != 'fail'
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           script: |
-            const marker = '<!-- support-branch-scope-check -->';
-            const comments = await github.paginate(github.rest.issues.listComments, {
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-            });
-            const existing = comments.find(c => c.body?.includes(marker));
-            if (existing) {
-              await github.rest.issues.deleteComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: existing.id,
-              });
-            }
+            const { removeScopeComment } = await import(`${process.env.GITHUB_WORKSPACE}/.github/scripts/support-branch-scope-comment.mjs`);
+            await removeScopeComment({ github, context });
 
       - name: Fail if out of scope
         if: steps.scope.outputs.status == 'fail'

--- a/.uip-go.json
+++ b/.uip-go.json
@@ -47,6 +47,13 @@
         "APOLLO_CODED_APP": "1"
       }
     },
+    "apollo-design-diff": {
+      "type": "codedapp",
+      "outputDir": ".uipath-build/apollo-design-diff",
+      "pathNameEnv": "APOLLO_CODED_APP_PATH",
+      "folderKeyEnv": "UIPATH_FOLDER_KEY",
+      "tags": "apollo,apollo-design-diff"
+    },
     "apollo-vertex": {
       "type": "codedapp",
       "build": {


### PR DESCRIPTION
## What

Two related CI changes:

1. **Storybook visual diff check** (informational, never merge-blocking): every PR sync compares the PR's `apollo-design` preview Storybook against the deployed main Storybook using [`@uipath/storybook-visual-diff`](https://github.com/UiPath/storybook-diff) (**v1.1.1**, GitHub Packages) and posts/updates a PR comment with the outcome.
2. **Workflow scripts refactor**: ~500 lines of YAML-embedded JavaScript across six workflows moved into standalone modules under `.github/scripts/`, so workflow steps are 2–3-line stubs and the logic is readable and testable.

### `visual-diff` job (in `preview-deploy.yml`)

- Runs after the deploy matrix, only for non-fork PRs targeting `main` (the deployed baseline tracks main). Reads the `apollo-design` leg's result artifact, so failures in other matrix legs don't block it; if the preview leg failed, the comment says the diff was skipped.
- Runs sbdiff on Node 24 with `--baseline` = deployed main Storybook and `--current` = the PR preview. Stories are scoped via `git diff origin/main...HEAD` plus sbdiff's transitive import graph, captured in light + dark themes. The report directory comes from sbdiff's `--report-dir-file` pointer and counts from the `counts` object in `summary.json`.
- Exit 0 (clean) and exit 1 (visual changes / story errors) are both valid outcomes; only a broken run (exit ≥ 2) fails the job.
- When there are diffs, `sbdiff bundle` assembles the static report (viewer + summary + referenced images, with the static-mode marker) and it deploys as the `apollo-design-diff-pr-<N>` Coded App via a new build-less `.uip-go.json` recipe. The comment shows changed/added/removed/errored counts with a **View report** link (side-by-side, pixel-diff, onion-skin). The report app is deleted on PR close with the other previews.

### Scripts refactor (`.github/scripts/`)

- `lib/pr-comments.mjs`: the marker-comment find/upsert/remove pattern written once, shared by every workflow that owns a PR comment (preview deploys, visual diff, dependency license review, support branch scope).
- `preview-deploy/`: preview comment table (init + update), visual diff comment, `derive-app-url.mjs` (was a heredoc duplicated in two steps), summary counts.
- `pr-size-labels.mjs`: label set + sizing logic in one place. The `prepare-config` job existed only to ship that config between jobs as a JSON output and is **removed** — if branch protection lists the "Prepare PR size config" check as required, it needs unlisting.
- Also extracted: `find-size-baseline.mjs` (pr-checks), `support-branch-scope-comment.mjs`, `dependency-review-comment.mjs`, `test-registry/generate-matrix-batches.mjs`.
- Hardening drive-bys: comment lookups in dependency-review and support-branch-scope now paginate and filter by bot author like the rest (previously any user pasting the marker string could hijack the comment slot), and dependency-review no longer interpolates `runner.temp` inside the script. Pure github-script jobs gained a sparse `.github/scripts` checkout.

## Validation (all on this PR)

- **No affected stories** (this branch's own state): "✅ No stories are affected by this PR's changes; nothing to compare."
- **Preview deploy failure** (staging 504s): diff job stays green and comments "⏭️ Skipped…".
- **Widely-imported component** (temporary Badge change, since dropped): 68 changed of 170 compared — Badge feeds four foundation stories, tree-view, multi-select, and forms, so the fan-out is real.
- **Leaf component** (temporary Breadcrumb change, since dropped): **10 changed of 10 compared** — scoping traced exactly its own stories. Report app verified serving with correct `summary.json` counts.
- Comment-body parity for the refactor verified by rendering all five comment builders through a mock Octokit — byte-identical to the live formats; `actionlint`, `node --check`, import resolution, and Biome pass on everything changed.

## Notes

- Baseline is main's tip (redeployed on every main push), so a branch behind main can show other people's merged visual changes; the comment calls this out. Rerunning after a rebase refreshes it.
- Pixel thresholds are at sbdiff's strict defaults; the tuning knobs are `--max-diff-pixels` and `--mask` on the sbdiff invocation.
- Scoping follows relative and `@/` imports; cross-package changes reaching stories only through bare `@uipath/*` imports are not traced (a follow-up if it proves to matter).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
