### PR TITLE
fix(apollo-react): give the stage task card its own test id prefix

### DIFF
--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.test.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.test.tsx
@@ -1438,8 +1438,8 @@ describe('StageNode - pulse on the paused breakpoint', () => {
     renderArmedAdhocTask('Paused');
 
     // Emotion injects its styles at runtime, so a card animation would show up here.
-    expect(getComputedStyle(screen.getByTestId('stage-task-adhoc-1')).animation).toBe('');
-    expect(screen.getByTestId('stage-task-adhoc-1')).not.toHaveClass('animate-glow');
+    expect(getComputedStyle(screen.getByTestId('stage-task-card-adhoc-1')).animation).toBe('');
+    expect(screen.getByTestId('stage-task-card-adhoc-1')).not.toHaveClass('animate-glow');
   });
 });
 

--- a/packages/apollo-react/src/canvas/components/StageNode/tasks/AdhocTask.test.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/tasks/AdhocTask.test.tsx
@@ -39,7 +39,30 @@ describe('AdhocTaskItem', () => {
     it('renders task with correct testid', () => {
       render(<AdhocTaskItem {...defaultProps} />);
 
-      expect(screen.getByTestId('stage-task-adhoc-1')).toBeInTheDocument();
+      expect(screen.getByTestId('stage-task-card-adhoc-1')).toBeInTheDocument();
+    });
+
+    it('exposes exactly one element under the stage-task-card- prefix with every part rendered', () => {
+      const { container } = render(
+        <AdhocTaskItem
+          {...defaultProps}
+          taskExecution={{
+            status: 'Completed',
+            retryCount: 2,
+            retryDuration: '5s',
+            durationMs: 1234,
+          }}
+          getContextMenuItems={() => createMenuItems(vi.fn())}
+          onTaskPlay={vi.fn().mockResolvedValue(undefined)}
+          onToggleBreakpoint={vi.fn()}
+        />
+      );
+
+      const matches = container.querySelectorAll('[data-testid^="stage-task-card-"]');
+
+      expect(Array.from(matches, (match) => match.getAttribute('data-testid'))).toEqual([
+        'stage-task-card-adhoc-1',
+      ]);
     });
 
     it('renders task label', () => {
@@ -51,7 +74,7 @@ describe('AdhocTaskItem', () => {
     it('renders with selected state', () => {
       render(<AdhocTaskItem {...defaultProps} isSelected={true} />);
 
-      expect(screen.getByTestId('stage-task-adhoc-1')).toBeInTheDocument();
+      expect(screen.getByTestId('stage-task-card-adhoc-1')).toBeInTheDocument();
     });
   });
 
@@ -62,7 +85,7 @@ describe('AdhocTaskItem', () => {
 
       render(<AdhocTaskItem {...defaultProps} onTaskClick={onTaskClick} />);
 
-      const task = screen.getByTestId('stage-task-adhoc-1');
+      const task = screen.getByTestId('stage-task-card-adhoc-1');
       await user.click(task);
 
       expect(onTaskClick).toHaveBeenCalledTimes(1);
@@ -100,7 +123,7 @@ describe('AdhocTaskItem', () => {
       });
 
       // Now task click should work
-      const task = screen.getByTestId('stage-task-adhoc-1');
+      const task = screen.getByTestId('stage-task-card-adhoc-1');
       await user.click(task);
 
       expect(onTaskClick).toHaveBeenCalledWith(expect.any(Object), 'adhoc-1');
@@ -330,7 +353,7 @@ describe('AdhocTaskItem', () => {
         />
       );
 
-      const task = screen.getByTestId('stage-task-adhoc-1');
+      const task = screen.getByTestId('stage-task-card-adhoc-1');
       await user.pointer({ keys: '[MouseRight]', target: task });
 
       expect(screen.queryByText('Replace task')).not.toBeInTheDocument();

--- a/packages/apollo-react/src/canvas/components/StageNode/tasks/AdhocTask.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/tasks/AdhocTask.tsx
@@ -50,7 +50,7 @@ const AdhocTaskItemComponent = ({
   return (
     <StageItemPill
       ref={taskRef}
-      data-testid={`stage-task-${task.id}`}
+      data-testid={`stage-task-card-${task.id}`}
       selected={isSelected}
       status={taskExecution?.status}
       isPlaceholder={task.isPlaceholder}

--- a/packages/apollo-react/src/canvas/components/StageNode/tasks/DraggableTask.test.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/tasks/DraggableTask.test.tsx
@@ -57,6 +57,29 @@ const defaultProps: DraggableTaskProps = {
 };
 
 describe('DraggableTask', () => {
+  it('exposes exactly one element under the stage-task-card- prefix with every part rendered', () => {
+    const { container } = render(
+      <DraggableTask
+        {...defaultProps}
+        task={{ ...defaultProps.task, isRequired: true }}
+        taskExecution={{
+          status: 'Completed',
+          retryCount: 2,
+          retryDuration: '5s',
+          durationMs: 1234,
+        }}
+        getContextMenuItems={() => createMenuItems(vi.fn())}
+        onToggleBreakpoint={vi.fn()}
+      />
+    );
+
+    const matches = container.querySelectorAll('[data-testid^="stage-task-card-"]');
+
+    expect(Array.from(matches, (match) => match.getAttribute('data-testid'))).toEqual([
+      'stage-task-card-task-1',
+    ]);
+  });
+
   describe('Menu Button Rendering', () => {
     it('renders menu button with correct testid when getContextMenuItems is provided', () => {
       const onRemove = vi.fn();
@@ -152,7 +175,7 @@ describe('DraggableTask', () => {
 
       render(<DraggableTask {...defaultProps} isReadOnly getContextMenuItems={() => menuItems} />);
 
-      fireEvent.contextMenu(screen.getByTestId('stage-task-task-1'));
+      fireEvent.contextMenu(screen.getByTestId('stage-task-card-task-1'));
 
       await waitFor(() => {
         expect(screen.getByText('Move Up')).toBeInTheDocument();
@@ -276,7 +299,7 @@ describe('DraggableTask', () => {
 
       render(<DraggableTask {...defaultProps} onTaskClick={onTaskClick} />);
 
-      const task = screen.getByTestId('stage-task-task-1');
+      const task = screen.getByTestId('stage-task-card-task-1');
       await user.click(task);
 
       expect(onTaskClick).toHaveBeenCalledTimes(1);
@@ -314,7 +337,7 @@ describe('DraggableTask', () => {
       });
 
       // Now task click should work
-      const task = screen.getByTestId('stage-task-task-1');
+      const task = screen.getByTestId('stage-task-card-task-1');
       await user.click(task);
 
       expect(onTaskClick).toHaveBeenCalledWith(expect.any(Object), 'task-1');
@@ -386,7 +409,7 @@ describe('DraggableTask', () => {
         />
       );
 
-      const task = screen.getByTestId('stage-task-task-1');
+      const task = screen.getByTestId('stage-task-card-task-1');
       await user.pointer({ keys: '[MouseRight]', target: task });
 
       expect(screen.queryByText('Move Up')).not.toBeInTheDocument();
@@ -403,19 +426,19 @@ describe('DraggableTask', () => {
     it('renders with selected state', () => {
       const { container } = render(<DraggableTask {...defaultProps} isSelected={true} />);
 
-      const task = screen.getByTestId('stage-task-task-1');
+      const task = screen.getByTestId('stage-task-card-task-1');
       expect(task).toBeInTheDocument();
       // The task should be rendered (selected state is applied via styled-components)
-      expect(container.querySelector('[data-testid="stage-task-task-1"]')).toBeInTheDocument();
+      expect(container.querySelector('[data-testid="stage-task-card-task-1"]')).toBeInTheDocument();
     });
 
     it('renders with parallel state', () => {
       const { container } = render(<DraggableTask {...defaultProps} isParallel={true} />);
 
-      const task = screen.getByTestId('stage-task-task-1');
+      const task = screen.getByTestId('stage-task-card-task-1');
       expect(task).toBeInTheDocument();
       // The task should be rendered (parallel state is applied via styled-components)
-      expect(container.querySelector('[data-testid="stage-task-task-1"]')).toBeInTheDocument();
+      expect(container.querySelector('[data-testid="stage-task-card-task-1"]')).toBeInTheDocument();
     });
   });
 

--- a/packages/apollo-react/src/canvas/components/StageNode/tasks/DraggableTask.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/tasks/DraggableTask.tsx
@@ -85,7 +85,7 @@ const DraggableTaskComponent = ({
   const taskElement = (
     <StageItemPill
       ref={taskRef}
-      data-testid={`stage-task-${task.id}`}
+      data-testid={`stage-task-card-${task.id}`}
       selected={isSelected}
       status={taskExecution?.status}
       isParallel={isParallel}

--- a/packages/apollo-react/src/canvas/components/StageNode/tasks/EventDrivenTask.test.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/tasks/EventDrivenTask.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import type { StageTaskItem } from '../StageNode.types';
+import { EventDrivenTaskItem } from './EventDrivenTask';
+
+const createTask = (id: string, label?: string): StageTaskItem => ({
+  id,
+  label: label ?? `Task ${id}`,
+  taskGroupType: 'event-driven',
+});
+
+describe('EventDrivenTaskItem', () => {
+  const defaultProps = {
+    task: createTask('event-driven-1', 'Event Driven Task'),
+    isSelected: false,
+    onTaskClick: vi.fn(),
+  };
+
+  it('renders task with correct testid', () => {
+    render(<EventDrivenTaskItem {...defaultProps} />);
+
+    expect(screen.getByTestId('stage-task-card-event-driven-1')).toBeInTheDocument();
+  });
+
+  it('renders task label', () => {
+    render(<EventDrivenTaskItem {...defaultProps} />);
+
+    expect(screen.getByText('Event Driven Task')).toBeInTheDocument();
+  });
+
+  it('exposes exactly one element under the stage-task-card- prefix with every part rendered', () => {
+    const { container } = render(
+      <EventDrivenTaskItem
+        {...defaultProps}
+        taskExecution={{
+          status: 'Completed',
+          retryCount: 2,
+          retryDuration: '5s',
+          durationMs: 1234,
+        }}
+        getContextMenuItems={() => [{ id: 'remove-task', label: 'Delete task', onClick: vi.fn() }]}
+        onToggleBreakpoint={vi.fn()}
+      />
+    );
+
+    const matches = container.querySelectorAll('[data-testid^="stage-task-card-"]');
+
+    expect(Array.from(matches, (match) => match.getAttribute('data-testid'))).toEqual([
+      'stage-task-card-event-driven-1',
+    ]);
+  });
+});

--- a/packages/apollo-react/src/canvas/components/StageNode/tasks/EventDrivenTask.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/tasks/EventDrivenTask.tsx
@@ -48,7 +48,7 @@ const EventDrivenTaskItemComponent = ({
   return (
     <StageItemPill
       ref={taskRef}
-      data-testid={`stage-task-${task.id}`}
+      data-testid={`stage-task-card-${task.id}`}
       selected={isSelected}
       status={taskExecution?.status}
       isPlaceholder={task.isPlaceholder}


### PR DESCRIPTION
## Problem
Stage task card for tests querying through `stage-task-<id>` keeps breaking as we change and adjust and add data test id's as everthing inside also starts with `stage-task-` (`-label-`, `-identity-`, `-status-`, …), so a prefix match returns the card plus its descendants 

Makes stage task card data test id be "stage-task-card-" and add test to attemp to prevent more that matched stage-task-card so we don't keep breaking tests. 

- 6.6.0 added `-label-`/`-icon-`/`-status-`, then 6.12.0 added `-identity-` between the card and its label. The second one doubled every task count in e2e (`Expected: 1, Received: 2` after adding the first task to a stage).

## Change

The card becomes `stage-task-card-<id>` in the three card components, so `[data-testid^="stage-task-card-"]` selects exactly the cards. Descendant ids are unchanged.

`tasks/taskCardTestId.test.tsx` pins the invariant for all three: exactly one element per card under that prefix. It fails if a descendant re-enters the card's prefix — verified by temporarily renaming `stage-task-identity-` to `stage-task-card-badge-`, which is the regression it exists to catch. (It's also the first test coverage `EventDrivenTask` has.)

## Migration

Exact lookups of `stage-task-<id>` become `stage-task-card-<id>`. PO.Frontend has 3, fixed alongside its version bump; other consumers should grep for `` `stage-task-${ ``.

Typed `fix`, following `265f2d91` (the earlier `task-` → `stage-task-` rename): test ids aren't runtime API, so only consumers' suites are affected, never their users. Happy to add a `BREAKING CHANGE:` footer and cut a major if you'd rather signal it louder.

## Verification

`vitest --run src/canvas/components/StageNode` — 21 files, 292 tests passing (15 existing test references updated). Biome clean.

## Follow-up worth considering

`role="list"` / `role="listitem"` on the tasks section would make cards identifiable without depending on test ids at all, and carries a11y value. Out of scope here; happy to open it separately.
