### PR TITLE
feat(apollo-vertex): show IXP provenance before & after with shared version-delta

### DIFF
--- a/apps/apollo-vertex/locales/en.json
+++ b/apps/apollo-vertex/locales/en.json
@@ -148,7 +148,6 @@
   "ixp_verdict_different": "Different",
   "ixp_verdict_identical": "Identical",
   "ixp_verdict_semantically_same": "Semantically same",
-  "ixp_version_changed": "changed",
   "japanese": "Japanese",
   "process_results_viewer_description": "Inspect the process output.",
   "debug_dev_only": "Debug — Dev only",

--- a/apps/apollo-vertex/registry.json
+++ b/apps/apollo-vertex/registry.json
@@ -1788,7 +1788,7 @@
       "title": "Data Table",
       "description": "A data table component built on TanStack Table with sorting, filtering, pagination, row selection, and column reordering.",
       "dependencies": [
-        "@tanstack/react-table",
+        "@tanstack/react-table@^8.21.0",
         "@dnd-kit/core",
         "@dnd-kit/sortable",
         "@dnd-kit/utilities",
@@ -1947,7 +1947,7 @@
       "type": "registry:ui",
       "title": "Filter Dropdown",
       "description": "A versatile filter dropdown with multi-select, single-select, search, and optional TanStack Table column integration.",
-      "dependencies": ["@tanstack/react-table", "lucide-react"],
+      "dependencies": ["@tanstack/react-table@^8.21.0", "lucide-react"],
       "registryDependencies": [
         "@uipath/button",
         "@uipath/checkbox",
@@ -2396,7 +2396,10 @@
       "type": "registry:hook",
       "title": "useDataTable",
       "description": "A generic data table hook that manages sorting, filtering, pagination, column visibility, and column order with localStorage persistence.",
-      "dependencies": ["@tanstack/react-table", "@mantine/hooks@^9.0.0"],
+      "dependencies": [
+        "@tanstack/react-table@^8.21.0",
+        "@mantine/hooks@^9.0.0"
+      ],
       "files": [
         {
           "path": "registry/use-data-table/types.ts",
@@ -2435,7 +2438,7 @@
       "title": "useEntityDataTable",
       "description": "A data table hook for VSS entities that fetches live data from collections and builds column definitions from entity metadata.",
       "dependencies": [
-        "@tanstack/react-table",
+        "@tanstack/react-table@^8.21.0",
         "@tanstack/react-db",
         "@uipath/vs-core@^1.2.2"
       ],
@@ -2964,7 +2967,7 @@
       "dependencies": [
         "@tanstack/react-db@^0.1.86",
         "@tanstack/react-query@^5.90.0",
-        "@tanstack/react-table",
+        "@tanstack/react-table@^8.21.0",
         "@tanstack/react-router",
         "@uipath/vs-core@^2.0.6",
         "@uipath/uipath-typescript@^1.5.4",

--- a/apps/apollo-vertex/registry.json
+++ b/apps/apollo-vertex/registry.json
@@ -3177,6 +3177,11 @@
           "target": "components/ui/solution-tests/run-details-view.tsx"
         },
         {
+          "path": "registry/solution-tests/version-delta-glyph.tsx",
+          "type": "registry:ui",
+          "target": "components/ui/solution-tests/version-delta-glyph.tsx"
+        },
+        {
           "path": "registry/solution-tests/run-details-agent-list.tsx",
           "type": "registry:ui",
           "target": "components/ui/solution-tests/run-details-agent-list.tsx"

--- a/apps/apollo-vertex/registry/solution-tests/constants.ts
+++ b/apps/apollo-vertex/registry/solution-tests/constants.ts
@@ -3,6 +3,9 @@
 
 import { RunResultStatus, RunStatus, SolutionTestStatus } from "./types";
 
+/** Placeholder rendered where a value is absent (missing baseline, no score). */
+export const EMPTY_VALUE = "—";
+
 /** Well-known Solution Test collection names on `solution.api.collections.solutionTests`. */
 export const ENTITY = {
   tests: "UiPathSTTests",

--- a/apps/apollo-vertex/registry/solution-tests/evaluators/generic-evaluator-result.tsx
+++ b/apps/apollo-vertex/registry/solution-tests/evaluators/generic-evaluator-result.tsx
@@ -2,6 +2,7 @@
 
 import { z } from "zod";
 import { useTranslation } from "react-i18next";
+import { EMPTY_VALUE } from "../constants";
 import { useSolutionTestsConfig } from "../context";
 import { JsonPanel } from "./output-panels";
 import type { EvaluatorResultProps } from "./registry";
@@ -35,7 +36,7 @@ export const GenericEvaluatorResult = ({
   const { passThreshold } = useSolutionTestsConfig();
   const displayLabel = label ?? evaluatorId;
   const justification = evaluatorDetails.justification;
-  const scoreStr = score == null ? "—" : `${Math.round(score * 100)}%`;
+  const scoreStr = score == null ? EMPTY_VALUE : `${Math.round(score * 100)}%`;
 
   return (
     <div className="flex flex-col gap-4">

--- a/apps/apollo-vertex/registry/solution-tests/evaluators/ixp-extraction/internal/provenance-bar.tsx
+++ b/apps/apollo-vertex/registry/solution-tests/evaluators/ixp-extraction/internal/provenance-bar.tsx
@@ -1,12 +1,15 @@
 "use client";
 
+import type { ReactNode } from "react";
 import { useTranslation } from "react-i18next";
-import { ArrowRight } from "lucide-react";
-import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
+import { EMPTY_VALUE } from "../../../constants";
+import { versionDelta } from "../../../utils";
+import { VersionDeltaGlyph } from "../../../version-delta-glyph";
 import type { IxpProvenance } from "../schema";
 
-/** Informational banner showing which IXP taxonomy version / extractor produced
- * the baseline vs the new run, highlighting a version change. */
+// Shows baseline and new-run values side by side rather than collapsing to a
+// single value, so an unchanged version reads as unchanged on its own.
 export const ProvenanceBar = ({
   expected,
   actual,
@@ -17,37 +20,67 @@ export const ProvenanceBar = ({
   const { t } = useTranslation();
   if (!expected && !actual) return null;
 
-  const ev = expected?.resolved_project_version ?? null;
-  const av = actual?.resolved_project_version ?? null;
-  const versionChanged = ev != null && av != null && String(ev) !== String(av);
-  const extractor = actual?.extractor ?? expected?.extractor ?? null;
+  const baselineVersion = expected?.resolved_project_version;
+  const currentVersion = actual?.resolved_project_version;
+  const { direction } = versionDelta(baselineVersion, currentVersion);
 
   return (
-    <div className="flex flex-wrap items-center gap-x-4 gap-y-1 rounded-md border bg-muted/30 px-3 py-2 text-xs">
-      <span className="font-medium text-muted-foreground">
-        {t("ixp_taxonomy_version")}
-      </span>
-      {versionChanged ? (
-        <span className="flex items-center gap-1.5">
-          <span className="text-muted-foreground">{`v${ev}`}</span>
-          <ArrowRight
-            className="size-3 text-muted-foreground"
-            aria-hidden="true"
+    <div className="grid w-fit grid-cols-[max-content_max-content_max-content] items-center gap-x-6 gap-y-1 rounded-md border bg-muted/30 px-3 py-2 text-xs text-muted-foreground">
+      <ProvenanceRow
+        label={t("ixp_taxonomy_version")}
+        baseline={formatVersion(baselineVersion)}
+        current={formatVersion(currentVersion)}
+        glyph={
+          <VersionDeltaGlyph
+            direction={direction}
+            baseline={formatVersion(baselineVersion)}
           />
-          <span className="font-semibold">{`v${av}`}</span>
-          <Badge status="warning" variant="secondary">
-            {t("ixp_version_changed")}
-          </Badge>
-        </span>
-      ) : (
-        <span className="font-semibold">{`v${av ?? ev ?? "—"}`}</span>
-      )}
-      {extractor && (
-        <span className="text-muted-foreground">
-          {`${t("ixp_extractor")}: `}
-          <span className="font-mono">{extractor}</span>
-        </span>
-      )}
+        }
+      />
+      <ProvenanceRow
+        label={t("ixp_extractor")}
+        baseline={expected?.extractor ?? null}
+        current={actual?.extractor ?? null}
+        mono
+      />
     </div>
   );
 };
+
+const ProvenanceRow = ({
+  label,
+  baseline,
+  current,
+  mono = false,
+  glyph = null,
+}: {
+  label: string;
+  baseline: string | null;
+  current: string | null;
+  mono?: boolean;
+  glyph?: ReactNode;
+}) => {
+  const { t } = useTranslation();
+  if (baseline == null && current == null) return null;
+
+  const valueClass = cn("text-foreground", mono && "font-mono");
+
+  return (
+    <div className="contents">
+      <span className="font-medium">{label}</span>
+      <span>
+        {`${t("ixp_baseline")}: `}
+        <span className={valueClass}>{baseline ?? EMPTY_VALUE}</span>
+      </span>
+      <span className="inline-flex items-center gap-1">
+        {`${t("ixp_new")}: `}
+        <span className={valueClass}>{current ?? EMPTY_VALUE}</span>
+        {glyph}
+      </span>
+    </div>
+  );
+};
+
+const formatVersion = (
+  version: number | string | null | undefined,
+): string | null => (version == null ? null : `v${version}`);

--- a/apps/apollo-vertex/registry/solution-tests/run-details-view.tsx
+++ b/apps/apollo-vertex/registry/solution-tests/run-details-view.tsx
@@ -14,11 +14,6 @@ import {
   PageHeaderTitleGroup,
 } from "@/components/ui/page-header";
 import { Spinner } from "@/components/ui/spinner";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
 import { renderValueOrEmptyState } from "@/lib/renderValueOrEmptyState";
 import {
   defaultRunResultStatusLabels,
@@ -39,7 +34,8 @@ import {
   type SolutionTestRun,
   type SolutionTestRunResult,
 } from "./types";
-import { compareVersions } from "./utils";
+import { versionDelta } from "./utils";
+import { VersionDeltaGlyph } from "./version-delta-glyph";
 
 export type BaselineJobMap = Map<
   string,
@@ -189,25 +185,15 @@ const RunDetailsPane = ({
 }: RunDetailsPaneProps) => {
   const { t } = useTranslation();
   const status = result.Status;
-  const versionChanged =
-    result.BaselineProcessVersion &&
-    result.ProcessVersion &&
-    result.BaselineProcessVersion !== result.ProcessVersion;
-
   const showBaselineVersion = status !== RunResultStatus.NoBaseline;
   const showActualVersion = status !== RunResultStatus.Missing;
   const showScore =
     status === RunResultStatus.Passed || status === RunResultStatus.Failed;
 
-  // Directional triangle indicating the tested version moved up or down from
-  // the baseline (not a warning — just a signal that it changed). Versions that
-  // are numerically equal ("1.0" vs "1.0.0") or non-numeric get no glyph.
-  const versionComparison = compareVersions(
-    result.ProcessVersion ?? "",
-    result.BaselineProcessVersion ?? "",
+  const { direction: versionDirection } = versionDelta(
+    result.BaselineProcessVersion,
+    result.ProcessVersion,
   );
-  const versionGlyph =
-    versionComparison < 0 ? "▼" : versionComparison > 0 ? "▲" : null;
 
   const baselineInfo = baselineJobMap.get(result.ProcessName);
   const inBaseline = !!baselineInfo;
@@ -245,22 +231,11 @@ const RunDetailsPane = ({
             <span className="inline-flex items-center gap-1">
               {`${t("tested_agent_version")}: `}
               {showActualVersion ? (result.ProcessVersion ?? "-") : "—"}
-              {showActualVersion && versionChanged && versionGlyph && (
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <span
-                      tabIndex={0}
-                      role="img"
-                      aria-label={t("version_differs_from_baseline")}
-                      className="text-foreground"
-                    >
-                      {versionGlyph}
-                    </span>
-                  </TooltipTrigger>
-                  <TooltipContent>
-                    {`${t("version_differs_from_baseline")} (${result.BaselineProcessVersion})`}
-                  </TooltipContent>
-                </Tooltip>
+              {showActualVersion && (
+                <VersionDeltaGlyph
+                  direction={versionDirection}
+                  baseline={result.BaselineProcessVersion}
+                />
               )}
             </span>
             <span>

--- a/apps/apollo-vertex/registry/solution-tests/utils.ts
+++ b/apps/apollo-vertex/registry/solution-tests/utils.ts
@@ -20,6 +20,34 @@ export function compareVersions(a: string, b: string): number {
   return 0;
 }
 
+function isNumericVersion(v: string): boolean {
+  return v.split(".").every((seg) => seg !== "" && !Number.isNaN(Number(seg)));
+}
+
+export interface VersionDelta {
+  changed: boolean;
+  /** 0 also covers "can't tell a direction" (non-numeric or missing), so callers
+   *  can treat it as "no arrow to show". */
+  direction: number;
+}
+
+// Numeric versions can be ordered (so a bump yields a direction and "2.0" equals
+// 2); non-numeric tags can't, so they fall back to a plain string equality check.
+export function versionDelta(
+  baseline?: string | number | null,
+  actual?: string | number | null,
+): VersionDelta {
+  if (baseline == null || actual == null)
+    return { changed: false, direction: 0 };
+  const b = String(baseline);
+  const a = String(actual);
+  if (isNumericVersion(a) && isNumericVersion(b)) {
+    const direction = compareVersions(a, b);
+    return { changed: direction !== 0, direction };
+  }
+  return { changed: a !== b, direction: 0 };
+}
+
 export function hasAutoPass(evaluatorResults: unknown): boolean {
   let parsed = evaluatorResults;
   if (typeof parsed === "string") {

--- a/apps/apollo-vertex/registry/solution-tests/version-delta-glyph.tsx
+++ b/apps/apollo-vertex/registry/solution-tests/version-delta-glyph.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { useTranslation } from "react-i18next";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+
+interface VersionDeltaGlyphProps {
+  direction: number;
+  baseline?: string | null;
+}
+
+export const VersionDeltaGlyph = ({
+  direction,
+  baseline,
+}: VersionDeltaGlyphProps) => {
+  const { t } = useTranslation();
+  if (direction === 0) return null;
+
+  const label = t("version_differs_from_baseline");
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <button type="button" aria-label={label} className="text-foreground">
+          {direction > 0 ? "▲" : "▼"}
+        </button>
+      </TooltipTrigger>
+      <TooltipContent>
+        {baseline ? `${label} (${baseline})` : label}
+      </TooltipContent>
+    </Tooltip>
+  );
+};


### PR DESCRIPTION
## What & why

The IXP evaluator's provenance bar collapsed the taxonomy version to a single value whenever it matched the baseline, so a run rendered only `IXP Taxonomy version v2 / Extractor: gpt_ixp_2` with no sign a baseline-vs-new-run comparison had even happened. This makes the before/after explicit and reuses the agent-version delta convention.

## Changes

**1. `refactor(apollo-vertex)`: share a numeric-aware version delta helper**
- New `versionDelta(baseline, actual)` in `solution-tests/utils.ts`: numeric-aware (so `2.0` equals `2`) and returns a `direction` (+1 up / -1 down / 0 none).
- New shared `VersionDeltaGlyph` component (`▲`/`▼` + tooltip).
- Adopted in the agent-version header (`run-details-view.tsx`), replacing its inline, duplicated logic. No behavior change for agent versions.

**2. `feat(apollo-vertex)`: show IXP provenance before & after**
- Provenance bar now shows **Baseline** and **New run** for both the taxonomy version and the extractor, in a 3-column grid so the columns align across rows.
- Equal values read as unchanged on their own (no badge); a version delta is flagged on the new run via the shared `VersionDeltaGlyph`.
- Removes the now-unused `ixp_version_changed` translation key (en only).

### Result
<img width="559" height="76" alt="image" src="https://github.com/user-attachments/assets/ec9a27d5-89da-4e2a-8711-0c83f16f8cdc" />

and on a real change the new-run version gets a directional `▲`/`▼` with a "Version differs from baseline (v1)" tooltip.

## Verification
- `biome format` clean, `oxlint --type-aware` clean, `tsc --noEmit` clean for the changed files (one pre-existing unrelated error in `registry/shell/shell-text.tsx`).
- `registry:build` succeeds with the new `version-delta-glyph` entry.

## Follow-up (not in this PR)
The QAQC and loanSetup webapps in `fins-vertical-solution` will pick this up when the shadcn components are re-pulled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)