### PR TITLE
ci(ci): bump uip-go to 0.3.2 for gateway-timeout deploy recovery

### DIFF
--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -13,7 +13,7 @@ permissions: {}
 env:
   TURBO_TELEMETRY_DISABLED: 1
   DO_NOT_TRACK: 1
-  UIP_GO_VERSION: 0.3.1
+  UIP_GO_VERSION: 0.3.2
 
 concurrency:
   group: coded-app-preview-pr-${{ github.event.pull_request.number }}

--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -16,7 +16,7 @@ concurrency:
 env:
   TURBO_TELEMETRY_DISABLED: 1
   DO_NOT_TRACK: 1
-  UIP_GO_VERSION: 0.3.1
+  UIP_GO_VERSION: 0.3.2
 
 jobs:
   deploy:


### PR DESCRIPTION
uip-go 0.3.2 ships uip CLI 1.200.0-dev.8116, which includes UiPath/cli#3360: when the staging gateway 504s on a large coded app upgrade (the recurring apollo-design production deploy flake), the CLI now checks whether the upgrade actually landed instead of failing the run. Applies to both production and preview deploys.