### PR TITLE
fix(apollo-react): recompute preview connections only when they change

### DIFF
--- a/packages/apollo-react/src/canvas/components/AddNodePanel/AddNodePanel.types.ts
+++ b/packages/apollo-react/src/canvas/components/AddNodePanel/AddNodePanel.types.ts
@@ -19,6 +19,10 @@ export interface AddNodePanelProps {
   /**
    * The options to show in the panel.
    * When left undefined, the panel will generate options from the NodeTypeRegistry.
+   *
+   * Passed straight through to the Toolbox, so it carries the same requirement:
+   * memoize it and keep the same reference while the content is unchanged. A fresh
+   * array every render resets the list and re-runs any active search.
    */
   items?: ListItem[];
   loading?: boolean;

--- a/packages/apollo-react/src/canvas/components/Toolbox/Toolbox.tsx
+++ b/packages/apollo-react/src/canvas/components/Toolbox/Toolbox.tsx
@@ -71,6 +71,13 @@ export type ToolboxSearchHandler<T = any> = (
 
 export interface ToolboxProps<T> {
   title: string;
+  /**
+   * The root-level items. A new array reference is treated as a content change:
+   * it replaces the current items, rebuilds the navigation stack, and re-runs any
+   * active search (including an async `onSearch`). Memoize it and pass the same
+   * reference while the content is unchanged, or a caller that rebuilds the array
+   * every render will reset the list underneath the user.
+   */
   initialItems: ListItem<T>[];
   loading?: boolean;
   fullWidth?: boolean; // If true, the toolbox will be full width of the container.

--- a/packages/apollo-react/src/canvas/hooks/usePreviewNode.test.tsx
+++ b/packages/apollo-react/src/canvas/hooks/usePreviewNode.test.tsx
@@ -1,0 +1,227 @@
+import { act, renderHook } from '@testing-library/react';
+import {
+  type Edge,
+  type Node,
+  ReactFlowProvider,
+  useStoreApi,
+} from '@uipath/apollo-react/canvas/xyflow/react';
+import type { ReactNode } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { PREVIEW_EDGE_ID, PREVIEW_NODE_ID } from '../constants';
+import { NodeRegistryProvider } from '../core';
+import type { NodeManifest } from '../schema/node-definition';
+import { usePreviewNode } from './usePreviewNode';
+
+// These tests assert how the hook subscribes to the React Flow store, so they need the
+// real store instead of the stubbed one from the global canvas test mocks.
+vi.mock('@uipath/apollo-react/canvas/xyflow/react', async () => ({
+  ...(await vi.importActual('@uipath/apollo-react/canvas/xyflow/react')),
+}));
+
+const existingManifest = {
+  nodeType: 'existing',
+  display: { label: 'Existing', icon: 'agent', shape: 'rectangle' },
+  handleConfiguration: [
+    {
+      position: 'right',
+      boundary: 'outer',
+      handles: [{ id: 'output', type: 'source', handleType: 'output' }],
+    },
+  ],
+} as NodeManifest;
+
+const otherManifest = {
+  nodeType: 'other',
+  display: { label: 'Other', icon: 'tool', shape: 'rectangle' },
+  handleConfiguration: [
+    {
+      position: 'right',
+      boundary: 'outer',
+      handles: [{ id: 'output', type: 'source', handleType: 'output' }],
+    },
+  ],
+} as NodeManifest;
+
+// Hoisted so the provider's registry keeps a stable identity across renders — an inline
+// array would rebuild the registry and invalidate the memo the identity tests assert on.
+const registrations = [existingManifest, otherManifest];
+
+const existingNode: Node = {
+  id: 'existing-node',
+  type: 'existing',
+  position: { x: 0, y: 0 },
+  data: {},
+};
+
+const previewNode: Node = {
+  id: PREVIEW_NODE_ID,
+  type: 'preview',
+  position: { x: 100, y: 100 },
+  selected: true,
+  data: {},
+};
+
+const previewEdge: Edge = {
+  id: PREVIEW_EDGE_ID,
+  source: existingNode.id,
+  sourceHandle: 'output',
+  target: PREVIEW_NODE_ID,
+  targetHandle: 'input',
+};
+
+const Wrapper = ({ children }: { children: ReactNode }) => (
+  <ReactFlowProvider>
+    <NodeRegistryProvider registrations={registrations}>{children}</NodeRegistryProvider>
+  </ReactFlowProvider>
+);
+
+/** Renders the hook alongside the store api so tests can drive store updates directly. */
+function renderPreviewNodeHook({ nodes, edges }: { nodes: Node[]; edges: Edge[] }) {
+  const result = renderHook(
+    () => ({
+      preview: usePreviewNode(),
+      store: useStoreApi(),
+    }),
+    { wrapper: Wrapper }
+  );
+
+  act(() => {
+    result.result.current.store.getState().setNodes(nodes);
+    result.result.current.store.getState().setEdges(edges);
+  });
+
+  return result;
+}
+
+describe('usePreviewNode', () => {
+  it('returns connection info for the selected preview node', () => {
+    const { result } = renderPreviewNodeHook({
+      nodes: [existingNode, previewNode],
+      edges: [previewEdge],
+    });
+
+    expect(result.current.preview.previewNode?.id).toBe(PREVIEW_NODE_ID);
+    expect(result.current.preview.previewNodeConnectionInfo).toEqual([
+      {
+        addNewNodeAsSource: false,
+        existingNodeId: existingNode.id,
+        existingHandleId: 'output',
+        existingNodeManifest: expect.objectContaining({ nodeType: 'existing' }),
+        existingHandleManifest: expect.objectContaining({ id: 'output' }),
+        previewEdgeId: PREVIEW_EDGE_ID,
+      },
+    ]);
+  });
+
+  it('returns null when no preview node is selected', () => {
+    const { result } = renderPreviewNodeHook({
+      nodes: [existingNode, { ...previewNode, selected: false }],
+      edges: [previewEdge],
+    });
+
+    expect(result.current.preview.previewNode).toBeNull();
+    expect(result.current.preview.previewNodeConnectionInfo).toBeNull();
+  });
+
+  it('keeps the same connection info reference across unrelated store updates', () => {
+    const { result } = renderPreviewNodeHook({
+      nodes: [existingNode, previewNode],
+      edges: [previewEdge],
+    });
+
+    const initial = result.current.preview.previewNodeConnectionInfo;
+    expect(initial).toHaveLength(1);
+
+    // Viewport change: touches the store but not the preview connections.
+    act(() => {
+      result.current.store.setState({ transform: [10, 20, 1.5] });
+    });
+    expect(result.current.preview.previewNodeConnectionInfo).toBe(initial);
+
+    // Preview node drag: replaces the nodes array and the preview node object.
+    act(() => {
+      result.current.store
+        .getState()
+        .setNodes([existingNode, { ...previewNode, position: { x: 400, y: 500 } }]);
+    });
+    expect(result.current.preview.previewNodeConnectionInfo).toBe(initial);
+
+    // Unrelated edge added: the preview connections are unchanged.
+    act(() => {
+      result.current.store
+        .getState()
+        .setEdges([previewEdge, { id: 'other', source: 'a', target: 'b' }]);
+    });
+    expect(result.current.preview.previewNodeConnectionInfo).toBe(initial);
+
+    // Equivalent edges: new edge objects, identical connection topology. Holds because
+    // the signature compares by value rather than by reference.
+    act(() => {
+      result.current.store.getState().setEdges([{ ...previewEdge }]);
+    });
+    expect(result.current.preview.previewNodeConnectionInfo).toBe(initial);
+  });
+
+  it('ignores a handle change that resolves to the same effective handle', () => {
+    // An omitted source handle resolves to 'output', the same value an explicit
+    // 'output' resolves to, so the connection info is unchanged either way.
+    const { result } = renderPreviewNodeHook({
+      nodes: [existingNode, previewNode],
+      edges: [{ ...previewEdge, sourceHandle: null }],
+    });
+
+    const initial = result.current.preview.previewNodeConnectionInfo;
+    expect(initial?.[0]?.existingHandleId).toBe('output');
+
+    act(() => {
+      result.current.store.getState().setEdges([{ ...previewEdge, sourceHandle: 'output' }]);
+    });
+
+    expect(result.current.preview.previewNodeConnectionInfo).toBe(initial);
+  });
+
+  it('recomputes when the connected node changes type', () => {
+    // Both manifests are looked up from the node type, so a type change has to invalidate
+    // even though every edge field stayed the same.
+    const { result } = renderPreviewNodeHook({
+      nodes: [existingNode, previewNode],
+      edges: [previewEdge],
+    });
+
+    const initial = result.current.preview.previewNodeConnectionInfo;
+    expect(initial?.[0]?.existingNodeManifest?.nodeType).toBe('existing');
+
+    act(() => {
+      result.current.store.getState().setNodes([{ ...existingNode, type: 'other' }, previewNode]);
+    });
+
+    expect(result.current.preview.previewNodeConnectionInfo).not.toBe(initial);
+    expect(
+      result.current.preview.previewNodeConnectionInfo?.[0]?.existingNodeManifest?.nodeType
+    ).toBe('other');
+  });
+
+  it('recomputes connection info when the preview connections change', () => {
+    const { result } = renderPreviewNodeHook({
+      nodes: [existingNode, previewNode],
+      edges: [previewEdge],
+    });
+
+    const initial = result.current.preview.previewNodeConnectionInfo;
+
+    act(() => {
+      result.current.store
+        .getState()
+        .setEdges([{ ...previewEdge, source: PREVIEW_NODE_ID, target: existingNode.id }]);
+    });
+
+    expect(result.current.preview.previewNodeConnectionInfo).not.toBe(initial);
+    expect(result.current.preview.previewNodeConnectionInfo).toEqual([
+      expect.objectContaining({
+        addNewNodeAsSource: true,
+        existingNodeId: existingNode.id,
+        existingHandleId: 'input',
+      }),
+    ]);
+  });
+});

--- a/packages/apollo-react/src/canvas/hooks/usePreviewNode.ts
+++ b/packages/apollo-react/src/canvas/hooks/usePreviewNode.ts
@@ -6,7 +6,6 @@ import {
   useStore,
 } from '@uipath/apollo-react/canvas/xyflow/react';
 import { useMemo } from 'react';
-import { shallow } from 'zustand/shallow';
 import { PREVIEW_NODE_ID } from '../constants';
 import { useOptionalNodeTypeRegistry } from '../core';
 import type { HandleManifest, NodeManifest } from '../schema/node-definition';
@@ -34,22 +33,38 @@ export interface PreviewNodeConnectionInfo {
 }
 
 // Optimized selector - return boolean to prevent re-renders on position changes
-const previewNodeSelectedSelector = (state: ReactFlowState) => {
-  const node = state.nodes.find((n) => n.id === PREVIEW_NODE_ID);
-  return node?.selected ?? false;
+const previewNodeSelectedSelector = (state: ReactFlowState) =>
+  state.nodeLookup.get(PREVIEW_NODE_ID)?.selected ?? false;
+
+/**
+ * One key per preview connection, built from the same values `connectionInfo` derives below,
+ * so the subscription invalidates exactly when the computed output would change. Notably the
+ * handles are defaulted here the same way, and the node type is included because both manifest
+ * lookups hang off it.
+ *
+ * Order is deliberately preserved by the caller: consumers treat the first connection as the
+ * primary one, so a reordering has to produce a new array rather than reuse the old order.
+ */
+const previewConnectionKey = (edge: Edge, state: ReactFlowState): string => {
+  const sourceIsPreviewNode = edge.source === PREVIEW_NODE_ID;
+  const existingNodeId = sourceIsPreviewNode ? edge.target : edge.source;
+  const existingHandleId = sourceIsPreviewNode
+    ? edge.targetHandle || 'input'
+    : edge.sourceHandle || 'output';
+  const existingNodeType = state.nodeLookup.get(existingNodeId)?.type ?? '';
+
+  return `${edge.id},${existingNodeId},${existingHandleId},${existingNodeType},${sourceIsPreviewNode}`;
 };
 
-// Selector to track edges connected to preview node
-// Returns minimal edge data to avoid unnecessary re-renders
-const edgesConnectedToPreviewSelector = (state: ReactFlowState): Edge[] => {
-  return state.edges.filter(isPreviewEdge).map((edge) => ({
-    id: edge.id,
-    source: edge.source,
-    target: edge.target,
-    sourceHandle: edge.sourceHandle,
-    targetHandle: edge.targetHandle,
-  }));
-};
+// Selector to track edges connected to the preview node.
+// Returns a primitive signature rather than edge objects, so the subscription stays
+// memoized even when a caller hands React Flow equivalent but newly allocated edges.
+// Returning objects here (even copies) would compare unequal on every store update.
+const previewEdgeSignatureSelector = (state: ReactFlowState): string =>
+  state.edges
+    .filter(isPreviewEdge)
+    .map((edge) => previewConnectionKey(edge, state))
+    .join('|');
 
 interface UsePreviewNodeResult {
   /** The currently selected preview node, or null if no preview node is selected. */
@@ -68,15 +83,17 @@ interface UsePreviewNodeResult {
  * about all connected edges and pre-computes handle manifests for efficient
  * constraint validation in the Add Node Panel.
  *
- * Performance optimization: Uses boolean selector for node selection and tracks
- * edges separately to prevent re-renders when only the preview node position changes.
+ * Performance optimization: both store selectors return primitives, so the hook only
+ * re-renders when the preview node's selection state or its connections change, not on
+ * position changes or unrelated store updates. `previewNode` is therefore a snapshot from
+ * the last such change; read the live node via `getNode` when up-to-date data is needed.
  *
  * @returns Object containing the preview node and its connection information.
  */
 export const usePreviewNode = (): UsePreviewNodeResult => {
   const reactFlowInstance = useReactFlow();
   const isPreviewNodeSelected = useStore(previewNodeSelectedSelector);
-  const previewEdges = useStore(edgesConnectedToPreviewSelector, shallow);
+  const previewEdgeSignature = useStore(previewEdgeSignatureSelector);
   const registry = useOptionalNodeTypeRegistry();
 
   // Get the actual node object for the return value (doesn't affect memoization)
@@ -85,12 +102,18 @@ export const usePreviewNode = (): UsePreviewNodeResult => {
     : null;
 
   // Extract connection info when preview node is selected.
-  // This now only recalculates when selection state or edges change, not on position changes.
+  // This only recalculates when the selection state or the preview connections change,
+  // not on position changes or any other unrelated React Flow store update.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: previewEdgeSignature is the cache key for the edges read via getEdges().
   const connectionInfo: Array<PreviewNodeConnectionInfo> | null = useMemo(() => {
     if (!isPreviewNodeSelected) {
       // Preview node was deselected - clear connection info.
       return null;
     }
+
+    // Read the edges on demand, keyed by the signature above, so the subscription
+    // doesn't have to hold on to edge objects.
+    const previewEdges = reactFlowInstance.getEdges().filter(isPreviewEdge);
 
     // Build connection info with cached handle manifests.
     const connections = previewEdges.map((previewEdge) => {
@@ -132,7 +155,7 @@ export const usePreviewNode = (): UsePreviewNodeResult => {
       };
     });
     return connections;
-  }, [isPreviewNodeSelected, previewEdges, reactFlowInstance, registry]);
+  }, [isPreviewNodeSelected, previewEdgeSignature, reactFlowInstance, registry]);
 
   return { previewNode, previewNodeConnectionInfo: connectionInfo };
 };


### PR DESCRIPTION
## Summary

MST-11892: pressing CMD in the add-node panel after a search toggles the list items.

Root cause is that `usePreviewNode` rebuilt its connection info on **every** React Flow store update while the panel was open, not just when the preview connections changed. The edge selector mapped each edge into a fresh object literal, so the `shallow` equality guard it was paired with compared unequal every time (zustand's `shallow` compares array elements with `Object.is`). The "performance optimization" comment above it described intent the `.map()` cancelled out.

CMD is React Flow's default `multiSelectionKeyCode`, and its global key handler writes `store.setState({ multiSelectionActive })` on each press and release — so a bare CMD keypress was enough to trigger the whole chain. Each new `connectionInfo` array invalidated `AddNodePanel`'s `useMemo`, re-running a full category-tree constraint filter and flatten, whose new `ListItem[]` identity made the Toolbox reset its navigation state and re-run the active search. Same chain fires on pan, zoom, and node drags; CMD-after-search is just the most visible symptom.

## Changes

- `usePreviewNode`: the edge selector now returns a primitive signature instead of edge objects, so the subscription stays memoized when the preview connections are unchanged. The memo is keyed on that signature and reads the edges via `getEdges()`. The now-pointless `zustand/shallow` import is gone.
- `usePreviewNode`: the selection selector uses `state.nodeLookup.get(...)` (O(1)) instead of `state.nodes.find(...)` (O(nodes) on every store notification, for an always-mounted component).
- New `usePreviewNode.test.tsx` — 4 cases, including identity stability across a viewport change, a preview-node drag, an unrelated edge, and equivalent-but-new edge objects. Verified to fail against the previous implementation.
- Doc comments on `ToolboxProps.initialItems` and `AddNodePanelProps.items` recording that a new array reference is treated as a content change (resets navigation, re-runs active search), so the stability requirement is visible to callers.

## Flow

```mermaid
flowchart TD
    A["CMD pressed (or pan / zoom / drag)"] --> B["store.setState({ multiSelectionActive })"]
    B --> C[edge selector runs]
    C --> D{equality check}
    D -->|"before: .map() to new objects<br/>shallow always false"| E[new connectionInfo array]
    D -->|"after: primitive signature<br/>equal when unchanged"| F[same array, memo holds]
    E --> G[AddNodePanel re-runs getNodeOptions<br/>tree filter + flatten + adapter]
    G --> H[new ListItem identity]
    H --> I[Toolbox resets navigation<br/>+ re-runs active search]
    F --> J[no downstream work]
```

## Testing

- [x] `pnpm lint` passes (JS, CSS, deps)
- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes — 136 files, 2299 tests
- [ ] `pnpm test:visual` — no `test:visual` task is defined in any package; no rendered output changes in this PR
- [x] New regression test verified to fail against the pre-fix implementation
- [x] Type-safe (no `as any` / type suppressions added)

**Reviewer note:** the CMD → `multiSelectionActive` → panel-rebuild chain is verified at the code level and by the new test (a bare store write no longer invalidates the memo). The reported *disabled-looking rows* are downstream of that rebuild; worth a manual confirm in the app that the visual symptom is gone, since I did not reproduce the rendering end-to-end.

### Note on behavior

The returned `previewNode` no longer refreshes on preview-node *position* changes — which is what the hook's docblock already claimed. Consumers don't depend on a live position: `AddNodeManager` uses it for truthiness and `data.originalEdge`, `FloatingCanvasPanel` positions itself from `nodeId`, and `handleNodeSelect` re-reads the node via `getNode`. The docblock now states this explicitly.
