### PR TITLE
fix(apollo-core): add exact export aliases for scss token entrypoints

### DIFF
--- a/packages/apollo-core/package.json
+++ b/packages/apollo-core/package.json
@@ -33,6 +33,14 @@
       "require": "./dist/tokens/jss/palette.cjs",
       "types": "./dist/tokens/jss/palette.d.ts"
     },
+    "./tokens/scss/variables": "./dist/tokens/scss/_variables.scss",
+    "./tokens/scss/theme": "./dist/tokens/scss/theme.scss",
+    "./tokens/scss/theme-variables": "./dist/tokens/scss/theme-variables.scss",
+    "./tokens/scss/helpers": "./dist/tokens/scss/helpers.scss",
+    "./tokens/scss/mixins": "./dist/tokens/scss/mixins.scss",
+    "./tokens/scss/base-host": "./dist/tokens/scss/base-host.scss",
+    "./tokens/scss/css-variables": "./dist/tokens/scss/_css-variables.scss",
+    "./tokens/scss/scoped-theme-variables": "./dist/tokens/scss/_scoped-theme-variables.scss",
     "./tokens/*": "./dist/tokens/*"
   },
   "files": [


### PR DESCRIPTION
## Summary
- Adds eight exact `exports` aliases mapping the conventional extensionless scss specifiers (e.g. `@uipath/apollo-core/tokens/scss/variables`) to their real published files (`./dist/tokens/scss/_variables.scss`, …).

## Why
The `"./tokens/*"` wildcard resolves by literal substitution: `tokens/scss/variables` → `dist/tokens/scss/variables`, which isn't a file (`_variables.scss` is). Sass's omit-the-underscore/extension convention only works when the resolver retries partial/extension candidates *through* the exports mapping — webpack's sass importer does, but **esbuild-based pipelines (ng-packagr / Angular application builder) and rspack do not**, so extensionless imports of these entrypoints fail there with `Can't find stylesheet to import`.

This bites apollo's own packages: `apollo-angular-mdc-theme@6.x` internals import these paths extensionless and break rspack-built consumers (UiPath/Orchestrator hit this migrating to apollo-core 5.x — currently worked around with bundler `resolve.alias` entries, removable once this ships). Verified empirically: with the exact alias added, a previously-failing ng-packagr 20.3 build resolves the clean form.

## Side effects
Additive only — exact keys take precedence over patterns in every exports implementation, but for these specifiers the wildcard either already resolves to the same file (candidate-expanding resolvers) or fails outright. Specifiers written with extensions don't match the new keys and flow through the wildcard unchanged. Plain string targets carry no condition requirements. Patch-level change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
