### PR TITLE
feat(apollo-react): format stage durations narrow, and take a duration label

### DIFF
--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.stories.tsx
@@ -900,9 +900,14 @@ export const ExecutionModeWithSla: Story = {
   },
 };
 
-/** 6 months, 2 weeks, 2 days, 2 hours, 59 minutes, 36 seconds. */
-const LONG_RUN_MS =
+/**
+ * Stage and task durations are independent values, formatted independently — the stage rolls up
+ * every task's runs while a task row shows only its own — so they are deliberately different here.
+ * (Months approximated as 30 days; this is a story, not a calendar.)
+ */
+const STAGE_RUN_MS =
   6 * 30 * 86400000 + 2 * 7 * 86400000 + 2 * 86400000 + 2 * 3600000 + 59 * 60000 + 36000;
+const TASK_RUN_MS = 3 * 7 * 86400000 + 4 * 86400000 + 5 * 3600000 + 12 * 60000 + 8000;
 
 export const MaximumTaskAdornments: Story = {
   name: 'Execution Mode - Maximum Task Adornments',
@@ -934,7 +939,7 @@ export const MaximumTaskAdornments: Story = {
               status: 'InProgress',
               label: 'In progress',
               // Half a year down to the second — only the 3 largest units are rendered.
-              durationMs: LONG_RUN_MS,
+              durationMs: STAGE_RUN_MS,
               // Consumer-supplied, already localised. Task rows have no label; the header does.
               durationLabel: 'Duration:',
             },
@@ -942,7 +947,7 @@ export const MaximumTaskAdornments: Story = {
               'long-running-task': {
                 status: 'InProgress',
                 breakpoint: true,
-                durationMs: LONG_RUN_MS,
+                durationMs: TASK_RUN_MS,
                 durationTooltip: 'Started just over 6 months ago',
                 retryCount: 98,
                 retryDuration: '5m, 4w, 3d, 2h, 1m',

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.stories.tsx
@@ -935,6 +935,8 @@ export const MaximumTaskAdornments: Story = {
               label: 'In progress',
               // Half a year down to the second — only the 3 largest units are rendered.
               durationMs: LONG_RUN_MS,
+              // Consumer-supplied, already localised. Task rows have no label; the header does.
+              durationLabel: 'Duration:',
             },
             taskStatus: {
               'long-running-task': {

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.test.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.test.tsx
@@ -855,7 +855,26 @@ describe('StageNode - SLA Indicator', () => {
       },
     });
 
-    expect(screen.getByTestId('stage-duration-stage-1')).toHaveTextContent('2 days, 3 hr, 4 min');
+    expect(screen.getByTestId('stage-duration-stage-1')).toHaveTextContent('2d, 3h, 4m');
+  });
+
+  it('puts the consumer-supplied label in front of the duration', () => {
+    renderStageNode({
+      execution: {
+        stageStatus: { durationMs: 2 * 3600000 + 4 * 60000, durationLabel: 'Duration:' },
+        taskStatus: {},
+      },
+    });
+
+    expect(screen.getByTestId('stage-duration-stage-1')).toHaveTextContent('Duration: 2h, 4m');
+  });
+
+  it('renders the duration bare when no label is supplied', () => {
+    renderStageNode({
+      execution: { stageStatus: { durationMs: 2 * 3600000 + 4 * 60000 }, taskStatus: {} },
+    });
+
+    expect(screen.getByTestId('stage-duration-stage-1')).toHaveTextContent('2h, 4m');
   });
 
   it('renders a legacy pre-formatted stage duration verbatim', () => {

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.types.ts
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.types.ts
@@ -87,6 +87,12 @@ export interface StageNodeBaseProps {
       /** How long the stage has run, in milliseconds. Rendered as its 3 largest units. */
       durationMs?: number;
       /**
+       * Optional localised label rendered in front of the duration, e.g. `"Duration:"` giving
+       * `"Duration: 1h, 2m"`. Supply it already translated and carrying its own punctuation —
+       * Apollo only places it, since the wording belongs to the consumer's catalogues.
+       */
+      durationLabel?: string;
+      /**
        * @deprecated Pass `durationMs` instead and let Apollo format it. A pre-formatted string
        * is rendered verbatim, so it cannot be shortened to the largest units in a way that
        * holds across locales.

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNodeHeader.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNodeHeader.tsx
@@ -149,10 +149,17 @@ const StageNodeHeaderInner = ({
   // `durationMs` wins: only the number can be shortened to its largest units. A legacy
   // pre-formatted string is rendered as the consumer supplied it.
   const stageDurationMs = execution?.stageStatus?.durationMs;
-  const stageDuration =
+  const formattedStageDuration =
     stageDurationMs !== undefined
       ? formatDurationMs(stageDurationMs, locale)
       : execution?.stageStatus?.duration;
+  // The label is the consumer's word, already localised — Apollo only decides that it sits in front
+  // of the value. Joined with a plain space so the label carries its own punctuation ("Duration:").
+  const stageDurationLabel = execution?.stageStatus?.durationLabel;
+  const stageDuration =
+    formattedStageDuration && stageDurationLabel
+      ? `${stageDurationLabel} ${formattedStageDuration}`
+      : formattedStageDuration;
   const slaText = execution?.stageStatus?.slaText;
   const slaIcon = execution?.stageStatus?.slaIcon;
   const slaIndicator = slaIcon ? SLA_ICON_CONFIG[slaIcon] : undefined;

--- a/packages/apollo-react/src/canvas/components/StageNode/formatDuration.test.ts
+++ b/packages/apollo-react/src/canvas/components/StageNode/formatDuration.test.ts
@@ -47,6 +47,19 @@ describe('formatDurationMs', () => {
     expect(formatDurationMs(10 * DAY)).toBe('1w, 3d');
   });
 
+  it('rounds the smallest kept unit instead of flooring it', () => {
+    // The unit truncation keeps last is the one carrying the fraction, so it has to round:
+    // flooring silently shortened every duration with a fractional tail.
+    expect(formatDurationMs(12_669)).toBe('13s');
+  });
+
+  it('rounds that unit in place, so a rounded-up value does not carry', () => {
+    // 59.6s becomes "60s" rather than "1m". Deliberate: this matches what consumers have always
+    // rendered, and rounding the total instead would carry across units and change durations that
+    // are not ambiguous at all (2h 59m 36s would collapse from "2h, 59m" to "3h").
+    expect(formatDurationMs(2 * HOUR + 59.6 * SECOND)).toBe('2h, 60s');
+  });
+
   it('drops sub-second precision instead of rendering a zero', () => {
     expect(formatDurationMs(1 * MINUTE + 30 * SECOND + 400)).toBe('1m, 30s');
     expect(formatDurationMs(400)).toBe('');

--- a/packages/apollo-react/src/canvas/components/StageNode/formatDuration.test.ts
+++ b/packages/apollo-react/src/canvas/components/StageNode/formatDuration.test.ts
@@ -11,22 +11,22 @@ describe('formatDurationMs', () => {
     // 2 days, 3 hr, 4 min, 5 sec -> the seconds are dropped.
     const ms = 2 * DAY + 3 * HOUR + 4 * MINUTE + 5 * SECOND;
 
-    expect(formatDurationMs(ms)).toBe('2 days, 3 hr, 4 min');
+    expect(formatDurationMs(ms)).toBe('2d, 3h, 4m');
   });
 
   it('leaves durations with fewer than three units alone', () => {
-    expect(formatDurationMs(2 * HOUR + 15 * MINUTE)).toBe('2 hr, 15 min');
+    expect(formatDurationMs(2 * HOUR + 15 * MINUTE)).toBe('2h, 15m');
   });
 
   it('skips units that are zero rather than padding to three', () => {
     // No hours between the days and the minutes.
-    expect(formatDurationMs(2 * DAY + 4 * MINUTE)).toBe('2 days, 4 min');
+    expect(formatDurationMs(2 * DAY + 4 * MINUTE)).toBe('2d, 4m');
   });
 
   it('honours a custom unit count', () => {
     const ms = 2 * DAY + 3 * HOUR + 4 * MINUTE;
 
-    expect(formatDurationMs(ms, 'en', 1)).toBe('2 days');
+    expect(formatDurationMs(ms, 'en', 1)).toBe('2d');
   });
 
   it('keeps the cap in other locales (de, ja)', () => {
@@ -34,19 +34,21 @@ describe('formatDurationMs', () => {
     // spellings that happened to look like "2h 3m".
     const ms = 2 * DAY + 3 * HOUR + 4 * MINUTE + 5 * SECOND;
 
-    expect(formatDurationMs(ms, 'de')).toBe('2 Tg., 3 Std. und 4 Min.');
-    expect(formatDurationMs(ms, 'ja')).toBe('2 日、3 時間、4 分');
+    expect(formatDurationMs(ms, 'de')).toBe('2 T, 3h und 4 Min.');
+    // Narrow keeps Latin abbreviations in ja and only localises the separator. That is CLDR's
+    // narrow data, not a bug here — but it is thinner than the "2時間 1分" a consumer can hand-roll,
+    // so pass `short` for surfaces where ja readability matters more than width.
+    expect(formatDurationMs(ms, 'ja')).toBe('2d、3h、4m');
+    expect(formatDurationMs(ms, 'ja', 3, 'short')).toBe('2 日、3 時間、4 分');
   });
 
   it('caps long durations that would otherwise run to six units', () => {
-    expect(formatDurationMs(196 * DAY + 2 * HOUR + 59 * MINUTE + 36 * SECOND)).toBe(
-      '7 mths, 2 hr, 59 min'
-    );
-    expect(formatDurationMs(10 * DAY)).toBe('1 wk, 3 days');
+    expect(formatDurationMs(196 * DAY + 2 * HOUR + 59 * MINUTE + 36 * SECOND)).toBe('7m, 2h, 59m');
+    expect(formatDurationMs(10 * DAY)).toBe('1w, 3d');
   });
 
   it('drops sub-second precision instead of rendering a zero', () => {
-    expect(formatDurationMs(1 * MINUTE + 30 * SECOND + 400)).toBe('1 min, 30 sec');
+    expect(formatDurationMs(1 * MINUTE + 30 * SECOND + 400)).toBe('1m, 30s');
     expect(formatDurationMs(400)).toBe('');
   });
 

--- a/packages/apollo-react/src/canvas/components/StageNode/formatDuration.ts
+++ b/packages/apollo-react/src/canvas/components/StageNode/formatDuration.ts
@@ -15,10 +15,20 @@ const UNITS = ['years', 'months', 'weeks', 'days', 'hours', 'minutes', 'seconds'
  * locale. (Formatting first and trimming the string back does not: "2 hr, 59 min" and
  * "2 Std., 59 Min." share no unit spelling.) The conversion and wording are luxon's.
  *
+ * `unitDisplay` defaults to `narrow` ("1h, 2m, 3s"). A canvas node has no width to spend on
+ * "1 hr, 2 min, 3 sec", and narrow is the wording these surfaces have always shipped. Pass `short`
+ * or `long` for a roomier surface. Note that luxon's narrow forms collide for months and minutes —
+ * both render as "m" — which is inherent to the locale data, not something this can disambiguate.
+ *
  * Returns `''` for a non-positive, non-finite, or sub-second duration — callers skip rendering
  * rather than show "0 sec".
  */
-export function formatDurationMs(ms: number, locale = 'en', maxUnits = 3): string {
+export function formatDurationMs(
+  ms: number,
+  locale = 'en',
+  maxUnits = 3,
+  unitDisplay: 'narrow' | 'short' | 'long' = 'narrow'
+): string {
   if (!Number.isFinite(ms) || ms <= 0 || maxUnits < 1) {
     return '';
   }
@@ -29,9 +39,9 @@ export function formatDurationMs(ms: number, locale = 'en', maxUnits = 3): strin
   const largest: Record<string, number> = {};
 
   for (const unit of UNITS) {
-    // Seconds come back fractional; a partial unit is never worth a decimal here.
-    const value = Math.floor(parts[unit] ?? 0);
-    if (value <= 0) {
+    const value = parts[unit] ?? 0;
+    // Below one whole unit does not earn a part of its own at this size.
+    if (value < 1) {
       continue;
     }
     largest[unit] = value;
@@ -40,9 +50,20 @@ export function formatDurationMs(ms: number, locale = 'en', maxUnits = 3): strin
     }
   }
 
-  if (Object.keys(largest).length === 0) {
+  const kept = Object.keys(largest);
+  if (kept.length === 0) {
     return '';
   }
 
-  return Duration.fromObject(largest).reconfigure({ locale }).toHuman({ unitDisplay: 'short' });
+  // `shiftTo` leaves a fraction on the smallest unit only, and that is exactly the unit truncation
+  // keeps last — so round it rather than floor it. 12.669s reads as "13s", which is what these
+  // surfaces rendered before this helper existed; flooring silently shortened every duration with
+  // a fractional tail. The larger units are already whole.
+  const smallest = kept[kept.length - 1] as string;
+  largest[smallest] = Math.round(largest[smallest] as number);
+  for (const unit of kept.slice(0, -1)) {
+    largest[unit] = Math.floor(largest[unit] as number);
+  }
+
+  return Duration.fromObject(largest).reconfigure({ locale }).toHuman({ unitDisplay });
 }

--- a/packages/apollo-react/src/canvas/components/StageNode/tasks/TaskContent.test.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/tasks/TaskContent.test.tsx
@@ -254,8 +254,9 @@ describe('TaskContent - duration tooltip', () => {
       },
     });
 
-    expect(screen.getByText('2 days, 3 hr, 4 min')).toBeInTheDocument();
-    expect(screen.queryByText(/sec/)).not.toBeInTheDocument();
+    expect(screen.getByText('2d, 3h, 4m')).toBeInTheDocument();
+    // Narrow renders seconds as "s", so assert the dropped value itself rather than "sec".
+    expect(screen.queryByText(/5s/)).not.toBeInTheDocument();
   });
 
   it('renders a legacy pre-formatted duration verbatim', () => {


### PR DESCRIPTION
## Summary

Formatting **stays in Apollo** — consumers pass `durationMs`, the shared `formatDurationMs` turns it into text — and this fixes the two things that drove the only consumer to format its own instead. Supersedes #1003, which took the opposite approach; closing that in favour of this, per @KittyLi's point that ms in / Apollo formats is the right split.

## Demo

<img width="379" height="271" alt="image" src="https://github.com/user-attachments/assets/ee072ccd-35c4-4ffa-a652-447e564f6549" />


## Changes

**1. Narrow units by default.** `1h, 2m, 3s`, not `1 hr, 2 min, 3 sec`. A task row has no width for the long form, and narrow is what these surfaces have always rendered. `unitDisplay` is a parameter (`narrow` | `short` | `long`), so the roomier forms stay available.

**2. The smallest kept unit is rounded, not floored.** `shiftTo` leaves the fraction on the smallest unit, and that is exactly the unit truncation keeps last — so `12.669s` must read `13s`. Flooring quietly shortened every duration with a fractional tail.

**3. New `stageStatus.durationLabel`.** The stage header renders `"Duration: 1h, 2m"` when given one:

```ts
execution: { stageStatus: { durationMs: 7_440_000, durationLabel: 'Duration:' } }
```

The word is the consumer's — already localised, carrying its own punctuation. Apollo only decides that it sits in front of the value, joined with a space. Without it the duration renders bare, as today. Task rows have no label and are untouched.

That prop is what makes "pass ms" actually workable for the case canvas: the `"Duration: "` prefix lives in PO.Frontend's translation catalogues, so before this there was nowhere for it to go once Apollo owned the formatting.

## Known trade-off: Japanese

CLDR's narrow data keeps Latin abbreviations for `ja` and localises only the separator, so `ja` renders `2d、3h、4m` rather than `2 日、3 時間、4 分`. That is narrow's data, not a bug here, but it *is* thinner than what a consumer can hand-roll — PO.Frontend currently special-cases `ja` to build `2時間 1分 41秒`, and that nuance is lost when Apollo formats.

Both behaviours are pinned in the tests. If `ja` readability matters more than width on a given surface, `short` produces the fuller form. Flagging rather than deciding — happy to default `ja` to `short` if you'd prefer, though a per-locale branch inside the design system is its own smell.

## Testing

- [x] `vitest --run src/canvas` — 111 files, 1932 tests passing
- [x] New tests: label in front of the value, bare without a label, and the `ja` narrow-vs-short pair
- [x] Existing expectations updated from short to narrow, and one assertion that had gone vacuous under narrow (`queryByText(/sec/)` can never match `5s`) now asserts the dropped value
- [x] `tsc --noEmit` clean; `biome lint src` + `biome format src` (what CI runs) both exit 0
- [x] Type-safe (no `as any` added; two `as` narrowings on a `Record` index that TS cannot prove)

## Consumer side

PO.Frontend goes back to passing `durationMs` + `durationLabel` and drops its local formatting once this releases.
