### PR TITLE
fix(apollo-react): readable ListView tooltip description on the inverse tooltip surface [MST-13033]

### DIFF
--- a/packages/apollo-react/src/canvas/components/Toolbox/ListView.tsx
+++ b/packages/apollo-react/src/canvas/components/Toolbox/ListView.tsx
@@ -394,7 +394,8 @@ const ListViewRow = memo(
       <div className="flex flex-col gap-0.5">
         {showName && <span className="text-sm">{item.name}</span>}
         {showDescription && (
-          <span className="text-xs text-foreground-muted">{item.description}</span>
+          // De-emphasize on the tooltip's inverse surface - the regular muted token has no contrast there.
+          <span className="text-xs text-foreground-inverse/70">{item.description}</span>
         )}
         {item.detail && <span className="text-xs">{item.detail}</span>}
       </div>


### PR DESCRIPTION
## What

One-line fix in the canvas `ListView` tooltip body: the truncated-description span now uses `text-foreground-inverse/70` instead of `text-foreground-muted`.

## Why

#900 (MST-11921) moved `TooltipContent` to the inverse surface, but the ListView tooltip body kept the normal-surface muted token for `item.description`. On the inverse surface that token has almost no contrast in either theme:

- **Dark theme**: `--foreground-muted` `#a4b1b8` (light gray) on the near-white `#f8f9fa` tooltip — ~1.6:1
- **Light theme**: `#6b7280` (dark gray) on the near-black `#182027` tooltip — ~3:1

Reported from the Flow bug bash on both VS Code (dark theme) and Studio Web's agent picker (light theme, the `folder · version` line on published-item rows): [MST-13033](https://uipath.atlassian.net/browse/MST-13033).

`text-foreground-inverse/70` is the same de-emphasis pattern #900 adopted for the tooltip stories — it follows the tooltip's own surface, giving ~8.5:1 in both themes while keeping the name/description hierarchy.

## Testing

- `pnpm vitest run src/canvas/components/Toolbox` — 131 tests pass
- `biome lint` — no new diagnostics

[MST-13033]: https://uipath.atlassian.net/browse/MST-13033?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ