### PR TITLE
fix(apollo-react): restore label error colour, free field-adornment icon buttons from fixed boxes

### DIFF
--- a/packages/apollo-react/src/material/theme/overrides/MuiFormLabel.ts
+++ b/packages/apollo-react/src/material/theme/overrides/MuiFormLabel.ts
@@ -3,13 +3,8 @@ import type { Palette } from '@uipath/apollo-core/tokens/jss/palette';
 
 export const MuiFormLabel = (palette: Palette): ComponentsOverrides['MuiFormLabel'] => ({
   root: {
-    color: palette.semantic.colorForegroundDeEmp,
-    '&.Mui-error': { color: palette.semantic.colorForegroundDeEmp },
+    color: palette.semantic.colorForeground,
     '&.Mui-disabled': { color: palette.semantic.colorForegroundDisable },
-  },
-  asterisk: {
-    color: 'inherit',
-    '&.Mui-disabled': { color: 'inherit' },
-    '&.Mui-error': { color: 'inherit' },
+    '.MuiFormLabel-asterisk.Mui-error': { color: palette.semantic.colorErrorText },
   },
 });

--- a/packages/apollo-react/src/material/theme/overrides/MuiIconButton.ts
+++ b/packages/apollo-react/src/material/theme/overrides/MuiIconButton.ts
@@ -37,6 +37,15 @@ export const MuiIconButton = (palette: Palette): ComponentsOverrides['MuiIconBut
       width: token.Spacing.SpacingXxl,
       height: token.Spacing.SpacingXxl,
     },
+    // Icon buttons inside a field's adornments (autocomplete popup/clear
+    // indicators, datepicker calendar) share the field's box; the fixed
+    // per-size box misaligns them and shifts the field's edge, so they keep
+    // MUI's natural, padding-driven geometry.
+    '&.MuiAutocomplete-popupIndicator, &.MuiAutocomplete-clearIndicator, .MuiInputAdornment-root &':
+      {
+        width: 'auto',
+        height: 'auto',
+      },
     '&.Mui-disabled': { color: palette.semantic.colorForegroundDisable },
   },
 });

--- a/packages/apollo-react/src/material/theme/overrides/MuiInputLabel.ts
+++ b/packages/apollo-react/src/material/theme/overrides/MuiInputLabel.ts
@@ -14,12 +14,7 @@ export const MuiInputLabel = (palette: Palette): ComponentsOverrides['MuiInputLa
     },
     '& + .MuiInputBase-root > .MuiOutlinedInput-notchedOutline': { top: '-5px !important' },
     '&.Mui-focused': { color: palette.semantic.colorForegroundDeEmp },
-    '&.Mui-error': { color: palette.semantic.colorForegroundDeEmp },
+    '&.Mui-error': { color: palette.semantic.colorErrorText },
     '&.Mui-disabled': { color: palette.semantic.colorForegroundDisable },
-  },
-  asterisk: {
-    color: 'inherit',
-    '&.Mui-disabled': { color: 'inherit' },
-    '&.Mui-error': { color: 'inherit' },
   },
 });


### PR DESCRIPTION
## Why

apollo-design-system#5354 makes these themes the single source of truth for `apollo-mui5`, so every place apollo-react's overrides drift from what Portal ships today becomes a visual change for Portal. Design review of that drift (storybook-diff of the bumped apollo-mui5 against its master baseline) identified two things to fix here; the rest of the reviewed drift was confirmed as intended apollo-react behaviour and stays documented in #5354.

## What

Two commits:

1. **Labels** (`MuiFormLabel`, `MuiInputLabel`): error-state input labels and the required asterisk are `colorErrorText` again; form labels return to regular foreground. apollo-react had kept error labels de-emphasized, so invalid fields gave no colour signal on the label. `MuiInputLabel` renders through `MuiFormLabel`, so the restored `.MuiFormLabel-asterisk.Mui-error` rule covers input-label asterisks too.
2. **Icon buttons** (`MuiIconButton`): Autocomplete popup/clear indicators and the datepicker calendar button live inside a field's adornments; the fixed per-size box misaligned the combobox chevron and shifted the field's right edge. Adornment icon buttons keep MUI's natural padding-driven geometry; the fixed boxes stay for standalone icon buttons.

## Reviewed and kept as-is (intentional divergence from apollo-mui5)

Earlier revisions of this PR also moved links, text fields, and a datepicker token to the apollo-mui5 baseline. Review resolved all three the other way:

- **Links**: hover-only underline is intentional apollo-react design (matches the ApLink web component); Portal picks it up via #5354 as a documented change.
- **Text fields**: the filled background, 3px radius, and 2px `colorErrorText` error border stay; the small drift vs Portal is accepted and documented in #5354.
- **Datepicker selected day**: keeps `colorForegroundOnAccent`. It is identical to the baseline's `colorForegroundInverse` in all four classic themes and is the correct, accessible token on the accent background in future-light, where the two diverge.

## Verification

Two [`sbdiff`](https://github.com/UiPath/storybook-diff) runs on this exact branch state:

**apollo-mui5 vs its master baseline** (local apollo-mui5 build carrying these overrides, all 519 comparable stories, four themes):

| Stories | Result |
| --- | --- |
| `controls-combobox--*` (12) | **pass, pixel-identical** (was changed) |
| `controls-date-picker--*` (8) | **pass, pixel-identical** (was changed; the label fix plus the adornment fix fully account for it) |
| link (3), text-field (12), alert, checkbox, radio, stepper, tab, tooltip, icon-button sizing | changed; intentional, documented drift for #5354 sign-off |

**apollo-react's own storybook vs deployed main**: 4 changed of 196. Two are `text-field--variants` at 0.047% showing exactly the intended red error label and asterisk; two are the known flaky sankey story. Chat, links, and all other stories: no change.

`tsc --noEmit` and `biome` are clean on the touched files.

## Follow-up

Once this releases, apollo-design-system#5354 bumps apollo-react; its diff against the Portal baseline should then show only the documented, intentionally-kept drift.
