### PR TITLE
ci(repo): bump uip-go to 0.3.3 for gateway-error deploy retries

### DIFF
--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -13,7 +13,7 @@ permissions: {}
 env:
   TURBO_TELEMETRY_DISABLED: 1
   DO_NOT_TRACK: 1
-  UIP_GO_VERSION: 0.3.2
+  UIP_GO_VERSION: 0.3.3
 
 concurrency:
   group: coded-app-preview-pr-${{ github.event.pull_request.number }}

--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -16,7 +16,7 @@ concurrency:
 env:
   TURBO_TELEMETRY_DISABLED: 1
   DO_NOT_TRACK: 1
-  UIP_GO_VERSION: 0.3.2
+  UIP_GO_VERSION: 0.3.3
 
 jobs:
   deploy:


### PR DESCRIPTION
## What

Bumps `UIP_GO_VERSION` from 0.3.2 to 0.3.3 in both `preview-deploy.yml` and `production-deploy.yml`.

## Why

0.3.3 (uip-go [PR #3](https://github.com/UiPath/uip-go/pull/3)) makes Coded App deploys resilient to the intermittent staging gateway errors that have been failing preview deploys (most often apollo-design, the heaviest package). It retries publish/registration and the deploy API calls on transient gateway statuses (HTTP 520, 504, and other 5xx) and network errors, using the existing `--deploy-retries` / `--deploy-retry-delay-ms` budget, so a blip is retried in-process instead of failing the job and needing a manual re-run.

## Note

This is a mitigation for transient origin blips, not a cure for a sustained staging outage; a failure that outlasts the retry window can still occur.
