### PR TITLE
chore: change to centralized managed GitHub pool

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,14 @@
+# Self-hosted runner labels for the UiPath centralized managed GitHub pool.
+# actionlint only knows the GitHub-hosted labels, so the uipath- prefixed
+# images have to be declared here or every `runs-on` fails [runner-label].
+self-hosted-runner:
+  labels:
+    - uipath-ubuntu-latest
+    - uipath-ubuntu-slim
+    - uipath-ubuntu-24.04
+    - uipath-ubuntu-24.04-arm
+    - uipath-ubuntu-22.04
+    - uipath-ubuntu-22.04-arm
+    - uipath-ubuntu-20.04
+    - uipath-ubuntu-18.04
+    - uipath-windows-latest

--- a/.github/workflows/apollo-vertex-auto-merge.yml
+++ b/.github/workflows/apollo-vertex-auto-merge.yml
@@ -21,7 +21,7 @@ jobs:
         permissions:
             contents: read
             pull-requests: write
-        runs-on: ubuntu-latest
+        runs-on: uipath-ubuntu-latest
 
         steps:
             - name: Check for changes outside apollo-vertex
@@ -42,7 +42,7 @@ jobs:
 
             - name: Generate GitHub App token
               if: steps.scope.outputs.vertex_only == 'true'
-              uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+              uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
               id: app-token
               with:
                   client-id: ${{ vars.RELEASER_APP_CLIENT_ID }}

--- a/.github/workflows/apollo-vertex-lint.yml
+++ b/.github/workflows/apollo-vertex-lint.yml
@@ -17,11 +17,11 @@ permissions:
 jobs:
   lint:
     name: Lint & Format
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     if: github.event.pull_request.head.repo.fork == false
     steps:
       - name: Checkout code
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
         with:
           persist-credentials: false
 

--- a/.github/workflows/apollo-vertex-registry-check.yml
+++ b/.github/workflows/apollo-vertex-registry-check.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   detect-changes:
     name: Detect changes
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     permissions:
       contents: read
       pull-requests: read
@@ -38,14 +38,14 @@ jobs:
     name: Prepare
     needs: detect-changes
     if: needs.detect-changes.outputs.has_vertex_changes == 'true' && github.event.pull_request.head.repo.fork == false
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     permissions:
       contents: read
     outputs:
       matrix: ${{ steps.matrix.outputs.result }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
         with:
           persist-credentials: false
 
@@ -84,14 +84,14 @@ jobs:
         run: rm -rf ${{ runner.temp }}/minimal-app/node_modules
 
       - name: Upload base app
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
           name: base-app
           path: ${{ runner.temp }}/minimal-app
           retention-days: 1
 
       - name: Upload registry files
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
           name: registry-files
           path: apps/apollo-vertex/public/r/
@@ -101,7 +101,7 @@ jobs:
     name: Test batch ${{ matrix.batch_index }}
     needs: [detect-changes, prepare]
     if: needs.detect-changes.outputs.has_vertex_changes == 'true' && github.event.pull_request.head.repo.fork == false
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     # Simulates a downstream consumer installing apollo-vertex shadcn components
     # into a fresh project. Some components pull in @uipath/proteus-client, which
     # is GHP-only — so this job needs GHP read auth on its setup-node + test step.
@@ -114,7 +114,7 @@ jobs:
         include: ${{ fromJson(needs.prepare.outputs.matrix) }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
         with:
           persist-credentials: false
           sparse-checkout: |
@@ -124,23 +124,23 @@ jobs:
             pnpm-lock.yaml
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320  # v5.0.0
 
       - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
         with:
           node-version: "22"
           registry-url: "https://npm.pkg.github.com"
           scope: "@uipath"
 
       - name: Download base app
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
         with:
           name: base-app
           path: ${{ runner.temp }}/base-app
 
       - name: Download registry files
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
         with:
           name: registry-files
           path: ${{ runner.temp }}/serve-dir/r
@@ -162,7 +162,7 @@ jobs:
     name: Apollo Vertex Registry Check
     needs: [detect-changes, test-components]
     if: always()
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     permissions:
       contents: read
     steps:

--- a/.github/workflows/close-stale-prs.yml
+++ b/.github/workflows/close-stale-prs.yml
@@ -20,7 +20,7 @@ permissions: {}
 jobs:
   close-stale:
     name: Close stale PRs
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -32,7 +32,7 @@ concurrency:
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
 
     strategy:
       fail-fast: false
@@ -45,7 +45,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
         with:
           persist-credentials: false
 
@@ -72,7 +72,7 @@ jobs:
       # for source-file suppressions, reviewers must manually check.
       - name: Dismiss suppressed alerts
         if: github.ref == 'refs/heads/main' && matrix.language == 'javascript-typescript'
-        uses: advanced-security/dismiss-alerts@a18f986bdb40edba0dd7a74382c15d4a3d50a1c8 # v2.0.3
+        uses: advanced-security/dismiss-alerts@a18f986bdb40edba0dd7a74382c15d4a3d50a1c8  # v2.0.3
         with:
           sarif-id: ${{ steps.analyze.outputs['sarif-id'] }}
           sarif-file: sarif-results/javascript.sarif

--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -14,11 +14,11 @@ permissions:
 jobs:
   commitlint:
     name: Validate Commit Messages
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     if: github.event.pull_request.head.repo.fork == false
     steps:
       - name: Checkout code
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -7,7 +7,7 @@ permissions: {}
 jobs:
   vulnerability-review:
     name: Vulnerability & advisory review
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     permissions:
       contents: read
       pull-requests: write
@@ -15,20 +15,20 @@ jobs:
     if: github.event_name == 'pull_request'
     steps:
       - name: Checkout
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
         with:
           persist-credentials: false
 
       - name: Dependency Review
         # Scans added/changed deps against GitHub Advisory Database. Fails on high+ severity by default.
-        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294  # v5.0.0
         with:
           fail-on-severity: high
           comment-summary-in-pr: on-failure
 
   dependency-review:
     name: Dependencies license check
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     if: github.event.pull_request.head.repo.fork == false
     permissions:
       contents: read
@@ -36,7 +36,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
         with:
           persist-credentials: false
 
@@ -50,7 +50,7 @@ jobs:
 
       - name: Post or update PR comment
         if: github.event.pull_request.head.repo.fork == false
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd  # v8
         env:
           REPORT_PATH: ${{ runner.temp }}/license-report.md
         with:

--- a/.github/workflows/dev-cleanup.yml
+++ b/.github/workflows/dev-cleanup.yml
@@ -17,7 +17,7 @@ env:
 jobs:
   cleanup:
     name: Cleanup Dev Packages
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     # Skip fork PRs — cleanup uses publish-scoped tokens; fork PRs must not receive them.
     if: github.event.pull_request.head.repo.fork == false
     permissions:
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
         with:
           ref: ${{ github.event.pull_request.base.ref }}
           persist-credentials: false

--- a/.github/workflows/dev-publish.yml
+++ b/.github/workflows/dev-publish.yml
@@ -22,7 +22,7 @@ concurrency:
 jobs:
   detect-changes:
     name: Detect Changed Packages
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     permissions:
       contents: read
       issues: read
@@ -36,7 +36,7 @@ jobs:
       previous_matrix: ${{ steps.previous-matrix.outputs.matrix }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -155,7 +155,7 @@ jobs:
     name: Cleanup ${{ matrix.package_version }}
     needs: detect-changes
     if: needs.detect-changes.outputs.has_previous == 'true' && github.event.pull_request.head.repo.fork == false
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     permissions:
       contents: read
       packages: write
@@ -165,7 +165,7 @@ jobs:
         package_version: ${{ fromJSON(needs.detect-changes.outputs.previous_matrix) }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
         with:
           persist-credentials: false
 
@@ -192,13 +192,13 @@ jobs:
     name: Update Comment - Publishing
     needs: [detect-changes, cleanup]
     if: always() && needs.detect-changes.outputs.has_label == 'true' && needs.detect-changes.outputs.has_changes == 'true' && github.event.pull_request.head.repo.fork == false
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     permissions:
       contents: read
       pull-requests: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
         with:
           persist-credentials: false
 
@@ -219,7 +219,7 @@ jobs:
     name: Publish ${{ matrix.package }}
     needs: [detect-changes, cleanup, update-comment-publishing]
     if: always() && needs.detect-changes.outputs.has_label == 'true' && needs.detect-changes.outputs.has_changes == 'true' && github.event.pull_request.head.repo.fork == false
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     permissions:
       contents: read
       packages: write
@@ -230,7 +230,7 @@ jobs:
         package: ${{ fromJSON(needs.detect-changes.outputs.matrix) }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
         with:
           persist-credentials: false
 
@@ -304,7 +304,7 @@ jobs:
     name: Update Comment - Cleanup Only
     needs: [detect-changes, cleanup]
     if: always() && needs.detect-changes.outputs.has_previous == 'true' && needs.detect-changes.outputs.has_label == 'false' && github.event.pull_request.head.repo.fork == false
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/monitor-npm-publishes.yml
+++ b/.github/workflows/monitor-npm-publishes.yml
@@ -11,14 +11,14 @@ permissions: {}
 jobs:
   check:
     name: Verify @uipath/* npm versions match GitHub releases
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     permissions:
       contents: read
       issues: write
 
     steps:
       - name: Checkout
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
         with:
           persist-credentials: false
 

--- a/.github/workflows/notify-vertex-updates.yml
+++ b/.github/workflows/notify-vertex-updates.yml
@@ -12,10 +12,10 @@ permissions:
 jobs:
   notify:
     name: Notify changed registry components
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -28,7 +28,7 @@ permissions: {}
 jobs:
   checks:
     name: ${{ matrix.check }}
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     if: github.event.pull_request.head.repo.fork == false
     permissions:
       contents: read
@@ -47,7 +47,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -56,7 +56,7 @@ jobs:
         uses: ./.github/actions/install-node-deps
 
       - name: Cache Turborepo
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
         with:
           path: .turbo
           key: ${{ runner.os }}-turbo-${{ github.ref_name }}-${{ github.sha }}
@@ -99,7 +99,7 @@ jobs:
 
       - name: Upload Coverage
         if: matrix.check == 'Test Coverage'
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
           name: coverage
           path: |
@@ -125,7 +125,7 @@ jobs:
 
       - name: Upload package sizes
         if: matrix.check == 'Build'
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
           name: package-sizes
           path: pkg-sizes.json
@@ -134,7 +134,7 @@ jobs:
 
       - name: Upload Failure Artifacts
         if: failure()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
           name: failure-${{ matrix.check }}-${{ github.sha }}
           path: |
@@ -148,7 +148,7 @@ jobs:
     name: Coverage Comment
     needs: checks
     if: always() && github.event.pull_request.head.repo.fork == false
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     continue-on-error: true
     permissions:
       contents: read
@@ -156,19 +156,19 @@ jobs:
       actions: read # read the last main build's run + download its package-sizes artifact
     steps:
       - name: Checkout code
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
         with:
           fetch-depth: 0
           persist-credentials: false
 
       - name: Download coverage
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
         continue-on-error: true
         with:
           name: coverage
 
       - name: Download package sizes
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
         continue-on-error: true
         with:
           name: package-sizes
@@ -182,7 +182,7 @@ jobs:
         # still skips the rest of the job. Without this, a transient Actions API error here would
         # suppress the whole coverage+size comment. Failure → empty run_id → "vs main" shows "—".
         continue-on-error: true
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd  # v8
         with:
           script: |
             const { findSizeBaseline } = await import(`${process.env.GITHUB_WORKSPACE}/.github/scripts/find-size-baseline.mjs`);
@@ -190,7 +190,7 @@ jobs:
 
       - name: Download main size baseline
         if: steps.baseline.outputs.run_id
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
         continue-on-error: true
         with:
           name: package-sizes
@@ -199,7 +199,7 @@ jobs:
           github-token: ${{ github.token }}
 
       - name: Post coverage + size comment
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd  # v8
         env:
           PKG_SIZES_BASE_FILE: base-sizes/pkg-sizes.json
         with:
@@ -209,14 +209,14 @@ jobs:
 
   detect-lockfile-changes:
     name: Detect Lockfile Changes
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     permissions:
       contents: read
     outputs:
       changed: ${{ steps.lockfile_check.outputs.changed }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -234,7 +234,7 @@ jobs:
     name: ${{ matrix.check }}
     needs: detect-lockfile-changes
     if: needs.detect-lockfile-changes.outputs.changed == 'true' && github.event.pull_request.head.repo.fork == false
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     permissions:
       contents: read
     strategy:
@@ -247,7 +247,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -13,11 +13,11 @@ permissions: {}
 
 jobs:
   label:
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     permissions:
       contents: read
       pull-requests: write
     steps:
-      - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5
+      - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9  # v5
         with:
           sync-labels: true

--- a/.github/workflows/pr-size.yml
+++ b/.github/workflows/pr-size.yml
@@ -20,20 +20,20 @@ permissions:
 jobs:
   sync-label-definitions:
     name: Sync PR size label definitions
-    runs-on: ubuntu-24.04
+    runs-on: uipath-ubuntu-24.04
     permissions:
       contents: read
       issues: write
       pull-requests: write
     steps:
       - name: Checkout scripts
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
         with:
           sparse-checkout: .github/scripts
           persist-credentials: false
 
       - name: Ensure PR size labels exist
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd  # v8
         with:
           script: |
             const { ensureLabels } = await import(`${process.env.GITHUB_WORKSPACE}/.github/scripts/pr-size-labels.mjs`);
@@ -42,7 +42,7 @@ jobs:
   label:
     name: Label PR size
     needs: sync-label-definitions
-    runs-on: ubuntu-24.04
+    runs-on: uipath-ubuntu-24.04
     permissions:
       contents: read
       issues: write
@@ -52,13 +52,13 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: Checkout scripts
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
         with:
           sparse-checkout: .github/scripts
           persist-credentials: false
 
       - name: Sync PR size label
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd  # v8
         with:
           script: |
             const { syncLabel } = await import(`${process.env.GITHUB_WORKSPACE}/.github/scripts/pr-size-labels.mjs`);

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -23,20 +23,20 @@ jobs:
   initialize-comment:
     name: Initialize Apollo Coded App Preview Comment
     if: github.event.action != 'closed' && github.event.pull_request.head.repo.fork == false
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     permissions:
       pull-requests: write
 
     steps:
       # Comment scripts live in the repo, not inline (see .github/scripts/).
       - name: Checkout scripts
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
         with:
           sparse-checkout: .github/scripts
           persist-credentials: false
 
       - name: Initialize PR comment
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd  # v8
         with:
           script: |
             const { initComment } = await import(`${process.env.GITHUB_WORKSPACE}/.github/scripts/preview-deploy/preview-comment.mjs`);
@@ -46,7 +46,7 @@ jobs:
     name: Deploy ${{ matrix.label }}
     needs: initialize-comment
     if: ${{ !cancelled() && github.event.action != 'closed' && needs.initialize-comment.result == 'success' && github.event.pull_request.head.repo.fork == false }}
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     permissions:
       contents: read
       packages: read
@@ -67,7 +67,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -76,7 +76,7 @@ jobs:
         uses: ./.github/actions/install-node-deps
 
       - name: Restore Turborepo cache
-        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
         with:
           path: .turbo
           # Per-app key so parallel legs don't race to save one shared cache
@@ -177,7 +177,7 @@ jobs:
 
       - name: Save Turborepo cache
         if: always()
-        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
         with:
           path: .turbo
           key: ${{ runner.os }}-turbo-${{ matrix.label }}-${{ github.ref_name }}-${{ github.sha }}
@@ -208,7 +208,7 @@ jobs:
 
       - name: Upload deploy result
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
           name: deploy-result-${{ matrix.label }}
           path: ${{ runner.temp }}/deploy-result/
@@ -218,26 +218,26 @@ jobs:
     name: Update Apollo Coded App Preview Comment
     needs: [initialize-comment, deploy]
     if: ${{ always() && github.event.action != 'closed' && github.event.pull_request.head.repo.fork == false && needs.initialize-comment.result != 'skipped' }}
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     permissions:
       pull-requests: write
 
     steps:
       # Comment scripts live in the repo, not inline (see .github/scripts/).
       - name: Checkout scripts
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
         with:
           sparse-checkout: .github/scripts
           persist-credentials: false
 
       - name: Download deploy results
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
         with:
           pattern: deploy-result-*
           path: ${{ runner.temp }}/results
 
       - name: Update PR comment
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd  # v8
         env:
           RESULTS_DIR: ${{ runner.temp }}/results
         with:
@@ -255,7 +255,7 @@ jobs:
     # tracks main). The apollo-design leg's outcome is read from its result
     # artifact so a failure in another matrix leg doesn't skip this job.
     if: ${{ !cancelled() && github.event.action != 'closed' && github.event.pull_request.head.repo.fork == false && github.event.pull_request.base.ref == 'main' && needs.deploy.result != 'skipped' }}
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     permissions:
       contents: read
       packages: read
@@ -265,7 +265,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
         with:
           # Full history: sbdiff scopes captured stories via
           # git diff origin/main...HEAD plus a transitive import graph.
@@ -273,7 +273,7 @@ jobs:
           persist-credentials: false
 
       - name: Download apollo-design deploy result
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
         with:
           name: deploy-result-apollo-design
           path: ${{ runner.temp }}/apollo-design-result
@@ -306,14 +306,14 @@ jobs:
 
       - name: Set up Node 24
         if: steps.urls.outputs.ready == 'true'
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
         with:
           # sbdiff runs its TypeScript entry directly (requires Node >= 23.6).
           node-version: 24
 
       - name: Cache Playwright browsers
         if: steps.urls.outputs.ready == 'true'
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
         with:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-sbdiff-${{ env.SBDIFF_VERSION }}
@@ -441,7 +441,7 @@ jobs:
 
       - name: Post visual diff comment
         if: ${{ !cancelled() }}
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd  # v8
         env:
           READY: ${{ steps.urls.outputs.ready }}
           SBDIFF_OUTCOME: ${{ steps.sbdiff.outcome }}
@@ -463,14 +463,14 @@ jobs:
   cleanup-previews:
     name: Cleanup Apollo Coded App Previews
     if: github.event.action == 'closed' && github.event.pull_request.head.repo.fork == false
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     permissions:
       contents: read
       packages: read
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
         with:
           fetch-depth: 1
           persist-credentials: false

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -50,6 +50,10 @@ jobs:
     permissions:
       contents: read
       packages: read
+    env:
+      # uipath-ubuntu-* runners have less RAM than ubuntu-latest, so Node
+      # auto-sizes its heap to ~2 GB and the Storybook build OOMs (exit 134).
+      NODE_OPTIONS: --max-old-space-size=6144
     strategy:
       # One app per runner, in parallel. Keep going if one app fails so the
       # others still publish; each leg reports status via an artifact and the

--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -21,14 +21,14 @@ env:
 jobs:
   deploy:
     name: Deploy Apollo Coded Apps
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     permissions:
       contents: read
       packages: read
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -37,7 +37,7 @@ jobs:
         uses: ./.github/actions/install-node-deps
 
       - name: Restore Turborepo cache
-        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
         with:
           path: .turbo
           key: ${{ runner.os }}-turbo-${{ github.ref_name }}-${{ github.sha }}
@@ -146,7 +146,7 @@ jobs:
 
       - name: Save Turborepo cache
         if: always()
-        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
         with:
           path: .turbo
           key: ${{ runner.os }}-turbo-${{ github.ref_name }}-${{ github.sha }}

--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -25,6 +25,10 @@ jobs:
     permissions:
       contents: read
       packages: read
+    env:
+      # uipath-ubuntu-* runners have less RAM than ubuntu-latest, so Node
+      # auto-sizes its heap to ~2 GB and the Storybook build OOMs (exit 134).
+      NODE_OPTIONS: --max-old-space-size=6144
 
     steps:
       - name: Checkout code

--- a/.github/workflows/prune-release-age-exemptions.yml
+++ b/.github/workflows/prune-release-age-exemptions.yml
@@ -11,19 +11,19 @@ permissions: {}
 jobs:
   prune:
     name: Remove stale exemptions
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     permissions:
       contents: write
       pull-requests: write
 
     steps:
       - name: Checkout
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
         with:
           persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
         with:
           node-version: '22'
 
@@ -33,7 +33,7 @@ jobs:
 
       - name: Generate GitHub App token
         if: steps.check.outputs.count != '' && steps.check.outputs.count != '0'
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
         id: app-token
         with:
           client-id: ${{ vars.RELEASER_APP_CLIENT_ID }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
   release:
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     name: Release and Publish
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     timeout-minutes: 30
     outputs:
       changed: ${{ steps.bump.outputs.changed }}
@@ -33,7 +33,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -46,7 +46,7 @@ jobs:
           ACTIONS_ID_TOKEN_REQUEST_TOKEN: ""
 
       - name: Cache Turborepo
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
         with:
           path: .turbo
           key: ${{ runner.os }}-turbo-${{ github.ref_name }}-${{ github.sha }}
@@ -149,7 +149,7 @@ jobs:
 
       - name: Upload version-bump patch
         if: steps.bump.outputs.changed == 'true'
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
           name: version-bump-patch
           path: ${{ runner.temp }}/version-bump.patch
@@ -165,35 +165,35 @@ jobs:
 
       - name: Attest SBOM — apollo-core
         if: steps.bump.outputs.changed == 'true'
-        uses: actions/attest-sbom@c604332985a26aa8cf1bdc465b92731239ec6b9e # v4.1.0
+        uses: actions/attest-sbom@c604332985a26aa8cf1bdc465b92731239ec6b9e  # v4.1.0
         with:
           subject-path: ${{ runner.temp }}/dist-apollo-core.tar.gz
           sbom-path: ${{ runner.temp }}/sbom-apollo-core.cyclonedx.json
 
       - name: Attest SBOM — apollo-react
         if: steps.bump.outputs.changed == 'true'
-        uses: actions/attest-sbom@c604332985a26aa8cf1bdc465b92731239ec6b9e # v4.1.0
+        uses: actions/attest-sbom@c604332985a26aa8cf1bdc465b92731239ec6b9e  # v4.1.0
         with:
           subject-path: ${{ runner.temp }}/dist-apollo-react.tar.gz
           sbom-path: ${{ runner.temp }}/sbom-apollo-react.cyclonedx.json
 
       - name: Attest SBOM — apollo-wind
         if: steps.bump.outputs.changed == 'true'
-        uses: actions/attest-sbom@c604332985a26aa8cf1bdc465b92731239ec6b9e # v4.1.0
+        uses: actions/attest-sbom@c604332985a26aa8cf1bdc465b92731239ec6b9e  # v4.1.0
         with:
           subject-path: ${{ runner.temp }}/dist-apollo-wind.tar.gz
           sbom-path: ${{ runner.temp }}/sbom-apollo-wind.cyclonedx.json
 
       - name: Attest SBOM — ap-chat
         if: steps.bump.outputs.changed == 'true'
-        uses: actions/attest-sbom@c604332985a26aa8cf1bdc465b92731239ec6b9e # v4.1.0
+        uses: actions/attest-sbom@c604332985a26aa8cf1bdc465b92731239ec6b9e  # v4.1.0
         with:
           subject-path: ${{ runner.temp }}/dist-ap-chat.tar.gz
           sbom-path: ${{ runner.temp }}/sbom-ap-chat.cyclonedx.json
 
       - name: Upload SBOMs and dist tarballs as release artifact
         if: steps.bump.outputs.changed == 'true'
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
           name: release-${{ github.sha }}
           path: |
@@ -242,7 +242,7 @@ jobs:
 
       - name: Upload package sizes baseline
         continue-on-error: true
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
           name: package-sizes
           path: pkg-sizes.json
@@ -255,19 +255,19 @@ jobs:
     name: Commit version bump
     needs: release
     if: needs.release.outputs.changed == 'true'
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     timeout-minutes: 5
     permissions:
       contents: read
 
     steps:
       - name: Checkout
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
         with:
           persist-credentials: false
 
       - name: Download version-bump patch
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
         with:
           name: version-bump-patch
           path: ${{ runner.temp }}
@@ -283,7 +283,7 @@ jobs:
         run: node .github/scripts/validate-package-json-mutations.mjs "$RUNNER_TEMP/version-bump.patch"
 
       - name: Generate GitHub App token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
         id: app-token
         with:
           client-id: ${{ vars.RELEASER_APP_CLIENT_ID }}

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -20,7 +20,7 @@ permissions: {}
 jobs:
   zizmor:
     name: Zizmor Security Scan
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     permissions:
       contents: read
       security-events: write
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
         with:
           persist-credentials: false
 
@@ -44,7 +44,7 @@ jobs:
 
   actionlint:
     name: Actionlint Workflow Syntax Check
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     # github-pr-check reporter only surfaces results in PR context; skip on push.
     if: github.event_name == 'pull_request'
     permissions:
@@ -53,7 +53,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
         with:
           persist-credentials: false
 

--- a/.github/workflows/support-branch-scope.yml
+++ b/.github/workflows/support-branch-scope.yml
@@ -15,7 +15,7 @@ permissions: {}
 jobs:
   check-scope:
     name: Check package scope
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     permissions:
       contents: read
       pull-requests: read
@@ -35,7 +35,7 @@ jobs:
           echo "package=$PACKAGE" >> "$GITHUB_OUTPUT"
 
       - name: Sparse checkout base branch
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
         with:
           ref: ${{ github.event.pull_request.base.ref }}
           sparse-checkout: |
@@ -107,7 +107,7 @@ jobs:
 
       - name: Post or update PR comment
         if: steps.scope.outputs.status == 'fail'
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd  # v8
         env:
           PACKAGE: ${{ steps.parse.outputs.package }}
           PKG_DIR: ${{ steps.resolve.outputs.pkg_dir }}
@@ -121,7 +121,7 @@ jobs:
 
       - name: Remove comment if scope is clean
         if: steps.scope.outputs.status != 'fail'
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd  # v8
         with:
           script: |
             const { removeScopeComment } = await import(`${process.env.GITHUB_WORKSPACE}/.github/scripts/support-branch-scope-comment.mjs`);


### PR DESCRIPTION
## Summary

Moves this repository's workflows to the centralized managed GitHub pool.

- Runner images are prefixed with `uipath-` in all workflow files
- e.g. `ubuntu-latest` → `uipath-ubuntu-latest`

## Changes

All workflow `.yml` files (including non-standard locations like `workflows-src/`) with static `runs-on` values are updated.
Dynamic expressions (`${{ ... }}`) and already-prefixed images are skipped.

## Action Version Pinning

All `uses:` references are pinned to the SHA of the latest release published ≥ **48h** ago.
This prevents supply-chain attacks via recently-published compromised versions.