### PR TITLE
fix(apollo-react): align Material switch and icon button with apollo-mui5

### DIFF
--- a/packages/apollo-react/src/material/theme/overrides/MuiIconButton.ts
+++ b/packages/apollo-react/src/material/theme/overrides/MuiIconButton.ts
@@ -7,13 +7,21 @@ export const MuiIconButton = (palette: Palette): ComponentsOverrides['MuiIconBut
     padding: token.Padding.PadL,
     '&&:hover': { backgroundColor: palette.semantic.colorIconButtonHover },
     '&&:focus-visible': { boxShadow: `inset 0 0 0 1px ${palette.semantic.colorBackground}` },
-    '&.MuiIconButton-colorPrimary:not(.Mui-disabled)': { color: palette.semantic.colorPrimary },
+    '&.MuiIconButton-colorPrimary:not(.Mui-disabled)': {
+      color: palette.semantic.colorPrimary,
+      '&&:hover': { backgroundColor: palette.semantic.colorIconButtonHover },
+      '&&:focus-visible': {
+        backgroundColor: palette.semantic.colorIconButtonHover,
+        outline: `2px solid ${palette.semantic.colorFocusIndicator} !important`,
+      },
+      '&&:active': { backgroundColor: palette.semantic.colorIconButtonPressed },
+    },
     '&.MuiIconButton-colorSecondary:not(.Mui-disabled)': {
       color: palette.semantic.colorIconDefault,
       '&&:hover': { backgroundColor: palette.semantic.colorIconButtonHover },
       '&&:focus-visible': {
         backgroundColor: palette.semantic.colorIconButtonHover,
-        outline: `${palette.semantic.colorFocusIndicator} solid 2px !important`,
+        outline: `2px solid ${palette.semantic.colorFocusIndicator} !important`,
       },
       '&&:active': { backgroundColor: palette.semantic.colorIconButtonPressed },
     },

--- a/packages/apollo-react/src/material/theme/overrides/MuiSwitch.ts
+++ b/packages/apollo-react/src/material/theme/overrides/MuiSwitch.ts
@@ -1,36 +1,33 @@
 import type { ComponentsOverrides } from '@mui/material/styles';
-import token from '@uipath/apollo-core';
 import type { Palette } from '@uipath/apollo-core/tokens/jss/palette';
 
 export const MuiSwitch = (palette: Palette): ComponentsOverrides['MuiSwitch'] => ({
   root: {
-    padding: token.Padding.PadXxl,
-    width: '60px',
-    height: '40px',
+    width: '40px',
+    height: '20px',
+    padding: 0,
+    borderRadius: '10px',
+    marginRight: '8px',
     '&:has(.Mui-focusVisible)': {
       outline: `2px solid ${palette.semantic.colorFocusIndicator}`,
       outlineOffset: '2px',
     },
     '& .MuiSwitch-switchBase': {
-      padding: token.Padding.PadXl,
-      marginLeft: '2px',
+      padding: 0,
+      '&.Mui-focusVisible': {
+        outline: 'unset',
+        backgroundColor: 'unset',
+      },
       '&.Mui-checked': {
-        transform: 'translateX(16px)',
         '&.Mui-focusVisible': {
           outline: 'unset',
           backgroundColor: 'unset',
         },
       },
-      '&.Mui-focusVisible': {
-        outline: `2px solid ${palette.semantic.colorFocusIndicator} !important`,
-        boxShadow: `inset 0 0 0 1px ${palette.semantic.colorBackground}`,
-        backgroundColor: 'unset',
-      },
     },
     '& .MuiSwitch-track': {
       backgroundColor: palette.semantic.colorForegroundDeEmp,
       opacity: 1,
-      borderRadius: '10px',
     },
     '& .MuiSwitch-thumb': {
       backgroundColor: palette.semantic.colorBackground,
@@ -40,8 +37,7 @@ export const MuiSwitch = (palette: Palette): ComponentsOverrides['MuiSwitch'] =>
       position: 'relative',
       top: '3px',
       left: '3px',
-      boxShadow:
-        'rgba(0, 0, 0, 0.12) 0px 2px 1px -1px, rgba(0, 0, 0, 0.14) 0px 1px 1px 0px, rgba(0, 0, 0, 0.2) 0px 1px 3px 0px',
+      boxShadow: 'unset',
     },
     '& .MuiSwitch-switchBase.Mui-disabled + .MuiSwitch-track': {
       backgroundColor: palette.semantic.colorToggleTrackOffDisabled,
@@ -49,8 +45,6 @@ export const MuiSwitch = (palette: Palette): ComponentsOverrides['MuiSwitch'] =>
     },
     '& .MuiSwitch-switchBase.Mui-disabled .MuiSwitch-thumb': {
       backgroundColor: palette.semantic.colorForegroundDisable,
-      boxShadow:
-        'rgba(0, 0, 0, 0.06) 0px 2px 1px 0px, rgba(0, 0, 0, 0.07) 0px 1px 1px 0px, rgba(0, 0, 0, 0.1) 0px 1px 3px 0px !important',
     },
     '& .MuiSwitch-switchBase.Mui-checked + .MuiSwitch-track': {
       backgroundColor: palette.semantic.colorToggleThumbOn,
@@ -59,27 +53,11 @@ export const MuiSwitch = (palette: Palette): ComponentsOverrides['MuiSwitch'] =>
     '& .MuiSwitch-switchBase.Mui-checked .MuiSwitch-thumb': {
       backgroundColor: palette.semantic.colorBackground,
     },
-
     '& .MuiSwitch-switchBase.Mui-checked.Mui-disabled + .MuiSwitch-track': {
       backgroundColor: palette.semantic.colorBackgroundDisabled,
     },
-
     '& .MuiSwitch-switchBase.Mui-checked.Mui-disabled .MuiSwitch-thumb': {
       backgroundColor: palette.semantic.colorForegroundDisable,
     },
   },
-  thumb: {
-    boxShadow:
-      'rgba(0, 0, 0, 0.12) 0px 2px 1px -1px, rgba(0, 0, 0, 0.14) 0px 1px 1px 0px, rgba(0, 0, 0, 0.2) 0px 1px 3px 0px',
-  },
-  switchBase: {
-    padding: token.Padding.PadXl,
-    marginLeft: '2px',
-    '&.Mui-checked': { transform: 'translateX(16px)' },
-    '&.Mui-focusVisible': {
-      outline: `2px solid ${palette.semantic.colorFocusIndicator} !important`,
-      boxShadow: `inset 0 0 0 1px ${palette.semantic.colorBackground}`,
-    },
-  },
-  track: { borderRadius: '10px' },
 });


### PR DESCRIPTION
## Why

apollo-design-system is consolidating `apollo-mui5` onto these themes ([apollo-design-system#5354](https://github.com/UiPath/apollo-design-system/pull/5354)) so React Material theming has one source of truth. That surfaced places where apollo-react's overrides have drifted from apollo-mui5's since [`9633023b`](https://github.com/UiPath/apollo-ui/commit/9633023b) ("merge remaining overrides from apollo", Jan 2026), and adopting them as-is would push those changes into portal-shell and Portal.

## What

Two independent commits:

1. **`MuiSwitch`: restore compact geometry.** 60x40 with 12px padding and an elevated thumb goes back to 40x20, padding 0, flat thumb. Also drops the duplicated `thumb`/`switchBase`/`track` slots that repeated what `root` already sets. The old geometry is MUI's default box model; the compact one is what apollo-mui5 ships today. Portal's org-settings UI-customization table has 14 switches, each row 20px taller under the new geometry.
2. **`MuiIconButton`: give primary a visible focus ring.** `colorSecondary` had hover/focus-visible/active; `colorPrimary` had only a colour, so it fell through to the generic root rule whose focus affordance is `inset 0 0 0 1px colorBackground`: an inset ring in the *background* colour, invisible against the surface it sits on. This is the missing tenant focus indicator. Both colours now share one block, keeping the 2px focus-indicator outline this package already used for secondary.

**Dropped from this PR:** a third commit removed the fixed `24/32/40` width/height per icon-button size so the box would size from padding, matching apollo-mui5. The storybook diff showed why those fixed sizes exist here: without them the box grows to icon + 16px padding, icons render larger, and flex rows that hold plain `IconButton`s (ap-chat header and input actions) visibly shift. Icon-button sizing needs its own deliberate change, decided together with the consumers it moves; until then apollo-design-system#5354 keeps apollo-mui5's own padding-only `MuiIconButton` sizing as a documented divergence.

## Verification

Diffed with [`sbdiff`](https://github.com/UiPath/storybook-diff) against apollo-design-system's `apollo-mui5` storybook (published `2.31.26` as baseline, a local build carrying these changes as current):

| Stories | Before | After |
| --- | --- | --- |
| `controls-switch--*` (32, all four classic themes) | changed, ~0.086% pixels | **pass, pixel-identical** |

With the sizing commit dropped, this PR should produce no static visual change in apollo-react's own storybook beyond the intended switch compacting: the focus ring only renders on `:focus-visible`, which the stories don't capture. The previous diff report's icon-button/chat changes came from the dropped commit.

`tsc --noEmit` and `biome` are clean on apollo-react for the touched files. Note `pnpm build` currently fails at ESM declaration generation on this branch **and on `main`** in my worktree, so that failure is pre-existing and unrelated.

## Note

The generic root `&&:focus-visible` still sets `inset 0 0 0 1px colorBackground`, so an icon button that is neither primary nor secondary keeps an invisible focus ring. Left untouched here to keep the diff tight; happy to fold it in.

Once this releases, apollo-design-system#5354 bumps to pick it up.
