### PR TITLE
feat(apollo-react): freeze edges between read-only nodes

### DIFF
--- a/packages/apollo-react/src/canvas/components/BaseCanvas/BaseCanvas.hooks.readonly.test.tsx
+++ b/packages/apollo-react/src/canvas/components/BaseCanvas/BaseCanvas.hooks.readonly.test.tsx
@@ -1,10 +1,16 @@
 import { renderHook } from '@testing-library/react';
 import type { Edge, Node, OnBeforeDelete } from '@uipath/apollo-react/canvas/xyflow/react';
 import { describe, expect, it, vi } from 'vitest';
-import { useReadOnlyBeforeDelete } from './BaseCanvas.hooks';
+import { useReadOnlyBeforeDelete, useReadOnlyEdgeIds } from './BaseCanvas.hooks';
 
 const node = (id: string): Node => ({ id, position: { x: 0, y: 0 }, data: {} });
 const edge = (id: string, source: string, target: string): Edge => ({ id, source, target });
+
+// a -> b entirely inside the lockable region; b -> c reaches outside it.
+const makeEdges = (): Edge[] => [
+  { id: 'a-b', source: 'a', target: 'b' },
+  { id: 'b-c', source: 'b', target: 'c' },
+];
 
 const EMPTY: ReadonlySet<string> = new Set();
 
@@ -68,6 +74,20 @@ describe('useReadOnlyBeforeDelete', () => {
     await expect(run()).resolves.toEqual({ nodes: [], edges: [edge('a-c', 'a', 'c')] });
   });
 
+  // A frozen connection (both endpoints locked) is undeletable in its own right,
+  // not just as a side effect of its nodes being vetoed.
+  it('vetoes an explicitly selected frozen edge', async () => {
+    const { run } = guardWith(new Set(['a', 'b']), undefined, { edges: [edge('a-b', 'a', 'b')] });
+
+    await expect(run()).resolves.toEqual({ nodes: [], edges: [] });
+  });
+
+  it('leaves an edge with one locked endpoint deletable', async () => {
+    const { run } = guardWith(new Set(['a']), undefined, { edges: [edge('a-b', 'a', 'b')] });
+
+    await expect(run()).resolves.toEqual({ nodes: [], edges: [edge('a-b', 'a', 'b')] });
+  });
+
   it('honors a consumer veto of the whole deletion', async () => {
     const consumer = vi.fn().mockResolvedValue(false);
     const { run } = guardWith(new Set(['a']), consumer, { nodes: [node('a'), node('b')] });
@@ -91,5 +111,22 @@ describe('useReadOnlyBeforeDelete', () => {
     const first = result.current;
     rerender({ s: locked });
     expect(result.current).toBe(first);
+  });
+});
+
+describe('useReadOnlyEdgeIds', () => {
+  it('returns no frozen edges when no nodes are locked', () => {
+    const { result } = renderHook(() => useReadOnlyEdgeIds(makeEdges(), EMPTY));
+    expect(result.current.size).toBe(0);
+  });
+
+  it('freezes an edge when both connected nodes are locked', () => {
+    const { result } = renderHook(() => useReadOnlyEdgeIds(makeEdges(), new Set(['a', 'b'])));
+    expect([...result.current]).toEqual(['a-b']);
+  });
+
+  it('keeps an edge editable when either connected node is unlocked', () => {
+    const { result } = renderHook(() => useReadOnlyEdgeIds(makeEdges(), new Set(['a'])));
+    expect(result.current.size).toBe(0);
   });
 });

--- a/packages/apollo-react/src/canvas/components/BaseCanvas/BaseCanvas.hooks.ts
+++ b/packages/apollo-react/src/canvas/components/BaseCanvas/BaseCanvas.hooks.ts
@@ -3,6 +3,8 @@ import { useReactFlow, useStoreApi } from '@uipath/apollo-react/canvas/xyflow/re
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { BASE_CANVAS_DEFAULTS, FIT_VIEW_DELAY_MS } from './BaseCanvas.constants';
 import type { BaseCanvasFitViewOptions, EnsureNodesInViewOptions } from './BaseCanvas.types';
+import { isConnectionReadOnly } from './ReadOnlyNodesContext';
+import { EMPTY_SET } from './set-utils';
 
 const waitForNodeMeasurements = (getNodes: () => Node[]): Promise<void> => {
   return new Promise((resolve) => {
@@ -342,19 +344,29 @@ export const useMaintainNodesInView = (
 };
 
 /**
- * Composes an `onBeforeDelete` that vetoes deletion of locked nodes.
+ * Composes an `onBeforeDelete` that vetoes deletion of locked nodes and frozen
+ * connections.
  *
- * Chosen over stamping `deletable: false` onto the nodes handed to React Flow.
- * That clone round-trips out through `getNodes()` and `toObject()`, so a
- * consumer saving the graph persists our lock as their own data, and unlocking
- * the node could never undo it. A veto touches nothing the consumer owns and
- * covers keyboard delete, `deleteElements`, and toolbar actions in one place.
+ * Chosen over stamping `deletable: false` onto the elements handed to React
+ * Flow. That clone round-trips out through `getNodes()`, `getEdges()`, and
+ * `toObject()`, so a consumer saving the graph persists our lock as their own
+ * data and unlocking could never undo it. A veto touches nothing the consumer
+ * owns and covers keyboard delete, `deleteElements`, and toolbar actions in one
+ * place.
  *
- * Edges need the same care: React Flow gathers the edges of every node in the
- * delete set, so vetoing a node without pruning its edges would leave it
- * standing with its connections gone. An edge is dropped when it touches a
- * vetoed node and no node that is actually being deleted, which keeps
- * mixed selections from stranding a dangling edge.
+ * Cascading edges need care of their own: React Flow gathers the edges of every
+ * node in the delete set, so vetoing a node without pruning its edges would
+ * leave it standing with its connections gone. An edge is dropped when it
+ * touches a vetoed node and no node that is actually being deleted, which stops
+ * a mixed selection from stranding a dangling edge.
+ *
+ * Not enforced here, deliberately:
+ * - `connectable`: React Flow never consults it when validating a connection,
+ *   and connecting to a locked node is allowed anyway.
+ * - `draggable`: position is layout, not content. Freezing it would also strand
+ *   locked nodes when a mixed selection is dragged.
+ * - reconnection: guarded by `useReadOnlyConnectionCallbacks`, which rejects the
+ *   gesture with the lock set read at completion time.
  */
 export function useReadOnlyBeforeDelete<NodeType extends Node, EdgeType extends Edge>(
   readOnlyNodeIds: ReadonlySet<string>,
@@ -375,19 +387,45 @@ export function useReadOnlyBeforeDelete<NodeType extends Node, EdgeType extends 
       for (const node of candidate.nodes) {
         (readOnlyNodeIds.has(node.id) ? vetoedNodeIds : deletedNodeIds).add(node.id);
       }
-      if (vetoedNodeIds.size === 0) return candidate;
 
       const touchesVetoedNode = (edge: EdgeType) =>
         vetoedNodeIds.has(edge.source) || vetoedNodeIds.has(edge.target);
       const touchesDeletedNode = (edge: EdgeType) =>
         deletedNodeIds.has(edge.source) || deletedNodeIds.has(edge.target);
+      const isFrozen = (edge: EdgeType) =>
+        isConnectionReadOnly(readOnlyNodeIds, edge.source, edge.target);
+
+      const keptEdges = candidate.edges.filter(
+        (edge) => !isFrozen(edge) && (!touchesVetoedNode(edge) || touchesDeletedNode(edge))
+      );
+      if (vetoedNodeIds.size === 0 && keptEdges.length === candidate.edges.length) {
+        return candidate;
+      }
 
       return {
         nodes: candidate.nodes.filter((node) => !vetoedNodeIds.has(node.id)),
-        edges: candidate.edges.filter(
-          (edge) => !touchesVetoedNode(edge) || touchesDeletedNode(edge)
-        ),
+        edges: keptEdges,
       };
     };
   }, [readOnlyNodeIds, onBeforeDelete]);
+}
+
+/**
+ * Ids of the edges to freeze: those whose source and target are both locked.
+ * An edge with either end unlocked is left editable.
+ */
+export function useReadOnlyEdgeIds<EdgeType extends Edge>(
+  edges: EdgeType[],
+  readOnlyNodeIds: ReadonlySet<string>
+): ReadonlySet<string> {
+  return useMemo(() => {
+    if (readOnlyNodeIds.size === 0) return EMPTY_SET;
+    const frozen = new Set<string>();
+    for (const edge of edges) {
+      if (isConnectionReadOnly(readOnlyNodeIds, edge.source, edge.target)) {
+        frozen.add(edge.id);
+      }
+    }
+    return frozen.size === 0 ? EMPTY_SET : frozen;
+  }, [edges, readOnlyNodeIds]);
 }

--- a/packages/apollo-react/src/canvas/components/BaseCanvas/BaseCanvas.readonly.integration.test.tsx
+++ b/packages/apollo-react/src/canvas/components/BaseCanvas/BaseCanvas.readonly.integration.test.tsx
@@ -1,12 +1,17 @@
 import { render, screen } from '@testing-library/react';
-import type { Node } from '@uipath/apollo-react/canvas/xyflow/react';
+import type { Edge, Node } from '@uipath/apollo-react/canvas/xyflow/react';
 import { ReactFlowProvider } from '@uipath/apollo-react/canvas/xyflow/react';
 import type { ReactNode } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { BaseCanvas } from './BaseCanvas';
-import { useIsNodeReadOnly } from './ReadOnlyNodesContext';
+import { useIsConnectionReadOnly, useIsNodeReadOnly } from './ReadOnlyNodesContext';
+
+// CanvasProviders and ReadOnlyNodesContext are deliberately NOT mocked: the
+// unit tests stub that seam, so the wiring can be deleted without one failing.
+// Only ReactFlow is replaced, by a stand-in that renders nodeTypes for real.
 
 let lastNodes: Node[] = [];
+let lastEdges: Edge[] = [];
 
 vi.mock('@uipath/apollo-react/canvas/xyflow/react', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@uipath/apollo-react/canvas/xyflow/react')>();
@@ -15,18 +20,24 @@ vi.mock('@uipath/apollo-react/canvas/xyflow/react', async (importOriginal) => {
     ReactFlow: ({
       children,
       nodes,
+      edges,
       nodeTypes,
     }: {
       children?: ReactNode;
       nodes: Node[];
+      edges: Edge[];
       nodeTypes: Record<string, React.ComponentType<{ id: string }>>;
     }) => {
       lastNodes = nodes;
+      lastEdges = edges;
       return (
         <div data-testid="react-flow">
           {nodes.map((node) => {
             const NodeComponent = nodeTypes[node.type ?? ''];
-            return NodeComponent ? <NodeComponent key={node.id} id={node.id} /> : null;
+            if (!NodeComponent) {
+              return null;
+            }
+            return <NodeComponent key={node.id} id={node.id} />;
           })}
           {children}
         </div>
@@ -39,12 +50,28 @@ vi.mock('@uipath/apollo-react/canvas/xyflow/react', async (importOriginal) => {
 });
 
 const nodes: Node[] = [
-  { id: 'locked', type: 'probe', position: { x: 0, y: 0 }, data: {} },
-  { id: 'free', type: 'probe', position: { x: 100, y: 0 }, data: {} },
+  { id: 'locked-a', type: 'probe', position: { x: 0, y: 0 }, data: {} },
+  { id: 'locked-b', type: 'probe', position: { x: 100, y: 0 }, data: {} },
+  { id: 'free', type: 'probe', position: { x: 200, y: 0 }, data: {} },
+];
+
+// 'inside' lives wholly in the locked region; 'crossing' reaches out of it.
+const edges: Edge[] = [
+  { id: 'inside', source: 'locked-a', target: 'locked-b' },
+  { id: 'crossing', source: 'locked-b', target: 'free' },
 ];
 
 function ProbeNode({ id }: { id: string }) {
   return <div data-testid={`node-${id}`} data-readonly={String(useIsNodeReadOnly(id))} />;
+}
+
+function EdgeProbe({ source, target }: { source: string; target: string }) {
+  return (
+    <div
+      data-testid={`edge-${source}-${target}`}
+      data-frozen={String(useIsConnectionReadOnly(source, target))}
+    />
+  );
 }
 
 const renderCanvas = (readOnlyNodeIds?: ReadonlySet<string>) =>
@@ -52,42 +79,59 @@ const renderCanvas = (readOnlyNodeIds?: ReadonlySet<string>) =>
     <ReactFlowProvider>
       <BaseCanvas
         nodes={nodes}
-        edges={[]}
+        edges={edges}
         nodeTypes={{ probe: ProbeNode }}
         mode="design"
         readOnlyNodeIds={readOnlyNodeIds}
-      />
+      >
+        <EdgeProbe source="locked-a" target="locked-b" />
+        <EdgeProbe source="locked-b" target="free" />
+      </BaseCanvas>
     </ReactFlowProvider>
   );
 
 const readOnlyAttr = (id: string) => screen.getByTestId(`node-${id}`).dataset.readonly;
+const frozenAttr = (source: string, target: string) =>
+  screen.getByTestId(`edge-${source}-${target}`).dataset.frozen;
 const byId = <T extends { id: string }>(items: T[], id: string) =>
   items.find((item) => item.id === id);
 
 describe('BaseCanvas with individually locked nodes', () => {
   beforeEach(() => {
     lastNodes = [];
+    lastEdges = [];
   });
 
   it('tells each node whether it is locked', () => {
-    renderCanvas(new Set(['locked']));
+    renderCanvas(new Set(['locked-a', 'locked-b']));
 
-    expect(readOnlyAttr('locked')).toBe('true');
+    expect(readOnlyAttr('locked-a')).toBe('true');
     expect(readOnlyAttr('free')).toBe('false');
   });
 
   it('treats every node as editable when no locks are provided', () => {
     renderCanvas();
 
-    expect(readOnlyAttr('locked')).toBe('false');
+    expect(readOnlyAttr('locked-a')).toBe('false');
   });
 
-  // Enforcement is a delete-time veto, not a flag on the node, so the objects
-  // React Flow holds stay the consumer's own. See BaseCanvas.readonlyLeak.
+  // Enforcement is a delete-time veto, not a flag on the elements, so the
+  // objects React Flow holds stay the consumer's own. See
+  // BaseCanvas.readonlyLeak for the round-trip that matters.
   it('hands React Flow the consumer node objects untouched', () => {
-    renderCanvas(new Set(['locked']));
+    renderCanvas(new Set(['locked-a', 'locked-b']));
 
-    expect(byId(lastNodes, 'locked')).toBe(nodes[0]);
-    expect(byId(lastNodes, 'free')).toBe(nodes[1]);
+    expect(byId(lastNodes, 'locked-a')).toBe(nodes[0]);
+    expect(byId(lastNodes, 'free')).toBe(nodes[2]);
+  });
+
+  it('freezes only edges between two locked nodes', () => {
+    renderCanvas(new Set(['locked-a', 'locked-b']));
+
+    expect(frozenAttr('locked-a', 'locked-b')).toBe('true');
+    expect(frozenAttr('locked-b', 'free')).toBe('false');
+
+    expect(byId(lastEdges, 'inside')).toBe(edges[0]);
+    expect(byId(lastEdges, 'crossing')).toBe(edges[1]);
   });
 });

--- a/packages/apollo-react/src/canvas/components/BaseCanvas/BaseCanvas.readonlyChanges.test.tsx
+++ b/packages/apollo-react/src/canvas/components/BaseCanvas/BaseCanvas.readonlyChanges.test.tsx
@@ -1,26 +1,40 @@
 import { render } from '@testing-library/react';
-import type { Node, NodeChange } from '@uipath/apollo-react/canvas/xyflow/react';
+import type {
+  Connection,
+  Edge,
+  EdgeChange,
+  Node,
+  NodeChange,
+} from '@uipath/apollo-react/canvas/xyflow/react';
 import { ReactFlowProvider } from '@uipath/apollo-react/canvas/xyflow/react';
 import type { ReactNode } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { BaseCanvas } from './BaseCanvas';
 import type { BaseCanvasProps } from './BaseCanvas.types';
 
-// Only the viewport hooks are stubbed, so the change guard is exercised for
-// real. This covers the direct-caller path: React Flow's own deletion paths go
+// Only the viewport hooks are stubbed, so the change guards are exercised for
+// real. They cover the direct-caller path: React Flow's own deletion paths go
 // through `onBeforeDelete` instead.
-vi.mock('./BaseCanvas.hooks', async () => ({
-  ...(await vi.importActual('./BaseCanvas.hooks')),
-  useAutoLayout: () => ({ isLayouting: false, isReady: true }),
-  useEnsureNodesInView: () => ({
-    ensureNodesInView: vi.fn(),
-    ensureAllNodesInView: vi.fn(),
-    centerNode: vi.fn(),
-  }),
-  useMaintainNodesInView: vi.fn(),
-}));
+vi.mock('./BaseCanvas.hooks', async () => {
+  const actual = await vi.importActual<typeof import('./BaseCanvas.hooks')>('./BaseCanvas.hooks');
+  return {
+    ...actual,
+    useAutoLayout: () => ({ isLayouting: false, isReady: true }),
+    useEnsureNodesInView: () => ({
+      ensureNodesInView: vi.fn(),
+      ensureAllNodesInView: vi.fn(),
+      centerNode: vi.fn(),
+    }),
+    useMaintainNodesInView: vi.fn(),
+  };
+});
 
+// Capture the change and connection handlers BaseCanvas hands to ReactFlow so
+// we can invoke them directly with synthetic interactions.
+let capturedOnEdgesChange: ((changes: EdgeChange[]) => void) | undefined;
 let capturedOnNodesChange: ((changes: NodeChange[]) => void) | undefined;
+let capturedIsValidConnection: BaseCanvasProps['isValidConnection'];
+let capturedOnConnect: BaseCanvasProps['onConnect'];
 
 vi.mock('@uipath/apollo-react/canvas/xyflow/react', async () => {
   const actual = await vi.importActual('@uipath/apollo-react/canvas/xyflow/react');
@@ -28,11 +42,20 @@ vi.mock('@uipath/apollo-react/canvas/xyflow/react', async () => {
     ...actual,
     ReactFlow: ({
       children,
+      isValidConnection,
+      onConnect,
+      onEdgesChange,
       onNodesChange,
     }: {
       children?: ReactNode;
+      isValidConnection?: BaseCanvasProps['isValidConnection'];
+      onConnect?: BaseCanvasProps['onConnect'];
+      onEdgesChange?: (changes: EdgeChange[]) => void;
       onNodesChange?: (changes: NodeChange[]) => void;
     }) => {
+      capturedIsValidConnection = isValidConnection;
+      capturedOnConnect = onConnect;
+      capturedOnEdgesChange = onEdgesChange;
       capturedOnNodesChange = onNodesChange;
       return <div data-testid="react-flow">{children}</div>;
     },
@@ -51,6 +74,15 @@ const nodes: Node[] = [
   { id: 'free', position: { x: 100, y: 0 }, data: {} },
 ];
 
+const edge: Edge = { id: 'locked-free', source: 'locked', target: 'free' };
+const editableEdge: Edge = { id: 'free-outside', source: 'free', target: 'outside' };
+const lockedToFreeConnection: Connection = {
+  source: 'locked',
+  target: 'free',
+  sourceHandle: null,
+  targetHandle: null,
+};
+
 const renderCanvas = (props: Partial<BaseCanvasProps>) =>
   render(
     <ReactFlowProvider>
@@ -60,6 +92,9 @@ const renderCanvas = (props: Partial<BaseCanvasProps>) =>
 
 describe('BaseCanvas node changes when nodes are locked', () => {
   beforeEach(() => {
+    capturedOnEdgesChange = undefined;
+    capturedIsValidConnection = undefined;
+    capturedOnConnect = undefined;
     capturedOnNodesChange = undefined;
   });
 
@@ -112,5 +147,49 @@ describe('BaseCanvas node changes when nodes are locked', () => {
     renderCanvas({ onNodesChange });
 
     expect(capturedOnNodesChange).toBe(onNodesChange);
+  });
+});
+
+describe('BaseCanvas edge changes when connected nodes are locked', () => {
+  beforeEach(() => {
+    capturedOnEdgesChange = undefined;
+  });
+
+  it('forwards only editable edge removals when an edge joins two locked nodes', () => {
+    const onEdgesChange = vi.fn();
+    renderCanvas({
+      edges: [edge, editableEdge],
+      onEdgesChange,
+      readOnlyNodeIds: new Set(['locked', 'free']),
+    });
+
+    capturedOnEdgesChange?.([
+      { type: 'remove', id: edge.id },
+      { type: 'remove', id: editableEdge.id },
+    ]);
+
+    expect(onEdgesChange).toHaveBeenCalledWith([{ type: 'remove', id: editableEdge.id }]);
+  });
+});
+
+// The guard semantics live in `useReadOnlyConnectionCallbacks.test.ts`; this
+// only proves the guarded callbacks are the ones handed to ReactFlow.
+describe('BaseCanvas connection callbacks when nodes are locked', () => {
+  it('gives ReactFlow the guarded connection callbacks', () => {
+    const consumerIsValidConnection = vi.fn(() => true);
+    const onConnect = vi.fn();
+    renderCanvas({
+      mode: 'design',
+      edges: [edge],
+      isValidConnection: consumerIsValidConnection,
+      onConnect,
+      readOnlyNodeIds: new Set(['locked', 'free']),
+    });
+
+    expect(capturedIsValidConnection?.(lockedToFreeConnection)).toBe(false);
+    capturedOnConnect?.(lockedToFreeConnection);
+
+    expect(consumerIsValidConnection).not.toHaveBeenCalled();
+    expect(onConnect).not.toHaveBeenCalled();
   });
 });

--- a/packages/apollo-react/src/canvas/components/BaseCanvas/BaseCanvas.reconnect.test.tsx
+++ b/packages/apollo-react/src/canvas/components/BaseCanvas/BaseCanvas.reconnect.test.tsx
@@ -1,0 +1,65 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+/**
+ * Reconnect anchors are rendered by React Flow only for edges it can measure,
+ * which jsdom never reports, so asserting on the anchor DOM would pass
+ * vacuously. Capture the props BaseCanvas hands to ReactFlow instead: anchors
+ * appear purely because `onReconnect` is defined (`edgesReconnectable`
+ * defaults to true), so the prop is the switch under test.
+ */
+const reactFlowProps: Record<string, unknown>[] = [];
+
+vi.mock('@uipath/apollo-react/canvas/xyflow/react', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    ReactFlow: (props: Record<string, unknown> & { children?: React.ReactNode }) => {
+      reactFlowProps.push(props);
+      return <div data-testid="react-flow">{props.children}</div>;
+    },
+  };
+});
+
+import type { Edge, Node } from '@uipath/apollo-react/canvas/xyflow/react';
+import { ReactFlowProvider } from '@uipath/apollo-react/canvas/xyflow/react';
+import { BaseCanvas } from './BaseCanvas';
+
+const nodes: Node[] = [
+  { id: 'a', position: { x: 0, y: 0 }, data: {} },
+  { id: 'b', position: { x: 300, y: 0 }, data: {} },
+];
+const edges: Edge[] = [{ id: 'a-b', source: 'a', target: 'b' }];
+
+const renderCanvas = (mode: React.ComponentProps<typeof BaseCanvas>['mode']) => {
+  reactFlowProps.length = 0;
+  render(
+    <ReactFlowProvider>
+      <BaseCanvas
+        nodes={nodes}
+        edges={edges}
+        mode={mode}
+        onReconnect={vi.fn()}
+        onReconnectEnd={vi.fn()}
+      />
+    </ReactFlowProvider>
+  );
+
+  return reactFlowProps.at(-1) as Record<string, unknown>;
+};
+
+describe('BaseCanvas reconnect callbacks', () => {
+  it('forwards them in design mode', () => {
+    const props = renderCanvas('design');
+
+    expect(props.onReconnect).toBeTypeOf('function');
+    expect(props.onReconnectEnd).toBeTypeOf('function');
+  });
+
+  it.each(['view', 'readonly'] as const)('withholds them in %s mode', (mode) => {
+    const props = renderCanvas(mode);
+
+    expect(props.onReconnect).toBeUndefined();
+    expect(props.onReconnectEnd).toBeUndefined();
+  });
+});

--- a/packages/apollo-react/src/canvas/components/BaseCanvas/BaseCanvas.stories.fixtures.ts
+++ b/packages/apollo-react/src/canvas/components/BaseCanvas/BaseCanvas.stories.fixtures.ts
@@ -1,0 +1,45 @@
+import type { Node } from '@uipath/apollo-react/canvas/xyflow/react';
+import { Position } from '@uipath/apollo-react/canvas/xyflow/react';
+import { createNode } from '../../storybook-utils';
+import type { BaseNodeData } from '../BaseNode/BaseNode.types';
+
+export function createConnectionComparisonNodes(): Node<BaseNodeData>[] {
+  return [
+    createNode({
+      id: 'connection-source',
+      type: 'uipath.blank-node',
+      position: { x: 0, y: 0 },
+      display: { label: 'Submit expense' },
+      handleConfigurations: [
+        {
+          position: Position.Right,
+          handles: [
+            {
+              id: `out-${Position.Right}`,
+              type: 'source',
+              handleType: 'output',
+            },
+          ],
+        },
+      ],
+    }),
+    createNode({
+      id: 'connection-target',
+      type: 'uipath.blank-node',
+      position: { x: 320, y: 0 },
+      display: { label: 'Review expense' },
+      handleConfigurations: [
+        {
+          position: Position.Left,
+          handles: [
+            {
+              id: `in-${Position.Left}`,
+              type: 'target',
+              handleType: 'input',
+            },
+          ],
+        },
+      ],
+    }),
+  ];
+}

--- a/packages/apollo-react/src/canvas/components/BaseCanvas/BaseCanvas.stories.independence.test.ts
+++ b/packages/apollo-react/src/canvas/components/BaseCanvas/BaseCanvas.stories.independence.test.ts
@@ -4,8 +4,9 @@ import { type ComponentProps, createElement } from 'react';
 import { describe, expect, it, vi } from 'vitest';
 import * as stories from './BaseCanvas.stories';
 
-const { specializedNodeStores } = vi.hoisted(() => ({
+const { specializedNodeStores, connectionStores } = vi.hoisted(() => ({
   specializedNodeStores: new Map<number, { getState: () => unknown }>(),
+  connectionStores: new Map<number, { getState: () => unknown }>(),
 }));
 
 // Cancels the global xyflow stub from `src/test/canvas-mocks.ts` (loaded for every
@@ -46,6 +47,11 @@ vi.mock('./BaseCanvas', async (importOriginal) => {
     ...actual,
     BaseCanvas: (props: ComponentProps<typeof actual.BaseCanvas>) => {
       const store = useStoreApi();
+
+      if (props.edges?.some((edge) => edge.id === 'connection-comparison-edge')) {
+        connectionStores.set(props.readOnlyNodeIds?.size ?? 0, store);
+        return createElement('div');
+      }
 
       if (props.nodes?.[0]?.type === 'comparison-agent') {
         specializedNodeStores.set(props.readOnlyNodeIds?.size ?? 0, store);
@@ -94,5 +100,15 @@ describe('specialized node comparison previews', () => {
 
     expect(screen.getAllByText('Agent manifest available')).toHaveLength(2);
     expect(screen.queryByText('Manifest Undefined')).not.toBeInTheDocument();
+  });
+
+  it('keeps the connection comparison previews independent', () => {
+    connectionStores.clear();
+
+    render(createElement(PerNodeReadOnly));
+
+    // Neither, one, and both endpoints locked, each on its own store.
+    expect([...connectionStores.keys()].sort()).toEqual([0, 1, 2]);
+    expect(new Set([...connectionStores.values()].map((store) => store.getState)).size).toBe(3);
   });
 });

--- a/packages/apollo-react/src/canvas/components/BaseCanvas/BaseCanvas.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/BaseCanvas/BaseCanvas.stories.tsx
@@ -42,12 +42,14 @@ import { AgentNodeElement } from '../AgentCanvas/nodes/AgentNode';
 import { AgentFlowProvider } from '../AgentCanvas/store/agent-flow-store';
 import type { BaseNodeData } from '../BaseNode/BaseNode.types';
 import { CanvasPositionControls } from '../CanvasPositionControls';
+import { CanvasEdge } from '../Edges';
 import { LoopNode } from '../LoopNode';
 import { StageNodeWrapper } from '../StageNode/StageNode.stories.utils';
 import type { StageNodeBaseProps } from '../StageNode/StageNode.types';
 import { StickyNoteNode } from '../StickyNoteNode';
 import type { StickyNoteData } from '../StickyNoteNode/StickyNoteNode.types';
 import { BaseCanvas } from './BaseCanvas';
+import { createConnectionComparisonNodes } from './BaseCanvas.stories.fixtures';
 import type { BaseCanvasRef } from './BaseCanvas.types';
 
 // ============================================================================
@@ -1636,9 +1638,9 @@ const specializedNodeComparisons = [
   {
     value: 'stage',
     label: 'StageNode',
-    unlocked: 'Title, task, rule, and add or replace affordances are shown on the stage.',
+    unlocked: 'Title, task, rule, and add affordances are shown on the stage.',
     locked:
-      'Stage mutation affordances are hidden while tasks, rules, statuses, and host menu items stay visible.',
+      'Stage mutation affordances are hidden while configured tasks, rules, and host menu items stay visible.',
   },
   {
     value: 'sticky-note',
@@ -1679,6 +1681,105 @@ function SpecializedNodeComparison({
   );
 }
 
+type ConnectionLockState = 'neither' | 'one' | 'both';
+
+const CONNECTION_SOURCE_ID = 'connection-source';
+const CONNECTION_TARGET_ID = 'connection-target';
+const connectionReadOnlyNodeIds: Record<ConnectionLockState, ReadonlySet<string>> = {
+  neither: new Set(),
+  one: new Set([CONNECTION_SOURCE_ID]),
+  both: new Set([CONNECTION_SOURCE_ID, CONNECTION_TARGET_ID]),
+};
+
+const connectionComparisonEdge: Edge = {
+  id: 'connection-comparison-edge',
+  source: CONNECTION_SOURCE_ID,
+  sourceHandle: `out-${Position.Right}`,
+  target: CONNECTION_TARGET_ID,
+  targetHandle: `in-${Position.Left}`,
+  type: 'connection-comparison-edge',
+  selected: true,
+  data: {
+    enableToolbar: true,
+    label: 'Approval',
+    routing: 'handle',
+  },
+};
+
+function ConnectionStatePill({ label, locked }: { label: string; locked: boolean }) {
+  return (
+    <span
+      className={cn(
+        'rounded-full border px-2 py-1 text-[11px] font-medium',
+        locked
+          ? 'border-primary/30 bg-primary/10 text-primary'
+          : 'border-border bg-background text-muted-foreground'
+      )}
+    >
+      {label} · {locked ? 'Locked' : 'Unlocked'}
+    </span>
+  );
+}
+
+function ConnectionComparisonSpecimen({ state }: { state: ConnectionLockState }) {
+  const initialNodes = useMemo(() => createConnectionComparisonNodes(), []);
+  const initialEdges = useMemo(() => [connectionComparisonEdge], []);
+  const { canvasProps } = useCanvasStory({ initialNodes, initialEdges });
+  const lockedIds = connectionReadOnlyNodeIds[state];
+
+  return (
+    <div className="flex h-full w-full flex-col">
+      <div className="flex flex-wrap justify-center gap-2 border-b border-border bg-card px-3 py-2.5">
+        <ConnectionStatePill label="Source" locked={lockedIds.has(CONNECTION_SOURCE_ID)} />
+        <ConnectionStatePill label="Target" locked={lockedIds.has(CONNECTION_TARGET_ID)} />
+      </div>
+      <div className="min-h-0 flex-1">
+        <ReactFlowProvider>
+          <BaseCanvas
+            {...canvasProps}
+            id={`connection-comparison-${state}`}
+            edgeTypes={{
+              ...canvasProps.edgeTypes,
+              'connection-comparison-edge': CanvasEdge,
+            }}
+            mode="design"
+            readOnlyNodeIds={lockedIds}
+            fitView
+            fitViewOptions={{ padding: 0.16, maxZoom: 0.75 }}
+            minZoom={0.35}
+          />
+        </ReactFlowProvider>
+      </div>
+    </div>
+  );
+}
+
+const connectionComparisons = [
+  {
+    state: 'neither',
+    title: 'Neither endpoint',
+    policy: 'editable',
+    description: 'Create, delete, reconnect, and split the connection normally.',
+  },
+  {
+    state: 'one',
+    title: 'One endpoint',
+    policy: 'editable',
+    description: 'The unlocked endpoint keeps the graph boundary available for connection edits.',
+  },
+  {
+    state: 'both',
+    title: 'Both endpoints',
+    policy: 'frozen',
+    description: 'Create, delete, reconnect, and split operations are blocked for the connection.',
+  },
+] as const satisfies readonly {
+  state: ConnectionLockState;
+  title: string;
+  policy: string;
+  description: string;
+}[];
+
 function PerNodeReadOnlyPage({ globalTheme }: { globalTheme: string }) {
   return (
     <StoryPage
@@ -1703,6 +1804,10 @@ function PerNodeReadOnlyPage({ globalTheme }: { globalTheme: string }) {
             <p>
               Drag locked nodes or use Organize to confirm that layout stays available while node
               content is protected.
+            </p>
+            <p>
+              Connections stay editable while either endpoint is unlocked. Lock both ends of an edge
+              to freeze its connection operations too.
             </p>
           </>
         }
@@ -1791,6 +1896,46 @@ function CustomNode({ id }: NodeProps) {
           same <StoryCode>readOnlyNodeIds</StoryCode> set to these renderers without adding a second
           policy layer.
         </p>
+      </StorySection>
+
+      <StorySection
+        title="Connection behavior"
+        description={
+          <>
+            <p>
+              A connection becomes read-only only when both endpoint nodes are locked. This keeps
+              the boundary of a locked region editable while protecting its internal wiring.
+            </p>
+            <p>
+              The guards read the current lock set when a connection gesture completes, so a lock
+              applied after the drag starts still takes effect. Custom edge renderers can mirror the
+              same policy with <StoryCode>useIsConnectionReadOnly</StoryCode>.
+            </p>
+          </>
+        }
+      >
+        <StoryWideContent>
+          <div className="grid gap-4 md:grid-cols-3">
+            {connectionComparisons.map((comparison) => (
+              <StoryCard
+                key={comparison.state}
+                title={comparison.title}
+                code={comparison.policy}
+                description={comparison.description}
+                preview={<ConnectionComparisonSpecimen state={comparison.state} />}
+                previewClassName="h-[300px] w-full overflow-hidden rounded-lg border border-border bg-background"
+              />
+            ))}
+          </div>
+        </StoryWideContent>
+        <div className="mt-6">
+          <StoryCodeBlock>
+            {`function CustomEdge({ source, target }: EdgeProps) {
+  const isReadOnly = useIsConnectionReadOnly(source, target);
+  return <CustomEdgeToolbar hidden={isReadOnly} />;
+}`}
+          </StoryCodeBlock>
+        </div>
       </StorySection>
     </StoryPage>
   );

--- a/packages/apollo-react/src/canvas/components/BaseCanvas/BaseCanvas.test.tsx
+++ b/packages/apollo-react/src/canvas/components/BaseCanvas/BaseCanvas.test.tsx
@@ -21,6 +21,7 @@ vi.mock('./BaseCanvas.hooks', () => ({
   }),
   useMaintainNodesInView: vi.fn(),
   useReadOnlyBeforeDelete: () => undefined,
+  useReadOnlyEdgeIds: () => new Set<string>(),
 }));
 
 // Mock ReactFlow

--- a/packages/apollo-react/src/canvas/components/BaseCanvas/BaseCanvas.tsx
+++ b/packages/apollo-react/src/canvas/components/BaseCanvas/BaseCanvas.tsx
@@ -22,12 +22,14 @@ import {
   useEnsureNodesInView,
   useMaintainNodesInView,
   useReadOnlyBeforeDelete,
+  useReadOnlyEdgeIds,
 } from './BaseCanvas.hooks';
 import type { BaseCanvasProps, BaseCanvasRef } from './BaseCanvas.types';
 import { CanvasBackground } from './CanvasBackground';
 import { CanvasProviders } from './CanvasProviders';
 import { PanShortcutTeachingUI } from './PanShortcutTeachingUI';
 import { useStableNodeIdSet } from './ReadOnlyNodesContext';
+import { useReadOnlyConnectionCallbacks } from './useReadOnlyConnectionCallbacks';
 
 const BaseCanvasInnerComponent = <NodeType extends Node = Node, EdgeType extends Edge = Edge>(
   props: BaseCanvasProps<NodeType, EdgeType> & {
@@ -73,8 +75,12 @@ const BaseCanvasInnerComponent = <NodeType extends Node = Node, EdgeType extends
     onNodesChange,
     onEdgesChange,
     onConnect,
+    onReconnect,
+    onReconnectStart,
+    onReconnectEnd,
     onConnectStart,
     onConnectEnd,
+    isValidConnection,
     onNodeClick,
     onNodeDragStart,
     onNodeDrag,
@@ -117,12 +123,18 @@ const BaseCanvasInnerComponent = <NodeType extends Node = Node, EdgeType extends
   // Derive interactivity from mode
   const isInteractive = mode !== 'readonly';
   const isDesignMode = mode === 'design';
+
+  // Per-node read-only: stabilize the set by content, then apply React Flow's
+  // flags. Only edges with both endpoints locked are frozen.
   const stableReadOnlyNodeIds = useStableNodeIdSet(readOnlyNodeIds);
+  const readOnlyEdgeIds = useReadOnlyEdgeIds(edges, stableReadOnlyNodeIds);
   const guardedBeforeDelete = useReadOnlyBeforeDelete(stableReadOnlyNodeIds, onBeforeDelete);
 
   // `onBeforeDelete` already covers every React Flow deletion path. This is the
-  // safety net for consumers that invoke the change handler directly. Layout
-  // changes pass through: position and size are layout, not content.
+  // safety net for a consumer calling the change handler directly. `replace`
+  // and layout changes pass through on purpose: React Flow emits `replace` for
+  // layout writes such as BaseNode's height sync, and position and size are
+  // layout rather than content.
   const handleNodesChange = useMemo(() => {
     if (!onNodesChange || stableReadOnlyNodeIds.size === 0) return onNodesChange;
     const guarded: typeof onNodesChange = (changes) => {
@@ -133,6 +145,26 @@ const BaseCanvasInnerComponent = <NodeType extends Node = Node, EdgeType extends
     };
     return guarded;
   }, [onNodesChange, stableReadOnlyNodeIds]);
+
+  const handleEdgesChange = useMemo(() => {
+    if (!onEdgesChange || readOnlyEdgeIds.size === 0) return onEdgesChange;
+    const guarded: typeof onEdgesChange = (changes) => {
+      const allowed = changes.filter((change) =>
+        change.type === 'remove' ? !readOnlyEdgeIds.has(change.id) : true
+      );
+      if (allowed.length > 0) onEdgesChange(allowed);
+    };
+    return guarded;
+  }, [onEdgesChange, readOnlyEdgeIds]);
+
+  const { guardedIsValidConnection, guardedOnConnect, guardedOnReconnect, guardedOnReconnectEnd } =
+    useReadOnlyConnectionCallbacks<EdgeType>({
+      readOnlyNodeIds: stableReadOnlyNodeIds,
+      isValidConnection,
+      onConnect,
+      onReconnect,
+      onReconnectEnd,
+    });
 
   const [reactFlowInstance, setReactFlowInstance] =
     useState<ReactFlowInstance<NodeType, EdgeType>>();
@@ -192,6 +224,7 @@ const BaseCanvasInnerComponent = <NodeType extends Node = Node, EdgeType extends
         colorMode={'' as unknown as ColorMode}
         nodes={nodes}
         edges={edges}
+        isValidConnection={guardedIsValidConnection}
         nodeTypes={nodeTypes}
         edgeTypes={edgeTypes}
         fitViewOptions={fitViewOptions}
@@ -217,9 +250,12 @@ const BaseCanvasInnerComponent = <NodeType extends Node = Node, EdgeType extends
         panOnDrag={isInteractive ? PAN_ON_DRAG : false}
         onInit={handleInit}
         onNodesChange={isInteractive ? handleNodesChange : undefined}
-        onEdgesChange={isInteractive ? onEdgesChange : undefined}
+        onEdgesChange={isInteractive ? handleEdgesChange : undefined}
         onBeforeDelete={guardedBeforeDelete}
-        onConnect={isDesignMode ? onConnect : undefined}
+        onConnect={isDesignMode ? guardedOnConnect : undefined}
+        onReconnect={isDesignMode ? guardedOnReconnect : undefined}
+        onReconnectStart={isDesignMode ? onReconnectStart : undefined}
+        onReconnectEnd={isDesignMode ? guardedOnReconnectEnd : undefined}
         onConnectStart={isDesignMode ? onConnectStart : undefined}
         onConnectEnd={isDesignMode ? onConnectEnd : undefined}
         onNodeClick={isInteractive ? onNodeClick : undefined}

--- a/packages/apollo-react/src/canvas/components/BaseCanvas/BaseCanvas.types.ts
+++ b/packages/apollo-react/src/canvas/components/BaseCanvas/BaseCanvas.types.ts
@@ -76,25 +76,35 @@ export interface BaseCanvasProps<NodeType extends Node = Node, EdgeType extends 
   mode?: 'design' | 'readonly' | 'view';
 
   /**
-   * Node ids whose content is read-only while the rest of the canvas remains editable.
-   * Locked nodes cannot be deleted or label-edited and hide their inline
-   * content-editing controls. Toolbars are the exception: they stay visible with
-   * every action disabled, so the lock is discoverable. Locked nodes remain
-   * selectable and draggable. Resizable nodes generally remain resizable, except
-   * StickyNoteNode, which hides its resize controls.
+   * Node ids to lock while the rest of the canvas stays interactive. A node is
+   * editable only when `mode === 'design' && !readOnlyNodeIds?.has(id)`.
    *
-   * Honored by nodes built on BaseNode, AgentNode, LoopNode, StageNode, and
-   * StickyNoteNode. Custom renderers can observe state with `useIsNodeReadOnly`.
+   * Locked nodes cannot be deleted or label-edited, and hide their inline
+   * content-editing controls such as handle add buttons. Toolbars are the
+   * exception: they stay visible with every action disabled, so the lock is
+   * discoverable. Locked nodes stay selectable and draggable, and resizable
+   * nodes generally stay resizable, except `StickyNoteNode`, which disables its
+   * resize controls. To freeze all layout interaction, use `mode="readonly"`.
    *
-   * Compared by content, so passing a fresh set with the same ids is a no-op.
-   * Do not mutate a set after passing it; pass a new set instead.
+   * Connections to and from a locked node are still allowed. Only connections
+   * with *both* endpoints locked are frozen: they cannot be created, deleted,
+   * reconnected, or split by the edge toolbar.
+   *
+   * Honored by nodes built on `BaseNode` (including `AgentNode` and `LoopNode`),
+   * by `StageNode`, and by `StickyNoteNode`. Custom node types opt in via
+   * `useIsNodeReadOnly`.
    *
    * A `Set` or an array; both are normalized to a set internally. Deliberately
    * not `Iterable<string>`: a bare `string` satisfies that type and would be
    * spread per character, and a single-use iterator would read as empty on
    * every render after the first.
    *
-   * @default undefined
+   * Compared by content, so a fresh set with the same ids changes nothing. Do
+   * not mutate a set after passing it; pass a new one. Any iterable is accepted
+   * (an array is fine) and is normalized to a set internally.
+   *
+   * @example new Set(['agent-1', 'tool-1', 'tool-2'])
+   * @default undefined (no nodes are individually read-only)
    */
   readOnlyNodeIds?: ReadonlySet<string> | readonly string[];
 

--- a/packages/apollo-react/src/canvas/components/BaseCanvas/ReadOnlyNodesContext.test.tsx
+++ b/packages/apollo-react/src/canvas/components/BaseCanvas/ReadOnlyNodesContext.test.tsx
@@ -1,8 +1,10 @@
 import { render, renderHook, screen } from '@testing-library/react';
 import { memo, type PropsWithChildren } from 'react';
+import { renderToString } from 'react-dom/server';
 import { describe, expect, it } from 'vitest';
 import {
   ReadOnlyNodesProvider,
+  useIsConnectionReadOnly,
   useIsNodeReadOnly,
   useStableNodeIdSet,
 } from './ReadOnlyNodesContext';
@@ -11,6 +13,10 @@ function wrapperWith(ids?: ReadonlySet<string>) {
   return ({ children }: PropsWithChildren) => (
     <ReadOnlyNodesProvider readOnlyNodeIds={ids}>{children}</ReadOnlyNodesProvider>
   );
+}
+
+function ConnectionProbe({ source, target }: { source: string; target: string }) {
+  return <span data-frozen={String(useIsConnectionReadOnly(source, target))} />;
 }
 
 describe('useIsNodeReadOnly', () => {
@@ -96,6 +102,16 @@ describe('ReadOnlyNodesProvider updates', () => {
     const readOnly = useIsNodeReadOnly(id);
     counts[id] = (counts[id] ?? 0) + 1;
     return <span data-testid={`probe-${id}`}>{String(readOnly)}</span>;
+  });
+
+  it('starts with a frozen connection when both endpoints are locked', () => {
+    const markup = renderToString(
+      <ReadOnlyNodesProvider readOnlyNodeIds={new Set(['a', 'b'])}>
+        <ConnectionProbe source="a" target="b" />
+      </ReadOnlyNodesProvider>
+    );
+
+    expect(markup).toContain('data-frozen="true"');
   });
 
   it('re-renders only the nodes whose lock state changed', () => {

--- a/packages/apollo-react/src/canvas/components/BaseCanvas/ReadOnlyNodesContext.tsx
+++ b/packages/apollo-react/src/canvas/components/BaseCanvas/ReadOnlyNodesContext.tsx
@@ -16,8 +16,8 @@ class ReadOnlyNodesStore {
   private ids: ReadonlySet<string>;
   private listeners = new Map<string, Set<Listener>>();
 
-  constructor(initial: ReadonlySet<string> = EMPTY_SET) {
-    this.ids = initial.size === 0 ? EMPTY_SET : new Set(initial);
+  constructor(initialIds: ReadonlySet<string> = EMPTY_SET) {
+    this.ids = initialIds.size === 0 ? EMPTY_SET : new Set(initialIds);
   }
 
   /** Subscribe to changes for a specific node. */
@@ -40,6 +40,13 @@ class ReadOnlyNodesStore {
   /** Boolean snapshots let React bail out when a node's state is unchanged. */
   isReadOnly(nodeId: string): boolean {
     return this.ids.has(nodeId);
+  }
+
+  isConnectionReadOnly(
+    source: string | null | undefined,
+    target: string | null | undefined
+  ): boolean {
+    return isConnectionReadOnly(this.ids, source, target);
   }
 
   /**
@@ -99,8 +106,21 @@ export function useStableNodeIdSet(
 }
 
 /**
- * Distributes BaseCanvas `readOnlyNodeIds` to node renderers.
- * Mounted by CanvasProviders; not intended for direct use.
+ * True when both endpoints are read-only. Locking a node freezes the
+ * connections wholly inside the locked region, not every connection it touches.
+ */
+export function isConnectionReadOnly(
+  readOnlyNodeIds: ReadonlySet<string>,
+  source: string | null | undefined,
+  target: string | null | undefined
+): boolean {
+  if (readOnlyNodeIds.size === 0 || !source || !target) return false;
+  return readOnlyNodeIds.has(source) && readOnlyNodeIds.has(target);
+}
+
+/**
+ * Distributes per-node read-only state (from BaseCanvas `readOnlyNodeIds`) to
+ * node renderers. Mounted by CanvasProviders; not intended for direct use.
  */
 export const ReadOnlyNodesProvider: React.FC<
   React.PropsWithChildren<{ readOnlyNodeIds?: ReadonlySet<string> }>
@@ -140,4 +160,31 @@ export function useIsNodeReadOnly(nodeId: string): boolean {
   const getSnapshot = useCallback(() => store?.isReadOnly(nodeId) ?? false, [store, nodeId]);
 
   return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+}
+
+/**
+ * True when the connection between these two nodes is frozen, i.e. both
+ * endpoints are read-only. False outside a provider.
+ */
+export function useIsConnectionReadOnly(
+  source: string | null | undefined,
+  target: string | null | undefined
+): boolean {
+  const sourceReadOnly = useIsNodeReadOnly(source ?? '');
+  const targetReadOnly = useIsNodeReadOnly(target ?? '');
+  return !!source && !!target && sourceReadOnly && targetReadOnly;
+}
+
+/**
+ * Returns a stable call-time check for event handlers and deferred work. Unlike
+ * `useIsConnectionReadOnly`, this does not capture the value from a render.
+ */
+export function useReadOnlyConnectionCheck() {
+  const store = useContext(ReadOnlyNodesContext);
+
+  return useCallback(
+    (source: string | null | undefined, target: string | null | undefined) =>
+      store?.isConnectionReadOnly(source, target) ?? false,
+    [store]
+  );
 }

--- a/packages/apollo-react/src/canvas/components/BaseCanvas/index.test.ts
+++ b/packages/apollo-react/src/canvas/components/BaseCanvas/index.test.ts
@@ -4,5 +4,6 @@ import * as BaseCanvasExports from './index';
 describe('BaseCanvas public exports', () => {
   it('keeps read-only enforcement helpers private when the barrel is imported', () => {
     expect(BaseCanvasExports).not.toHaveProperty('useReadOnlyBeforeDelete');
+    expect(BaseCanvasExports).not.toHaveProperty('useReadOnlyEdgeIds');
   });
 });

--- a/packages/apollo-react/src/canvas/components/BaseCanvas/index.ts
+++ b/packages/apollo-react/src/canvas/components/BaseCanvas/index.ts
@@ -14,5 +14,5 @@ export * from './CanvasThemeContext';
 export * from './ConnectedHandlesContext';
 // Named, not wildcard: the provider and the set-stabilizing helper are
 // internal, and anything exported here is public API we have to keep.
-export { useIsNodeReadOnly } from './ReadOnlyNodesContext';
+export { useIsConnectionReadOnly, useIsNodeReadOnly } from './ReadOnlyNodesContext';
 export * from './SelectionStateContext';

--- a/packages/apollo-react/src/canvas/components/BaseCanvas/useReadOnlyConnectionCallbacks.test.ts
+++ b/packages/apollo-react/src/canvas/components/BaseCanvas/useReadOnlyConnectionCallbacks.test.ts
@@ -1,0 +1,115 @@
+import { renderHook } from '@testing-library/react';
+import type {
+  Connection,
+  Edge,
+  FinalConnectionState,
+} from '@uipath/apollo-react/canvas/xyflow/react';
+import { describe, expect, it, vi } from 'vitest';
+import { useReadOnlyConnectionCallbacks } from './useReadOnlyConnectionCallbacks';
+
+const edge: Edge = { id: 'locked-free', source: 'locked', target: 'free' };
+const lockedToFree: Connection = {
+  source: 'locked',
+  target: 'free',
+  sourceHandle: null,
+  targetHandle: null,
+};
+const lockedToOutside: Connection = {
+  source: 'locked',
+  target: 'outside',
+  sourceHandle: null,
+  targetHandle: null,
+};
+// Only forwarded, never inspected, by the guards.
+const connectionState = {} as FinalConnectionState;
+const mouseUp = new MouseEvent('mouseup');
+
+type Options = Parameters<typeof useReadOnlyConnectionCallbacks<Edge>>[0];
+
+const renderCallbacks = (initialProps: Options) =>
+  renderHook((props: Options) => useReadOnlyConnectionCallbacks(props), { initialProps });
+
+const bothLocked: ReadonlySet<string> = new Set(['locked', 'free']);
+
+describe('useReadOnlyConnectionCallbacks', () => {
+  it('rejects a connection between two locked nodes without consulting the consumer', () => {
+    const isValidConnection = vi.fn(() => true);
+    const { result, rerender } = renderCallbacks({
+      readOnlyNodeIds: new Set(),
+      isValidConnection,
+    });
+    // XYFlow captures the wrapper when the gesture starts, so hold the initial
+    // reference and lock afterwards: the guard must read the current lock set.
+    const capturedAtPointerDown = result.current.guardedIsValidConnection;
+
+    rerender({ readOnlyNodeIds: bothLocked, isValidConnection });
+
+    expect(capturedAtPointerDown(lockedToFree)).toBe(false);
+    expect(isValidConnection).not.toHaveBeenCalled();
+  });
+
+  it('drops connect, reconnect, and reconnect-end for a frozen connection', () => {
+    const onConnect = vi.fn();
+    const onReconnect = vi.fn();
+    // Guarding reconnect-end matters: consumers delete the edge there when no
+    // reconnect landed, which would remove a frozen edge by the back door.
+    const onReconnectEnd = vi.fn();
+    const { result, rerender } = renderCallbacks({
+      readOnlyNodeIds: new Set(),
+      onConnect,
+      onReconnect,
+      onReconnectEnd,
+    });
+    const { guardedOnConnect, guardedOnReconnect, guardedOnReconnectEnd } = result.current;
+
+    rerender({ readOnlyNodeIds: bothLocked, onConnect, onReconnect, onReconnectEnd });
+
+    guardedOnConnect?.(lockedToFree);
+    guardedOnReconnect?.(edge, lockedToOutside);
+    guardedOnReconnectEnd?.(mouseUp, edge, 'target', connectionState);
+
+    expect(onConnect).not.toHaveBeenCalled();
+    expect(onReconnect).not.toHaveBeenCalled();
+    expect(onReconnectEnd).not.toHaveBeenCalled();
+  });
+
+  it('forwards every callback when only one endpoint is locked', () => {
+    const isValidConnection = vi.fn(() => true);
+    const onConnect = vi.fn();
+    const onReconnect = vi.fn();
+    const onReconnectEnd = vi.fn();
+    const { result } = renderCallbacks({
+      readOnlyNodeIds: new Set(['locked']),
+      isValidConnection,
+      onConnect,
+      onReconnect,
+      onReconnectEnd,
+    });
+
+    expect(result.current.guardedIsValidConnection(lockedToFree)).toBe(true);
+    result.current.guardedOnConnect?.(lockedToFree);
+    result.current.guardedOnReconnect?.(edge, lockedToFree);
+    result.current.guardedOnReconnectEnd?.(mouseUp, edge, 'target', connectionState);
+
+    expect(isValidConnection).toHaveBeenCalledWith(lockedToFree);
+    expect(onConnect).toHaveBeenCalledWith(lockedToFree);
+    expect(onReconnect).toHaveBeenCalledWith(edge, lockedToFree);
+    expect(onReconnectEnd).toHaveBeenCalledWith(mouseUp, edge, 'target', connectionState);
+  });
+
+  it('accepts a connection when no consumer validator is provided', () => {
+    const { result } = renderCallbacks({ readOnlyNodeIds: new Set(['locked']) });
+
+    expect(result.current.guardedIsValidConnection(lockedToFree)).toBe(true);
+  });
+
+  // BaseCanvas forwards these straight to ReactFlow, so an absent consumer
+  // callback must stay absent rather than become a no-op handler.
+  it('leaves optional callbacks undefined when the consumer provides none', () => {
+    const { result } = renderCallbacks({ readOnlyNodeIds: bothLocked });
+
+    expect(result.current.guardedOnConnect).toBeUndefined();
+    expect(result.current.guardedOnReconnect).toBeUndefined();
+    expect(result.current.guardedOnReconnectEnd).toBeUndefined();
+  });
+});

--- a/packages/apollo-react/src/canvas/components/BaseCanvas/useReadOnlyConnectionCallbacks.ts
+++ b/packages/apollo-react/src/canvas/components/BaseCanvas/useReadOnlyConnectionCallbacks.ts
@@ -1,0 +1,105 @@
+import type {
+  Connection,
+  Edge,
+  Node,
+  ReactFlowProps,
+} from '@uipath/apollo-react/canvas/xyflow/react';
+import { useCallback } from 'react';
+import { useLatestRef } from '../../hooks/useLatestRef';
+import { isConnectionReadOnly } from './ReadOnlyNodesContext';
+
+type ConnectionEndpoints = Pick<Connection, 'source' | 'target'>;
+
+type ConnectionCallbacks<EdgeType extends Edge> = Pick<
+  ReactFlowProps<Node, EdgeType>,
+  'isValidConnection' | 'onConnect' | 'onReconnect' | 'onReconnectEnd'
+>;
+
+type UseReadOnlyConnectionCallbacksOptions<EdgeType extends Edge> =
+  ConnectionCallbacks<EdgeType> & {
+    readOnlyNodeIds: ReadonlySet<string>;
+  };
+
+const includesReadOnlyConnection = (
+  readOnlyNodeIds: ReadonlySet<string>,
+  ...connections: ConnectionEndpoints[]
+) =>
+  connections.some(({ source, target }) => isConnectionReadOnly(readOnlyNodeIds, source, target));
+
+export function useReadOnlyConnectionCallbacks<EdgeType extends Edge>({
+  readOnlyNodeIds,
+  isValidConnection,
+  onConnect,
+  onReconnect,
+  onReconnectEnd,
+}: UseReadOnlyConnectionCallbacksOptions<EdgeType>) {
+  const readOnlyNodeIdsRef = useLatestRef(readOnlyNodeIds);
+  const isValidConnectionRef = useLatestRef(isValidConnection);
+  const onConnectRef = useLatestRef(onConnect);
+  const onReconnectRef = useLatestRef(onReconnect);
+  const onReconnectEndRef = useLatestRef(onReconnectEnd);
+
+  // XYFlow captures these callbacks when a connection gesture starts. Keep the
+  // wrappers stable and read the current lock set when the gesture validates or
+  // completes, so a lock applied mid-gesture takes effect immediately.
+  const guardedIsValidConnection = useCallback<NonNullable<typeof isValidConnection>>(
+    (connection) => {
+      const currentReadOnlyNodeIds = readOnlyNodeIdsRef.current;
+      if (includesReadOnlyConnection(currentReadOnlyNodeIds, connection)) {
+        return false;
+      }
+      return isValidConnectionRef.current?.(connection) ?? true;
+    },
+    [isValidConnectionRef, readOnlyNodeIdsRef]
+  );
+
+  const guardedOnConnect = useCallback<NonNullable<typeof onConnect>>(
+    (connection) => {
+      const currentOnConnect = onConnectRef.current;
+      const currentReadOnlyNodeIds = readOnlyNodeIdsRef.current;
+      if (!currentOnConnect || includesReadOnlyConnection(currentReadOnlyNodeIds, connection)) {
+        return;
+      }
+      currentOnConnect(connection);
+    },
+    [onConnectRef, readOnlyNodeIdsRef]
+  );
+
+  const guardedOnReconnect = useCallback<NonNullable<typeof onReconnect>>(
+    (edgeBeingReconnected, proposedConnection) => {
+      const currentOnReconnect = onReconnectRef.current;
+      const currentReadOnlyNodeIds = readOnlyNodeIdsRef.current;
+      if (
+        !currentOnReconnect ||
+        includesReadOnlyConnection(currentReadOnlyNodeIds, edgeBeingReconnected, proposedConnection)
+      ) {
+        return;
+      }
+      currentOnReconnect(edgeBeingReconnected, proposedConnection);
+    },
+    [onReconnectRef, readOnlyNodeIdsRef]
+  );
+
+  // Checks only the original edge: the proposed target is already guarded above.
+  const guardedOnReconnectEnd = useCallback<NonNullable<typeof onReconnectEnd>>(
+    (event, edgeBeingReconnected, handleType, connectionState) => {
+      const currentOnReconnectEnd = onReconnectEndRef.current;
+      const currentReadOnlyNodeIds = readOnlyNodeIdsRef.current;
+      if (
+        !currentOnReconnectEnd ||
+        includesReadOnlyConnection(currentReadOnlyNodeIds, edgeBeingReconnected)
+      ) {
+        return;
+      }
+      currentOnReconnectEnd(event, edgeBeingReconnected, handleType, connectionState);
+    },
+    [onReconnectEndRef, readOnlyNodeIdsRef]
+  );
+
+  return {
+    guardedIsValidConnection,
+    guardedOnConnect: onConnect ? guardedOnConnect : undefined,
+    guardedOnReconnect: onReconnect ? guardedOnReconnect : undefined,
+    guardedOnReconnectEnd: onReconnectEnd ? guardedOnReconnectEnd : undefined,
+  };
+}

--- a/packages/apollo-react/src/canvas/components/Toolbar/EdgeToolbar/useEdgeToolbarState.test.ts
+++ b/packages/apollo-react/src/canvas/components/Toolbar/EdgeToolbar/useEdgeToolbarState.test.ts
@@ -9,6 +9,7 @@ import { createElement, type ReactNode } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { PREVIEW_NODE_ID } from '../../../constants';
 import { NodeRegistryContext, type NodeTypeRegistry } from '../../../core';
+import { ReadOnlyNodesProvider } from '../../BaseCanvas/ReadOnlyNodesContext';
 import type { EdgeToolbarPositionData } from './EdgeToolbar.types';
 import { useEdgeToolbarState } from './useEdgeToolbarState';
 
@@ -88,6 +89,17 @@ function createContainerRegistry(): NodeTypeRegistry {
           }
     ),
   } as unknown as NodeTypeRegistry;
+}
+
+// Reads the ids on every render so a test can lock nodes between renders.
+function createReadOnlyWrapper(getReadOnlyNodeIds: () => ReadonlySet<string>) {
+  return function ReadOnlyWrapper({ children }: { children: ReactNode }) {
+    return createElement(
+      ReadOnlyNodesProvider,
+      { readOnlyNodeIds: getReadOnlyNodeIds() },
+      children
+    );
+  };
 }
 
 function createRegistryWrapper(registry: NodeTypeRegistry) {
@@ -193,6 +205,19 @@ describe('useEdgeToolbarState', () => {
       expect(result.current.showToolbar).toBe(false);
     });
 
+    it('should not show toolbar for a frozen connection', () => {
+      const { result } = renderHook(
+        () =>
+          useEdgeToolbarState({
+            ...defaultProps,
+            isHovered: true,
+          }),
+        { wrapper: createReadOnlyWrapper(() => new Set(['node-1', 'node-2'])) }
+      );
+
+      expect(result.current.showToolbar).toBe(false);
+    });
+
     it('should not show toolbar when positionData is null', () => {
       vi.mocked(useEdgeToolbarPositioning).mockReturnValue({
         positionData: null,
@@ -276,6 +301,64 @@ describe('useEdgeToolbarState', () => {
   });
 
   describe('add node action', () => {
+    // The action and the preview it requests are checked at two different
+    // moments: `showPreviewGraph` defers the graph edit, so the hook also hands
+    // it a `canApply` guard that re-checks the edge just before it lands.
+    describe('read-only guards', () => {
+      const renderWithLocks = () => {
+        let readOnlyNodeIds: ReadonlySet<string> = new Set();
+        const view = renderHook(() => useEdgeToolbarState({ ...defaultProps, isHovered: true }), {
+          wrapper: createReadOnlyWrapper(() => readOnlyNodeIds),
+        });
+
+        return {
+          ...view,
+          lockEndpoints: () => {
+            readOnlyNodeIds = new Set(['node-1', 'node-2']);
+            view.rerender();
+          },
+        };
+      };
+
+      const addNode = (result: { current: ReturnType<typeof useEdgeToolbarState> }) => {
+        act(() => {
+          result.current.config.actions[0]?.onAction('edge-1', { x: 150, y: 100 });
+        });
+      };
+
+      const lastCanApply = () => vi.mocked(showPreviewGraph).mock.calls[0]?.[1]?.canApply;
+
+      it('blocks the action when both endpoints are locked before it runs', () => {
+        const { result, lockEndpoints } = renderWithLocks();
+
+        lockEndpoints();
+        addNode(result);
+
+        expect(showPreviewGraph).not.toHaveBeenCalled();
+      });
+
+      it('cancels the preview when both endpoints are locked before it opens', () => {
+        const { result, lockEndpoints } = renderWithLocks();
+
+        addNode(result);
+        lockEndpoints();
+
+        expect(lastCanApply()?.([originalEdge])).toBe(false);
+      });
+
+      it('cancels the preview when the edge is reconnected or removed before it opens', () => {
+        const { result } = renderWithLocks();
+
+        addNode(result);
+        const canApply = lastCanApply();
+
+        expect(canApply?.([originalEdge])).toBe(true);
+        expect(canApply?.([{ ...originalEdge, targetHandle: 'other-input' }])).toBe(false);
+        expect(canApply?.([{ ...originalEdge, target: 'node-3' }])).toBe(false);
+        expect(canApply?.([])).toBe(false);
+      });
+    });
+
     it('should create preview node at given position', () => {
       const { result } = renderHook(() =>
         useEdgeToolbarState({
@@ -290,25 +373,28 @@ describe('useEdgeToolbarState', () => {
         result.current.config.actions[0]?.onAction('edge-1', position);
       });
 
-      expect(showPreviewGraph).toHaveBeenCalledWith({
-        source: {
-          nodeId: 'node-1',
-          handleId: 'output',
+      expect(showPreviewGraph).toHaveBeenCalledWith(
+        {
+          source: {
+            nodeId: 'node-1',
+            handleId: 'output',
+          },
+          reactFlowInstance: mockReactFlowInstance,
+          position,
+          positionMode: 'drop',
+          data: {
+            originalEdge,
+          },
+          sourceHandleType: 'source',
+          handlePosition: Position.Right,
+          ignoredNodeTypes: [],
+          target: {
+            nodeId: 'node-2',
+            handleId: 'input',
+          },
         },
-        reactFlowInstance: mockReactFlowInstance,
-        position,
-        positionMode: 'drop',
-        data: {
-          originalEdge,
-        },
-        sourceHandleType: 'source',
-        handlePosition: Position.Right,
-        ignoredNodeTypes: [],
-        target: {
-          nodeId: 'node-2',
-          handleId: 'input',
-        },
-      });
+        { canApply: expect.any(Function) }
+      );
     });
 
     it('should not create a preview when the edge is no longer in the store', () => {
@@ -374,7 +460,8 @@ describe('useEdgeToolbarState', () => {
             nodeId: 'node-2',
             handleId: 'input',
           },
-        })
+        }),
+        { canApply: expect.any(Function) }
       );
       expect(vi.mocked(showPreviewGraph).mock.calls[0]?.[0]).not.toHaveProperty('containerId');
     });
@@ -504,11 +591,19 @@ describe('useEdgeToolbarState', () => {
         measured: { width: 80, height: 40 },
         data: {},
       };
+      const structuralEdge: Edge = {
+        ...originalEdge,
+        source: childNode.id,
+        sourceHandle: 'output',
+        target: containerNode.id,
+        targetHandle: 'continue',
+      };
       const nodes = [containerNode, childNode];
       mockReactFlowInstance.getNode.mockImplementation((id: string) =>
         nodes.find((node) => node.id === id)
       );
       mockReactFlowInstance.getNodes.mockReturnValue(nodes);
+      mockReactFlowInstance.getEdges.mockReturnValue([structuralEdge]);
 
       const { result } = renderHook(() =>
         useEdgeToolbarState({
@@ -536,7 +631,8 @@ describe('useEdgeToolbarState', () => {
             nodeId: 'loop-1',
             handleId: 'continue',
           },
-        })
+        }),
+        { canApply: expect.any(Function) }
       );
       expect(vi.mocked(showPreviewGraph).mock.calls[0]?.[0]).not.toHaveProperty('containerId');
     });

--- a/packages/apollo-react/src/canvas/components/Toolbar/EdgeToolbar/useEdgeToolbarState.ts
+++ b/packages/apollo-react/src/canvas/components/Toolbar/EdgeToolbar/useEdgeToolbarState.ts
@@ -1,10 +1,14 @@
-import { type Position, useReactFlow } from '@uipath/apollo-react/canvas/xyflow/react';
+import { type Edge, type Position, useReactFlow } from '@uipath/apollo-react/canvas/xyflow/react';
 import { useCallback, useMemo } from 'react';
 import { DEFAULT_SOURCE_HANDLE_ID } from '../../../constants';
 import { useCanvasNodeLayout } from '../../../hooks/useCanvasNodeLayout';
 import { showPreviewGraph } from '../../../utils/createPreviewGraph';
 import { isPreviewEdge } from '../../../utils/createPreviewNode';
 import { useBaseCanvasMode } from '../../BaseCanvas/BaseCanvasModeProvider';
+import {
+  useIsConnectionReadOnly,
+  useReadOnlyConnectionCheck,
+} from '../../BaseCanvas/ReadOnlyNodesContext';
 import { resolveContainerAddNodePreview } from '../../LoopNode/LoopNode.helpers';
 import type { EdgeToolbarConfig, EdgeToolbarPositionData } from './EdgeToolbar.types';
 import { useEdgeToolbarPositioning } from './useEdgeToolbarPositioning';
@@ -29,6 +33,21 @@ export interface EdgeToolbarState {
   handleMouseMoveOnPath?: (event: React.MouseEvent) => void;
 }
 
+type EdgeConnection = Pick<Edge, 'source' | 'sourceHandle' | 'target' | 'targetHandle'>;
+
+function hasSameConnection(edge: Edge | undefined, expected: EdgeConnection): edge is Edge {
+  if (!edge) {
+    return false;
+  }
+
+  return (
+    edge.source === expected.source &&
+    edge.target === expected.target &&
+    (edge.sourceHandle ?? null) === (expected.sourceHandle ?? null) &&
+    (edge.targetHandle ?? null) === (expected.targetHandle ?? null)
+  );
+}
+
 export function useEdgeToolbarState({
   edgeId,
   pathElementRef,
@@ -45,6 +64,8 @@ export function useEdgeToolbarState({
   const { getManifestForNode } = useCanvasNodeLayout();
   const { mode } = useBaseCanvasMode();
   const isDesignMode = mode === 'design';
+  const isFrozenConnection = useIsConnectionReadOnly(source, target);
+  const isConnectionReadOnlyNow = useReadOnlyConnectionCheck();
 
   const previewEdge = isPreviewEdge({ id: edgeId, source, target });
 
@@ -59,7 +80,17 @@ export function useEdgeToolbarState({
   const handleAddNodeOnEdge = useCallback(
     (position: { x: number; y: number }) => {
       const originalEdge = reactFlow.getEdges().find((edge) => edge.id === edgeId);
-      if (!originalEdge) return;
+      if (
+        !hasSameConnection(originalEdge, {
+          source,
+          sourceHandle: sourceHandleId,
+          target,
+          targetHandle: targetHandleId,
+        }) ||
+        isConnectionReadOnlyNow(originalEdge.source, originalEdge.target)
+      ) {
+        return;
+      }
 
       const sourceEndpoint = {
         nodeId: source,
@@ -73,21 +104,32 @@ export function useEdgeToolbarState({
         replacedEdge: originalEdge,
       });
 
-      showPreviewGraph({
-        source: sourceEndpoint,
-        reactFlowInstance: reactFlow,
-        position,
-        positionMode: 'drop',
-        data: { originalEdge },
-        sourceHandleType: 'source', // Source handle type
-        handlePosition: sourcePosition,
-        ignoredNodeTypes: ignoredNodeTypes ?? [],
-        target: {
-          nodeId: target,
-          handleId: targetHandleId,
+      showPreviewGraph(
+        {
+          source: sourceEndpoint,
+          reactFlowInstance: reactFlow,
+          position,
+          positionMode: 'drop',
+          data: { originalEdge },
+          sourceHandleType: 'source', // Source handle type
+          handlePosition: sourcePosition,
+          ignoredNodeTypes: ignoredNodeTypes ?? [],
+          target: {
+            nodeId: target,
+            handleId: targetHandleId,
+          },
+          ...(containerOverrides ?? {}),
         },
-        ...(containerOverrides ?? {}),
-      });
+        {
+          canApply: (edges) => {
+            const currentEdge = edges.find((edge) => edge.id === edgeId);
+            return (
+              hasSameConnection(currentEdge, originalEdge) &&
+              !isConnectionReadOnlyNow(currentEdge.source, currentEdge.target)
+            );
+          },
+        }
+      );
     },
     [
       sourcePosition,
@@ -99,6 +141,7 @@ export function useEdgeToolbarState({
       targetHandleId,
       edgeId,
       ignoredNodeTypes,
+      isConnectionReadOnlyNow,
     ]
   );
 
@@ -120,8 +163,10 @@ export function useEdgeToolbarState({
     [handleAddNodeOnEdge]
   );
 
-  // Show toolbar when hovering, in design mode, have a valid mouse position, and not a preview edge
-  const showToolbar = isHovered && isDesignMode && positionData !== null && !previewEdge;
+  // Show toolbar when hovering, in design mode, have a valid mouse position, and not a preview edge.
+  // Frozen connections hide it: its only action splices a node into the edge.
+  const showToolbar =
+    isHovered && isDesignMode && positionData !== null && !previewEdge && !isFrozenConnection;
 
   return {
     showToolbar,

--- a/packages/apollo-react/src/canvas/utils/createPreviewGraph.test.ts
+++ b/packages/apollo-react/src/canvas/utils/createPreviewGraph.test.ts
@@ -272,4 +272,130 @@ describe('createPreviewGraph', () => {
       }),
     ]);
   });
+
+  it('keeps the existing canvas unchanged when an add-node preview is cancelled before opening', () => {
+    vi.useFakeTimers();
+
+    const replacedEdge: Edge = {
+      id: 'edge-to-replace',
+      source: sourceNode.id,
+      sourceHandle: 'source-output',
+      target: targetNode.id,
+      targetHandle: 'target-input',
+    };
+    const originalNodes = [sourceNode, targetNode];
+    const reactFlowInstance = createReactFlowInstance({
+      nodes: originalNodes,
+      edges: [replacedEdge],
+    });
+    const preview = createPreviewGraph({
+      source: {
+        nodeId: sourceNode.id,
+        handleId: 'source-output',
+      },
+      reactFlowInstance,
+      position: { x: 200, y: 100 },
+      handlePosition: Position.Right,
+      data: { originalEdge: replacedEdge },
+      target: {
+        nodeId: targetNode.id,
+        handleId: 'target-input',
+      },
+    });
+
+    applyPreviewGraphToReactFlow(preview!, reactFlowInstance, {
+      canApply: () => false,
+    });
+    vi.runOnlyPendingTimers();
+
+    expect(reactFlowInstance.getNodes()).toEqual(originalNodes);
+    expect(reactFlowInstance.getEdges()).toEqual([replacedEdge]);
+  });
+
+  // `canApply` reads the store when the preview lands, not a snapshot from when
+  // it was created, so edits made in between are visible to the guard.
+  it('keeps a reconnected edge when reconnection occurs before an add-node preview opens', () => {
+    vi.useFakeTimers();
+
+    const replacedEdge: Edge = {
+      id: 'edge-to-replace',
+      source: sourceNode.id,
+      sourceHandle: 'source-output',
+      target: targetNode.id,
+      targetHandle: 'target-input',
+    };
+    const reconnectedEdge: Edge = {
+      ...replacedEdge,
+      target: 'new-target',
+      targetHandle: 'new-target-input',
+    };
+    const originalNodes = [sourceNode, targetNode];
+    const reactFlowInstance = createReactFlowInstance({
+      nodes: originalNodes,
+      edges: [replacedEdge],
+    });
+    const preview = createPreviewGraph({
+      source: {
+        nodeId: sourceNode.id,
+        handleId: 'source-output',
+      },
+      reactFlowInstance,
+      position: { x: 200, y: 100 },
+      handlePosition: Position.Right,
+      data: { originalEdge: replacedEdge },
+      target: {
+        nodeId: targetNode.id,
+        handleId: 'target-input',
+      },
+    });
+
+    applyPreviewGraphToReactFlow(preview!, reactFlowInstance, {
+      canApply: (edges) =>
+        edges.some(
+          (edge) =>
+            edge.id === replacedEdge.id &&
+            edge.target === replacedEdge.target &&
+            edge.targetHandle === replacedEdge.targetHandle
+        ),
+    });
+    reactFlowInstance.setEdges(() => [reconnectedEdge]);
+    vi.runOnlyPendingTimers();
+
+    expect(reactFlowInstance.getNodes()).toEqual(originalNodes);
+    expect(reactFlowInstance.getEdges()).toEqual([reconnectedEdge]);
+  });
+
+  it.each([
+    ['no guard', undefined],
+    ['a passing canApply guard', () => true],
+  ])('adds the preview node before the edges that point at it, with %s', (_label, canApply) => {
+    vi.useFakeTimers();
+
+    const reactFlowInstance = createReactFlowInstance({ nodes: [sourceNode, targetNode] });
+    const calls: string[] = [];
+    const setNodes: ReactFlowInstance['setNodes'] = (updater) => {
+      calls.push('setNodes');
+      reactFlowInstance.setNodes(updater);
+    };
+    const setEdges: ReactFlowInstance['setEdges'] = (updater) => {
+      calls.push('setEdges');
+      reactFlowInstance.setEdges(updater);
+    };
+    const instrumented = { ...reactFlowInstance, setNodes, setEdges } as ReactFlowInstance;
+
+    const preview = createPreviewGraph({
+      source: { nodeId: sourceNode.id, handleId: 'source-output' },
+      reactFlowInstance,
+      position: { x: 200, y: 100 },
+      handlePosition: Position.Right,
+      target: { nodeId: targetNode.id, handleId: 'target-input' },
+    });
+
+    applyPreviewGraphToReactFlow(preview!, instrumented, { canApply });
+    vi.runOnlyPendingTimers();
+
+    expect(calls).toEqual(['setNodes', 'setEdges']);
+    expect(reactFlowInstance.getNodes()).toContainEqual(preview!.node);
+    expect(reactFlowInstance.getEdges()).toEqual(preview!.edges);
+  });
 });

--- a/packages/apollo-react/src/canvas/utils/createPreviewGraph.ts
+++ b/packages/apollo-react/src/canvas/utils/createPreviewGraph.ts
@@ -20,6 +20,14 @@ export interface PreviewGraph {
   edges: Edge[];
 }
 
+export interface PreviewApplicationOptions {
+  /**
+   * Re-checks the live edge list just before the preview lands and drops it entirely if the edge the user
+   * targeted has since been deleted, rewired, or made read-only.
+   */
+  canApply?: (edges: Edge[]) => boolean;
+}
+
 /** Node/handle pair used for preview graph endpoints. */
 export interface PreviewEndpoint {
   nodeId: string;
@@ -202,10 +210,13 @@ export function createPreviewGraph(options: CreatePreviewGraphOptions): PreviewG
  * Returns the created preview graph when successful so callers can still
  * inspect the result if needed.
  */
-export function showPreviewGraph(options: CreatePreviewGraphOptions): PreviewGraph | null {
+export function showPreviewGraph(
+  options: CreatePreviewGraphOptions,
+  applicationOptions: PreviewApplicationOptions = {}
+): PreviewGraph | null {
   const preview = createPreviewGraph(options);
   if (preview) {
-    applyPreviewGraphToReactFlow(preview, options.reactFlowInstance);
+    applyPreviewGraphToReactFlow(preview, options.reactFlowInstance, applicationOptions);
   }
   return preview;
 }
@@ -217,21 +228,29 @@ export function showPreviewGraph(options: CreatePreviewGraphOptions): PreviewGra
  */
 export function applyPreviewGraphToReactFlow(
   preview: PreviewGraph,
-  reactFlowInstance: ReactFlowInstance
+  reactFlowInstance: ReactFlowInstance,
+  { canApply }: PreviewApplicationOptions = {}
 ): void {
   const originalEdge = preview.node.data?.originalEdge as Edge | undefined;
 
-  setTimeout(() => {
+  const applyNodes = () => {
     reactFlowInstance.setNodes((nodes) => [
       ...nodes
         .filter((node) => node.id !== PREVIEW_NODE_ID)
         .map((node) => ({ ...node, selected: false })),
       preview.node,
     ]);
+  };
 
-    reactFlowInstance.setEdges((edges) => [
-      ...edges.filter((edge) => !isPreviewEdge(edge) && edge.id !== originalEdge?.id),
-      ...preview.edges,
-    ]);
+  const applyEdges = (edges: Edge[]) => [
+    ...edges.filter((edge) => !isPreviewEdge(edge) && edge.id !== originalEdge?.id),
+    ...preview.edges,
+  ];
+
+  setTimeout(() => {
+    if (canApply?.(reactFlowInstance.getEdges()) === false) return;
+
+    applyNodes();
+    reactFlowInstance.setEdges(applyEdges);
   }, 0);
 }


### PR DESCRIPTION
## Summary

Completes per-node read-only support by freezing graph connections wholly inside the locked region and documenting the complete behavior in Storybook.

## Demo

https://github.com/user-attachments/assets/efaaf744-ad11-4fb7-a82a-ec3351f0caf3

## Scope

- Freezes edges only when both source and target nodes are locked
- Prevents frozen-edge deletion, reconnection, creation, and edge-toolbar splitting
- Keeps connections involving an unlocked endpoint editable
- Guards connection callbacks using the current lock set, including locks applied after a gesture starts
- Exports `useIsConnectionReadOnly(source, target)` for custom edge renderers
- Adds the interactive per-node read-only Storybook demo and final API documentation

## Stack

Part 4 of 4. Depends on #1053. This is the original PR, narrowed to the final edge-policy and documentation layer.

## Testing

- 5 focused edge/core test files
- 48 tests passing after the final API-boundary adjustment
- The cumulative 13-file read-only regression set passed 335 tests

## Out of scope

- GroupNode resize/collapse gating
- Per-node reason codes for tooltip and accessibility messaging
