### PR TITLE
fix(apollo-react): restore stage task tooltips and surface exact durations on hover

### DIFF
--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.stories.tsx
@@ -993,6 +993,59 @@ export const MaximumTaskAdornments: Story = {
   },
 };
 
+/**
+ * A duration shows only its 3 largest units. Hover to read the exact value in full.
+ *
+ * - "Ran for weeks" hides 2 units, so it gets a tooltip.
+ * - "Ran for seconds" shows everything, so it gets none.
+ * - "Has its own tooltip" supplies `durationTooltip`, which wins.
+ * - The stage header behaves like a task row.
+ */
+export const DurationTooltips: Story = {
+  name: 'Execution Mode - Duration Tooltips',
+  parameters: {
+    nodes: [
+      {
+        id: 'duration-tooltips',
+        type: 'stage',
+        position: { x: 48, y: 96 },
+        width: DEFAULT_STAGE_WIDTH,
+        data: {
+          stageDetails: {
+            label: 'Durations',
+            isReadOnly: true,
+            tasks: [
+              [{ id: 'weeks', label: 'Ran for weeks', icon: <ProcessIcon /> }],
+              [{ id: 'seconds', label: 'Ran for seconds', icon: <ProcessIcon /> }],
+              [{ id: 'own-tooltip', label: 'Has its own tooltip', icon: <VerificationIcon /> }],
+            ],
+          },
+          execution: {
+            stageStatus: {
+              status: 'Completed',
+              label: 'Completed',
+              durationMs: STAGE_RUN_MS,
+              durationLabel: 'Duration:',
+            },
+            taskStatus: {
+              // 3 weeks, 4 days, 5 hours, 12 minutes, 8 seconds: the row shows the first 3.
+              weeks: { status: 'Completed', durationMs: TASK_RUN_MS },
+              // Nothing is hidden at this size, so no tooltip is added.
+              seconds: { status: 'Completed', durationMs: 16000 },
+              // A consumer-supplied tooltip takes precedence over the exact duration.
+              'own-tooltip': {
+                status: 'InProgress',
+                durationMs: TASK_RUN_MS,
+                durationTooltip: 'Waiting on the timer, 4s remaining',
+              },
+            },
+          },
+        },
+      },
+    ],
+  },
+};
+
 export const LoanProcessingWorkflow: Story = {
   name: 'Loan Processing Workflow',
   parameters: {

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.test.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.test.tsx
@@ -2,6 +2,7 @@ import userEvent from '@testing-library/user-event';
 import { ReactFlowProvider } from '@uipath/apollo-react/canvas/xyflow/react';
 import React from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { DAY, HOUR, MINUTE, SECOND } from '../../../test/durations';
 import { render, screen, waitFor } from '../../utils/testing';
 import type { ListItem } from '../Toolbox';
 import { StageNode } from './StageNode';
@@ -851,7 +852,7 @@ describe('StageNode - SLA Indicator', () => {
     // 2 days, 3 hr, 4 min, 5 sec — the seconds are dropped.
     renderStageNode({
       execution: {
-        stageStatus: { durationMs: 2 * 86400000 + 3 * 3600000 + 4 * 60000 + 5000 },
+        stageStatus: { durationMs: 2 * DAY + 3 * HOUR + 4 * MINUTE + 5 * SECOND },
         taskStatus: {},
       },
     });
@@ -862,7 +863,7 @@ describe('StageNode - SLA Indicator', () => {
   it('puts the consumer-supplied label in front of the duration', () => {
     renderStageNode({
       execution: {
-        stageStatus: { durationMs: 2 * 3600000 + 4 * 60000, durationLabel: 'Duration:' },
+        stageStatus: { durationMs: 2 * HOUR + 4 * MINUTE, durationLabel: 'Duration:' },
         taskStatus: {},
       },
     });
@@ -872,7 +873,7 @@ describe('StageNode - SLA Indicator', () => {
 
   it('renders the duration bare when no label is supplied', () => {
     renderStageNode({
-      execution: { stageStatus: { durationMs: 2 * 3600000 + 4 * 60000 }, taskStatus: {} },
+      execution: { stageStatus: { durationMs: 2 * HOUR + 4 * MINUTE }, taskStatus: {} },
     });
 
     expect(screen.getByTestId('stage-duration-stage-1')).toHaveTextContent('2h, 4m');

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNodeHeader.integration.test.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNodeHeader.integration.test.tsx
@@ -1,5 +1,6 @@
 import { ReactFlowProvider } from '@uipath/apollo-react/canvas/xyflow/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { DAY, HOUR, MINUTE, SECOND, WEEK } from '../../../test/durations';
 import { act, fireEvent, render, screen } from '../../utils/testing';
 import type { StageNodeProps } from './StageNode.types';
 import { StageNodeHeader } from './StageNodeHeader';
@@ -8,12 +9,6 @@ import { StageNodeHeader } from './StageNodeHeader';
 // opens only when the header dropped units. Radix does not portal in happy-dom, so assertions
 // use the trigger's `data-state`.
 vi.unmock('@uipath/apollo-wind/components/ui/tooltip');
-
-const SECOND = 1000;
-const MINUTE = 60 * SECOND;
-const HOUR = 60 * MINUTE;
-const DAY = 24 * HOUR;
-const WEEK = 7 * DAY;
 
 const renderHeader = (durationMs: number) => {
   const props = {

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNodeHeader.integration.test.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNodeHeader.integration.test.tsx
@@ -1,0 +1,72 @@
+import { ReactFlowProvider } from '@uipath/apollo-react/canvas/xyflow/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { act, fireEvent, render, screen } from '../../utils/testing';
+import type { StageNodeProps } from './StageNode.types';
+import { StageNodeHeader } from './StageNodeHeader';
+
+// Uses the real Radix tooltip (the shared setup stubs it out) to cover that the exact duration
+// opens only when the header dropped units. Radix does not portal in happy-dom, so assertions
+// use the trigger's `data-state`.
+vi.unmock('@uipath/apollo-wind/components/ui/tooltip');
+
+const SECOND = 1000;
+const MINUTE = 60 * SECOND;
+const HOUR = 60 * MINUTE;
+const DAY = 24 * HOUR;
+const WEEK = 7 * DAY;
+
+const renderHeader = (durationMs: number) => {
+  const props = {
+    id: 'stage-1',
+    stageDetails: { label: 'Stage 1', tasks: [] },
+    execution: { stageStatus: { durationMs }, taskStatus: {} },
+  } as unknown as StageNodeProps;
+
+  return render(
+    <ReactFlowProvider>
+      <StageNodeHeader
+        props={props}
+        isReadOnly={true}
+        status={undefined}
+        handleTaskAddClick={vi.fn()}
+      />
+    </ReactFlowProvider>
+  );
+};
+
+function hover(element: HTMLElement) {
+  fireEvent.mouseEnter(element);
+  fireEvent.pointerMove(element, { pointerType: 'mouse' });
+  act(() => {
+    vi.advanceTimersByTime(500);
+  });
+}
+
+describe('StageNodeHeader duration tooltip (real CanvasTooltip)', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('opens the exact duration when the header dropped units', () => {
+    vi.useFakeTimers();
+    renderHeader(3 * WEEK + 1 * DAY + 20 * HOUR + 14 * MINUTE + 3 * SECOND);
+
+    const duration = screen.getByTestId('stage-duration-stage-1');
+    expect(duration).toHaveTextContent('3w, 1d, 20h');
+
+    hover(duration);
+    expect(duration).toHaveAttribute('data-state', 'delayed-open');
+  });
+
+  it('stays closed when the header already shows every unit', () => {
+    vi.useFakeTimers();
+    renderHeader(2 * HOUR + 4 * MINUTE);
+
+    const duration = screen.getByTestId('stage-duration-stage-1');
+    expect(duration).toHaveTextContent('2h, 4m');
+
+    hover(duration);
+    expect(duration).toHaveAttribute('data-state', 'closed');
+  });
+});

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNodeHeader.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNodeHeader.tsx
@@ -2,14 +2,14 @@ import { Icon, Padding, Spacing } from '@uipath/apollo-core';
 import { Row } from '@uipath/apollo-react/canvas/layouts';
 import { Button } from '@uipath/apollo-wind';
 import { memo } from 'react';
+import { useSafeLingui } from '../../../i18n';
 import { ChecklistIcon } from '../../../icons';
 import { EntryConditionIcon, ExitConditionIcon, ReturnToOriginIcon } from '../../icons';
 import { CanvasIcon } from '../../utils/icon-registry';
-import { useSafeLingui } from '../../../i18n';
 import { CanvasTooltip } from '../CanvasTooltip';
 import { ExecutionStatusIcon } from '../ExecutionStatusIcon';
 import { getExecutionStatusColor } from '../ExecutionStatusIcon/ExecutionStatusIcon';
-import { formatDurationMs } from './formatDuration';
+import { formatDurationMs, formatExactDurationMs, hasHiddenDurationParts } from './formatDuration';
 import { StageChip, StageHeader } from './StageNode.styles';
 import type { StageNodeProps, StageSlaIcon, StageStatus } from './StageNode.types';
 import { StageHeaderChipType } from './StageNode.types';
@@ -160,6 +160,10 @@ const StageNodeHeaderInner = ({
     formattedStageDuration && stageDurationLabel
       ? `${stageDurationLabel} ${formattedStageDuration}`
       : formattedStageDuration;
+  const exactStageDuration =
+    stageDurationMs !== undefined && hasHiddenDurationParts(stageDurationMs)
+      ? formatExactDurationMs(stageDurationMs, locale)
+      : undefined;
   const slaText = execution?.stageStatus?.slaText;
   const slaIcon = execution?.stageStatus?.slaIcon;
   const slaIndicator = slaIcon ? SLA_ICON_CONFIG[slaIcon] : undefined;
@@ -286,12 +290,14 @@ const StageNodeHeaderInner = ({
         </div>
       )}
       {stageDuration && (
-        <span
-          className="flex min-h-8 items-center text-xs text-foreground-muted"
-          data-testid={`stage-duration-${id}`}
-        >
-          {stageDuration}
-        </span>
+        <CanvasTooltip content={exactStageDuration} placement="top">
+          <span
+            className="flex min-h-8 items-center text-xs text-foreground-muted"
+            data-testid={`stage-duration-${id}`}
+          >
+            {stageDuration}
+          </span>
+        </CanvasTooltip>
       )}
     </StageHeader>
   );

--- a/packages/apollo-react/src/canvas/components/StageNode/formatDuration.test.ts
+++ b/packages/apollo-react/src/canvas/components/StageNode/formatDuration.test.ts
@@ -1,11 +1,6 @@
 import { describe, expect, it } from 'vitest';
+import { DAY, HOUR, MINUTE, SECOND, WEEK } from '../../../test/durations';
 import { formatDurationMs, formatExactDurationMs, hasHiddenDurationParts } from './formatDuration';
-
-const SECOND = 1000;
-const MINUTE = 60 * SECOND;
-const HOUR = 60 * MINUTE;
-const DAY = 24 * HOUR;
-const WEEK = 7 * DAY;
 
 describe('formatDurationMs', () => {
   it('keeps only the three largest units', () => {

--- a/packages/apollo-react/src/canvas/components/StageNode/formatDuration.test.ts
+++ b/packages/apollo-react/src/canvas/components/StageNode/formatDuration.test.ts
@@ -1,10 +1,11 @@
 import { describe, expect, it } from 'vitest';
-import { formatDurationMs } from './formatDuration';
+import { formatDurationMs, formatExactDurationMs, hasHiddenDurationParts } from './formatDuration';
 
 const SECOND = 1000;
 const MINUTE = 60 * SECOND;
 const HOUR = 60 * MINUTE;
 const DAY = 24 * HOUR;
+const WEEK = 7 * DAY;
 
 describe('formatDurationMs', () => {
   it('keeps only the three largest units', () => {
@@ -70,5 +71,60 @@ describe('formatDurationMs', () => {
     expect(formatDurationMs(-1)).toBe('');
     expect(formatDurationMs(Number.NaN)).toBe('');
     expect(formatDurationMs(HOUR, 'en', 0)).toBe('');
+  });
+});
+
+describe('formatExactDurationMs', () => {
+  it('keeps every unit the capped format drops, spelled out', () => {
+    const ms = 2 * WEEK + 19 * HOUR + 8 * MINUTE + 42 * SECOND;
+
+    expect(formatDurationMs(ms)).toBe('2w, 19h, 8m');
+    expect(formatExactDurationMs(ms)).toBe('2 weeks, 19 hours, 8 minutes, 42 seconds');
+  });
+
+  it('spells out a duration that was not capped at all', () => {
+    expect(formatExactDurationMs(16 * SECOND)).toBe('16 seconds');
+  });
+
+  it('still drops sub-second precision', () => {
+    expect(formatExactDurationMs(1 * MINUTE + 30 * SECOND + 400)).toBe('1 minute, 30 seconds');
+    expect(formatExactDurationMs(400)).toBe('');
+  });
+
+  it('uses the locale for the unit wording and list joining', () => {
+    // Luxon's locale data joins the last pair with "und", so the output is not a fixed
+    // comma-separated list.
+    expect(formatExactDurationMs(2 * HOUR + 5 * MINUTE, 'de')).toBe('2 Stunden und 5 Minuten');
+  });
+});
+
+describe('hasHiddenDurationParts', () => {
+  it('is true when a fourth unit is dropped', () => {
+    expect(hasHiddenDurationParts(2 * WEEK + 19 * HOUR + 8 * MINUTE + 42 * SECOND)).toBe(true);
+  });
+
+  it('is false when every whole unit is shown', () => {
+    expect(hasHiddenDurationParts(16 * SECOND)).toBe(false);
+    expect(hasHiddenDurationParts(2 * DAY + 3 * HOUR + 4 * MINUTE)).toBe(false);
+  });
+
+  it('does not count zero units towards the cap', () => {
+    // 2 days and 5 seconds is two whole parts, however far apart the units sit.
+    expect(hasHiddenDurationParts(2 * DAY + 5 * SECOND)).toBe(false);
+  });
+
+  it('does not treat sub-second precision as a hidden part', () => {
+    expect(hasHiddenDurationParts(2 * DAY + 3 * HOUR + 4 * MINUTE + 400)).toBe(false);
+  });
+
+  it('honours a custom unit count', () => {
+    expect(hasHiddenDurationParts(2 * DAY + 3 * HOUR, 1)).toBe(true);
+    expect(hasHiddenDurationParts(2 * DAY + 3 * HOUR, 2)).toBe(false);
+  });
+
+  it('is false for a non-positive or unusable duration', () => {
+    expect(hasHiddenDurationParts(0)).toBe(false);
+    expect(hasHiddenDurationParts(-1)).toBe(false);
+    expect(hasHiddenDurationParts(Number.NaN)).toBe(false);
   });
 });

--- a/packages/apollo-react/src/canvas/components/StageNode/formatDuration.ts
+++ b/packages/apollo-react/src/canvas/components/StageNode/formatDuration.ts
@@ -67,3 +67,35 @@ export function formatDurationMs(
 
   return Duration.fromObject(largest).reconfigure({ locale }).toHuman({ unitDisplay });
 }
+
+/**
+ * Formats a duration uncapped, in luxon's `long` wording, e.g.
+ * `"2 weeks, 19 hours, 8 minutes, 42 seconds"`. For tooltips, where the hidden units fit.
+ */
+export function formatExactDurationMs(ms: number, locale = 'en'): string {
+  return formatDurationMs(ms, locale, UNITS.length, 'long');
+}
+
+/**
+ * Whether rendering `ms` with `maxUnits` hides any part, so callers can skip a tooltip that would
+ * just repeat the text under the cursor. Sub-second precision never counts as hidden: it rounds
+ * into the smallest unit shown either way.
+ */
+export function hasHiddenDurationParts(ms: number, maxUnits = 3): boolean {
+  if (!Number.isFinite(ms) || ms <= 0) {
+    return false;
+  }
+
+  const parts = Duration.fromMillis(ms)
+    .shiftTo(...UNITS)
+    .toObject();
+  let wholeParts = 0;
+
+  for (const unit of UNITS) {
+    if ((parts[unit] ?? 0) >= 1) {
+      wholeParts++;
+    }
+  }
+
+  return wholeParts > maxUnits;
+}

--- a/packages/apollo-react/src/canvas/components/StageNode/rules/StageRuleContent.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/rules/StageRuleContent.tsx
@@ -36,23 +36,13 @@ export const StageRuleContent = memo(({ rule, ruleType }: StageRuleContentProps)
       >
         <StageItemIcon data-testid={`stage-rule-icon-${rule.id}`}>{icon}</StageItemIcon>
         <CanvasTooltip content={rule.label} placement="top" smartTooltip>
-          <Row
-            gap={'2px'}
-            align="center"
-            style={{
-              overflow: 'hidden',
-              textOverflow: 'ellipsis',
-              whiteSpace: 'nowrap',
-            }}
+          <span
+            data-testid={`stage-rule-label-${rule.id}`}
+            className="text-sm truncate"
+            style={{ minWidth: 0 }}
           >
-            <span
-              data-testid={`stage-rule-label-${rule.id}`}
-              className="text-sm truncate"
-              style={{ minWidth: 0 }}
-            >
-              {rule.label}
-            </span>
-          </Row>
+            {rule.label}
+          </span>
         </CanvasTooltip>
       </Row>
     </Row>

--- a/packages/apollo-react/src/canvas/components/StageNode/shared/CollapsibleStageHeader.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/shared/CollapsibleStageHeader.tsx
@@ -65,23 +65,13 @@ export const CollapsibleStageHeader = ({
           />
         </span>
         <CanvasTooltip content={label} placement="top" smartTooltip>
-          <Row
-            gap={'2px'}
-            align="center"
-            style={{
-              overflow: 'hidden',
-              textOverflow: 'ellipsis',
-              whiteSpace: 'nowrap',
-            }}
+          <span
+            data-testid={`${testId}-label`}
+            className="text-sm truncate"
+            style={{ minWidth: 0 }}
           >
-            <span
-              data-testid={`${testId}-label`}
-              className="text-sm truncate"
-              style={{ minWidth: 0 }}
-            >
-              {label}
-            </span>
-          </Row>
+            {label}
+          </span>
         </CanvasTooltip>
       </StyledRow>
       <div

--- a/packages/apollo-react/src/canvas/components/StageNode/tasks/TaskContent.integration.test.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/tasks/TaskContent.integration.test.tsx
@@ -1,0 +1,154 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { act, fireEvent, render, screen } from '../../../utils/testing';
+import type { StageTaskExecution, StageTaskItem } from '../StageNode.types';
+import { DraggableTask } from './DraggableTask';
+import { TaskContent } from './TaskContent';
+
+vi.mock('@uipath/apollo-react/canvas/xyflow/react', () => ({
+  useStore: (selector: (state: Record<string, unknown>) => unknown) =>
+    selector({ transform: [0, 0, 1] }),
+}));
+
+// Uses the real Radix tooltip (the shared setup stubs it out) to cover which element is the
+// trigger and which one truncation measures. Radix does not portal in happy-dom, so assertions
+// use the trigger's `data-state`.
+vi.unmock('@uipath/apollo-wind/components/ui/tooltip');
+
+const baseTask: StageTaskItem = { id: 'task-1', label: 'A very long task name that is truncated' };
+
+const renderTaskContent = (overrides?: {
+  task?: Partial<StageTaskItem>;
+  taskExecution?: StageTaskExecution;
+}) =>
+  render(
+    <TaskContent
+      task={{ ...baseTask, ...overrides?.task }}
+      taskExecution={overrides?.taskExecution}
+    />
+  );
+
+// happy-dom resolves no Tailwind classes, so report the `truncate` styles for the
+// element under test and drive scroll/client width to decide if it overflows.
+function mockTruncation(element: HTMLElement, { overflowing }: { overflowing: boolean }) {
+  const originalGetComputedStyle = window.getComputedStyle;
+  vi.spyOn(window, 'getComputedStyle').mockImplementation((target) => {
+    const style = originalGetComputedStyle.call(window, target);
+    if (target !== element) {
+      return style;
+    }
+
+    return new Proxy(style, {
+      get(proxyTarget, prop, receiver) {
+        if (prop === 'textOverflow') return 'ellipsis';
+        if (prop === 'overflow') return 'hidden';
+        if (prop === 'whiteSpace') return 'nowrap';
+        // Report no line clamp so the width-based branch is the one exercised.
+        if (prop === 'getPropertyValue') {
+          return (property: string) =>
+            property === '-webkit-line-clamp' ? '' : proxyTarget.getPropertyValue(property);
+        }
+        return Reflect.get(proxyTarget, prop, receiver);
+      },
+    });
+  });
+
+  Object.defineProperties(element, {
+    clientWidth: { configurable: true, value: 120 },
+    scrollWidth: { configurable: true, value: overflowing ? 320 : 120 },
+  });
+}
+
+// Radix opens on pointer move (mouse only) after its delay.
+function hover(element: HTMLElement) {
+  fireEvent.mouseEnter(element);
+  fireEvent.pointerMove(element, { pointerType: 'mouse' });
+  act(() => {
+    vi.advanceTimersByTime(500);
+  });
+}
+
+describe('TaskContent tooltips (real CanvasTooltip)', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('makes the truncating label element itself the tooltip trigger', () => {
+    renderTaskContent();
+
+    // Smart truncation measures its own trigger, so the trigger has to be the
+    // element that ellipsises. A wrapper row never overflows (the span inside
+    // it truncates instead), which would read as "not truncated" forever.
+    expect(screen.getByTestId('stage-task-label-task-1')).toHaveAttribute('data-state');
+  });
+
+  it('shows the name tooltip on hover when the label is truncated', () => {
+    vi.useFakeTimers();
+    renderTaskContent();
+
+    const label = screen.getByTestId('stage-task-label-task-1');
+    mockTruncation(label, { overflowing: true });
+    hover(label);
+
+    expect(label).toHaveAttribute('data-state', 'delayed-open');
+  });
+
+  it('keeps the name tooltip closed when the label is not truncated', () => {
+    vi.useFakeTimers();
+    renderTaskContent({ task: { label: 'Short' } });
+
+    const label = screen.getByTestId('stage-task-label-task-1');
+    mockTruncation(label, { overflowing: false });
+    hover(label);
+
+    expect(label).toHaveAttribute('data-state', 'closed');
+  });
+
+  it('opens the runs chip tooltip on hover regardless of truncation', () => {
+    vi.useFakeTimers();
+    renderTaskContent({ taskExecution: { status: 'Completed', retryCount: 2 } });
+
+    // The chip is a Badge, i.e. a component rather than a DOM element: it has to
+    // forward the trigger ref so Radix has an anchor to position against.
+    const chip = screen.getByTestId('stage-task-runs-task-1');
+    hover(chip);
+
+    expect(chip).toHaveAttribute('data-state', 'delayed-open');
+  });
+
+  it('opens the rework chip tooltip on hover', () => {
+    vi.useFakeTimers();
+    renderTaskContent({ taskExecution: { status: 'Completed', retryDuration: '25m' } });
+
+    const chip = screen.getByTestId('stage-task-rework-task-1');
+    hover(chip);
+
+    expect(chip).toHaveAttribute('data-state', 'delayed-open');
+  });
+
+  // Read-only rows (monitoring, instance view) go through the same content, and
+  // read-only is exactly where the run counts and full names matter most.
+  it('keeps the name and runs chip tooltips on a read-only task row', () => {
+    vi.useFakeTimers();
+    render(
+      <DraggableTask
+        task={baseTask}
+        taskExecution={{ status: 'Completed', retryCount: 2 }}
+        isSelected={false}
+        isParallel={false}
+        onTaskClick={vi.fn()}
+        isDragDisabled
+        isReadOnly
+      />
+    );
+
+    const label = screen.getByTestId('stage-task-label-task-1');
+    mockTruncation(label, { overflowing: true });
+    hover(label);
+    expect(label).toHaveAttribute('data-state', 'delayed-open');
+
+    const chip = screen.getByTestId('stage-task-runs-task-1');
+    hover(chip);
+    expect(chip).toHaveAttribute('data-state', 'delayed-open');
+  });
+});

--- a/packages/apollo-react/src/canvas/components/StageNode/tasks/TaskContent.test.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/tasks/TaskContent.test.tsx
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { DAY, HOUR, MINUTE, SECOND, WEEK } from '../../../../test/durations';
 import { render, screen } from '../../../utils/testing';
 import type { StageTaskExecution, StageTaskItem } from '../StageNode.types';
 import { TaskContent } from './TaskContent';
@@ -250,7 +251,7 @@ describe('TaskContent - duration tooltip', () => {
     renderTaskContent({
       taskExecution: {
         status: 'Completed',
-        durationMs: 2 * 604800000 + 19 * 3600000 + 8 * 60000 + 42000,
+        durationMs: 2 * WEEK + 19 * HOUR + 8 * MINUTE + 42 * SECOND,
       },
     });
 
@@ -272,7 +273,7 @@ describe('TaskContent - duration tooltip', () => {
     renderTaskContent({
       taskExecution: {
         status: 'InProgress',
-        durationMs: 2 * 604800000 + 19 * 3600000 + 8 * 60000 + 42000,
+        durationMs: 2 * WEEK + 19 * HOUR + 8 * MINUTE + 42 * SECOND,
         durationTooltip: '4s remaining',
       },
     });
@@ -296,7 +297,7 @@ describe('TaskContent - duration tooltip', () => {
     renderTaskContent({
       taskExecution: {
         status: 'InProgress',
-        durationMs: 2 * 86400000 + 3 * 3600000 + 4 * 60000 + 5000,
+        durationMs: 2 * DAY + 3 * HOUR + 4 * MINUTE + 5 * SECOND,
       },
     });
 

--- a/packages/apollo-react/src/canvas/components/StageNode/tasks/TaskContent.test.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/tasks/TaskContent.test.tsx
@@ -245,6 +245,52 @@ describe('TaskContent - duration tooltip', () => {
     expect(tooltipWrapper).toBeNull();
   });
 
+  it('falls back to the exact duration when units were dropped to fit the row', () => {
+    // 2 weeks, 19 hr, 8 min, 42 sec -> the row shows the three largest, the tooltip all four.
+    renderTaskContent({
+      taskExecution: {
+        status: 'Completed',
+        durationMs: 2 * 604800000 + 19 * 3600000 + 8 * 60000 + 42000,
+      },
+    });
+
+    const durationText = screen.getByText('2w, 19h, 8m');
+    expect(durationText.closest('[data-testid="canvas-tooltip"]')).toHaveAttribute(
+      'data-tooltip-content',
+      '2 weeks, 19 hours, 8 minutes, 42 seconds'
+    );
+  });
+
+  it('adds no duration tooltip when the row already shows every unit', () => {
+    renderTaskContent({ taskExecution: { status: 'Completed', durationMs: 16000 } });
+
+    const durationText = screen.getByText('16s');
+    expect(durationText.closest('[data-testid="canvas-tooltip"]')).toBeNull();
+  });
+
+  it('keeps a consumer-supplied durationTooltip in front of the exact duration', () => {
+    renderTaskContent({
+      taskExecution: {
+        status: 'InProgress',
+        durationMs: 2 * 604800000 + 19 * 3600000 + 8 * 60000 + 42000,
+        durationTooltip: '4s remaining',
+      },
+    });
+
+    const durationText = screen.getByText('2w, 19h, 8m');
+    expect(durationText.closest('[data-testid="canvas-tooltip"]')).toHaveAttribute(
+      'data-tooltip-content',
+      '4s remaining'
+    );
+  });
+
+  it('adds no duration tooltip to a legacy pre-formatted duration', () => {
+    renderTaskContent({ taskExecution: { status: 'Completed', duration: '2w, 19h, 8m' } });
+
+    const durationText = screen.getByText('2w, 19h, 8m');
+    expect(durationText.closest('[data-testid="canvas-tooltip"]')).toBeNull();
+  });
+
   it('shows only the three largest duration units', () => {
     // 2 days, 3 hr, 4 min, 5 sec — the seconds are dropped.
     renderTaskContent({

--- a/packages/apollo-react/src/canvas/components/StageNode/tasks/TaskContent.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/tasks/TaskContent.tsx
@@ -7,7 +7,7 @@ import { memo, useCallback, useMemo, useState } from 'react';
 import { useSafeLingui } from '../../../../i18n';
 import { CanvasTooltip } from '../../CanvasTooltip';
 import { ExecutionStatusIcon } from '../../ExecutionStatusIcon';
-import { formatDurationMs } from '../formatDuration';
+import { formatDurationMs, formatExactDurationMs, hasHiddenDurationParts } from '../formatDuration';
 import { StageItemIcon } from '../StageNode.styles';
 import type { StageTaskExecution, StageTaskItem } from '../StageNode.types';
 import { useExecutionStatusLabel } from '../useExecutionStatusLabel';
@@ -133,6 +133,11 @@ export const TaskContent = memo(
         {durationText}
       </span>
     ) : null;
+    const exactDuration =
+      taskExecution?.durationMs !== undefined && hasHiddenDurationParts(taskExecution.durationMs)
+        ? formatExactDurationMs(taskExecution.durationMs, locale)
+        : undefined;
+    const durationTooltip = taskExecution?.durationTooltip || exactDuration;
 
     return (
       <Row
@@ -195,12 +200,8 @@ export const TaskContent = memo(
           data-testid={`stage-task-actions-${task.id}`}
         >
           {durationLabel &&
-            (taskExecution?.durationTooltip ? (
-              <CanvasTooltip
-                content={taskExecution.durationTooltip}
-                placement="top"
-                hide={isDragging}
-              >
+            (durationTooltip ? (
+              <CanvasTooltip content={durationTooltip} placement="top" hide={isDragging}>
                 {durationLabel}
               </CanvasTooltip>
             ) : (

--- a/packages/apollo-react/src/canvas/components/StageNode/tasks/TaskContent.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/tasks/TaskContent.tsx
@@ -155,20 +155,19 @@ export const TaskContent = memo(
               {task.icon ?? <ProcessCanvasIcon />}
             </StageItemIcon>
           </Row>
-          <CanvasTooltip
-            content={task.label}
-            placement="top"
-            smartTooltip
-            {...(isDragging && { isOpen: false })}
+          <Row
+            gap={'2px'}
+            align="center"
+            style={{
+              overflow: 'hidden',
+              whiteSpace: 'nowrap',
+            }}
           >
-            <Row
-              gap={'2px'}
-              align="center"
-              style={{
-                overflow: 'hidden',
-                textOverflow: 'ellipsis',
-                whiteSpace: 'nowrap',
-              }}
+            <CanvasTooltip
+              content={task.label}
+              placement="top"
+              smartTooltip
+              {...(isDragging && { isOpen: false })}
             >
               <span
                 data-testid={`stage-task-label-${task.id}`}
@@ -177,17 +176,17 @@ export const TaskContent = memo(
               >
                 {task.label}
               </span>
-              {showRequiredMarker && (
-                <span
-                  data-testid={`stage-task-required-marker-${task.id}`}
-                  className="text-sm"
-                  style={{ flexShrink: 0 }}
-                >
-                  {'*'}
-                </span>
-              )}
-            </Row>
-          </CanvasTooltip>
+            </CanvasTooltip>
+            {showRequiredMarker && (
+              <span
+                data-testid={`stage-task-required-marker-${task.id}`}
+                className="text-sm"
+                style={{ flexShrink: 0 }}
+              >
+                {'*'}
+              </span>
+            )}
+          </Row>
         </Row>
         <Row
           align="center"

--- a/packages/apollo-react/src/canvas/layouts/Column.test.tsx
+++ b/packages/apollo-react/src/canvas/layouts/Column.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/react';
+import { createRef } from 'react';
 import { describe, expect, it } from 'vitest';
 import { Column } from './Stack';
 
@@ -136,5 +137,18 @@ describe('Column', () => {
       margin: '16px',
       gap: '1rem',
     });
+  });
+
+  // Columns are used as Radix `asChild` triggers and as measurement targets, and
+  // React 18 consumers drop refs handed to plain function components.
+  it('forwards its ref to the rendered element', () => {
+    const ref = createRef<HTMLDivElement>();
+    render(
+      <Column ref={ref}>
+        <div>Child</div>
+      </Column>
+    );
+
+    expect(ref.current).toBe(screen.getByText('Child').parentElement);
   });
 });

--- a/packages/apollo-react/src/canvas/layouts/Row.test.tsx
+++ b/packages/apollo-react/src/canvas/layouts/Row.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/react';
+import { createRef } from 'react';
 import { describe, expect, it } from 'vitest';
 import { Row } from './Stack';
 
@@ -136,5 +137,19 @@ describe('Row', () => {
       margin: '16px',
       gap: '1rem',
     });
+  });
+
+  // Rows are used as Radix `asChild` triggers and as measurement targets (e.g.
+  // truncation detection). React 18 consumers drop refs handed to plain function
+  // components, so the ref has to reach the rendered element.
+  it('forwards its ref to the rendered element', () => {
+    const ref = createRef<HTMLDivElement>();
+    render(
+      <Row ref={ref}>
+        <div>Child</div>
+      </Row>
+    );
+
+    expect(ref.current).toBe(screen.getByText('Child').parentElement);
   });
 });

--- a/packages/apollo-react/src/canvas/layouts/Stack.tsx
+++ b/packages/apollo-react/src/canvas/layouts/Stack.tsx
@@ -1,5 +1,4 @@
-import type React from 'react';
-import { useMemo } from 'react';
+import React, { useMemo } from 'react';
 import type { FlexProps, OverflowProps, PositionProps, SizeProps, SpacingProps } from './core';
 import { alignMap, calcSpacingPx, justifyMap } from './core';
 
@@ -10,145 +9,157 @@ type StackProps = FlexProps &
   SizeProps &
   SpacingProps;
 
-const Stack: React.FC<StackProps> = ({
-  children,
-  className,
-  style,
-  // Extract all our custom props
-  direction = 'row',
-  align,
-  justify,
-  wrap,
-  gap,
-  flex,
-  w,
-  h,
-  maxW,
-  minW,
-  maxH,
-  minH,
-  overflow,
-  overflowX,
-  overflowY,
-  position,
-  p,
-  pt,
-  pb,
-  pl,
-  pr,
-  px,
-  py,
-  m,
-  mt,
-  mb,
-  ml,
-  mr,
-  mx,
-  my,
-  // Rest of HTML props
-  ...htmlProps
-}) => {
-  // Keep useMemo for style calculations - this is still valuable
-  const dynamicStyle: React.CSSProperties = useMemo(() => {
-    return {
-      display: 'flex',
-      flexDirection: direction,
+// forwardRef so a stack can be a Radix `asChild` trigger (tooltip, popover, …) and so
+// callers can measure it. React 18 consumers drop refs handed to plain function
+// components, which leaves such triggers without an anchor and without a node to
+// measure for truncation.
+const Stack = React.forwardRef<HTMLDivElement, StackProps>(
+  (
+    {
+      children,
+      className,
+      style,
+      // Extract all our custom props
+      direction = 'row',
+      align,
+      justify,
+      wrap,
+      gap,
+      flex,
+      w,
+      h,
+      maxW,
+      minW,
+      maxH,
+      minH,
+      overflow,
+      overflowX,
+      overflowY,
+      position,
+      p,
+      pt,
+      pb,
+      pl,
+      pr,
+      px,
+      py,
+      m,
+      mt,
+      mb,
+      ml,
+      mr,
+      mx,
+      my,
+      // Rest of HTML props
+      ...htmlProps
+    },
+    ref
+  ) => {
+    // Keep useMemo for style calculations - this is still valuable
+    const dynamicStyle: React.CSSProperties = useMemo(() => {
+      return {
+        display: 'flex',
+        flexDirection: direction,
 
-      // Flex properties
-      ...(wrap && { flexWrap: wrap }),
-      ...(flex !== undefined && { flex }),
-      ...(gap !== undefined && { gap: calcSpacingPx(gap) }),
-      ...(justify && { justifyContent: justifyMap[justify] }),
-      ...(align && { alignItems: alignMap[align] }),
+        // Flex properties
+        ...(wrap && { flexWrap: wrap }),
+        ...(flex !== undefined && { flex }),
+        ...(gap !== undefined && { gap: calcSpacingPx(gap) }),
+        ...(justify && { justifyContent: justifyMap[justify] }),
+        ...(align && { alignItems: alignMap[align] }),
 
-      // Size properties
-      ...(w !== undefined && { width: calcSpacingPx(w) }),
-      ...(h !== undefined && { height: calcSpacingPx(h) }),
-      ...(maxW !== undefined && { maxWidth: calcSpacingPx(maxW) }),
-      ...(minW !== undefined && { minWidth: calcSpacingPx(minW) }),
-      ...(maxH !== undefined && { maxHeight: calcSpacingPx(maxH) }),
-      ...(minH !== undefined && { minHeight: calcSpacingPx(minH) }),
+        // Size properties
+        ...(w !== undefined && { width: calcSpacingPx(w) }),
+        ...(h !== undefined && { height: calcSpacingPx(h) }),
+        ...(maxW !== undefined && { maxWidth: calcSpacingPx(maxW) }),
+        ...(minW !== undefined && { minWidth: calcSpacingPx(minW) }),
+        ...(maxH !== undefined && { maxHeight: calcSpacingPx(maxH) }),
+        ...(minH !== undefined && { minHeight: calcSpacingPx(minH) }),
 
-      // Overflow properties
-      ...(overflow && { overflow }),
-      ...(overflowX && { overflowX }),
-      ...(overflowY && { overflowY }),
+        // Overflow properties
+        ...(overflow && { overflow }),
+        ...(overflowX && { overflowX }),
+        ...(overflowY && { overflowY }),
 
-      // Position
-      ...(position && { position }),
+        // Position
+        ...(position && { position }),
 
-      // Padding
-      ...(p !== undefined && { padding: calcSpacingPx(p) }),
-      ...(pt !== undefined && { paddingTop: calcSpacingPx(pt) }),
-      ...(pb !== undefined && { paddingBottom: calcSpacingPx(pb) }),
-      ...(pl !== undefined && { paddingLeft: calcSpacingPx(pl) }),
-      ...(pr !== undefined && { paddingRight: calcSpacingPx(pr) }),
-      ...(px !== undefined && !pl && { paddingLeft: calcSpacingPx(px) }),
-      ...(px !== undefined && !pr && { paddingRight: calcSpacingPx(px) }),
-      ...(py !== undefined && !pt && { paddingTop: calcSpacingPx(py) }),
-      ...(py !== undefined && !pb && { paddingBottom: calcSpacingPx(py) }),
+        // Padding
+        ...(p !== undefined && { padding: calcSpacingPx(p) }),
+        ...(pt !== undefined && { paddingTop: calcSpacingPx(pt) }),
+        ...(pb !== undefined && { paddingBottom: calcSpacingPx(pb) }),
+        ...(pl !== undefined && { paddingLeft: calcSpacingPx(pl) }),
+        ...(pr !== undefined && { paddingRight: calcSpacingPx(pr) }),
+        ...(px !== undefined && !pl && { paddingLeft: calcSpacingPx(px) }),
+        ...(px !== undefined && !pr && { paddingRight: calcSpacingPx(px) }),
+        ...(py !== undefined && !pt && { paddingTop: calcSpacingPx(py) }),
+        ...(py !== undefined && !pb && { paddingBottom: calcSpacingPx(py) }),
 
-      // Margin
-      ...(m !== undefined && { margin: calcSpacingPx(m) }),
-      ...(mt !== undefined && { marginTop: calcSpacingPx(mt) }),
-      ...(mb !== undefined && { marginBottom: calcSpacingPx(mb) }),
-      ...(ml !== undefined && { marginLeft: calcSpacingPx(ml) }),
-      ...(mr !== undefined && { marginRight: calcSpacingPx(mr) }),
-      ...(mx !== undefined && !ml && { marginLeft: calcSpacingPx(mx) }),
-      ...(mx !== undefined && !mr && { marginRight: calcSpacingPx(mx) }),
-      ...(my !== undefined && !mt && { marginTop: calcSpacingPx(my) }),
-      ...(my !== undefined && !mb && { marginBottom: calcSpacingPx(my) }),
+        // Margin
+        ...(m !== undefined && { margin: calcSpacingPx(m) }),
+        ...(mt !== undefined && { marginTop: calcSpacingPx(mt) }),
+        ...(mb !== undefined && { marginBottom: calcSpacingPx(mb) }),
+        ...(ml !== undefined && { marginLeft: calcSpacingPx(ml) }),
+        ...(mr !== undefined && { marginRight: calcSpacingPx(mr) }),
+        ...(mx !== undefined && !ml && { marginLeft: calcSpacingPx(mx) }),
+        ...(mx !== undefined && !mr && { marginRight: calcSpacingPx(mx) }),
+        ...(my !== undefined && !mt && { marginTop: calcSpacingPx(my) }),
+        ...(my !== undefined && !mb && { marginBottom: calcSpacingPx(my) }),
 
-      // User style overrides
-      ...style,
-    };
-  }, [
-    direction,
-    align,
-    justify,
-    wrap,
-    gap,
-    flex,
-    w,
-    h,
-    maxW,
-    minW,
-    maxH,
-    minH,
-    overflow,
-    overflowX,
-    overflowY,
-    position,
-    p,
-    pt,
-    pb,
-    pl,
-    pr,
-    px,
-    py,
-    m,
-    mt,
-    mb,
-    ml,
-    mr,
-    mx,
-    my,
-    style,
-  ]);
+        // User style overrides
+        ...style,
+      };
+    }, [
+      direction,
+      align,
+      justify,
+      wrap,
+      gap,
+      flex,
+      w,
+      h,
+      maxW,
+      minW,
+      maxH,
+      minH,
+      overflow,
+      overflowX,
+      overflowY,
+      position,
+      p,
+      pt,
+      pb,
+      pl,
+      pr,
+      px,
+      py,
+      m,
+      mt,
+      mb,
+      ml,
+      mr,
+      mx,
+      my,
+      style,
+    ]);
 
-  return (
-    <div className={className} style={dynamicStyle} {...htmlProps}>
-      {children}
-    </div>
-  );
-};
+    return (
+      <div ref={ref} className={className} style={dynamicStyle} {...htmlProps}>
+        {children}
+      </div>
+    );
+  }
+);
+Stack.displayName = 'Stack';
 
-const Row: React.FC<StackProps> = (props) => {
-  return <Stack direction="row" {...props} />;
-};
+const Row = React.forwardRef<HTMLDivElement, StackProps>((props, ref) => {
+  return <Stack ref={ref} direction="row" {...props} />;
+});
+Row.displayName = 'Row';
 
-const Column: React.FC<StackProps> = (props) => {
-  return <Stack direction="column" {...props} />;
-};
+const Column = React.forwardRef<HTMLDivElement, StackProps>((props, ref) => {
+  return <Stack ref={ref} direction="column" {...props} />;
+});
+Column.displayName = 'Column';
 
 export { Row, Column };

--- a/packages/apollo-react/src/canvas/layouts/index.test.ts
+++ b/packages/apollo-react/src/canvas/layouts/index.test.ts
@@ -1,14 +1,20 @@
+import { render } from '@testing-library/react';
+import { createElement } from 'react';
 import { describe, expect, it } from 'vitest';
 import { Column, Row } from './index';
 
+// The stacks are `forwardRef` components (objects, not functions), so assert they
+// render rather than asserting on their `typeof`.
 describe('Layout Components Exports', () => {
   it('exports Column component', () => {
     expect(Column).toBeDefined();
-    expect(typeof Column).toBe('function');
+    const { container } = render(createElement(Column, null, 'content'));
+    expect(container.firstElementChild).toHaveTextContent('content');
   });
 
   it('exports Row component', () => {
     expect(Row).toBeDefined();
-    expect(typeof Row).toBe('function');
+    const { container } = render(createElement(Row, null, 'content'));
+    expect(container.firstElementChild).toHaveTextContent('content');
   });
 });

--- a/packages/apollo-react/src/test/durations.ts
+++ b/packages/apollo-react/src/test/durations.ts
@@ -1,0 +1,6 @@
+/** Durations in milliseconds, so tests can write `2 * WEEK + 19 * HOUR` instead of `1272480000`. */
+export const SECOND = 1000;
+export const MINUTE = 60 * SECOND;
+export const HOUR = 60 * MINUTE;
+export const DAY = 24 * HOUR;
+export const WEEK = 7 * DAY;

--- a/packages/apollo-wind/src/components/ui/badge.test.tsx
+++ b/packages/apollo-wind/src/components/ui/badge.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import { axe } from 'jest-axe';
+import { createRef } from 'react';
 import { describe, expect, it } from 'vitest';
 import { Badge } from './badge';
 
@@ -70,5 +71,15 @@ describe('Badge', () => {
   it('accepts custom className', () => {
     render(<Badge className="custom-badge">Custom</Badge>);
     expect(screen.getByText('Custom')).toHaveClass('custom-badge');
+  });
+
+  // Radix triggers (tooltip, popover, …) hand the badge a ref through `asChild`.
+  // A plain function component would drop it on React 18 consumers, leaving the
+  // popup without an anchor to position against, so it must be forwarded.
+  it('forwards its ref to the rendered element', () => {
+    const ref = createRef<HTMLDivElement>();
+    render(<Badge ref={ref}>Anchored</Badge>);
+
+    expect(ref.current).toBe(screen.getByText('Anchored'));
   });
 });

--- a/packages/apollo-wind/src/components/ui/badge.tsx
+++ b/packages/apollo-wind/src/components/ui/badge.tsx
@@ -32,8 +32,14 @@ export interface BadgeProps
   extends React.HTMLAttributes<HTMLDivElement>,
     VariantProps<typeof badgeVariants> {}
 
-function Badge({ className, variant, ...props }: BadgeProps) {
-  return <div className={cn(badgeVariants({ variant }), className)} {...props} />;
-}
+// forwardRef so the badge can be a Radix `asChild` trigger (tooltip, popover, …).
+// Without it React 18 consumers silently drop the ref, leaving the tooltip
+// without an anchor to position against, so it never becomes visible.
+const Badge = React.forwardRef<HTMLDivElement, BadgeProps>(
+  ({ className, variant, ...props }, ref) => (
+    <div ref={ref} className={cn(badgeVariants({ variant }), className)} {...props} />
+  )
+);
+Badge.displayName = 'Badge';
 
 export { Badge, badgeVariants };

--- a/turbo.json
+++ b/turbo.json
@@ -6,12 +6,7 @@
     "build": {
       "dependsOn": ["^build"],
       "env": ["APOLLO_CODED_APP", "APOLLO_CODED_APP_PATH", "UIP_GO_PLATFORM_AUTH_*", "UIP_GO_AICHAT_*"],
-      "inputs": [
-        "$TURBO_DEFAULT$",
-        "!src/**/*.stories.*",
-        "!src/**/*.test.*",
-        "!src/**/*.spec.*"
-      ],
+      "inputs": ["$TURBO_DEFAULT$", "!src/**/*.test.*", "!src/**/*.spec.*"],
       "outputs": ["dist/**", ".next/**", "build/**", "storybook-static/**"]
     },
     "dev": {


### PR DESCRIPTION
Tooltips missing on a stage task row: the task name, the run/rework chips, and the duration text. Three separate causes, fixed here.

## Root causes

**1. The name tooltip measured the wrong element**

`smartTooltip` measures its own trigger for overflow, and the trigger was a wrapper `Row`. A wrapper never overflows: the `truncate` span inside it ellipsises instead, so `scrollWidth === clientWidth` and truncation always evaluated to false. Every task name was suppressed, regardless of length. The stage rule labels and the collapsible section headers had the identical pattern.

**2. Refs were dropped on React 18 consumers**

Radix hands an `asChild` trigger its ref through `cloneElement`. `Badge` (the run/rework chips) and `Row`/`Column` were plain function components, and React 18 drops refs given to those, logging *&#34;Function components cannot be given refs&#34;*. Radix&#39;s popper was left without an anchor, so the chip tooltip never became visible.

This is why the neighbouring status-icon and play-button tooltips worked: `Button` already used `forwardRef`. It also explains why the bug does not reproduce in Storybook, which runs React 19, where the ref survives as an ordinary prop.

**3. Durations had no tooltip at all**

A duration renders only its **three largest units**, so anything below them (`2w, 19h, 8m` hiding 42 seconds; `Duration: 3w, 1d, 20h` hiding minutes and seconds) was readable nowhere. There was no tooltip unless the consumer passed `durationTooltip`, which PO.Frontend only does for wait-for-timer countdowns.

## Changes

- `apollo-wind` `Badge`: `forwardRef` so it can anchor a Radix popup.
- `apollo-react` `Stack`/`Row`/`Column`: `forwardRef`, so a stack can be a Radix trigger and a measurement target.
- `TaskContent`, `StageRuleContent`, `CollapsibleStageHeader`: the tooltip now wraps the truncating span itself instead of a wrapper row.
- `formatDuration`: new `formatExactDurationMs` (all units, spelled out) and `hasHiddenDurationParts` (did the cap drop anything?).
- `TaskContent` and `StageNodeHeader`: hovering a duration shows the exact value, e.g. `2 weeks, 19 hours, 8 minutes, 42 seconds`.

Nothing is added where it would only repeat what is already on screen: the name tooltip stays `smartTooltip` (truncated names only), and a duration the row already shows in full gains no tooltip. A consumer-supplied `durationTooltip` still wins, since a countdown says something the duration itself cannot. Legacy pre-formatted `duration` strings get no tooltip: without the milliseconds there is nothing to be exact about.

Read-only rows (monitoring, instance view) render the same `TaskContent`, so they are covered by the same fixes.

## Testing

- `TaskContent.integration.test.tsx` and `StageNodeHeader.integration.test.tsx` unmock the globally-stubbed Radix tooltip and assert real open/closed state: truncated name opens, untruncated stays closed, runs chip opens, rework chip opens, a read-only task row opens both, and a duration opens only when units were dropped.
- Verified the new tests fail on the pre-fix code (6 across the two rounds; the chip cases cannot fail under the repo&#39;s React 19 dev dependency, which is the React-18-specific half of the bug).
- `formatExactDurationMs` / `hasHiddenDurationParts` unit-tested including locale wording (German joins with &#34;und&#34;), sub-second rounding, and zero units between parts.
- `Row`/`Column`/`Badge` ref-forwarding tests added. `layouts/index.test.ts` now asserts the stacks render rather than asserting `typeof === &#39;function&#39;`, which no longer holds for `forwardRef` components.
- Full suites green: apollo-react 2393+ tests, apollo-wind 1073 tests. `tsc --noEmit` clean, Biome clean on all changed files.

## Consumer note

PO.Frontend pins `@uipath/apollo-react` 6.16.5 and needs a version bump to pick this up once apollo-react publishes.

## Demo

https://github.com/user-attachments/assets/d4c71117-00f5-42c2-8936-d8d59e7baf25


