### PR TITLE
fix(apollo-react): disambiguate BYO selections by connection id

### DIFF
--- a/packages/apollo-react/src/material/components/ap-model-picker/ModelPicker.test.tsx
+++ b/packages/apollo-react/src/material/components/ap-model-picker/ModelPicker.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, within } from '@testing-library/react';
+import { cleanup, render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import type React from 'react';
 import { describe, expect, it, vi } from 'vitest';
@@ -47,6 +47,49 @@ describe('<ModelPicker>', () => {
       <ModelPicker models={MODELS} value="anthropic.claude-sonnet-4-6" onChange={() => {}} />
     );
     expect(screen.getByText('anthropic.claude-sonnet-4-6')).toBeInTheDocument();
+  });
+
+  it('disambiguates two BYO rows with the same model name by valueConnectionId', async () => {
+    const user = userEvent.setup();
+    const models: DiscoveryModel[] = [
+      {
+        modelId: 'byo-gpt-4o-acme',
+        modelName: 'gpt-4o',
+        vendor: 'OpenAi',
+        modelSubscriptionType: 'BYOMAdded',
+        byomDetails: { integrationServiceConnectionId: 'conn-acme' },
+        byoConnectionLabel: 'Acme Azure',
+      },
+      {
+        modelId: 'byo-gpt-4o-cigna',
+        modelName: 'gpt-4o',
+        vendor: 'OpenAi',
+        modelSubscriptionType: 'BYOMAdded',
+        byomDetails: { integrationServiceConnectionId: 'conn-cigna' },
+        byoConnectionLabel: 'Cigna Sandbox',
+      },
+    ];
+
+    // Without valueConnectionId, `value="gpt-4o"` matches the first row (Acme).
+    renderPicker(<ModelPicker models={models} value="gpt-4o" onChange={() => {}} />);
+    await user.click(screen.getByRole('button', { expanded: false }));
+    const acmeRow = await screen.findByRole('option', { name: /Acme Azure/i });
+    expect(acmeRow).toHaveAttribute('aria-selected', 'true');
+
+    cleanup();
+
+    // With valueConnectionId="conn-cigna", the Cigna row is selected instead.
+    renderPicker(
+      <ModelPicker
+        models={models}
+        value="gpt-4o"
+        valueConnectionId="conn-cigna"
+        onChange={() => {}}
+      />
+    );
+    await user.click(screen.getByRole('button', { expanded: false }));
+    const cignaRow = await screen.findByRole('option', { name: /Cigna Sandbox/i });
+    expect(cignaRow).toHaveAttribute('aria-selected', 'true');
   });
 
   it('renders the Discovery displayName as the friendly label', () => {

--- a/packages/apollo-react/src/material/components/ap-model-picker/ModelPicker.tsx
+++ b/packages/apollo-react/src/material/components/ap-model-picker/ModelPicker.tsx
@@ -131,6 +131,14 @@ export interface ModelPickerProps {
   /** Selected `modelId`, or `null`/`undefined` for no selection. */
   value?: string | null;
   /**
+   * Connection id of the selected BYO model. Two BYO configurations can
+   * serve the same model name under different connections; `value` alone
+   * matches the first, so the wrong row highlights. When provided,
+   * selection also requires `byomDetails.integrationServiceConnectionId`
+   * to match. Omit for non-BYO selections.
+   */
+  valueConnectionId?: string | null;
+  /**
    * Selection callback — receives the picked `DiscoveryModel`. See
    * `ModelPickerChangeHandler` above for the migration note from the
    * legacy `(modelId, model)` shape.
@@ -368,6 +376,7 @@ export const ModelPicker = React.forwardRef<HTMLButtonElement, ModelPickerProps>
     {
       models,
       value,
+      valueConnectionId,
       onChange,
       label,
       required,
@@ -528,6 +537,7 @@ export const ModelPicker = React.forwardRef<HTMLButtonElement, ModelPickerProps>
     const state = useModelPickerState({
       models: effectiveModels,
       value,
+      valueConnectionId,
       onChange,
       groupBy,
       recommendedModelIds,
@@ -978,7 +988,7 @@ export const ModelPicker = React.forwardRef<HTMLButtonElement, ModelPickerProps>
                 options={filtered}
                 activeIndex={activeIndex}
                 setActiveIndex={setActiveIndex}
-                selectedId={value ?? null}
+                selectedId={selected?.modelId ?? value ?? null}
                 onSelect={choose}
                 tagContext={tagContext}
                 tagVariants={customTagVariants}

--- a/packages/apollo-react/src/material/components/ap-model-picker/useModelPickerState.ts
+++ b/packages/apollo-react/src/material/components/ap-model-picker/useModelPickerState.ts
@@ -9,6 +9,15 @@ export interface UseModelPickerStateOptions {
   models: DiscoveryModel[];
   value?: string | null;
   /**
+   * Connection id of the selected BYO model, when the host persists one.
+   * Disambiguates two BYO configurations that serve the same model name
+   * under different connections: `value` alone matches the first row,
+   * so the wrong one highlights. When provided, `matchesValue` also
+   * requires `byomDetails.integrationServiceConnectionId` to equal this.
+   * Omit for non-BYO selections.
+   */
+  valueConnectionId?: string | null;
+  /**
    * Selection callback. New shape: `(model)`. Legacy `(modelId, model)`
    * callers can wrap at the call site — see `ModelPickerChangeHandler`
    * in ModelPicker.tsx for the migration note.
@@ -119,6 +128,7 @@ export function useModelPickerState(opts: UseModelPickerStateOptions): UseModelP
   const {
     models,
     value,
+    valueConnectionId,
     onChange,
     groupBy: initialGroupBy = 'subscription',
     recommendedModelIds,
@@ -192,8 +202,14 @@ export function useModelPickerState(opts: UseModelPickerStateOptions): UseModelP
   // but hosts persist model *names*, so name matching keeps stored
   // selections resolving if the two ever diverge.
   const matchesValue = useCallback(
-    (m: DiscoveryModel) => m.modelId === value || m.modelName === value,
-    [value]
+    (m: DiscoveryModel) => {
+      if (valueConnectionId) {
+        const connId = m.byomDetails?.integrationServiceConnectionId;
+        if (connId !== valueConnectionId) return false;
+      }
+      return m.modelId === value || m.modelName === value;
+    },
+    [value, valueConnectionId]
   );
   const selected = useMemo<DiscoveryModel | null>(
     () => annotated.find(matchesValue) ?? models.find(matchesValue) ?? null,


### PR DESCRIPTION
Two BYO configurations can serve the same model name under different connections. `value` alone matches the first row, so the wrong one highlights — and an `onChange` from the wrong row can overwrite the persisted connection id.

**New `valueConnectionId` prop:** when provided, `matchesValue` also requires `byomDetails.integrationServiceConnectionId` to equal it, so the resolved selection is the right row. Omit for non-BYO selections.

**Also fixes a pre-existing bug** the new test exposed: the row highlight compared `opt.modelId` against `value` directly, bypassing the hook's id-or-name resolution. Now uses `selected?.modelId`, so a `value` passed as `modelName` highlights correctly too.

105 tests, +1: two BYO rows with the same name, same `value`, different `valueConnectionId` — the right row gets `aria-selected`.