### PR TITLE
fix(apollo-react): match ApTextArea label styling to ApTextField [MST-13121]

### DIFF
--- a/packages/apollo-react/src/material/components/ap-text-area/ApTextArea.tsx
+++ b/packages/apollo-react/src/material/components/ap-text-area/ApTextArea.tsx
@@ -152,7 +152,14 @@ export const ApTextArea = React.forwardRef<HTMLTextAreaElement, ApTextAreaProps>
           descendant `textarea`'s border and padding, which would override the styling above.
         */}
         {label && (
-          <InputLabel id={labelId} required={required}>
+          <InputLabel
+            id={labelId}
+            required={required}
+            // The theme's `asterisk: { color: 'inherit' }` would render a de-emphasized asterisk.
+            // ApTextArea has always shown a red one, so keep that rather than change existing
+            // behaviour while fixing the label typography.
+            sx={{ '& .MuiInputLabel-asterisk': { color: 'var(--color-error-text)' } }}
+          >
             {label}
           </InputLabel>
         )}

--- a/packages/apollo-react/src/material/components/ap-text-area/ApTextArea.tsx
+++ b/packages/apollo-react/src/material/components/ap-text-area/ApTextArea.tsx
@@ -1,7 +1,7 @@
-import { Box, TextareaAutosize } from '@mui/material';
+import { Box, InputLabel, TextareaAutosize } from '@mui/material';
 import { styled } from '@mui/material/styles';
 import token, { FontVariantToken } from '@uipath/apollo-core';
-import React, { useCallback, useRef, useState } from 'react';
+import React, { useCallback, useId, useRef, useState } from 'react';
 
 import { ApTypography } from '../ap-typography';
 import type { ApTextAreaProps } from './ApTextArea.types';
@@ -134,33 +134,27 @@ export const ApTextArea = React.forwardRef<HTMLTextAreaElement, ApTextAreaProps>
       [ref]
     );
 
-    const labelId = label ? `textarea-label-${dataTestid || 'default'}` : undefined;
-    const helperId =
-      helperText || errorMessage ? `textarea-helper-${dataTestid || 'default'}` : undefined;
+    // Per-instance: deriving these from `dataTestid` gave every instance without one the same
+    // `-default` id, so two text areas on a page cross-wired their accessible names.
+    const instanceId = useId();
+    const labelId = label ? `textarea-label-${instanceId}` : undefined;
+    const helperId = helperText || errorMessage ? `textarea-helper-${instanceId}` : undefined;
 
     return (
       <Box sx={{ width: width || '100%' }}>
+        {/*
+          Rendered with MUI's InputLabel rather than a hand-rolled ApTypography so the label picks
+          up the theme's `MuiInputLabel` override — the same weight, size, colour and margins
+          ApTextField gets. The previous body-text label (weight 400, primary foreground, 4px
+          bottom margin) did not match sibling field labels in a form.
+
+          Not wrapped in a MUI FormControl on purpose: the `MuiFormControl` override restyles any
+          descendant `textarea`'s border and padding, which would override the styling above.
+        */}
         {label && (
-          <Box sx={{ marginBottom: token.Spacing.SpacingMicro }}>
-            <ApTypography
-              variant={FontVariantToken.fontSizeM}
-              id={labelId}
-              style={{ color: 'var(--color-foreground)' }}
-            >
-              {label}
-              {required && (
-                <Box
-                  component="span"
-                  sx={{
-                    color: 'var(--color-error-text)',
-                    marginLeft: token.Spacing.SpacingMicro,
-                  }}
-                >
-                  *
-                </Box>
-              )}
-            </ApTypography>
-          </Box>
+          <InputLabel id={labelId} required={required}>
+            {label}
+          </InputLabel>
         )}
 
         <StyledTextareaAutosize

--- a/packages/apollo-react/src/material/components/ap-text-area/ApTextArea.tsx
+++ b/packages/apollo-react/src/material/components/ap-text-area/ApTextArea.tsx
@@ -152,14 +152,7 @@ export const ApTextArea = React.forwardRef<HTMLTextAreaElement, ApTextAreaProps>
           descendant `textarea`'s border and padding, which would override the styling above.
         */}
         {label && (
-          <InputLabel
-            id={labelId}
-            required={required}
-            // The theme's `asterisk: { color: 'inherit' }` would render a de-emphasized asterisk.
-            // ApTextArea has always shown a red one, so keep that rather than change existing
-            // behaviour while fixing the label typography.
-            sx={{ '& .MuiInputLabel-asterisk': { color: 'var(--color-error-text)' } }}
-          >
+          <InputLabel id={labelId} required={required}>
             {label}
           </InputLabel>
         )}

--- a/packages/apollo-react/src/material/components/ap-text-area/ApTextArea.tsx
+++ b/packages/apollo-react/src/material/components/ap-text-area/ApTextArea.tsx
@@ -78,6 +78,7 @@ export const ApTextArea = React.forwardRef<HTMLTextAreaElement, ApTextAreaProps>
       resize = 'vertical',
       dataTestid,
       onChange,
+      id,
       ...restProps
     },
     ref
@@ -139,6 +140,8 @@ export const ApTextArea = React.forwardRef<HTMLTextAreaElement, ApTextAreaProps>
     const instanceId = useId();
     const labelId = label ? `textarea-label-${instanceId}` : undefined;
     const helperId = helperText || errorMessage ? `textarea-helper-${instanceId}` : undefined;
+    // Needed for the label's `htmlFor`, so clicking the label focuses the textarea.
+    const textareaId = id ?? `textarea-${instanceId}`;
 
     return (
       <Box sx={{ width: width || '100%' }}>
@@ -152,13 +155,14 @@ export const ApTextArea = React.forwardRef<HTMLTextAreaElement, ApTextAreaProps>
           descendant `textarea`'s border and padding, which would override the styling above.
         */}
         {label && (
-          <InputLabel id={labelId} required={required}>
+          <InputLabel id={labelId} htmlFor={textareaId} required={required}>
             {label}
           </InputLabel>
         )}
 
         <StyledTextareaAutosize
           ref={combinedRef}
+          id={textareaId}
           value={stringValue}
           placeholder={placeholder}
           readOnly={readOnly}

--- a/packages/apollo-react/src/material/stories/text-area.stories.tsx
+++ b/packages/apollo-react/src/material/stories/text-area.stories.tsx
@@ -164,7 +164,7 @@ function LabelAlignmentDemo() {
           minRows={3}
         />
       </Labeled>
-      <Labeled label="Required — asterisk styling should also match">
+      <Labeled label="Required — ApTextArea keeps its red asterisk, ApTextField's stays de-emphasized">
         <ApTextField label="Name" value={name} onChange={setName} required />
         <ApTextArea
           label="Description"

--- a/packages/apollo-react/src/material/stories/text-area.stories.tsx
+++ b/packages/apollo-react/src/material/stories/text-area.stories.tsx
@@ -154,7 +154,7 @@ function LabelAlignmentDemo() {
   const [required, setRequired] = useState('');
   return (
     <>
-      <Labeled label="Stacked in a form — labels should be indistinguishable">
+      <Labeled label="Stacked in a form: labels should be indistinguishable">
         <ApTextField label="Name" value={name} onChange={setName} placeholder="Enter a name..." />
         <ApTextArea
           label="Description"
@@ -164,7 +164,7 @@ function LabelAlignmentDemo() {
           minRows={3}
         />
       </Labeled>
-      <Labeled label="Required — asterisk styling should also match">
+      <Labeled label="Required: asterisk styling should also match">
         <ApTextField label="Name" value={name} onChange={setName} required />
         <ApTextArea
           label="Description"

--- a/packages/apollo-react/src/material/stories/text-area.stories.tsx
+++ b/packages/apollo-react/src/material/stories/text-area.stories.tsx
@@ -164,7 +164,7 @@ function LabelAlignmentDemo() {
           minRows={3}
         />
       </Labeled>
-      <Labeled label="Required — ApTextArea keeps its red asterisk, ApTextField's stays de-emphasized">
+      <Labeled label="Required — asterisk styling should also match">
         <ApTextField label="Name" value={name} onChange={setName} required />
         <ApTextArea
           label="Description"

--- a/packages/apollo-react/src/material/stories/text-area.stories.tsx
+++ b/packages/apollo-react/src/material/stories/text-area.stories.tsx
@@ -3,7 +3,7 @@ import Typography from '@mui/material/Typography';
 import type { Meta, StoryObj } from '@storybook/react';
 import type { ReactNode } from 'react';
 import { useState } from 'react';
-import { ApTextArea } from '../components';
+import { ApTextArea, ApTextField } from '../components';
 import { materialParameters, Section } from './storybook-helpers';
 
 /**
@@ -147,6 +147,47 @@ function StatesDemo() {
     </>
   );
 }
+
+function LabelAlignmentDemo() {
+  const [name, setName] = useState('');
+  const [description, setDescription] = useState('');
+  const [required, setRequired] = useState('');
+  return (
+    <>
+      <Labeled label="Stacked in a form — labels should be indistinguishable">
+        <ApTextField label="Name" value={name} onChange={setName} placeholder="Enter a name..." />
+        <ApTextArea
+          label="Description"
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          placeholder="Describe something..."
+          minRows={3}
+        />
+      </Labeled>
+      <Labeled label="Required — asterisk styling should also match">
+        <ApTextField label="Name" value={name} onChange={setName} required />
+        <ApTextArea
+          label="Description"
+          value={required}
+          onChange={(e) => setRequired(e.target.value)}
+          required
+          minRows={3}
+        />
+      </Labeled>
+    </>
+  );
+}
+
+export const LabelAlignment: Story = {
+  render: () => (
+    <Section
+      title="Label alignment with ApTextField"
+      description="ApTextArea's label comes from the theme's MuiInputLabel override, the same as ApTextField's, so the two read identically when stacked in a form."
+    >
+      <LabelAlignmentDemo />
+    </Section>
+  ),
+};
 
 export const Basic: Story = {
   render: () => (


### PR DESCRIPTION
## Summary

`ApTextArea` hand-rolls its label as `<ApTypography variant={fontSizeM}>` — weight **400**, `var(--color-foreground)`, wrapped in a `Box` with a 4px bottom margin. Its sibling `ApTextField` doesn't hand-roll a label at all: it passes `label` to MUI's `TextField`, so the label picks up the theme's `MuiInputLabel` override — weight **600**, `colorForegroundDeEmp`, `margin: 8px 0`.

The result is that a `Description` textarea placed under a `Name` text field in the same form has a visibly lighter, differently-spaced label. Reported against Maestro in a Case Management bug bash ([MST-13121](https://uipath.atlassian.net/browse/MST-13121)).

This replaces the hand-rolled label with MUI's `InputLabel`, so both consumption paths get their label styling from the same theme override instead of one of them duplicating it with hardcoded values.

## Demo

<img width="418" height="529" alt="Screenshot 2026-08-04 at 9 32 20 AM" src="https://github.com/user-attachments/assets/e9cea03b-cb24-42b5-9c1d-1313a6e6ba59" />


## Changes

- **`ApTextArea.tsx`** — render `label` via MUI's `InputLabel` (with `required`, so the themed asterisk is used) instead of `Box` + `ApTypography`. `ApTypography` is still used for helper text, error message and the character counter, so the import stays.
- **`ApTextArea.tsx`** — derive `labelId` / `helperId` from `useId()` instead of `dataTestid`. They were `textarea-label-${dataTestid || 'default'}`, so every instance rendered without a `dataTestid` got the *same* `-default` id: duplicate DOM ids, and `aria-labelledby` pointing at whichever label happened to be first. Two flagged this independently on the downstream PR (Epixa `config_risk`, and Copilot).
- **`text-area.stories.tsx`** — new **Label Alignment** story stacking `ApTextField` above `ApTextArea`, plus a required-field pair, so the match is visually checkable.

Deliberately **not** wrapped in a MUI `FormControl`: the `MuiFormControl` override restyles any descendant `textarea`'s `borderColor` and `padding`, which would override `StyledTextareaAutosize` and regress the fill/border. A bare `InputLabel` avoids that — MUI only applies `position: absolute` and the shrink transforms when the label is inside a `FormControl`.

## Required asterisk — now follows the theme

The old code hardcoded `color: 'var(--color-error-text)'` for the asterisk. MUI's `InputLabel` uses the theme's `asterisk: { color: 'inherit' }`, so it now inherits the de-emphasized label colour.

This is an intentional behaviour change: `ApTextArea` was the **only** field in Apollo with a red asterisk. `ApTextField` (both here and via portal-shell), and `ApRadioGroup`'s `<span> *</span>`, all render a de-emphasized one — so the red asterisk made a text area stand out from every field it sits beside in a form, which is the same class of inconsistency this PR is fixing for the label itself.

It is invisible in the reported case either way: every labeled `ApTextArea` in PO.Frontend is non-required, so no asterisk renders there.

## Verification

Measured in Storybook (Label Alignment story) with Playwright, comparing the `ApTextField` label against the `ApTextArea` label:

| Property | `ApTextField` "Name" | `ApTextArea` "Description" |
| --- | --- | --- |
| `font-weight` | 600 | 600 |
| `font-size` | 14px | 14px |
| `color` | `rgb(159, 159, 169)` | `rgb(159, 159, 169)` |
| `margin-top` / `-bottom` | 8px / 8px | 8px / 8px |
| `line-height` | 20px | 20px |
| asterisk colour | `rgb(159, 159, 169)` | `rgb(159, 159, 169)` |

`aria-labelledby` on the two text areas resolves to `textarea-label-_r_2_` and `textarea-label-_r_4_` — distinct per instance, confirming the id fix.

- `pnpm --filter @uipath/apollo-react test` — 135 files, 2294 tests, all passing
- `biome check` clean on both changed files; `pnpm --filter @uipath/apollo-react format:check` clean
- `pnpm build:packages` succeeds

## Note on scope

Storybook labels `material/` as "Maintenance Only". If changes shouldn't land there, say so and this fix can stay patched downstream in PO.Frontend ([PR #6541](https://github.com/UiPath/PO.Frontend/pull/6541)) instead — that PR does the same thing in its local `TextArea` wrapper and can be dropped in favour of a version bump if this lands.


[MST-13121]: https://uipath.atlassian.net/browse/MST-13121?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

