### PR TITLE
fix(canvas): pin TaskMockedChip flask icon size so host MFE styles can't oversize it

### DIFF
--- a/packages/apollo-react/src/canvas/components/StageNode/tasks/TaskMockedChip.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/tasks/TaskMockedChip.tsx
@@ -31,7 +31,7 @@ function TaskMockedChipInner({ mocked, taskId }: TaskMockedChipProps) {
           className="h-3.5 w-3.5 justify-center rounded-full border-0 bg-primary p-0 text-primary-foreground [&>svg]:size-2.5"
           data-testid={`stage-task-mocked-${taskId}`}
         >
-          <FlaskConical aria-hidden />
+          <FlaskConical size={10} aria-hidden />
         </Badge>
       </div>
     </CanvasTooltip>


### PR DESCRIPTION
## Component

`StageNode/tasks/TaskMockedChip` (feeds `DraggableTask`, `AdhocTask`, `EventDrivenTask`)

## Symptom

In a host app where the canvas runs as a micro-frontend, the mocked-output flask renders at lucide's default **24px** and overflows the 14px badge. Correct in Storybook.

| In-host (before) | Expected (Storybook) |
|---|---|
| flask overflows the circle | flask fits inside |

## Root cause

The chip sizes its icon **only** via the `@layer utilities` class `[&>svg]:size-2.5` and passes no `size` to `<FlaskConical>`:

```tsx
className="… [&>svg]:size-2.5"
…
<FlaskConical aria-hidden />
```

Cascade-layer rules lose to **any unlayered declaration**. In a federated runtime, an unlayered `svg { … }` rule leaking from the shell or a sibling MFE overrides the layered `size-2.5` utility, so the icon falls back to its intrinsic 24px. The badge box (`h-3.5 w-3.5 bg-primary`) is unaffected because nothing leaked competes with it — only the `svg` sizing loses.

## Fix

Give the icon an explicit `size`, so width/height land as **svg attributes**, independent of the cascade — matching the robust pattern used by other design-system icons:

```tsx
<FlaskConical size={10} aria-hidden />
```

`size-2.5` = 10px, so this is a no-op in Storybook and a fix under leakage. The `[&>svg]:size-2.5` class is kept as-is; the explicit size is simply cascade-proof.

<img width="1148" height="614" alt="image" src="https://github.com/user-attachments/assets/d4dce845-fbab-4eed-a425-81fd3ca6fcf3" />


## Verification

- Confirmed in a consumer build that the compiled rule `.[&>svg]:size-2.5>svg{width:calc(var(--spacing)*2.5)…}` ships intact and is loaded — the failure is cascade priority, not a dropped rule.
- Confirmed `cn()`/tailwind-merge keeps `[&>svg]:size-2.5` on the element, so the class reaches the DOM.

Reported by the Maestro / PO.Frontend team (consumes `@uipath/apollo-react`).