### PR TITLE
feat(apollo-react): officially support early exit status for stages

### DIFF
--- a/packages/apollo-react/src/canvas/components/ExecutionStatusIcon/ExecutionStatusIcon.test.tsx
+++ b/packages/apollo-react/src/canvas/components/ExecutionStatusIcon/ExecutionStatusIcon.test.tsx
@@ -41,6 +41,13 @@ describe('ExecutionStatusIcon', () => {
     expect(icon).toHaveAttribute('data-color', 'var(--color-info-icon)');
     expect(icon).toHaveAttribute('data-size', '20');
   });
+
+  it('renders EarlyExit with the early exit glyph and success color', () => {
+    render(<ExecutionStatusIcon status="EarlyExit" size={20} />);
+
+    const icon = screen.getByTestId('early-exit-status-icon');
+    expect(icon).toBeInTheDocument();
+  });
 });
 
 describe('getExecutionStatusColor', () => {

--- a/packages/apollo-react/src/canvas/components/ExecutionStatusIcon/ExecutionStatusIcon.tsx
+++ b/packages/apollo-react/src/canvas/components/ExecutionStatusIcon/ExecutionStatusIcon.tsx
@@ -1,6 +1,7 @@
 import { Spinner } from '@uipath/apollo-wind';
 import { type CSSProperties, useMemo } from 'react';
 import { useSafeLingui } from '../../../i18n';
+import { EarlyExitStatusIcon } from '../../icons';
 import { CanvasIcon } from '../../utils/icon-registry';
 
 export function getExecutionStatusColor(status: string | undefined): string {
@@ -10,6 +11,7 @@ export function getExecutionStatusColor(status: string | undefined): string {
     case 'InProgress':
       return 'var(--color-primary)';
     case 'Completed':
+    case 'EarlyExit':
       return 'var(--color-success-icon)';
     case 'ActionNeeded':
     case 'Paused':
@@ -59,6 +61,7 @@ export function ExecutionStatusIcon({
     | 'NotExecuted'
     | 'Terminated'
     | 'Warning'
+    | 'EarlyExit'
     | string;
   size?: number;
 }) {
@@ -101,6 +104,8 @@ export function ExecutionStatusIcon({
         return <CanvasIcon icon="circle-stop" size={size} color={color} />;
       case 'NotExecuted':
         return <CanvasIcon icon="circle-dashed" size={size} color={color} />;
+      case 'EarlyExit':
+        return <EarlyExitStatusIcon />;
       default:
         return null;
     }

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.stories.tsx
@@ -557,6 +557,30 @@ export const ExecutionStatus: Story = {
           },
         },
       },
+      {
+        id: '5',
+        type: 'stage',
+        position: { x: 1456, y: 96 },
+        width: DEFAULT_STAGE_WIDTH,
+        data: {
+          stageDetails: {
+            label: 'Exited',
+            isException: true,
+            isReadOnly: true,
+            tasks: [
+              [{ id: '7', label: 'Task One', icon: <ProcessIcon /> }],
+              [{ id: '8', label: 'Task Two', icon: <DocumentIcon /> }],
+            ],
+          },
+          execution: {
+            stageStatus: {
+              status: 'EarlyExit',
+              label: 'Early exit',
+            },
+            taskStatus: {},
+          },
+        },
+      },
     ],
     edges: [
       {

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.types.ts
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.types.ts
@@ -13,6 +13,7 @@ enum ElementStatusValues {
   Paused = 'Paused',
   Terminated = 'Terminated',
   Warning = 'Warning',
+  EarlyExit = 'EarlyExit',
 }
 
 export type StageStatus = `${ElementStatusValues}`;

--- a/packages/apollo-react/src/canvas/components/StageNode/useExecutionStatusLabel.test.ts
+++ b/packages/apollo-react/src/canvas/components/StageNode/useExecutionStatusLabel.test.ts
@@ -16,6 +16,7 @@ describe('useExecutionStatusLabel', () => {
     expect(getLabel('Terminated')).toBe('Terminated');
     expect(getLabel('NotExecuted')).toBe('Not started');
     expect(getLabel('Warning')).toBe('Warning');
+    expect(getLabel('EarlyExit')).toBe('Early exit');
   });
 
   it('returns an empty string for undefined or unknown statuses', () => {

--- a/packages/apollo-react/src/canvas/components/StageNode/useExecutionStatusLabel.ts
+++ b/packages/apollo-react/src/canvas/components/StageNode/useExecutionStatusLabel.ts
@@ -32,6 +32,8 @@ export function useExecutionStatusLabel() {
           return _({ id: 'stage-node.status.not-executed', message: 'Not started' });
         case 'Warning':
           return _({ id: 'stage-node.status.warning', message: 'Warning' });
+        case 'EarlyExit':
+          return _({ id: 'stage-node.status.early-exit', message: 'Early exit' });
         default:
           return '';
       }

--- a/packages/apollo-react/src/canvas/icons/EarlyExitStatusIcon.tsx
+++ b/packages/apollo-react/src/canvas/icons/EarlyExitStatusIcon.tsx
@@ -1,0 +1,33 @@
+export const EarlyExitStatusIcon = () => {
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        top: '20px',
+        right: '20px',
+      }}
+    >
+      <svg
+        width="20"
+        height="20"
+        viewBox="0 0 20 20"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M9.45792 4.39058C9.61909 4.20282 9.88073 4.20281 10.0419 4.39058L14.1288 9.15914C14.2899 9.34713 14.2897 9.6517 14.1288 9.8398L10.0419 14.6084C9.88068 14.7965 9.61914 14.7964 9.45792 14.6084L5.371 9.8398C5.21006 9.6517 5.20992 9.34713 5.371 9.15914L9.45792 4.39058Z"
+          fill="var(--color-foreground)"
+        />
+        <circle
+          cx="9.75"
+          cy="9.75"
+          r="9"
+          stroke="var(--color-success-icon)"
+          strokeWidth="1.5"
+          strokeLinecap="round"
+          strokeDasharray="3 6"
+        />
+      </svg>
+    </div>
+  );
+};

--- a/packages/apollo-react/src/canvas/icons/EarlyExitStatusIcon.tsx
+++ b/packages/apollo-react/src/canvas/icons/EarlyExitStatusIcon.tsx
@@ -6,6 +6,7 @@ export const EarlyExitStatusIcon = () => {
         top: '20px',
         right: '20px',
       }}
+      data-testid="early-exit-status-icon"
     >
       <svg
         width="20"

--- a/packages/apollo-react/src/canvas/icons/index.ts
+++ b/packages/apollo-react/src/canvas/icons/index.ts
@@ -22,6 +22,7 @@ export { DataTransformGroupIcon } from './DataTransformGroupIcon';
 export { DataTransformIcon } from './DataTransformIcon';
 export { DataTransformMapIcon } from './DataTransformMapIcon';
 export { DecisionIcon } from './DecisionIcon';
+export { EarlyExitStatusIcon } from './EarlyExitStatusIcon';
 export { EntryConditionIcon } from './EntryConditionIcon';
 export { ExitConditionIcon } from './ExitConditionIcon';
 export { FlaskRunIcon } from './FlaskRunIcon';

--- a/packages/apollo-react/src/canvas/locales/en.json
+++ b/packages/apollo-react/src/canvas/locales/en.json
@@ -31,6 +31,7 @@
   "stage-node.status.paused": "Paused",
   "stage-node.status.terminated": "Terminated",
   "stage-node.status.warning": "Warning",
+  "stage-node.status.early-exit": "Early exit",
   "stage-node.task-badge.ran-n-times": "{count, plural, one {Ran # time} other {Ran # times}}",
   "stage-node.task-badge.running-again": "Running again",
   "stage-node.ungroup-parallel-tasks": "Ungroup parallel tasks",


### PR DESCRIPTION
This adds official support for the Early Exit status/icon for stages. Right now in the FE we're rendering this icon separately and not in Apollo which is a little awkward. Now it will be properly rendered in apollo

<img width="1473" height="653" alt="Screenshot 2026-08-04 at 12 45 12 PM" src="https://github.com/user-attachments/assets/6b6e2de2-d062-4f02-a1f5-52be5a8ec807" />
