### PR TITLE
feat(apollo-react): pulse the breakpoint on the task the run is paused at

### DIFF
--- a/packages/apollo-react/src/canvas/components/StageNode/AdhocTask.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/AdhocTask.tsx
@@ -60,6 +60,7 @@ const AdhocTaskItemComponent = ({
       <TaskBreakpointDot
         taskId={task.id}
         active={!!taskExecution?.breakpoint}
+        paused={taskExecution?.status === 'Paused'}
         onToggle={onToggleBreakpoint}
       />
       <TaskContent task={task} taskExecution={taskExecution} onTaskPlay={onTaskPlay} />

--- a/packages/apollo-react/src/canvas/components/StageNode/DraggableTask.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/DraggableTask.tsx
@@ -97,6 +97,7 @@ const DraggableTaskComponent = ({
       <TaskBreakpointDot
         taskId={task.id}
         active={!!taskExecution?.breakpoint}
+        paused={taskExecution?.status === 'Paused'}
         onToggle={onToggleBreakpoint}
       />
       <TaskContent

--- a/packages/apollo-react/src/canvas/components/StageNode/EventDrivenTask.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/EventDrivenTask.tsx
@@ -58,6 +58,7 @@ const EventDrivenTaskItemComponent = ({
       <TaskBreakpointDot
         taskId={task.id}
         active={!!taskExecution?.breakpoint}
+        paused={taskExecution?.status === 'Paused'}
         onToggle={onToggleBreakpoint}
       />
       <TaskContent task={task} taskExecution={taskExecution} />

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.breakpoints.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.breakpoints.stories.tsx
@@ -27,10 +27,12 @@ import type {
 //
 // A task carries a breakpoint when its `execution.taskStatus[id].breakpoint` is
 // true. The marker is a solid red dot at the top-left corner of the task card
-// (debugger-gutter style) and is display-only. Adding and removing breakpoints is
-// done through the task's right-click / task menu, whose items the consumer
+// (debugger-gutter style); it is static while armed and pulses a ring once the run
+// is stopped on it (`status: 'Paused'`). Adding and removing breakpoints is done
+// through the task's right-click / task menu, whose items the consumer
 // (PO.frontend) supplies via `getTaskContextMenuItems`; these stories wire that up
-// the same way.
+// the same way. In the read-only Debug view the dot is the control itself, via
+// `onTaskBreakpointToggle`.
 // ============================================================================
 
 const ProcessIcon = () => (
@@ -212,8 +214,8 @@ const BreakpointPlaygroundStory = ({
 
 // The full breakpoint lifecycle in one stage:
 // - "Classify Request": completed with a breakpoint -> solid dot (passed).
-// - "Review and Decide": the run is paused here on its breakpoint -> solid dot
-//   plus the card's amber Paused border and pause icon (the dot itself is static).
+// - "Review and Decide": the run is paused here on its breakpoint -> the dot pulses a ring, and
+//   the card carries the amber Paused border and pause icon. Only the dot moves.
 // - "Notify Outcome": no breakpoint.
 // Right-click any task to add / remove its breakpoint.
 export const Interactive: Story = {

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.styles.ts
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.styles.ts
@@ -1,34 +1,7 @@
-import { css, keyframes } from '@emotion/react';
+import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import { Padding, Spacing } from '@uipath/apollo-core';
 import type { StageStatus } from './StageNode.types';
-
-/**
- * Ring that travels out of the breakpoint marker on the task the run is paused at (design
- * treatment 2b). The marker itself draws the eye, so the card around it stays static and a stage
- * full of tasks has exactly one thing moving.
- *
- * Geometry and timing are the design's (3px -> 11px, 55% -> 0 alpha, 1.8s ease-out); the colors are
- * tokens instead of its hardcoded hex. The inner 2px of canvas background rides along at every step
- * so the red never touches the dot and the dot keeps a crisp edge against the card.
- */
-const breakpointPausedPulse = keyframes`
-  0% {
-    box-shadow:
-      0 0 0 2px var(--canvas-background),
-      0 0 0 3px color-mix(in srgb, var(--canvas-error-icon) 55%, transparent);
-  }
-  70% {
-    box-shadow:
-      0 0 0 2px var(--canvas-background),
-      0 0 0 11px color-mix(in srgb, var(--canvas-error-icon) 0%, transparent);
-  }
-  100% {
-    box-shadow:
-      0 0 0 2px var(--canvas-background),
-      0 0 0 3px color-mix(in srgb, var(--canvas-error-icon) 0%, transparent);
-  }
-`;
 
 export const INDENTATION_WIDTH = 26;
 export const STAGE_CONTENT_PADDING_X = 14;
@@ -196,10 +169,6 @@ export const StageTask = styled.div<{
   .task-breakpoint-add {
     opacity: 0;
     transition: opacity 0.2s ease-in-out;
-  }
-
-  .task-breakpoint-paused {
-    animation: ${breakpointPausedPulse} 1.8s ease-out infinite;
   }
 
   &:hover .task-breakpoint-add,

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.styles.ts
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.styles.ts
@@ -1,7 +1,34 @@
-import { css } from '@emotion/react';
+import { css, keyframes } from '@emotion/react';
 import styled from '@emotion/styled';
 import { Padding, Spacing } from '@uipath/apollo-core';
 import type { StageStatus } from './StageNode.types';
+
+/**
+ * Ring that travels out of the breakpoint marker on the task the run is paused at (design
+ * treatment 2b). The marker itself draws the eye, so the card around it stays static and a stage
+ * full of tasks has exactly one thing moving.
+ *
+ * Geometry and timing are the design's (3px -> 11px, 55% -> 0 alpha, 1.8s ease-out); the colors are
+ * tokens instead of its hardcoded hex. The inner 2px of canvas background rides along at every step
+ * so the red never touches the dot and the dot keeps a crisp edge against the card.
+ */
+const breakpointPausedPulse = keyframes`
+  0% {
+    box-shadow:
+      0 0 0 2px var(--canvas-background),
+      0 0 0 3px color-mix(in srgb, var(--canvas-error-icon) 55%, transparent);
+  }
+  70% {
+    box-shadow:
+      0 0 0 2px var(--canvas-background),
+      0 0 0 11px color-mix(in srgb, var(--canvas-error-icon) 0%, transparent);
+  }
+  100% {
+    box-shadow:
+      0 0 0 2px var(--canvas-background),
+      0 0 0 3px color-mix(in srgb, var(--canvas-error-icon) 0%, transparent);
+  }
+`;
 
 export const INDENTATION_WIDTH = 26;
 export const STAGE_CONTENT_PADDING_X = 14;
@@ -169,6 +196,10 @@ export const StageTask = styled.div<{
   .task-breakpoint-add {
     opacity: 0;
     transition: opacity 0.2s ease-in-out;
+  }
+
+  .task-breakpoint-paused {
+    animation: ${breakpointPausedPulse} 1.8s ease-out infinite;
   }
 
   &:hover .task-breakpoint-add,

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.test.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.test.tsx
@@ -1406,22 +1406,20 @@ describe('StageNode - pulse on the paused breakpoint', () => {
   it('pulses the marker the run is paused on, so it can be found at a glance', () => {
     renderArmedAdhocTask('Paused');
 
-    expect(getComputedStyle(screen.getByTestId('stage-task-breakpoint-adhoc-1')).animation).toMatch(
-      /1.8s ease-out infinite/
-    );
+    expect(screen.getByTestId('stage-task-breakpoint-adhoc-1')).toHaveClass('animate-glow');
   });
 
   it('leaves a merely armed breakpoint static', () => {
     renderArmedAdhocTask('InProgress');
 
-    expect(getComputedStyle(screen.getByTestId('stage-task-breakpoint-adhoc-1')).animation).toBe(
-      ''
-    );
+    expect(screen.getByTestId('stage-task-breakpoint-adhoc-1')).not.toHaveClass('animate-glow');
   });
 
   it('never animates the task card — only the marker moves', () => {
     renderArmedAdhocTask('Paused');
 
+    // Emotion injects its styles at runtime, so a card animation would show up here.
     expect(getComputedStyle(screen.getByTestId('stage-task-adhoc-1')).animation).toBe('');
+    expect(screen.getByTestId('stage-task-adhoc-1')).not.toHaveClass('animate-glow');
   });
 });

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.test.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.test.tsx
@@ -5,7 +5,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { render, screen, waitFor } from '../../utils/testing';
 import type { ListItem } from '../Toolbox';
 import { StageNode } from './StageNode';
-import type { StageNodeProps, StageTaskItem } from './StageNode.types';
+import type { StageNodeProps, StageTaskItem, StageTaskStatus } from './StageNode.types';
 import { StageHeaderChipType } from './StageNode.types';
 
 // Mock DndContext and related components
@@ -1387,5 +1387,41 @@ describe('StageNode - Breakpoints on adhoc and event-driven tasks', () => {
     });
 
     expect(screen.queryByTestId('stage-task-breakpoint-adhoc-1')).not.toBeInTheDocument();
+  });
+});
+
+// The marker only pulses on the breakpoint the run is stopped at, and only the marker moves —
+// asserted on the ad hoc path, which renders the real TaskBreakpointDot and StageTask.
+describe('StageNode - pulse on the paused breakpoint', () => {
+  const renderArmedAdhocTask = (status: StageTaskStatus) =>
+    renderStageNode({
+      stageDetails: {
+        label: 'Test Stage',
+        isReadOnly: true,
+        tasks: [[{ id: 'adhoc-1', label: 'Adhoc Task', isAdhoc: true }]],
+      },
+      execution: { stageStatus: {}, taskStatus: { 'adhoc-1': { status, breakpoint: true } } },
+    });
+
+  it('pulses the marker the run is paused on, so it can be found at a glance', () => {
+    renderArmedAdhocTask('Paused');
+
+    expect(getComputedStyle(screen.getByTestId('stage-task-breakpoint-adhoc-1')).animation).toMatch(
+      /1.8s ease-out infinite/
+    );
+  });
+
+  it('leaves a merely armed breakpoint static', () => {
+    renderArmedAdhocTask('InProgress');
+
+    expect(getComputedStyle(screen.getByTestId('stage-task-breakpoint-adhoc-1')).animation).toBe(
+      ''
+    );
+  });
+
+  it('never animates the task card — only the marker moves', () => {
+    renderArmedAdhocTask('Paused');
+
+    expect(getComputedStyle(screen.getByTestId('stage-task-adhoc-1')).animation).toBe('');
   });
 });

--- a/packages/apollo-react/src/canvas/components/StageNode/TaskBreakpointDot.test.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/TaskBreakpointDot.test.tsx
@@ -35,33 +35,29 @@ describe('TaskBreakpointDot', () => {
     it('is static while the breakpoint is only armed', () => {
       render(<TaskBreakpointDot taskId="t1" active={true} />);
 
-      expect(screen.getByTestId('stage-task-breakpoint-t1')).not.toHaveClass(
-        'task-breakpoint-paused'
-      );
+      expect(screen.getByTestId('stage-task-breakpoint-t1')).not.toHaveClass('animate-glow');
     });
   });
 
-  // The run stopping on a breakpoint is what makes its marker pulse — see the
-  // `.task-breakpoint-paused` keyframes in StageNode.styles.
+  // The run stopping on a breakpoint is what makes its marker pulse, via apollo-wind's
+  // `animate-glow` utility — which also gives it prefers-reduced-motion handling.
   describe('when the run is paused on it', () => {
     it('pulses the marker', () => {
       render(<TaskBreakpointDot taskId="t1" active={true} paused={true} />);
 
-      expect(screen.getByTestId('stage-task-breakpoint-t1')).toHaveClass('task-breakpoint-paused');
+      expect(screen.getByTestId('stage-task-breakpoint-t1')).toHaveClass('animate-glow');
     });
 
     it('pulses the marker in the Debug view too, where it is a button', () => {
       render(<TaskBreakpointDot taskId="t1" active={true} paused={true} onToggle={vi.fn()} />);
 
-      expect(screen.getByTestId('stage-task-breakpoint-t1')).toHaveClass('task-breakpoint-paused');
+      expect(screen.getByTestId('stage-task-breakpoint-t1')).toHaveClass('animate-glow');
     });
 
     it('does not pulse the ghosted add affordance when no breakpoint is set', () => {
       render(<TaskBreakpointDot taskId="t1" active={false} paused={true} onToggle={vi.fn()} />);
 
-      expect(screen.getByTestId('stage-task-add-breakpoint-t1')).not.toHaveClass(
-        'task-breakpoint-paused'
-      );
+      expect(screen.getByTestId('stage-task-add-breakpoint-t1')).not.toHaveClass('animate-glow');
     });
   });
 

--- a/packages/apollo-react/src/canvas/components/StageNode/TaskBreakpointDot.test.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/TaskBreakpointDot.test.tsx
@@ -23,7 +23,10 @@ describe('TaskBreakpointDot', () => {
       // The marker must let clicks/drags on the card corner pass through to the task.
       render(<TaskBreakpointDot taskId="t1" active={true} />);
 
-      expect(screen.getByTestId('stage-task-breakpoint-t1')).toHaveClass('pointer-events-none');
+      const marker = screen.getByTestId('stage-task-breakpoint-t1');
+      expect(marker).toHaveClass('pointer-events-none');
+      // ...so it must not claim to be clickable either.
+      expect(marker).not.toHaveClass('cursor-pointer');
     });
 
     it('offers no add affordance', () => {
@@ -81,6 +84,19 @@ describe('TaskBreakpointDot', () => {
       await user.click(screen.getByTestId('stage-task-add-breakpoint-t1'));
 
       expect(onToggle).toHaveBeenCalledWith('t1');
+    });
+
+    // The marker sits on a card that shows the canvas grab cursor, so it has to say it is clickable.
+    it('shows a pointer cursor on the marker that removes the breakpoint', () => {
+      render(<TaskBreakpointDot taskId="t1" active={true} onToggle={vi.fn()} />);
+
+      expect(screen.getByTestId('stage-task-breakpoint-t1')).toHaveClass('cursor-pointer');
+    });
+
+    it('shows a pointer cursor on the affordance that adds one', () => {
+      render(<TaskBreakpointDot taskId="t1" active={false} onToggle={vi.fn()} />);
+
+      expect(screen.getByTestId('stage-task-add-breakpoint-t1')).toHaveClass('cursor-pointer');
     });
 
     it('keeps the add affordance out of the way until the row is hovered', () => {

--- a/packages/apollo-react/src/canvas/components/StageNode/TaskBreakpointDot.test.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/TaskBreakpointDot.test.tsx
@@ -32,10 +32,36 @@ describe('TaskBreakpointDot', () => {
       expect(screen.queryByTestId('stage-task-add-breakpoint-t1')).not.toBeInTheDocument();
     });
 
-    it('is static: the marker never animates (matches Flow, which does not pulse)', () => {
-      const { container } = render(<TaskBreakpointDot taskId="t1" active={true} />);
+    it('is static while the breakpoint is only armed', () => {
+      render(<TaskBreakpointDot taskId="t1" active={true} />);
 
-      expect(container.querySelector('[class*="animate-"]')).not.toBeInTheDocument();
+      expect(screen.getByTestId('stage-task-breakpoint-t1')).not.toHaveClass(
+        'task-breakpoint-paused'
+      );
+    });
+  });
+
+  // The run stopping on a breakpoint is what makes its marker pulse — see the
+  // `.task-breakpoint-paused` keyframes in StageNode.styles.
+  describe('when the run is paused on it', () => {
+    it('pulses the marker', () => {
+      render(<TaskBreakpointDot taskId="t1" active={true} paused={true} />);
+
+      expect(screen.getByTestId('stage-task-breakpoint-t1')).toHaveClass('task-breakpoint-paused');
+    });
+
+    it('pulses the marker in the Debug view too, where it is a button', () => {
+      render(<TaskBreakpointDot taskId="t1" active={true} paused={true} onToggle={vi.fn()} />);
+
+      expect(screen.getByTestId('stage-task-breakpoint-t1')).toHaveClass('task-breakpoint-paused');
+    });
+
+    it('does not pulse the ghosted add affordance when no breakpoint is set', () => {
+      render(<TaskBreakpointDot taskId="t1" active={false} paused={true} onToggle={vi.fn()} />);
+
+      expect(screen.getByTestId('stage-task-add-breakpoint-t1')).not.toHaveClass(
+        'task-breakpoint-paused'
+      );
     });
   });
 

--- a/packages/apollo-react/src/canvas/components/StageNode/TaskBreakpointDot.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/TaskBreakpointDot.tsx
@@ -8,6 +8,11 @@ export interface TaskBreakpointDotProps {
   /** Task id, used for a stable test id. */
   taskId: string;
   /**
+   * Whether the run is currently stopped on this breakpoint. A set breakpoint is a static dot;
+   * the one execution is paused at pulses, so it can be found without reading the whole stage.
+   */
+  paused?: boolean;
+  /**
    * Adds or removes this task's breakpoint. Supplied only in the Debug view: there the marker
    * becomes a button, and an empty gutter offers a ghosted dot on hover. Omit it and the marker
    * stays display-only, as it is at design time — where a red dot on every hover would be noise
@@ -23,12 +28,13 @@ const DOT = 'absolute -top-1.5 -left-1.5 z-10 h-3.5 w-3.5 rounded-full bg-(--can
  *
  * Mirrors the Flow/BPMN canvas breakpoint (`ExecutionBreakpoint`): a 14px solid circle filled
  * with the canvas error-icon color, no border or shadow; an unset one ghosts in at 0.5 opacity
- * while the row is hovered, and a click toggles it.
+ * while the row is hovered, and a click toggles it. While the run is stopped on it, a ring pulses
+ * out of it (`.task-breakpoint-paused`, see StageNode.styles).
  *
  * Without `onToggle` it renders nothing until a breakpoint is set and never intercepts pointer
  * events — the display-only marker used at design time.
  */
-function TaskBreakpointDotInner({ active, taskId, onToggle }: TaskBreakpointDotProps) {
+function TaskBreakpointDotInner({ active, taskId, paused, onToggle }: TaskBreakpointDotProps) {
   const { _ } = useSafeLingui();
 
   const handleClick = useCallback(
@@ -41,12 +47,13 @@ function TaskBreakpointDotInner({ active, taskId, onToggle }: TaskBreakpointDotP
   );
 
   const stopPointerDown = useCallback((e: React.PointerEvent) => e.stopPropagation(), []);
+  const pulse = active && paused ? 'task-breakpoint-paused ' : '';
 
   if (!onToggle) {
     return active ? (
       <span
         data-testid={`stage-task-breakpoint-${taskId}`}
-        className={`pointer-events-none ${DOT}`}
+        className={`${pulse}pointer-events-none ${DOT}`}
       />
     ) : null;
   }
@@ -63,7 +70,7 @@ function TaskBreakpointDotInner({ active, taskId, onToggle }: TaskBreakpointDotP
           active ? `stage-task-breakpoint-${taskId}` : `stage-task-add-breakpoint-${taskId}`
         }
         aria-label={label}
-        className={active ? DOT : `task-breakpoint-add ${DOT}`}
+        className={active ? `${pulse}${DOT}` : `task-breakpoint-add ${DOT}`}
         onClick={handleClick}
         onPointerDown={stopPointerDown}
       />

--- a/packages/apollo-react/src/canvas/components/StageNode/TaskBreakpointDot.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/TaskBreakpointDot.tsx
@@ -24,12 +24,20 @@ export interface TaskBreakpointDotProps {
 const DOT = 'absolute -top-1.5 -left-1.5 z-10 h-3.5 w-3.5 rounded-full bg-(--canvas-error-icon)';
 
 /**
+ * Ring that pulses out of the marker while the run is stopped on it, the way an executing node's
+ * border pulses (`getStatusBorder`). apollo-wind's `animate-glow` is the canvas-wide utility for
+ * this, so it comes with `prefers-reduced-motion: reduce` handling — it falls back to a static
+ * ring rather than dropping the cue. `--glow-strength` is the design's 55%.
+ */
+const PAUSED_GLOW = 'animate-glow [--glow-color:var(--canvas-error-icon)] [--glow-strength:55%]';
+
+/**
  * Breakpoint marker for a stage task, at the top-left corner of the task card.
  *
  * Mirrors the Flow/BPMN canvas breakpoint (`ExecutionBreakpoint`): a 14px solid circle filled
  * with the canvas error-icon color, no border or shadow; an unset one ghosts in at 0.5 opacity
  * while the row is hovered, and a click toggles it. While the run is stopped on it, a ring pulses
- * out of it (`.task-breakpoint-paused`, see StageNode.styles).
+ * out of it (see `PAUSED_GLOW`).
  *
  * Without `onToggle` it renders nothing until a breakpoint is set and never intercepts pointer
  * events — the display-only marker used at design time.
@@ -47,7 +55,7 @@ function TaskBreakpointDotInner({ active, taskId, paused, onToggle }: TaskBreakp
   );
 
   const stopPointerDown = useCallback((e: React.PointerEvent) => e.stopPropagation(), []);
-  const pulse = active && paused ? 'task-breakpoint-paused ' : '';
+  const pulse = active && paused ? `${PAUSED_GLOW} ` : '';
 
   if (!onToggle) {
     return active ? (

--- a/packages/apollo-react/src/canvas/components/StageNode/TaskBreakpointDot.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/TaskBreakpointDot.tsx
@@ -36,8 +36,8 @@ const PAUSED_GLOW = 'animate-glow [--glow-color:var(--canvas-error-icon)] [--glo
  *
  * Mirrors the Flow/BPMN canvas breakpoint (`ExecutionBreakpoint`): a 14px solid circle filled
  * with the canvas error-icon color, no border or shadow; an unset one ghosts in at 0.5 opacity
- * while the row is hovered, and a click toggles it. While the run is stopped on it, a ring pulses
- * out of it (see `PAUSED_GLOW`).
+ * while the row is hovered, and a click toggles it — with a pointer cursor, since it is the
+ * add/remove control. While the run is stopped on it, a ring pulses out of it (see `PAUSED_GLOW`).
  *
  * Without `onToggle` it renders nothing until a breakpoint is set and never intercepts pointer
  * events — the display-only marker used at design time.
@@ -78,7 +78,9 @@ function TaskBreakpointDotInner({ active, taskId, paused, onToggle }: TaskBreakp
           active ? `stage-task-breakpoint-${taskId}` : `stage-task-add-breakpoint-${taskId}`
         }
         aria-label={label}
-        className={active ? `${pulse}${DOT}` : `task-breakpoint-add ${DOT}`}
+        // `cursor-pointer` on both states: in the Debug view the marker is the add/remove control,
+        // and it sits on a card that otherwise shows the canvas grab cursor.
+        className={`${active ? pulse : 'task-breakpoint-add '}cursor-pointer ${DOT}`}
         onClick={handleClick}
         onPointerDown={stopPointerDown}
       />


### PR DESCRIPTION
## Summary

Follow-up to #989, closing out the last item from the [design thread](https://uipath-product.slack.com/archives/C090NTF6LRL/p1784216031237709): the breakpoint marker on the task the run is stopped at now pulses, so it can be found without reading the whole stage. Design direction is treatment 2b from the *Breakpoints for Case Management* doc.

Only that one marker moves. An armed-but-not-hit breakpoint stays a static dot — the design's legend distinguishes **"Breakpoint set (armed)"** from **"Execution paused here"**, and in its in-context flow only 1 of 3 markers pulses. The task card keeps its plain amber `Paused` border.

## Demo

https://github.com/user-attachments/assets/073932dd-7df5-4675-ace3-9194c2dbcad9

## Changes

- **`TaskBreakpointDot` takes `paused`** — when a breakpoint is both set and hit, the marker gets apollo-wind's `animate-glow` utility: `animate-glow [--glow-color:var(--canvas-error-icon)] [--glow-strength:55%]` (55% is the design's alpha). Same mechanism `BaseNodeContainer` already uses for executing / paused node borders, so the canvas has one way of expressing "this is live", not two.
- **`paused={taskExecution?.status === 'Paused'}`** threaded from `DraggableTask`, `AdhocTask` and `EventDrivenTask`.
- Applies to the display-only marker and to the Debug-view button alike; never to the hover ghost.
- **`cursor-pointer` on the marker in the Debug view**, on the solid dot that removes a breakpoint and the ghosted one that adds it. It is the control there, but a `<button>` gets the default arrow and the card underneath shows the canvas grab cursor, so nothing said it was clickable. The display-only marker keeps the arrow — it is `pointer-events-none`.
- Story docs updated: the breakpoints header block and the `Interactive` story comment described the marker as static and menu-only, both stale since #989.

No testids added or changed. No new keyframes — `apollo-glow` already existed.

## Accessibility

`animate-glow` ships a `prefers-reduced-motion: reduce` rule, so this is covered by construction: the animation is dropped and the ring settles at a static 5px, meaning motion-sensitive users still get the "paused here" cue without the movement. That is the main reason for using the utility over a bespoke animation — the first version of this PR hand-rolled emotion keyframes and silently had no reduced-motion path at all.

## Rejected alternatives

1. **Pulsing the task card** (reusing `pulseAnimation` / `getExecutionStatusBorder`, as every other paused node does). Invisible at this size: that ring peaks at 20% alpha with *zero* spread and has faded by the time it is 10px wide, which reads on a full-size node but not on a 36px row. Driving it harder made the whole card breathe — a lot of movement for "one task is holding the run".
2. **Bespoke emotion keyframes on the marker**, matching the design's numbers exactly (`3px → 11px`, `55% → 0`, `1.8s ease-out`, plus an inner background ring). Dropped in favour of `animate-glow`: pixel-matching a mock is not worth a second animation primitive on the canvas, a class-name selector reaching from `StageTask` into a Tailwind-styled child, and re-implementing reduced-motion by hand. The visible difference is `0 → 10px` over `2s` instead.

## Flow

```mermaid
flowchart TD
    A["execution.taskStatus[id]"] --> B{breakpoint set?}
    B -- no --> C["hover ghost only<br/>.task-breakpoint-add"]
    B -- yes --> D{status === 'Paused'?}
    D -- no --> E["static dot<br/>(armed)"]
    D -- yes --> F["animate-glow<br/>ring pulses, or static 5px<br/>under reduced motion"]
```

## E2E Impact

N/A for this repo — `apollo-ui` has no Playwright/E2E or visual-regression suite. No testids were added, renamed or removed, so no downstream exposure in PO.Frontend's E2E either; the only new hook is a utility class.

## Testing

- [x] `vitest --run src/canvas` — 99 files, 1866 tests passing
- [x] Unit tests added: pulses when paused, static when merely armed, no pulse on the hover ghost, the card never animates, and both interactive markers carry `cursor-pointer` while the display-only one does not
- [x] Verified in Storybook (**Breakpoints → Read-only / Debug view**) that the ring reads at task size and does not clip against `StageContent`'s `overflow: hidden`
- [x] Confirmed the built `dist/canvas/styles/tailwind.canvas.css` emits `.animate-glow`, `@keyframes apollo-glow`, the `prefers-reduced-motion: reduce` override and `.cursor-pointer`, and that the only `!important` cursor rules in the bundle are Tailwind's opt-in `cursor-*!` utilities (nothing overrides the marker)
- [x] `biome lint` + `format` clean on changed paths; `tsc --noEmit` clean
- [x] Type-safe (no `as any` / suppressions added)

## Note for the consumer

PO.Frontend's breakpoint toggle is async (it round-trips to PIMS), and the dot still has no loading state — between click and the state landing there is no feedback. Flow's `ExecutionBreakpoint` shows a spinner for this. Worth a follow-up on top.

