### PR TITLE
fix(apollo-react): remove background fill from outlined Chip variant [MST-13017]

### DIFF
--- a/packages/apollo-react/src/material/theme/overrides/MuiChip.ts
+++ b/packages/apollo-react/src/material/theme/overrides/MuiChip.ts
@@ -4,6 +4,13 @@ import type { Palette } from '@uipath/apollo-core/tokens/jss/palette';
 
 export const MuiChip = (palette: Palette): ComponentsOverrides['MuiChip'] => ({
   deletable: { '&:focus:not(.Mui-disabled)': { backgroundColor: palette.semantic.colorHover } },
+  // The outlined variant is border-only: undo the filled background the root slot applies,
+  // keeping the hover fill for clickable chips (matches MUI's own outlined variant).
+  outlined: {
+    backgroundColor: 'transparent',
+    '&:hover': { backgroundColor: 'transparent' },
+    '&.MuiChip-clickable:hover': { backgroundColor: palette.semantic.colorHover },
+  },
   root: {
     paddingLeft: token.Padding.PadL,
     paddingRight: token.Padding.PadL,


### PR DESCRIPTION
## Summary

The MUI `Chip` `variant="outlined"` rendered with the filled gray background instead of being border-only, so it looked identical to the default filled chip (see [MST-13017](https://uipath.atlassian.net/browse/MST-13017), and the [docs page](https://engdogfood.staging.uipath.host/apollo-design/?path=/docs/apollo-react-material-maintenance-only-components-chip--docs&globals=theme:future-light) whose own copy says "outlined style instead of filled background").

The theme's `root` slot sets `backgroundColor: colorBackgroundGray` (plus a `:hover` fill) for every chip. MUI appends `styleOverrides.root` after the component's own variant styles, so it clobbered MUI's `outlined` rule (`background-color: transparent`). Adding an `outlined` slot override is the minimal fix: MUI's `overridesResolver` orders `styles[variant]` after `styles.root`, so the outlined slot wins without touching any other chip state.

## Demo
Before
<img width="772" height="182" alt="image" src="https://github.com/user-attachments/assets/227e8588-fe5e-4351-95f0-0bc45b865a79" />


After
<img width="700" height="465" alt="Screenshot 2026-07-31 at 2 07 28 PM" src="https://github.com/user-attachments/assets/6f52b3c7-aded-4a74-be1c-1166313872a6" />


## Changes

- `packages/apollo-react/src/material/theme/overrides/MuiChip.ts`: new `outlined` slot override that resets the background to `transparent` (idle and hover) and keeps `colorHover` as the hover fill for clickable outlined chips — matching MUI, which only tints outlined chips on hover when they are clickable.

## Testing

Verified in Storybook (`Components/Chip → ColorsAndVariants`) in both `future-light` and `future-dark`:

- All outlined chips (Default / Primary / Secondary / Deletable, plus Small & Medium Outlined) compute `background-color: rgba(0, 0, 0, 0)` with their 1px border intact.
- Filled chips are unchanged (`rgb(212, 212, 216)`), including the semantic `warning` / `success` / `info` / `error` classes.
- On a clickable outlined chip, `.MuiChip-clickable:hover` still resolves to `colorHover`; non-clickable outlined chips stay transparent on hover.

- [ ] Manual testing (Storybook, light + dark)
- [ ] No tests exist for the theme overrides / chip; `biome lint` and `biome format` pass on the changed file
- [ ] Type-safe (no `as any` / type suppressions added)


[MST-13017]: https://uipath.atlassian.net/browse/MST-13017?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ