### PR TITLE
fix(apollo-wind): gate the dark: variant on classes, not OS media [MST-13527]

### DIFF
--- a/packages/apollo-wind/src/styles/tailwind.consumer.css
+++ b/packages/apollo-wind/src/styles/tailwind.consumer.css
@@ -24,6 +24,19 @@
 /* Variant active when the component is inside a Future Dark or Light theme */
 @custom-variant future (:is(.future-dark, .future-light) &);
 
+/* Apollo theming is class-driven (see apollo-core theme-variables.css), so
+   override Tailwind's default OS-media `dark` variant to match. Covers the
+   three apollo-core themes that are dark: .dark, .dark-hc, .future-dark.
+   The prototype-only .vertex / .canvas themes are deliberately left out;
+   they name a palette, not a mode, and are snapshots of the dark half of a
+   two-mode source, so they can't be assumed dark long-term.
+
+   The :not(.react-flow) exclusion mirrors the token selectors below, so a
+   ReactFlow wrapper's colorMode class can't flip `dark:` utilities while the
+   tokens around them stay on the host theme. Only .dark needs it, since
+   colorMode emits `light`/`dark` and never `dark-hc`/`future-dark`. */
+@custom-variant dark (&:is(.dark:not(.react-flow), .dark-hc, .future-dark, .dark:not(.react-flow) *, .dark-hc *, .future-dark *));
+
 /**
  * Theme definitions
  *

--- a/packages/apollo-wind/src/styles/tailwind.consumer.test.ts
+++ b/packages/apollo-wind/src/styles/tailwind.consumer.test.ts
@@ -1,0 +1,84 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const css = readFileSync(resolve(__dirname, './tailwind.consumer.css'), 'utf8');
+
+const DARK_VARIANT =
+  '@custom-variant dark (&:is(.dark:not(.react-flow), .dark-hc, .future-dark, .dark:not(.react-flow) *, .dark-hc *, .future-dark *));';
+
+describe('tailwind.consumer.css dark variant', () => {
+  it('overrides the built-in dark variant with a class-based selector', () => {
+    expect(css).toContain(DARK_VARIANT);
+  });
+
+  it('declares the override after @import "tailwindcss" so it wins', () => {
+    // Tailwind v4 resolves the last declaration of a variant name.
+    expect(css.indexOf('@custom-variant dark')).toBeGreaterThan(
+      css.indexOf('@import "tailwindcss"')
+    );
+  });
+
+  it('does not gate theming on the OS colour scheme', () => {
+    // Apollo semantic tokens switch on .dark / .dark-hc / .future-dark only.
+    expect(css).not.toContain('prefers-color-scheme');
+  });
+});
+
+describe('dark variant selector behaviour', () => {
+  // Parsed from the stylesheet so these cases can't drift from what ships.
+  const selector = /@custom-variant dark \((&:is\(.+\))\);/.exec(css)?.[1].replace(/^&/, '');
+
+  const matches = (html: string) => {
+    document.body.innerHTML = html;
+    const target = document.querySelector('#target');
+    if (!target || !selector) throw new Error('missing target or selector');
+    return target.matches(selector);
+  };
+
+  it('activates inside a .dark subtree', () => {
+    expect(matches('<div class="dark"><span id="target"></span></div>')).toBe(true);
+  });
+
+  it('activates inside a .dark-hc subtree', () => {
+    expect(matches('<div class="dark-hc"><span id="target"></span></div>')).toBe(true);
+  });
+
+  it('activates inside a .future-dark subtree', () => {
+    expect(matches('<div class="future-dark"><span id="target"></span></div>')).toBe(true);
+  });
+
+  it('activates on an element that is itself .dark', () => {
+    expect(matches('<span id="target" class="dark"></span>')).toBe(true);
+  });
+
+  it('stays off in a light app when ReactFlow sets colorMode="dark"', () => {
+    // Tokens deliberately ignore .dark.react-flow, so utilities must too.
+    expect(matches('<div class="react-flow dark"><span id="target"></span></div>')).toBe(false);
+  });
+
+  it('stays on inside a ReactFlow canvas when the host app is dark', () => {
+    expect(
+      matches(
+        '<div class="dark"><div class="react-flow light"><span id="target"></span></div></div>'
+      )
+    ).toBe(true);
+  });
+
+  it('excludes .react-flow only for .dark, matching apollo-core', () => {
+    // Core writes :where(.dark-hc) with no exclusion, since ReactFlow's
+    // colorMode prop only ever emits `light` or `dark`.
+    expect(matches('<div class="react-flow dark-hc"><span id="target"></span></div>')).toBe(true);
+  });
+
+  it('stays off for the prototype-only .vertex / .canvas themes', () => {
+    // Both are snapshots of the dark half of a two-mode source, so their
+    // class names name a palette rather than a mode. See the css comment.
+    expect(matches('<div class="vertex"><span id="target"></span></div>')).toBe(false);
+    expect(matches('<div class="canvas"><span id="target"></span></div>')).toBe(false);
+  });
+
+  it('stays off with no theme class', () => {
+    expect(matches('<span id="target"></span>')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Problem

Tailwind v4's built-in `dark` variant is `@media (prefers-color-scheme: dark)`. Apollo's semantic theme tokens are class-driven only: `@uipath/apollo-core/tokens/css/theme-variables.css` switches on `body.dark`, `.apollo-design.dark`, and `:where(.dark:not(.react-flow))`, with no `prefers-color-scheme` anywhere.

`src/styles/tailwind.consumer.css` overrides `future` but never `dark`, so every consumer compile (and our own precompiled `dist/styles.css`) inherits the OS-media default. On a machine with macOS in dark mode, a `dark:` utility goes dark inside a light-themed app while every token around it stays light.

Reported from Studio Web (flow-workbench): variables-panel string values rendered dark-green (`dark:text-green-400`) in a light app. It surfaced through traceview, whose runtime-injected, scope-boosted sheet let the media-gated rule outrank the host's correctly class-gated one. traceview is adding a tactical override in its own repo. This is the systemic fix.

**Slack thread for context: https://uipath-product.slack.com/archives/C0A4F7G370R/p1786474790069139**

## Demo

### Before

<img width="848" height="429" alt="image" src="https://github.com/user-attachments/assets/8a641832-fdce-4427-b817-b2d10d9a45f4" />
<img width="349" height="273" alt="image" src="https://github.com/user-attachments/assets/b12e33b3-1332-4b9a-8f5f-7df419da3b66" />

### After

**Verified in Flow**
Used this dev package in traceview, then published a traceview dev package and consumed that dev package in flow.

<img width="1298" height="1023" alt="image" src="https://github.com/user-attachments/assets/433fdcd8-f614-4a7d-bac6-73aa4eb10683" />

## Change

- `src/styles/tailwind.consumer.css`: declare `@custom-variant dark (&:is(.dark, .future-dark, .dark *, .future-dark *));` below the `future` variant. Placement is after `@import "tailwindcss"`, so it replaces the built-in definition (last declaration wins).
- `src/styles/tailwind.consumer.test.ts`: regression guard asserting the override exists, sits after the `tailwindcss` import, and that the file has no `prefers-color-scheme`. It reads the source CSS, so it needs no build step in CI.

`.future-dark` is included because it sets dark *tokens*, so `dark:` utilities should track it. This matches the form flow-workbench studio/workbench already declare locally (`packages/{studio,workbench}/src/index.css:12`). apollo-vertex uses a narrower `(&:is(.dark *))`. **Apollo owners: shout if you want `future` and `dark` fully orthogonal instead.**

## Verification

Compiled the pre-fix CSS as a baseline, then compiled after the change:

| | `prefers-color-scheme` rules in `dist/styles.css` |
|---|---|
| before | 4 |
| after | 0 |

The four were `dark:text-green-400`, `dark:text-red-400`, `dark:border-destructive`, `dark:bg-green-900/10` (from `alert.tsx`, `chart.tsx`, `stats-card.tsx`, `form-state-viewer.tsx`). They now compile class-gated:

```css
.dark\:text-green-400 {
  &:is(.dark, .future-dark, .dark *, .future-dark *) {
    color: var(--color-green-400);
  }
}
```

Also green: full apollo-wind suite (63 files, 1075 tests), `tsc --noEmit`, `pnpm lint`.

## Consumer impact

**Behavior change** for any consumer that compiles `apollo-wind/tailwind.css` without its own `dark` override, uses `dark:` utilities, and relied on OS media. An org-wide code search for importers found no consumer in all three buckets:

| Consumer | Overrides `dark`? | Own `dark:` usage | Impact |
|---|---|---|---|
| flow-workbench (studio, workbench, evals) | yes | yes | no-op, their later declaration still wins |
| ixp-platform | yes | — | no-op |
| apollo-vertex (this repo) | yes, narrower form | — | no-op |
| traceview-ui playground | yes | — | no-op |
| AgenticProductSupport, Agents, PO.Frontend, storybook-diff, uipath-typescript sample, uipath-ui-widgets | no | 0 files with `dark:text-` / `dark:bg-` | inherit only apollo-wind's ~4 internal `dark:` rules, which now align with class theming |
| flow-workbench vsix webview | consumes precompiled `styles.css` | — | improvement, the webview already sets `.dark` / `.light` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
