### PR TITLE
feat(apollo-react): persist edge routing and fix router anchors

### DIFF
--- a/packages/apollo-react/src/canvas/components/Edges/CanvasEdge.test.tsx
+++ b/packages/apollo-react/src/canvas/components/Edges/CanvasEdge.test.tsx
@@ -5,15 +5,21 @@ import { BaseCanvasModeProvider } from '../BaseCanvas/BaseCanvasModeProvider';
 import { CanvasEdge } from './CanvasEdge';
 import type { CanvasEdgeProps } from './shared/types';
 
-const { addSelectedEdges, edgeLookup, getState, setState, unselectNodesAndEdges } = vi.hoisted(
-  () => ({
+const { addSelectedEdges, edgeLookup, getState, setState, unselectNodesAndEdges, useEdgeGeometry } =
+  vi.hoisted(() => ({
     addSelectedEdges: vi.fn(),
     edgeLookup: new Map(),
     getState: vi.fn(),
     setState: vi.fn(),
     unselectNodesAndEdges: vi.fn(),
-  })
-);
+    useEdgeGeometry: vi.fn((_args: { autoRouted: boolean }) => ({
+      arrow: { angle: 0, offset: 0 },
+      edgePath: 'M 0 0 L 100 0',
+      labelPoint: { x: 50, y: 0 },
+      pathPoints: [],
+      segments: [],
+    })),
+  }));
 
 vi.mock('@uipath/apollo-react/canvas/xyflow/react', async () => {
   const actual = await vi.importActual('@uipath/apollo-react/canvas/xyflow/react');
@@ -21,13 +27,7 @@ vi.mock('@uipath/apollo-react/canvas/xyflow/react', async () => {
 });
 
 vi.mock('./shared/hooks', () => ({
-  useEdgeGeometry: () => ({
-    arrow: { angle: 0, offset: 0 },
-    edgePath: 'M 0 0 L 100 0',
-    labelPoint: { x: 50, y: 0 },
-    pathPoints: [],
-    segments: [],
-  }),
+  useEdgeGeometry,
   useExecutionEdge: () => ({ animation: null, statusColor: undefined }),
   useNodeDragRebalance: ({ waypoints }: { waypoints: unknown[] }) => waypoints,
   useWaypointEditor: () => ({
@@ -69,7 +69,8 @@ const baseProps = {
 
 function renderEdge(
   mode: 'design' | 'readonly' = 'design',
-  edge: { selected?: boolean; selectable?: boolean } = {}
+  edge: { selected?: boolean; selectable?: boolean } = {},
+  data: CanvasEdgeProps['data'] = baseProps.data
 ) {
   edgeLookup.set('e1', { id: 'e1', ...edge });
   getState.mockReturnValue({
@@ -83,7 +84,7 @@ function renderEdge(
   render(
     <BaseCanvasModeProvider mode={mode}>
       <svg>
-        <CanvasEdge {...baseProps} selected={edge.selected ?? false} />
+        <CanvasEdge {...baseProps} data={data} selected={edge.selected ?? false} />
       </svg>
     </BaseCanvasModeProvider>
   );
@@ -138,5 +139,43 @@ describe('CanvasEdge label selection', () => {
 
     expect(addSelectedEdges).not.toHaveBeenCalled();
     expect(setState).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * `autoRouted` is what applies node-face clearance, so a host that persists both
+ * route fields needs it to be a declared input rather than something inferred
+ * from which key the route happened to land in.
+ */
+describe('CanvasEdge autoRouted', () => {
+  const lastAutoRouted = () => useEdgeGeometry.mock.lastCall?.[0].autoRouted;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    edgeLookup.clear();
+  });
+
+  it('treats a route arriving in routedWaypoints as auto-routed', () => {
+    renderEdge('design', {}, { routedWaypoints: [{ id: 'r0', x: 50, y: 20 }] });
+
+    expect(lastAutoRouted()).toBe(true);
+  });
+
+  it('treats manual waypoints as not auto-routed', () => {
+    renderEdge('design', {}, { waypoints: [{ id: 'w1', x: 50, y: 20 }] });
+
+    expect(lastAutoRouted()).toBe(false);
+  });
+
+  it('honours an explicit flag over the field the route arrived in', () => {
+    renderEdge('design', {}, { waypoints: [{ id: 'w1', x: 50, y: 20 }], autoRouted: true });
+
+    expect(lastAutoRouted()).toBe(true);
+  });
+
+  it('honours an explicit false for a route stored in routedWaypoints', () => {
+    renderEdge('design', {}, { routedWaypoints: [{ id: 'r0', x: 50, y: 20 }], autoRouted: false });
+
+    expect(lastAutoRouted()).toBe(false);
   });
 });

--- a/packages/apollo-react/src/canvas/components/Edges/CanvasEdge.tsx
+++ b/packages/apollo-react/src/canvas/components/Edges/CanvasEdge.tsx
@@ -27,6 +27,9 @@ import type { CanvasEdgeProps } from './shared/types';
  * on `data`:
  *
  * - `routing: 'waypoint' | 'handle'` (default `'waypoint'`)
+ * - `autoRouted`      — route came from a router/layout engine, so its bends get
+ *                       node-face clearance (default: inferred from whether the
+ *                       route arrived in `waypoints` or `routedWaypoints`)
  * - `enableEditing`   — drag/insert/remove waypoints (waypoint routing only)
  * - `enableExecution` — subscribe to execution + validation status
  * - `enableToolbar`   — render add-node toolbar
@@ -126,8 +129,7 @@ export const CanvasEdge = memo(function CanvasEdge({
     targetY,
     targetPosition,
     waypoints: effectiveWaypoints,
-    // Face-clearance applies to router waypoints only; manual ones render as-is.
-    autoRouted: waypoints.length === 0,
+    autoRouted: data?.autoRouted ?? waypoints.length === 0,
     enableSegments: editingEnabled,
     hideArrowHead,
     enableLineJumps: !!data?.enableLineJumps,

--- a/packages/apollo-react/src/canvas/components/Edges/index.ts
+++ b/packages/apollo-react/src/canvas/components/Edges/index.ts
@@ -1,17 +1,25 @@
 export { CanvasEdge } from './CanvasEdge';
 export * from './SequenceEdge';
 export { EdgeCrossingsProvider } from './shared/crossings';
+// Pure route geometry. Exported so a host that moves nodes itself (auto-layout,
+// paste, subflow expand/collapse, container auto-fit) can keep stored routes
+// attached with the same math the drag path uses, instead of reimplementing it.
+export { calculateAutoWaypoints, snapPointToGrid } from './shared/geometry';
 export type {
   EdgeRouter,
   RouteAnchor,
+  RouteAnchorPair,
   RoutedEdge,
   RouteEdgeRequest,
+  RouteNodeLookup,
   RouteNodeRequest,
   RouteRequest,
 } from './shared/routing';
 export {
   defaultEdgeRouter,
   defaultIsRoutable,
+  resolveRouteAnchors,
+  toRouteNode,
   useGraphRouter,
 } from './shared/routing';
 export type {
@@ -25,3 +33,11 @@ export type {
   SegmentOrientation,
   Waypoint,
 } from './shared/types';
+export type { RebalanceEndpoint } from './shared/waypoints';
+export {
+  generateWaypointId,
+  moveWaypoint,
+  rebalanceWaypoints,
+  waypointsEqual,
+  waypointsPositionallyEqual,
+} from './shared/waypoints';

--- a/packages/apollo-react/src/canvas/components/Edges/shared/geometry.ts
+++ b/packages/apollo-react/src/canvas/components/Edges/shared/geometry.ts
@@ -56,6 +56,18 @@ function getCollinearAxis(
 /**
  * Auto-route a path between source and target with orthogonal segments
  * when no manual waypoints are provided.
+ *
+ * The turn convention is load-bearing for anyone generating routes externally,
+ * because this is what the user sees the instant a stored route is dropped or a
+ * node is dragged. When both faces exit on the same axis, the jog sits at the
+ * **midpoint between the two (offset) anchors** on that axis, snapped to the
+ * grid; for adjacent layers that is exactly half the layer gap. When the faces
+ * exit on different axes, a single elbow forms the L.
+ *
+ * A host layout engine that puts its turns anywhere else will produce edges that
+ * visibly jump the first time a node moves, with no obstacle to justify the new
+ * path. Call this function in a test to assert agreement rather than checking by
+ * eye.
  */
 export function calculateAutoWaypoints(
   sourceX: number,

--- a/packages/apollo-react/src/canvas/components/Edges/shared/routing/anchors.test.ts
+++ b/packages/apollo-react/src/canvas/components/Edges/shared/routing/anchors.test.ts
@@ -1,0 +1,208 @@
+import {
+  ConnectionMode,
+  type Edge,
+  type InternalNode,
+  Position,
+} from '@uipath/apollo-react/canvas/xyflow/react';
+import { describe, expect, it, vi } from 'vitest';
+
+// These resolvers run against real React Flow node internals; the global canvas
+// test setup stubs the module out entirely.
+vi.unmock('@uipath/apollo-react/canvas/xyflow/react');
+
+import { type RouteNodeLookup, resolveRouteAnchors, toRouteNode } from './anchors';
+
+type HandleSpec = {
+  id: string | null;
+  position: Position;
+  x: number;
+  y: number;
+};
+
+/**
+ * A node as React Flow's store holds it: `position` is parent-relative, while
+ * `internals.positionAbsolute` is resolved against the parent chain.
+ */
+function makeNode(
+  id: string,
+  {
+    position,
+    positionAbsolute = position,
+    width = 100,
+    height = 40,
+    sourceHandles = [],
+    targetHandles = [],
+    measured = true,
+  }: {
+    position: { x: number; y: number };
+    positionAbsolute?: { x: number; y: number };
+    width?: number;
+    height?: number;
+    sourceHandles?: HandleSpec[];
+    targetHandles?: HandleSpec[];
+    measured?: boolean;
+  }
+): InternalNode {
+  const toHandles = (specs: HandleSpec[], type: 'source' | 'target') =>
+    specs.map((spec) => ({
+      ...spec,
+      nodeId: id,
+      type,
+      width: 10,
+      height: 10,
+    }));
+
+  return {
+    id,
+    position,
+    data: {},
+    width,
+    height,
+    measured: { width, height },
+    internals: {
+      positionAbsolute,
+      z: 0,
+      userNode: { id, position, data: {} },
+      handleBounds: measured
+        ? {
+            source: toHandles(sourceHandles, 'source'),
+            target: toHandles(targetHandles, 'target'),
+          }
+        : undefined,
+    },
+  } as unknown as InternalNode;
+}
+
+function makeEdge(overrides: Partial<Edge> = {}): Edge {
+  return { id: 'e1', source: 'a', target: 'b', ...overrides };
+}
+
+function lookup(...nodes: InternalNode[]): RouteNodeLookup {
+  return new Map(nodes.map((node) => [node.id, node])) as RouteNodeLookup;
+}
+
+describe('toRouteNode', () => {
+  it('reports the absolute box for a child of a container, not the parent-relative one', () => {
+    const child = makeNode('child', {
+      position: { x: 40, y: 20 },
+      positionAbsolute: { x: 540, y: 320 },
+    });
+
+    expect(toRouteNode(child)).toEqual({ id: 'child', x: 540, y: 320, width: 100, height: 40 });
+  });
+});
+
+describe('resolveRouteAnchors', () => {
+  it('resolves anchors from the addressed handle on a multi-handle node', () => {
+    // Two source handles stacked on the right face: routing from the second one
+    // must not land on the node-box midpoint the first one is near.
+    const source = makeNode('a', {
+      position: { x: 0, y: 0 },
+      sourceHandles: [
+        { id: 'continue', position: Position.Right, x: 95, y: 5 },
+        { id: 'start', position: Position.Right, x: 95, y: 25 },
+      ],
+    });
+    const target = makeNode('b', {
+      position: { x: 300, y: 0 },
+      targetHandles: [{ id: 'input', position: Position.Left, x: -5, y: 15 }],
+    });
+
+    const anchors = resolveRouteAnchors(
+      lookup(source, target),
+      makeEdge({ sourceHandle: 'start', targetHandle: 'input' }),
+      ConnectionMode.Strict
+    );
+
+    // Right face: x is the handle's far edge, y its centre.
+    expect(anchors?.source).toEqual({
+      nodeId: 'a',
+      handleId: 'start',
+      x: 105,
+      y: 30,
+      position: Position.Right,
+    });
+    // Left face: x is the handle's near edge, y its centre.
+    expect(anchors?.target).toEqual({
+      nodeId: 'b',
+      handleId: 'input',
+      x: 295,
+      y: 20,
+      position: Position.Left,
+    });
+  });
+
+  it('anchors a nested node from its absolute position', () => {
+    const child = makeNode('a', {
+      position: { x: 40, y: 20 },
+      positionAbsolute: { x: 540, y: 320 },
+      sourceHandles: [{ id: 'out', position: Position.Right, x: 95, y: 15 }],
+    });
+    const target = makeNode('b', {
+      position: { x: 900, y: 320 },
+      targetHandles: [{ id: 'in', position: Position.Left, x: -5, y: 15 }],
+    });
+
+    const anchors = resolveRouteAnchors(
+      lookup(child, target),
+      makeEdge({ sourceHandle: 'out', targetHandle: 'in' }),
+      ConnectionMode.Strict
+    );
+
+    expect(anchors?.source.x).toBe(645);
+    expect(anchors?.source.y).toBe(340);
+  });
+
+  it('honours a handle on a face other than left/right', () => {
+    const source = makeNode('a', {
+      position: { x: 0, y: 0 },
+      sourceHandles: [{ id: 'out', position: Position.Bottom, x: 45, y: 35 }],
+    });
+    const target = makeNode('b', {
+      position: { x: 0, y: 200 },
+      targetHandles: [{ id: 'in', position: Position.Top, x: 45, y: -5 }],
+    });
+
+    const anchors = resolveRouteAnchors(
+      lookup(source, target),
+      makeEdge({ sourceHandle: 'out', targetHandle: 'in' }),
+      ConnectionMode.Strict
+    );
+
+    // Bottom face: y is the handle's far edge; top face: its near edge.
+    expect(anchors?.source).toMatchObject({ x: 50, y: 45, position: Position.Bottom });
+    expect(anchors?.target).toMatchObject({ x: 50, y: 195, position: Position.Top });
+  });
+
+  it('falls back to node-box faces when handles are not measured yet', () => {
+    const source = makeNode('a', { position: { x: 0, y: 0 }, measured: false });
+    const target = makeNode('b', {
+      position: { x: 100, y: 100 },
+      positionAbsolute: { x: 400, y: 100 },
+      measured: false,
+    });
+
+    const anchors = resolveRouteAnchors(lookup(source, target), makeEdge(), ConnectionMode.Strict);
+
+    expect(anchors?.source).toEqual({
+      nodeId: 'a',
+      handleId: null,
+      x: 100,
+      y: 20,
+      position: Position.Right,
+    });
+    expect(anchors?.target).toEqual({
+      nodeId: 'b',
+      handleId: null,
+      x: 400,
+      y: 120,
+      position: Position.Left,
+    });
+  });
+
+  it('returns null for a dangling edge', () => {
+    const source = makeNode('a', { position: { x: 0, y: 0 } });
+
+    expect(resolveRouteAnchors(lookup(source), makeEdge(), ConnectionMode.Strict)).toBeNull();
+  });
+});

--- a/packages/apollo-react/src/canvas/components/Edges/shared/routing/anchors.ts
+++ b/packages/apollo-react/src/canvas/components/Edges/shared/routing/anchors.ts
@@ -1,0 +1,106 @@
+import {
+  type ConnectionMode,
+  type Edge,
+  type InternalNode,
+  Position,
+  type ReactFlowState,
+} from '@uipath/apollo-react/canvas/xyflow/react';
+import { getEdgePosition } from '@uipath/apollo-react/canvas/xyflow/system';
+import { getNodeDimensions } from '../../../../utils/container';
+import type { RouteAnchor, RouteNodeRequest } from './types';
+
+export type RouteNodeLookup = ReactFlowState['nodeLookup'];
+
+export type RouteAnchorPair = {
+  source: RouteAnchor;
+  target: RouteAnchor;
+};
+
+/**
+ * A node as the router sees it, in absolute canvas coordinates.
+ *
+ * `internals.positionAbsolute` rather than `position`: a node with a `parentId`
+ * stores a parent-relative position, so reading `position` puts every child of a
+ * container into the request short by the container's own position and the whole
+ * route is computed in the wrong frame.
+ */
+export function toRouteNode(node: InternalNode): RouteNodeRequest {
+  const { width, height } = getNodeDimensions(node);
+  const { x, y } = node.internals.positionAbsolute;
+  return { id: node.id, x, y, width, height };
+}
+
+/**
+ * The absolute anchor points an edge actually attaches to, resolved from the
+ * handle geometry React Flow measured, so the router plans from the same points
+ * the renderer draws from. Nodes with several handles (containers, branching
+ * nodes, multi-port nodes) would otherwise be routed from a point no handle
+ * occupies.
+ *
+ * Returns `null` when either endpoint node is missing (a dangling edge). When
+ * the nodes exist but handle bounds aren't available yet — first render, before
+ * measurement — falls back to the node-box faces of a left-to-right flow, which
+ * is what this used to do unconditionally.
+ */
+export function resolveRouteAnchors(
+  nodeLookup: RouteNodeLookup,
+  edge: Edge,
+  connectionMode: ConnectionMode
+): RouteAnchorPair | null {
+  const sourceNode = nodeLookup.get(edge.source);
+  const targetNode = nodeLookup.get(edge.target);
+  if (!sourceNode || !targetNode) return null;
+
+  const sourceHandle = edge.sourceHandle ?? null;
+  const targetHandle = edge.targetHandle ?? null;
+
+  const position = getEdgePosition({
+    id: edge.id,
+    sourceNode,
+    sourceHandle,
+    targetNode,
+    targetHandle,
+    connectionMode,
+  });
+
+  if (!position) {
+    return {
+      source: approximateAnchor(sourceNode, sourceHandle, Position.Right),
+      target: approximateAnchor(targetNode, targetHandle, Position.Left),
+    };
+  }
+
+  return {
+    source: {
+      nodeId: sourceNode.id,
+      handleId: sourceHandle,
+      x: position.sourceX,
+      y: position.sourceY,
+      position: position.sourcePosition,
+    },
+    target: {
+      nodeId: targetNode.id,
+      handleId: targetHandle,
+      x: position.targetX,
+      y: position.targetY,
+      position: position.targetPosition,
+    },
+  };
+}
+
+/** Node-box face midpoint, for when no measured handle is available. */
+function approximateAnchor(
+  node: InternalNode,
+  handleId: string | null,
+  face: Position.Left | Position.Right
+): RouteAnchor {
+  const { width, height } = getNodeDimensions(node);
+  const { x, y } = node.internals.positionAbsolute;
+  return {
+    nodeId: node.id,
+    handleId,
+    x: face === Position.Right ? x + width : x,
+    y: y + height / 2,
+    position: face,
+  };
+}

--- a/packages/apollo-react/src/canvas/components/Edges/shared/routing/index.ts
+++ b/packages/apollo-react/src/canvas/components/Edges/shared/routing/index.ts
@@ -1,3 +1,5 @@
+export type { RouteAnchorPair, RouteNodeLookup } from './anchors';
+export { resolveRouteAnchors, toRouteNode } from './anchors';
 export { defaultEdgeRouter } from './defaultEdgeRouter';
 export type {
   EdgeRouter,

--- a/packages/apollo-react/src/canvas/components/Edges/shared/routing/useGraphRouter.test.tsx
+++ b/packages/apollo-react/src/canvas/components/Edges/shared/routing/useGraphRouter.test.tsx
@@ -50,12 +50,12 @@ function Probe({ router, latestEdges }: { router: EdgeRouter; latestEdges: { cur
   return null;
 }
 
-function renderRouter(initialEdges: Edge[], router: EdgeRouter) {
+function renderRouter(initialEdges: Edge[], router: EdgeRouter, graphNodes: Node[] = nodes) {
   const latestEdges = { current: initialEdges };
   render(
     // defaultNodes/defaultEdges (not initial*) make the store own the elements,
     // so the hook's setEdges writes land instead of no-opping as "controlled".
-    <ReactFlowProvider defaultNodes={nodes} defaultEdges={initialEdges}>
+    <ReactFlowProvider defaultNodes={graphNodes} defaultEdges={initialEdges}>
       <Probe router={router} latestEdges={latestEdges} />
     </ReactFlowProvider>
   );
@@ -129,6 +129,38 @@ describe('useGraphRouter', () => {
       expect((edge?.data as CanvasEdgeData).routedWaypoints).toBeDefined();
     });
     expect(requests.length).toBe(1);
+  });
+
+  it('requests nested nodes in absolute coordinates, not parent-relative ones', async () => {
+    const { router, requests } = makeRecordingRouter();
+    renderRouter(
+      [{ id: 'nested', source: 'child', target: 'b', data: { routing: 'waypoint' } }],
+      router,
+      [
+        { id: 'container', position: { x: 500, y: 300 }, width: 400, height: 200, data: {} },
+        {
+          id: 'child',
+          parentId: 'container',
+          // Parent-relative, as React Flow stores it for a child node.
+          position: { x: 40, y: 20 },
+          width: 100,
+          height: 40,
+          data: {},
+        },
+        { id: 'b', position: { x: 1000, y: 320 }, width: 100, height: 40, data: {} },
+      ]
+    );
+
+    await waitFor(() => expect(requests.length).toBeGreaterThan(0));
+
+    const child = requests[0]!.nodes.find((node) => node.id === 'child');
+    expect(child).toMatchObject({ x: 540, y: 320 });
+
+    // Anchors sit on the child's absolute box, so the route is planned in the
+    // same coordinate frame the edge is drawn in.
+    const routed = requests[0]!.edges[0]!;
+    expect(routed.source).toMatchObject({ x: 640, y: 340 });
+    expect(routed.target).toMatchObject({ x: 1000, y: 340 });
   });
 
   it('never invokes the router when no edge is routable and nothing is stale', async () => {

--- a/packages/apollo-react/src/canvas/components/Edges/shared/routing/useGraphRouter.ts
+++ b/packages/apollo-react/src/canvas/components/Edges/shared/routing/useGraphRouter.ts
@@ -1,22 +1,17 @@
 import {
+  type ConnectionMode,
   type Edge,
-  type Node,
-  Position,
   type ReactFlowState,
   useReactFlow,
   useStore,
+  useStoreApi,
 } from '@uipath/apollo-react/canvas/xyflow/react';
 import { useCallback, useEffect } from 'react';
 import { getNodeDimensions } from '../../../../utils/container';
 import type { CanvasEdgeData } from '../types';
 import { waypointsPositionallyEqual } from '../waypoints';
-import type {
-  EdgeRouter,
-  RoutedEdge,
-  RouteEdgeRequest,
-  RouteNodeRequest,
-  RouteRequest,
-} from './types';
+import { type RouteNodeLookup, resolveRouteAnchors, toRouteNode } from './anchors';
+import type { EdgeRouter, RoutedEdge, RouteEdgeRequest, RouteRequest } from './types';
 
 /**
  * An edge is router-controlled only while it explicitly declares
@@ -66,15 +61,18 @@ export function defaultIsRoutable(edge: Edge): boolean {
  * Both `router` and `isRoutable` must be referentially stable (module
  * constants or memoized) — new identities re-run routing every render.
  *
- * Handle positions are approximated as the right edge of the source node
- * and the left edge of the target node. Routers needing precise handle
- * locations can introspect React Flow's handle bounds directly.
+ * Anchors and node boxes are absolute canvas coordinates resolved from React
+ * Flow's measured handle bounds (see {@link resolveRouteAnchors}), so nested
+ * graphs and multi-handle nodes are routed from the same points the renderer
+ * draws from. Before handles are measured, anchors fall back to the node-box
+ * faces of a left-to-right flow.
  */
 export function useGraphRouter(
   router: EdgeRouter,
   isRoutable: (edge: Edge) => boolean = defaultIsRoutable
 ): void {
-  const { getNodes, getEdges, setEdges } = useReactFlow();
+  const { getEdges, setEdges } = useReactFlow();
+  const store = useStoreApi();
   const signature = useStore(
     useCallback((state: ReactFlowState) => routeSignature(state, isRoutable), [isRoutable])
   );
@@ -118,7 +116,8 @@ export function useGraphRouter(
       return;
     }
 
-    const request = buildRequest(getNodes(), edges, isRoutable);
+    const { nodeLookup, connectionMode } = store.getState();
+    const request = buildRequest(nodeLookup, edges, isRoutable, connectionMode);
     if (request.edges.length === 0) {
       // Routable edges exist but none could be resolved (dangling endpoints).
       apply([]);
@@ -139,7 +138,7 @@ export function useGraphRouter(
     return () => {
       cancelled = true;
     };
-  }, [signature, router, isRoutable, getNodes, getEdges, setEdges]);
+  }, [signature, router, isRoutable, store, getEdges, setEdges]);
 }
 
 /**
@@ -177,12 +176,21 @@ function reconcileEdge(
  * edge `data` — except each edge's routability, so the transition to/from
  * manual waypoints triggers a reconcile (routing or cleanup) — and notably
  * excludes `routedWaypoints`, so the router's own output never re-triggers it.
+ *
+ * Node boxes are absolute, and each node carries its handle counts, so the first
+ * measurement — and any port added or removed afterwards — re-routes even when
+ * no node box changed. Resolving each edge's anchors here instead would be the
+ * exact input, but it roughly triples the cost of a selector that runs on every
+ * store update; anything that moves a handle without changing the handle set
+ * moves the node box too.
  */
 function routeSignature(state: ReactFlowState, isRoutable: (edge: Edge) => boolean): string {
   let sig = '';
-  for (const node of state.nodes) {
+  for (const node of state.nodeLookup.values()) {
     const { width, height } = getNodeDimensions(node);
-    sig += `${node.id}:${node.position.x},${node.position.y},${width},${height}|`;
+    const { x, y } = node.internals.positionAbsolute;
+    const bounds = node.internals.handleBounds;
+    sig += `${node.id}:${x},${y},${width},${height},${bounds?.source?.length ?? -1},${bounds?.target?.length ?? -1}|`;
   }
   for (const edge of state.edges) {
     sig += `${edge.id}:${edge.source}/${edge.sourceHandle ?? ''}>${edge.target}/${edge.targetHandle ?? ''}:${isRoutable(edge) ? 'r' : 'm'}|`;
@@ -191,39 +199,23 @@ function routeSignature(state: ReactFlowState, isRoutable: (edge: Edge) => boole
 }
 
 function buildRequest(
-  nodes: Node[],
+  nodeLookup: RouteNodeLookup,
   edges: Edge[],
-  isRoutable: (edge: Edge) => boolean
+  isRoutable: (edge: Edge) => boolean,
+  connectionMode: ConnectionMode
 ): RouteRequest {
-  const routeNodes: RouteNodeRequest[] = nodes.map((n) => {
-    const { width, height } = getNodeDimensions(n);
-    return { id: n.id, x: n.position.x, y: n.position.y, width, height };
-  });
-  const nodeMap = new Map(routeNodes.map((n) => [n.id, n]));
+  const routeNodes = Array.from(nodeLookup.values(), toRouteNode);
 
   const routeEdges: RouteEdgeRequest[] = [];
   for (const edge of edges) {
     if (!isRoutable(edge)) continue;
-    const source = nodeMap.get(edge.source);
-    const target = nodeMap.get(edge.target);
-    if (!source || !target) continue;
+    const anchors = resolveRouteAnchors(nodeLookup, edge, connectionMode);
+    if (!anchors) continue;
 
     routeEdges.push({
       edgeId: edge.id,
-      source: {
-        nodeId: edge.source,
-        handleId: edge.sourceHandle ?? null,
-        x: source.x + source.width,
-        y: source.y + source.height / 2,
-        position: Position.Right,
-      },
-      target: {
-        nodeId: edge.target,
-        handleId: edge.targetHandle ?? null,
-        x: target.x,
-        y: target.y + target.height / 2,
-        position: Position.Left,
-      },
+      source: anchors.source,
+      target: anchors.target,
     });
   }
 

--- a/packages/apollo-react/src/canvas/components/Edges/shared/types.ts
+++ b/packages/apollo-react/src/canvas/components/Edges/shared/types.ts
@@ -98,12 +98,44 @@ export type CanvasEdgeData = {
   waypoints?: Waypoint[];
 
   /**
-   * Pre-computed waypoints from a graph router (see `EdgeRouter`). Used as
-   * the path geometry when no manual `waypoints` are present. Manual edits
-   * always take priority — the moment the user drags a routed segment, the
-   * routed points materialize into `waypoints` and the edge becomes manual.
+   * Pre-computed waypoints from a graph router (see `EdgeRouter`) or a host's
+   * own layout engine. Used as the path geometry when no manual `waypoints` are
+   * present. Manual edits always take priority — the moment the user drags a
+   * routed segment, the routed points materialize into `waypoints` and the edge
+   * becomes manual.
+   *
+   * Routes supplied here are treated as auto-routed (see {@link autoRouted}),
+   * which is what a layout engine wants: bends get node-face clearance, so an
+   * edge leaving a multi-handle node face does not kink at the handle.
+   *
+   * A host with its own layout engine should match the renderer's fallback
+   * convention for the no-route case, or every laid-out edge visibly jumps the
+   * first time its node is dragged. For nodes in adjacent layers the fallback
+   * (`calculateAutoWaypoints`) puts the turn at the **midpoint between the two
+   * handles**, i.e. at half the layer gap.
    */
   routedWaypoints?: Waypoint[];
+
+  /**
+   * Whether this edge's route came from a router/layout engine rather than from
+   * the user. Auto-routed bends get node-face clearance applied at render time;
+   * manual bends are drawn exactly where they were placed.
+   *
+   * Defaults to `waypoints.length === 0`, i.e. a route arriving in
+   * `routedWaypoints` is auto-routed and one in `waypoints` is manual. Set it
+   * explicitly when that inference is wrong for your graph — for instance when a
+   * host persists both fields and needs the distinction to survive a round trip
+   * independently of which key the route landed in.
+   *
+   * Setting it makes the edge's provenance yours to maintain. The default
+   * inference self-corrects when the user drags a routed segment (the points
+   * materialize into `waypoints`, so the edge reads as manual from then on); an
+   * explicit `true` does not, and in controlled mode — where
+   * `onWaypointsChange` is supplied — the editor never touches `data`, so
+   * nothing but the host can clear it. Reset it there, or the user's own bends
+   * keep getting face clearance applied to them.
+   */
+  autoRouted?: boolean;
 
   /**
    * Controlled-mutation callback. When present, the editor calls this instead

--- a/packages/apollo-react/src/canvas/schema/node-instance/edge.test.ts
+++ b/packages/apollo-react/src/canvas/schema/node-instance/edge.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, expectTypeOf, it } from 'vitest';
+import type { Waypoint } from '../../components/Edges/shared/types';
+import type { EdgeInstance, EdgeInstanceUiConfig, WaypointInstance } from './edge';
+import { edgeSchema } from './edge';
+
+const connection = {
+  id: 'e1',
+  sourceNodeId: 'a',
+  sourcePort: 'output',
+  targetNodeId: 'b',
+  targetPort: 'input',
+};
+
+describe('edgeSchema', () => {
+  it('round-trips a stored route so a save/reload keeps the user edits', () => {
+    const parsed = edgeSchema.parse({
+      ...connection,
+      ui: { waypoints: [{ id: 'w1', x: 120, y: 240 }] },
+    });
+
+    expect(parsed.ui?.waypoints).toEqual([{ id: 'w1', x: 120, y: 240 }]);
+  });
+
+  it('round-trips a layout-produced route in its own field', () => {
+    const parsed = edgeSchema.parse({
+      ...connection,
+      ui: { routedWaypoints: [{ id: 'r0', x: 60, y: 0 }] },
+    });
+
+    expect(parsed.ui?.routedWaypoints).toEqual([{ id: 'r0', x: 60, y: 0 }]);
+    expect(parsed.ui?.waypoints).toBeUndefined();
+  });
+
+  it('keeps host-specific ui keys, so a file from a newer client survives an older one', () => {
+    const parsed = edgeSchema.parse({
+      ...connection,
+      ui: { waypoints: [], hostOwnedFlag: true, futureField: { nested: 1 } },
+    });
+
+    expect(parsed.ui?.hostOwnedFlag).toBe(true);
+    expect(parsed.ui?.futureField).toEqual({ nested: 1 });
+  });
+
+  it('round-trips the route provenance a host keeps both kinds of route in one field', () => {
+    const parsed = edgeSchema.parse({
+      ...connection,
+      ui: { waypoints: [{ id: 'w1', x: 120, y: 240 }], autoRouted: true },
+    });
+
+    expect(parsed.ui?.autoRouted).toBe(true);
+  });
+
+  it('leaves ui absent for a straight edge rather than defaulting it', () => {
+    const parsed = edgeSchema.parse(connection);
+
+    expect('ui' in parsed).toBe(false);
+  });
+
+  it('normalises an explicit null ui to absent rather than failing the parse', () => {
+    // `ui` is a new key, so a file written before it existed may carry a null
+    // from a host that serialises every optional slot.
+    const parsed = edgeSchema.parse({ ...connection, ui: null });
+
+    expect(parsed.ui).toBeUndefined();
+  });
+
+  it('keeps null out of the parsed type so consumers only handle absent', () => {
+    expectTypeOf<EdgeInstance['ui']>().toEqualTypeOf<EdgeInstanceUiConfig | undefined>();
+  });
+
+  it('rejects a malformed waypoint instead of silently dropping the route', () => {
+    const result = edgeSchema.safeParse({
+      ...connection,
+      ui: { waypoints: [{ id: 'w1', x: '120', y: 240 }] },
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('describes the same waypoint shape the edge components render', () => {
+    // A parsed instance is handed straight to `CanvasEdgeData.waypoints`, so the
+    // two must not drift apart.
+    expectTypeOf<WaypointInstance>().toEqualTypeOf<Waypoint>();
+  });
+});

--- a/packages/apollo-react/src/canvas/schema/node-instance/edge.ts
+++ b/packages/apollo-react/src/canvas/schema/node-instance/edge.ts
@@ -2,6 +2,50 @@ import { z } from 'zod';
 import { idSchema } from './base';
 
 /**
+ * A single bend in an edge's route, in absolute canvas coordinates.
+ *
+ * Structurally identical to the `Waypoint` type the edge components render, so a
+ * parsed instance can be handed straight to `CanvasEdgeData.waypoints` (and back)
+ * without a mapping step.
+ */
+export const waypointSchema = z.object({
+  id: z.string().min(1),
+  x: z.number(),
+  y: z.number(),
+});
+
+/**
+ * UI configuration for edge rendering (how the line is routed).
+ *
+ * The counterpart to a node's `ui` slot: layout that belongs to the drawing
+ * rather than to the workflow. Optional, because most edges are straight and
+ * carry no stored route.
+ *
+ * `waypoints` are user-placed and authoritative. `routedWaypoints` come from a
+ * layout engine or an `EdgeRouter` and are only drawn when there are no manual
+ * waypoints. Which of the two a route is stored in is not just bookkeeping: the
+ * renderer applies node-face clearance to routed bends only, so a layout route
+ * promoted to `waypoints` draws differently unless `autoRouted` says otherwise.
+ *
+ * The `catchall` keeps host-specific keys, and keys written by a newer client,
+ * intact through a parse instead of silently dropping them.
+ */
+export const edgeUiSchema = z
+  .object({
+    /** User-placed bends. Take priority over `routedWaypoints` when present. */
+    waypoints: z.array(waypointSchema).optional(),
+    /** Bends produced by a layout engine or `EdgeRouter`. */
+    routedWaypoints: z.array(waypointSchema).optional(),
+    /**
+     * Whether the stored route is layout-produced rather than user-placed, for
+     * hosts that keep both kinds in one field. Maps to `CanvasEdgeData.autoRouted`;
+     * omit it to let the renderer infer from which field the route is in.
+     */
+    autoRouted: z.boolean().optional(),
+  })
+  .catchall(z.unknown()); // Allow additional UI properties
+
+/**
  * A connection between nodes in a workflow
  */
 export const edgeSchema = z.object({
@@ -12,6 +56,18 @@ export const edgeSchema = z.object({
   targetNodeId: idSchema,
   /** The target port name (input port) */
   targetPort: z.string().min(1),
+  /**
+   * UI configuration (edge route). Absent when the edge has no stored route.
+   *
+   * `null` is accepted and normalised to absent: this key is new, so a file
+   * written before it existed may carry an explicit null from a host that
+   * serialises every optional slot, and rejecting those would fail the whole
+   * parse at load time over a route that isn't there.
+   */
+  ui: edgeUiSchema
+    .nullish()
+    .transform((value) => value ?? undefined)
+    .optional(),
   data: z
     .object({
       /** Optional label displayed at the edge midpoint */
@@ -21,5 +77,9 @@ export const edgeSchema = z.object({
     .optional(),
 });
 
-// Export inferred TypeScript type
+// Export inferred TypeScript types
+export type WaypointInstance = z.infer<typeof waypointSchema>;
+
+export type EdgeInstanceUiConfig = z.infer<typeof edgeUiSchema>;
+
 export type EdgeInstance = z.infer<typeof edgeSchema>;

--- a/packages/apollo-react/src/canvas/schema/node-instance/index.ts
+++ b/packages/apollo-react/src/canvas/schema/node-instance/index.ts
@@ -7,7 +7,7 @@ export type {
 } from './base';
 // Re-export schemas
 export { displayConfigSchema, idSchema, typeVersionKeySchema, versionSchema } from './base';
-export type { EdgeInstance } from './edge';
-export { edgeSchema } from './edge';
+export type { EdgeInstance, EdgeInstanceUiConfig, WaypointInstance } from './edge';
+export { edgeSchema, edgeUiSchema, waypointSchema } from './edge';
 export type { InstanceUiConfig, NodeInstance } from './node';
 export { nodeSchema, uiSchema } from './node';


### PR DESCRIPTION
Canvas ships interactive edge routing but no way to store a route or resolve one correctly. A host that saves a graph has to fork the schema and reimplement Apollo's geometry from the outside. Reported from Flow Workbench (MST-13539).

## Changes

**`edgeSchema` gains a `ui` slot.** Nodes have a required, open-ended `ui`; edges had none and silently discarded one under zod's default strip mode, so `waypoints`/`routedWaypoints` had nowhere to live. Now optional, with a `catchall` so host keys and keys from a newer client survive a parse.

**Route helpers are exported.** `rebalanceWaypoints`, `waypointsEqual`, `waypointsPositionallyEqual`, `moveWaypoint`, `generateWaypointId`, `calculateAutoWaypoints`, `snapPointToGrid`. `rebalanceWaypoints` keeps a route attached when endpoints move by different deltas, which hosts otherwise have to give up on during layout, paste and subflow moves.

**`CanvasEdgeData.autoRouted` is now explicit.** Node-face clearance was keyed entirely off which field a route arrived in, so unifying the fields (a plausible refactor once both persist) silently dropped it.

**`useGraphRouter` routes from real anchors.** It built requests from node bounding boxes and `node.position`, so multi-handle nodes routed from a point no handle occupies, vertical flows were told Right/Left regardless of face, and container children were computed in the wrong coordinate frame. Anchors now come from xyflow's `getEdgePosition` and boxes from `positionAbsolute`.

## Compatibility

Additive. `CanvasEdge` renders identically when `autoRouted` is unset, no exports were removed, no new dependencies.

Two behaviour changes, both intentional:

- `useGraphRouter` consumers get different (correct) routes. Vertical and nested graphs shift the most. No in-repo consumers outside a story.
- Nested graphs re-route when a container moves, where the stale route previously persisted.

`edgeSchema` now rejects a malformed `ui` (array, string, wrong-typed waypoints) that was previously stripped. An explicit `ui: null` is accepted and normalised to absent, verified against a copy of the 6.17.2 schema.

## Testing

2405 tests pass. New coverage for schema round-tripping, `autoRouted` in both directions, anchor resolution (multi-handle, nesting, non-horizontal faces, unmeasured fallback), and a store-level test proving a container child is requested in absolute coordinates.

The signature selector runs on every store update, so handle changes are tracked via per-node handle counts rather than resolving anchors there; resolving anchors per tick measured ~3x the previous cost.

## Not included

Decoupling `useNodeDragRebalance` from xyflow's `dragging` flag, so programmatic moves rebalance too. It changes when Apollo writes to consumer state (undo/redo entries during layout), has a mount-measurement hazard, and races host-authored routes. Worth doing separately, and the exported helpers unblock hosts today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)