### PR TITLE
fix(apollo-wind): anchor dialog close button inside the dialog

### DIFF
--- a/packages/apollo-wind/src/components/ui/dialog.tsx
+++ b/packages/apollo-wind/src/components/ui/dialog.tsx
@@ -57,7 +57,7 @@ const DialogContent = React.forwardRef<
         <DialogPrimitive.Content
           data-slot="dialog-content"
           className={cn(
-            'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 z-50 grid w-full max-w-[calc(100%-2rem)] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg',
+            'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 relative z-50 grid w-full max-w-[calc(100%-2rem)] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg',
             className
           )}
           ref={ref}
@@ -67,7 +67,7 @@ const DialogContent = React.forwardRef<
           {showCloseButton && (
             <DialogPrimitive.Close
               data-slot="dialog-close"
-              className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
+              className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 cursor-pointer rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:cursor-default disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
             >
               <XIcon />
               <span className="sr-only">Close</span>


### PR DESCRIPTION
## Problem

The `Dialog` close button (X) rendered in the **top-right corner of the page** instead of inside the dialog.

## Root cause

Commit d1e34176 (*"switch dialog from transform to flex positioning"*) changed `DialogContent` from `fixed top-[50%] left-[50%] translate-x-[-50%] translate-y-[-50%]` to a plain flex child of `DialogOverlay`. Dropping `fixed` left the content **statically positioned**.

The close button is `absolute top-4 right-4`, and an absolutely positioned element anchors to its nearest *positioned* ancestor. With the content static, that became `DialogOverlay` (`fixed inset-0`), i.e. the viewport. So `top-4 right-4` meant "16px from the top-right of the page."

Measured in the browser before the fix, at 1200px wide: the X sat at `top:16, right:1184` while the dialog occupied `344-856 x 442-782`, and `offsetParent` was `dialog-overlay`.

`alert-dialog.tsx` and `sheet.tsx` are unaffected; their content is still `fixed`.

## Changes

Both in `packages/apollo-wind/src/components/ui/dialog.tsx`:

1. **`relative` on `DialogContent`** restores it as the containing block, which is what the original `fixed` variant provided.
2. **`cursor-pointer` on the close button** (plus `disabled:cursor-default`). Tailwind v4 dropped the browser default `cursor: pointer` on buttons, which is why this repo's `Button` variants set it explicitly. The hand-written X never got it, so it did not read as clickable next to the footer buttons.

## Validation

Verified in Storybook with Playwright against this branch:

- X renders inside the dialog at 17px from the top/right edge (16px inset + 1px border); `offsetParent` is now `dialog-content`.
- `cursor` computes to `pointer` on the button and its SVG; hit-testing at the X's center returns the button, so the pointer shows on hover.
- Clicking the X closes the dialog.
- All 6 dialog stories pass (basic, complex, link, scrollable, sticky-footer, delete-confirmation, no-button): all `position: relative`, `cursor: pointer`, inset 17/17.
- 39 unit tests pass across `dialog` / `alert-dialog` / `sheet`; Biome clean.

## Note on stacking context

Since the content also carries `z-50`, adding `relative` means it now forms a stacking context (a static element ignores `z-index`, so it previously did not). This matches the pre-d1e34176 behavior and matches `alert-dialog` / `sheet`. Portaled children such as popovers render to `body`, so they are unaffected.

## Follow-up, not in this PR

`sheet.tsx:64` has the same missing `cursor-pointer` on its close button. Its positioning is correct. Left out to keep this PR scoped; happy to fold it in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)