### PR TITLE
feat(apollo-react): add granular read-only node state

### DIFF
--- a/packages/apollo-react/src/canvas/components/BaseCanvas/BaseCanvas.readonly.integration.test.tsx
+++ b/packages/apollo-react/src/canvas/components/BaseCanvas/BaseCanvas.readonly.integration.test.tsx
@@ -1,0 +1,73 @@
+import { render, screen } from '@testing-library/react';
+import type { Node } from '@uipath/apollo-react/canvas/xyflow/react';
+import { ReactFlowProvider } from '@uipath/apollo-react/canvas/xyflow/react';
+import type { ReactNode } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { BaseCanvas } from './BaseCanvas';
+import { useIsNodeReadOnly } from './ReadOnlyNodesContext';
+
+vi.mock('@uipath/apollo-react/canvas/xyflow/react', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@uipath/apollo-react/canvas/xyflow/react')>();
+  return {
+    ...actual,
+    ReactFlow: ({
+      children,
+      nodes,
+      nodeTypes,
+    }: {
+      children?: ReactNode;
+      nodes: Node[];
+      nodeTypes: Record<string, React.ComponentType<{ id: string }>>;
+    }) => (
+      <div data-testid="react-flow">
+        {nodes.map((node) => {
+          const NodeComponent = nodeTypes[node.type ?? ''];
+          return NodeComponent ? <NodeComponent key={node.id} id={node.id} /> : null;
+        })}
+        {children}
+      </div>
+    ),
+    Background: () => <div data-testid="background" />,
+    Panel: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+    useReactFlow: () => ({ fitView: vi.fn(), getNodes: () => [], getEdges: () => [] }),
+  };
+});
+
+const nodes: Node[] = [
+  { id: 'locked', type: 'probe', position: { x: 0, y: 0 }, data: {} },
+  { id: 'free', type: 'probe', position: { x: 100, y: 0 }, data: {} },
+];
+
+function ProbeNode({ id }: { id: string }) {
+  return <div data-testid={`node-${id}`} data-readonly={String(useIsNodeReadOnly(id))} />;
+}
+
+const renderCanvas = (readOnlyNodeIds?: ReadonlySet<string>) =>
+  render(
+    <ReactFlowProvider>
+      <BaseCanvas
+        nodes={nodes}
+        edges={[]}
+        nodeTypes={{ probe: ProbeNode }}
+        mode="design"
+        readOnlyNodeIds={readOnlyNodeIds}
+      />
+    </ReactFlowProvider>
+  );
+
+const readOnlyAttr = (id: string) => screen.getByTestId(`node-${id}`).dataset.readonly;
+
+describe('BaseCanvas with individually locked nodes', () => {
+  it('tells each node whether it is locked', () => {
+    renderCanvas(new Set(['locked']));
+
+    expect(readOnlyAttr('locked')).toBe('true');
+    expect(readOnlyAttr('free')).toBe('false');
+  });
+
+  it('treats every node as editable when no locks are provided', () => {
+    renderCanvas();
+
+    expect(readOnlyAttr('locked')).toBe('false');
+  });
+});

--- a/packages/apollo-react/src/canvas/components/BaseCanvas/BaseCanvas.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/BaseCanvas/BaseCanvas.stories.tsx
@@ -9,17 +9,21 @@ import {
 } from '@uipath/apollo-react/canvas/xyflow/react';
 import {
   Button,
+  cn,
   Select,
   SelectContent,
   SelectItem,
   SelectTrigger,
   SelectValue,
-  cn,
 } from '@uipath/apollo-wind';
 import { useMemo, useRef, useState } from 'react';
 import {
   createNode,
+  StoryCode,
+  StoryCodeBlock,
   StoryInfoPanel,
+  StoryPage,
+  StorySection,
   useCanvasStory,
   withCanvasProviders,
 } from '../../storybook-utils';
@@ -1280,4 +1284,73 @@ export const WithNodeFocusControls: Story = {
 export const WithMaintainNodesInView: Story = {
   name: 'Maintain Nodes In View',
   render: () => <WithMaintainNodesInViewStory />,
+};
+
+// ============================================================================
+// Per-Node Read-Only
+// ============================================================================
+
+function PerNodeReadOnlyPage({ globalTheme }: { globalTheme: string }) {
+  return (
+    <StoryPage
+      theme={globalTheme}
+      title="Per-node read-only"
+      description={
+        <>
+          Keep a canvas in <StoryCode>design</StoryCode> mode while locking the content of selected
+          nodes. This is useful when part of a workflow is executing or when a host needs to protect
+          in-flight configuration without freezing the rest of the graph.
+        </>
+      }
+    >
+      <StorySection
+        title="State and API"
+        divider={false}
+        description={
+          <>
+            <p>
+              Pass the locked ids through <StoryCode>readOnlyNodeIds</StoryCode>. The canvas
+              compares sets by their contents, so a freshly allocated set with the same ids does not
+              notify node renderers again. Treat the set as immutable and pass a new one when
+              membership changes.
+            </p>
+            <p>
+              Custom renderers subscribe to their own id with{' '}
+              <StoryCode>useIsNodeReadOnly</StoryCode>. The hook returns{' '}
+              <StoryCode>false</StoryCode> outside a canvas provider, which lets the same renderer
+              work in isolated previews and tests.
+            </p>
+            <p>
+              This is a client-side interaction policy, not an authorization boundary. Enforce
+              permissions again when the host saves or executes the workflow.
+            </p>
+          </>
+        }
+      >
+        <StoryCodeBlock>
+          {`const readOnlyNodeIds = useMemo(
+  () => new Set(['agent-1', 'tool-1']),
+  []
+);
+
+<BaseCanvas
+  mode="design"
+  readOnlyNodeIds={readOnlyNodeIds}
+  nodes={nodes}
+  edges={edges}
+/>
+
+function CustomNode({ id }: NodeProps) {
+  const isReadOnly = useIsNodeReadOnly(id);
+  return <CustomEditor disabled={isReadOnly} />;
+}`}
+        </StoryCodeBlock>
+      </StorySection>
+    </StoryPage>
+  );
+}
+
+export const PerNodeReadOnly: Story = {
+  name: 'Per-Node Read-Only',
+  render: (_, { globals }) => <PerNodeReadOnlyPage globalTheme={globals.theme || 'future-dark'} />,
 };

--- a/packages/apollo-react/src/canvas/components/BaseCanvas/BaseCanvas.tsx
+++ b/packages/apollo-react/src/canvas/components/BaseCanvas/BaseCanvas.tsx
@@ -22,6 +22,7 @@ import type { BaseCanvasProps, BaseCanvasRef } from './BaseCanvas.types';
 import { CanvasBackground } from './CanvasBackground';
 import { CanvasProviders } from './CanvasProviders';
 import { PanShortcutTeachingUI } from './PanShortcutTeachingUI';
+import { useStableNodeIdSet } from './ReadOnlyNodesContext';
 
 const BaseCanvasInnerComponent = <NodeType extends Node = Node, EdgeType extends Edge = Edge>(
   props: BaseCanvasProps<NodeType, EdgeType> & {
@@ -42,6 +43,7 @@ const BaseCanvasInnerComponent = <NodeType extends Node = Node, EdgeType extends
 
     // Behavior
     mode = 'view',
+    readOnlyNodeIds,
 
     // Styling
     showBackground = true,
@@ -109,6 +111,7 @@ const BaseCanvasInnerComponent = <NodeType extends Node = Node, EdgeType extends
   // Derive interactivity from mode
   const isInteractive = mode !== 'readonly';
   const isDesignMode = mode === 'design';
+  const stableReadOnlyNodeIds = useStableNodeIdSet(readOnlyNodeIds);
 
   const [reactFlowInstance, setReactFlowInstance] =
     useState<ReactFlowInstance<NodeType, EdgeType>>();
@@ -160,6 +163,7 @@ const BaseCanvasInnerComponent = <NodeType extends Node = Node, EdgeType extends
       isDarkMode={isDarkMode}
       locale={locale}
       stickyNoteOptions={stickyNoteOptions}
+      readOnlyNodeIds={stableReadOnlyNodeIds}
     >
       <ReactFlow
         {...reactFlowProps}

--- a/packages/apollo-react/src/canvas/components/BaseCanvas/BaseCanvas.types.ts
+++ b/packages/apollo-react/src/canvas/components/BaseCanvas/BaseCanvas.types.ts
@@ -76,6 +76,22 @@ export interface BaseCanvasProps<NodeType extends Node = Node, EdgeType extends 
   mode?: 'design' | 'readonly' | 'view';
 
   /**
+   * Node ids whose content is read-only while the rest of the canvas remains editable.
+   * Custom node renderers can observe their state with `useIsNodeReadOnly`.
+   *
+   * Compared by content, so passing a fresh set with the same ids is a no-op.
+   * Do not mutate a set after passing it; pass a new set instead.
+   *
+   * A `Set` or an array; both are normalized to a set internally. Deliberately
+   * not `Iterable<string>`: a bare `string` satisfies that type and would be
+   * spread per character, and a single-use iterator would read as empty on
+   * every render after the first.
+   *
+   * @default undefined
+   */
+  readOnlyNodeIds?: ReadonlySet<string> | readonly string[];
+
+  /**
    * Canvas-wide sticky-note behavior. Individual StickyNoteNode props take precedence.
    * @example `{ enableMediaEmbedding: true, readOnly: false }`
    */

--- a/packages/apollo-react/src/canvas/components/BaseCanvas/CanvasProviders.tsx
+++ b/packages/apollo-react/src/canvas/components/BaseCanvas/CanvasProviders.tsx
@@ -10,6 +10,7 @@ import type { BaseCanvasProps } from './BaseCanvas.types';
 import { BaseCanvasModeProvider } from './BaseCanvasModeProvider';
 import { CanvasThemeProvider } from './CanvasThemeContext';
 import { ConnectedHandlesProvider } from './ConnectedHandlesContext';
+import { ReadOnlyNodesProvider } from './ReadOnlyNodesContext';
 import { SelectionStateProvider } from './SelectionStateContext';
 
 interface CanvasProvidersProps {
@@ -20,6 +21,7 @@ interface CanvasProvidersProps {
   isDarkMode?: boolean;
   locale?: BaseCanvasProps['locale'];
   stickyNoteOptions?: StickyNoteCanvasOptions;
+  readOnlyNodeIds?: ReadonlySet<string>;
 }
 
 /**
@@ -35,6 +37,7 @@ export function CanvasProviders({
   isDarkMode,
   locale,
   stickyNoteOptions,
+  readOnlyNodeIds,
   children,
 }: CanvasProvidersProps) {
   return (
@@ -45,9 +48,11 @@ export function CanvasProviders({
             <ConnectedHandlesProvider edges={edges}>
               <EdgeCrossingsProvider>
                 <BaseCanvasModeProvider mode={mode}>
-                  <StickyNoteCanvasOptionsProvider options={stickyNoteOptions}>
-                    <SelectionStateProvider nodes={nodes}>{children}</SelectionStateProvider>
-                  </StickyNoteCanvasOptionsProvider>
+                  <ReadOnlyNodesProvider readOnlyNodeIds={readOnlyNodeIds}>
+                    <StickyNoteCanvasOptionsProvider options={stickyNoteOptions}>
+                      <SelectionStateProvider nodes={nodes}>{children}</SelectionStateProvider>
+                    </StickyNoteCanvasOptionsProvider>
+                  </ReadOnlyNodesProvider>
                 </BaseCanvasModeProvider>
               </EdgeCrossingsProvider>
             </ConnectedHandlesProvider>

--- a/packages/apollo-react/src/canvas/components/BaseCanvas/ConnectedHandlesContext.tsx
+++ b/packages/apollo-react/src/canvas/components/BaseCanvas/ConnectedHandlesContext.tsx
@@ -9,10 +9,10 @@ import {
   useSyncExternalStore,
 } from 'react';
 
+import { EMPTY_SET, setsEqual } from './set-utils';
+
 type ConnectedHandlesMap = Map<string, Set<string>>;
 type Listener = () => void;
-
-const EMPTY_SET: ReadonlySet<string> = Object.freeze(new Set()) as ReadonlySet<string>;
 
 /**
  * Store that manages connected handles with granular subscriptions.
@@ -97,21 +97,6 @@ class ConnectedHandlesStore {
       }
     }
   }
-}
-
-/**
- * Compare two Sets for equality.
- */
-function setsEqual(a?: Set<string>, b?: Set<string>): boolean {
-  if (a === b) return true;
-  if (!a || !b) return false;
-  if (a.size !== b.size) return false;
-
-  for (const value of a) {
-    if (!b.has(value)) return false;
-  }
-
-  return true;
 }
 
 /**

--- a/packages/apollo-react/src/canvas/components/BaseCanvas/ReadOnlyNodesContext.test.tsx
+++ b/packages/apollo-react/src/canvas/components/BaseCanvas/ReadOnlyNodesContext.test.tsx
@@ -1,0 +1,135 @@
+import { render, renderHook, screen } from '@testing-library/react';
+import { memo, type PropsWithChildren } from 'react';
+import { describe, expect, it } from 'vitest';
+import {
+  ReadOnlyNodesProvider,
+  useIsNodeReadOnly,
+  useStableNodeIdSet,
+} from './ReadOnlyNodesContext';
+
+function wrapperWith(ids?: ReadonlySet<string>) {
+  return ({ children }: PropsWithChildren) => (
+    <ReadOnlyNodesProvider readOnlyNodeIds={ids}>{children}</ReadOnlyNodesProvider>
+  );
+}
+
+describe('useIsNodeReadOnly', () => {
+  it('reports nodes as editable when used outside a provider', () => {
+    const { result } = renderHook(() => useIsNodeReadOnly('a'));
+    expect(result.current).toBe(false);
+  });
+
+  it('reports only listed nodes as locked', () => {
+    const wrapper = wrapperWith(new Set(['a', 'b']));
+    const { result: a } = renderHook(() => useIsNodeReadOnly('a'), { wrapper });
+    const { result: c } = renderHook(() => useIsNodeReadOnly('c'), { wrapper });
+    expect(a.current).toBe(true);
+    expect(c.current).toBe(false);
+  });
+
+  it('reports nodes as editable when no lock list is provided', () => {
+    const { result } = renderHook(() => useIsNodeReadOnly('a'), {
+      wrapper: wrapperWith(undefined),
+    });
+    expect(result.current).toBe(false);
+  });
+});
+
+describe('useStableNodeIdSet', () => {
+  it('reuses the lock set when its ids do not change', () => {
+    const { result, rerender } = renderHook(({ ids }) => useStableNodeIdSet(ids), {
+      initialProps: { ids: new Set(['a', 'b']) as ReadonlySet<string> },
+    });
+    const first = result.current;
+    rerender({ ids: new Set(['a', 'b']) });
+    expect(result.current).toBe(first);
+  });
+
+  it('creates a new lock set when its ids change', () => {
+    const { result, rerender } = renderHook(({ ids }) => useStableNodeIdSet(ids), {
+      initialProps: { ids: new Set(['a']) as ReadonlySet<string> },
+    });
+    const first = result.current;
+    rerender({ ids: new Set(['a', 'b']) });
+    expect(result.current).not.toBe(first);
+    expect(result.current.has('b')).toBe(true);
+  });
+
+  // Arrays are a supported input, so the normalization has to hold the
+  // stability guarantee on its own: `setsEqual` would read every array as
+  // unequal.
+  it('keeps the same lock set when the ids arrive as an array', () => {
+    const { result, rerender } = renderHook(({ ids }) => useStableNodeIdSet(ids), {
+      initialProps: { ids: ['a', 'b'] as readonly string[] },
+    });
+    const first = result.current;
+    expect(first.has('a')).toBe(true);
+    rerender({ ids: ['a', 'b'] });
+    expect(result.current).toBe(first);
+    rerender({ ids: ['a', 'b', 'c'] });
+    expect(result.current).not.toBe(first);
+    expect(result.current.has('c')).toBe(true);
+  });
+
+  it('reuses an empty lock set when no ids are provided', () => {
+    const { result, rerender } = renderHook(({ ids }) => useStableNodeIdSet(ids), {
+      initialProps: { ids: undefined as ReadonlySet<string> | undefined },
+    });
+    const first = result.current;
+    expect(first.size).toBe(0);
+    rerender({ ids: undefined });
+    expect(result.current).toBe(first);
+  });
+});
+
+describe('ReadOnlyNodesProvider updates', () => {
+  // The reason this is a store and not a plain context value: locking one node
+  // must not re-render every other node on the canvas. Probe is memoized (as
+  // BaseNode is) so a parent re-render alone cannot explain a re-render here.
+  const Probe = memo(function Probe({
+    id,
+    counts,
+  }: {
+    id: string;
+    counts: Record<string, number>;
+  }) {
+    const readOnly = useIsNodeReadOnly(id);
+    counts[id] = (counts[id] ?? 0) + 1;
+    return <span data-testid={`probe-${id}`}>{String(readOnly)}</span>;
+  });
+
+  it('re-renders only the nodes whose lock state changed', () => {
+    const counts: Record<string, number> = {};
+    const tree = (ids: ReadonlySet<string>) => (
+      <ReadOnlyNodesProvider readOnlyNodeIds={ids}>
+        <Probe id="a" counts={counts} />
+        <Probe id="b" counts={counts} />
+      </ReadOnlyNodesProvider>
+    );
+
+    const { rerender } = render(tree(new Set()));
+    const before = { ...counts };
+
+    rerender(tree(new Set(['a'])));
+
+    expect(screen.getByTestId('probe-a')).toHaveTextContent('true');
+    expect(screen.getByTestId('probe-b')).toHaveTextContent('false');
+    expect(counts.a ?? 0).toBeGreaterThan(before.a ?? 0);
+    expect(counts.b).toBe(before.b);
+  });
+
+  it('updates a node when it becomes unlocked', () => {
+    const counts: Record<string, number> = {};
+    const tree = (ids: ReadonlySet<string>) => (
+      <ReadOnlyNodesProvider readOnlyNodeIds={ids}>
+        <Probe id="a" counts={counts} />
+      </ReadOnlyNodesProvider>
+    );
+
+    const { rerender } = render(tree(new Set(['a'])));
+    expect(screen.getByTestId('probe-a')).toHaveTextContent('true');
+
+    rerender(tree(new Set()));
+    expect(screen.getByTestId('probe-a')).toHaveTextContent('false');
+  });
+});

--- a/packages/apollo-react/src/canvas/components/BaseCanvas/ReadOnlyNodesContext.tsx
+++ b/packages/apollo-react/src/canvas/components/BaseCanvas/ReadOnlyNodesContext.tsx
@@ -8,17 +8,9 @@ import {
   useSyncExternalStore,
 } from 'react';
 
+import { EMPTY_SET, setsEqual } from './set-utils';
+
 type Listener = () => void;
-
-const EMPTY_SET: ReadonlySet<string> = new Set();
-
-function setsEqual(a: ReadonlySet<string>, b: ReadonlySet<string>): boolean {
-  if (a.size !== b.size) return false;
-  for (const id of a) {
-    if (!b.has(id)) return false;
-  }
-  return true;
-}
 
 /**
  * Store for per-node read-only state with granular subscriptions.

--- a/packages/apollo-react/src/canvas/components/BaseCanvas/ReadOnlyNodesContext.tsx
+++ b/packages/apollo-react/src/canvas/components/BaseCanvas/ReadOnlyNodesContext.tsx
@@ -1,13 +1,7 @@
 import type React from 'react';
-import {
-  createContext,
-  useCallback,
-  useContext,
-  useEffect,
-  useRef,
-  useSyncExternalStore,
-} from 'react';
+import { createContext, useCallback, useContext, useRef, useSyncExternalStore } from 'react';
 
+import { useIsomorphicLayoutEffect } from '../../hooks/useIsomorphicLayoutEffect';
 import { EMPTY_SET, setsEqual } from './set-utils';
 
 type Listener = () => void;
@@ -116,10 +110,11 @@ export const ReadOnlyNodesProvider: React.FC<
     storeRef.current = new ReadOnlyNodesStore(readOnlyNodeIds);
   }
 
-  // The constructor seeds the mount; the effect handles updates without
-  // notifying subscribers during render. Enforcement is applied to node and
-  // edge objects in the same render.
-  useEffect(() => {
+  // The constructor seeds the mount; this handles updates without notifying
+  // subscribers during render. Layout timing, not `useEffect`: a passive effect
+  // runs after paint, so subscribed nodes would paint once with the stale lock
+  // state before flipping.
+  useIsomorphicLayoutEffect(() => {
     storeRef.current?.update(readOnlyNodeIds ?? EMPTY_SET);
   }, [readOnlyNodeIds]);
 

--- a/packages/apollo-react/src/canvas/components/BaseCanvas/ReadOnlyNodesContext.tsx
+++ b/packages/apollo-react/src/canvas/components/BaseCanvas/ReadOnlyNodesContext.tsx
@@ -1,0 +1,156 @@
+import type React from 'react';
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useSyncExternalStore,
+} from 'react';
+
+type Listener = () => void;
+
+const EMPTY_SET: ReadonlySet<string> = new Set();
+
+function setsEqual(a: ReadonlySet<string>, b: ReadonlySet<string>): boolean {
+  if (a.size !== b.size) return false;
+  for (const id of a) {
+    if (!b.has(id)) return false;
+  }
+  return true;
+}
+
+/**
+ * Store for per-node read-only state with granular subscriptions.
+ *
+ * Each node subscribes under its own id, so locking one node only notifies that
+ * node. Mirrors ConnectedHandlesStore.
+ */
+class ReadOnlyNodesStore {
+  private ids: ReadonlySet<string>;
+  private listeners = new Map<string, Set<Listener>>();
+
+  constructor(initial: ReadonlySet<string> = EMPTY_SET) {
+    this.ids = initial.size === 0 ? EMPTY_SET : new Set(initial);
+  }
+
+  /** Subscribe to changes for a specific node. */
+  subscribe(nodeId: string, listener: Listener): () => void {
+    let nodeListeners = this.listeners.get(nodeId);
+    if (!nodeListeners) {
+      nodeListeners = new Set();
+      this.listeners.set(nodeId, nodeListeners);
+    }
+    nodeListeners.add(listener);
+
+    return () => {
+      nodeListeners.delete(listener);
+      if (nodeListeners.size === 0) {
+        this.listeners.delete(nodeId);
+      }
+    };
+  }
+
+  /** Boolean snapshots let React bail out when a node's state is unchanged. */
+  isReadOnly(nodeId: string): boolean {
+    return this.ids.has(nodeId);
+  }
+
+  /**
+   * Replace the locked set, notifying only the nodes whose state flipped.
+   * Stores a copy so in-place mutation of the caller's Set is detected.
+   */
+  update(next: ReadonlySet<string>): void {
+    const prev = this.ids;
+    if (setsEqual(prev, next)) return;
+
+    const changedNodeIds = new Set<string>();
+    for (const id of next) {
+      if (!prev.has(id)) changedNodeIds.add(id);
+    }
+    for (const id of prev) {
+      if (!next.has(id)) changedNodeIds.add(id);
+    }
+
+    this.ids = next.size === 0 ? EMPTY_SET : new Set(next);
+
+    for (const nodeId of changedNodeIds) {
+      const nodeListeners = this.listeners.get(nodeId);
+      if (nodeListeners) {
+        for (const listener of nodeListeners) listener();
+      }
+    }
+  }
+}
+
+const ReadOnlyNodesContext = createContext<ReadOnlyNodesStore | null>(null);
+
+/**
+ * Returns a reference-stable id set, preserving the previous reference when
+ * contents are unchanged.
+ *
+ * Copies the input so in-place mutation (`ids.add('x')`) is detected;
+ * `ReadonlySet` is only a compile-time guarantee.
+ *
+ * Accepts a set or an array and normalizes here, so every downstream consumer
+ * sees a real set. A plain array would otherwise pass through `setsEqual`,
+ * whose `size` comparison is `n !== undefined` on an array: always unequal, so
+ * the hook would hand back a fresh set every render and lose the exact
+ * stability it exists to provide. TypeScript cannot catch that for a JS
+ * consumer.
+ */
+export function useStableNodeIdSet(
+  ids: ReadonlySet<string> | readonly string[] | undefined
+): ReadonlySet<string> {
+  const ref = useRef<ReadonlySet<string>>(EMPTY_SET);
+  // Only copy when the input is not already a set; the documented set path
+  // keeps its previous zero-allocation behavior.
+  const next = ids === undefined ? EMPTY_SET : ids instanceof Set ? ids : new Set(ids);
+  if (!setsEqual(ref.current, next)) {
+    ref.current = next.size === 0 ? EMPTY_SET : new Set(next);
+  }
+  return ref.current;
+}
+
+/**
+ * Distributes BaseCanvas `readOnlyNodeIds` to node renderers.
+ * Mounted by CanvasProviders; not intended for direct use.
+ */
+export const ReadOnlyNodesProvider: React.FC<
+  React.PropsWithChildren<{ readOnlyNodeIds?: ReadonlySet<string> }>
+> = ({ children, readOnlyNodeIds }) => {
+  const storeRef = useRef<ReadOnlyNodesStore | undefined>(undefined);
+  if (!storeRef.current) {
+    storeRef.current = new ReadOnlyNodesStore(readOnlyNodeIds);
+  }
+
+  // The constructor seeds the mount; the effect handles updates without
+  // notifying subscribers during render. Enforcement is applied to node and
+  // edge objects in the same render.
+  useEffect(() => {
+    storeRef.current?.update(readOnlyNodeIds ?? EMPTY_SET);
+  }, [readOnlyNodeIds]);
+
+  return (
+    <ReadOnlyNodesContext.Provider value={storeRef.current}>
+      {children}
+    </ReadOnlyNodesContext.Provider>
+  );
+};
+
+/**
+ * True when this node is marked read-only by BaseCanvas `readOnlyNodeIds`.
+ * Re-renders only when this node's own state changes.
+ * Returns false outside a provider so nodes render safely in isolation.
+ */
+export function useIsNodeReadOnly(nodeId: string): boolean {
+  const store = useContext(ReadOnlyNodesContext);
+
+  const subscribe = useCallback(
+    (onStoreChange: Listener) => store?.subscribe(nodeId, onStoreChange) ?? (() => {}),
+    [store, nodeId]
+  );
+  const getSnapshot = useCallback(() => store?.isReadOnly(nodeId) ?? false, [store, nodeId]);
+
+  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+}

--- a/packages/apollo-react/src/canvas/components/BaseCanvas/index.ts
+++ b/packages/apollo-react/src/canvas/components/BaseCanvas/index.ts
@@ -7,4 +7,7 @@ export * from './CanvasBackground';
 export * from './CanvasProviders';
 export * from './CanvasThemeContext';
 export * from './ConnectedHandlesContext';
+// Named, not wildcard: the provider and the set-stabilizing helper are
+// internal, and anything exported here is public API we have to keep.
+export { useIsNodeReadOnly } from './ReadOnlyNodesContext';
 export * from './SelectionStateContext';

--- a/packages/apollo-react/src/canvas/components/BaseCanvas/set-utils.ts
+++ b/packages/apollo-react/src/canvas/components/BaseCanvas/set-utils.ts
@@ -1,0 +1,28 @@
+/**
+ * Shared set helpers for the canvas context stores.
+ *
+ * Deliberately not re-exported from `index.ts`: these back the identity
+ * stability that `useSyncExternalStore` relies on, and are not public API.
+ */
+
+/**
+ * Shared empty-set sentinel, so an empty store keeps a stable reference.
+ *
+ * Not frozen: `Object.freeze` seals own properties, and a `Set`'s contents live
+ * in an internal slot, so it neither blocks `add` nor throws. `ReadonlySet` is
+ * the only guarantee here, and it is compile-time only.
+ */
+export const EMPTY_SET: ReadonlySet<string> = new Set<string>();
+
+/** Compare two sets by contents. Two `undefined` inputs count as equal. */
+export function setsEqual(a?: ReadonlySet<string>, b?: ReadonlySet<string>): boolean {
+  if (a === b) return true;
+  if (!a || !b) return false;
+  if (a.size !== b.size) return false;
+
+  for (const value of a) {
+    if (!b.has(value)) return false;
+  }
+
+  return true;
+}

--- a/packages/apollo-react/src/canvas/hooks/useIsomorphicLayoutEffect.ts
+++ b/packages/apollo-react/src/canvas/hooks/useIsomorphicLayoutEffect.ts
@@ -1,0 +1,10 @@
+import { useEffect, useLayoutEffect } from 'react';
+
+/**
+ * `useLayoutEffect` in the browser, `useEffect` on the server.
+ *
+ * Avoids React's "useLayoutEffect does nothing on the server" warning during
+ * SSR while keeping pre-paint timing where it matters on the client.
+ */
+export const useIsomorphicLayoutEffect =
+  typeof window === 'undefined' ? useEffect : useLayoutEffect;

--- a/packages/apollo-react/src/canvas/hooks/useLatestRef.ts
+++ b/packages/apollo-react/src/canvas/hooks/useLatestRef.ts
@@ -1,6 +1,5 @@
-import { useEffect, useLayoutEffect, useRef } from 'react';
-
-const useIsomorphicLayoutEffect = typeof window !== 'undefined' ? useLayoutEffect : useEffect;
+import { useRef } from 'react';
+import { useIsomorphicLayoutEffect } from './useIsomorphicLayoutEffect';
 
 export function useLatestRef<T>(value: T) {
   const ref = useRef(value);


### PR DESCRIPTION
## Summary

Introduces the state and public API foundation for locking individual canvas nodes while the rest of the canvas remains editable.

## Scope

- Adds `BaseCanvas.readOnlyNodeIds`
- Adds a granular external store so only nodes whose lock state changes re-render
- Stabilizes lock sets by content when callers pass an equivalent new `Set`
- Exports `useIsNodeReadOnly(nodeId)` for custom node renderers
- Returns `false` safely when the hook is used outside a canvas provider
- Wires the provider into `BaseCanvas` without enforcing mutations yet

## Stack

Part 1 of 4. The next PR applies this state to generic `BaseCanvas` and `BaseNode` behavior.

## Testing

- `ReadOnlyNodesContext.test.tsx`
- `BaseCanvas.readonly.integration.test.tsx`
- 10 focused tests passing
