### PR TITLE
fix(apollo-react): bump sanitize-html to 2.17.6 for XSS fixes

### DIFF
--- a/packages/apollo-react/package.json
+++ b/packages/apollo-react/package.json
@@ -234,7 +234,7 @@
     "remark-gfm": "^4.0.1",
     "remark-math": "^6.0.0",
     "reselect": "^5.1.1",
-    "sanitize-html": "^2.17.4",
+    "sanitize-html": "^2.17.6",
     "unist-util-visit": "^5.0.0",
     "use-sync-external-store": "^1.2.0",
     "zod": "^4.3.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -775,8 +775,8 @@ importers:
         specifier: ^5.1.1
         version: 5.2.0
       sanitize-html:
-        specifier: ^2.17.4
-        version: 2.17.4
+        specifier: ^2.17.6
+        version: 2.17.6
       unist-util-visit:
         specifier: ^5.0.0
         version: 5.1.0
@@ -8015,18 +8015,34 @@ packages:
   dom-serializer@2.0.0:
     resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
 
+  dom-serializer@3.1.1:
+    resolution: {integrity: sha512-4MEa38/QexBob6gFNwu+EGdWvhJ1OKuNwdYY3Y3NyeWDQfnGeDYQUDfIRzWu5B5gsv03so2Uxd28YC6zrsx3Lw==}
+    engines: {node: '>=20.19.0'}
+
   domelementtype@2.3.0:
     resolution: {integrity: sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==}
+
+  domelementtype@3.0.0:
+    resolution: {integrity: sha512-umCQid3jKbDmVjx8jGaW7uUykm4DEUeyV21hPxNMo2nV955DhUThwqyOIDtreepP31hl84X7G5U9ZfsWvIB3Pg==}
+    engines: {node: '>=20.19.0'}
 
   domhandler@5.0.3:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
     engines: {node: '>= 4'}
+
+  domhandler@6.0.1:
+    resolution: {integrity: sha512-gYzvtM72ZtxQO0T048kd6HWSbbGCNOUwcnfQ01cqIJ4X2IYKFFHZ5mKvrQETcFXxsRObZulDaKmy//R7TPtsBg==}
+    engines: {node: '>=20.19.0'}
 
   dompurify@3.4.12:
     resolution: {integrity: sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==}
 
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
+
+  domutils@4.0.2:
+    resolution: {integrity: sha512-qI4JLRKnSzqFqr7hAlS5xQDusBCjKSEG4t4+7aNrIQMHBcsC2TGEhuyABJdYkgSewL57PNLYEiibY2iPKhKpaA==}
+    engines: {node: '>=20.19.0'}
 
   dot-case@3.0.4:
     resolution: {integrity: sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==}
@@ -8140,6 +8156,10 @@ packages:
   entities@7.0.1:
     resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
     engines: {node: '>=0.12'}
+
+  entities@8.0.0:
+    resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
+    engines: {node: '>=20.19.0'}
 
   env-ci@11.2.0:
     resolution: {integrity: sha512-D5kWfzkmaOQDioPmiviWAVtKmpPT4/iJmMVQxWxMPJTFyTkdc5JQUfc5iXEeWxcOdsYTKSAiA/Age4NUOqKsRA==}
@@ -8971,8 +8991,9 @@ packages:
   html-void-elements@3.0.0:
     resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
 
-  htmlparser2@10.1.0:
-    resolution: {integrity: sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==}
+  htmlparser2@12.0.0:
+    resolution: {integrity: sha512-Tz7u1i95/g2x2jz81+x0FBVhBhY5aRTvD3tXXdFaljuNdzDLJ8UGNRrTcj2cgQvAg3iW/h77Fz15nLW0L0CrZw==}
+    engines: {node: '>=20.19.0'}
 
   htmlparser2@8.0.2:
     resolution: {integrity: sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==}
@@ -11886,8 +11907,9 @@ packages:
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
-  sanitize-html@2.17.4:
-    resolution: {integrity: sha512-2HW7v2ol/uAM7sX4hbD8Z59OGWmAPrvjL8E71UWlBcj6m+kcF6ilQBLny+cIgY214QJeJT5tQuxKKqX0SQqjGQ==}
+  sanitize-html@2.17.6:
+    resolution: {integrity: sha512-M4bo9tfv1yfhQZZKkc6dL07ALrGJtfvNOuhX3hU9AVPR/uPQ+nKOJBqTYc7LfMQblTW04mtSWDJWEyLvygJsLA==}
+    engines: {node: '>=22.12.0'}
 
   sax@1.5.0:
     resolution: {integrity: sha512-21IYA3Q5cQf089Z6tgaUTr7lDAyzoTPx5HRtbhsME8Udispad8dC/+sziTNugOEx54ilvatQ9YCzl4KQLPcRHA==}
@@ -20508,11 +20530,23 @@ snapshots:
       domhandler: 5.0.3
       entities: 4.5.0
 
+  dom-serializer@3.1.1:
+    dependencies:
+      domelementtype: 3.0.0
+      domhandler: 6.0.1
+      entities: 8.0.0
+
   domelementtype@2.3.0: {}
+
+  domelementtype@3.0.0: {}
 
   domhandler@5.0.3:
     dependencies:
       domelementtype: 2.3.0
+
+  domhandler@6.0.1:
+    dependencies:
+      domelementtype: 3.0.0
 
   dompurify@3.4.12:
     optionalDependencies:
@@ -20523,6 +20557,12 @@ snapshots:
       dom-serializer: 2.0.0
       domelementtype: 2.3.0
       domhandler: 5.0.3
+
+  domutils@4.0.2:
+    dependencies:
+      dom-serializer: 3.1.1
+      domelementtype: 3.0.0
+      domhandler: 6.0.1
 
   dot-case@3.0.4:
     dependencies:
@@ -20637,6 +20677,8 @@ snapshots:
   entities@6.0.1: {}
 
   entities@7.0.1: {}
+
+  entities@8.0.0: {}
 
   env-ci@11.2.0:
     dependencies:
@@ -21777,12 +21819,12 @@ snapshots:
 
   html-void-elements@3.0.0: {}
 
-  htmlparser2@10.1.0:
+  htmlparser2@12.0.0:
     dependencies:
-      domelementtype: 2.3.0
-      domhandler: 5.0.3
-      domutils: 3.2.2
-      entities: 7.0.1
+      domelementtype: 3.0.0
+      domhandler: 6.0.1
+      domutils: 4.0.2
+      entities: 8.0.0
 
   htmlparser2@8.0.2:
     dependencies:
@@ -25202,11 +25244,11 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
-  sanitize-html@2.17.4:
+  sanitize-html@2.17.6:
     dependencies:
       deepmerge: 4.3.1
       escape-string-regexp: 4.0.0
-      htmlparser2: 10.1.0
+      htmlparser2: 12.0.0
       is-plain-object: 5.0.0
       launder: 1.7.1
       parse-srcset: 1.0.2


### PR DESCRIPTION
## What

Bumps `sanitize-html` in `packages/apollo-react` from `^2.17.4` to `^2.17.6` (resolves to 2.17.6).

Closes Dependabot alert [#274](https://github.com/UiPath/apollo-ui/security/dependabot/274).

## Why 2.17.6 and not 2.17.5

`pnpm audit` flags [CVE-2026-53606 / GHSA-vccv-cmxp-4j9h](https://github.com/advisories/GHSA-vccv-cmxp-4j9h) (moderate), patched in 2.17.5. Two things make 2.17.6 the correct target instead:

1. **The audited advisory was not exploitable here.** It requires a consumer to explicitly allow non-default tags *and* non-default attributes (`action`, `formaction`, `poster`, …). The only call site in this repo is `packages/apollo-react/src/canvas/utils/coded-agents/mermaid-parser.ts:96`, which passes the maximally restrictive config:

   ```ts
   label = sanitizeHtml(label, { allowedTags: [], allowedAttributes: {} });
   ```

2. **2.17.6 fixes an issue that *is* reachable, and audit does not report it.** It patches a raw-text sanitization bypass (`textarea` / `xmp` nested in SVG or MathML contexts) plus end tags with trailing slashes (`</textarea/>`). No GHSA has been published for it yet, so no tooling flags it. That bug class fires under default and restrictive configs. The closely related earlier `xmp` passthrough bug ([GHSA-rpr9-rxv7-x643](https://github.com/advisories/GHSA-rpr9-rxv7-x643)) was rated **critical** for exactly that reason.

Pinning at 2.17.5 would have turned the audit green while leaving the reachable issue open.

## Dependency impact

`htmlparser2` moves `^10.1.0` to `^12.0.0`. This bump **is the fix mechanism**, not drive-by churn: v12 adds the namespace handling the raw-text fix depends on. It pulls a new `fb55` major line into the tree.

Lockfile diff is 68 lines and confined to the target:

| Removed | Added |
|---|---|
| `sanitize-html@2.17.4` | `sanitize-html@2.17.6` |
| `htmlparser2@10.1.0` | `htmlparser2@12.0.0` |
| | `domutils@4.0.2`, `entities@8.0.0`, `domhandler@6.0.1`, `domelementtype@3.0.0`, `dom-serializer@3.1.1` |

`htmlparser2@10.1.0` drops out entirely since sanitize-html was its only consumer. `htmlparser2@8.0.2` is untouched. No unrelated packages shifted.

## Supply-chain vetting (2026-07-31)

| Check | Result |
|---|---|
| Publisher | `boutell <tom@apostrophecms.com>`, unchanged across 2.17.4 / 2.17.5 / 2.17.6 |
| Signing key | Identical npm keyid across all three |
| Provenance | None, but sanitize-html has **never** published it (2.17.0 also has none), so consistent rather than a regression |
| Tag + diff | `#5501` (`</textarea/>` fix, boutell), `#5432` (raw-text fix + regression tests), plus a security-fork merge commit. Diff matches the advisory description |
| Integrity | Tarball sha512 recorded for each version |
| New transitives | All sole-maintainer `fb55`, all published via **GitHub Actions OIDC with SLSA provenance**, all 3+ months old |
| Quarantine | No `minimumReleaseAgeExclude` entry needed. 2.17.6 is 21 days old; every new transitive clears the 14-day window |

No red flags. The `repository` field moved from `apostrophecms/sanitize-html` to the `apostrophecms/apostrophe` monorepo back at 2.17.1, well before these releases, so it is not a recent change.

## Verification

- `pnpm audit` exits 0, no known vulnerabilities
- `pnpm check:dependencies` exits 0
- `pnpm vitest run src/canvas/utils/coded-agents src/canvas/components/CodedAgent` passes 25/25, confirming the two-major htmlparser2 jump does not change behavior at the call site
- No stray untracked artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)
