### PR TITLE
fix(apollo-react): cost badges are opt-in, not a picker default

### DIFF
--- a/packages/apollo-react/src/material/components/ap-model-picker/ModelPicker.stories.tsx
+++ b/packages/apollo-react/src/material/components/ap-model-picker/ModelPicker.stories.tsx
@@ -379,9 +379,12 @@ export const DeleteWithConfirmation: Story = {
     docs: {
       description: {
         story:
-          'Pass `onDeleteModel` and BYO rows gain a delete action. The picker ' +
-          'always shows a confirmation dialog naming the configuration before ' +
-          'invoking the handler — deletion affects every consumer in the tenant.',
+          'BYO rows gain a delete action, and the picker always shows a ' +
+          'confirmation dialog naming the configuration first — deletion ' +
+          'affects every consumer in the tenant. In self-fetch mode the picker ' +
+          'issues the DELETE itself and you only pass `onModelDeleted` to react. ' +
+          'This story uses `onDeleteModel`, the opt-out for hosts that must own ' +
+          'the request, because stories have no request context.',
       },
     },
   },

--- a/packages/apollo-react/src/material/components/ap-model-picker/ModelPicker.test.tsx
+++ b/packages/apollo-react/src/material/components/ap-model-picker/ModelPicker.test.tsx
@@ -6,6 +6,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { ModelPicker } from './ModelPicker';
 import type { DiscoveryModel } from './types';
 import { platformNavigation } from './usePlatformAccess';
+import { isTextGenerationModel } from './utils';
 
 /**
  * Render helper. No I18nProvider on purpose: the picker resolves its
@@ -282,6 +283,200 @@ describe('<ModelPicker>', () => {
     expect(onDeleteModel.mock.calls[0][0]).toMatchObject({ modelSubscriptionType: 'BYOMAdded' });
   });
 
+  it('deletes the BYO configuration itself when no onDeleteModel is supplied', async () => {
+    const user = userEvent.setup();
+    const onModelDeleted = vi.fn();
+    // Discovery on mount, then the DELETE, then the post-delete refetch.
+    const fetchMock = vi.fn().mockImplementation((_url: string, init?: RequestInit) =>
+      init?.method === 'DELETE'
+        ? Promise.resolve({ ok: true, json: async () => ({}) })
+        : Promise.resolve({
+            ok: true,
+            json: async () => [
+              {
+                modelId: 'byo-acme-gpt-4o',
+                modelName: 'gpt-4o',
+                vendor: 'OpenAi',
+                modelSubscriptionType: 'BYOMAdded',
+                byomDetails: { byoConfigurationId: 'cfg-9' },
+              },
+            ],
+          })
+    );
+    vi.stubGlobal('fetch', fetchMock);
+    try {
+      renderPicker(
+        <ModelPicker
+          value={null}
+          onChange={() => {}}
+          canManageByo
+          onModelDeleted={onModelDeleted}
+          requestContext={{
+            token: 't',
+            baseUrl: 'https://cloud.local/acme',
+            tenantName: 'DefaultTenant',
+            organizationId: 'org-guid',
+            tenantId: 'tenant-guid',
+          }}
+        />
+      );
+      await user.click(await screen.findByRole('button', { expanded: false }));
+      await user.click(await screen.findByRole('button', { name: /delete configuration/i }));
+      await user.click(await screen.findByRole('button', { name: /^delete$/i }));
+
+      const deleteCall = fetchMock.mock.calls.find(([, init]) => init?.method === 'DELETE');
+      expect(deleteCall?.[0]).toBe(
+        'https://cloud.local/org-guid/tenant-guid/llmgateway_/api/byo/product/llm-configurations/cfg-9'
+      );
+      expect(deleteCall?.[1]).toMatchObject({
+        headers: expect.objectContaining({ Authorization: 'Bearer t' }),
+      });
+      expect(onModelDeleted).toHaveBeenCalledTimes(1);
+      expect(onModelDeleted.mock.calls[0][0]).toMatchObject({ modelId: 'byo-acme-gpt-4o' });
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it('surfaces a failed delete and does not report it as deleted', async () => {
+    const user = userEvent.setup();
+    const onModelDeleted = vi.fn();
+    const fetchMock = vi.fn().mockImplementation((_url: string, init?: RequestInit) =>
+      init?.method === 'DELETE'
+        ? Promise.resolve({
+            ok: false,
+            status: 409,
+            json: async () => ({ Message: 'Configuration is in use.' }),
+          })
+        : Promise.resolve({
+            ok: true,
+            json: async () => [
+              {
+                modelId: 'byo-acme-gpt-4o',
+                modelName: 'gpt-4o',
+                vendor: 'OpenAi',
+                modelSubscriptionType: 'BYOMAdded',
+                byomDetails: { byoConfigurationId: 'cfg-9' },
+              },
+            ],
+          })
+    );
+    vi.stubGlobal('fetch', fetchMock);
+    try {
+      renderPicker(
+        <ModelPicker
+          value={null}
+          onChange={() => {}}
+          canManageByo
+          onModelDeleted={onModelDeleted}
+          requestContext={{
+            token: 't',
+            baseUrl: 'https://cloud.local/acme',
+            tenantName: 'DefaultTenant',
+            organizationId: 'org-guid',
+            tenantId: 'tenant-guid',
+          }}
+        />
+      );
+      await user.click(await screen.findByRole('button', { expanded: false }));
+      await user.click(await screen.findByRole('button', { name: /delete configuration/i }));
+      await user.click(await screen.findByRole('button', { name: /^delete$/i }));
+
+      // The gateway's own message reaches the user, and the host is not told
+      // a model went away when it did not.
+      expect(await screen.findByText(/configuration is in use/i)).toBeInTheDocument();
+      expect(onModelDeleted).not.toHaveBeenCalled();
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it('surfaces a throwing onModelDeleted instead of swallowing it', async () => {
+    const user = userEvent.setup();
+    const fetchMock = vi.fn().mockImplementation((_url: string, init?: RequestInit) =>
+      init?.method === 'DELETE'
+        ? Promise.resolve({ ok: true, json: async () => ({}) })
+        : Promise.resolve({
+            ok: true,
+            json: async () => [
+              {
+                modelId: 'byo-acme-gpt-4o',
+                modelName: 'gpt-4o',
+                vendor: 'OpenAi',
+                modelSubscriptionType: 'BYOMAdded',
+                byomDetails: { byoConfigurationId: 'cfg-9' },
+              },
+            ],
+          })
+    );
+    vi.stubGlobal('fetch', fetchMock);
+    try {
+      renderPicker(
+        <ModelPicker
+          value={null}
+          onChange={() => {}}
+          canManageByo
+          onModelDeleted={() => {
+            throw new Error('host reconciliation blew up');
+          }}
+          requestContext={{
+            token: 't',
+            baseUrl: 'https://cloud.local/acme',
+            tenantName: 'DefaultTenant',
+            organizationId: 'org-guid',
+            tenantId: 'tenant-guid',
+          }}
+        />
+      );
+      await user.click(await screen.findByRole('button', { expanded: false }));
+      await user.click(await screen.findByRole('button', { name: /delete configuration/i }));
+      await user.click(await screen.findByRole('button', { name: /^delete$/i }));
+
+      // The click handler's promise is floating, so without this the host's
+      // throw would vanish as an unhandled rejection.
+      expect(await screen.findByText(/host reconciliation blew up/i)).toBeInTheDocument();
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it('offers no delete action on a BYO row with no configuration id to target', async () => {
+    const user = userEvent.setup();
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => [
+        {
+          modelId: 'byo-acme-gpt-4o',
+          modelName: 'gpt-4o',
+          vendor: 'OpenAi',
+          modelSubscriptionType: 'BYOMAdded',
+        },
+      ],
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    try {
+      renderPicker(
+        <ModelPicker
+          value={null}
+          onChange={() => {}}
+          canManageByo
+          requestContext={{
+            token: 't',
+            baseUrl: 'https://cloud.local/acme',
+            tenantName: 'DefaultTenant',
+            organizationId: 'org-guid',
+            tenantId: 'tenant-guid',
+          }}
+        />
+      );
+      await user.click(await screen.findByRole('button', { expanded: false }));
+      await screen.findByText('gpt-4o');
+      expect(screen.queryByRole('button', { name: /delete configuration/i })).toBeNull();
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
   it('deep-links the edit form when the DTO carries byomDetails.byoConfigurationId', async () => {
     const user = userEvent.setup();
     const assign = vi.spyOn(platformNavigation, 'openInNewTab').mockImplementation(() => {});
@@ -509,5 +704,99 @@ describe('<ModelPicker>', () => {
     } finally {
       vi.unstubAllGlobals();
     }
+  });
+});
+
+describe('<ModelPicker> catalog scoping', () => {
+  const NON_CHAT_MODELS: DiscoveryModel[] = [
+    ...MODELS,
+    {
+      modelId: 'text-embedding-3-large',
+      modelName: 'text-embedding-3-large',
+      vendor: 'OpenAi',
+      modelSubscriptionType: 'UiPathOwned',
+      apiFlavor: 'OpenAiEmbeddings',
+    },
+    {
+      modelId: 'gpt-realtime',
+      modelName: 'gpt-realtime',
+      vendor: 'OpenAi',
+      modelSubscriptionType: 'UiPathOwned',
+      modelType: 'Realtime',
+    },
+  ];
+
+  // Which modalities a product offers is the product's call: an indexing or
+  // context-grounding surface picks embeddings from the same catalog.
+  it('renders embeddings and realtime models when the host does not filter them', async () => {
+    const user = userEvent.setup();
+    renderPicker(<ModelPicker models={NON_CHAT_MODELS} value={null} onChange={() => {}} />);
+    await user.click(screen.getByRole('button', { expanded: false }));
+    const listbox = await screen.findByRole('listbox');
+    expect(within(listbox).getByText('text-embedding-3-large')).toBeInTheDocument();
+    expect(within(listbox).getByText('gpt-realtime')).toBeInTheDocument();
+  });
+
+  it('drops them when the host opts into isTextGenerationModel', async () => {
+    const user = userEvent.setup();
+    renderPicker(
+      <ModelPicker
+        models={NON_CHAT_MODELS}
+        value={null}
+        onChange={() => {}}
+        filter={isTextGenerationModel}
+      />
+    );
+    await user.click(screen.getByRole('button', { expanded: false }));
+    const listbox = await screen.findByRole('listbox');
+    expect(within(listbox).queryByText('text-embedding-3-large')).toBeNull();
+    expect(within(listbox).queryByText('gpt-realtime')).toBeNull();
+    expect(within(listbox).getByText('anthropic.claude-sonnet-4-6')).toBeInTheDocument();
+  });
+
+  it('resolves the selection by modelName when it differs from modelId', () => {
+    const models: DiscoveryModel[] = [
+      {
+        modelId: 'byo-row-guid',
+        modelName: 'my-custom-gpt',
+        vendor: 'OpenAi',
+        modelSubscriptionType: 'BYOMAdded',
+      },
+    ];
+    renderPicker(<ModelPicker models={models} value="my-custom-gpt" onChange={() => {}} />);
+    expect(screen.getByText('my-custom-gpt')).toBeInTheDocument();
+    expect(screen.getByRole('button', { expanded: false })).not.toHaveAttribute(
+      'aria-invalid',
+      'true'
+    );
+  });
+
+  it('accepts a raw OMS region name as homeRegion for out-of-region chips', async () => {
+    const user = userEvent.setup();
+    const models: DiscoveryModel[] = [
+      {
+        modelId: 'us-hosted',
+        modelName: 'us-hosted',
+        vendor: 'OpenAi',
+        modelSubscriptionType: 'UiPathOwned',
+        routingDetails: { geography: 'US' },
+      },
+      {
+        modelId: 'ja-hosted',
+        modelName: 'ja-hosted',
+        vendor: 'OpenAi',
+        modelSubscriptionType: 'UiPathOwned',
+        routingDetails: { geography: 'JA' },
+      },
+    ];
+    renderPicker(
+      <ModelPicker models={models} value={null} onChange={() => {}} homeRegion="Japan" />
+    );
+    await user.click(screen.getByRole('button', { expanded: false }));
+    const listbox = await screen.findByRole('listbox');
+    // homeRegion "Japan" resolves to JA: the US-routed model is out of
+    // region, the JA-routed one is home.
+    expect(within(listbox).getByText(/out of region \(US\)/i)).toBeInTheDocument();
+    expect(within(listbox).queryByText(/out of region \(JA\)/i)).toBeNull();
   });
 });

--- a/packages/apollo-react/src/material/components/ap-model-picker/ModelPicker.tsx
+++ b/packages/apollo-react/src/material/components/ap-model-picker/ModelPicker.tsx
@@ -12,8 +12,8 @@ import Typography from '@mui/material/Typography';
 import { Colors, FontFamily } from '@uipath/apollo-core';
 import React from 'react';
 import { useSafeLingui } from '../../../i18n';
-import { DELETE_CONFIRM } from './i18n';
 import type { ModelBadgeKind } from './badges';
+import { DELETE_CONFIRM } from './i18n';
 import { FolderSwitcher, type FolderSwitcherFolder } from './primitives/FolderSwitcher';
 import { defaultRowActions } from './primitives/ModelOptionRow';
 import { GroupedOptionList, optionDomId, VirtualOptionList } from './primitives/OptionList';
@@ -29,10 +29,12 @@ import {
   platformNavigation,
   useByoConnectionNames,
   useCanManageByo,
+  useDeleteByoConfiguration,
   usePlatformDiscoveryModels,
   useUserFolders,
 } from './usePlatformAccess';
 import type { DeriveModelTagsContext, GroupStrategy } from './utils';
+import { resolveHomeGeography } from './utils';
 
 const EMPTY_MODELS: DiscoveryModel[] = [];
 
@@ -171,7 +173,13 @@ export interface ModelPickerProps {
    * toolbar. Default: `true`.
    */
   allowGroupingChange?: boolean;
-  /** User's home region (e.g. `'EU'`). Used to flag out-of-region models. */
+  /**
+   * User's home region — used to flag out-of-region models. Accepts a
+   * Discovery geography code (`'EU'`) or the raw OMS organization region
+   * exactly as PortalShell serves it (`'UnitedStates'`, `'Japan'`, …);
+   * the picker owns the OMS→geography mapping so hosts don't each
+   * maintain one. Unknown values disable out-of-region chips.
+   */
   homeRegion?: string;
   /**
    * Test/storybook override for the Recommended signal. In production
@@ -312,14 +320,28 @@ export interface ModelPickerProps {
    */
   disablePortal?: boolean;
   /**
-   * Delete handler for a BYO model. When provided (and BYO management is
-   * enabled), the picker renders a delete row action next to edit on BYO rows.
-   * Omit to keep the default (no delete action — removal via the configurations
-   * page). The host performs the delete; with a host-owned `models` it also
-   * refreshes the catalog, while in self-fetch mode the picker refetches
-   * Discovery itself once the returned promise resolves.
+   * Opt out of picker-owned deletion and perform the DELETE yourself.
+   *
+   * Rarely needed: in self-fetch mode the picker already deletes the BYO
+   * configuration through the platform route it has credentials for, so
+   * hosts only need `onModelDeleted`. Pass this when a product must route
+   * the call somewhere else — the picker then confirms, calls this, and
+   * refetches, but issues no request of its own.
+   *
+   * With a host-owned `models` list there is no request context to delete
+   * with, so this is the only way to surface a delete action at all.
    */
   onDeleteModel?: (model: DiscoveryModel) => void | Promise<void>;
+  /**
+   * Fired after a BYO model is successfully deleted, whether the picker or
+   * `onDeleteModel` performed it. The catalog has already been refetched.
+   *
+   * Use it to reconcile host state the picker cannot know about — most
+   * importantly, to pick a replacement when the deleted model was the
+   * current selection (the picker does not choose one for you, since what
+   * to fall back to is a product decision).
+   */
+  onModelDeleted?: (model: DiscoveryModel) => void | Promise<void>;
   /** Extensibility slots. See `ModelPickerSlots`. */
   slots?: ModelPickerSlots;
   /** Rendered as `data-testid` on the picker's root element. */
@@ -377,6 +399,7 @@ export const ModelPicker = React.forwardRef<HTMLButtonElement, ModelPickerProps>
       popupContainer,
       disablePortal,
       onDeleteModel,
+      onModelDeleted,
       slots,
       testId,
     },
@@ -427,28 +450,69 @@ export const ModelPicker = React.forwardRef<HTMLButtonElement, ModelPickerProps>
     } = usePlatformDiscoveryModels(selfFetchCtx, folder ?? null);
     const catalog = models ?? fetchedModels ?? EMPTY_MODELS;
     const effectiveLoading = (loading ?? false) || discoveryLoading;
-    const effectiveError = error ?? discoveryError;
 
-    // In self-fetch mode a BYO delete refetches the catalog once the
-    // host's handler resolves; with host-owned models the host refreshes.
-    // Deleting a configuration affects every consumer in the tenant, so the
-    // picker always confirms before invoking the host's handler.
+    // Deleting a BYO configuration removes it for every consumer in the
+    // tenant, so the picker always confirms first. In self-fetch mode it
+    // then issues the DELETE itself — it already holds the credentials and
+    // org/tenant path that route needs — and refetches. `onDeleteModel`
+    // overrides that for hosts who must own the request.
+    const { deleteConfiguration } = useDeleteByoConfiguration(selfFetchCtx);
     const [pendingDelete, setPendingDelete] = React.useState<DiscoveryModel | null>(null);
+    const [deleteError, setDeleteError] = React.useState<Error | null>(null);
+    const canSelfDelete = !onDeleteModel && !!selfFetchCtx;
     const handleDeleteModel = React.useMemo(() => {
-      if (!onDeleteModel) return undefined;
-      return (m: DiscoveryModel) => setPendingDelete(m);
-    }, [onDeleteModel]);
+      if (!onDeleteModel && !canSelfDelete) return undefined;
+      return (m: DiscoveryModel) => {
+        setDeleteError(null);
+        setPendingDelete(m);
+      };
+    }, [onDeleteModel, canSelfDelete]);
     const confirmPendingDelete = React.useCallback(async () => {
       const model = pendingDelete;
       setPendingDelete(null);
       if (!model) return;
-      await onDeleteModel?.(model);
-      if (selfFetchCtx) refetchDiscovery();
-    }, [pendingDelete, onDeleteModel, selfFetchCtx, refetchDiscovery]);
+      try {
+        if (onDeleteModel) {
+          await onDeleteModel(model);
+        } else {
+          const configurationId = model.byomDetails?.byoConfigurationId;
+          // Rows without a configuration id never render the action, so this
+          // is unreachable in practice — but deleting "nothing" must not look
+          // like success to the host.
+          if (!configurationId)
+            throw new Error('This custom model has no configuration to delete.');
+          await deleteConfiguration(configurationId);
+        }
+      } catch (err) {
+        setDeleteError(err instanceof Error ? err : new Error(String(err)));
+        return;
+      }
+      try {
+        // Awaited so the host reacts to a refreshed catalog, not the one that
+        // still lists the model it just deleted.
+        if (selfFetchCtx) await refetchDiscovery();
+        await onModelDeleted?.(model);
+      } catch (err) {
+        // The delete itself succeeded, but this runs from an onClick whose
+        // promise nobody holds — a throwing host callback would otherwise be
+        // an unhandled rejection with no trace of why nothing happened.
+        setDeleteError(err instanceof Error ? err : new Error(String(err)));
+      }
+    }, [
+      pendingDelete,
+      onDeleteModel,
+      onModelDeleted,
+      deleteConfiguration,
+      selfFetchCtx,
+      refetchDiscovery,
+    ]);
+    const effectiveError = error ?? deleteError ?? discoveryError;
 
     // BYO rows without a host-supplied `byoConnectionLabel` get their
     // Integration Service connection name resolved by the picker itself.
     // Policy-blocked models are never rendered (same as the platform BFFs).
+    // Which modalities a product offers is the product's call — pass `filter`
+    // (see `isTextGenerationModel` for the common chat-only case).
     const connectionNames = useByoConnectionNames(catalog, requestContext ?? null);
     const effectiveModels = React.useMemo(() => {
       const allowed = catalog.filter((m) => !m.isBlockedByPolicy);
@@ -513,7 +577,14 @@ export const ModelPicker = React.forwardRef<HTMLButtonElement, ModelPickerProps>
       [forwardedRef, triggerRef]
     );
 
-    const closePopup = React.useCallback(() => setOpen(false), [setOpen]);
+    // Closing the popup also drops a failed-delete message. The failure
+    // happens while the popup is shut (the confirm dialog closed it), so the
+    // message waits for the next open — but it is a transient action failure,
+    // not a state of the field, and must not outlive being read.
+    const closePopup = React.useCallback(() => {
+      setOpen(false);
+      setDeleteError(null);
+    }, [setOpen]);
     const slotCtx = React.useMemo<ModelPickerSlotContext>(
       () => ({ selected, close: closePopup }),
       [selected, closePopup]
@@ -590,17 +661,20 @@ export const ModelPicker = React.forwardRef<HTMLButtonElement, ModelPickerProps>
 
     // Single tagContext value passed to both trigger + option rows so
     // chip derivation stays consistent. Carries the active i18n instance
-    // so tag labels + tooltips render in the host's locale.
+    // so tag labels + tooltips render in the host's locale. `homeRegion`
+    // is normalized here — hosts may pass a geography code or the raw
+    // OMS region name.
+    const homeGeography = resolveHomeGeography(homeRegion);
     const tagContext = React.useMemo<DeriveModelTagsContext>(
       () => ({
         i18n,
-        homeRegion,
+        homeRegion: homeGeography,
         recommendedModelIds,
         previewModelIds,
         badgesFor,
         customTagsFor,
       }),
-      [i18n, homeRegion, recommendedModelIds, previewModelIds, badgesFor, customTagsFor]
+      [i18n, homeGeography, recommendedModelIds, previewModelIds, badgesFor, customTagsFor]
     );
 
     // In Category view the section header *is* the Recommended/Preview
@@ -632,13 +706,24 @@ export const ModelPicker = React.forwardRef<HTMLButtonElement, ModelPickerProps>
             })
         : undefined;
       if (!onEdit && !handleDeleteModel) return () => null;
-      return (m: DiscoveryModel) =>
-        defaultRowActions(m, { i18n, onEdit, onDelete: handleDeleteModel });
+      return (m: DiscoveryModel) => {
+        // When the picker owns the DELETE it needs a configuration id to
+        // target, so rows lacking one get edit only. A host-supplied
+        // handler may know another way, so it always gets the action.
+        const deletable =
+          handleDeleteModel && (onDeleteModel || !!m.byomDetails?.byoConfigurationId);
+        return defaultRowActions(m, {
+          i18n,
+          onEdit,
+          onDelete: deletable ? handleDeleteModel : undefined,
+        });
+      };
     }, [
       slots?.optionActions,
       effectiveCanManageByo,
       navigateToLlmConfigurations,
       handleDeleteModel,
+      onDeleteModel,
       i18n,
     ]);
 

--- a/packages/apollo-react/src/material/components/ap-model-picker/README.md
+++ b/packages/apollo-react/src/material/components/ap-model-picker/README.md
@@ -43,7 +43,7 @@ The picker is one shared visual + behavioral contract. Everything below is a pro
 
 ### 1. Filter the visible catalog
 
-When your product should only show a subset of what Discovery returns (specific operation codes, current-user permissions, region constraints), pass a `filter`:
+When your product should only show a subset of what Discovery returns (specific modalities, operation codes, current-user permissions, region constraints), pass a `filter`:
 
 ```tsx
 <ModelPicker
@@ -62,6 +62,16 @@ When your product should only show a subset of what Discovery returns (specific 
 - `filter` runs **before** grouping and search. Empty groups disappear cleanly.
 - A `value` whose id is filtered out still resolves — the trigger renders normally, no spurious "unknown model" error.
 - Pass a **stable function reference** if `models` is large; the hook re-derives groups whenever `filter` changes identity.
+
+**Modality is a product decision.** The picker renders whatever Discovery serves — it does not assume text generation. Products that only offer chat models opt in with the exported helper, which drops embeddings (by `apiFlavor`) and realtime (by `modelType`):
+
+```tsx
+import { isTextGenerationModel } from '@uipath/apollo-react/material/components';
+
+<ModelPicker filter={isTextGenerationModel} … />
+```
+
+An indexing or context-grounding surface picks embeddings from the same catalog, so excluding them centrally would break it. The one thing the picker *does* drop unconditionally is `isBlockedByPolicy` — that's an org-wide governance verdict, not a product preference.
 
 ### 2. Friendly names
 
@@ -185,7 +195,28 @@ Under the hood: `GET {baseUrl}/portal_/api/organization/UserOrganizationInfo` �
 
 - The **"Use custom model" footer** opens the *add configuration* form, deep-linked to `/{tenantId}/{folderId}/add` and pre-populated via `?product=&feature=` from `requestingProduct`/`requestingFeature`. The folder id is the switcher's current selection, or — when none is selected ("All folders") — the first available folder, matching the configurations page's own default. Only when no folders exist does it fall back to the configurations list.
 - The **edit row action** (BYO rows only) opens the configuration's *edit* form when the model carries `byomDetails.byoConfigurationId` (served by Discovery on UiPath/Arima#2659); when absent it lands on the configurations list scoped to the tenant + folder.
-- The **delete row action** (BYO rows only) is opt-in: pass `onDeleteModel` and the picker renders a delete icon next to edit. The picker always asks for confirmation first (a built-in dialog naming the configuration), then calls your handler; in self-fetch mode it refetches Discovery once your handler resolves. Omit it to keep removal on the configurations page only.
+- The **delete row action** (BYO rows only) is owned by the picker in self-fetch mode. It renders a delete icon next to edit on BYO rows that carry a `byoConfigurationId`, confirms first (a built-in dialog naming the configuration), then issues the platform call itself:
+
+  ```
+  DELETE {gateway}/api/byo/product/llm-configurations/{byoConfigurationId}
+  ```
+
+  It reuses the credentials and org/tenant path it already holds for Discovery, refetches the catalog, and reports failures in its own error surface (the gateway's message, verbatim). Products do **not** implement this request.
+
+  Pass `onModelDeleted` to react afterwards. Its one real job is reconciling state the picker cannot see — above all, choosing a replacement when the deleted model was the current selection. The picker deliberately does not choose one for you:
+
+  ```tsx
+  <ModelPicker
+    requestContext={ctx}
+    value={selected}
+    onChange={setSelected}
+    onModelDeleted={(model) => {
+      if (model.modelName === selected) setSelected(nextDefault());
+    }}
+  />
+  ```
+
+  `onDeleteModel` remains as an opt-out for hosts that must route the call elsewhere — the picker then confirms, calls it, and refetches, but issues no request of its own. With a host-owned `models` list there is no request context to delete with, so `onDeleteModel` is the only way to surface a delete action at all.
 
 These navigations always open the AI Trust Layer pages in a new browser tab - the picker is embedded in a product surface, and navigating it away would unload the user's in-progress work. `onUseCustomModel` overrides the footer's default navigation (e.g. an in-app wizard), and `slots.optionActions` overrides the row actions. Products with their own authorization model can pass `canManageByo` (`true`/`false`); when set, no admin check request is made.
 
@@ -274,7 +305,7 @@ Slots are the "I need to do something the picker doesn't natively support" surfa
 | `variant`             | `'searchable' \| 'virtualized'`                       | Default `'searchable'`; auto-switches to the virtualized renderer above 120 visible options. Pass `'virtualized'` to force it. |
 | `groupBy`             | `'subscription' \| 'vendor' \| 'flat'`                 | Initial view. Default `'subscription'`.                                                                              |
 | `allowGroupingChange` | `boolean`                                             | Show the Category ⇆ Provider toggle. Default `true`.                                                                  |
-| `homeRegion`          | `string`                                              | User's home region (`'EU'`, `'US'`, …). Triggers the Out-of-region chip when a model's `routingDetails.geography` differs. |
+| `homeRegion`          | `string`                                              | User's home region — a geography code (`'EU'`) or the raw OMS organization region (`'UnitedStates'`, `'Japan'`, …); the picker owns the OMS→geography mapping. Triggers the Out-of-region chip when a model's `routingDetails.geography` differs. |
 | `recommendedModelIds` | `readonly string[]`                                   | Test/storybook override for the Recommended set. Production reads `model.isRecommended` from the Discovery DTO.      |
 | `previewModelIds`     | `readonly string[]`                                   | Same, for Preview (production: DTO `isPreview`).                                                                     |
 | `filter`              | `(m) => boolean`                                      | Per-product filter applied before grouping and search.                                                               |
@@ -338,6 +369,27 @@ Every user-visible string is keyed under the `modelPicker.*` namespace:
 - Data-driven labels (group names, tag labels) are defined once in `i18n.ts` as `msg()` descriptors and resolved via `i18n._(descriptor)` at render time.
 
 The component has its own catalog entry in `packages/apollo-react/lingui.config.ts` (`ap-model-picker/locales/{locale}`). Extract keys with `pnpm i18n:extract` from `packages/apollo-react`; catalogs compile automatically before `build` and `test`.
+
+### Loading the catalogs in a host
+
+The picker's translations live in its own catalogs, so a host that already runs Lingui has to merge them into its instance. Use the exported loader:
+
+```ts
+import { loadModelPickerMessages } from '@uipath/apollo-react/material/components';
+
+const pickerMessages = await loadModelPickerMessages(locale);
+// Host keys last: an app key always wins a collision.
+i18n.loadAndActivate({ locale, messages: { ...pickerMessages, ...appMessages } });
+```
+
+That is the whole integration. Notes:
+
+- **Do not hand-roll the per-locale imports.** A template-literal dynamic import (`` import(`.../locales/${locale}`) ``) cannot be resolved by a consumer's bundler through the package `exports` map, so it fails at build or serves nothing at runtime — and the symptom is raw `modelPicker.*` keys on screen, which reads like a translation bug rather than a bundling one. The loader keeps the literal import map on this side.
+- **Locale matching is forgiving**, because hosts source locales from very different places (PortalShell, `navigator.language`, a preferences API). Tags match case-insensitively across both separators (`pt_BR`, `pt-br`), and an unshipped regional variant falls back to its base language (`fr-CA` → `fr`). `MODEL_PICKER_LOCALES` lists what ships; `resolveModelPickerLocale` exposes the matching if a host needs to pre-check.
+- **It never rejects.** An unknown locale or a failed chunk falls back to English, then to `{}` — a host's i18n bootstrap is the wrong place to throw. Missing messages degrade to the picker's English source strings via `useSafeLingui`.
+- **A host with no Lingui at all needs none of this**: the picker renders its English source strings unaided.
+
+> **Duplicate Lingui breaks translations.** `@lingui/react` is currently a regular *dependency* of `apollo-react`, not a peer. If your app resolves a copy outside apollo's range, you get two `@lingui/react` instances — two React contexts — and the picker cannot see your `I18nProvider`, so it renders raw keys no matter how correctly you load the catalogs. Until that is a peer dependency, hosts should dedupe it (e.g. a pnpm `overrides` entry pinning one version). The same applies to `@emotion/styled`, where a second copy forks `@mui/material` into two peer-variants and your ThemeProvider stops reaching the picker.
 
 ---
 

--- a/packages/apollo-react/src/material/components/ap-model-picker/README.md
+++ b/packages/apollo-react/src/material/components/ap-model-picker/README.md
@@ -164,13 +164,23 @@ Resolution order: `recommendedModelIds` prop (test/storybook override) → DTO `
 
 ### 5. Cost badges
 
-Cost badges are **on by default**: whenever the Discovery DTO carries cost data, each row gets its tier from the Apollo pool (`cost-basic` / `cost-standard` / `cost-premium`) via `defaultCostTier`, which bins `modelDetails.costDetails.flatCosts.inputTokenCost` (cents per million input tokens, the gateway's unit; the first tier is used for tiered pricing) at `$1`/M and `$5`/M. No wiring needed.
+Cost badges are **opt-in** — what counts as expensive is a product decision, not a design-system one, so the picker does not stamp them itself. The pool owns the chip kinds (`cost-basic` / `cost-standard` / `cost-premium`); your `badgesFor` decides which models get which.
 
-A host-supplied `badgesFor` takes over entirely — return your own pool kinds to reclassify, or `[]` to suppress badges:
+The example classifier `defaultCostTier` bins `modelDetails.costDetails.flatCosts.inputTokenCost` (cents per million input tokens, the gateway's unit; the first tier is used for tiered pricing) at `$1`/M and `$5`/M — copy it and tune the thresholds, or classify on something else entirely:
 
 ```tsx
-<ModelPicker badgesFor={(m) => (isExpensive(m) ? ['cost-premium'] : [])} … />
+import { defaultCostTier } from '@uipath/apollo-react/material/components';
+
+<ModelPicker
+  badgesFor={(m) => {
+    const tier = defaultCostTier(m);
+    return tier ? [`cost-${tier}`] : [];
+  }}
+  …
+/>
 ```
+
+Return `[]` to suppress badges, or your own pool kinds to reclassify.
 
 ### 6. BYO management
 

--- a/packages/apollo-react/src/material/components/ap-model-picker/index.ts
+++ b/packages/apollo-react/src/material/components/ap-model-picker/index.ts
@@ -7,6 +7,12 @@ export { MODEL_BADGES } from './badges';
 
 // i18n contract
 export type { PickerTranslator } from './i18n';
+// i18n catalogs (merge into the host's Lingui instance)
+export {
+  loadModelPickerMessages,
+  MODEL_PICKER_LOCALES,
+  resolveModelPickerLocale,
+} from './loadMessages';
 export type {
   ModelPickerChangeHandler,
   ModelPickerProps,
@@ -66,11 +72,13 @@ export type {
   PlatformRequestContext,
   PlatformToken,
   UseCanManageByoResult,
+  UseDeleteByoConfigurationResult,
   UseUserFoldersResult,
 } from './usePlatformAccess';
 export {
   useByoConnectionNames,
   useCanManageByo,
+  useDeleteByoConfiguration,
   usePlatformDiscoveryModels,
   useUserFolders,
 } from './usePlatformAccess';
@@ -86,4 +94,5 @@ export {
   filterModels,
   getSubstitutionTarget,
   groupModels,
+  isTextGenerationModel,
 } from './utils';

--- a/packages/apollo-react/src/material/components/ap-model-picker/loadMessages.test.ts
+++ b/packages/apollo-react/src/material/components/ap-model-picker/loadMessages.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  loadModelPickerMessages,
+  MODEL_PICKER_LOCALES,
+  resolveModelPickerLocale,
+} from './loadMessages';
+
+describe('resolveModelPickerLocale', () => {
+  it('matches shipped tags case-insensitively and across separators', () => {
+    expect(resolveModelPickerLocale('de')).toBe('de');
+    expect(resolveModelPickerLocale('ZH-cn')).toBe('zh-CN');
+    // Hosts source locales from PortalShell, navigator.language, or a prefs
+    // API, so both separators show up in practice.
+    expect(resolveModelPickerLocale('pt_BR')).toBe('pt-BR');
+  });
+
+  it('falls back to the base language for unshipped regional variants', () => {
+    expect(resolveModelPickerLocale('fr-CA')).toBe('fr');
+    expect(resolveModelPickerLocale('es-AR')).toBe('es');
+  });
+
+  it('resolves unknown or empty values to undefined', () => {
+    expect(resolveModelPickerLocale(undefined)).toBeUndefined();
+    expect(resolveModelPickerLocale('   ')).toBeUndefined();
+    expect(resolveModelPickerLocale('kl-GL')).toBeUndefined();
+  });
+});
+
+describe('loadModelPickerMessages', () => {
+  it('loads a shipped catalog', async () => {
+    const messages = await loadModelPickerMessages('de');
+    expect(Object.keys(messages).length).toBeGreaterThan(0);
+    // Every key is namespaced, so merging into a host catalog cannot collide
+    // with app keys.
+    expect(Object.keys(messages).every((k) => k.startsWith('modelPicker.'))).toBe(true);
+  });
+
+  it('falls back to English for an unknown locale instead of rejecting', async () => {
+    const unknown = await loadModelPickerMessages('kl-GL');
+    const english = await loadModelPickerMessages('en');
+    expect(unknown).toEqual(english);
+  });
+
+  it('never rejects on a missing locale', async () => {
+    await expect(loadModelPickerMessages(undefined)).resolves.toBeTruthy();
+  });
+
+  it('ships a catalog for every locale it advertises', async () => {
+    const loaded = await Promise.all(
+      MODEL_PICKER_LOCALES.map(async (tag) => [tag, await loadModelPickerMessages(tag)] as const)
+    );
+    for (const [tag, messages] of loaded) {
+      expect(Object.keys(messages).length, `${tag} catalog is empty`).toBeGreaterThan(0);
+    }
+  });
+});

--- a/packages/apollo-react/src/material/components/ap-model-picker/loadMessages.ts
+++ b/packages/apollo-react/src/material/components/ap-model-picker/loadMessages.ts
@@ -1,0 +1,86 @@
+import type { Messages } from '@lingui/core';
+
+/**
+ * The picker's own message catalogs, keyed by the locale tags it ships.
+ *
+ * Written as literal imports on purpose: a template-literal dynamic import
+ * (`import(\`./locales/${locale}\`)`) cannot be resolved by a consumer's
+ * bundler through the package `exports` map, so every host that tried would
+ * silently render raw `modelPicker.*` keys. Keeping the map here means hosts
+ * never write it — and never rediscover that.
+ */
+const CATALOGS = {
+  de: () => import('./locales/de'),
+  en: () => import('./locales/en'),
+  es: () => import('./locales/es'),
+  'es-MX': () => import('./locales/es-MX'),
+  fr: () => import('./locales/fr'),
+  ja: () => import('./locales/ja'),
+  ko: () => import('./locales/ko'),
+  pt: () => import('./locales/pt'),
+  'pt-BR': () => import('./locales/pt-BR'),
+  ro: () => import('./locales/ro'),
+  ru: () => import('./locales/ru'),
+  tr: () => import('./locales/tr'),
+  'zh-CN': () => import('./locales/zh-CN'),
+  'zh-TW': () => import('./locales/zh-TW'),
+} satisfies Record<string, () => Promise<{ messages: Messages }>>;
+
+/** A locale tag the picker ships a catalog for. */
+export type ModelPickerLocale = keyof typeof CATALOGS;
+
+/** Locale tags the picker ships a catalog for. */
+export const MODEL_PICKER_LOCALES = Object.keys(CATALOGS) as ModelPickerLocale[];
+
+/**
+ * Resolves a host locale to a shipped catalog tag.
+ *
+ * Matches case-insensitively and tolerates both separators (`pt_BR`,
+ * `pt-br`), because hosts source this from wildly different places —
+ * PortalShell, `navigator.language`, a user-preferences API. Falls back to
+ * the base language (`fr-CA` → `fr`), then `undefined`.
+ */
+export function resolveModelPickerLocale(
+  locale: string | undefined
+): ModelPickerLocale | undefined {
+  const raw = locale?.trim().replace(/_/g, '-');
+  if (!raw) return undefined;
+  const exact = MODEL_PICKER_LOCALES.find((tag) => tag.toLowerCase() === raw.toLowerCase());
+  if (exact) return exact;
+  const base = raw.split('-')[0]?.toLowerCase();
+  return MODEL_PICKER_LOCALES.find((tag) => tag.toLowerCase() === base);
+}
+
+/**
+ * Loads the picker's messages for `locale`, for merging into the host's own
+ * Lingui catalog:
+ *
+ * ```ts
+ * const pickerMessages = await loadModelPickerMessages(locale);
+ * // Host keys last: an app key always wins a collision.
+ * i18n.loadAndActivate({ locale, messages: { ...pickerMessages, ...appMessages } });
+ * ```
+ *
+ * Keys are namespaced `modelPicker.*`, so collisions with host keys are not
+ * expected — merge in that order anyway, so a host is never held hostage to
+ * a design-system key.
+ *
+ * Never rejects: an unknown locale, or a chunk that fails to load, falls back
+ * to English and finally to `{}`. Missing messages degrade to the picker's
+ * English source strings, which is a worse experience than a translation but
+ * a better one than a blank UI or a thrown error inside the host's i18n
+ * bootstrap.
+ */
+export async function loadModelPickerMessages(locale: string | undefined): Promise<Messages> {
+  const tag = resolveModelPickerLocale(locale) ?? 'en';
+  try {
+    return (await CATALOGS[tag]()).messages;
+  } catch {
+    if (tag === 'en') return {} as Messages;
+    try {
+      return (await CATALOGS.en()).messages;
+    } catch {
+      return {} as Messages;
+    }
+  }
+}

--- a/packages/apollo-react/src/material/components/ap-model-picker/types.ts
+++ b/packages/apollo-react/src/material/components/ap-model-picker/types.ts
@@ -37,6 +37,8 @@ export type ModelGeography =
   | 'GLOBAL'
   | string;
 
+export type ModelType = 'RequestResponse' | 'Realtime' | string;
+
 export interface DeprecationDetails {
   usageEndDate?: string;
   replacedBy?: string;
@@ -126,6 +128,12 @@ export interface DiscoveryModel {
    */
   isBlockedByPolicy?: boolean;
   isPreview?: boolean;
+  /**
+   * Interaction shape of the model (`RequestResponse` | `Realtime`).
+   * The picker renders text-generation (`RequestResponse`) models only —
+   * realtime models never show, same policy as `isBlockedByPolicy`.
+   */
+  modelType?: ModelType;
   deprecationDetails?: DeprecationDetails | null;
   byomDetails?: ByomDetails | null;
   modelDetails?: ModelDetails;

--- a/packages/apollo-react/src/material/components/ap-model-picker/useModelPickerState.ts
+++ b/packages/apollo-react/src/material/components/ap-model-picker/useModelPickerState.ts
@@ -188,10 +188,16 @@ export function useModelPickerState(opts: UseModelPickerStateOptions): UseModelP
   // the catalog would silently blank the field for legitimate,
   // recently-removed-from-view selections. `unknownValue` stays
   // reserved for ids missing from the catalog entirely.
+  // Matches `modelId` or `modelName`: Discovery serves them equal today,
+  // but hosts persist model *names*, so name matching keeps stored
+  // selections resolving if the two ever diverge.
+  const matchesValue = useCallback(
+    (m: DiscoveryModel) => m.modelId === value || m.modelName === value,
+    [value]
+  );
   const selected = useMemo<DiscoveryModel | null>(
-    () =>
-      annotated.find((m) => m.modelId === value) ?? models.find((m) => m.modelId === value) ?? null,
-    [annotated, models, value]
+    () => annotated.find(matchesValue) ?? models.find(matchesValue) ?? null,
+    [annotated, models, matchesValue]
   );
 
   const unknownValue = useMemo<string | null>(() => {
@@ -222,7 +228,7 @@ export function useModelPickerState(opts: UseModelPickerStateOptions): UseModelP
   // biome-ignore lint/correctness/useExhaustiveDependencies: runs on open/close only — re-running on `filtered`/`value` would reset the keyboard highlight on every keystroke
   useEffect(() => {
     if (open) {
-      const sel = filtered.findIndex((m) => m.modelId === value);
+      const sel = filtered.findIndex(matchesValue);
       setActiveIndex(sel >= 0 ? sel : 0);
       requestAnimationFrame(() => searchRef.current?.focus());
     } else {

--- a/packages/apollo-react/src/material/components/ap-model-picker/usePlatformAccess.ts
+++ b/packages/apollo-react/src/material/components/ap-model-picker/usePlatformAccess.ts
@@ -22,6 +22,30 @@ export type PlatformToken = string | (() => string | Promise<string>);
 const resolveToken = async (token: PlatformToken): Promise<string> =>
   typeof token === 'function' ? token() : token;
 
+/**
+ * Builds an LLM Gateway URL for `path` (e.g. `'api/discovery'`).
+ *
+ * Prefers the canonical GUID route — the form the platform's own LLM pages
+ * use. `baseUrl` carries the org *name* path, so it is stripped to the
+ * origin first. Falls back to the name-based route when GUIDs are absent.
+ *
+ * Shared by every gateway call the picker makes so they cannot drift on
+ * this (non-obvious) route resolution.
+ */
+const buildGatewayUrl = (ctx: PlatformRequestContext, path: string): string => {
+  const base = (ctx.baseUrl ?? '').replace(/\/$/, '');
+  if (ctx.organizationId && ctx.tenantId) {
+    let origin = '';
+    try {
+      origin = base ? new URL(base).origin : '';
+    } catch {
+      origin = '';
+    }
+    return `${origin}/${ctx.organizationId}/${ctx.tenantId}/llmgateway_/${path}`;
+  }
+  return `${base}/${ctx.tenantName}/llmgateway_/${path}`;
+};
+
 export interface PlatformRequestContext {
   /** Bearer token (no `Bearer ` prefix), or a getter resolved per request. */
   token: PlatformToken;
@@ -104,7 +128,8 @@ export interface UseUserFoldersResult {
   folders: FolderSwitcherFolder[];
   loading: boolean;
   error: Error | null;
-  refetch: () => void;
+  /** Resolves once the refetch settles; reports failures through `error`. */
+  refetch: () => Promise<void>;
 }
 
 // Enough for the switcher's flat menu; catalogs with more folders than
@@ -216,7 +241,12 @@ export interface UsePlatformDiscoveryModelsResult {
   models: DiscoveryModel[] | undefined;
   loading: boolean;
   error: Error | null;
-  refetch: () => void;
+  /**
+   * Resolves once the refetch settles (it reports failures through `error`
+   * rather than rejecting), so callers that must act on a fresh catalog can
+   * await it. Safe to ignore the promise.
+   */
+  refetch: () => Promise<void>;
 }
 
 /**
@@ -251,22 +281,7 @@ export function usePlatformDiscoveryModels(
     setLoading(true);
     setError(null);
 
-    const base = (ctx.baseUrl ?? '').replace(/\/$/, '');
-    // Prefer the canonical GUID route (the form the platform's own LLM
-    // pages use); `baseUrl` carries the org *name* path, so strip to the
-    // origin. Fall back to the name-based route when GUIDs are absent.
-    let url: string;
-    if (ctx.organizationId && ctx.tenantId) {
-      let origin = '';
-      try {
-        origin = base ? new URL(base).origin : '';
-      } catch {
-        origin = '';
-      }
-      url = `${origin}/${ctx.organizationId}/${ctx.tenantId}/llmgateway_/api/discovery`;
-    } else {
-      url = `${base}/${ctx.tenantName}/llmgateway_/api/discovery`;
-    }
+    const url = buildGatewayUrl(ctx, 'api/discovery');
 
     try {
       const bearer = await resolveToken(ctx.token);
@@ -314,6 +329,64 @@ export function usePlatformDiscoveryModels(
   }, [ctx, fetchModels]);
 
   return { models, loading, error, refetch: fetchModels };
+}
+
+/* ──────────────────────────────────────────────────────────────────────
+ * BYO configuration deletion
+ * ─────────────────────────────────────────────────────────────────── */
+
+export interface UseDeleteByoConfigurationResult {
+  /** Rejects with the gateway's message when the delete fails. */
+  deleteConfiguration: (configurationId: string) => Promise<void>;
+}
+
+/**
+ * Deletes a BYO product LLM configuration:
+ *
+ *   DELETE {gateway}/api/byo/product/llm-configurations/{configurationId}
+ *
+ * The same platform route every product used to call for itself. It needs
+ * exactly the credentials and org/tenant path the picker already holds for
+ * Discovery, so the picker owns the call and hosts react to the result
+ * instead of re-implementing the request (and its failure handling) each
+ * time.
+ */
+export function useDeleteByoConfiguration(
+  ctx: PlatformRequestContext | null
+): UseDeleteByoConfigurationResult {
+  const deleteConfiguration = useCallback(
+    async (configurationId: string) => {
+      if (!ctx) throw new Error('Cannot delete a BYO configuration without a request context.');
+      const bearer = await resolveToken(ctx.token);
+      const res = await fetch(
+        buildGatewayUrl(
+          ctx,
+          `api/byo/product/llm-configurations/${encodeURIComponent(configurationId)}`
+        ),
+        {
+          method: 'DELETE',
+          headers: { Authorization: `Bearer ${bearer}`, Accept: 'application/json' },
+        }
+      );
+      if (!res.ok) {
+        // The gateway sends `{ Message }` on failure; fall back to the status.
+        let message = '';
+        try {
+          const body: unknown = await res.json();
+          if (body && typeof body === 'object' && 'Message' in body) {
+            const raw = (body as { Message?: unknown }).Message;
+            if (typeof raw === 'string') message = raw;
+          }
+        } catch {
+          message = '';
+        }
+        throw new Error(message || `Failed to delete the custom model (HTTP ${res.status}).`);
+      }
+    },
+    [ctx]
+  );
+
+  return { deleteConfiguration };
 }
 
 /* ──────────────────────────────────────────────────────────────────────

--- a/packages/apollo-react/src/material/components/ap-model-picker/utils.test.ts
+++ b/packages/apollo-react/src/material/components/ap-model-picker/utils.test.ts
@@ -8,6 +8,8 @@ import {
   filterModels,
   getSubstitutionTarget,
   groupModels,
+  isTextGenerationModel,
+  resolveHomeGeography,
 } from './utils';
 
 // Helper: minimal Discovery model. Tests override fields as needed.
@@ -161,6 +163,30 @@ describe('deriveModelTags', () => {
     expect(tags.find((t) => t.kind === 'recommended')).toBeTruthy();
   });
 
+  it('matches override lists by modelName too, not just modelId', () => {
+    // Hosts author these lists from Model Hub config, which carries model
+    // *names*. Discovery serves modelId === modelName today, but a list of
+    // names must keep working if the two ever diverge.
+    const byName = model({ modelId: 'deployment-guid', modelName: 'gpt-5.6-terra' });
+
+    const rec = deriveModelTags(byName, { recommendedModelIds: ['gpt-5.6-terra'] });
+    expect(rec.find((t) => t.kind === 'recommended')).toBeTruthy();
+
+    const prev = deriveModelTags(byName, { previewModelIds: ['gpt-5.6-terra'] });
+    expect(prev.find((t) => t.kind === 'preview')).toBeTruthy();
+
+    // Grouping must agree with chip derivation, or a model chips Recommended
+    // while sitting in the More models group.
+    const groups = groupModels([byName], 'subscription', {
+      recommendedModelIds: ['gpt-5.6-terra'],
+    });
+    expect(groups.find((g) => g.key === 'recommended')?.models).toHaveLength(1);
+
+    // A list naming neither field still matches nothing.
+    const miss = deriveModelTags(byName, { recommendedModelIds: ['something-else'] });
+    expect(miss.find((t) => t.kind === 'recommended')).toBeFalsy();
+  });
+
   it('emits Preview chip for hosted preview models, never for BYO', () => {
     const hostedPreview = deriveModelTags(model({ modelId: 'a', isPreview: true }));
     expect(hostedPreview.find((t) => t.kind === 'preview')).toBeTruthy();
@@ -213,6 +239,12 @@ describe('deriveModelTags', () => {
       homeRegion: 'EU',
     });
     expect(globalForEuUser.find((t) => t.kind === 'out-of-region')).toBeFalsy();
+
+    // A GLOBAL home region is not a place — it must not flag every regional model.
+    const euHostedForGlobalUser = deriveModelTags(model({ routingDetails: { geography: 'EU' } }), {
+      homeRegion: 'GLOBAL',
+    });
+    expect(euHostedForGlobalUser.find((t) => t.kind === 'out-of-region')).toBeFalsy();
   });
 
   it('emits Substituted chip (not Deprecating) when effectiveModel routes elsewhere', () => {
@@ -432,5 +464,66 @@ describe('i18n resolution', () => {
       recommendedModelIds: ['a'],
     });
     expect(tags.find((t) => t.kind === 'recommended')?.label).toBe('Recommended');
+  });
+});
+
+describe('resolveHomeGeography', () => {
+  it('passes geography codes through, case-insensitively', () => {
+    expect(resolveHomeGeography('EU')).toBe('EU');
+    expect(resolveHomeGeography('ja')).toBe('JA');
+  });
+
+  it('tolerates surrounding whitespace', () => {
+    expect(resolveHomeGeography('  EU ')).toBe('EU');
+    expect(resolveHomeGeography(' United States ')).toBe('US');
+    expect(resolveHomeGeography('   ')).toBeUndefined();
+  });
+
+  it('treats GLOBAL as no home region', () => {
+    expect(resolveHomeGeography('GLOBAL')).toBeUndefined();
+    expect(resolveHomeGeography('Global')).toBeUndefined();
+  });
+
+  it('maps OMS region names to Discovery geography codes', () => {
+    expect(resolveHomeGeography('UnitedStates')).toBe('US');
+    expect(resolveHomeGeography('Japan')).toBe('JA');
+    expect(resolveHomeGeography('Singapore')).toBe('SI');
+    expect(resolveHomeGeography('SouthKorea')).toBe('SK');
+    expect(resolveHomeGeography('UnitedArabEmirates')).toBe('UAE');
+  });
+
+  it('ignores case and separators in OMS names', () => {
+    expect(resolveHomeGeography('unitedkingdom')).toBe('UK');
+    expect(resolveHomeGeography('united-states')).toBe('US');
+    expect(resolveHomeGeography('UNITED_ARAB_EMIRATES')).toBe('UAE');
+  });
+
+  it('resolves unknown or missing values to undefined', () => {
+    expect(resolveHomeGeography(undefined)).toBeUndefined();
+    expect(resolveHomeGeography('')).toBeUndefined();
+    expect(resolveHomeGeography('Atlantis')).toBeUndefined();
+  });
+});
+
+describe('isTextGenerationModel', () => {
+  it('keeps request-response models', () => {
+    expect(isTextGenerationModel(model({ modelId: 'a' }))).toBe(true);
+    expect(isTextGenerationModel(model({ modelId: 'a', modelType: 'RequestResponse' }))).toBe(true);
+    expect(isTextGenerationModel(model({ modelId: 'a', apiFlavor: 'OpenAiChatCompletions' }))).toBe(
+      true
+    );
+  });
+
+  it('drops realtime models', () => {
+    expect(isTextGenerationModel(model({ modelId: 'a', modelType: 'Realtime' }))).toBe(false);
+  });
+
+  it('drops embeddings flavors', () => {
+    expect(isTextGenerationModel(model({ modelId: 'a', apiFlavor: 'OpenAiEmbeddings' }))).toBe(
+      false
+    );
+    expect(isTextGenerationModel(model({ modelId: 'a', apiFlavor: 'GeminiEmbeddings' }))).toBe(
+      false
+    );
   });
 });

--- a/packages/apollo-react/src/material/components/ap-model-picker/utils.test.ts
+++ b/packages/apollo-react/src/material/components/ap-model-picker/utils.test.ts
@@ -274,20 +274,27 @@ describe('deriveModelTags', () => {
     expect(customIdx).toBeGreaterThan(recIdx);
   });
 
-  it('stamps the cost-tier pool badge by default when the DTO carries cost data', () => {
-    const tags = deriveModelTags(
+  it('does not stamp cost badges unless the product opts in via badgesFor', () => {
+    expect(
+      deriveModelTags(
+        model({
+          modelId: 'a',
+          modelDetails: { costDetails: { flatCosts: { inputTokenCost: 600 } } },
+        })
+      ).find((t) => t.kind.startsWith('cost-'))
+    ).toBeFalsy();
+
+    const opted = deriveModelTags(
       model({
         modelId: 'a',
         modelDetails: { costDetails: { flatCosts: { inputTokenCost: 600 } } },
-      })
+      }),
+      { badgesFor: (m) => (defaultCostTier(m) ? [`cost-${defaultCostTier(m)}` as const] : []) }
     );
-    expect(tags.find((t) => t.kind === 'cost-premium')).toBeTruthy();
+    expect(opted.find((t) => t.kind === 'cost-premium')).toBeTruthy();
   });
 
-  it('does not stamp cost badges without cost data, and badgesFor([]) suppresses them', () => {
-    expect(
-      deriveModelTags(model({ modelId: 'a' })).find((t) => t.kind.startsWith('cost-'))
-    ).toBeFalsy();
+  it('badgesFor([]) suppresses cost badges', () => {
     const suppressed = deriveModelTags(
       model({
         modelId: 'a',

--- a/packages/apollo-react/src/material/components/ap-model-picker/utils.ts
+++ b/packages/apollo-react/src/material/components/ap-model-picker/utils.ts
@@ -26,13 +26,15 @@ export interface DeriveModelTagsContext {
    * production the signal arrives ON the DTO (`model.isRecommended`),
    * merged into the Discovery response from Model_hub configs in
    * `gitops-centralized-cluster` — products should not set this.
-   * When provided (even as an empty array), only listed ids get the
-   * chip.
+   * When provided (even as an empty array), only listed models get the
+   * chip. Entries match `modelId` OR `modelName`, so a list authored
+   * from Model Hub config (which carries names) works as-is.
    */
   recommendedModelIds?: readonly string[];
   /**
    * Test/storybook override for the `preview` signal. Production
-   * sources it from the DTO's `isPreview`.
+   * sources it from the DTO's `isPreview`. Matches by `modelId` or
+   * `modelName`, same as `recommendedModelIds`.
    */
   previewModelIds?: readonly string[];
   /**
@@ -70,6 +72,84 @@ const isByoModel = (m: DiscoveryModel) =>
   !!m.byomDetails ||
   !!m.byoConnectionLabel;
 
+/**
+ * Ready-made `filter` predicate for products that only offer text-generation
+ * models: drops embeddings (by API flavor — `OpenAiEmbeddings`,
+ * `GeminiEmbeddings`) and realtime (by `modelType`).
+ *
+ * The picker does NOT apply this itself: which modalities to offer is a
+ * per-product decision — an indexing or context-grounding surface picks
+ * embeddings from the same catalog. Opt in with
+ * `filter={isTextGenerationModel}`.
+ */
+export function isTextGenerationModel(m: DiscoveryModel): boolean {
+  if (m.modelType === 'Realtime') return false;
+  return !(m.apiFlavor ?? '').includes('Embeddings');
+}
+
+/**
+ * OMS organization region → Discovery geography short code. Mirrors the
+ * gateway's `GeographyRegionMappings` (UiPath.LLMGateway.Domain) — OMS is
+ * the source of truth and serves exactly one canonical value per region.
+ */
+const OMS_REGION_TO_GEOGRAPHY: Record<string, string> = {
+  europe: 'EU',
+  unitedstates: 'US',
+  japan: 'JA',
+  canada: 'CA',
+  australia: 'AU',
+  india: 'IN',
+  unitedkingdom: 'UK',
+  singapore: 'SI',
+  switzerland: 'CH',
+  unitedarabemirates: 'UAE',
+  southkorea: 'SK',
+};
+
+const GEOGRAPHY_CODES = new Set([
+  'EU',
+  'CA',
+  'US',
+  'SI',
+  'JA',
+  'AU',
+  'IN',
+  'UK',
+  'CH',
+  'UAE',
+  'SK',
+  'GLOBAL',
+]);
+
+/**
+ * Resolves the `homeRegion` prop to a Discovery geography code. Accepts a
+ * geography code (`'EU'`) or a raw OMS region name (`'UnitedStates'`,
+ * case-insensitive, separators ignored) so hosts pass
+ * `organization.region` straight through instead of each maintaining a
+ * mapping. Unknown values resolve to `undefined` — no out-of-region chips.
+ * So does `'GLOBAL'`: it is a model routing target, not a place an org
+ * lives, and taking it as one would flag every regional model.
+ */
+export function resolveHomeGeography(homeRegion: string | undefined): string | undefined {
+  const raw = homeRegion?.trim();
+  if (!raw) return undefined;
+  const upper = raw.toUpperCase();
+  if (upper === 'GLOBAL') return undefined;
+  if (GEOGRAPHY_CODES.has(upper)) return upper;
+  return OMS_REGION_TO_GEOGRAPHY[raw.toLowerCase().replace(/[\s_-]/g, '')];
+}
+
+/**
+ * Whether a host-supplied id list names this model. Matches `modelId` OR
+ * `modelName`, mirroring how `value` resolves — Discovery serves the two
+ * equal today, and hosts author these lists from Model Hub config, which
+ * carries model *names*. Matching ids only made a correct list silently
+ * chip nothing the moment the two fields diverge.
+ */
+function listMatchesModel(ids: readonly string[], model: DiscoveryModel): boolean {
+  return ids.includes(model.modelId) || ids.includes(model.modelName);
+}
+
 export function deriveModelTags(
   model: DiscoveryModel,
   context: DeriveModelTagsContext = {}
@@ -100,7 +180,7 @@ export function deriveModelTags(
   // legacy heuristic (for backends that haven't rolled the field out).
   const isRecommended =
     context.recommendedModelIds !== undefined
-      ? context.recommendedModelIds.includes(model.modelId)
+      ? listMatchesModel(context.recommendedModelIds, model)
       : (model.isRecommended ??
         (model.modelSubscriptionType === RECOMMENDED_SUBSCRIPTION &&
           !model.isPreview &&
@@ -117,7 +197,7 @@ export function deriveModelTags(
   // list, DTO `isPreview` otherwise.
   const isPreview =
     context.previewModelIds !== undefined
-      ? context.previewModelIds.includes(model.modelId)
+      ? listMatchesModel(context.previewModelIds, model)
       : !!model.isPreview;
   if (!isByo && isPreview) {
     tags.push({ kind: 'preview', label: localize(TAG_LABELS.preview) });
@@ -186,7 +266,8 @@ export function deriveModelTags(
 
   if (!isByo) {
     const geo = model.routingDetails?.geography;
-    if (geo && context.homeRegion && geo !== 'GLOBAL' && geo !== context.homeRegion) {
+    const home = context.homeRegion === 'GLOBAL' ? undefined : context.homeRegion;
+    if (geo && home && geo !== 'GLOBAL' && geo !== home) {
       tags.push({
         kind: 'out-of-region',
         label: context.i18n
@@ -200,9 +281,9 @@ export function deriveModelTags(
           ? context.i18n._({
               id: 'modelPicker.tag.outOfRegion.tooltip',
               message: 'Routes traffic outside {homeRegion}',
-              values: { homeRegion: context.homeRegion },
+              values: { homeRegion: home },
             })
-          : `Routes traffic outside ${context.homeRegion}`,
+          : `Routes traffic outside ${home}`,
       });
     }
   }
@@ -359,13 +440,13 @@ function buildSubscriptionMatchers(ctx: GroupModelsContext): Array<{
   // (Model_hub merged into Discovery server-side) → legacy heuristic.
   const isRecommended = (m: DiscoveryModel): boolean =>
     ctx.recommendedModelIds !== undefined
-      ? ctx.recommendedModelIds.includes(m.modelId)
+      ? listMatchesModel(ctx.recommendedModelIds, m)
       : (m.isRecommended ??
         (m.modelSubscriptionType === RECOMMENDED_SUBSCRIPTION &&
           !m.isPreview &&
           !m.deprecationDetails?.usageEndDate));
   const isPreview = (m: DiscoveryModel): boolean =>
-    ctx.previewModelIds !== undefined ? ctx.previewModelIds.includes(m.modelId) : !!m.isPreview;
+    ctx.previewModelIds !== undefined ? listMatchesModel(ctx.previewModelIds, m) : !!m.isPreview;
   const localize = (desc: { id: string; message?: string }): string => {
     if (ctx.i18n) return tr(ctx.i18n, desc);
     return desc.message ?? desc.id;

--- a/packages/apollo-react/src/material/components/ap-model-picker/utils.ts
+++ b/packages/apollo-react/src/material/components/ap-model-picker/utils.ts
@@ -291,18 +291,9 @@ export function deriveModelTags(
   // Product chips come last — the picker's canonical signals
   // (Recommended / Preview / lifecycle) should always read first so
   // users see the design-system semantics before any tenant noise.
-  // Pool badges first (sanctioned, centrally defined), then any
-  // free-form `customTagsFor` extras (escape hatch).
-  // Default: stamp the model's cost tier from the pool whenever the DTO
-  // carries cost data — every product gets cost badges with no wiring.
-  // A host-supplied `badgesFor` takes over entirely (return [] to
-  // suppress badges).
-  const poolBadges =
-    context.badgesFor?.(model) ??
-    (() => {
-      const tier = defaultCostTier(model);
-      return tier ? ([`cost-${tier}`] as const) : [];
-    })();
+  // Pool badges (sanctioned, centrally defined), then any free-form
+  // `customTagsFor` extras (escape hatch).
+  const poolBadges = context.badgesFor?.(model) ?? [];
   for (const kind of poolBadges) {
     const def = MODEL_BADGES[kind];
     if (!def) continue;
@@ -322,21 +313,21 @@ export function deriveModelTags(
 }
 
 /**
- * EXAMPLE cost-tier classifier — the picker does NOT stamp cost chips
- * itself. Products that want cost badges (agents does) map a model to
- * one of the pool's cost kinds via `badgesFor`:
+ * Cost-tier classifier. A product decision the picker does not make for
+ * you: what counts as expensive is a product call, not a design-system
+ * one, so the thresholds live in your code, not here. This is the
+ * example classifier the picker used to ship; copy it and tune it, or
+ * classify on something else entirely — the pool badge kinds are the
+ * shared contract, the classifier is yours.
  *
  *   badgesFor={(m) => {
  *     const tier = defaultCostTier(m);
  *     return tier ? [`cost-${tier}` as const] : [];
  *   }}
  *
- * Bins Discovery's `costDetails.flatCosts.inputTokenCost` (cents per million input tokens) at
- * $1 / $5. Copy it and change the thresholds, or classify on something
- * else entirely — the pool badge kinds are the shared contract, the
- * classifier is yours.
+ * Bins Discovery's `costDetails.flatCosts.inputTokenCost` (cents per
+ * million input tokens) at $1 / $5.
  */
-// Cents per million input tokens: $1/M and $5/M.
 const DEFAULT_BASIC_THRESHOLD = 100;
 const DEFAULT_PREMIUM_THRESHOLD = 500;
 export function defaultCostTier(model: DiscoveryModel): CostTier | null {


### PR DESCRIPTION
The picker stamped cost-tier chips itself whenever the DTO carried cost data, using hardcoded $1/M and $5/M thresholds. That made a product decision — what counts as expensive — in the design system, where no product could configure it. Its own doc comment said the picker did NOT do this; the code did.

The picker now stamps nothing unless the product passes `badgesFor`. `defaultCostTier` stays as the example classifier, documented as such — copy it and tune the thresholds, or classify on something else. The pool badge kinds are the shared contract; the classifier is not.

104 tests. The "stamps by default" test is now "does not stamp unless opted in"; `badgesFor([])` suppression is its own case.