### PR TITLE
Fix manual alignment hinting

### DIFF
--- a/packages/apollo-react/src/canvas/components/AlignmentGuides/AlignmentGuides.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/AlignmentGuides/AlignmentGuides.stories.tsx
@@ -3,6 +3,7 @@ import type { Edge, Node } from '@uipath/apollo-react/canvas/xyflow/react';
 import { BackgroundVariant, Panel } from '@uipath/apollo-react/canvas/xyflow/react';
 import {
   type Dispatch,
+  type MouseEvent,
   type ReactNode,
   type SetStateAction,
   useCallback,
@@ -336,6 +337,18 @@ function MultiSelectDemo() {
   const { guides, draggedBounds, onNodeDrag, onNodeDragStop } = useAlignmentGuides(nodes, {
     onSnap,
   });
+  const onNodeClick = useCallback(
+    (event: MouseEvent, clickedNode: Node) => {
+      if (!event.shiftKey) return;
+
+      const selectedIds = new Set(nodes.filter(({ selected }) => selected).map(({ id }) => id));
+      selectedIds.add(clickedNode.id);
+      setNodes((currentNodes) =>
+        currentNodes.map((node) => ({ ...node, selected: selectedIds.has(node.id) }))
+      );
+    },
+    [nodes, setNodes]
+  );
 
   return (
     <BaseCanvas
@@ -344,6 +357,8 @@ function MultiSelectDemo() {
       multiSelectionKeyCode="Shift"
       selectionKeyCode={null}
       selectionOnDrag
+      selectNodesOnDrag={false}
+      onNodeClick={onNodeClick}
       onNodeDrag={onNodeDrag}
       onNodeDragStop={onNodeDragStop}
     >

--- a/packages/apollo-react/src/canvas/components/AlignmentGuides/useAlignmentGuides.test.ts
+++ b/packages/apollo-react/src/canvas/components/AlignmentGuides/useAlignmentGuides.test.ts
@@ -85,6 +85,16 @@ describe('computeAlignmentSnapDelta', () => {
     ).toEqual([300, 350, 400]);
   });
 
+  it('uses unique guide IDs when zero-size bounds share every anchor', () => {
+    const existing = [bounds('existing', 300, 100, 0, 0)];
+    const dragged = bounds('dragged', 300, 100, 0, 0);
+
+    const { guides } = computeAlignmentResult(dragged, existing, 8);
+
+    expect(guides).toHaveLength(6);
+    expect(new Set(guides.map(({ id }) => id)).size).toBe(guides.length);
+  });
+
   it('applies one rigid delta to every node in a multi-selection', () => {
     const selected = [
       { id: 'first', position: { x: 100, y: 200 } },

--- a/packages/apollo-react/src/canvas/components/AlignmentGuides/useAlignmentGuides.test.ts
+++ b/packages/apollo-react/src/canvas/components/AlignmentGuides/useAlignmentGuides.test.ts
@@ -64,7 +64,25 @@ describe('computeAlignmentSnapDelta', () => {
     const result = computeAlignmentResult(dragged, existing, 8);
 
     expect(result.delta.dx).toBe(-5);
-    expect(result.guides.find(({ orientation }) => orientation === 'vertical')?.position).toBe(350);
+    expect(
+      result.guides.some(
+        ({ orientation, position }) => orientation === 'vertical' && position === 350
+      )
+    ).toBe(true);
+  });
+
+  it('shows left, center, and right guides when equal-size nodes align', () => {
+    const existing = [bounds('existing', 300, 100)];
+    const dragged = bounds('dragged', 305, 300);
+
+    const result = computeAlignmentResult(dragged, existing, 8);
+
+    expect(result.delta.dx).toBe(-5);
+    expect(
+      result.guides
+        .filter(({ orientation }) => orientation === 'vertical')
+        .map(({ position }) => position)
+    ).toEqual([300, 350, 400]);
   });
 
   it('applies one rigid delta to every node in a multi-selection', () => {

--- a/packages/apollo-react/src/canvas/components/AlignmentGuides/useAlignmentGuides.ts
+++ b/packages/apollo-react/src/canvas/components/AlignmentGuides/useAlignmentGuides.ts
@@ -116,7 +116,7 @@ function buildAlignedGuides(
 
     return [
       {
-        id: `${orientation}-${position}`,
+        id: `${orientation}-${draggedIndex}-${position}`,
         orientation,
         position,
         start: Math.min(...ranges.map(([rangeStart]) => rangeStart)),

--- a/packages/apollo-react/src/canvas/components/AlignmentGuides/useAlignmentGuides.ts
+++ b/packages/apollo-react/src/canvas/components/AlignmentGuides/useAlignmentGuides.ts
@@ -92,38 +92,47 @@ function resolveAxisCandidate(
     )[0];
 }
 
-function buildGuide(
-  candidate: AxisCandidate,
+function buildAlignedGuides(
   dragged: NodeBounds,
   others: NodeBounds[],
   orientation: 'vertical' | 'horizontal'
-): AlignmentGuideLine {
-  const matchingOthers = others.filter((other) => {
-    const anchors = getAxisAnchors(other, orientation);
-    const candidateAnchors = candidate.kind === 'center' ? [anchors[1]] : [anchors[0], anchors[2]];
-    return candidateAnchors.some((anchor) => Math.abs(anchor - candidate.position) < 0.5);
-  });
-  const ranges = [dragged, ...matchingOthers].map((bounds) =>
-    orientation === 'vertical'
-      ? ([bounds.y1, bounds.y2] as const)
-      : ([bounds.x1, bounds.x2] as const)
-  );
+): AlignmentGuideLine[] {
+  const draggedAnchors = getAxisAnchors(dragged, orientation);
 
-  return {
-    id: `${orientation}-${candidate.position}`,
-    orientation,
-    position: candidate.position,
-    start: Math.min(...ranges.map(([rangeStart]) => rangeStart)),
-    end: Math.max(...ranges.map(([, rangeEnd]) => rangeEnd)),
-    kind: candidate.kind,
-    matchedNodeIds: matchingOthers.map(({ id }) => id),
-  };
+  return draggedAnchors.flatMap((position, draggedIndex) => {
+    const matchingOthers = others.filter((other) => {
+      const anchors = getAxisAnchors(other, orientation);
+      const comparableAnchors = draggedIndex === 1 ? [anchors[1]] : [anchors[0], anchors[2]];
+      return comparableAnchors.some((anchor) => Math.abs(anchor - position) < 0.5);
+    });
+
+    if (matchingOthers.length === 0) return [];
+
+    const ranges = [dragged, ...matchingOthers].map((bounds) =>
+      orientation === 'vertical'
+        ? ([bounds.y1, bounds.y2] as const)
+        : ([bounds.x1, bounds.x2] as const)
+    );
+
+    return [
+      {
+        id: `${orientation}-${position}`,
+        orientation,
+        position,
+        start: Math.min(...ranges.map(([rangeStart]) => rangeStart)),
+        end: Math.max(...ranges.map(([, rangeEnd]) => rangeEnd)),
+        kind: draggedIndex === 1 ? 'center' : 'edge',
+        matchedNodeIds: matchingOthers.map(({ id }) => id),
+      },
+    ];
+  });
 }
 
 /**
- * Resolves the single winning alignment candidate on each axis. The returned
- * guide lines and snap delta come from the same candidates, so the visual cue
- * can never disagree with the position applied by a consumer.
+ * Resolves the single winning snap candidate on each axis, then renders every
+ * exact edge/center match at that snapped position. This keeps placement
+ * deterministic while showing the full left/center/right alignment hint for
+ * equal-size nodes.
  */
 export function computeAlignmentResult(
   dragged: NodeBounds,
@@ -143,8 +152,8 @@ export function computeAlignmentResult(
     cy: dragged.cy + delta.dy,
   };
   const guides = [
-    ...(vertical ? [buildGuide(vertical, snapped, others, 'vertical')] : []),
-    ...(horizontal ? [buildGuide(horizontal, snapped, others, 'horizontal')] : []),
+    ...(vertical ? buildAlignedGuides(snapped, others, 'vertical') : []),
+    ...(horizontal ? buildAlignedGuides(snapped, others, 'horizontal') : []),
   ];
 
   return { guides, delta };


### PR DESCRIPTION
## Summary

This PR fixes two issues found while reviewing canvas alignment guides.

<img width="1905" height="1422" alt="Screenshot 2026-08-05 at 8 22 35 AM" src="https://github.com/user-attachments/assets/88976845-b172-4088-9d8f-b79e4fb487b0" />
<img width="1905" height="1422" alt="Screenshot 2026-08-05 at 8 22 32 AM" src="https://github.com/user-attachments/assets/d6456fe3-264b-4582-a76a-72f57c7975f0" />

### 1. Restore the three-line alignment hint

- Equal-size aligned nodes once again show their left edge, center, and right edge guides.
- Magnetic placement still uses one deterministic winning candidate per axis, so snapping remains stable and unchanged.
- The additional lines are visual confirmation derived from the final snapped geometry.

### 2. Fix Shift-click multi-selection

- Shift-clicking a second node now preserves the first selection and adds the second node.
- Selected nodes can then be dragged together as a group.
- The multi-select story uses the click event's actual Shift modifier state instead of relying solely on React Flow's iframe-level key tracking.

## Root cause

During PR #956's finalization, snapping and visual guide selection were coupled around one winning candidate per axis. That correctly made snapping deterministic, but unintentionally reduced the approved left/center/right visual treatment to one guide.

The multi-select story also relied on React Flow's global modifier-key state. In Storybook's iframe, that state was not reliably active when node selection occurred, causing the second Shift-click to replace rather than extend the selection.

## User impact

Users receive the intended three-line visual confirmation without any change to final snapped placement. The multi-select example now behaves as documented, allowing multiple nodes to be selected with Shift-click and dragged together.

## Validation

- `pnpm --filter @uipath/apollo-react exec vitest --run src/canvas/components/AlignmentGuides/useAlignmentGuides.test.ts` — 10 tests passed
- `pnpm --filter @uipath/apollo-react format:check` — passed
- Verified the Alignment Guides story locally
- Verified Shift-click retains both selections in Multi-select Drag
- Verified selected nodes drag together
