### PR TITLE
fix(apollo-react): anchor task mocked chip tooltip

### DIFF
--- a/packages/apollo-react/package.json
+++ b/packages/apollo-react/package.json
@@ -128,7 +128,9 @@
   },
   "sideEffects": [
     "**/*.css",
-    "dist/**/*.css"
+    "dist/**/*.css",
+    "dist/canvas/index.js",
+    "dist/canvas/index.cjs"
   ],
   "files": [
     "dist"

--- a/packages/apollo-react/src/canvas/components/StageNode/tasks/TaskMockedChip.test.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/tasks/TaskMockedChip.test.tsx
@@ -41,7 +41,7 @@ describe('TaskMockedChip', () => {
   it('sits at the top-right corner of the task card, mirroring the breakpoint dot', () => {
     render(<TaskMockedChip taskId="t1" mocked={true} />);
 
-    expect(screen.getByTestId('stage-task-mocked-t1')).toHaveClass(
+    expect(screen.getByTestId('stage-task-mocked-t1').parentElement).toHaveClass(
       'absolute',
       '-top-1.5',
       '-right-1.5'

--- a/packages/apollo-react/src/canvas/components/StageNode/tasks/TaskMockedChip.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/tasks/TaskMockedChip.tsx
@@ -22,15 +22,18 @@ function TaskMockedChipInner({ mocked, taskId }: TaskMockedChipProps) {
 
   return (
     <CanvasTooltip content={label} placement="top">
-      <Badge
-        variant="outline"
-        role="img"
-        aria-label={label}
-        className="absolute -top-1.5 -right-1.5 z-10 h-3.5 w-3.5 justify-center rounded-full border-0 bg-primary p-0 text-primary-foreground [&>svg]:size-2.5"
-        data-testid={`stage-task-mocked-${taskId}`}
-      >
-        <FlaskConical aria-hidden />
-      </Badge>
+      {/* The positioned wrapper is the tooltip trigger: the tooltip needs a ref-forwarding anchor element. */}
+      <div className="absolute -top-1.5 -right-1.5 z-10 flex">
+        <Badge
+          variant="outline"
+          role="img"
+          aria-label={label}
+          className="h-3.5 w-3.5 justify-center rounded-full border-0 bg-primary p-0 text-primary-foreground [&>svg]:size-2.5"
+          data-testid={`stage-task-mocked-${taskId}`}
+        >
+          <FlaskConical aria-hidden />
+        </Badge>
+      </div>
     </CanvasTooltip>
   );
 }


### PR DESCRIPTION
## Summary

The mocked chip's tooltip (#994) opens but renders at the viewport origin, offscreen — users see no tooltip on hover.

**Root cause:** `CanvasTooltip` → the tooltip's `TooltipTrigger asChild` attaches a ref to its child to anchor the popup. apollo-wind's `Badge` is a plain function component (no `forwardRef`), so the ref is silently swallowed: the pointer handlers still spread through `...props` (the tooltip *opens*), but with no anchor element it positions the content at `(0, 0)` and the collision logic pushes it above the viewport.

**Fix:** the tooltip trigger is now a positioned `div` wrapper (a real, measurable, ref-forwarding element); the `Badge` fills it. Rendered output is visually identical. A `div` (not `span`) matches the Badge's own `div` content model.

Verified in a browser harness (Chromium + Playwright): before — tooltip content mounted at `y≈-68`, invisible; after — anchored above the chip, correct placement both standalone and inside `StageNode`.

## Also included

`dist/canvas/index.js` / `.cjs` added to `sideEffects`. The canvas barrel side-effect-imports `reactflow-reset.css`, but webpack-family bundlers treat the unlisted barrel as pure and rewrite named imports past it — so the reset CSS (connection-line / hover z-index rules) silently never reaches consumer bundles. Found while consuming 6.19.1 in PO.Frontend: its production build contained none of the reset rules.

Follow-up worth considering: add `forwardRef` to `Badge` in apollo-wind — any `TooltipTrigger asChild` + `Badge` combination hits this same trap.

## Testing

- `vitest run src/canvas/components/StageNode/tasks/` — 7 files, 106 tests pass
- positioning assertion updated to target the trigger wrapper
