### PR TITLE
perf(apollo-vertex): scope group-member query to requested group ids

### DIFF
--- a/apps/apollo-vertex/registry/shell/use-group-members.ts
+++ b/apps/apollo-vertex/registry/shell/use-group-members.ts
@@ -1,4 +1,4 @@
-import { useLiveQuery } from "@tanstack/react-db";
+import { eq, useLiveQuery } from "@tanstack/react-db";
 import { type GroupMember, useSolution } from "@uipath/vs-core";
 
 export interface UseGroupMembersOptions {
@@ -16,9 +16,10 @@ export const useGroupMembers = ({
   const solution = useSolution();
 
   const { data, isLoading } = useLiveQuery<GroupMember>((q) =>
-    q.from({ members: solution?.api.collections.identity.groupMembers }),
+    q
+      .from({ members: solution?.api.collections.identity.groupMembers })
+      .where(({ members }) => eq(members.groupId, groupId)),
   );
 
-  const users = (data ?? []).filter((member) => member.groupId === groupId);
-  return { users, isLoading };
+  return { users: data ?? [], isLoading };
 };

--- a/apps/apollo-vertex/registry/shell/use-is-group-member.ts
+++ b/apps/apollo-vertex/registry/shell/use-is-group-member.ts
@@ -1,4 +1,4 @@
-import { useLiveQuery } from "@tanstack/react-db";
+import { inArray, useLiveQuery } from "@tanstack/react-db";
 import { type GroupMember, useSolution } from "@uipath/vs-core";
 import { useAuth } from "./shell-auth-provider";
 
@@ -18,7 +18,9 @@ export const useIsGroupMember = ({
   const solution = useSolution();
 
   const { data, isLoading } = useLiveQuery<GroupMember>((q) =>
-    q.from({ members: solution?.api.collections.identity.groupMembers }),
+    q
+      .from({ members: solution?.api.collections.identity.groupMembers })
+      .where(({ members }) => inArray(members.groupId, groupIds)),
   );
 
   if (!user) {
@@ -27,9 +29,7 @@ export const useIsGroupMember = ({
 
   const userEmail = user.email.toLowerCase();
   const isMember = (data ?? []).some(
-    (member) =>
-      groupIds.includes(member.groupId) &&
-      member.email.toLowerCase() === userEmail,
+    (member) => member.email.toLowerCase() === userEmail,
   );
 
   return { isMember, isLoading };

--- a/apps/apollo-vertex/types/optional-deps.d.ts
+++ b/apps/apollo-vertex/types/optional-deps.d.ts
@@ -15,19 +15,39 @@ declare module "@tanstack/react-db" {
     // collection's own mutators).
     readonly utils: { refetch(): Promise<void> };
   }
+  // Opaque boolean predicate produced by the filter operators (`inArray`, …)
+  // and consumed by `.where()`.
+  interface Expression {
+    readonly __expression?: true;
+  }
   interface QueryResult<T = unknown> {
     readonly __row?: T;
+    // `.where()` receives the `from()` aliases as row refs keyed by alias, so
+    // `({ members }) => inArray(members.groupId, ids)` type-checks.
+    where(predicate: (refs: Record<string, T>) => Expression): QueryResult<T>;
   }
   // Result of a source the stub can't type (e.g. the generic entity
   // collections). It carries no row type, so the row type is supplied by an
   // explicit `useLiveQuery` type argument instead.
   interface UntypedQueryResult {
     readonly __untyped?: true;
+    where(
+      predicate: (refs: Record<string, Record<string, unknown>>) => Expression,
+    ): UntypedQueryResult;
   }
   interface QueryBuilder {
     from<T>(source: Record<string, Collection<T>>): QueryResult<T>;
     from(source: Record<string, unknown>): UntypedQueryResult;
   }
+
+  // Filter operator: matches rows whose `field` equals `value`.
+  export function eq(field: unknown, value: unknown): Expression;
+
+  // Filter operator: matches rows whose `field` value is one of `values`.
+  export function inArray(
+    field: unknown,
+    values: readonly unknown[],
+  ): Expression;
 
   export function useLiveQuery<T>(
     queryFn: (


### PR DESCRIPTION
Both `useIsGroupMember` (used by `GroupMembershipGuard`) and `useGroupMembers` previously pulled the entire `groupMembers` collection and filtered client-side, which overloads the query as the collection grows. They now push the filter into the live query via `.where()`: `useIsGroupMember` uses `inArray(members.groupId, groupIds)` and `useGroupMembers` uses `eq(members.groupId, groupId)`, so only members of the requested group(s) are fetched. The `@tanstack/react-db` type stub in `optional-deps.d.ts` gained a `.where()` method plus the `eq` and `inArray` operators to support this. This depends on the upstream `groupMembers` collection translating the predicate into a server-side filtered fetch.

👨 Generated with Kluijt Code