### PR TITLE
fix(apollo-react): prevent native image drag on URL-based icons

### DIFF
--- a/packages/apollo-react/src/canvas/components/AgentCanvas/components/ToolResourceIcon/ToolResourceIcon.tsx
+++ b/packages/apollo-react/src/canvas/components/AgentCanvas/components/ToolResourceIcon/ToolResourceIcon.tsx
@@ -26,6 +26,7 @@ export const ToolResourceIcon = ({ size = 24, tool }: ToolResourceIconProps) => 
       <img
         src={tool.iconUrl}
         alt={tool.name}
+        draggable={false}
         style={{ width: size, height: size, objectFit: 'contain' }}
         onError={() => setImgError(true)}
       />

--- a/packages/apollo-react/src/canvas/components/Toolbox/ListView.tsx
+++ b/packages/apollo-react/src/canvas/components/Toolbox/ListView.tsx
@@ -340,7 +340,9 @@ const ListViewRow = memo(
           style={item.contentColor ? { color: item.contentColor } : undefined}
           data-testid="list-item-icon"
         >
-          {item.icon?.url && <img src={item.icon?.url} alt={item.name} className="w-5 h-5" />}
+          {item.icon?.url && (
+            <img src={item.icon?.url} alt={item.name} draggable={false} className="w-5 h-5" />
+          )}
           {item.icon?.name && <CanvasIcon icon={item.icon.name} size={20} />}
           {item.icon?.Component && <item.icon.Component />}
           {!item.icon?.url && !item.icon?.name && !item.icon?.Component && (

--- a/packages/apollo-react/src/canvas/utils/icon-registry.test.tsx
+++ b/packages/apollo-react/src/canvas/utils/icon-registry.test.tsx
@@ -33,6 +33,7 @@ describe('getIcon', () => {
     const img = container.querySelector('img');
     expect(img).toBeInTheDocument();
     expect(img).toHaveAttribute('src', 'https://example.com/icon.svg');
+    expect(img).toHaveAttribute('draggable', 'false');
   });
 
   it('returns the CaseManagementProject icon for the registered case-management id', () => {

--- a/packages/apollo-react/src/canvas/utils/icon-registry.tsx
+++ b/packages/apollo-react/src/canvas/utils/icon-registry.tsx
@@ -86,6 +86,7 @@ export function getIcon(iconId?: string): IconComponent {
       <img
         src={iconId}
         alt="icon"
+        draggable={false}
         style={{
           width: w,
           height: h,


### PR DESCRIPTION
## Summary

MST-13226: dragging a node whose icon is an image URL kicked off the browser's
native image drag, which surfaced as a file-drop operation instead of moving the
node. The three places that render an icon from a URL inside a drag-capable
surface now opt out of native image dragging with `draggable={false}`, matching
the pattern already used for sticky-note media.

The ticket suggested fixing this in BaseNode. The actual root cause sits one
level lower, in the icon registry's URL branch, so the fix lands there and
covers every `CanvasIcon` consumer rather than BaseNode alone.

## Changes

- `utils/icon-registry.tsx` — the URL branch of `getIcon` sets
  `draggable={false}`. This is the BaseNode path (`BaseNode.tsx` resolves
  `display.icon` through `getIcon`), and it also fixes every other
  `CanvasIcon` / `getIcon` call site.
- `components/Toolbox/ListView.tsx` — the list item's `item.icon.url` image no
  longer competes with the row's drag-to-canvas gesture.
- `components/AgentCanvas/components/ToolResourceIcon/ToolResourceIcon.tsx` —
  same bug in the AgentCanvas node-icon path (`ResourceNode` renders it at size
  48 inside a draggable node).
- `utils/icon-registry.test.tsx` — the existing URL-icon test now asserts the
  attribute so it cannot silently regress.

## Flow

```mermaid
flowchart TD
    A[Pointer down on node icon] --> B{icon is an http/https URL?}
    B -- no --> C[Inline SVG, no native drag]
    B -- yes --> D["img draggable=false"]
    C --> E[React Flow moves the node]
    D --> E
    D -. before .-> F[Native image drag, became a file drop]
```

## Testing

- [x] `pnpm lint` passes (JS; no CSS tasks in the affected packages)
- [x] `pnpm lint:deps` + `pnpm check:dependencies` pass
- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes (apollo-react: 136 files, 2303 tests)
- [x] `pnpm test:visual` — not applicable, no `test:visual` tasks are defined in
      any package
- [x] Type-safe (no `as any` / type suppressions added)

Notes for the reviewer:

- No dependency changes here. `pnpm audit --prod` reports 3 pre-existing
  transitive advisories (`socket.io-parser`, `brace-expansion`, `postcss`), all
  under `apps/**` paths and all present on `main`.
- `StickyNoteMediaMarkdown.tsx:140` spreads `imageProps` without `draggable`,
  unlike its siblings on lines 185 and 248. That is the media error/fallback
  path rather than an icon, so it is left out of this change, but it looks like
  the same oversight if we want it swept up separately.
