### PR TITLE
feat(apollo-react): enforce read-only BaseCanvas nodes

### DIFF
--- a/packages/apollo-react/src/canvas/components/AgentCanvas/AgentFlow.test.tsx
+++ b/packages/apollo-react/src/canvas/components/AgentCanvas/AgentFlow.test.tsx
@@ -2,8 +2,10 @@ import { vi } from 'vitest';
 import type { AgentFlowProps } from '../../types';
 import { render, screen } from '../../utils/testing';
 
-// Mock BaseCanvas hooks to avoid ReactFlow dependencies in tests
-vi.mock('../BaseCanvas/BaseCanvas.hooks', () => ({
+// Mock the BaseCanvas viewport hooks to avoid ReactFlow dependencies in tests.
+// The rest of the module is kept so newly added hooks don't break this mock.
+vi.mock('../BaseCanvas/BaseCanvas.hooks', async () => ({
+  ...(await vi.importActual('../BaseCanvas/BaseCanvas.hooks')),
   useAutoLayout: () => ({
     isReady: true,
   }),

--- a/packages/apollo-react/src/canvas/components/BaseCanvas/BaseCanvas.hooks.readonly.test.tsx
+++ b/packages/apollo-react/src/canvas/components/BaseCanvas/BaseCanvas.hooks.readonly.test.tsx
@@ -1,0 +1,95 @@
+import { renderHook } from '@testing-library/react';
+import type { Edge, Node, OnBeforeDelete } from '@uipath/apollo-react/canvas/xyflow/react';
+import { describe, expect, it, vi } from 'vitest';
+import { useReadOnlyBeforeDelete } from './BaseCanvas.hooks';
+
+const node = (id: string): Node => ({ id, position: { x: 0, y: 0 }, data: {} });
+const edge = (id: string, source: string, target: string): Edge => ({ id, source, target });
+
+const EMPTY: ReadonlySet<string> = new Set();
+
+/** Renders the hook and calls the composed guard with a delete set. */
+const guardWith = (
+  locked: ReadonlySet<string>,
+  consumer?: OnBeforeDelete,
+  { nodes = [] as Node[], edges = [] as Edge[] } = {}
+) => {
+  const { result } = renderHook(() => useReadOnlyBeforeDelete(locked, consumer));
+  return { guard: result.current, run: () => result.current?.({ nodes, edges }) };
+};
+
+describe('useReadOnlyBeforeDelete', () => {
+  it('passes the consumer handler straight through when nothing is locked', () => {
+    const consumer = vi.fn();
+    const { guard } = guardWith(EMPTY, consumer);
+    expect(guard).toBe(consumer);
+  });
+
+  it('stays undefined when nothing is locked and the consumer has no handler', () => {
+    const { guard } = guardWith(EMPTY);
+    expect(guard).toBeUndefined();
+  });
+
+  it('drops a locked node from the delete set and keeps the rest', async () => {
+    const { run } = guardWith(new Set(['a']), undefined, { nodes: [node('a'), node('b')] });
+
+    await expect(run()).resolves.toEqual({ nodes: [node('b')], edges: [] });
+  });
+
+  // React Flow gathers the edges of every node in the delete set, so a veto has
+  // to take the vetoed node's own edges back out or it survives with no
+  // connections.
+  it('keeps the edges of a node it vetoed', async () => {
+    const { run } = guardWith(new Set(['a']), undefined, {
+      nodes: [node('a')],
+      edges: [edge('a-c', 'a', 'c')],
+    });
+
+    await expect(run()).resolves.toEqual({ nodes: [], edges: [] });
+  });
+
+  // The other half: an edge between a vetoed node and one that really is being
+  // deleted would be left dangling, so it still goes.
+  it('deletes an edge from a vetoed node to a node that is being deleted', async () => {
+    const { run } = guardWith(new Set(['a']), undefined, {
+      nodes: [node('a'), node('b')],
+      edges: [edge('a-b', 'a', 'b'), edge('a-c', 'a', 'c')],
+    });
+
+    await expect(run()).resolves.toEqual({
+      nodes: [node('b')],
+      edges: [edge('a-b', 'a', 'b')],
+    });
+  });
+
+  it('leaves an explicitly selected edge alone when no node is vetoed', async () => {
+    const { run } = guardWith(new Set(['a']), undefined, { edges: [edge('a-c', 'a', 'c')] });
+
+    await expect(run()).resolves.toEqual({ nodes: [], edges: [edge('a-c', 'a', 'c')] });
+  });
+
+  it('honors a consumer veto of the whole deletion', async () => {
+    const consumer = vi.fn().mockResolvedValue(false);
+    const { run } = guardWith(new Set(['a']), consumer, { nodes: [node('a'), node('b')] });
+
+    await expect(run()).resolves.toBe(false);
+  });
+
+  it('applies the lock to whatever the consumer allowed', async () => {
+    const consumer = vi.fn().mockResolvedValue({ nodes: [node('a')], edges: [] });
+    const { run } = guardWith(new Set(['a']), consumer, { nodes: [node('a'), node('b')] });
+
+    await expect(run()).resolves.toEqual({ nodes: [], edges: [] });
+    expect(consumer).toHaveBeenCalledWith({ nodes: [node('a'), node('b')], edges: [] });
+  });
+
+  it('reuses the guard when the locks and handler do not change', () => {
+    const locked: ReadonlySet<string> = new Set(['a']);
+    const { result, rerender } = renderHook(({ s }) => useReadOnlyBeforeDelete(s, undefined), {
+      initialProps: { s: locked },
+    });
+    const first = result.current;
+    rerender({ s: locked });
+    expect(result.current).toBe(first);
+  });
+});

--- a/packages/apollo-react/src/canvas/components/BaseCanvas/BaseCanvas.hooks.ts
+++ b/packages/apollo-react/src/canvas/components/BaseCanvas/BaseCanvas.hooks.ts
@@ -1,6 +1,6 @@
-import type { Node } from '@uipath/apollo-react/canvas/xyflow/react';
+import type { Edge, Node, OnBeforeDelete } from '@uipath/apollo-react/canvas/xyflow/react';
 import { useReactFlow, useStoreApi } from '@uipath/apollo-react/canvas/xyflow/react';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { BASE_CANVAS_DEFAULTS, FIT_VIEW_DELAY_MS } from './BaseCanvas.constants';
 import type { BaseCanvasFitViewOptions, EnsureNodesInViewOptions } from './BaseCanvas.types';
 
@@ -340,3 +340,54 @@ export const useMaintainNodesInView = (
     };
   }, [flowStoreApi, reactFlowInstance, fitViewOptions]); // Only depend on flowStoreApi and reactFlowInstance
 };
+
+/**
+ * Composes an `onBeforeDelete` that vetoes deletion of locked nodes.
+ *
+ * Chosen over stamping `deletable: false` onto the nodes handed to React Flow.
+ * That clone round-trips out through `getNodes()` and `toObject()`, so a
+ * consumer saving the graph persists our lock as their own data, and unlocking
+ * the node could never undo it. A veto touches nothing the consumer owns and
+ * covers keyboard delete, `deleteElements`, and toolbar actions in one place.
+ *
+ * Edges need the same care: React Flow gathers the edges of every node in the
+ * delete set, so vetoing a node without pruning its edges would leave it
+ * standing with its connections gone. An edge is dropped when it touches a
+ * vetoed node and no node that is actually being deleted, which keeps
+ * mixed selections from stranding a dangling edge.
+ */
+export function useReadOnlyBeforeDelete<NodeType extends Node, EdgeType extends Edge>(
+  readOnlyNodeIds: ReadonlySet<string>,
+  onBeforeDelete: OnBeforeDelete<NodeType, EdgeType> | undefined
+): OnBeforeDelete<NodeType, EdgeType> | undefined {
+  return useMemo(() => {
+    if (readOnlyNodeIds.size === 0) return onBeforeDelete;
+
+    return async ({ nodes, edges }) => {
+      // The consumer runs first, so our policy is applied to whatever they
+      // allowed rather than being overridden by it.
+      const upstream = onBeforeDelete ? await onBeforeDelete({ nodes, edges }) : true;
+      if (upstream === false) return false;
+      const candidate = upstream === true ? { nodes, edges } : upstream;
+
+      const vetoedNodeIds = new Set<string>();
+      const deletedNodeIds = new Set<string>();
+      for (const node of candidate.nodes) {
+        (readOnlyNodeIds.has(node.id) ? vetoedNodeIds : deletedNodeIds).add(node.id);
+      }
+      if (vetoedNodeIds.size === 0) return candidate;
+
+      const touchesVetoedNode = (edge: EdgeType) =>
+        vetoedNodeIds.has(edge.source) || vetoedNodeIds.has(edge.target);
+      const touchesDeletedNode = (edge: EdgeType) =>
+        deletedNodeIds.has(edge.source) || deletedNodeIds.has(edge.target);
+
+      return {
+        nodes: candidate.nodes.filter((node) => !vetoedNodeIds.has(node.id)),
+        edges: candidate.edges.filter(
+          (edge) => !touchesVetoedNode(edge) || touchesDeletedNode(edge)
+        ),
+      };
+    };
+  }, [readOnlyNodeIds, onBeforeDelete]);
+}

--- a/packages/apollo-react/src/canvas/components/BaseCanvas/BaseCanvas.readonly.integration.test.tsx
+++ b/packages/apollo-react/src/canvas/components/BaseCanvas/BaseCanvas.readonly.integration.test.tsx
@@ -2,9 +2,11 @@ import { render, screen } from '@testing-library/react';
 import type { Node } from '@uipath/apollo-react/canvas/xyflow/react';
 import { ReactFlowProvider } from '@uipath/apollo-react/canvas/xyflow/react';
 import type { ReactNode } from 'react';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { BaseCanvas } from './BaseCanvas';
 import { useIsNodeReadOnly } from './ReadOnlyNodesContext';
+
+let lastNodes: Node[] = [];
 
 vi.mock('@uipath/apollo-react/canvas/xyflow/react', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@uipath/apollo-react/canvas/xyflow/react')>();
@@ -18,15 +20,18 @@ vi.mock('@uipath/apollo-react/canvas/xyflow/react', async (importOriginal) => {
       children?: ReactNode;
       nodes: Node[];
       nodeTypes: Record<string, React.ComponentType<{ id: string }>>;
-    }) => (
-      <div data-testid="react-flow">
-        {nodes.map((node) => {
-          const NodeComponent = nodeTypes[node.type ?? ''];
-          return NodeComponent ? <NodeComponent key={node.id} id={node.id} /> : null;
-        })}
-        {children}
-      </div>
-    ),
+    }) => {
+      lastNodes = nodes;
+      return (
+        <div data-testid="react-flow">
+          {nodes.map((node) => {
+            const NodeComponent = nodeTypes[node.type ?? ''];
+            return NodeComponent ? <NodeComponent key={node.id} id={node.id} /> : null;
+          })}
+          {children}
+        </div>
+      );
+    },
     Background: () => <div data-testid="background" />,
     Panel: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
     useReactFlow: () => ({ fitView: vi.fn(), getNodes: () => [], getEdges: () => [] }),
@@ -56,8 +61,14 @@ const renderCanvas = (readOnlyNodeIds?: ReadonlySet<string>) =>
   );
 
 const readOnlyAttr = (id: string) => screen.getByTestId(`node-${id}`).dataset.readonly;
+const byId = <T extends { id: string }>(items: T[], id: string) =>
+  items.find((item) => item.id === id);
 
 describe('BaseCanvas with individually locked nodes', () => {
+  beforeEach(() => {
+    lastNodes = [];
+  });
+
   it('tells each node whether it is locked', () => {
     renderCanvas(new Set(['locked']));
 
@@ -69,5 +80,14 @@ describe('BaseCanvas with individually locked nodes', () => {
     renderCanvas();
 
     expect(readOnlyAttr('locked')).toBe('false');
+  });
+
+  // Enforcement is a delete-time veto, not a flag on the node, so the objects
+  // React Flow holds stay the consumer's own. See BaseCanvas.readonlyLeak.
+  it('hands React Flow the consumer node objects untouched', () => {
+    renderCanvas(new Set(['locked']));
+
+    expect(byId(lastNodes, 'locked')).toBe(nodes[0]);
+    expect(byId(lastNodes, 'free')).toBe(nodes[1]);
   });
 });

--- a/packages/apollo-react/src/canvas/components/BaseCanvas/BaseCanvas.readonlyChanges.test.tsx
+++ b/packages/apollo-react/src/canvas/components/BaseCanvas/BaseCanvas.readonlyChanges.test.tsx
@@ -1,0 +1,116 @@
+import { render } from '@testing-library/react';
+import type { Node, NodeChange } from '@uipath/apollo-react/canvas/xyflow/react';
+import { ReactFlowProvider } from '@uipath/apollo-react/canvas/xyflow/react';
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { BaseCanvas } from './BaseCanvas';
+import type { BaseCanvasProps } from './BaseCanvas.types';
+
+// Only the viewport hooks are stubbed, so the change guard is exercised for
+// real. This covers the direct-caller path: React Flow's own deletion paths go
+// through `onBeforeDelete` instead.
+vi.mock('./BaseCanvas.hooks', async () => ({
+  ...(await vi.importActual('./BaseCanvas.hooks')),
+  useAutoLayout: () => ({ isLayouting: false, isReady: true }),
+  useEnsureNodesInView: () => ({
+    ensureNodesInView: vi.fn(),
+    ensureAllNodesInView: vi.fn(),
+    centerNode: vi.fn(),
+  }),
+  useMaintainNodesInView: vi.fn(),
+}));
+
+let capturedOnNodesChange: ((changes: NodeChange[]) => void) | undefined;
+
+vi.mock('@uipath/apollo-react/canvas/xyflow/react', async () => {
+  const actual = await vi.importActual('@uipath/apollo-react/canvas/xyflow/react');
+  return {
+    ...actual,
+    ReactFlow: ({
+      children,
+      onNodesChange,
+    }: {
+      children?: ReactNode;
+      onNodesChange?: (changes: NodeChange[]) => void;
+    }) => {
+      capturedOnNodesChange = onNodesChange;
+      return <div data-testid="react-flow">{children}</div>;
+    },
+    Background: () => <div data-testid="background" />,
+    Panel: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+    useReactFlow: () => ({
+      fitView: vi.fn(),
+      getNodes: vi.fn(() => []),
+      getEdges: vi.fn(() => []),
+    }),
+  };
+});
+
+const nodes: Node[] = [
+  { id: 'locked', position: { x: 0, y: 0 }, data: {} },
+  { id: 'free', position: { x: 100, y: 0 }, data: {} },
+];
+
+const renderCanvas = (props: Partial<BaseCanvasProps>) =>
+  render(
+    <ReactFlowProvider>
+      <BaseCanvas nodes={nodes} edges={[]} nodeTypes={{}} {...props} />
+    </ReactFlowProvider>
+  );
+
+describe('BaseCanvas node changes when nodes are locked', () => {
+  beforeEach(() => {
+    capturedOnNodesChange = undefined;
+  });
+
+  it('ignores removal requests for locked nodes', () => {
+    const onNodesChange = vi.fn();
+    renderCanvas({ onNodesChange, readOnlyNodeIds: new Set(['locked']) });
+
+    capturedOnNodesChange?.([
+      { type: 'remove', id: 'locked' },
+      { type: 'remove', id: 'free' },
+    ]);
+
+    expect(onNodesChange).toHaveBeenCalledWith([{ type: 'remove', id: 'free' }]);
+  });
+
+  it('does not report changes when every removal targets a locked node', () => {
+    const onNodesChange = vi.fn();
+    renderCanvas({ onNodesChange, readOnlyNodeIds: new Set(['locked']) });
+
+    capturedOnNodesChange?.([{ type: 'remove', id: 'locked' }]);
+
+    expect(onNodesChange).not.toHaveBeenCalled();
+  });
+
+  it('allows locked nodes to move', () => {
+    const onNodesChange = vi.fn();
+    renderCanvas({ onNodesChange, readOnlyNodeIds: new Set(['locked']) });
+
+    const changes: NodeChange[] = [{ type: 'position', id: 'locked', position: { x: 5, y: 5 } }];
+    capturedOnNodesChange?.(changes);
+
+    expect(onNodesChange).toHaveBeenCalledWith(changes);
+  });
+
+  it('allows selection and resize changes for locked nodes', () => {
+    const onNodesChange = vi.fn();
+    renderCanvas({ onNodesChange, readOnlyNodeIds: new Set(['locked']) });
+
+    const changes: NodeChange[] = [
+      { type: 'select', id: 'locked', selected: true },
+      { type: 'dimensions', id: 'locked', dimensions: { width: 10, height: 10 } },
+    ];
+    capturedOnNodesChange?.(changes);
+
+    expect(onNodesChange).toHaveBeenCalledWith(changes);
+  });
+
+  it('uses the original change handler when no nodes are locked', () => {
+    const onNodesChange = vi.fn();
+    renderCanvas({ onNodesChange });
+
+    expect(capturedOnNodesChange).toBe(onNodesChange);
+  });
+});

--- a/packages/apollo-react/src/canvas/components/BaseCanvas/BaseCanvas.readonlyLeak.test.tsx
+++ b/packages/apollo-react/src/canvas/components/BaseCanvas/BaseCanvas.readonlyLeak.test.tsx
@@ -1,0 +1,133 @@
+import { render } from '@testing-library/react';
+import { act } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+// The suite-wide mock in `src/test/setup.ts` renders ReactFlow as a bare div
+// that never emits changes, which hides how the real store round-trips our
+// nodes. These tests deliberately run against real React Flow.
+vi.unmock('@uipath/apollo-react/canvas/xyflow/react');
+
+import type {
+  Edge,
+  EdgeChange,
+  Node,
+  NodeChange,
+  ReactFlowInstance,
+} from '@uipath/apollo-react/canvas/xyflow/react';
+import { ReactFlowProvider, useReactFlow } from '@uipath/apollo-react/canvas/xyflow/react';
+import { BaseCanvas } from './BaseCanvas';
+
+const LOCKED_IDS: ReadonlySet<string> = new Set(['locked']);
+
+/** One locked node plus one free node; `lockedProps` seeds the locked one. */
+const makeNodes = (lockedProps: Partial<Node> = {}): Node[] => [
+  { id: 'locked', position: { x: 0, y: 0 }, data: { v: 1 }, ...lockedProps },
+  { id: 'free', position: { x: 100, y: 0 }, data: { v: 1 } },
+];
+
+const renderWithRealFlow = (nodes: Node[], edges: Edge[] = []) => {
+  const changes: NodeChange[] = [];
+  const edgeChanges: EdgeChange[] = [];
+  let instance: ReactFlowInstance | undefined;
+
+  const Harness = () => {
+    instance = useReactFlow();
+    return (
+      <div style={{ width: 800, height: 600 }}>
+        <BaseCanvas
+          nodes={nodes}
+          edges={edges}
+          readOnlyNodeIds={LOCKED_IDS}
+          onNodesChange={(c) => changes.push(...c)}
+          onEdgesChange={(c) => edgeChanges.push(...c)}
+        />
+      </div>
+    );
+  };
+
+  render(
+    <ReactFlowProvider>
+      <Harness />
+    </ReactFlowProvider>
+  );
+
+  return {
+    changes,
+    edgeChanges,
+    flush: async (run: (instance: ReactFlowInstance) => void) => {
+      await act(async () => {
+        run(instance as ReactFlowInstance);
+        await new Promise((resolve) => setTimeout(resolve, 50));
+      });
+    },
+    replaceItem: (id: string) =>
+      changes.find(
+        (c): c is NodeChange & { id: string; item: Node } => c.type === 'replace' && c.id === id
+      )?.item,
+  };
+};
+
+describe('BaseCanvas read-only enforcement against real React Flow', () => {
+  // `'absent'` means the node must come back with no `deletable` key at all.
+  // Otherwise consumers persist our lock as their own data and unlocking the
+  // node can never undo it.
+  it.each([
+    ['a locked node authored without the key', {}, 'locked', 'absent'],
+    ['a locked node authored deletable: true', { deletable: true }, 'locked', true],
+    ['a consumer-owned deletable: false', { deletable: false }, 'locked', false],
+    ['an unlocked node', {}, 'free', 'absent'],
+  ] as const)('round-trips %s through a replace change', async (_, lockedProps, id, expected) => {
+    const { flush, replaceItem } = renderWithRealFlow(makeNodes(lockedProps));
+
+    await flush((instance) => instance.updateNodeData(id, { v: 99 }));
+
+    const item = replaceItem(id);
+    expect(item?.data).toEqual({ v: 99 });
+    if (expected === 'absent') {
+      expect(item && 'deletable' in item).toBe(false);
+    } else {
+      expect(item?.deletable).toBe(expected);
+    }
+  });
+
+  // The reason enforcement is a delete-time veto rather than a flag: whatever
+  // the store holds is what a consumer saves, and a persisted `deletable: false`
+  // is indistinguishable from their own, so unlocking could never undo it.
+  it('keeps enforcement flags out of the saved graph', async () => {
+    const { flush } = renderWithRealFlow(makeNodes());
+    let saved: ReturnType<ReactFlowInstance['toObject']> | undefined;
+
+    await flush((instance) => {
+      saved = instance.toObject();
+    });
+
+    for (const node of saved?.nodes ?? []) {
+      expect('deletable' in node).toBe(false);
+    }
+  });
+
+  // Vetoing the node is only half the job: React Flow collects the edges of
+  // every node in the delete set, so its connections have to come back out too.
+  it('keeps the edges of a locked node when its deletion is vetoed', async () => {
+    const edges: Edge[] = [{ id: 'locked-free', source: 'locked', target: 'free' }];
+    const { edgeChanges, flush } = renderWithRealFlow(makeNodes(), edges);
+
+    await flush((instance) => instance.deleteElements({ nodes: [{ id: 'locked' }] }));
+
+    expect(edgeChanges.filter((c) => c.type === 'remove')).toEqual([]);
+  });
+
+  // Kept at this level because the veto runs inside `deleteElements`, a path the
+  // mocked-flow suites cannot exercise.
+  it('still blocks deletion of a locked node', async () => {
+    const { changes, flush } = renderWithRealFlow(makeNodes());
+
+    await flush((instance) =>
+      instance.deleteElements({ nodes: [{ id: 'locked' }, { id: 'free' }] })
+    );
+
+    const removed = changes.filter((c) => c.type === 'remove').map((c) => c.id);
+    expect(removed).not.toContain('locked');
+    expect(removed).toContain('free');
+  });
+});

--- a/packages/apollo-react/src/canvas/components/BaseCanvas/BaseCanvas.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/BaseCanvas/BaseCanvas.stories.tsx
@@ -16,14 +16,17 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@uipath/apollo-wind';
-import { useMemo, useRef, useState } from 'react';
+import { useCallback, useMemo, useRef, useState } from 'react';
 import {
   createNode,
   StoryCode,
   StoryCodeBlock,
   StoryInfoPanel,
   StoryPage,
+  StoryPreview,
   StorySection,
+  type StorySpecColumn,
+  StorySpecTable,
   useCanvasStory,
   withCanvasProviders,
 } from '../../storybook-utils';
@@ -1290,6 +1293,177 @@ export const WithMaintainNodesInView: Story = {
 // Per-Node Read-Only
 // ============================================================================
 
+// BaseCanvas disables the delete key by default; the story opts in so locking
+// is observable.
+const READ_ONLY_DELETE_KEY_CODES = ['Backspace', 'Delete'];
+
+const TIDY_COLUMN_GAP = 260;
+const TIDY_ROW_GAP = 170;
+
+/** Longest-path depth per node, used as the tidy column index. */
+function computeTidyDepths(nodes: Node[], edges: Edge[]): Map<string, number> {
+  const depths = new Map(nodes.map((node) => [node.id, 0]));
+  // Bounded relaxation: converges on a DAG, terminates on cycles.
+  for (let pass = 0; pass < nodes.length; pass++) {
+    let changed = false;
+    for (const edge of edges) {
+      const candidate = (depths.get(edge.source) ?? 0) + 1;
+      if (depths.has(edge.target) && candidate > (depths.get(edge.target) ?? 0)) {
+        depths.set(edge.target, candidate);
+        changed = true;
+      }
+    }
+    if (!changed) break;
+  }
+  return depths;
+}
+
+function PerNodeReadOnlyCanvas() {
+  const initialNodes = useMemo(() => createPipelineNodes(), []);
+  const { canvasProps, setNodes } = useCanvasStory({
+    initialNodes,
+    initialEdges: pipelineEdges,
+  });
+  const [lockedIds, setLockedIds] = useState<ReadonlySet<string>>(new Set());
+  const [selectedIds, setSelectedIds] = useState<string[]>([]);
+
+  // Must be stable: React Flow re-fires onSelectionChange whenever the handler
+  // identity changes, so an inline arrow + setState is an infinite render loop.
+  const handleSelectionChange = useCallback(({ nodes }: { nodes: Node[] }) => {
+    const ids = nodes.map((node) => node.id);
+    setSelectedIds((previous) =>
+      previous.length === ids.length && previous.every((id, index) => id === ids[index])
+        ? previous
+        : ids
+    );
+  }, []);
+
+  // Lays out every node, locked included: position is layout, not content.
+  const handleTidy = useCallback(() => {
+    setNodes((current) => {
+      const depths = computeTidyDepths(current, pipelineEdges);
+      const rowByColumn = new Map<number, number>();
+      return current.map((node) => {
+        const column = depths.get(node.id) ?? 0;
+        const row = rowByColumn.get(column) ?? 0;
+        rowByColumn.set(column, row + 1);
+        return { ...node, position: { x: column * TIDY_COLUMN_GAP, y: row * TIDY_ROW_GAP } };
+      });
+    });
+  }, [setNodes]);
+
+  return (
+    <Column h="100%">
+      <Column
+        gap={8}
+        p={20}
+        style={{
+          color: 'var(--canvas-foreground)',
+          backgroundColor: 'var(--canvas-background-secondary)',
+        }}
+      >
+        <span className="text-lg font-bold">Choose what stays editable</span>
+        <span className="text-base">
+          Select one or more nodes, then lock or unlock their content without leaving design mode.
+        </span>
+        <Row gap={8} align="center">
+          <Button
+            size="sm"
+            disabled={selectedIds.length === 0}
+            onClick={() => setLockedIds(new Set([...lockedIds, ...selectedIds]))}
+          >
+            Lock selected ({selectedIds.length})
+          </Button>
+          <Button
+            size="sm"
+            variant="secondary"
+            disabled={!selectedIds.some((id) => lockedIds.has(id))}
+            onClick={() =>
+              setLockedIds(new Set([...lockedIds].filter((id) => !selectedIds.includes(id))))
+            }
+          >
+            Unlock selected
+          </Button>
+          <Button
+            size="sm"
+            variant="secondary"
+            disabled={lockedIds.size === 0}
+            onClick={() => setLockedIds(new Set())}
+          >
+            Unlock all ({lockedIds.size} locked)
+          </Button>
+        </Row>
+        <span className="text-sm">
+          Locked: {lockedIds.size > 0 ? [...lockedIds].join(', ') : 'none'}
+        </span>
+      </Column>
+      <div style={{ flex: 1, borderTop: '1px solid var(--canvas-border)' }}>
+        <BaseCanvas
+          {...canvasProps}
+          mode="design"
+          deleteKeyCode={READ_ONLY_DELETE_KEY_CODES}
+          readOnlyNodeIds={lockedIds}
+          onSelectionChange={handleSelectionChange}
+        >
+          <Panel position="bottom-right">
+            <CanvasPositionControls
+              translations={DefaultCanvasTranslations}
+              onOrganize={handleTidy}
+            />
+          </Panel>
+        </BaseCanvas>
+      </div>
+    </Column>
+  );
+}
+
+type ReadOnlyBehaviorRow = {
+  interaction: string;
+  lockedBehavior: string;
+  detail: string;
+};
+
+const baseNodeBehaviorRows: readonly ReadOnlyBehaviorRow[] = [
+  {
+    interaction: 'Delete',
+    lockedBehavior: 'Blocked',
+    detail: 'Delete and Backspace skip locked nodes, including within a mixed selection.',
+  },
+  {
+    interaction: 'Rename',
+    lockedBehavior: 'Blocked',
+    detail: 'Double-click does not edit the label; applying a lock discards an active draft.',
+  },
+  {
+    interaction: 'Toolbar',
+    lockedBehavior: 'Disabled',
+    detail:
+      'The toolbar still opens on hover or selection, with every action greyed out and inert. Labels keep working, so the lock explains itself.',
+  },
+  {
+    interaction: 'Add buttons',
+    lockedBehavior: 'Hidden',
+    detail:
+      'Handle add buttons sit inline in the layout, so they are removed rather than greyed out.',
+  },
+  {
+    interaction: 'Select and drag',
+    lockedBehavior: 'Available',
+    detail: 'Selection and position remain layout interactions, so both continue to work.',
+  },
+  {
+    interaction: 'Resize and organize',
+    lockedBehavior: 'Available',
+    detail: 'Layout tools can continue to reposition and resize locked nodes.',
+  },
+];
+
+const readOnlyBehaviorColumns: readonly StorySpecColumn<ReadOnlyBehaviorRow>[] = [
+  { key: 'interaction', header: 'Interaction', variant: 'strong' },
+  { key: 'lockedBehavior', header: 'While locked', variant: 'code' },
+  { key: 'detail', header: 'What happens' },
+];
+
 function PerNodeReadOnlyPage({ globalTheme }: { globalTheme: string }) {
   return (
     <StoryPage
@@ -1303,9 +1477,26 @@ function PerNodeReadOnlyPage({ globalTheme }: { globalTheme: string }) {
         </>
       }
     >
+      <StoryPreview
+        height={640}
+        description={
+          <>
+            <p>
+              Select nodes and lock them, then compare their controls with an unlocked neighbor.
+              Press Delete or Backspace on a mixed selection: only the unlocked nodes are removed.
+            </p>
+            <p>
+              Drag locked nodes or use Organize to confirm that layout stays available while node
+              content is protected.
+            </p>
+          </>
+        }
+      >
+        <PerNodeReadOnlyCanvas />
+      </StoryPreview>
+
       <StorySection
         title="State and API"
-        divider={false}
         description={
           <>
             <p>
@@ -1345,6 +1536,13 @@ function CustomNode({ id }: NodeProps) {
   return <CustomEditor disabled={isReadOnly} />;
 }`}
         </StoryCodeBlock>
+      </StorySection>
+
+      <StorySection
+        title="Base node behavior"
+        description="A lock protects BaseNode content without turning the node into a static object. Layout and navigation stay available so users can continue arranging and inspecting the graph. Actions that only appear on demand are disabled rather than removed, so the node still reports what it would otherwise offer. Specialized renderers can apply additional restrictions to their own controls."
+      >
+        <StorySpecTable columns={readOnlyBehaviorColumns} rows={baseNodeBehaviorRows} />
       </StorySection>
     </StoryPage>
   );

--- a/packages/apollo-react/src/canvas/components/BaseCanvas/BaseCanvas.test.tsx
+++ b/packages/apollo-react/src/canvas/components/BaseCanvas/BaseCanvas.test.tsx
@@ -20,6 +20,7 @@ vi.mock('./BaseCanvas.hooks', () => ({
     centerNode: vi.fn(),
   }),
   useMaintainNodesInView: vi.fn(),
+  useReadOnlyBeforeDelete: () => undefined,
 }));
 
 // Mock ReactFlow

--- a/packages/apollo-react/src/canvas/components/BaseCanvas/BaseCanvas.tsx
+++ b/packages/apollo-react/src/canvas/components/BaseCanvas/BaseCanvas.tsx
@@ -17,7 +17,12 @@ import {
 } from 'react';
 import { useToolbarActionStore } from '../../hooks/ToolbarActionContext';
 import { BASE_CANVAS_DEFAULTS, PAN_ON_DRAG } from './BaseCanvas.constants';
-import { useAutoLayout, useEnsureNodesInView, useMaintainNodesInView } from './BaseCanvas.hooks';
+import {
+  useAutoLayout,
+  useEnsureNodesInView,
+  useMaintainNodesInView,
+  useReadOnlyBeforeDelete,
+} from './BaseCanvas.hooks';
 import type { BaseCanvasProps, BaseCanvasRef } from './BaseCanvas.types';
 import { CanvasBackground } from './CanvasBackground';
 import { CanvasProviders } from './CanvasProviders';
@@ -77,6 +82,7 @@ const BaseCanvasInnerComponent = <NodeType extends Node = Node, EdgeType extends
     onPaneClick,
     onInit,
     onSelectionChange,
+    onBeforeDelete,
 
     // Additional ReactFlow props
     proOptions = BASE_CANVAS_DEFAULTS.pro,
@@ -112,6 +118,21 @@ const BaseCanvasInnerComponent = <NodeType extends Node = Node, EdgeType extends
   const isInteractive = mode !== 'readonly';
   const isDesignMode = mode === 'design';
   const stableReadOnlyNodeIds = useStableNodeIdSet(readOnlyNodeIds);
+  const guardedBeforeDelete = useReadOnlyBeforeDelete(stableReadOnlyNodeIds, onBeforeDelete);
+
+  // `onBeforeDelete` already covers every React Flow deletion path. This is the
+  // safety net for consumers that invoke the change handler directly. Layout
+  // changes pass through: position and size are layout, not content.
+  const handleNodesChange = useMemo(() => {
+    if (!onNodesChange || stableReadOnlyNodeIds.size === 0) return onNodesChange;
+    const guarded: typeof onNodesChange = (changes) => {
+      const allowed = changes.filter(
+        (change) => !(change.type === 'remove' && stableReadOnlyNodeIds.has(change.id))
+      );
+      if (allowed.length > 0) onNodesChange(allowed);
+    };
+    return guarded;
+  }, [onNodesChange, stableReadOnlyNodeIds]);
 
   const [reactFlowInstance, setReactFlowInstance] =
     useState<ReactFlowInstance<NodeType, EdgeType>>();
@@ -195,8 +216,9 @@ const BaseCanvasInnerComponent = <NodeType extends Node = Node, EdgeType extends
         zoomOnDoubleClick={isInteractive && zoomOnDoubleClick}
         panOnDrag={isInteractive ? PAN_ON_DRAG : false}
         onInit={handleInit}
-        onNodesChange={isInteractive ? onNodesChange : undefined}
+        onNodesChange={isInteractive ? handleNodesChange : undefined}
         onEdgesChange={isInteractive ? onEdgesChange : undefined}
+        onBeforeDelete={guardedBeforeDelete}
         onConnect={isDesignMode ? onConnect : undefined}
         onConnectStart={isDesignMode ? onConnectStart : undefined}
         onConnectEnd={isDesignMode ? onConnectEnd : undefined}

--- a/packages/apollo-react/src/canvas/components/BaseCanvas/BaseCanvas.types.ts
+++ b/packages/apollo-react/src/canvas/components/BaseCanvas/BaseCanvas.types.ts
@@ -77,6 +77,9 @@ export interface BaseCanvasProps<NodeType extends Node = Node, EdgeType extends 
 
   /**
    * Node ids whose content is read-only while the rest of the canvas remains editable.
+   * Locked nodes cannot be deleted or label-edited and hide BaseNode add buttons.
+   * Their toolbar stays visible with every action disabled, so the lock is
+   * discoverable. They remain selectable, draggable, and resizable.
    * Custom node renderers can observe their state with `useIsNodeReadOnly`.
    *
    * Compared by content, so passing a fresh set with the same ids is a no-op.

--- a/packages/apollo-react/src/canvas/components/BaseCanvas/index.test.ts
+++ b/packages/apollo-react/src/canvas/components/BaseCanvas/index.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from 'vitest';
+import * as BaseCanvasExports from './index';
+
+describe('BaseCanvas public exports', () => {
+  it('keeps read-only enforcement helpers private when the barrel is imported', () => {
+    expect(BaseCanvasExports).not.toHaveProperty('useReadOnlyBeforeDelete');
+  });
+});

--- a/packages/apollo-react/src/canvas/components/BaseCanvas/index.ts
+++ b/packages/apollo-react/src/canvas/components/BaseCanvas/index.ts
@@ -1,6 +1,11 @@
 export { BaseCanvas } from './BaseCanvas';
 export * from './BaseCanvas.constants';
-export * from './BaseCanvas.hooks';
+export {
+  useAutoLayout,
+  useEnsureNodesInView,
+  useFitView,
+  useMaintainNodesInView,
+} from './BaseCanvas.hooks';
 export * from './BaseCanvas.types';
 export * from './BaseCanvasModeProvider';
 export * from './CanvasBackground';

--- a/packages/apollo-react/src/canvas/components/BaseNode/BaseNode.test.tsx
+++ b/packages/apollo-react/src/canvas/components/BaseNode/BaseNode.test.tsx
@@ -22,6 +22,8 @@ const {
   mockMultipleNodesSelected,
   mockIsConnecting,
   mockNodeToolbar,
+  mockNodeLabel,
+  mockReadOnlyNodeIds,
 } = vi.hoisted(() => ({
   mockUpdateNode: vi.fn(),
   mockGetNode: vi.fn(),
@@ -42,6 +44,9 @@ const {
   mockIsConnecting: { current: false },
   // biome-ignore lint/suspicious/noExplicitAny: captures the toolbar props for assertions
   mockNodeToolbar: vi.fn() as any,
+  // biome-ignore lint/suspicious/noExplicitAny: captures the label props for assertions
+  mockNodeLabel: vi.fn() as any,
+  mockReadOnlyNodeIds: { current: new Set<string>() as ReadonlySet<string> },
 }));
 
 // getNode reflects whatever updateNode last wrote, so the height-sync effect converges
@@ -78,6 +83,10 @@ vi.mock('../../core', () => ({
 
 vi.mock('../BaseCanvas/BaseCanvasModeProvider', () => ({
   useBaseCanvasMode: () => ({ mode: mockMode.current }),
+}));
+vi.mock('../BaseCanvas/ReadOnlyNodesContext', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../BaseCanvas/ReadOnlyNodesContext')>()),
+  useIsNodeReadOnly: (nodeId: string) => mockReadOnlyNodeIds.current.has(nodeId),
 }));
 vi.mock('../BaseCanvas/ConnectedHandlesContext', () => ({ useConnectedHandles: () => new Set() }));
 vi.mock('../BaseCanvas/SelectionStateContext', () => ({
@@ -137,7 +146,10 @@ vi.mock('../../utils/manifest-resolver', () => ({
 }));
 
 vi.mock('./NodeLabel', () => ({
-  NodeLabel: ({ label }: { label?: string }) => <div data-testid="node-label">{label}</div>,
+  NodeLabel: (props: { label?: string }) => {
+    mockNodeLabel(props);
+    return <div data-testid="node-label">{props.label}</div>;
+  },
 }));
 
 import type { HandleGroupManifest } from '../../schema';
@@ -177,6 +189,8 @@ describe('BaseNode', () => {
     mockNodeState.current = { height: undefined };
     mockUseButtonHandles.mockClear();
     mockNodeToolbar.mockClear();
+    mockNodeLabel.mockClear();
+    mockReadOnlyNodeIds.current = new Set();
     mockHandleConfigs.current = undefined;
     mockManifest.current = { ...DEFAULT_MANIFEST };
     mockOverrideConfig.current = {};
@@ -425,7 +439,12 @@ describe('BaseNode', () => {
     type Handle = HandleGroupManifest['handles'][number];
 
     const TOP_TOOLBAR = {
-      actions: [{ id: 'edit', icon: 'edit', label: 'Edit', onAction: vi.fn() }],
+      actions: [
+        { id: 'edit', icon: 'edit', label: 'Edit', onAction: vi.fn() },
+        { id: 'separator' },
+        { id: 'delete', icon: 'trash', label: 'Delete', onAction: vi.fn() },
+      ],
+      overflowActions: [{ id: 'rename', icon: 'pencil', label: 'Rename', onAction: vi.fn() }],
       position: 'top',
     };
 
@@ -589,6 +608,83 @@ describe('BaseNode', () => {
       mockHandleConfigs.current = topHandles(buttonHandle);
       render(<BaseNode {...defaultProps} selected={true} />);
       expect(offset()).toBe('button');
+    });
+  });
+
+  // A node listed in BaseCanvas `readOnlyNodeIds` loses its editing affordances
+  // even while the canvas is in design mode: add buttons and label editing are
+  // hidden, and the toolbar stays mounted with every action disabled.
+  // NodeLabel and NodeToolbar are module-mocked above, so the label/toolbar
+  // contract is asserted on the props they receive.
+  describe('when individual nodes are locked', () => {
+    const NODE_ID = defaultProps.id;
+
+    const TOP_TOOLBAR = {
+      actions: [
+        { id: 'edit', icon: 'edit', label: 'Edit', onAction: vi.fn() },
+        { id: 'separator' },
+        { id: 'delete', icon: 'trash', label: 'Delete', onAction: vi.fn() },
+      ],
+      overflowActions: [{ id: 'rename', icon: 'pencil', label: 'Rename', onAction: vi.fn() }],
+      position: 'top',
+    };
+
+    const renderNode = (overrides: Partial<NodeProps<Node<BaseNodeData>>> = {}) => {
+      mockOverrideConfig.current = { toolbarConfig: TOP_TOOLBAR };
+      return render(<BaseNode {...defaultProps} {...overrides} />);
+    };
+
+    // The latest `readonly` value handed to NodeLabel.
+    const labelReadonly = () => mockNodeLabel.mock.calls.at(-1)?.[0]?.readonly;
+
+    // The latest config handed to NodeToolbar.
+    const toolbarConfig = () => mockNodeToolbar.mock.calls.at(-1)?.[0]?.config;
+
+    it('keeps the toolbar mounted but disables every action when the node is locked', () => {
+      mockReadOnlyNodeIds.current = new Set([NODE_ID]);
+      renderNode({ selected: true });
+      const config = toolbarConfig();
+      expect(config.actions).toEqual([
+        expect.objectContaining({ id: 'edit', disabled: true }),
+        { id: 'separator' },
+        expect.objectContaining({ id: 'delete', disabled: true }),
+      ]);
+      expect(config.overflowActions).toEqual([
+        expect.objectContaining({ id: 'rename', disabled: true }),
+      ]);
+    });
+
+    it('leaves the toolbar config untouched when the node is not locked', () => {
+      renderNode({ selected: true });
+      expect(toolbarConfig()).toBe(TOP_TOOLBAR);
+    });
+
+    it('keeps the toolbar visible in non-design modes unless the node is locked', () => {
+      mockMode.current = 'readonly';
+      renderNode({ selected: true });
+      expect(mockNodeToolbar).toHaveBeenCalled();
+    });
+
+    it('prevents label editing when the node is locked', () => {
+      mockMode.current = 'design';
+      mockReadOnlyNodeIds.current = new Set([NODE_ID]);
+      renderNode({ selected: true });
+      expect(labelReadonly()).toBe(true);
+    });
+
+    it('keeps an unlocked node editable', () => {
+      mockMode.current = 'design';
+      mockReadOnlyNodeIds.current = new Set(['some-other-node']);
+      renderNode({ selected: true });
+      expect(labelReadonly()).toBe(false);
+    });
+
+    it('hides connection add buttons when the node is locked', () => {
+      mockMode.current = 'design';
+      mockReadOnlyNodeIds.current = new Set([NODE_ID]);
+      renderNode({ selected: true });
+      const opts = mockUseButtonHandles.mock.calls.at(-1)?.[0] as { showAddButton?: boolean };
+      expect(opts.showAddButton).toBe(false);
     });
   });
 });

--- a/packages/apollo-react/src/canvas/components/BaseNode/BaseNode.tsx
+++ b/packages/apollo-react/src/canvas/components/BaseNode/BaseNode.tsx
@@ -36,11 +36,13 @@ import { resolveToolbar } from '../../utils/toolbar-resolver';
 import { useBaseCanvasMode } from '../BaseCanvas/BaseCanvasModeProvider';
 import { useCanvasTheme } from '../BaseCanvas/CanvasThemeContext';
 import { useConnectedHandles } from '../BaseCanvas/ConnectedHandlesContext';
+import { useIsNodeReadOnly } from '../BaseCanvas/ReadOnlyNodesContext';
 import { useSelectionState } from '../BaseCanvas/SelectionStateContext';
 import type { HandleActionEvent } from '../ButtonHandle/ButtonHandle';
 import { SmartHandle, SmartHandleProvider } from '../ButtonHandle/SmartHandle';
 import { useButtonHandles } from '../ButtonHandle/useButtonHandles';
 import { InitialsBadge } from '../shared/InitialsBadge';
+import type { NodeToolbarConfig, ToolbarAction } from '../Toolbar';
 import { NodeToolbar } from '../Toolbar';
 import type {
   BaseNodeData,
@@ -54,6 +56,16 @@ import { BaseContainer } from './BaseNodeContainer';
 import { BaseInnerShape } from './BaseNodeInnerShape';
 import { MissingManifestNode } from './BaseNodeMissingManifest';
 import { NodeLabel } from './NodeLabel';
+
+/** Stable predicate used to hard-disable add buttons on read-only nodes. */
+const NEVER_SHOW_ADD_BUTTON = () => false;
+
+/**
+ * Returns the actions with every item disabled, separators untouched. Used to
+ * lock a read-only node's toolbar instead of unmounting it.
+ */
+const disableToolbarActions = (actions: ToolbarAction[]): ToolbarAction[] =>
+  actions.map((action) => (action.id === 'separator' ? action : { ...action, disabled: true }));
 
 const getContainerWidth = (shape: NodeShape | undefined, width: number | undefined) => {
   const defaultWidth = shape === 'rectangle' ? DEFAULT_RECTANGLE_NODE_WIDTH : DEFAULT_NODE_SIZE;
@@ -120,6 +132,10 @@ const BaseNodeComponent = (props: NodeProps<Node<BaseNodeData>>) => {
   const validationState = useElementValidationStatus(id);
   const nodeTypeRegistry = useNodeTypeRegistry();
   const { mode } = useBaseCanvasMode();
+  const isNodeReadOnly = useIsNodeReadOnly(id);
+  // Per-node read-only composes with canvas mode: a node is editable only in
+  // design mode AND when not individually locked via readOnlyNodeIds.
+  const canEdit = mode === 'design' && !isNodeReadOnly;
 
   // Use context for connected handles - O(1) lookup instead of O(edges) per node
   const connectedHandleIds = useConnectedHandles(id);
@@ -156,7 +172,10 @@ const BaseNodeComponent = (props: NodeProps<Node<BaseNodeData>>) => {
 
   // Callbacks: Use props only (no longer in data)
   const onHandleActionCallback = onHandleActionProp;
-  const shouldShowAddButtonFn = shouldShowAddButtonFnProp;
+  // A locked node drops the custom predicate: predicates commonly OR in their
+  // own conditions (`showAddButton || selected`), which would hand the button
+  // back on selection. Canvas-mode readonly still honors it, as before.
+  const shouldShowAddButtonFn = isNodeReadOnly ? NEVER_SHOW_ADD_BUTTON : shouldShowAddButtonFnProp;
   const shouldShowButtonHandleNotchesFn = shouldShowButtonHandleNotchesFnProp;
 
   // Use executionStatusOverride if provided, otherwise use hook value
@@ -235,6 +254,24 @@ const BaseNodeComponent = (props: NodeProps<Node<BaseNodeData>>) => {
     // Priority 2: Manifest default
     return manifest ? resolveToolbar(manifest, statusContext) : undefined;
   }, [toolbarConfigProp, manifest, statusContext]);
+
+  // A locked node keeps its toolbar and disables it rather than hiding it: the
+  // greyed-out actions (with their tooltips intact) say "read-only", where a
+  // missing toolbar just reads as a node with nothing to offer. Disabling is
+  // also real enforcement, since a consumer's `onAction` never reaches the
+  // canvas-level delete veto.
+  const effectiveToolbarConfig = useMemo((): NodeToolbarConfig | undefined => {
+    if (!toolbarConfig || !isNodeReadOnly) {
+      return toolbarConfig;
+    }
+    return {
+      ...toolbarConfig,
+      actions: disableToolbarActions(toolbarConfig.actions),
+      ...(toolbarConfig.overflowActions && {
+        overflowActions: disableToolbarActions(toolbarConfig.overflowActions),
+      }),
+    };
+  }, [toolbarConfig, isNodeReadOnly]);
 
   // Adornments resolution: use default resolver, then override with props if provided
   const adornments: NodeAdornments = useMemo(() => {
@@ -479,9 +516,9 @@ const BaseNodeComponent = (props: NodeProps<Node<BaseNodeData>>) => {
     const isAddButtonShown = () => {
       // SmartHandle add buttons require selection (and ignore connect/drag state).
       if (useSmartHandles) {
-        return mode === 'design' && !!selected;
+        return canEdit && !!selected;
       }
-      const showAddButton = mode === 'design' && !isConnecting && !dragging;
+      const showAddButton = canEdit && !isConnecting && !dragging;
       if (shouldShowAddButtonFn) {
         return shouldShowAddButtonFn({ showAddButton, selected: !!selected });
       }
@@ -496,7 +533,7 @@ const BaseNodeComponent = (props: NodeProps<Node<BaseNodeData>>) => {
     return false;
   }, [
     toolbarSideHandleAffordances,
-    mode,
+    canEdit,
     multipleNodesSelected,
     useSmartHandles,
     selected,
@@ -517,7 +554,7 @@ const BaseNodeComponent = (props: NodeProps<Node<BaseNodeData>>) => {
     nodeId: id,
     selected: selected ?? false,
     hovered: isHovered,
-    showAddButton: mode === 'design' && !multipleNodesSelected && !isConnecting && !dragging,
+    showAddButton: canEdit && !multipleNodesSelected && !isConnecting && !dragging,
     showNotches,
     // Deterministic geometry (not the measured props) so handles are grid-aligned from first render.
     nodeWidth: containerWidth,
@@ -552,8 +589,7 @@ const BaseNodeComponent = (props: NodeProps<Node<BaseNodeData>>) => {
         const isVisible = hasConnection || (shouldShowHandles && configVisible);
 
         // Determine if add button should be shown (hide when multiple nodes selected)
-        const shouldShowButton =
-          mode === 'design' && selected && handle.showButton && !multipleNodesSelected;
+        const shouldShowButton = canEdit && selected && handle.showButton && !multipleNodesSelected;
 
         return (
           <SmartHandle
@@ -583,7 +619,7 @@ const BaseNodeComponent = (props: NodeProps<Node<BaseNodeData>>) => {
     shouldShowHandles,
     containerWidth,
     computedHeight,
-    mode,
+    canEdit,
     selected,
     showNotches,
     handleAction,
@@ -680,17 +716,18 @@ const BaseNodeComponent = (props: NodeProps<Node<BaseNodeData>>) => {
           hasBottomHandles={hasVisibleBottomHandles}
           selected={selected}
           dragging={dragging}
-          readonly={mode !== 'design'}
+          readonly={!canEdit}
+          discardDraftOnReadonly={isNodeReadOnly}
           onChange={handleLabelChange}
         />
         {displayFooter && (
           <div className="basis-full pt-0.5 min-w-0 overflow-hidden">{displayFooter}</div>
         )}
       </BaseContainer>
-      {toolbarConfig && (
+      {effectiveToolbarConfig && (
         <NodeToolbar
           nodeId={id}
-          config={toolbarConfig}
+          config={effectiveToolbarConfig}
           expanded={selected || isHovered}
           hidden={dragging || multipleNodesSelected}
           offsetToolbar={offsetToolbar}

--- a/packages/apollo-react/src/canvas/components/BaseNode/NodeLabel.test.tsx
+++ b/packages/apollo-react/src/canvas/components/BaseNode/NodeLabel.test.tsx
@@ -121,6 +121,36 @@ describe('NodeLabel', () => {
       expect(screen.getByRole('textbox', { name: 'Edit node description' })).toBeInTheDocument();
     });
 
+    // Locking is often an execution lock, so it must not commit the draft as a
+    // side effect of taking hold.
+    it('discards the draft when the label becomes read-only while editing', async () => {
+      const onChange = vi.fn();
+      const { rerender } = render(<NodeLabel {...defaultProps} onChange={onChange} />);
+
+      await user.dblClick(screen.getByText('Test Node'));
+      await user.clear(screen.getByRole('textbox', { name: 'Edit node name' }));
+      await user.type(screen.getByRole('textbox', { name: 'Edit node name' }), 'Renamed');
+
+      rerender(<NodeLabel {...defaultProps} onChange={onChange} readonly discardDraftOnReadonly />);
+
+      expect(onChange).not.toHaveBeenCalled();
+      expect(screen.queryByRole('textbox', { name: 'Edit node name' })).not.toBeInTheDocument();
+      expect(screen.getByText('Test Node')).toBeInTheDocument();
+    });
+
+    it('saves the draft when the node is deselected while editable', async () => {
+      const onChange = vi.fn();
+      const { rerender } = render(<NodeLabel {...defaultProps} onChange={onChange} />);
+
+      await user.dblClick(screen.getByText('Test Node'));
+      await user.clear(screen.getByRole('textbox', { name: 'Edit node name' }));
+      await user.type(screen.getByRole('textbox', { name: 'Edit node name' }), 'Renamed');
+
+      rerender(<NodeLabel {...defaultProps} onChange={onChange} selected={false} />);
+
+      expect(onChange).toHaveBeenCalledWith({ label: 'Renamed', subLabel: 'Test Description' });
+    });
+
     it('should enter edit mode when subLabel is double clicked', async () => {
       render(<NodeLabel {...defaultProps} />);
 
@@ -178,6 +208,14 @@ describe('NodeLabel', () => {
       await user.dblClick(screen.getByText('Test Node'));
 
       expect(screen.queryByRole('textbox', { name: 'Edit node name' })).not.toBeInTheDocument();
+    });
+
+    it('should disable the empty placeholder when readonly', () => {
+      render(<NodeLabel {...defaultProps} label="" subLabel="" readonly />);
+
+      // Disabled keeps it out of the tab order, so it can't be focused to
+      // announce an action a read-only node won't perform.
+      expect(screen.getByRole('button', { name: 'Add node label' })).toBeDisabled();
     });
 
     it('should allow editing label value', async () => {

--- a/packages/apollo-react/src/canvas/components/BaseNode/NodeLabel.tsx
+++ b/packages/apollo-react/src/canvas/components/BaseNode/NodeLabel.tsx
@@ -185,12 +185,16 @@ const EditableLabel = forwardRef<HTMLTextAreaElement, EditableLabelProps>(
 EditableLabel.displayName = 'EditableLabel';
 
 interface EmptyLabelPlaceholderProps {
+  disabled?: boolean;
   onDoubleClick?: (e: React.MouseEvent) => void;
 }
 
-const EmptyLabelPlaceholder = ({ onDoubleClick }: EmptyLabelPlaceholderProps) => (
+// `disabled` keeps the placeholder out of the tab order when read-only, so it
+// can't be focused to announce an action it won't perform.
+const EmptyLabelPlaceholder = ({ disabled, onDoubleClick }: EmptyLabelPlaceholderProps) => (
   <button
     type="button"
+    disabled={disabled}
     onDoubleClick={onDoubleClick}
     className="nodrag nowheel text-sm leading-[18px] font-semibold text-foreground-muted bg-transparent border border-dashed border-border-de-emp rounded-sm cursor-pointer opacity-0 transition-opacity duration-200 min-w-5 min-h-5 hover:opacity-100"
     aria-label="Add node label"
@@ -209,6 +213,8 @@ export interface NodeLabelProps {
   dragging?: boolean;
   centerAdornment?: React.ReactNode;
   readonly?: boolean;
+  /** Discard rather than commit an in-progress edit when `readonly` turns on. */
+  discardDraftOnReadonly?: boolean;
   onChange?: (values: { label: string; subLabel: string }) => void;
 }
 
@@ -223,6 +229,7 @@ const NodeLabelInternal = ({
   dragging,
   centerAdornment,
   readonly,
+  discardDraftOnReadonly,
   onChange,
 }: NodeLabelProps) => {
   const [isEditing, setIsEditing] = useState(false);
@@ -273,19 +280,24 @@ const NodeLabelInternal = ({
     }
   }, [isEditing, focusTarget]);
 
-  // Exit edit mode when node is deselected, dragged, or set to readonly
-  useEffect(() => {
-    if (isEditing && (!selected || dragging || readonly)) {
-      handleSave();
-    }
-  }, [selected, dragging, isEditing, readonly, handleSave]);
-
   const handleCancel = useCallback(() => {
     setIsEditing(false);
     setFocusTarget(null);
     setLocalLabel(label);
     setLocalSubLabel(subLabel);
   }, [label, subLabel]);
+
+  // Exit edit mode when deselected, dragged, or set to readonly. A per-node
+  // lock discards the draft: locking is often an execution lock and must not
+  // mutate data as a side effect. Every other exit commits.
+  useEffect(() => {
+    if (!isEditing) return;
+    if (readonly && discardDraftOnReadonly) {
+      handleCancel();
+    } else if (!selected || dragging || readonly) {
+      handleSave();
+    }
+  }, [selected, dragging, isEditing, readonly, discardDraftOnReadonly, handleSave, handleCancel]);
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
@@ -322,6 +334,7 @@ const NodeLabelInternal = ({
     return (
       <BaseTextContainer hasBottomHandles={hasBottomHandles} shape={shape}>
         <EmptyLabelPlaceholder
+          disabled={readonly}
           onDoubleClick={readonly ? undefined : handleDoubleClick(labelInputRef)}
         />
         {centerAdornment}

--- a/packages/apollo-react/src/canvas/components/Toolbar/NodeToolbar/NodeToolbar.test.tsx
+++ b/packages/apollo-react/src/canvas/components/Toolbar/NodeToolbar/NodeToolbar.test.tsx
@@ -137,6 +137,28 @@ describe('NodeToolbar', () => {
       expect(mockDisabledAction.onAction).not.toHaveBeenCalled();
     });
 
+    // A disabled button emits no pointer events, so its label tooltip only
+    // survives if the trigger sits on a wrapper around it. Tooltip content
+    // itself is unassertable here (the Radix tooltip is mocked out globally in
+    // src/test/canvas-mocks.ts), so this guards the hover target instead.
+    it('gives a disabled action a hover target so its tooltip still works', () => {
+      const configWithDisabled: NodeToolbarConfig = {
+        actions: [mockDisabledAction],
+        position: 'top',
+      };
+
+      render(<NodeToolbar {...defaultProps} config={configWithDisabled} />);
+
+      const hoverTarget = screen.getByTestId('toolbar-action-hover-target');
+      expect(hoverTarget).toContainElement(screen.getByLabelText('Locked'));
+    });
+
+    it('does not wrap an enabled action, which is hoverable on its own', () => {
+      render(<NodeToolbar {...defaultProps} />);
+
+      expect(screen.queryByTestId('toolbar-action-hover-target')).not.toBeInTheDocument();
+    });
+
     it('should call onAction with correct nodeId', async () => {
       const differentNodeId = 'different-node';
       render(<NodeToolbar {...defaultProps} nodeId={differentNodeId} />);

--- a/packages/apollo-react/src/canvas/components/Toolbar/shared/ToolbarButton.tsx
+++ b/packages/apollo-react/src/canvas/components/Toolbar/shared/ToolbarButton.tsx
@@ -30,29 +30,42 @@ export const ToolbarButton = memo(({ action, layoutId }: ToolbarButtonProps) => 
     }
   };
 
+  const button = (
+    <ToolbarIconButton
+      layout={layoutId ? true : undefined}
+      layoutId={layoutId}
+      transition={{ type: 'tween', duration: 0.2, ease: 'easeOut' }}
+      type="button"
+      className="nodrag nopan"
+      onClick={handleClick}
+      aria-label={action.label}
+      aria-disabled={!isEnabled}
+      aria-pressed={action.isToggled}
+      disabled={!isEnabled}
+      isToggled={action.isToggled}
+      color={action.color}
+      hoverBg={hoverBg}
+    >
+      {action.icon && typeof action.icon === 'string' ? (
+        <CanvasIcon icon={action.icon} size={16} color={action.color} />
+      ) : (
+        action.icon
+      )}
+    </ToolbarIconButton>
+  );
+
   return (
     <CanvasTooltip content={action.label} placement="top">
-      <ToolbarIconButton
-        layout={layoutId ? true : undefined}
-        layoutId={layoutId}
-        transition={{ type: 'tween', duration: 0.2, ease: 'easeOut' }}
-        type="button"
-        className="nodrag nopan"
-        onClick={handleClick}
-        aria-label={action.label}
-        aria-disabled={!isEnabled}
-        aria-pressed={action.isToggled}
-        disabled={!isEnabled}
-        isToggled={action.isToggled}
-        color={action.color}
-        hoverBg={hoverBg}
-      >
-        {action.icon && typeof action.icon === 'string' ? (
-          <CanvasIcon icon={action.icon} size={16} color={action.color} />
-        ) : (
-          action.icon
-        )}
-      </ToolbarIconButton>
+      {isEnabled ? (
+        button
+      ) : (
+        // A disabled button emits no pointer events, so the tooltip trigger has
+        // to sit on a wrapper. Without it a disabled action is an unlabelled
+        // grey icon, which is exactly when the label matters most.
+        <span className="inline-flex" data-testid="toolbar-action-hover-target">
+          {button}
+        </span>
+      )}
     </CanvasTooltip>
   );
 });


### PR DESCRIPTION
## Summary

Applies per-node read-only state to generic `BaseCanvas` and `BaseNode` behavior.

## Scope

- Marks locked React Flow nodes as undeletable
- Filters direct locked-node removal requests as a defensive backstop
- Preserves selection, dragging, and resize/layout changes
- Hides BaseNode add buttons and toolbars while locked
- Prevents label editing and discards an in-progress label draft when a lock activates
- Leaves unlocked nodes unchanged by identity

## Stack

Part 2 of 4. Depends on #1051. The next PR adapts Apollo's specialized node renderers and higher-level canvas wrappers.

## Testing

- 7 focused test files
- 119 tests passing
