### PR TITLE
feat(apollo-react): add line jumps to crossing canvas edges

### DIFF
--- a/packages/apollo-react/src/canvas/components/BaseCanvas/CanvasProviders.tsx
+++ b/packages/apollo-react/src/canvas/components/BaseCanvas/CanvasProviders.tsx
@@ -3,6 +3,7 @@ import { TooltipProvider } from '@uipath/apollo-wind/components/ui/tooltip';
 import type { ReactNode } from 'react';
 import { ApI18nProvider } from '../../../i18n';
 import { CanvasTooltipProviderMarker } from '../CanvasTooltip';
+import { EdgeCrossingsProvider } from '../Edges/shared/crossings';
 import { StickyNoteCanvasOptionsProvider } from '../StickyNoteNode/StickyNoteCanvasOptionsContext';
 import type { StickyNoteCanvasOptions } from '../StickyNoteNode/StickyNoteNode.types';
 import type { BaseCanvasProps } from './BaseCanvas.types';
@@ -42,11 +43,13 @@ export function CanvasProviders({
         <TooltipProvider delayDuration={200} skipDelayDuration={100}>
           <CanvasTooltipProviderMarker>
             <ConnectedHandlesProvider edges={edges}>
-              <BaseCanvasModeProvider mode={mode}>
-                <StickyNoteCanvasOptionsProvider options={stickyNoteOptions}>
-                  <SelectionStateProvider nodes={nodes}>{children}</SelectionStateProvider>
-                </StickyNoteCanvasOptionsProvider>
-              </BaseCanvasModeProvider>
+              <EdgeCrossingsProvider>
+                <BaseCanvasModeProvider mode={mode}>
+                  <StickyNoteCanvasOptionsProvider options={stickyNoteOptions}>
+                    <SelectionStateProvider nodes={nodes}>{children}</SelectionStateProvider>
+                  </StickyNoteCanvasOptionsProvider>
+                </BaseCanvasModeProvider>
+              </EdgeCrossingsProvider>
             </ConnectedHandlesProvider>
           </CanvasTooltipProviderMarker>
         </TooltipProvider>

--- a/packages/apollo-react/src/canvas/components/BaseNode/BaseNode.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/BaseNode/BaseNode.stories.tsx
@@ -16,7 +16,16 @@ import {
   allCategoryManifests,
   allNodeManifests,
   createNode,
+  StoryCard,
+  StoryCode,
+  StoryCodeBlock,
+  StoryCollapsibleSection,
   StoryInfoPanel,
+  StoryPage,
+  StoryPreview,
+  StorySection,
+  type StorySpecColumn,
+  StorySpecTable,
   useCanvasStory,
   withCanvasProviders,
 } from '../../storybook-utils';
@@ -345,7 +354,7 @@ const shapeRows = [
     shape: 'square',
     value: "'square'",
     example: 'uipath.blank-node',
-    use: 'Standard actions — the default for most task nodes',
+    use: 'Standard actions, the default for most task nodes',
   },
   {
     shape: 'rectangle',
@@ -355,168 +364,60 @@ const shapeRows = [
   },
 ] as const;
 
-function CanvasPreviewButton({
-  expanded,
-  onExpand,
-  onClose,
-}: {
-  expanded: boolean;
-  onExpand: () => void;
-  onClose: () => void;
-}) {
-  return expanded ? (
-    <button
-      type="button"
-      onClick={onClose}
-      className="absolute right-3 top-3 z-10 flex items-center gap-1.5 rounded-md border border-border bg-background/80 px-2.5 py-1.5 text-xs font-medium text-muted-foreground backdrop-blur-sm transition-colors hover:bg-surface-hover hover:text-foreground"
-    >
-      <svg width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden="true">
-        <path
-          d="M7.5 4.5l-6 6M10.5 1.5l-6 6M1.5 1.5l4 4M10.5 10.5l-4-4"
-          stroke="currentColor"
-          strokeWidth="1.5"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-        />
-      </svg>
-      Close
-    </button>
-  ) : (
-    <button
-      type="button"
-      onClick={onExpand}
-      className="absolute right-3 top-3 z-10 flex items-center gap-1.5 rounded-md border border-border bg-background/80 px-2.5 py-1.5 text-xs font-medium text-muted-foreground backdrop-blur-sm transition-colors hover:bg-surface-hover hover:text-foreground"
-    >
-      <svg width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden="true">
-        <path
-          d="M7.5 1.5h3v3M4.5 10.5h-3v-3M10.5 4.5V1.5H7.5M1.5 7.5v3h3"
-          stroke="currentColor"
-          strokeWidth="1.5"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-        />
-      </svg>
-      Expand
-    </button>
-  );
-}
+const shapeColumns: readonly StorySpecColumn<(typeof shapeRows)[number]>[] = [
+  { key: 'shape', header: 'Shape', variant: 'strong' },
+  { key: 'value', header: <code className="text-xs">display.shape</code>, variant: 'code' },
+  { key: 'example', header: 'Example node type', variant: 'code-muted' },
+  { key: 'use', header: 'Typical use' },
+];
 
 function ShapesPage({ globalTheme }: { globalTheme: string }) {
-  const [expanded, setExpanded] = useState(false);
-
   return (
-    <div className={cn(globalTheme, 'min-h-screen w-full bg-background text-foreground')}>
-      {/* ── Header ── */}
-      <div className="mx-auto max-w-4xl px-8 pt-8">
-        <h2 className="mb-2 text-2xl font-bold tracking-tight text-foreground">Shapes</h2>
-        <p className="mb-6 text-sm leading-relaxed text-muted-foreground">
+    <StoryPage
+      theme={globalTheme}
+      title="Shapes"
+      description={
+        <>
           BaseNode supports three shapes: <strong className="text-foreground">circle</strong>,{' '}
           <strong className="text-foreground">square</strong>, and{' '}
           <strong className="text-foreground">rectangle</strong>. Shape is set via{' '}
-          <code className="rounded bg-muted px-1.5 py-0.5 text-xs text-primary">display.shape</code>{' '}
-          in the node data and controls both the rendered outline and the icon crop. Use the shape
-          that best communicates the node's role to the user.
-        </p>
-        <div className="mb-8 h-px bg-border" />
-      </div>
+          <StoryCode>display.shape</StoryCode> in the node data and controls both the rendered
+          outline and the icon crop. Use the shape that best communicates the node's role to the
+          user.
+        </>
+      }
+    >
+      <StoryPreview description="The three shapes rendered side by side in their default (NotExecuted) state.">
+        <ShapesCanvas />
+      </StoryPreview>
 
-      {/* ── Preview ── */}
-      <div className="pb-8">
-        <div className="mx-auto max-w-4xl px-8 mb-4">
-          <h2 className="mb-1 text-2xl font-bold tracking-tight text-foreground">Preview</h2>
-          <p className="text-sm leading-relaxed text-muted-foreground">
-            The three shapes rendered side by side in their default (NotExecuted) state.
-          </p>
-        </div>
-        <div className="flex justify-center">
-          <div className="relative w-[90vw] h-[560px] overflow-hidden rounded-xl border border-border">
-            {!expanded && <ShapesCanvas />}
-            <CanvasPreviewButton
-              expanded={false}
-              onExpand={() => setExpanded(true)}
-              onClose={() => setExpanded(false)}
-            />
-          </div>
-        </div>
-      </div>
-
-      {/* Expanded overlay — single canvas instance, inline unmounted while open */}
-      {expanded && (
-        <div
-          className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm"
-          onClick={() => setExpanded(false)}
-        >
-          <div
-            className="relative overflow-hidden rounded-xl border border-border"
-            style={{ width: '90vw', height: '90vh' }}
-            onClick={(e) => e.stopPropagation()}
-          >
-            <ShapesCanvas />
-            <CanvasPreviewButton
-              expanded={true}
-              onExpand={() => setExpanded(true)}
-              onClose={() => setExpanded(false)}
-            />
-          </div>
-        </div>
-      )}
-
-      {/* ── Anatomy + How to use ── */}
-      <div className="mx-auto max-w-4xl px-8 pb-8">
-        <div className="mb-8 h-px bg-border" />
-        <h2 className="mb-2 text-2xl font-bold tracking-tight text-foreground">Anatomy</h2>
-        <p className="mb-6 text-sm leading-relaxed text-muted-foreground">
-          Each shape communicates a distinct role in the flow. Choose the shape that best maps to
-          the node's function — not just its appearance.
-        </p>
-
-        {/* Shape gallery */}
+      <StorySection
+        title="Anatomy"
+        description="Each shape communicates a distinct role in the flow. Choose the shape that best maps to the node's function, not just its appearance."
+      >
         <div className="mb-8 grid grid-cols-3 gap-4">
-          {/* Circle */}
-          <div className="flex flex-col gap-4 rounded-xl border border-border bg-card p-6">
-            <div className="flex h-24 items-center justify-center">
+          <StoryCard
+            preview={
               <div className="flex h-16 w-16 items-center justify-center rounded-full border-2 border-border bg-surface-raised">
                 <div className="h-7 w-7 rounded-full bg-muted" />
               </div>
-            </div>
-            <div className="flex flex-col gap-2">
-              <div className="flex items-center gap-2">
-                <span className="text-base font-semibold text-foreground">Circle</span>
-                <code className="rounded bg-muted px-1.5 py-0.5 text-xs text-primary">
-                  'circle'
-                </code>
-              </div>
-              <p className="text-sm text-muted-foreground">
-                Triggers and entry/exit points. Signals a boundary event — where a flow begins or
-                ends.
-              </p>
-            </div>
-          </div>
-
-          {/* Square */}
-          <div className="flex flex-col gap-4 rounded-xl border border-border bg-card p-6">
-            <div className="flex h-24 items-center justify-center">
+            }
+            title="Circle"
+            code="'circle'"
+            description="Triggers and entry/exit points. Signals a boundary event, where a flow begins or ends."
+          />
+          <StoryCard
+            preview={
               <div className="flex h-16 w-16 items-center justify-center rounded-lg border-2 border-border bg-surface-raised">
                 <div className="h-7 w-7 rounded bg-muted" />
               </div>
-            </div>
-            <div className="flex flex-col gap-2">
-              <div className="flex items-center gap-2">
-                <span className="text-base font-semibold text-foreground">Square</span>
-                <code className="rounded bg-muted px-1.5 py-0.5 text-xs text-primary">
-                  'square'
-                </code>
-              </div>
-              <p className="text-sm text-muted-foreground">
-                Standard actions — the default for most task nodes. Use when no other shape more
-                specifically communicates the node's role.
-              </p>
-            </div>
-          </div>
-
-          {/* Rectangle */}
-          <div className="flex flex-col gap-4 rounded-xl border border-border bg-card p-6">
-            <div className="flex h-24 items-center justify-center">
+            }
+            title="Square"
+            code="'square'"
+            description="Standard actions, the default for most task nodes. Use when no other shape more specifically communicates the node's role."
+          />
+          <StoryCard
+            preview={
               <div className="flex h-12 w-40 items-center gap-3 rounded-lg border-2 border-border bg-surface-raised px-3">
                 <div className="h-6 w-6 flex-shrink-0 rounded bg-muted" />
                 <div className="flex flex-col gap-1.5">
@@ -524,68 +425,26 @@ function ShapesPage({ globalTheme }: { globalTheme: string }) {
                   <div className="h-1.5 w-10 rounded-full bg-muted opacity-50" />
                 </div>
               </div>
-            </div>
-            <div className="flex flex-col gap-2">
-              <div className="flex items-center gap-2">
-                <span className="text-base font-semibold text-foreground">Rectangle</span>
-                <code className="rounded bg-muted px-1.5 py-0.5 text-xs text-primary">
-                  'rectangle'
-                </code>
-              </div>
-              <p className="text-sm text-muted-foreground">
-                Agents and complex nodes that need more horizontal space for labels or internal
-                layout.
-              </p>
-            </div>
-          </div>
+            }
+            title="Rectangle"
+            code="'rectangle'"
+            description="Agents and complex nodes that need more horizontal space for labels or internal layout."
+          />
         </div>
 
-        {/* Spec table */}
-        <div className="overflow-hidden rounded-lg border border-border">
-          <table className="w-full text-sm">
-            <thead>
-              <tr className="border-b border-border bg-muted">
-                <th className="px-4 py-2.5 text-left font-medium text-muted-foreground">Shape</th>
-                <th className="px-4 py-2.5 text-left font-medium text-muted-foreground">
-                  <code className="text-xs">display.shape</code>
-                </th>
-                <th className="px-4 py-2.5 text-left font-medium text-muted-foreground">
-                  Example node type
-                </th>
-                <th className="px-4 py-2.5 text-left font-medium text-muted-foreground">
-                  Typical use
-                </th>
-              </tr>
-            </thead>
-            <tbody>
-              {shapeRows.map((row) => (
-                <tr key={row.shape} className="border-b border-border last:border-b-0">
-                  <td className="px-4 py-3 font-medium text-foreground">{row.shape}</td>
-                  <td className="px-4 py-3">
-                    <code className="text-xs text-primary">{row.value}</code>
-                  </td>
-                  <td className="px-4 py-3">
-                    <code className="text-xs text-muted-foreground">{row.example}</code>
-                  </td>
-                  <td className="px-4 py-3 text-muted-foreground">{row.use}</td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
+        <StorySpecTable columns={shapeColumns} rows={shapeRows} />
+      </StorySection>
 
-        <div className="my-10 h-px bg-border" />
-
-        {/* ── How to use ── */}
-        <h2 className="mb-2 text-2xl font-bold tracking-tight text-foreground">How to use</h2>
-        <p className="mb-4 text-sm leading-relaxed text-muted-foreground">
-          Set{' '}
-          <code className="rounded bg-muted px-1.5 py-0.5 text-xs text-primary">display.shape</code>{' '}
-          when creating node data. If omitted, the registry manifest's{' '}
-          <code className="rounded bg-muted px-1.5 py-0.5 text-xs text-primary">display.shape</code>{' '}
-          is used as the fallback.
-        </p>
-        <pre className="overflow-x-auto rounded-lg border border-border bg-card p-4 text-[13px] leading-relaxed text-foreground">
+      <StorySection
+        title="How to use"
+        description={
+          <>
+            Set <StoryCode>display.shape</StoryCode> when creating node data. If omitted, the
+            registry manifest's <StoryCode>display.shape</StoryCode> is used as the fallback.
+          </>
+        }
+      >
+        <StoryCodeBlock>
           {`createNode({
   id: 'my-node',
   type: 'uipath.blank-node',
@@ -599,9 +458,9 @@ function ShapesPage({ globalTheme }: { globalTheme: string }) {
     },
   },
 })`}
-        </pre>
-      </div>
-    </div>
+        </StoryCodeBlock>
+      </StorySection>
+    </StoryPage>
   );
 }
 
@@ -668,52 +527,6 @@ function ExecutionStatesCanvas({ onActionNeeded }: { onActionNeeded?: (nodeId: s
         </Panel>
       </BaseCanvas>
     </BaseNodeOverrideConfigProvider>
-  );
-}
-
-function ExecutionStatesPreviewButton({
-  isExpanded,
-  onExpand,
-  onClose,
-}: {
-  isExpanded: boolean;
-  onExpand: () => void;
-  onClose: () => void;
-}) {
-  return isExpanded ? (
-    <button
-      type="button"
-      onClick={onClose}
-      className="absolute right-3 top-3 z-10 flex items-center gap-1.5 rounded-md border border-border bg-background/80 px-2.5 py-1.5 text-xs font-medium text-muted-foreground backdrop-blur-sm transition-colors hover:bg-surface-hover hover:text-foreground"
-    >
-      <svg width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden="true">
-        <path
-          d="M7.5 4.5l-6 6M10.5 1.5l-6 6M1.5 1.5l4 4M10.5 10.5l-4-4"
-          stroke="currentColor"
-          strokeWidth="1.5"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-        />
-      </svg>
-      Close
-    </button>
-  ) : (
-    <button
-      type="button"
-      onClick={onExpand}
-      className="absolute right-3 top-3 z-10 flex items-center gap-1.5 rounded-md border border-border bg-background/80 px-2.5 py-1.5 text-xs font-medium text-muted-foreground backdrop-blur-sm transition-colors hover:bg-surface-hover hover:text-foreground"
-    >
-      <svg width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden="true">
-        <path
-          d="M7.5 1.5h3v3M4.5 10.5h-3v-3M10.5 4.5V1.5H7.5M1.5 7.5v3h3"
-          stroke="currentColor"
-          strokeWidth="1.5"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-        />
-      </svg>
-      Expand
-    </button>
   );
 }
 
@@ -811,38 +624,17 @@ const executionStateRows = [
   {
     state: 'ActionNeeded',
     trigger: "status: 'ActionNeeded'",
-    meaning: 'Process blocked — waiting for human input before continuing',
+    meaning: 'Process blocked, waiting for human input before continuing',
   },
 ] as const;
 
-function CollapsibleSection({
-  title,
-  open,
-  onToggle,
-  children,
-}: {
-  title: string;
-  open: boolean;
-  onToggle: () => void;
-  children: React.ReactNode;
-}) {
-  return (
-    <div className="border-t border-border">
-      <button
-        type="button"
-        onClick={onToggle}
-        className="flex w-full items-center justify-between py-5 text-left transition-colors hover:text-foreground"
-      >
-        <h2 className="text-2xl font-bold tracking-tight text-foreground">{title}</h2>
-        <CanvasIcon icon={open ? 'chevron-up' : 'chevron-down'} size={16} />
-      </button>
-      {open && <div className="pb-8">{children}</div>}
-    </div>
-  );
-}
+const executionStateColumns: readonly StorySpecColumn<(typeof executionStateRows)[number]>[] = [
+  { key: 'state', header: 'State', variant: 'strong' },
+  { key: 'trigger', header: 'How it is set', variant: 'code' },
+  { key: 'meaning', header: 'Meaning' },
+];
 
 function ExecutionStatesPage({ globalTheme }: { globalTheme: string }) {
-  const [expanded, setExpanded] = useState(false);
   const [anatomyOpen, setAnatomyOpen] = useState(false);
   const [howToUseOpen, setHowToUseOpen] = useState(false);
   const [takeActionOpen, setTakeActionOpen] = useState(false);
@@ -856,281 +648,173 @@ function ExecutionStatesPage({ globalTheme }: { globalTheme: string }) {
   };
 
   return (
-    <div className={cn(globalTheme, 'min-h-screen w-full bg-background text-foreground')}>
-      {/* ── Header ── */}
-      <div className="mx-auto max-w-4xl px-8 pt-8">
-        <h2 className="mb-2 text-2xl font-bold tracking-tight text-foreground">Execution States</h2>
+    <StoryPage
+      theme={globalTheme}
+      title="Execution States"
+      description={
+        <>
+          Execution states reflect a node's runtime status: where it is in the current run. They are
+          applied externally via the <StoryCode>executionState</StoryCode> provider, not stored in
+          the node's own data. When no state is provided a node renders in its default{' '}
+          <StoryCode>NotExecuted</StoryCode> appearance.
+        </>
+      }
+    >
+      <StoryPreview
+        description={
+          <>
+            <p>All execution states across every shape. Rows are states, columns are shapes.</p>
+            <p>
+              <strong className="font-medium text-foreground">Note:</strong> This grid shows{' '}
+              <StoryCode>Failed</StoryCode> and <StoryCode>ActionNeeded</StoryCode> side by side for
+              documentation purposes only. In a real execution these states are mutually exclusive:
+              a node cannot be in both at the same time.
+            </p>
+          </>
+        }
+      >
+        <ExecutionStatesCanvas onActionNeeded={setActionNodeId} />
+      </StoryPreview>
+
+      <div className="mx-auto flex max-w-4xl justify-end px-8 pb-2">
+        <button
+          type="button"
+          onClick={toggleAll}
+          className="text-xs text-muted-foreground transition-colors hover:text-foreground"
+        >
+          {allOpen ? 'Collapse all' : 'Expand all'}
+        </button>
+      </div>
+
+      <StoryCollapsibleSection
+        title="Anatomy"
+        open={anatomyOpen}
+        onToggle={() => setAnatomyOpen((o) => !o)}
+      >
         <p className="mb-6 text-sm leading-relaxed text-muted-foreground">
-          Execution states reflect a node's runtime status — where it is in the current run. They
-          are applied externally via the{' '}
-          <code className="rounded bg-muted px-1.5 py-0.5 text-xs text-primary">
-            executionState
-          </code>{' '}
-          provider, not stored in the node's own data. When no state is provided a node renders in
-          its default{' '}
-          <code className="rounded bg-muted px-1.5 py-0.5 text-xs text-primary">NotExecuted</code>{' '}
-          appearance.
+          Each state communicates a distinct moment in the execution lifecycle. The visual treatment
+          (border color, overlay icon) updates automatically when the provider returns a new state.
         </p>
-        <div className="mb-8 h-px bg-border" />
-      </div>
 
-      {/* ── Preview — 90vw centered ── */}
-      <div className="pb-8">
-        <div className="mx-auto max-w-4xl px-8 mb-4">
-          <h2 className="mb-1 text-2xl font-bold tracking-tight text-foreground">Preview</h2>
-          <p className="text-sm leading-relaxed text-muted-foreground">
-            All execution states across every shape — rows are states, columns are shapes.
-          </p>
-          <p className="mt-1.5 text-sm text-muted-foreground">
-            <strong className="font-medium text-foreground">Note:</strong> This grid shows{' '}
-            <code className="rounded bg-muted px-1 py-0.5 text-xs text-primary">Failed</code> and{' '}
-            <code className="rounded bg-muted px-1 py-0.5 text-xs text-primary">ActionNeeded</code>{' '}
-            side by side for documentation purposes only. In a real execution these states are
-            mutually exclusive — a node cannot be in both at the same time.
-          </p>
-        </div>
-        <div className="flex justify-center">
-          <div className="relative w-[90vw] h-[560px] overflow-hidden rounded-xl border border-border">
-            {!expanded && <ExecutionStatesCanvas onActionNeeded={setActionNodeId} />}
-            <ExecutionStatesPreviewButton
-              isExpanded={false}
-              onExpand={() => setExpanded(true)}
-              onClose={() => setExpanded(false)}
-            />
-          </div>
-        </div>
-      </div>
-
-      {/* Expanded overlay */}
-      {expanded && (
-        <div
-          className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm"
-          onClick={() => setExpanded(false)}
-        >
-          <div
-            className="relative overflow-hidden rounded-xl border border-border"
-            style={{ width: '90vw', height: '90vh' }}
-            onClick={(e) => e.stopPropagation()}
-          >
-            <ExecutionStatesCanvas onActionNeeded={setActionNodeId} />
-            <ExecutionStatesPreviewButton
-              isExpanded={true}
-              onExpand={() => setExpanded(true)}
-              onClose={() => setExpanded(false)}
-            />
-          </div>
-        </div>
-      )}
-
-      {/* ── Collapsible sections ── */}
-      <div className="mx-auto max-w-4xl px-8 pb-8">
-        {/* Expand / Collapse all */}
-        <div className="flex justify-end pb-2">
-          <button
-            type="button"
-            onClick={toggleAll}
-            className="text-xs text-muted-foreground transition-colors hover:text-foreground"
-          >
-            {allOpen ? 'Collapse all' : 'Expand all'}
-          </button>
-        </div>
-
-        <CollapsibleSection
-          title="Anatomy"
-          open={anatomyOpen}
-          onToggle={() => setAnatomyOpen((o) => !o)}
-        >
-          <p className="mb-6 text-sm leading-relaxed text-muted-foreground">
-            Each state communicates a distinct moment in the execution lifecycle. The visual
-            treatment (border color, overlay icon) updates automatically when the provider returns a
-            new state.
-          </p>
-
-          <div className="mb-8 grid grid-cols-3 gap-4">
-            {executionStateCards.map((card) => (
-              <div
-                key={card.state}
-                className="flex flex-col gap-4 rounded-xl border border-border bg-card p-6"
-              >
-                <div className="flex h-24 items-center justify-center">
-                  <div
-                    className={cn(
-                      'flex h-16 w-16 items-center justify-center rounded-lg border-2',
-                      card.borderClass,
-                      card.bgClass
-                    )}
-                  >
-                    <div className={cn('h-7 w-7 rounded bg-opacity-80', card.iconClass)} />
-                  </div>
-                </div>
-                <div className="flex flex-col gap-2">
-                  <div className="flex flex-wrap items-center gap-2">
-                    <span className="text-base font-semibold text-foreground">{card.state}</span>
-                    <code className="rounded bg-muted px-1.5 py-0.5 text-xs text-primary">
-                      {card.value}
-                    </code>
-                  </div>
-                  <p className="text-sm text-muted-foreground">{card.description}</p>
-                </div>
-              </div>
-            ))}
-          </div>
-
-          {/* Spec table */}
-          <div className="overflow-hidden rounded-lg border border-border">
-            <table className="w-full text-sm">
-              <thead>
-                <tr className="border-b border-border bg-muted">
-                  <th className="px-4 py-2.5 text-left font-medium text-muted-foreground">State</th>
-                  <th className="px-4 py-2.5 text-left font-medium text-muted-foreground">
-                    How it is set
-                  </th>
-                  <th className="px-4 py-2.5 text-left font-medium text-muted-foreground">
-                    Meaning
-                  </th>
-                </tr>
-              </thead>
-              <tbody>
-                {executionStateRows.map((row) => (
-                  <tr key={row.state} className="border-b border-border last:border-b-0">
-                    <td className="px-4 py-3 font-medium text-foreground">{row.state}</td>
-                    <td className="px-4 py-3">
-                      <code className="text-xs text-primary">{row.trigger}</code>
-                    </td>
-                    <td className="px-4 py-3 text-muted-foreground">{row.meaning}</td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-        </CollapsibleSection>
-
-        <CollapsibleSection
-          title="Action needed"
-          open={takeActionOpen}
-          onToggle={() => setTakeActionOpen((o) => !o)}
-        >
-          <p className="mb-6 text-sm leading-relaxed text-muted-foreground">
-            When a node is in the{' '}
-            <code className="rounded bg-muted px-1.5 py-0.5 text-xs text-primary">
-              ActionNeeded
-            </code>{' '}
-            state, an "Action needed" pill is surfaced at the top-right of the node to prompt the
-            user to unblock execution.{' '}
-            <strong className="font-medium text-foreground">
-              This pill is only present on flows that are in an executing state
-            </strong>{' '}
-            — it will not appear during design-time or when no run is active.
-          </p>
-
-          <div className="mb-8 grid grid-cols-3 gap-8">
-            {/* Always visible */}
-            <div className="flex flex-col gap-3">
-              <div className="flex h-16 items-center">
-                <button
-                  type="button"
-                  onClick={() => setActionNodeId('state-1-preview')}
-                  className="flex items-center gap-1.5 rounded-full bg-amber-400 px-2.5 py-1 text-[11px] font-semibold text-stone-900 shadow-sm transition-colors hover:bg-amber-300"
+        <div className="mb-8 grid grid-cols-3 gap-4">
+          {executionStateCards.map((card) => (
+            <StoryCard
+              key={card.state}
+              preview={
+                <div
+                  className={cn(
+                    'flex h-16 w-16 items-center justify-center rounded-lg border-2',
+                    card.borderClass,
+                    card.bgClass
+                  )}
                 >
-                  <CanvasIcon icon="flag" size={12} />
-                  Action needed
-                </button>
-              </div>
-              <div className="flex flex-col gap-1">
-                <span className="text-sm font-semibold text-foreground">Always visible</span>
-                <p className="text-sm leading-relaxed text-muted-foreground">
-                  Solid amber pill with flag icon and label, always rendered at the top-right when
-                  the node is in{' '}
-                  <code className="rounded bg-muted px-1 py-0.5 text-xs text-primary">
-                    ActionNeeded
-                  </code>{' '}
-                  state. Clicking it triggers the{' '}
-                  <code className="rounded bg-muted px-1 py-0.5 text-xs text-primary">
-                    onActionNeeded
-                  </code>{' '}
-                  callback wired through{' '}
-                  <code className="rounded bg-muted px-1 py-0.5 text-xs text-primary">
-                    BaseNodeOverrideConfigProvider
-                  </code>
-                  .
-                </p>
-              </div>
-            </div>
+                  <div className={cn('h-7 w-7 rounded bg-opacity-80', card.iconClass)} />
+                </div>
+              }
+              title={card.state}
+              code={card.value}
+              description={card.description}
+            />
+          ))}
+        </div>
 
-            {/* TBD: Action response */}
-            <div className="flex flex-col gap-3">
-              <div className="flex h-16 items-center">
-                <span className="rounded-full bg-muted px-2.5 py-1 text-[11px] font-medium text-muted-foreground">
-                  Upcoming
-                </span>
-              </div>
-              <div className="flex flex-col gap-1">
-                <span className="text-sm font-semibold text-foreground">
-                  Action response — not yet defined
-                </span>
-                <p className="text-sm leading-relaxed text-muted-foreground">
-                  Clicking the pill fires{' '}
-                  <code className="rounded bg-muted px-1 py-0.5 text-xs text-primary">
-                    onActionNeeded(nodeId)
-                  </code>{' '}
-                  — what the app renders in response is a consumer responsibility. The surface
-                  (modal, side panel, or inline) and its content model have not yet been specified.
-                </p>
-              </div>
-            </div>
+        <StorySpecTable columns={executionStateColumns} rows={executionStateRows} />
+      </StoryCollapsibleSection>
 
-            {/* TBD: Execution count impact */}
-            <div className="flex flex-col gap-3">
-              <div className="flex h-16 items-center">
-                <span className="rounded-full bg-muted px-2.5 py-1 text-[11px] font-medium text-muted-foreground">
-                  Upcoming
-                </span>
-              </div>
-              <div className="flex flex-col gap-1">
-                <span className="text-sm font-semibold text-foreground">
-                  Execution count display — not yet defined
-                </span>
-                <p className="text-sm leading-relaxed text-muted-foreground">
-                  It has not yet been specified how{' '}
-                  <code className="rounded bg-muted px-1 py-0.5 text-xs text-primary">
-                    ActionNeeded
-                  </code>{' '}
-                  interacts with the execution count badge (
-                  <code className="rounded bg-muted px-1 py-0.5 text-xs text-primary">
-                    IterationNavigatorPill
-                  </code>
-                  ). Does the count freeze while blocked? Increment on resolution? Show a distinct
-                  state when a count is also present?
-                </p>
-              </div>
+      <StoryCollapsibleSection
+        title="Action needed"
+        open={takeActionOpen}
+        onToggle={() => setTakeActionOpen((o) => !o)}
+      >
+        <p className="mb-6 text-sm leading-relaxed text-muted-foreground">
+          When a node is in the <StoryCode>ActionNeeded</StoryCode> state, an "Action needed" pill
+          is surfaced at the top-right of the node to prompt the user to unblock execution.{' '}
+          <strong className="font-medium text-foreground">
+            This pill is only present on flows that are in an executing state
+          </strong>
+          . It will not appear during design-time or when no run is active.
+        </p>
+
+        <div className="mb-8 grid grid-cols-3 gap-8">
+          {/* Always visible */}
+          <div className="flex flex-col gap-3">
+            <div className="flex h-16 items-center">
+              <button
+                type="button"
+                onClick={() => setActionNodeId('state-1-preview')}
+                className="flex items-center gap-1.5 rounded-full bg-amber-400 px-2.5 py-1 text-[11px] font-semibold text-stone-900 shadow-sm transition-colors hover:bg-amber-300"
+              >
+                <CanvasIcon icon="flag" size={12} />
+                Action needed
+              </button>
+            </div>
+            <div className="flex flex-col gap-1">
+              <span className="text-sm font-semibold text-foreground">Always visible</span>
+              <p className="text-sm leading-relaxed text-muted-foreground">
+                Solid amber pill with flag icon and label, always rendered at the top-right when the
+                node is in <StoryCode>ActionNeeded</StoryCode> state. Clicking it triggers the{' '}
+                <StoryCode>onActionNeeded</StoryCode> callback wired through{' '}
+                <StoryCode>BaseNodeOverrideConfigProvider</StoryCode>.
+              </p>
             </div>
           </div>
-        </CollapsibleSection>
 
-        <CollapsibleSection
-          title="How to use"
-          open={howToUseOpen}
-          onToggle={() => setHowToUseOpen((o) => !o)}
-        >
-          <p className="mb-4 text-sm leading-relaxed text-muted-foreground">
-            Wire up the{' '}
-            <code className="rounded bg-muted px-1.5 py-0.5 text-xs text-primary">
-              executionState
-            </code>{' '}
-            option on{' '}
-            <code className="rounded bg-muted px-1.5 py-0.5 text-xs text-primary">
-              withCanvasProviders
-            </code>{' '}
-            to drive state from outside the node. In stories you can also set{' '}
-            <code className="rounded bg-muted px-1.5 py-0.5 text-xs text-primary">
-              data.executionStatus
-            </code>{' '}
-            directly as a shorthand.
-          </p>
+          {/* TBD: Action response */}
+          <div className="flex flex-col gap-3">
+            <div className="flex h-16 items-center">
+              <span className="rounded-full bg-muted px-2.5 py-1 text-[11px] font-medium text-muted-foreground">
+                Upcoming
+              </span>
+            </div>
+            <div className="flex flex-col gap-1">
+              <span className="text-sm font-semibold text-foreground">
+                Action response, not yet defined
+              </span>
+              <p className="text-sm leading-relaxed text-muted-foreground">
+                Clicking the pill fires <StoryCode>onActionNeeded(nodeId)</StoryCode>. What the app
+                renders in response is a consumer responsibility. The surface (modal, side panel, or
+                inline) and its content model have not yet been specified.
+              </p>
+            </div>
+          </div>
 
-          <div className="flex flex-col gap-4">
-            <pre className="overflow-x-auto rounded-lg border border-border bg-card p-4 text-[13px] leading-relaxed text-foreground">
-              {`// Via executionState provider (production pattern)
+          {/* TBD: Execution count impact */}
+          <div className="flex flex-col gap-3">
+            <div className="flex h-16 items-center">
+              <span className="rounded-full bg-muted px-2.5 py-1 text-[11px] font-medium text-muted-foreground">
+                Upcoming
+              </span>
+            </div>
+            <div className="flex flex-col gap-1">
+              <span className="text-sm font-semibold text-foreground">
+                Execution count display, not yet defined
+              </span>
+              <p className="text-sm leading-relaxed text-muted-foreground">
+                It has not yet been specified how <StoryCode>ActionNeeded</StoryCode> interacts with
+                the execution count badge (<StoryCode>IterationNavigatorPill</StoryCode>). Does the
+                count freeze while blocked? Increment on resolution? Show a distinct state when a
+                count is also present?
+              </p>
+            </div>
+          </div>
+        </div>
+      </StoryCollapsibleSection>
+
+      <StoryCollapsibleSection
+        title="How to use"
+        open={howToUseOpen}
+        onToggle={() => setHowToUseOpen((o) => !o)}
+      >
+        <p className="mb-4 text-sm leading-relaxed text-muted-foreground">
+          Wire up the <StoryCode>executionState</StoryCode> option on{' '}
+          <StoryCode>withCanvasProviders</StoryCode> to drive state from outside the node. In
+          stories you can also set <StoryCode>data.executionStatus</StoryCode> directly as a
+          shorthand.
+        </p>
+
+        <div className="flex flex-col gap-4">
+          <StoryCodeBlock>
+            {`// Via executionState provider (production pattern)
 withCanvasProviders({
   executionState: {
     getNodeExecutionState: (nodeId) => {
@@ -1142,9 +826,9 @@ withCanvasProviders({
     getEdgeExecutionState: () => undefined,
   },
 })`}
-            </pre>
-            <pre className="overflow-x-auto rounded-lg border border-border bg-card p-4 text-[13px] leading-relaxed text-foreground">
-              {`// Via node data (story / testing shorthand)
+          </StoryCodeBlock>
+          <StoryCodeBlock>
+            {`// Via node data (story / testing shorthand)
 createNode({
   id: 'my-node',
   type: 'uipath.blank-node',
@@ -1156,14 +840,14 @@ createNode({
     display: { label: 'My Node', shape: 'square' },
   },
 })`}
-            </pre>
-          </div>
-        </CollapsibleSection>
-      </div>
+          </StoryCodeBlock>
+        </div>
+      </StoryCollapsibleSection>
+
       {actionNodeId && (
         <TakeActionModal nodeId={actionNodeId} onClose={() => setActionNodeId(null)} />
       )}
-    </div>
+    </StoryPage>
   );
 }
 

--- a/packages/apollo-react/src/canvas/components/Edges/CanvasEdge.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/Edges/CanvasEdge.stories.tsx
@@ -8,16 +8,26 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import type { Edge, Node } from '@uipath/apollo-react/canvas/xyflow/react';
 import { Position } from '@uipath/apollo-react/canvas/xyflow/react';
+import { Label, Switch } from '@uipath/apollo-wind';
 import { useCallback, useMemo, useState } from 'react';
 import {
   createNode as createMockNode,
+  StoryCard,
+  StoryCode,
+  StoryCodeBlock,
   StoryInfoPanel,
+  StoryPage,
+  StoryPreview,
+  StorySection,
+  type StorySpecColumn,
+  StorySpecTable,
   useCanvasStory,
   withCanvasProviders,
 } from '../../storybook-utils';
 import { ElementStatusValues } from '../../types/execution';
 import { BaseCanvas } from '../BaseCanvas';
 import { CanvasEdge } from './CanvasEdge';
+import { EDGE_CONSTANTS } from './shared/constants';
 import type { EdgeRouter, RoutedEdge, RouteRequest } from './shared/routing';
 import { useGraphRouter } from './shared/routing';
 import type { CanvasEdgeData, Waypoint } from './shared/types';
@@ -728,4 +738,484 @@ export const ExecutionStates: Story = {
       },
     },
   },
+};
+
+// ============================================================================
+// Line Jumps Page
+// ============================================================================
+
+const JUMP_RADIUS = EDGE_CONSTANTS.LINE_JUMP_RADIUS;
+
+/**
+ * Three horizontal edges run under two vertical ones, so every row crosses
+ * every lane. Dragging a node keeps the crossings live, which is the point of
+ * deriving jumps from the rendered polylines rather than baking them in.
+ */
+function LineJumpsCanvas() {
+  const initialNodes = useMemo(() => {
+    // Rows are node y positions; lanes are node x positions. Each vertical
+    // edge runs through its lane node's center, crossing all three rows. The
+    // grid is sized to sit beside the info panel at 1:1, so the arcs render at
+    // the size a real canvas draws them rather than a zoomed-in approximation.
+    const rows = [40, 160, 280];
+    const lanes = [280, 520];
+    return [
+      ...rows.flatMap((y, i) => [
+        createNode({
+          id: `h${i}-src`,
+          label: `Row ${i + 1}`,
+          x: 40,
+          y,
+          sourcePositions: [Position.Right],
+        }),
+        createNode({
+          id: `h${i}-tgt`,
+          label: 'Target',
+          x: 640,
+          y,
+          targetPositions: [Position.Left],
+        }),
+      ]),
+      ...lanes.flatMap((x, i) => [
+        createNode({
+          id: `v${i}-src`,
+          label: `Lane ${i + 1}`,
+          x,
+          y: -80,
+          sourcePositions: [Position.Bottom],
+        }),
+        createNode({
+          id: `v${i}-tgt`,
+          label: 'Target',
+          x,
+          y: 360,
+          targetPositions: [Position.Top],
+        }),
+      ]),
+    ];
+  }, []);
+
+  const initialEdges: Edge<CanvasEdgeData>[] = useMemo(
+    () => [
+      ...[0, 1, 2].map((i) => ({
+        id: `h${i}`,
+        source: `h${i}-src`,
+        target: `h${i}-tgt`,
+        sourceHandle: `out-${Position.Right}`,
+        targetHandle: `in-${Position.Left}`,
+        type: 'canvas-edge',
+        data: { enableLineJumps: true, enableEditing: true },
+      })),
+      ...[0, 1].map((i) => ({
+        id: `v${i}`,
+        source: `v${i}-src`,
+        target: `v${i}-tgt`,
+        sourceHandle: `out-${Position.Bottom}`,
+        targetHandle: `in-${Position.Top}`,
+        type: 'canvas-edge',
+        data: { enableLineJumps: true, enableEditing: true },
+      })),
+    ],
+    []
+  );
+
+  const { canvasProps, setEdges } = useCanvasStory({ initialNodes, initialEdges });
+  const [enabled, setEnabled] = useState(true);
+
+  const toggle = useCallback(
+    (next: boolean) => {
+      setEnabled(next);
+      setEdges((eds) =>
+        eds.map((edge) => ({ ...edge, data: { ...edge.data, enableLineJumps: next } }))
+      );
+    },
+    [setEdges]
+  );
+
+  return (
+    <BaseCanvas
+      {...canvasProps}
+      edgeTypes={edgeTypes}
+      mode="design"
+      defaultViewport={{ x: 360, y: 140, zoom: 1 }}
+    >
+      <StoryInfoPanel
+        title="Line jumps"
+        description={enabled ? 'Crossings arc over' : 'Crossings drawn flat'}
+      >
+        <div className="mt-3 flex items-center gap-2">
+          <Switch id="line-jumps-toggle" checked={enabled} onCheckedChange={toggle} />
+          <Label htmlFor="line-jumps-toggle" className="text-xs">
+            enableLineJumps
+          </Label>
+        </div>
+      </StoryInfoPanel>
+    </BaseCanvas>
+  );
+}
+
+/** Schematic frame for the crossing diagrams, sized to the anatomy card slot. */
+function Diagram({
+  children,
+  width = 168,
+  height = 92,
+}: {
+  children: React.ReactNode;
+  width?: number;
+  height?: number;
+}) {
+  return (
+    <svg
+      viewBox={`0 0 ${width} ${height}`}
+      width={width}
+      height={height}
+      fill="none"
+      strokeWidth="2"
+      strokeLinecap="round"
+      aria-hidden="true"
+    >
+      {children}
+    </svg>
+  );
+}
+
+/** The edge that hops. */
+const HOP = 'text-primary';
+/** The edge that is hopped over, and any other supporting geometry. */
+const UNDER = 'text-muted-foreground';
+
+function AnnotatedJump() {
+  return (
+    <svg
+      viewBox="0 0 420 170"
+      className="h-auto w-full max-w-[420px]"
+      fill="none"
+      strokeLinecap="round"
+      aria-hidden="true"
+    >
+      {/* The crossing edge, drawn straight through */}
+      <path d="M 210 32 L 210 150" className={UNDER} stroke="currentColor" strokeWidth="2" />
+      {/* The hopping edge, arcing over it. Radius is exaggerated for legibility. */}
+      <path
+        d="M 30 96 L 188 96 A 22 22 0 0 1 232 96 L 390 96"
+        className={HOP}
+        stroke="currentColor"
+        strokeWidth="2"
+      />
+      {/* Radius, drawn under the arc where neither edge is stroked */}
+      <path
+        d="M 188 96 L 210 96"
+        className={UNDER}
+        stroke="currentColor"
+        strokeWidth="1"
+        strokeDasharray="3 3"
+      />
+      <circle cx="188" cy="96" r="3" className={HOP} fill="currentColor" />
+      <circle cx="232" cy="96" r="3" className={HOP} fill="currentColor" />
+
+      {/* Leaders out to the entry and exit labels, clear of the crossing edge */}
+      <g className={UNDER} stroke="currentColor" strokeWidth="1">
+        <path d="M 186 102 L 140 126" />
+        <path d="M 234 102 L 280 126" />
+      </g>
+
+      <g className="fill-current text-[11px] text-muted-foreground">
+        <text x="132" y="140" textAnchor="middle">
+          entry
+        </text>
+        <text x="288" y="140" textAnchor="middle">
+          exit
+        </text>
+        <text x="197" y="90" textAnchor="middle">
+          r
+        </text>
+        <text x="210" y="22" textAnchor="middle">
+          crossing edge, drawn through
+        </text>
+        <text x="30" y="86">
+          hopping edge
+        </text>
+      </g>
+    </svg>
+  );
+}
+
+const crossingCases = [
+  {
+    title: 'Crossing',
+    outcome: 'Arc',
+    description:
+      'The intersection falls strictly inside both segments, so the horizontal one hops over.',
+    diagram: (
+      <Diagram>
+        <path d="M 84 12 L 84 80" className={UNDER} stroke="currentColor" />
+        <path
+          d="M 16 46 L 74 46 A 10 10 0 0 1 94 46 L 152 46"
+          className={HOP}
+          stroke="currentColor"
+        />
+      </Diagram>
+    ),
+  },
+  {
+    title: 'T-junction',
+    outcome: 'Flat',
+    description:
+      'One line ends on the other rather than passing through it. That reads as a join, so nothing is drawn over it.',
+    diagram: (
+      <Diagram>
+        <path d="M 84 12 L 84 46" className={UNDER} stroke="currentColor" />
+        <path d="M 16 46 L 152 46" className={HOP} stroke="currentColor" />
+      </Diagram>
+    ),
+  },
+  {
+    title: 'Shared handle',
+    outcome: 'Flat',
+    description:
+      'Two edges fanning out of one handle touch at their ends. Arcing there would suggest they are unrelated.',
+    diagram: (
+      <Diagram>
+        {/* Both leave the same point, then branch at different x so the pair reads as two edges */}
+        <path d="M 14 46 L 62 46 L 62 14" className={UNDER} stroke="currentColor" />
+        <path d="M 14 46 L 104 46 L 104 80" className={HOP} stroke="currentColor" />
+        <circle cx="14" cy="46" r="3.5" className={HOP} fill="currentColor" stroke="none" />
+      </Diagram>
+    ),
+  },
+  {
+    title: 'Shared lane',
+    outcome: 'Flat',
+    description:
+      'Collinear edges overlap rather than cross. There is no over and under to communicate.',
+    diagram: (
+      <Diagram>
+        <path d="M 16 46 L 120 46" className={UNDER} stroke="currentColor" />
+        <path d="M 48 46 L 152 46" className={HOP} stroke="currentColor" strokeDasharray="6 5" />
+      </Diagram>
+    ),
+  },
+] as const;
+
+const dropCases = [
+  {
+    title: 'Inside a corner',
+    description:
+      'A crossing within one radius of a bend has no straight run to sit on. The arc would deform the corner curve, so the line stays flat through it.',
+    diagram: (
+      <Diagram>
+        <path d="M 120 10 L 120 60" className={UNDER} stroke="currentColor" />
+        <path d="M 16 30 L 112 30 Q 126 30 126 44 L 126 82" className={HOP} stroke="currentColor" />
+        <circle
+          cx="120"
+          cy="30"
+          r="12"
+          className="text-muted-foreground"
+          stroke="currentColor"
+          strokeWidth="1"
+          strokeDasharray="3 3"
+        />
+      </Diagram>
+    ),
+  },
+  {
+    title: 'Too close together',
+    description:
+      'Crossings nearer than one arc width would scallop the line instead of notching it, so only the first of the cluster is drawn.',
+    diagram: (
+      <Diagram>
+        <path d="M 78 12 L 78 80" className={UNDER} stroke="currentColor" />
+        <path d="M 92 12 L 92 80" className={UNDER} stroke="currentColor" />
+        <path
+          d="M 16 46 L 68 46 A 10 10 0 0 1 88 46 L 152 46"
+          className={HOP}
+          stroke="currentColor"
+        />
+      </Diagram>
+    ),
+  },
+] as const;
+
+type CrossingRuleRow = {
+  situation: string;
+  drawn: string;
+  reason: string;
+};
+
+const crossingRuleRows: readonly CrossingRuleRow[] = [
+  {
+    situation: 'Horizontal crosses vertical',
+    drawn: 'Arc on the horizontal',
+    reason: 'Orientation alone decides, so the pattern holds still while nodes move.',
+  },
+  {
+    situation: 'Vertical crosses horizontal',
+    drawn: 'Straight through',
+    reason: 'Only one side of a crossing may hop, otherwise both lines break.',
+  },
+  {
+    situation: 'One line ends on another',
+    drawn: 'Flat',
+    reason: 'The intersection must be strictly interior to both segments.',
+  },
+  {
+    situation: 'Edges share a handle',
+    drawn: 'Flat',
+    reason: 'They meet at a segment end, which reads as a join.',
+  },
+  {
+    situation: 'Edges share a lane',
+    drawn: 'Flat',
+    reason: 'Collinear overlap is not a crossing.',
+  },
+  {
+    situation: 'An edge crosses itself',
+    drawn: 'Flat',
+    reason: 'One path passing over its own elbow reads as a knot, not a crossing.',
+  },
+  {
+    situation: 'Several edges stacked on one lane',
+    drawn: 'One arc',
+    reason: 'Identical crossings would otherwise stack arcs on the same spot.',
+  },
+  {
+    situation: 'The other edge has not opted in',
+    drawn: 'Flat',
+    reason: 'Only edges that set the flag publish geometry, so set it uniformly.',
+  },
+];
+
+const crossingRuleColumns: readonly StorySpecColumn<CrossingRuleRow>[] = [
+  { key: 'situation', header: 'Situation', variant: 'strong' },
+  { key: 'drawn', header: 'What is drawn' },
+  { key: 'reason', header: 'Why' },
+];
+
+function LineJumpsPage({ globalTheme }: { globalTheme: string }) {
+  return (
+    <StoryPage
+      theme={globalTheme}
+      title="Line Jumps"
+      description={
+        <>
+          Where two edges cross, the horizontal one hops over the vertical with a small arc instead
+          of drawing straight through it, so the crossing reads as a pass-over rather than a join.
+          Edges opt in with <StoryCode>enableLineJumps</StoryCode> and the jumps are derived from
+          the rendered geometry, so they track node drags and waypoint edits live. Waypoint routing
+          only.
+        </>
+      }
+    >
+      <StoryPreview
+        height={700}
+        description={
+          <>
+            <p>
+              Three rows crossing two lanes. Every crossing sits on a horizontal segment, so every
+              arc lands on a row edge while the lane edges run unbroken.
+            </p>
+            <p>
+              Toggle the flag to compare against flat crossings, and drag any node to watch the
+              notches follow.
+            </p>
+          </>
+        }
+      >
+        <LineJumpsCanvas />
+      </StoryPreview>
+
+      <StorySection
+        title="Anatomy"
+        description={
+          <>
+            A jump replaces a stretch of the straight run with a half-circle of{' '}
+            <StoryCode>{`EDGE_CONSTANTS.LINE_JUMP_RADIUS`}</StoryCode> ({JUMP_RADIUS}px). The arc
+            enters one radius before the crossing and leaves one radius after it, and always bulges
+            to the same side whichever way the line runs.
+          </>
+        }
+      >
+        <div className="mb-8 flex justify-center rounded-xl border border-border bg-card py-6">
+          <AnnotatedJump />
+        </div>
+
+        <h3 className="mb-2 text-base font-semibold text-foreground">What counts as a crossing</h3>
+        <p className="mb-6 text-sm leading-relaxed text-muted-foreground">
+          Two lines have to genuinely pass over one another. Lines that merely meet keep their flat
+          intersection, so a notch always means the paths are unrelated.
+        </p>
+        <div className="mb-8 grid grid-cols-2 gap-4">
+          {crossingCases.map((item) => (
+            <StoryCard
+              key={item.title}
+              preview={item.diagram}
+              title={item.title}
+              code={item.outcome}
+              description={item.description}
+            />
+          ))}
+        </div>
+
+        <StorySpecTable columns={crossingRuleColumns} rows={crossingRuleRows} />
+      </StorySection>
+
+      <StorySection
+        title="When a jump is dropped"
+        description="A crossing that has nowhere clean to sit is drawn flat rather than approximated. Dense stretches degrade to fewer notches instead of a rippled line."
+      >
+        <div className="grid grid-cols-2 gap-4">
+          {dropCases.map((item) => (
+            <StoryCard
+              key={item.title}
+              preview={item.diagram}
+              title={item.title}
+              description={item.description}
+            />
+          ))}
+        </div>
+      </StorySection>
+
+      <StorySection
+        title="How to use"
+        description={
+          <>
+            <p>
+              Set <StoryCode>enableLineJumps</StoryCode> on the edge data. Because both sides of a
+              crossing have to opt in, apply it across the whole graph rather than to single edges:{' '}
+              <StoryCode>defaultEdgeOptions</StoryCode> is the least error-prone place.
+            </p>
+            <p>
+              The store that collects the geometry is mounted by <StoryCode>BaseCanvas</StoryCode>.
+              A canvas assembled by hand needs <StoryCode>EdgeCrossingsProvider</StoryCode> above
+              its edges, otherwise the flag is inert and every crossing draws flat.
+            </p>
+          </>
+        }
+      >
+        <StoryCodeBlock>
+          {`// Whole graph (recommended): every edge participates
+<BaseCanvas
+  defaultEdgeOptions={{
+    type: 'canvas-edge',
+    data: { enableLineJumps: true },
+  }}
+/>
+
+// Per edge, when only part of a graph should hop
+const edge: Edge<CanvasEdgeData> = {
+  id: 'e1',
+  source: 'a',
+  target: 'b',
+  type: 'canvas-edge',
+  data: { enableLineJumps: true },
+};`}
+        </StoryCodeBlock>
+      </StorySection>
+    </StoryPage>
+  );
+}
+
+export const LineJumps: Story = {
+  name: 'Line Jumps',
+  render: (_, { globals }) => <LineJumpsPage globalTheme={globals.theme || 'future-dark'} />,
 };

--- a/packages/apollo-react/src/canvas/components/Edges/CanvasEdge.tsx
+++ b/packages/apollo-react/src/canvas/components/Edges/CanvasEdge.tsx
@@ -1,5 +1,5 @@
 import { Position, useStoreApi } from '@uipath/apollo-react/canvas/xyflow/react';
-import { type MouseEvent, memo, useCallback, useRef, useState } from 'react';
+import { type MouseEvent, memo, useCallback, useMemo, useRef, useState } from 'react';
 import { isPreviewEdge } from '../../utils/createPreviewNode';
 import { useBaseCanvasMode } from '../BaseCanvas/BaseCanvasModeProvider';
 import { EdgeToolbar, useEdgeToolbarState } from '../Toolbar';
@@ -30,6 +30,7 @@ import type { CanvasEdgeProps } from './shared/types';
  * - `enableEditing`   — drag/insert/remove waypoints (waypoint routing only)
  * - `enableExecution` — subscribe to execution + validation status
  * - `enableToolbar`   — render add-node toolbar
+ * - `enableLineJumps` — arc over crossing edges (waypoint routing only)
  */
 export const CanvasEdge = memo(function CanvasEdge({
   id,
@@ -113,6 +114,7 @@ export const CanvasEdge = memo(function CanvasEdge({
 
   const geometry = useEdgeGeometry({
     routing,
+    edgeId: id,
     sourceNodeId: source,
     targetNodeId: target,
     sourceHandleId,
@@ -128,6 +130,7 @@ export const CanvasEdge = memo(function CanvasEdge({
     autoRouted: waypoints.length === 0,
     enableSegments: editingEnabled,
     hideArrowHead,
+    enableLineJumps: !!data?.enableLineJumps,
   });
 
   const editor = useWaypointEditor({
@@ -171,6 +174,10 @@ export const CanvasEdge = memo(function CanvasEdge({
 
   const showEditingChrome = editingEnabled && (isHovered || selected || editor.isDragging);
   const opacity = (style?.opacity as number | undefined) ?? 1;
+
+  // Held stable so the memoized arrow survives re-renders that move nothing but
+  // the stroke, such as a line jump forming somewhere along the path.
+  const arrowTarget = useMemo(() => ({ x: targetX, y: targetY }), [targetX, targetY]);
 
   return (
     <>
@@ -219,7 +226,7 @@ export const CanvasEdge = memo(function CanvasEdge({
 
         {!hideArrowHead && (
           <EdgeArrow
-            target={{ x: targetX, y: targetY }}
+            target={arrowTarget}
             angle={geometry.arrow.angle}
             offset={geometry.arrow.offset}
             color={color}

--- a/packages/apollo-react/src/canvas/components/Edges/index.ts
+++ b/packages/apollo-react/src/canvas/components/Edges/index.ts
@@ -1,5 +1,6 @@
 export { CanvasEdge } from './CanvasEdge';
 export * from './SequenceEdge';
+export { EdgeCrossingsProvider } from './shared/crossings';
 export type {
   EdgeRouter,
   RouteAnchor,
@@ -18,6 +19,7 @@ export type {
   CanvasEdgeProps,
   EdgeRouting,
   EdgeStrokeStyle,
+  PathJump,
   Point,
   Segment,
   SegmentOrientation,

--- a/packages/apollo-react/src/canvas/components/Edges/shared/constants.ts
+++ b/packages/apollo-react/src/canvas/components/Edges/shared/constants.ts
@@ -34,6 +34,12 @@ export const EDGE_CONSTANTS = {
   /** Distance the arrow sits inset from the target node edge */
   ARROW_OFFSET: 8,
   /**
+   * Radius of the arc drawn where an edge hops over a crossing edge. Also sets
+   * the minimum clearance a jump needs from a corner, and half the minimum
+   * spacing between two jumps on the same straight run.
+   */
+  LINE_JUMP_RADIUS: 5,
+  /**
    * Minimum distance the path travels perpendicular to a node face before it
    * is allowed to turn. Keeps the connector from folding back across the node
    * when the adjacent waypoint sits behind the exit direction.

--- a/packages/apollo-react/src/canvas/components/Edges/shared/crossings/EdgeCrossingsContext.test.ts
+++ b/packages/apollo-react/src/canvas/components/Edges/shared/crossings/EdgeCrossingsContext.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { Point } from '../types';
+import { EdgeCrossingsStore } from './EdgeCrossingsContext';
+
+/** A horizontal line at y=50 and a vertical line at x=50 forming a plain X. */
+const horizontal: Point[] = [
+  { x: 0, y: 50 },
+  { x: 100, y: 50 },
+];
+const vertical: Point[] = [
+  { x: 50, y: 0 },
+  { x: 50, y: 100 },
+];
+
+/** A fresh array of the same positions, as a re-render would hand over. */
+const rebuilt = (points: Point[]): Point[] => points.map((p) => ({ x: p.x, y: p.y }));
+
+/** Let the store's coalescing microtask run. */
+const drain = () => Promise.resolve();
+
+function crossedStore(): EdgeCrossingsStore {
+  const store = new EdgeCrossingsStore();
+  store.register('h', horizontal);
+  store.register('v', vertical);
+  return store;
+}
+
+describe('EdgeCrossingsStore', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('derives the crossing once the coalescing microtask drains', async () => {
+    const store = crossedStore();
+    expect(store.getSnapshot('h')).toEqual([]);
+
+    await drain();
+
+    expect(store.getSnapshot('h')).toEqual([{ segmentIndex: 0, point: { x: 50, y: 50 } }]);
+    expect(store.getSnapshot('v')).toEqual([]);
+  });
+
+  it('drops a re-registration that repeats the stored positions', async () => {
+    const store = crossedStore();
+    await drain();
+
+    const schedule = vi.spyOn(globalThis, 'queueMicrotask');
+    store.register('h', rebuilt(horizontal));
+
+    expect(schedule).not.toHaveBeenCalled();
+  });
+
+  it('keeps snapshot identity across a no-op registration', async () => {
+    const store = crossedStore();
+    await drain();
+    const before = store.getSnapshot('h');
+
+    store.register('h', rebuilt(horizontal));
+    await drain();
+
+    expect(store.getSnapshot('h')).toBe(before);
+  });
+
+  it('recomputes when the polyline actually moves', async () => {
+    const store = crossedStore();
+    await drain();
+
+    const schedule = vi.spyOn(globalThis, 'queueMicrotask');
+    store.register('h', [
+      { x: 0, y: 70 },
+      { x: 100, y: 70 },
+    ]);
+
+    expect(schedule).toHaveBeenCalledTimes(1);
+    await drain();
+    expect(store.getSnapshot('h')).toEqual([{ segmentIndex: 0, point: { x: 50, y: 70 } }]);
+  });
+
+  it('notifies only the edges whose own jumps changed', async () => {
+    const store = crossedStore();
+    await drain();
+
+    const onHorizontal = vi.fn();
+    const onVertical = vi.fn();
+    store.subscribe('h', onHorizontal);
+    store.subscribe('v', onVertical);
+
+    // Slide the vertical across to x=70, moving the horizontal's notch with it.
+    store.register('v', [
+      { x: 70, y: 0 },
+      { x: 70, y: 100 },
+    ]);
+    await drain();
+
+    expect(onHorizontal).toHaveBeenCalledTimes(1);
+    expect(onVertical).not.toHaveBeenCalled();
+    expect(store.getSnapshot('h')).toEqual([{ segmentIndex: 0, point: { x: 70, y: 50 } }]);
+  });
+
+  it('withdraws an edge and clears the jumps that depended on it', async () => {
+    const store = crossedStore();
+    await drain();
+
+    store.unregister('v');
+    await drain();
+
+    expect(store.getSnapshot('h')).toEqual([]);
+  });
+});

--- a/packages/apollo-react/src/canvas/components/Edges/shared/crossings/EdgeCrossingsContext.tsx
+++ b/packages/apollo-react/src/canvas/components/Edges/shared/crossings/EdgeCrossingsContext.tsx
@@ -1,0 +1,153 @@
+import { createContext, type ReactNode, useContext, useRef } from 'react';
+import type { PathJump, Point } from '../types';
+import { computeLineJumps, type EdgePolyline, jumpsEqual, polylinesEqual } from './crossings';
+
+type Listener = () => void;
+
+export const EMPTY_JUMPS: readonly PathJump[] = Object.freeze([]);
+
+/**
+ * Registry of edge polylines with granular per-edge subscriptions, mirroring
+ * `ConnectedHandlesStore`. Edges publish their vertices, the store derives every
+ * crossing once, and each edge reads back only its own jumps.
+ *
+ * Jumps are derived from the vertices and change only the SVG `d` string the
+ * edge draws, never the vertices themselves, so publishing can't re-trigger the
+ * computation that produced it.
+ */
+export class EdgeCrossingsStore {
+  private geometry = new Map<string, Point[]>();
+  private jumps = new Map<string, readonly PathJump[]>();
+  private listeners = new Map<string, Set<Listener>>();
+  private scheduled = false;
+
+  /**
+   * Publish (or replace) one edge's polyline.
+   *
+   * A registration that repeats the stored positions is dropped rather than
+   * scheduling a recompute. Callers hand over a fresh array on every render
+   * whose geometry inputs changed identity but not value: `useNodeDragRebalance`
+   * rebuilds its waypoint list on each render while a drag is active, so the
+   * re-render this store triggers would otherwise schedule a second whole-graph
+   * pass that can only reproduce the jumps it just published.
+   *
+   * The stored array is kept and the incoming one dropped, so the retained
+   * baseline is never more than one tolerance behind the rendered path: a
+   * polyline creeping below the threshold each frame still trips the comparison
+   * once its total drift from the baseline exceeds it.
+   */
+  register(edgeId: string, points: Point[]): void {
+    const current = this.geometry.get(edgeId);
+    if (current && polylinesEqual(current, points)) return;
+
+    this.geometry.set(edgeId, points);
+    this.schedule();
+  }
+
+  /** Withdraw an edge — unmounted, or line jumps switched off. */
+  unregister(edgeId: string): void {
+    if (this.geometry.delete(edgeId)) this.schedule();
+  }
+
+  subscribe(edgeId: string, listener: Listener): () => void {
+    let edgeListeners = this.listeners.get(edgeId);
+    if (!edgeListeners) {
+      edgeListeners = new Set();
+      this.listeners.set(edgeId, edgeListeners);
+    }
+
+    edgeListeners.add(listener);
+
+    return () => {
+      edgeListeners.delete(listener);
+      if (edgeListeners.size === 0) this.listeners.delete(edgeId);
+    };
+  }
+
+  /**
+   * Jumps for one edge. The identity is stable until that edge's own jumps
+   * change, so it can drive a `useMemo` without invalidating it every frame.
+   */
+  getSnapshot(edgeId: string): readonly PathJump[] {
+    return this.jumps.get(edgeId) ?? EMPTY_JUMPS;
+  }
+
+  /**
+   * Coalesce the registrations from one commit into a single pass.
+   *
+   * Edges register in a layout effect, so the microtask drains before the
+   * browser paints and a drag keeps its arcs in step with the stroke. The
+   * opening commit is the exception: `useSyncExternalStore` subscribes in a
+   * passive effect, which the scheduler runs a macrotask later, so this first
+   * pass has nobody to notify. React's own check after subscribing picks the
+   * jumps up, one commit behind.
+   */
+  private schedule(): void {
+    if (this.scheduled) return;
+    this.scheduled = true;
+    queueMicrotask(() => {
+      this.scheduled = false;
+      this.recompute();
+    });
+  }
+
+  private recompute(): void {
+    const polylines: EdgePolyline[] = [];
+    for (const [edgeId, points] of this.geometry) polylines.push({ edgeId, points });
+
+    const next = computeLineJumps(polylines);
+    const changed: string[] = [];
+
+    for (const [edgeId, jumps] of next) {
+      if (jumpsEqual(this.jumps.get(edgeId) ?? EMPTY_JUMPS, jumps)) continue;
+      this.jumps.set(edgeId, jumps);
+      changed.push(edgeId);
+    }
+
+    for (const edgeId of [...this.jumps.keys()]) {
+      if (next.has(edgeId)) continue;
+      this.jumps.delete(edgeId);
+      changed.push(edgeId);
+    }
+
+    // Notify only the edges whose own notches moved — a crossing forming on the
+    // far side of the canvas must not re-render every edge.
+    for (const edgeId of changed) {
+      const edgeListeners = this.listeners.get(edgeId);
+      if (!edgeListeners) continue;
+      for (const listener of edgeListeners) listener();
+    }
+  }
+}
+
+const EdgeCrossingsContext = createContext<EdgeCrossingsStore | null>(null);
+
+/**
+ * Provides the crossings store to the tree. `BaseCanvas` mounts one already; a
+ * canvas assembled by hand needs this above its edges, or the flag is inert and
+ * every crossing draws flat.
+ *
+ * An ancestor store wins over a fresh one, so wrapping a `BaseCanvas` in this
+ * (or double-wrapping by accident) is a no-op rather than a trap. Two stores in
+ * one canvas would split the registry down the middle: edges on either side of
+ * the boundary would stop seeing each other, and the only symptom would be
+ * crossings that quietly refuse to hop.
+ */
+export function EdgeCrossingsProvider({ children }: { children: ReactNode }) {
+  const inherited = useContext(EdgeCrossingsContext);
+  const ownStoreRef = useRef<EdgeCrossingsStore | undefined>(undefined);
+
+  if (!ownStoreRef.current) {
+    ownStoreRef.current = new EdgeCrossingsStore();
+  }
+
+  return (
+    <EdgeCrossingsContext.Provider value={inherited ?? ownStoreRef.current}>
+      {children}
+    </EdgeCrossingsContext.Provider>
+  );
+}
+
+export function useEdgeCrossingsStore(): EdgeCrossingsStore | null {
+  return useContext(EdgeCrossingsContext);
+}

--- a/packages/apollo-react/src/canvas/components/Edges/shared/crossings/crossings.test.ts
+++ b/packages/apollo-react/src/canvas/components/Edges/shared/crossings/crossings.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, it } from 'vitest';
+import type { Point } from '../types';
+import { computeLineJumps, type EdgePolyline, jumpsEqual, polylinesEqual } from './crossings';
+
+const line = (edgeId: string, ...points: Point[]): EdgePolyline => ({ edgeId, points });
+
+/** A horizontal line at y=50 and a vertical line at x=50 forming a plain X. */
+const horizontal = line('h', { x: 0, y: 50 }, { x: 100, y: 50 });
+const vertical = line('v', { x: 50, y: 0 }, { x: 50, y: 100 });
+
+describe('computeLineJumps', () => {
+  it('puts a jump on the horizontal edge where it crosses a vertical one', () => {
+    const jumps = computeLineJumps([horizontal, vertical]);
+
+    expect(jumps.get('h')).toEqual([{ segmentIndex: 0, point: { x: 50, y: 50 } }]);
+    // The vertical line is drawn straight through.
+    expect(jumps.has('v')).toBe(false);
+  });
+
+  it('is independent of the order the edges are registered in', () => {
+    expect(computeLineJumps([vertical, horizontal])).toEqual(
+      computeLineJumps([horizontal, vertical])
+    );
+  });
+
+  it('reports the index of the segment the crossing sits on', () => {
+    // Two elbows: segment 0 is horizontal, 1 is vertical, 2 is horizontal again.
+    const elbowed = line(
+      'h',
+      { x: 0, y: 0 },
+      { x: 200, y: 0 },
+      { x: 200, y: 100 },
+      { x: 400, y: 100 }
+    );
+    const crossing = line('v', { x: 300, y: 50 }, { x: 300, y: 150 });
+
+    expect(computeLineJumps([elbowed, crossing]).get('h')).toEqual([
+      { segmentIndex: 2, point: { x: 300, y: 100 } },
+    ]);
+  });
+
+  it('ignores a T-junction where one line ends on the other', () => {
+    // The vertical stops exactly on the horizontal rather than passing through.
+    const tee = line('v', { x: 50, y: 0 }, { x: 50, y: 50 });
+
+    expect(computeLineJumps([horizontal, tee]).size).toBe(0);
+  });
+
+  it('ignores lines that meet at a shared endpoint', () => {
+    const fanOut = line('v', { x: 0, y: 50 }, { x: 0, y: 200 });
+
+    expect(computeLineJumps([horizontal, fanOut]).size).toBe(0);
+  });
+
+  it('ignores collinear overlap between two edges sharing a lane', () => {
+    const overlapping = line('h2', { x: 20, y: 50 }, { x: 80, y: 50 });
+
+    expect(computeLineJumps([horizontal, overlapping]).size).toBe(0);
+  });
+
+  it('ignores an edge crossing itself', () => {
+    const selfCrossing = line(
+      'h',
+      { x: 0, y: 50 },
+      { x: 100, y: 50 },
+      { x: 100, y: 0 },
+      { x: 50, y: 0 },
+      { x: 50, y: 100 }
+    );
+
+    expect(computeLineJumps([selfCrossing]).size).toBe(0);
+  });
+
+  it('returns several crossings on one segment ordered by x', () => {
+    const first = line('v1', { x: 30, y: 0 }, { x: 30, y: 100 });
+    const second = line('v2', { x: 70, y: 0 }, { x: 70, y: 100 });
+
+    expect(computeLineJumps([horizontal, second, first]).get('h')).toEqual([
+      { segmentIndex: 0, point: { x: 30, y: 50 } },
+      { segmentIndex: 0, point: { x: 70, y: 50 } },
+    ]);
+  });
+
+  it('collapses two verticals stacked on the same x into a single jump', () => {
+    const first = line('v1', { x: 50, y: 0 }, { x: 50, y: 100 });
+    const second = line('v2', { x: 50, y: 10 }, { x: 50, y: 90 });
+
+    expect(computeLineJumps([horizontal, first, second]).get('h')).toHaveLength(1);
+  });
+
+  it('ignores a crossing that lands where the vertical curves into a bend', () => {
+    // The vertical turns at (50, 100), so the rendered stroke peels away from
+    // x=50 for the border radius before it. An arc at y=92 would miss the line.
+    const bent = line('v', { x: 50, y: 0 }, { x: 50, y: 100 }, { x: 150, y: 100 });
+    const nearBend = line('h2', { x: 0, y: 92 }, { x: 100, y: 92 });
+
+    expect(computeLineJumps([nearBend, bent]).size).toBe(0);
+  });
+
+  it('keeps a crossing on the straight stretch of a bent vertical', () => {
+    const bent = line('v', { x: 50, y: 0 }, { x: 50, y: 100 }, { x: 150, y: 100 });
+
+    expect(computeLineJumps([horizontal, bent]).get('h')).toEqual([
+      { segmentIndex: 0, point: { x: 50, y: 50 } },
+    ]);
+  });
+
+  it('holds the bare tolerance at a terminal anchor, which is drawn straight', () => {
+    // Same geometry, but x=50 now ends the polyline instead of turning, so a
+    // crossing just shy of it still hops.
+    const straight = line('v', { x: 50, y: 0 }, { x: 50, y: 100 });
+    const nearEnd = line('h2', { x: 0, y: 92 }, { x: 100, y: 92 });
+
+    expect(computeLineJumps([nearEnd, straight]).get('h2')).toEqual([
+      { segmentIndex: 0, point: { x: 50, y: 92 } },
+    ]);
+  });
+
+  it('returns nothing when the graph has no vertical segments to cross', () => {
+    const other = line('h2', { x: 0, y: 80 }, { x: 100, y: 80 });
+
+    expect(computeLineJumps([horizontal, other]).size).toBe(0);
+  });
+});
+
+describe('polylinesEqual', () => {
+  const base: Point[] = [
+    { x: 0, y: 50 },
+    { x: 100, y: 50 },
+  ];
+
+  it('treats a rebuilt list of the same positions as equal', () => {
+    expect(
+      polylinesEqual(base, [
+        { x: 0, y: 50 },
+        { x: 100, y: 50 },
+      ])
+    ).toBe(true);
+  });
+
+  it('separates lists that differ in length or position', () => {
+    expect(polylinesEqual(base, [{ x: 0, y: 50 }])).toBe(false);
+    expect(
+      polylinesEqual(base, [
+        { x: 0, y: 50 },
+        { x: 100, y: 90 },
+      ])
+    ).toBe(false);
+  });
+
+  it('ignores movement under the tolerance the jumps are compared at', () => {
+    expect(
+      polylinesEqual(base, [
+        { x: 0.4, y: 50 },
+        { x: 100, y: 50.4 },
+      ])
+    ).toBe(true);
+  });
+});
+
+describe('jumpsEqual', () => {
+  it('treats positionally identical lists as equal', () => {
+    expect(
+      jumpsEqual(
+        [{ segmentIndex: 1, point: { x: 10, y: 20 } }],
+        [{ segmentIndex: 1, point: { x: 10, y: 20 } }]
+      )
+    ).toBe(true);
+  });
+
+  it('separates lists that differ in segment, position, or length', () => {
+    const base = [{ segmentIndex: 1, point: { x: 10, y: 20 } }];
+
+    expect(jumpsEqual(base, [{ segmentIndex: 2, point: { x: 10, y: 20 } }])).toBe(false);
+    expect(jumpsEqual(base, [{ segmentIndex: 1, point: { x: 40, y: 20 } }])).toBe(false);
+    expect(jumpsEqual(base, [])).toBe(false);
+  });
+});

--- a/packages/apollo-react/src/canvas/components/Edges/shared/crossings/crossings.ts
+++ b/packages/apollo-react/src/canvas/components/Edges/shared/crossings/crossings.ts
@@ -1,0 +1,179 @@
+import { EDGE_CONSTANTS } from '../constants';
+import type { PathJump, Point } from '../types';
+
+const { COLLINEAR_TOLERANCE: TOL, BORDER_RADIUS } = EDGE_CONSTANTS;
+
+/** One edge's rendered polyline, as registered with the crossings store. */
+export type EdgePolyline = {
+  edgeId: string;
+  /** Ordered path vertices. Segment `i` runs from `points[i]` to `points[i + 1]`. */
+  points: Point[];
+};
+
+type HorizontalSegment = {
+  edgeId: string;
+  segmentIndex: number;
+  y: number;
+  xMin: number;
+  xMax: number;
+};
+
+type VerticalSegment = {
+  edgeId: string;
+  x: number;
+  yMin: number;
+  yMax: number;
+  /** Clearance a crossing needs from the low-y end to count. */
+  minMargin: number;
+  /** Clearance a crossing needs from the high-y end to count. */
+  maxMargin: number;
+};
+
+/**
+ * Find every point where one edge's horizontal segment crosses another edge's
+ * vertical segment, and return the resulting line jumps keyed by edge id.
+ *
+ * Only the horizontal side of a crossing gets a jump — the vertical line is
+ * drawn through, unbroken. Making the choice depend on orientation alone (and
+ * not on edge order, selection, or registration order) keeps the notch pattern
+ * stable while nodes are dragged around.
+ *
+ * A crossing counts only when the intersection is strictly interior to both
+ * segments. Lines that merely meet — a T-junction, a shared node face, two
+ * edges fanning out of one handle — touch at a segment end and are skipped, so
+ * notches appear only where a line genuinely passes over another. Where the
+ * crossed segment runs into a bend, the clearance widens to the border radius:
+ * the rendered line curves away from the ideal corner there, and an arc placed
+ * on the corner would sit beside the stroke instead of over it.
+ *
+ * Jumps are returned grouped by edge, ordered by `segmentIndex` and then by
+ * ascending x within a segment. The path builder re-sorts them into travel
+ * order, since a segment may run right-to-left.
+ */
+export function computeLineJumps(polylines: EdgePolyline[]): Map<string, PathJump[]> {
+  const horizontals: HorizontalSegment[] = [];
+  const verticals: VerticalSegment[] = [];
+
+  for (const { edgeId, points } of polylines) {
+    for (let i = 0; i < points.length - 1; i++) {
+      const a = points[i]!;
+      const b = points[i + 1]!;
+      const dx = Math.abs(b.x - a.x);
+      const dy = Math.abs(b.y - a.y);
+
+      if (dy <= TOL && dx > TOL) {
+        horizontals.push({
+          edgeId,
+          segmentIndex: i,
+          y: a.y,
+          xMin: Math.min(a.x, b.x),
+          xMax: Math.max(a.x, b.x),
+        });
+      } else if (dx <= TOL && dy > TOL) {
+        // A bend is rendered as a curve that pulls the stroke off the ideal
+        // corner for up to the border radius, so a crossing that close to one
+        // would arc over a line that is no longer there. The radius the path
+        // builder uses is clamped by the adjoining segments; half this one is a
+        // cheap upper bound on it, and erring long only costs a notch. Terminal
+        // anchors are drawn straight, so they keep the bare tolerance.
+        const bendMargin = Math.min(BORDER_RADIUS, dy / 2);
+        const startMargin = i > 0 ? bendMargin : TOL;
+        const endMargin = i + 2 < points.length ? bendMargin : TOL;
+        const descending = b.y > a.y;
+
+        verticals.push({
+          edgeId,
+          x: a.x,
+          yMin: Math.min(a.y, b.y),
+          yMax: Math.max(a.y, b.y),
+          minMargin: descending ? startMargin : endMargin,
+          maxMargin: descending ? endMargin : startMargin,
+        });
+      }
+      // Diagonal segments never occur in an orthogonal path; anything that is
+      // neither horizontal nor vertical is ignored rather than approximated.
+    }
+  }
+
+  if (horizontals.length === 0 || verticals.length === 0) return new Map();
+
+  verticals.sort((a, b) => a.x - b.x);
+  const xs = verticals.map((v) => v.x);
+
+  const result = new Map<string, PathJump[]>();
+
+  for (const h of horizontals) {
+    // Only verticals inside the horizontal's span can cross it, and the search
+    // bounds already exclude the horizontal's own endpoints.
+    let jumps: PathJump[] | undefined;
+    let lastX = Number.NEGATIVE_INFINITY;
+
+    for (let i = lowerBound(xs, h.xMin + TOL); i < verticals.length; i++) {
+      const v = verticals[i]!;
+      if (v.x >= h.xMax - TOL) break;
+      if (v.edgeId === h.edgeId) continue;
+      // Clear of both ends of the vertical, so a line stopping on this one
+      // reads as a junction rather than a crossing, and one meeting it where it
+      // curves into a bend is left alone rather than hopping beside the stroke.
+      if (h.y <= v.yMin + v.minMargin || h.y >= v.yMax - v.maxMargin) continue;
+      // Exactly overlapping verticals (common when two edges share a lane)
+      // would otherwise stack identical arcs on the same spot.
+      if (v.x - lastX <= TOL) continue;
+
+      lastX = v.x;
+      jumps ??= [];
+      jumps.push({ segmentIndex: h.segmentIndex, point: { x: v.x, y: h.y } });
+    }
+
+    if (!jumps) continue;
+
+    const existing = result.get(h.edgeId);
+    if (existing) existing.push(...jumps);
+    else result.set(h.edgeId, jumps);
+  }
+
+  return result;
+}
+
+/** Index of the first entry in the ascending array that is `>= value`. */
+function lowerBound(sorted: number[], value: number): number {
+  let low = 0;
+  let high = sorted.length;
+  while (low < high) {
+    const mid = (low + high) >>> 1;
+    if (sorted[mid]! < value) low = mid + 1;
+    else high = mid;
+  }
+  return low;
+}
+
+/**
+ * Positional equality for two polylines, used to drop registrations that cannot
+ * move a crossing. Compared at the same tolerance as {@link jumpsEqual}, so a
+ * polyline that passes here provably derives the same jump set.
+ */
+export function polylinesEqual(a: readonly Point[], b: readonly Point[]): boolean {
+  if (a === b) return true;
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    const left = a[i]!;
+    const right = b[i]!;
+    if (Math.abs(left.x - right.x) > TOL) return false;
+    if (Math.abs(left.y - right.y) > TOL) return false;
+  }
+  return true;
+}
+
+/** Positional equality for two jump lists, used to keep snapshot identity stable. */
+export function jumpsEqual(a: readonly PathJump[], b: readonly PathJump[]): boolean {
+  if (a === b) return true;
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    const left = a[i]!;
+    const right = b[i]!;
+    if (left.segmentIndex !== right.segmentIndex) return false;
+    if (Math.abs(left.point.x - right.point.x) > TOL) return false;
+    if (Math.abs(left.point.y - right.point.y) > TOL) return false;
+  }
+  return true;
+}

--- a/packages/apollo-react/src/canvas/components/Edges/shared/crossings/index.ts
+++ b/packages/apollo-react/src/canvas/components/Edges/shared/crossings/index.ts
@@ -1,0 +1,3 @@
+export { computeLineJumps, type EdgePolyline, jumpsEqual } from './crossings';
+export { EdgeCrossingsProvider, EdgeCrossingsStore } from './EdgeCrossingsContext';
+export { useEdgeLineJumps } from './useEdgeLineJumps';

--- a/packages/apollo-react/src/canvas/components/Edges/shared/crossings/useEdgeLineJumps.test.tsx
+++ b/packages/apollo-react/src/canvas/components/Edges/shared/crossings/useEdgeLineJumps.test.tsx
@@ -1,0 +1,169 @@
+import { act, render, screen } from '@testing-library/react';
+import { Position } from '@uipath/apollo-react/canvas/xyflow/react';
+import { describe, expect, it } from 'vitest';
+import { EDGE_CONSTANTS, EMPTY_WAYPOINTS } from '../constants';
+import { useEdgeGeometry } from '../hooks';
+import type { Waypoint } from '../types';
+import { EdgeCrossingsProvider } from './EdgeCrossingsContext';
+
+const r = EDGE_CONSTANTS.LINE_JUMP_RADIUS;
+
+type ProbeProps = {
+  edgeId: string;
+  sourceX: number;
+  sourceY: number;
+  sourcePosition: Position;
+  targetX: number;
+  targetY: number;
+  targetPosition: Position;
+  enableLineJumps?: boolean;
+  waypoints?: Waypoint[];
+};
+
+/** Renders one edge's computed path so a test can read it back. */
+function EdgeProbe({
+  edgeId,
+  enableLineJumps = true,
+  waypoints = EMPTY_WAYPOINTS,
+  ...anchors
+}: ProbeProps) {
+  const geometry = useEdgeGeometry({
+    routing: 'waypoint',
+    edgeId,
+    sourceNodeId: `${edgeId}-source`,
+    targetNodeId: `${edgeId}-target`,
+    waypoints,
+    enableSegments: false,
+    enableLineJumps,
+    ...anchors,
+  });
+
+  return <div data-testid={edgeId} data-path={geometry.edgePath} />;
+}
+
+/** Straight horizontal line: anchors inset to (-8, 50) → (208, 50). */
+const horizontal = {
+  edgeId: 'horizontal',
+  sourceX: 0,
+  sourceY: 50,
+  sourcePosition: Position.Right,
+  targetX: 200,
+  targetY: 50,
+  targetPosition: Position.Left,
+} as const;
+
+/** Straight vertical line through x=100, crossing the horizontal at (100, 50). */
+const vertical = {
+  edgeId: 'vertical',
+  sourceX: 100,
+  sourceY: -100,
+  sourcePosition: Position.Bottom,
+  targetX: 100,
+  targetY: 200,
+  targetPosition: Position.Top,
+} as const;
+
+function pathOf(edgeId: string): string {
+  return screen.getByTestId(edgeId).getAttribute('data-path') ?? '';
+}
+
+async function renderCrossing(props: { enableLineJumps?: boolean } = {}) {
+  const result = render(
+    <EdgeCrossingsProvider>
+      <EdgeProbe {...horizontal} {...props} />
+      <EdgeProbe {...vertical} {...props} />
+    </EdgeCrossingsProvider>
+  );
+  // Let the store's coalescing microtask run and the notified edges re-render.
+  await act(async () => {});
+  return result;
+}
+
+describe('useEdgeLineJumps', () => {
+  it('arcs the horizontal edge over the vertical one it crosses', async () => {
+    await renderCrossing();
+
+    expect(pathOf('horizontal')).toBe(
+      `M -8 50 L ${100 - r} 50 A ${r} ${r} 0 0 1 ${100 + r} 50 L 208 50`
+    );
+    expect(pathOf('vertical')).toBe('M 100 -108 L 100 208');
+  });
+
+  it('draws both lines flat when the edges have not opted in', async () => {
+    await renderCrossing({ enableLineJumps: false });
+
+    expect(pathOf('horizontal')).toBe('M -8 50 L 208 50');
+    expect(pathOf('vertical')).toBe('M 100 -108 L 100 208');
+  });
+
+  it('drops the notch when the crossing edge unmounts', async () => {
+    const { rerender } = await renderCrossing();
+    expect(pathOf('horizontal')).toContain('A ');
+
+    rerender(
+      <EdgeCrossingsProvider>
+        <EdgeProbe {...horizontal} />
+      </EdgeCrossingsProvider>
+    );
+    await act(async () => {});
+
+    expect(pathOf('horizontal')).toBe('M -8 50 L 208 50');
+  });
+
+  it('keeps its notch when a re-render rebuilds the polyline in place', async () => {
+    // A fresh waypoint array of unchanged positions on every render, which is
+    // what `useNodeDragRebalance` hands over while a drag is active. The
+    // polyline is republished with a new identity, so the registration must
+    // survive without the edge being withdrawn in between.
+    const bend = (): Waypoint[] => [{ id: 'w', x: 60, y: 50 }];
+    const tree = (
+      <EdgeCrossingsProvider>
+        <EdgeProbe {...horizontal} waypoints={bend()} />
+        <EdgeProbe {...vertical} />
+      </EdgeCrossingsProvider>
+    );
+
+    const { rerender } = render(tree);
+    await act(async () => {});
+    const first = pathOf('horizontal');
+    expect(first).toContain('A ');
+
+    rerender(
+      <EdgeCrossingsProvider>
+        <EdgeProbe {...horizontal} waypoints={bend()} />
+        <EdgeProbe {...vertical} />
+      </EdgeCrossingsProvider>
+    );
+    await act(async () => {});
+
+    expect(pathOf('horizontal')).toBe(first);
+  });
+
+  it('shares one registry when a provider is nested inside another', async () => {
+    // A second provider inside the first must defer to it, or the two edges
+    // land in separate registries and the crossing silently draws flat.
+    render(
+      <EdgeCrossingsProvider>
+        <EdgeProbe {...horizontal} />
+        <EdgeCrossingsProvider>
+          <EdgeProbe {...vertical} />
+        </EdgeCrossingsProvider>
+      </EdgeCrossingsProvider>
+    );
+    await act(async () => {});
+
+    expect(pathOf('horizontal')).toContain('A ');
+  });
+
+  it('draws no jumps without a provider in the tree', async () => {
+    render(
+      <>
+        <EdgeProbe {...horizontal} />
+        <EdgeProbe {...vertical} />
+      </>
+    );
+    await act(async () => {});
+
+    expect(pathOf('horizontal')).toBe('M -8 50 L 208 50');
+  });
+});

--- a/packages/apollo-react/src/canvas/components/Edges/shared/crossings/useEdgeLineJumps.ts
+++ b/packages/apollo-react/src/canvas/components/Edges/shared/crossings/useEdgeLineJumps.ts
@@ -1,0 +1,54 @@
+import { useCallback, useLayoutEffect, useSyncExternalStore } from 'react';
+import type { PathJump, Point } from '../types';
+import { EMPTY_JUMPS, useEdgeCrossingsStore } from './EdgeCrossingsContext';
+
+/**
+ * Publish this edge's polyline to the shared crossings store and read back the
+ * points where it should hop over another edge.
+ *
+ * Registration runs in a layout effect so the store's recompute microtask
+ * drains before the browser paints, keeping the arcs in step with the stroke as
+ * a node is dragged. The opening frame is the exception: the subscription below
+ * is installed in a passive effect, so the first recompute has nobody to notify
+ * and the notch lands on the commit after it.
+ *
+ * When `enabled` is false, or no `EdgeCrossingsProvider` is mounted, this
+ * neither registers nor subscribes and returns a stable empty list — an edge
+ * that hasn't opted in stays invisible to the ones that have, and pays nothing
+ * beyond the hooks themselves.
+ */
+export function useEdgeLineJumps(
+  edgeId: string,
+  points: Point[],
+  enabled: boolean
+): readonly PathJump[] {
+  const store = useEdgeCrossingsStore();
+
+  // Publishing and withdrawing are deliberately separate effects. Publishing is
+  // keyed on the points so a moved edge republishes; withdrawing is keyed only
+  // on identity, so it runs when this edge stops taking part rather than on
+  // every geometry change. Combining them would delete the stored polyline
+  // before each re-registration, erasing the baseline `register` compares
+  // against and defeating its no-op guard.
+  useLayoutEffect(() => {
+    if (store && enabled) store.register(edgeId, points);
+  }, [store, enabled, edgeId, points]);
+
+  useLayoutEffect(() => {
+    if (!store || !enabled) return;
+    return () => store.unregister(edgeId);
+  }, [store, enabled, edgeId]);
+
+  const subscribe = useCallback(
+    (onStoreChange: () => void) =>
+      store && enabled ? store.subscribe(edgeId, onStoreChange) : () => {},
+    [store, enabled, edgeId]
+  );
+
+  const getSnapshot = useCallback(
+    () => (store && enabled ? store.getSnapshot(edgeId) : EMPTY_JUMPS),
+    [store, enabled, edgeId]
+  );
+
+  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+}

--- a/packages/apollo-react/src/canvas/components/Edges/shared/geometry.test.ts
+++ b/packages/apollo-react/src/canvas/components/Edges/shared/geometry.test.ts
@@ -370,6 +370,114 @@ describe('createRoundedPath', () => {
     expect(d.startsWith('M 0 0')).toBe(true);
     expect(d).toContain('Q');
   });
+
+  describe('line jumps', () => {
+    const r = EDGE_CONSTANTS.LINE_JUMP_RADIUS;
+    const straight: Point[] = [
+      { x: 0, y: 0 },
+      { x: 100, y: 0 },
+    ];
+
+    it('leaves the path untouched when no jumps are given', () => {
+      const corners: Point[] = [
+        { x: 0, y: 0 },
+        { x: 100, y: 0 },
+        { x: 100, y: 100 },
+      ];
+      expect(createRoundedPath(corners, EDGE_CONSTANTS.BORDER_RADIUS, [])).toBe(
+        createRoundedPath(corners)
+      );
+    });
+
+    it('hops over a crossing with an arc of the jump radius', () => {
+      const d = createRoundedPath(straight, EDGE_CONSTANTS.BORDER_RADIUS, [
+        { segmentIndex: 0, point: { x: 50, y: 0 } },
+      ]);
+
+      // Straight up to the arc's entry, half-circle across, then on to the end.
+      expect(d).toBe(`M 0 0 L ${50 - r} 0 A ${r} ${r} 0 0 1 ${50 + r} 0 L 100 0`);
+    });
+
+    it('flips the sweep flag so the arc bulges the same way on a reversed line', () => {
+      const rightward = createRoundedPath(straight, EDGE_CONSTANTS.BORDER_RADIUS, [
+        { segmentIndex: 0, point: { x: 50, y: 0 } },
+      ]);
+      const leftward = createRoundedPath(
+        [
+          { x: 100, y: 0 },
+          { x: 0, y: 0 },
+        ],
+        EDGE_CONSTANTS.BORDER_RADIUS,
+        [{ segmentIndex: 0, point: { x: 50, y: 0 } }]
+      );
+
+      expect(rightward).toContain(`A ${r} ${r} 0 0 1`);
+      expect(leftward).toContain(`A ${r} ${r} 0 0 0`);
+    });
+
+    it('walks the jumps in travel order on a right-to-left line', () => {
+      const d = createRoundedPath(
+        [
+          { x: 100, y: 0 },
+          { x: 0, y: 0 },
+        ],
+        EDGE_CONSTANTS.BORDER_RADIUS,
+        [
+          { segmentIndex: 0, point: { x: 30, y: 0 } },
+          { segmentIndex: 0, point: { x: 70, y: 0 } },
+        ]
+      );
+
+      expect(d.indexOf(`L ${70 + r} 0`)).toBeLessThan(d.indexOf(`L ${30 + r} 0`));
+    });
+
+    it('places a jump on the segment it belongs to', () => {
+      const d = createRoundedPath(
+        [
+          { x: 0, y: 0 },
+          { x: 100, y: 0 },
+          { x: 100, y: 100 },
+        ],
+        EDGE_CONSTANTS.BORDER_RADIUS,
+        [{ segmentIndex: 1, point: { x: 100, y: 50 } }]
+      );
+
+      expect(d).toContain(`A ${r} ${r} 0 0 1 100 ${50 + r}`);
+    });
+
+    it('drops a jump that would eat into an adjoining corner curve', () => {
+      const d = createRoundedPath(
+        [
+          { x: 0, y: 0 },
+          { x: 100, y: 0 },
+          { x: 100, y: 100 },
+        ],
+        EDGE_CONSTANTS.BORDER_RADIUS,
+        // Sits inside the rounded corner at (100, 0), so the run has no room.
+        [{ segmentIndex: 0, point: { x: 100 - EDGE_CONSTANTS.BORDER_RADIUS, y: 0 } }]
+      );
+
+      expect(d).not.toContain('A ');
+    });
+
+    it('collapses jumps spaced closer than a diameter into one arc', () => {
+      const d = createRoundedPath(straight, EDGE_CONSTANTS.BORDER_RADIUS, [
+        { segmentIndex: 0, point: { x: 50, y: 0 } },
+        { segmentIndex: 0, point: { x: 50 + r, y: 0 } },
+      ]);
+
+      expect(d.match(/A /g)).toHaveLength(1);
+    });
+
+    it('keeps jumps spaced beyond a diameter apart as separate arcs', () => {
+      const d = createRoundedPath(straight, EDGE_CONSTANTS.BORDER_RADIUS, [
+        { segmentIndex: 0, point: { x: 30, y: 0 } },
+        { segmentIndex: 0, point: { x: 70, y: 0 } },
+      ]);
+
+      expect(d.match(/A /g)).toHaveLength(2);
+    });
+  });
 });
 
 describe('snapPointToGrid', () => {

--- a/packages/apollo-react/src/canvas/components/Edges/shared/geometry.ts
+++ b/packages/apollo-react/src/canvas/components/Edges/shared/geometry.ts
@@ -1,7 +1,7 @@
 import type { Position } from '@uipath/apollo-react/canvas/xyflow/react';
 import { snapToGrid } from '../../../utils/NodeUtils';
 import { ARROW_OFFSETS, EDGE_CONSTANTS } from './constants';
-import type { PathVertex, Point, Segment, SegmentOrientation, Waypoint } from './types';
+import type { PathJump, PathVertex, Point, Segment, SegmentOrientation, Waypoint } from './types';
 
 const { BORDER_RADIUS, MIN_SEGMENT_LENGTH, COLLINEAR_TOLERANCE: TOL } = EDGE_CONSTANTS;
 
@@ -448,51 +448,132 @@ export function extractSegments(pathPoints: PathVertex[]): Segment[] {
   return segments;
 }
 
+/** Where a rounded corner starts and ends on the two segments it joins. */
+type Corner = {
+  start: Point;
+  end: Point;
+  /** False when the adjoining segments are too short to fit a curve. */
+  rounded: boolean;
+};
+
 /**
  * Build an SVG path string. Each interior point becomes a quadratic curve
  * with radius clamped to half the shorter adjoining segment.
+ *
+ * `jumps` optionally marks crossings where the line hops over another edge:
+ * each one replaces a stretch of the straight run with a semicircular arc (see
+ * {@link appendRun}). Passing none reproduces the plain rounded path exactly.
  */
-export function createRoundedPath(points: Point[], borderRadius: number = BORDER_RADIUS): string {
+export function createRoundedPath(
+  points: Point[],
+  borderRadius: number = BORDER_RADIUS,
+  jumps: readonly PathJump[] = []
+): string {
   if (points.length < 2) return '';
 
   const firstPoint = points[0]!;
+  const lastPoint = points[points.length - 1]!;
   const path: string[] = [`M ${firstPoint.x} ${firstPoint.y}`];
 
-  if (points.length === 2) {
-    const secondPoint = points[1]!;
-    path.push(`L ${secondPoint.x} ${secondPoint.y}`);
-    return path.join(' ');
-  }
-
+  // Corner `i` belongs to interior vertex `points[i]`, so it bounds the end of
+  // segment `i - 1` and the start of segment `i`.
+  const corners: (Corner | undefined)[] = [];
   for (let i = 1; i < points.length - 1; i++) {
-    const prev = points[i - 1]!;
-    const curr = points[i]!;
-    const next = points[i + 1]!;
-
-    const v1 = { x: curr.x - prev.x, y: curr.y - prev.y };
-    const v2 = { x: next.x - curr.x, y: next.y - curr.y };
-    const len1 = Math.sqrt(v1.x * v1.x + v1.y * v1.y);
-    const len2 = Math.sqrt(v2.x * v2.x + v2.y * v2.y);
-
-    const radius = Math.min(borderRadius, Math.min(len1, len2) / 2);
-
-    if (radius < 1) {
-      path.push(`L ${curr.x} ${curr.y}`);
-      continue;
-    }
-
-    const n1 = { x: v1.x / len1, y: v1.y / len1 };
-    const n2 = { x: v2.x / len2, y: v2.y / len2 };
-    const cornerStart = { x: curr.x - n1.x * radius, y: curr.y - n1.y * radius };
-    const cornerEnd = { x: curr.x + n2.x * radius, y: curr.y + n2.y * radius };
-
-    path.push(`L ${cornerStart.x} ${cornerStart.y}`);
-    path.push(`Q ${curr.x} ${curr.y} ${cornerEnd.x} ${cornerEnd.y}`);
+    corners[i] = buildCorner(points[i - 1]!, points[i]!, points[i + 1]!, borderRadius);
   }
 
-  const lastPoint = points[points.length - 1]!;
-  path.push(`L ${lastPoint.x} ${lastPoint.y}`);
+  const jumpsBySegment = groupJumpsBySegment(jumps);
+
+  for (let i = 0; i < points.length - 1; i++) {
+    const from = i === 0 ? firstPoint : corners[i]!.end;
+    const to = i === points.length - 2 ? lastPoint : corners[i + 1]!.start;
+
+    appendRun(path, from, to, jumpsBySegment?.get(i));
+
+    const corner = corners[i + 1];
+    if (corner?.rounded) {
+      const vertex = points[i + 1]!;
+      path.push(`Q ${vertex.x} ${vertex.y} ${corner.end.x} ${corner.end.y}`);
+    }
+  }
+
   return path.join(' ');
+}
+
+function buildCorner(prev: Point, curr: Point, next: Point, borderRadius: number): Corner {
+  const v1 = { x: curr.x - prev.x, y: curr.y - prev.y };
+  const v2 = { x: next.x - curr.x, y: next.y - curr.y };
+  const len1 = Math.sqrt(v1.x * v1.x + v1.y * v1.y);
+  const len2 = Math.sqrt(v2.x * v2.x + v2.y * v2.y);
+
+  const radius = Math.min(borderRadius, Math.min(len1, len2) / 2);
+  if (radius < 1) return { start: curr, end: curr, rounded: false };
+
+  return {
+    start: { x: curr.x - (v1.x / len1) * radius, y: curr.y - (v1.y / len1) * radius },
+    end: { x: curr.x + (v2.x / len2) * radius, y: curr.y + (v2.y / len2) * radius },
+    rounded: true,
+  };
+}
+
+function groupJumpsBySegment(jumps: readonly PathJump[]): Map<number, PathJump[]> | null {
+  if (jumps.length === 0) return null;
+
+  const bySegment = new Map<number, PathJump[]>();
+  for (const jump of jumps) {
+    const existing = bySegment.get(jump.segmentIndex);
+    if (existing) existing.push(jump);
+    else bySegment.set(jump.segmentIndex, [jump]);
+  }
+  return bySegment;
+}
+
+/**
+ * Draw one straight run, hopping over any crossings on it.
+ *
+ * A jump becomes `L` up to the arc's entry, then a half-circle of
+ * {@link EDGE_CONSTANTS.LINE_JUMP_RADIUS} to its exit. The sweep flag is picked
+ * from the direction of travel so every arc bulges to the same side, whichever
+ * way the line runs.
+ *
+ * Two guards keep the arcs from fighting the rest of the path: a jump within a
+ * radius of either end of the run would eat into the adjoining corner curve, and
+ * a jump within a diameter of the previous one would scallop the line rather
+ * than notch it. Both are dropped, so densely crossed stretches degrade to fewer
+ * notches instead of a mess.
+ */
+function appendRun(path: string[], from: Point, to: Point, jumps?: PathJump[]): void {
+  const dx = to.x - from.x;
+  const dy = to.y - from.y;
+  const length = Math.sqrt(dx * dx + dy * dy);
+
+  const radius = EDGE_CONSTANTS.LINE_JUMP_RADIUS;
+  if (jumps && jumps.length > 0 && length > radius * 2) {
+    const ux = dx / length;
+    const uy = dy / length;
+    const horizontal = Math.abs(dx) >= Math.abs(dy);
+    const sweep = (horizontal ? dx : dy) > 0 ? 1 : 0;
+
+    // Sort into travel order: a run may go right-to-left or bottom-to-top.
+    const distances = jumps
+      .map((jump) => (jump.point.x - from.x) * ux + (jump.point.y - from.y) * uy)
+      .filter((distance) => distance >= radius && distance <= length - radius)
+      .sort((a, b) => a - b);
+
+    let previous = Number.NEGATIVE_INFINITY;
+    for (const distance of distances) {
+      if (distance - previous < radius * 2) continue;
+      previous = distance;
+
+      const entry = { x: from.x + ux * (distance - radius), y: from.y + uy * (distance - radius) };
+      const exit = { x: from.x + ux * (distance + radius), y: from.y + uy * (distance + radius) };
+
+      path.push(`L ${entry.x} ${entry.y}`);
+      path.push(`A ${radius} ${radius} 0 0 ${sweep} ${exit.x} ${exit.y}`);
+    }
+  }
+
+  path.push(`L ${to.x} ${to.y}`);
 }
 
 export function getSegmentMidpoint(segment: Segment): Point {

--- a/packages/apollo-react/src/canvas/components/Edges/shared/hooks/useEdgeGeometry.ts
+++ b/packages/apollo-react/src/canvas/components/Edges/shared/hooks/useEdgeGeometry.ts
@@ -2,6 +2,7 @@ import type { Position } from '@uipath/apollo-react/canvas/xyflow/react';
 import { useMemo } from 'react';
 import { useEdgePath } from '../../../../hooks';
 import { ARROW_ANGLE_MAP, ARROW_OFFSETS, EDGE_CONSTANTS } from '../constants';
+import { useEdgeLineJumps } from '../crossings';
 import {
   buildPathVertices,
   createRoundedPath,
@@ -15,6 +16,8 @@ const EMPTY_SEGMENTS: Segment[] = [];
 
 export type UseEdgeGeometryArgs = {
   routing: EdgeRouting;
+  /** Edge id — the key this edge's polyline is published under for line jumps. */
+  edgeId: string;
   /** Source node id — used by handle routing for loop detection. */
   sourceNodeId: string;
   /** Target node id — used by handle routing for loop detection. */
@@ -50,6 +53,12 @@ export type UseEdgeGeometryArgs = {
    * arrow polygon would have filled.
    */
   hideArrowHead?: boolean;
+  /**
+   * When true, this edge shares its polyline with the other opted-in edges and
+   * hops over the ones it crosses. Waypoint routing only — handle-routed edges
+   * produce a path string with no vertices to intersect.
+   */
+  enableLineJumps?: boolean;
 };
 
 export type EdgeGeometry = {
@@ -79,6 +88,7 @@ export type EdgeGeometry = {
 export function useEdgeGeometry(args: UseEdgeGeometryArgs): EdgeGeometry {
   const {
     routing,
+    edgeId,
     sourceNodeId,
     targetNodeId,
     sourceHandleId,
@@ -93,6 +103,7 @@ export function useEdgeGeometry(args: UseEdgeGeometryArgs): EdgeGeometry {
     autoRouted = false,
     enableSegments = true,
     hideArrowHead = false,
+    enableLineJumps = false,
   } = args;
 
   const arrowOffset = ARROW_OFFSETS[targetPosition];
@@ -131,9 +142,14 @@ export function useEdgeGeometry(args: UseEdgeGeometryArgs): EdgeGeometry {
     [enableSegments, pathPoints]
   );
 
+  // Publishing the vertices and reading back the crossings happens between the
+  // two halves of the waypoint pipeline: jumps are derived from `pathPoints` and
+  // only ever change the path string, so this can't feed back into itself.
+  const jumps = useEdgeLineJumps(edgeId, pathPoints, isWaypoint && enableLineJumps);
+
   const waypointPath = useMemo(
-    () => createRoundedPath(pathPoints, EDGE_CONSTANTS.BORDER_RADIUS),
-    [pathPoints]
+    () => createRoundedPath(pathPoints, EDGE_CONSTANTS.BORDER_RADIUS, jumps),
+    [pathPoints, jumps]
   );
 
   const handle = useEdgePath({

--- a/packages/apollo-react/src/canvas/components/Edges/shared/primitives/EdgeArrow.tsx
+++ b/packages/apollo-react/src/canvas/components/Edges/shared/primitives/EdgeArrow.tsx
@@ -1,3 +1,4 @@
+import { memo } from 'react';
 import { EDGE_CONSTANTS } from '../constants';
 import type { Point } from '../types';
 
@@ -15,7 +16,18 @@ export type EdgeArrowProps = {
   opacity?: number;
 };
 
-export function EdgeArrow({ target, angle, offset, color, opacity = 1 }: EdgeArrowProps) {
+/**
+ * Memoized: the arrow is pinned to the target anchor, so it survives every
+ * re-render driven by the rest of the path. `target` must therefore be a stable
+ * reference (`angle` and `offset` already resolve to module constants).
+ */
+export const EdgeArrow = memo(function EdgeArrow({
+  target,
+  angle,
+  offset,
+  color,
+  opacity = 1,
+}: EdgeArrowProps) {
   const tipX = target.x;
   const tipY = target.y;
   const leftX = tipX - ARROW_SIZE * Math.cos(angle - ARROW_HALF_ANGLE);
@@ -35,4 +47,4 @@ export function EdgeArrow({ target, angle, offset, color, opacity = 1 }: EdgeArr
       }}
     />
   );
-}
+});

--- a/packages/apollo-react/src/canvas/components/Edges/shared/primitives/EdgeLabel.tsx
+++ b/packages/apollo-react/src/canvas/components/Edges/shared/primitives/EdgeLabel.tsx
@@ -1,6 +1,5 @@
 import { EdgeLabelRenderer } from '@uipath/apollo-react/canvas/xyflow/react';
-import type { MouseEventHandler } from 'react';
-import { useMemo } from 'react';
+import { type MouseEventHandler, memo, useMemo } from 'react';
 import { CanvasTooltip } from '../../../CanvasTooltip';
 
 export type EdgeLabelProps = {
@@ -30,8 +29,12 @@ export const EDGE_LABEL_DEFAULT_BORDER_COLOR = 'var(--canvas-border,var(--color-
  * `foreignObject` inside the edge's own `<g>` (the old approach) left it
  * competing in the same per-edge z-index/DOM-order stack as every other edge's
  * stroke, so a crossing unselected edge could paint over the label.
+ *
+ * Memoized: the label sits at the path's arc midpoint, which is unaffected by
+ * the re-renders that only restyle or reshape the stroke, and it carries a
+ * tooltip subtree that is not worth reconciling for those.
  */
-export function EdgeLabel({
+export const EdgeLabel = memo(function EdgeLabel({
   x,
   y,
   text,
@@ -57,4 +60,4 @@ export function EdgeLabel({
       </CanvasTooltip>
     </EdgeLabelRenderer>
   );
-}
+});

--- a/packages/apollo-react/src/canvas/components/Edges/shared/primitives/EdgePath.tsx
+++ b/packages/apollo-react/src/canvas/components/Edges/shared/primitives/EdgePath.tsx
@@ -1,4 +1,4 @@
-import type { CSSProperties } from 'react';
+import { type CSSProperties, memo } from 'react';
 import { EDGE_COLORS, EDGE_CONSTANTS, EDGE_DASHARRAY, EDGE_PATH_TRANSITION } from '../constants';
 import type { EdgeStrokeStyle } from '../types';
 
@@ -38,8 +38,12 @@ export type EdgePathProps = {
  *   1. Invisible thick stroke for hit testing
  *   2. Wide soft outline when selected
  *   3. The visible path itself
+ *
+ * Memoized: an edge re-renders for reasons that leave the stroke alone (toolbar
+ * state, a line jump forming elsewhere on the canvas), and reconciling three
+ * `path` elements for an unchanged `d` is the most expensive part of that.
  */
-export function EdgePath(props: EdgePathProps) {
+export const EdgePath = memo(function EdgePath(props: EdgePathProps) {
   const {
     d,
     color,
@@ -98,4 +102,4 @@ export function EdgePath(props: EdgePathProps) {
       />
     </>
   );
-}
+});

--- a/packages/apollo-react/src/canvas/components/Edges/shared/types.ts
+++ b/packages/apollo-react/src/canvas/components/Edges/shared/types.ts
@@ -16,6 +16,16 @@ export type PathVertex = Point & {
   waypointIndex: number;
 };
 
+/**
+ * A crossing on a rendered path where the line hops over another edge with a
+ * small arc. `segmentIndex` indexes the polyline segment the jump sits on:
+ * segment `i` runs from `points[i]` to `points[i + 1]`.
+ */
+export type PathJump = {
+  segmentIndex: number;
+  point: Point;
+};
+
 export type SegmentOrientation = 'horizontal' | 'vertical';
 
 export type Segment = {
@@ -71,6 +81,18 @@ export type CanvasEdgeData = {
   enableEditing?: boolean;
   enableExecution?: boolean;
   enableToolbar?: boolean;
+
+  /**
+   * Draw a small arc where this edge crosses another edge, so criss-crossing
+   * lines read as passing over rather than joining. Waypoint routing only.
+   *
+   * Only edges that opt in take part, both as the line that hops and as the
+   * line hopped over, and at each crossing it is the horizontal segment that
+   * arcs. Set it uniformly across a graph (via `defaultEdgeOptions` or the edge
+   * factory) for a consistent result: with a mixed config, a crossing between an
+   * opted-in edge and an opted-out one is drawn flat.
+   */
+  enableLineJumps?: boolean;
 
   // Data the editing behavior operates on
   waypoints?: Waypoint[];

--- a/packages/apollo-react/src/canvas/storybook-utils/components/StoryPage.tsx
+++ b/packages/apollo-react/src/canvas/storybook-utils/components/StoryPage.tsx
@@ -1,0 +1,142 @@
+import { cn } from '@uipath/apollo-wind';
+import type { ReactNode } from 'react';
+import { CanvasIcon } from '../../utils/icon-registry';
+
+/**
+ * Documentation page chrome for canvas stories.
+ *
+ * A story that documents a concept rather than demonstrating one call site
+ * reads better as a page: a lede, a live preview, then anatomy and usage. These
+ * pieces supply that layout so each story only writes its own content. Pair
+ * `StoryPage` with `StoryPreview` for the canvas and `StorySection` /
+ * `StoryCollapsibleSection` for the prose below it.
+ */
+
+/** Shared body width so every section on a page lines up. */
+const CONTAINER = 'mx-auto max-w-4xl px-8';
+
+const HEADING = 'text-2xl font-bold tracking-tight text-foreground';
+
+/**
+ * Prose blocks accept rich content, so they render into a `div` rather than a
+ * `p`: a caller passing several paragraphs would otherwise nest `p` in `p`.
+ */
+const PROSE = 'text-sm leading-relaxed text-muted-foreground [&>p+p]:mt-1.5';
+
+export interface StoryPageProps {
+  /** Storybook theme global, applied as a class to the page root. */
+  theme: string;
+  title: string;
+  /** Lede below the title. Plain text, or `p` elements for several paragraphs. */
+  description?: ReactNode;
+  /** Preview and sections, in the order they should appear. */
+  children?: ReactNode;
+}
+
+export function StoryPage({ theme, title, description, children }: StoryPageProps) {
+  return (
+    <div className={cn(theme, 'min-h-screen w-full bg-background text-foreground')}>
+      <div className={cn(CONTAINER, 'pt-8')}>
+        <h2 className={cn('mb-2', HEADING)}>{title}</h2>
+        {description && <div className={cn('mb-6', PROSE)}>{description}</div>}
+        <div className="mb-8 h-px bg-border" />
+      </div>
+      {children}
+    </div>
+  );
+}
+
+export interface StorySectionProps {
+  title: string;
+  description?: ReactNode;
+  children?: ReactNode;
+  /** Rule above the heading, separating this section from the one before it. */
+  divider?: boolean;
+}
+
+/** A titled block of documentation, always open. */
+export function StorySection({ title, description, children, divider = true }: StorySectionProps) {
+  return (
+    <section className={cn(CONTAINER, 'pb-10')}>
+      {divider && <div className="mb-10 h-px bg-border" />}
+      <h2 className={cn('mb-2', HEADING)}>{title}</h2>
+      {description && <div className={cn('mb-6', PROSE)}>{description}</div>}
+      {children}
+    </section>
+  );
+}
+
+export interface StoryCollapsibleSectionProps {
+  title: string;
+  open: boolean;
+  onToggle: () => void;
+  children?: ReactNode;
+}
+
+/**
+ * A section that folds away. Use when a page has enough sections that showing
+ * them all at once buries the preview; the caller owns the open state so it can
+ * offer an expand-all control.
+ */
+export function StoryCollapsibleSection({
+  title,
+  open,
+  onToggle,
+  children,
+}: StoryCollapsibleSectionProps) {
+  return (
+    <div className={CONTAINER}>
+      <div className="border-t border-border">
+        <button
+          type="button"
+          onClick={onToggle}
+          aria-expanded={open}
+          className="flex w-full items-center justify-between py-5 text-left transition-colors hover:text-foreground"
+        >
+          <h2 className={HEADING}>{title}</h2>
+          <CanvasIcon icon={open ? 'chevron-up' : 'chevron-down'} size={16} />
+        </button>
+        {open && <div className="pb-8">{children}</div>}
+      </div>
+    </div>
+  );
+}
+
+export interface StoryCardProps {
+  /** Visual sample, centered in a fixed-height slot so cards align in a grid. */
+  preview: ReactNode;
+  title: string;
+  /** Value chip beside the title, e.g. the prop value this card illustrates. */
+  code?: string;
+  description: ReactNode;
+}
+
+/** One entry in an anatomy gallery: a sample, a name, and what it is for. */
+export function StoryCard({ preview, title, code, description }: StoryCardProps) {
+  return (
+    <div className="flex flex-col gap-4 rounded-xl border border-border bg-card p-6">
+      <div className="flex h-24 items-center justify-center">{preview}</div>
+      <div className="flex flex-col gap-2">
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="text-base font-semibold text-foreground">{title}</span>
+          {code && <StoryCode>{code}</StoryCode>}
+        </div>
+        <p className="text-sm text-muted-foreground">{description}</p>
+      </div>
+    </div>
+  );
+}
+
+/** Inline code chip, for prop names and values mentioned in prose. */
+export function StoryCode({ children }: { children: ReactNode }) {
+  return <code className="rounded bg-muted px-1.5 py-0.5 text-xs text-primary">{children}</code>;
+}
+
+/** Fenced code sample. Pass the source as a template literal child. */
+export function StoryCodeBlock({ children }: { children: ReactNode }) {
+  return (
+    <pre className="overflow-x-auto rounded-lg border border-border bg-card p-4 text-[13px] leading-relaxed text-foreground">
+      {children}
+    </pre>
+  );
+}

--- a/packages/apollo-react/src/canvas/storybook-utils/components/StoryPreview.tsx
+++ b/packages/apollo-react/src/canvas/storybook-utils/components/StoryPreview.tsx
@@ -1,0 +1,103 @@
+import { type ReactNode, useEffect, useState } from 'react';
+
+const EXPAND_PATH = 'M7.5 1.5h3v3M4.5 10.5h-3v-3M10.5 4.5V1.5H7.5M1.5 7.5v3h3';
+const CLOSE_PATH = 'M7.5 4.5l-6 6M10.5 1.5l-6 6M1.5 1.5l4 4M10.5 10.5l-4-4';
+
+function PreviewToggleButton({ expanded, onClick }: { expanded: boolean; onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="absolute right-3 top-3 z-10 flex items-center gap-1.5 rounded-md border border-border bg-background/80 px-2.5 py-1.5 text-xs font-medium text-muted-foreground backdrop-blur-sm transition-colors hover:bg-surface-hover hover:text-foreground"
+    >
+      <svg width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden="true">
+        <path
+          d={expanded ? CLOSE_PATH : EXPAND_PATH}
+          stroke="currentColor"
+          strokeWidth="1.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+      </svg>
+      {expanded ? 'Close' : 'Expand'}
+    </button>
+  );
+}
+
+export interface StoryPreviewProps {
+  title?: string;
+  /** What the preview shows. Plain text, or `p` elements for several paragraphs. */
+  description?: ReactNode;
+  /** Height of the inline frame in pixels. The expanded view always fills 90vh. */
+  height?: number;
+  /** The canvas to render. Live in one branch at a time, so toggling remounts it. */
+  children: ReactNode;
+}
+
+/**
+ * A framed live canvas with an expand control.
+ *
+ * A canvas boxed into the docs column is too small to read, so the frame runs
+ * wider than the prose and can be blown up to fill the viewport. The children
+ * render in the inline frame or the overlay but never both, so only one canvas
+ * is ever live and the node registry is never duplicated. The two branches are
+ * different positions in the tree, though, so toggling remounts the canvas and
+ * its viewport starts over.
+ */
+export function StoryPreview({
+  title = 'Preview',
+  description,
+  height = 560,
+  children,
+}: StoryPreviewProps) {
+  const [expanded, setExpanded] = useState(false);
+
+  useEffect(() => {
+    if (!expanded) return;
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') setExpanded(false);
+    };
+    document.addEventListener('keydown', onKeyDown);
+    return () => document.removeEventListener('keydown', onKeyDown);
+  }, [expanded]);
+
+  return (
+    <>
+      <div className="pb-8">
+        <div className="mx-auto mb-4 max-w-4xl px-8">
+          <h2 className="mb-1 text-2xl font-bold tracking-tight text-foreground">{title}</h2>
+          {description && (
+            <div className="text-sm leading-relaxed text-muted-foreground [&>p+p]:mt-1.5">
+              {description}
+            </div>
+          )}
+        </div>
+        <div className="flex justify-center">
+          <div
+            className="relative w-[90vw] overflow-hidden rounded-xl border border-border"
+            style={{ height }}
+          >
+            {!expanded && children}
+            <PreviewToggleButton expanded={false} onClick={() => setExpanded(true)} />
+          </div>
+        </div>
+      </div>
+
+      {expanded && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm">
+          {/* Full-bleed backdrop button: click-outside to close, focusable and Escape-able. */}
+          <button
+            type="button"
+            aria-label="Close expanded preview"
+            onClick={() => setExpanded(false)}
+            className="absolute inset-0 cursor-default"
+          />
+          <div className="relative h-[90vh] w-[90vw] overflow-hidden rounded-xl border border-border">
+            {children}
+            <PreviewToggleButton expanded={true} onClick={() => setExpanded(false)} />
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/packages/apollo-react/src/canvas/storybook-utils/components/StorySpecTable.tsx
+++ b/packages/apollo-react/src/canvas/storybook-utils/components/StorySpecTable.tsx
@@ -1,0 +1,77 @@
+import type { ReactNode } from 'react';
+
+/**
+ * How a cell renders:
+ * - `strong` for the row's subject
+ * - `code` for a literal a consumer types
+ * - `code-muted` for a supporting identifier
+ * - `text` for prose
+ */
+export type StorySpecCellVariant = 'strong' | 'code' | 'code-muted' | 'text';
+
+export interface StorySpecColumn<Row> {
+  /** Field on the row this column reads. */
+  key: keyof Row & string;
+  header: ReactNode;
+  variant?: StorySpecCellVariant;
+}
+
+export interface StorySpecTableProps<Row> {
+  columns: readonly StorySpecColumn<Row>[];
+  rows: readonly Row[];
+  /** Defaults to the first column's value, which is unique in a spec table. */
+  getRowKey?: (row: Row, index: number) => string;
+}
+
+/**
+ * The reference table that closes an anatomy section: one row per variant, one
+ * column per thing a consumer needs to know about it.
+ */
+export function StorySpecTable<Row>({ columns, rows, getRowKey }: StorySpecTableProps<Row>) {
+  const firstKey = columns[0]?.key;
+
+  return (
+    <div className="overflow-hidden rounded-lg border border-border">
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="border-b border-border bg-muted">
+            {columns.map((column) => (
+              <th
+                key={column.key}
+                className="px-4 py-2.5 text-left font-medium text-muted-foreground"
+              >
+                {column.header}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row, index) => (
+            <tr
+              key={getRowKey?.(row, index) ?? (firstKey ? String(row[firstKey]) : index)}
+              className="border-b border-border last:border-b-0"
+            >
+              {columns.map((column) => (
+                <td key={column.key} className={cellClass(column.variant)}>
+                  {renderCell(row[column.key] as ReactNode, column.variant)}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function cellClass(variant: StorySpecCellVariant = 'text'): string {
+  if (variant === 'strong') return 'px-4 py-3 font-medium text-foreground';
+  return 'px-4 py-3 text-muted-foreground';
+}
+
+function renderCell(value: ReactNode, variant: StorySpecCellVariant = 'text'): ReactNode {
+  if (variant === 'code') return <code className="text-xs text-primary">{value}</code>;
+  if (variant === 'code-muted')
+    return <code className="text-xs text-muted-foreground">{value}</code>;
+  return value;
+}

--- a/packages/apollo-react/src/canvas/storybook-utils/components/index.ts
+++ b/packages/apollo-react/src/canvas/storybook-utils/components/index.ts
@@ -1,1 +1,4 @@
 export * from './StoryInfoPanel';
+export * from './StoryPage';
+export * from './StoryPreview';
+export * from './StorySpecTable';


### PR DESCRIPTION
## Summary

Implements visual line jumps (notches) where edges cross each other in waypoint-routed paths. When two edges intersect, the horizontal segment now draws a small arc to hop over the vertical one, making criss-crossing lines more readable. This is an opt-in feature controlled by the `enableLineJumps` flag on `CanvasEdgeData`.
<img width="2130" height="930" alt="image" src="https://github.com/user-attachments/assets/73b4a187-5f1c-475b-a5fe-fc4c17875a2a" />

## Key Changes

- **New crossing detection system** (`packages/apollo-react/src/canvas/components/Edges/shared/crossings/`):
  - `crossings.ts`: Core algorithm that finds all horizontal-vertical segment intersections and computes jump points
  - `EdgeCrossingsContext.tsx`: Shared store for registering edge polylines and deriving crossings with granular per-edge subscriptions
  - `useEdgeLineJumps.ts`: Hook for edges to publish their geometry and consume jump data
  - Comprehensive test coverage for both the algorithm and integration

- **Path rendering updates** (`geometry.ts`):
  - `createRoundedPath()` now accepts optional `jumps` parameter
  - New `appendRun()` function draws straight segments with semicircular arcs at crossing points
  - Arcs are positioned to avoid eating into rounded corners or stacking too densely
  - Sweep flag flips based on travel direction so all arcs bulge consistently

- **Integration**:
  - `EdgeCrossingsProvider` mounted in `CanvasProviders` to enable the feature tree-wide
  - `useEdgeGeometry` hook updated to call `useEdgeLineJumps` and pass jumps to path builder
  - New `enableLineJumps` field on `CanvasEdgeData` type
  - `LINE_JUMP_RADIUS` constant added to `EDGE_CONSTANTS`

- **Storybook story** demonstrating the feature with three horizontal edges crossing two vertical ones, with a toggle to compare against flat crossings

## Implementation Details

- **Orientation-based stability**: Only horizontal segments get jumps (vertical lines draw straight through), keeping the notch pattern stable during node drags
- **Strict interior intersections**: Crossings at segment endpoints (T-junctions, shared nodes) are ignored
- **Deduplication**: Verticals stacked on the same x-coordinate collapse into a single jump
- **Microtask coalescing**: Store recomputes once per commit, draining before paint so notches appear immediately
- **Snapshot identity**: Jump lists maintain stable identity until their own positions change, enabling efficient memoization
- **Waypoint routing only**: Feature requires explicit vertex data; handle-routed edges produce no jumps

https://claude.ai/code/session_01C3Toj3SHbt75zwJ9ufqojS