### PR TITLE
fix(apollo-react): improve tooltip text contrast [MST-13173]

### DIFF
--- a/packages/apollo-react/src/canvas/components/Toolbox/ListView.tsx
+++ b/packages/apollo-react/src/canvas/components/Toolbox/ListView.tsx
@@ -394,7 +394,7 @@ const ListViewRow = memo(
       <div className="flex flex-col gap-0.5">
         {showName && <span className="text-sm">{item.name}</span>}
         {showDescription && (
-          <span className="text-xs text-foreground-muted">{item.description}</span>
+          <span className="text-xs text-foreground-inv-de-emp">{item.description}</span>
         )}
         {item.detail && <span className="text-xs">{item.detail}</span>}
       </div>


### PR DESCRIPTION
- Adjusts the tooltip description text to use inverse color since tooltips use inverse background.

| Before      | After |
| ----------- | ----------- |
|    <img width="622" height="131" alt="Screenshot 2026-08-04 at 4 33 50 PM" src="https://github.com/user-attachments/assets/49885de3-c5f3-4ecb-816c-b0eff8453ba2" /> | <img width="590" height="126" alt="Screenshot 2026-08-04 at 4 34 02 PM" src="https://github.com/user-attachments/assets/e515e2b6-eebb-4852-9c22-1195c749a859" /> |