### PR TITLE
chore(repo): expose repository skills to Codex

### DIFF
--- a/.agents/skills/cut-maintenance-branch
+++ b/.agents/skills/cut-maintenance-branch
@@ -1,0 +1,1 @@
+../../.claude/skills/cut-maintenance-branch

--- a/.agents/skills/fix-security-vulnerabilities
+++ b/.agents/skills/fix-security-vulnerabilities
@@ -1,0 +1,1 @@
+../../.claude/skills/fix-security-vulnerabilities

--- a/.agents/skills/harden-github-action
+++ b/.agents/skills/harden-github-action
@@ -1,0 +1,1 @@
+../../.claude/skills/harden-github-action

--- a/.agents/skills/migrate-canvas-styled-to-tailwind
+++ b/.agents/skills/migrate-canvas-styled-to-tailwind
@@ -1,0 +1,1 @@
+../../.claude/skills/migrate-canvas-styled-to-tailwind


### PR DESCRIPTION
## Summary

- expose all repository skills from `.claude/skills` through `.agents/skills`
- use relative directory symlinks so Claude and Codex share one source of truth
- include `cut-maintenance-branch`, `fix-security-vulnerabilities`, `harden-github-action`, and `migrate-canvas-styled-to-tailwind`

## Why

Codex discovers repository-local skills under `.agents/skills`, while the existing skills only lived under `.claude/skills`. As a result, Codex could not discover or explicitly invoke these workflows.

## Impact

Codex users can discover and invoke the same repository workflows without duplicating skill instructions or assets. Future changes under `.claude/skills` automatically remain available through the links.

## Validation

- verified every `.agents/skills/*` entry is a symlink to its matching `.claude/skills/*` directory
- verified each link resolves to a `SKILL.md`
- verified each directory name matches the skill's declared `name`
- repository supply-chain/lockfile commit hook passed
- commitlint passed