### PR TITLE
feat(apollo-react): lock specialized canvas node controls

### DIFF
--- a/packages/apollo-react/src/canvas/components/AgentCanvas/AgentFlow.tsx
+++ b/packages/apollo-react/src/canvas/components/AgentCanvas/AgentFlow.tsx
@@ -3,10 +3,11 @@ import { Column } from '@uipath/apollo-react/canvas/layouts';
 import { Panel, useReactFlow } from '@uipath/apollo-react/canvas/xyflow/react';
 import type { NodeProps } from '@uipath/apollo-react/canvas/xyflow/system';
 import { StickyNote as StickyNoteIcon } from 'lucide-react';
-import type { PropsWithChildren } from 'react';
 import type React from 'react';
+import type { PropsWithChildren } from 'react';
 import { memo, useCallback, useEffect, useMemo, useRef } from 'react';
 import { BaseCanvas } from '../../components/BaseCanvas';
+import { NodeRegistryProvider } from '../../core/NodeRegistryProvider';
 import {
   type AgentFlowCustomEdge,
   type AgentFlowCustomNode,
@@ -29,6 +30,7 @@ import {
 import { hasAgentRunning } from '../../utils/props-helpers';
 import { CanvasPositionControls } from '../CanvasPositionControls';
 import { StickyNoteNode, type StickyNoteNodeProps } from '../StickyNoteNode';
+import { agentFlowManifest } from './agent-flow.manifest';
 import { PaneContextMenu } from './components/PaneContextMenu';
 import { SuggestionGroupPanel } from './components/SuggestionGroupPanel';
 import { TimelinePlayer } from './components/TimelinePlayer';
@@ -37,8 +39,6 @@ import { Edge } from './edges/Edge';
 import { AgentNodeElement } from './nodes/AgentNode';
 import { ResourceNode } from './nodes/ResourceNode';
 import { AgentFlowProvider, useAgentFlowStore } from './store/agent-flow-store';
-import { NodeRegistryProvider } from '../../core/NodeRegistryProvider';
-import { agentFlowManifest } from './agent-flow.manifest';
 
 const ToolbarContainer = styled.div`
   display: flex;
@@ -254,6 +254,7 @@ const AgentFlowInner = memo(
   ({
     children,
     mode,
+    readOnlyNodeIds,
     spans,
     onEnable,
     onDisable,
@@ -636,6 +637,7 @@ const AgentFlowInner = memo(
             nodeTypes={nodeTypes}
             edgeTypes={edgeTypes}
             mode={mode}
+            readOnlyNodeIds={readOnlyNodeIds}
             initialAutoLayout={autoArrange}
             fitViewOptions={adjustedFitViewOptions}
             defaultViewport={defaultViewport}

--- a/packages/apollo-react/src/canvas/components/AgentCanvas/nodes/AgentNode.styles.ts
+++ b/packages/apollo-react/src/canvas/components/AgentCanvas/nodes/AgentNode.styles.ts
@@ -32,7 +32,7 @@ export const InstructionsLabel = styled.div`
   line-height: 16px;
 `;
 
-export const InstructionsPreview = styled.div`
+export const InstructionsPreview = styled.div<{ $isInteractive: boolean }>`
   display: flex;
   flex-direction: column;
   gap: 2px;
@@ -40,7 +40,7 @@ export const InstructionsPreview = styled.div`
   font-size: 9px;
   line-height: 13px;
   color: var(--canvas-foreground-de-emp);
-  cursor: pointer;
+  cursor: ${({ $isInteractive }) => ($isInteractive ? 'pointer' : 'default')};
 `;
 
 export const InstructionsLine = styled.div`

--- a/packages/apollo-react/src/canvas/components/AgentCanvas/nodes/AgentNode.test.tsx
+++ b/packages/apollo-react/src/canvas/components/AgentCanvas/nodes/AgentNode.test.tsx
@@ -1,9 +1,10 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import type { ReactElement } from 'react';
 import { describe, expect, it, vi } from 'vitest';
 import { NodeRegistryProvider } from '../../../core/NodeRegistryProvider';
 import type { AgentNodeTranslations } from '../../../types';
 import { BaseCanvasModeProvider } from '../../BaseCanvas/BaseCanvasModeProvider';
+import { ReadOnlyNodesProvider } from '../../BaseCanvas/ReadOnlyNodesContext';
 import { agentFlowManifest } from '../agent-flow.manifest';
 import { AgentNodeElement } from './AgentNode';
 
@@ -117,10 +118,12 @@ const defaultNodeProps = {
 };
 
 // Test wrapper that provides required context
-const renderWithProviders = (ui: ReactElement) => {
+const renderWithProviders = (ui: ReactElement, readOnlyNodeIds?: ReadonlySet<string>) => {
   return render(
     <BaseCanvasModeProvider mode="design">
-      <NodeRegistryProvider manifest={agentFlowManifest}>{ui}</NodeRegistryProvider>
+      <ReadOnlyNodesProvider readOnlyNodeIds={readOnlyNodeIds}>
+        <NodeRegistryProvider manifest={agentFlowManifest}>{ui}</NodeRegistryProvider>
+      </ReadOnlyNodesProvider>
     </BaseCanvasModeProvider>
   );
 };
@@ -382,5 +385,25 @@ describe('AgentNode - Instructions Footer', () => {
     expect(screen.getByText('Instructions')).toBeInTheDocument();
     expect(screen.getByText(/System:/)).toBeInTheDocument();
     expect(screen.getByText(/User:/)).toBeInTheDocument();
+  });
+
+  it('uses a default cursor when instructions are locked', async () => {
+    renderWithProviders(
+      <AgentNodeElement
+        {...defaultNodeProps}
+        mode="design"
+        enableInstructions
+        onAddInstructions={vi.fn()}
+        data={{
+          ...defaultNodeProps.data,
+          instructions: { system: 'You are a helpful assistant' },
+        }}
+      />,
+      new Set(['test-agent-node'])
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Instructions').parentElement).toHaveStyle({ cursor: 'default' });
+    });
   });
 });

--- a/packages/apollo-react/src/canvas/components/AgentCanvas/nodes/AgentNode.tsx
+++ b/packages/apollo-react/src/canvas/components/AgentCanvas/nodes/AgentNode.tsx
@@ -10,11 +10,12 @@ import {
   type SuggestionType,
 } from '../../../types';
 import { CanvasIcon } from '../../../utils/icon-registry';
+import { useIsNodeReadOnly } from '../../BaseCanvas/ReadOnlyNodesContext';
 import { BaseNode } from '../../BaseNode/BaseNode';
 import type { BaseNodeData } from '../../BaseNode/BaseNode.types';
 import {
-  BaseNodeOverrideConfigProvider,
   type BaseNodeOverrideConfig,
+  BaseNodeOverrideConfigProvider,
 } from '../../BaseNode/BaseNodeConfigContext';
 import type { ButtonHandleConfig, HandleActionEvent } from '../../ButtonHandle/ButtonHandle';
 import { FloatingCanvasPanel } from '../../FloatingCanvasPanel';
@@ -207,6 +208,11 @@ const AgentNodeComponent = memo((props: NodeProps<Node<AgentNodeData>> & AgentNo
     return undefined;
   }, [hasError, hasSuccess, hasRunning]);
 
+  // Handle visibility still follows mode alone: a locked agent keeps showing
+  // the resources it has, it just cannot gain new ones.
+  const isNodeReadOnly = useIsNodeReadOnly(id);
+  const canEditNode = mode === 'design' && !isNodeReadOnly;
+
   const displayMemory =
     enableMemory === true && (mode === 'design' || (mode === 'view' && hasMemory));
   const displayContext = mode === 'design' || (mode === 'view' && hasContext);
@@ -232,7 +238,7 @@ const AgentNodeComponent = memo((props: NodeProps<Node<AgentNodeData>> & AgentNo
         type: 'source',
         handleType: 'artifact',
         label: translations.memory,
-        showButton: mode === 'design' && !hasMemory,
+        showButton: canEditNode && !hasMemory,
         labelBackgroundColor: 'var(--canvas-background-secondary)',
         visible: displayMemory,
         onAction: (_e: HandleActionEvent) => {
@@ -247,7 +253,7 @@ const AgentNodeComponent = memo((props: NodeProps<Node<AgentNodeData>> & AgentNo
         type: 'source',
         handleType: 'artifact',
         label: translations.escalations,
-        showButton: mode === 'design',
+        showButton: canEditNode,
         labelBackgroundColor: 'var(--canvas-background-secondary)',
         visible: displayEscalation,
         onAction: (_e: HandleActionEvent) => {
@@ -271,7 +277,7 @@ const AgentNodeComponent = memo((props: NodeProps<Node<AgentNodeData>> & AgentNo
           type: 'source',
           handleType: 'artifact',
           label: translations.context,
-          showButton: mode === 'design',
+          showButton: canEditNode,
           labelBackgroundColor: 'var(--canvas-background-secondary)',
           visible: displayContext,
           onAction: (_e: HandleActionEvent) => {
@@ -283,7 +289,7 @@ const AgentNodeComponent = memo((props: NodeProps<Node<AgentNodeData>> & AgentNo
           type: 'source',
           handleType: 'artifact',
           label: translations.tools,
-          showButton: mode === 'design',
+          showButton: canEditNode,
           labelBackgroundColor: 'var(--canvas-background-secondary)',
           visible: displayTool || displayMcp || displayA2a,
           onAction: (_e: HandleActionEvent) => {
@@ -307,7 +313,7 @@ const AgentNodeComponent = memo((props: NodeProps<Node<AgentNodeData>> & AgentNo
 
     return configs;
   }, [
-    mode,
+    canEditNode,
     displayContext,
     displayMemory,
     displayMcp,
@@ -374,10 +380,15 @@ const AgentNodeComponent = memo((props: NodeProps<Node<AgentNodeData>> & AgentNo
       return {
         instructionsFooter: (
           <InstructionsPreview
-            onClick={(e) => {
-              e.stopPropagation();
-              onAddInstructions?.();
-            }}
+            $isInteractive={canEditNode}
+            onClick={
+              canEditNode
+                ? (e) => {
+                    e.stopPropagation();
+                    onAddInstructions?.();
+                  }
+                : undefined
+            }
           >
             <InstructionsLabel>{translations.instructions}</InstructionsLabel>
             {system && (
@@ -396,8 +407,8 @@ const AgentNodeComponent = memo((props: NodeProps<Node<AgentNodeData>> & AgentNo
       };
     }
 
-    // Show add button in design mode when no content
-    if (mode !== 'design' || !onAddInstructions) {
+    // Show add button in design mode when no content, unless this node is locked
+    if (!canEditNode || !onAddInstructions) {
       return { instructionsFooter: null, footerVariant: 'none' };
     }
     return {
@@ -415,7 +426,7 @@ const AgentNodeComponent = memo((props: NodeProps<Node<AgentNodeData>> & AgentNo
       ),
       footerVariant: 'button',
     };
-  }, [enableInstructions, data.instructions, mode, onAddInstructions, translations]);
+  }, [enableInstructions, data.instructions, canEditNode, onAddInstructions, translations]);
 
   const shouldShowAddButtonFn = (opts: { showAddButton: boolean; selected: boolean }) => {
     return opts.showAddButton || opts.selected;

--- a/packages/apollo-react/src/canvas/components/BaseCanvas/BaseCanvas.stories.independence.test.ts
+++ b/packages/apollo-react/src/canvas/components/BaseCanvas/BaseCanvas.stories.independence.test.ts
@@ -1,0 +1,98 @@
+import { composeStories } from '@storybook/react';
+import { render, screen } from '@testing-library/react';
+import { type ComponentProps, createElement } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import * as stories from './BaseCanvas.stories';
+
+const { specializedNodeStores } = vi.hoisted(() => ({
+  specializedNodeStores: new Map<number, { getState: () => unknown }>(),
+}));
+
+// Cancels the global xyflow stub from `src/test/canvas-mocks.ts` (loaded for every
+// file by `test/setup.ts`): these stories need the real store, not the stub.
+vi.mock('@uipath/apollo-react/canvas/xyflow/react', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@uipath/apollo-react/canvas/xyflow/react')>()),
+}));
+
+vi.mock('../AgentCanvas/nodes/AgentNode', async () => {
+  const [{ useNodeTypeRegistry }, { createElement }] = await Promise.all([
+    import('../../core'),
+    import('react'),
+  ]);
+
+  return {
+    AgentNodeElement: () => {
+      const nodeTypeRegistry = useNodeTypeRegistry();
+      const hasAgentManifest =
+        nodeTypeRegistry.getManifest('uipath.agent.autonomous') !== undefined;
+
+      return createElement(
+        'span',
+        undefined,
+        hasAgentManifest ? 'Agent manifest available' : 'Manifest Undefined'
+      );
+    },
+  };
+});
+
+vi.mock('./BaseCanvas', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./BaseCanvas')>();
+  const [{ useStoreApi }, { createElement }] = await Promise.all([
+    import('@uipath/apollo-react/canvas/xyflow/react'),
+    import('react'),
+  ]);
+
+  return {
+    ...actual,
+    BaseCanvas: (props: ComponentProps<typeof actual.BaseCanvas>) => {
+      const store = useStoreApi();
+
+      if (props.nodes?.[0]?.type === 'comparison-agent') {
+        specializedNodeStores.set(props.readOnlyNodeIds?.size ?? 0, store);
+
+        const node = props.nodes[0];
+        const NodeComponent = props.nodeTypes?.[node.type ?? ''];
+        if (NodeComponent) {
+          return createElement(NodeComponent, {
+            id: node.id,
+            type: node.type,
+            data: node.data,
+            selected: node.selected ?? false,
+            dragging: node.dragging ?? false,
+            draggable: node.draggable ?? true,
+            selectable: node.selectable ?? true,
+            deletable: node.deletable ?? true,
+            isConnectable: node.connectable ?? true,
+            positionAbsoluteX: node.position.x,
+            positionAbsoluteY: node.position.y,
+            zIndex: node.zIndex ?? 0,
+          });
+        }
+      }
+
+      return createElement('div');
+    },
+  };
+});
+
+const { PerNodeReadOnly } = composeStories(stories);
+
+describe('specialized node comparison previews', () => {
+  it('keeps locked and unlocked previews independent when a node tab renders', () => {
+    specializedNodeStores.clear();
+
+    render(createElement(PerNodeReadOnly));
+
+    expect([...specializedNodeStores.keys()].sort()).toEqual([0, 1]);
+    expect(new Set([...specializedNodeStores.values()].map((store) => store.getState)).size).toBe(
+      2
+    );
+  });
+
+  it('provides the agent manifest when AgentNode comparisons render', () => {
+    render(createElement(PerNodeReadOnly));
+
+    expect(screen.getAllByText('Agent manifest available')).toHaveLength(2);
+    expect(screen.queryByText('Manifest Undefined')).not.toBeInTheDocument();
+  });
+});

--- a/packages/apollo-react/src/canvas/components/BaseCanvas/BaseCanvas.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/BaseCanvas/BaseCanvas.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { Column, Row } from '@uipath/apollo-react/canvas/layouts';
-import type { Edge, Node } from '@uipath/apollo-react/canvas/xyflow/react';
+import type { Edge, Node, NodeProps, NodeTypes } from '@uipath/apollo-react/canvas/xyflow/react';
 import {
   BackgroundVariant,
   Panel,
@@ -17,8 +17,10 @@ import {
   SelectValue,
 } from '@uipath/apollo-wind';
 import { useCallback, useMemo, useRef, useState } from 'react';
+import { NodeRegistryProvider } from '../../core';
 import {
   createNode,
+  StoryCard,
   StoryCode,
   StoryCodeBlock,
   StoryInfoPanel,
@@ -27,12 +29,24 @@ import {
   StorySection,
   type StorySpecColumn,
   StorySpecTable,
+  StoryTabs,
+  StoryWideContent,
   useCanvasStory,
   withCanvasProviders,
 } from '../../storybook-utils';
-import { DefaultCanvasTranslations } from '../../types';
+import type { AgentFlowProps } from '../../types';
+import { DefaultAgentNodeTranslations, DefaultCanvasTranslations } from '../../types';
+import { agentFlowManifest } from '../AgentCanvas/agent-flow.manifest';
+import type { AgentNodeData } from '../AgentCanvas/nodes/AgentNode';
+import { AgentNodeElement } from '../AgentCanvas/nodes/AgentNode';
+import { AgentFlowProvider } from '../AgentCanvas/store/agent-flow-store';
 import type { BaseNodeData } from '../BaseNode/BaseNode.types';
 import { CanvasPositionControls } from '../CanvasPositionControls';
+import { LoopNode } from '../LoopNode';
+import { StageNodeWrapper } from '../StageNode/StageNode.stories.utils';
+import type { StageNodeBaseProps } from '../StageNode/StageNode.types';
+import { StickyNoteNode } from '../StickyNoteNode';
+import type { StickyNoteData } from '../StickyNoteNode/StickyNoteNode.types';
 import { BaseCanvas } from './BaseCanvas';
 import type { BaseCanvasRef } from './BaseCanvas.types';
 
@@ -1464,6 +1478,207 @@ const readOnlyBehaviorColumns: readonly StorySpecColumn<ReadOnlyBehaviorRow>[] =
   { key: 'detail', header: 'What happens' },
 ];
 
+type SpecializedNodeKind = 'agent' | 'loop' | 'stage' | 'sticky-note';
+
+const SPECIALIZED_COMPARISON_NODE_ID = 'specialized-comparison-node';
+const EMPTY_READ_ONLY_NODE_IDS = new Set<string>();
+const LOCKED_SPECIALIZED_NODE_IDS = new Set([SPECIALIZED_COMPARISON_NODE_ID]);
+const noop = () => {};
+
+const comparisonAgentFlowProps: AgentFlowProps = {
+  mode: 'design',
+  definition: { processKey: SPECIALIZED_COMPARISON_NODE_ID },
+  spans: [],
+  name: 'Expense assistant',
+  description: 'Reviews receipts and prepares reimbursement requests',
+  resources: [],
+};
+
+function ComparisonAgentNode(props: NodeProps<Node<AgentNodeData>>) {
+  return (
+    <AgentNodeElement
+      {...props}
+      mode="design"
+      enableInstructions
+      enableMemory
+      onAddResource={noop}
+      onAddInstructions={noop}
+      translations={DefaultAgentNodeTranslations}
+    />
+  );
+}
+
+function ComparisonLoopNode(props: Parameters<typeof LoopNode>[0]) {
+  return <LoopNode {...props} onAddFirstChild={noop} />;
+}
+
+const specializedComparisonNodeTypes: Record<SpecializedNodeKind, NodeTypes> = {
+  agent: { 'comparison-agent': ComparisonAgentNode },
+  loop: { 'uipath.control-flow.foreach': ComparisonLoopNode },
+  stage: { 'comparison-stage': StageNodeWrapper },
+  'sticky-note': { 'comparison-sticky-note': StickyNoteNode },
+};
+
+function createSpecializedComparisonNode(kind: SpecializedNodeKind): Node {
+  const base = {
+    id: SPECIALIZED_COMPARISON_NODE_ID,
+    position: { x: 0, y: 0 },
+    selected: true,
+  };
+
+  switch (kind) {
+    case 'agent':
+      return {
+        ...base,
+        type: 'comparison-agent',
+        data: {
+          name: comparisonAgentFlowProps.name,
+          description: comparisonAgentFlowProps.description,
+          definition: comparisonAgentFlowProps.definition,
+          instructions: {
+            system: 'Review the submitted receipt for policy compliance.',
+            user: 'Summarize exceptions before creating the expense report.',
+          },
+        } satisfies AgentNodeData,
+      };
+    case 'loop':
+      return {
+        ...base,
+        type: 'uipath.control-flow.foreach',
+        data: {
+          display: { label: 'For each receipt', shape: 'container' },
+        } satisfies BaseNodeData,
+        style: { width: 360, height: 220 },
+      };
+    case 'stage':
+      return {
+        ...base,
+        type: 'comparison-stage',
+        width: 336,
+        data: {
+          stageDetails: {
+            label: 'Expense review',
+            tasks: [
+              [{ id: 'validate-receipt', label: 'Validate receipt' }],
+              [{ id: 'approve-expense', label: 'Approve expense', isRequired: true }],
+            ],
+            entryRules: [{ id: 'receipt-attached', label: 'Receipt is attached', onClick: noop }],
+          },
+          onTaskAdd: noop,
+          onTaskClick: noop,
+          onStageTitleChange: noop,
+          onTaskReorder: noop,
+          getTaskContextMenuItems: () => [
+            { id: 'inspect-task', label: 'Inspect task details', onClick: noop },
+          ],
+        } satisfies StageNodeBaseProps,
+      };
+    case 'sticky-note':
+      return {
+        ...base,
+        type: 'comparison-sticky-note',
+        data: {
+          color: 'yellow',
+          content:
+            '## Review checklist\n\n- Confirm the receipt\n- Check the policy\n\n[Open policy](https://example.com)',
+        } satisfies StickyNoteData,
+        width: 260,
+        height: 190,
+      };
+  }
+}
+
+function SpecializedNodeSpecimen({ kind, locked }: { kind: SpecializedNodeKind; locked: boolean }) {
+  const initialNodes = useMemo(() => [createSpecializedComparisonNode(kind)], [kind]);
+  const { canvasProps } = useCanvasStory({
+    initialNodes,
+    additionalNodeTypes: specializedComparisonNodeTypes[kind],
+  });
+
+  const canvas = (
+    <ReactFlowProvider>
+      <BaseCanvas
+        {...canvasProps}
+        id={`specialized-${kind}-${locked ? 'locked' : 'unlocked'}`}
+        mode="design"
+        readOnlyNodeIds={locked ? LOCKED_SPECIALIZED_NODE_IDS : EMPTY_READ_ONLY_NODE_IDS}
+        fitView
+        fitViewOptions={{ padding: 0.2, maxZoom: 1 }}
+        minZoom={0.35}
+      />
+    </ReactFlowProvider>
+  );
+
+  return kind === 'agent' ? (
+    <NodeRegistryProvider manifest={agentFlowManifest}>
+      <AgentFlowProvider {...comparisonAgentFlowProps}>{canvas}</AgentFlowProvider>
+    </NodeRegistryProvider>
+  ) : (
+    canvas
+  );
+}
+
+const specializedNodeComparisons = [
+  {
+    value: 'agent',
+    label: 'AgentNode',
+    unlocked:
+      'Resource add buttons and instruction-editing affordances are shown alongside existing previews.',
+    locked:
+      'Resource add buttons and instruction editing are hidden; configured instructions remain visible.',
+  },
+  {
+    value: 'loop',
+    label: 'LoopNode',
+    unlocked: 'Structural controls are shown inside the loop.',
+    locked: 'Structural controls are hidden while the loop remains movable and resizable.',
+  },
+  {
+    value: 'stage',
+    label: 'StageNode',
+    unlocked: 'Title, task, rule, and add or replace affordances are shown on the stage.',
+    locked:
+      'Stage mutation affordances are hidden while tasks, rules, statuses, and host menu items stay visible.',
+  },
+  {
+    value: 'sticky-note',
+    label: 'StickyNoteNode',
+    unlocked: 'Markdown editing, formatting, and resize affordances are available.',
+    locked:
+      'Editing and resize affordances are hidden while rendered content and links remain usable.',
+  },
+] as const satisfies readonly {
+  value: SpecializedNodeKind;
+  label: string;
+  unlocked: string;
+  locked: string;
+}[];
+
+function SpecializedNodeComparison({
+  comparison,
+}: {
+  comparison: (typeof specializedNodeComparisons)[number];
+}) {
+  return (
+    <div className="grid gap-4 md:grid-cols-2">
+      <StoryCard
+        title="Unlocked"
+        code="editable"
+        description={comparison.unlocked}
+        preview={<SpecializedNodeSpecimen kind={comparison.value} locked={false} />}
+        previewClassName="h-[360px] w-full overflow-hidden rounded-lg border border-border bg-background"
+      />
+      <StoryCard
+        title="Locked"
+        code="read-only"
+        description={comparison.locked}
+        preview={<SpecializedNodeSpecimen kind={comparison.value} locked />}
+        previewClassName="h-[360px] w-full overflow-hidden rounded-lg border border-border bg-background"
+      />
+    </div>
+  );
+}
+
 function PerNodeReadOnlyPage({ globalTheme }: { globalTheme: string }) {
   return (
     <StoryPage
@@ -1543,6 +1758,39 @@ function CustomNode({ id }: NodeProps) {
         description="A lock protects BaseNode content without turning the node into a static object. Layout and navigation stay available so users can continue arranging and inspecting the graph. Actions that only appear on demand are disabled rather than removed, so the node still reports what it would otherwise offer. Specialized renderers can apply additional restrictions to their own controls."
       >
         <StorySpecTable columns={readOnlyBehaviorColumns} rows={baseNodeBehaviorRows} />
+      </StorySection>
+
+      <StorySection
+        title="Specialized node coverage"
+        description={
+          <>
+            The renderers below consume the same per-node state, then gate the controls specific to
+            their content. Other renderers, <StoryCode>GroupNode</StoryCode> among them, do not read
+            it yet. A custom renderer can follow this pattern with{' '}
+            <StoryCode>useIsNodeReadOnly</StoryCode>.
+          </>
+        }
+      >
+        <StoryWideContent>
+          <StoryTabs
+            label="Specialized node renderers"
+            tabs={specializedNodeComparisons.map((comparison) => ({
+              value: comparison.value,
+              label: comparison.label,
+              content: <SpecializedNodeComparison comparison={comparison} />,
+            }))}
+          />
+        </StoryWideContent>
+        <p className="mt-4 text-sm leading-relaxed text-muted-foreground">
+          Stage task context menus remain host-controlled so inspection and debug actions can stay
+          available. When a stage is read-only, do not combine those menu items with task-mutation
+          callbacks.
+        </p>
+        <p className="mt-2 text-sm leading-relaxed text-muted-foreground">
+          <StoryCode>AgentFlow</StoryCode> and <StoryCode>HierarchicalCanvas</StoryCode> forward the
+          same <StoryCode>readOnlyNodeIds</StoryCode> set to these renderers without adding a second
+          policy layer.
+        </p>
       </StorySection>
     </StoryPage>
   );

--- a/packages/apollo-react/src/canvas/components/BaseCanvas/BaseCanvas.types.ts
+++ b/packages/apollo-react/src/canvas/components/BaseCanvas/BaseCanvas.types.ts
@@ -77,10 +77,14 @@ export interface BaseCanvasProps<NodeType extends Node = Node, EdgeType extends 
 
   /**
    * Node ids whose content is read-only while the rest of the canvas remains editable.
-   * Locked nodes cannot be deleted or label-edited and hide BaseNode add buttons.
-   * Their toolbar stays visible with every action disabled, so the lock is
-   * discoverable. They remain selectable, draggable, and resizable.
-   * Custom node renderers can observe their state with `useIsNodeReadOnly`.
+   * Locked nodes cannot be deleted or label-edited and hide their inline
+   * content-editing controls. Toolbars are the exception: they stay visible with
+   * every action disabled, so the lock is discoverable. Locked nodes remain
+   * selectable and draggable. Resizable nodes generally remain resizable, except
+   * StickyNoteNode, which hides its resize controls.
+   *
+   * Honored by nodes built on BaseNode, AgentNode, LoopNode, StageNode, and
+   * StickyNoteNode. Custom renderers can observe state with `useIsNodeReadOnly`.
    *
    * Compared by content, so passing a fresh set with the same ids is a no-op.
    * Do not mutate a set after passing it; pass a new set instead.

--- a/packages/apollo-react/src/canvas/components/BaseNode/BaseNode.tsx
+++ b/packages/apollo-react/src/canvas/components/BaseNode/BaseNode.tsx
@@ -42,8 +42,9 @@ import type { HandleActionEvent } from '../ButtonHandle/ButtonHandle';
 import { SmartHandle, SmartHandleProvider } from '../ButtonHandle/SmartHandle';
 import { useButtonHandles } from '../ButtonHandle/useButtonHandles';
 import { InitialsBadge } from '../shared/InitialsBadge';
-import type { NodeToolbarConfig, ToolbarAction } from '../Toolbar';
+import type { NodeToolbarConfig } from '../Toolbar';
 import { NodeToolbar } from '../Toolbar';
+import { lockToolbarConfig } from '../Toolbar/NodeToolbar/NodeToolbar.utils';
 import type {
   BaseNodeData,
   FooterVariant,
@@ -59,13 +60,6 @@ import { NodeLabel } from './NodeLabel';
 
 /** Stable predicate used to hard-disable add buttons on read-only nodes. */
 const NEVER_SHOW_ADD_BUTTON = () => false;
-
-/**
- * Returns the actions with every item disabled, separators untouched. Used to
- * lock a read-only node's toolbar instead of unmounting it.
- */
-const disableToolbarActions = (actions: ToolbarAction[]): ToolbarAction[] =>
-  actions.map((action) => (action.id === 'separator' ? action : { ...action, disabled: true }));
 
 const getContainerWidth = (shape: NodeShape | undefined, width: number | undefined) => {
   const defaultWidth = shape === 'rectangle' ? DEFAULT_RECTANGLE_NODE_WIDTH : DEFAULT_NODE_SIZE;
@@ -255,23 +249,13 @@ const BaseNodeComponent = (props: NodeProps<Node<BaseNodeData>>) => {
     return manifest ? resolveToolbar(manifest, statusContext) : undefined;
   }, [toolbarConfigProp, manifest, statusContext]);
 
-  // A locked node keeps its toolbar and disables it rather than hiding it: the
-  // greyed-out actions (with their tooltips intact) say "read-only", where a
-  // missing toolbar just reads as a node with nothing to offer. Disabling is
-  // also real enforcement, since a consumer's `onAction` never reaches the
-  // canvas-level delete veto.
-  const effectiveToolbarConfig = useMemo((): NodeToolbarConfig | undefined => {
-    if (!toolbarConfig || !isNodeReadOnly) {
-      return toolbarConfig;
-    }
-    return {
-      ...toolbarConfig,
-      actions: disableToolbarActions(toolbarConfig.actions),
-      ...(toolbarConfig.overflowActions && {
-        overflowActions: disableToolbarActions(toolbarConfig.overflowActions),
-      }),
-    };
-  }, [toolbarConfig, isNodeReadOnly]);
+  // A locked node keeps its toolbar and disables it rather than hiding it. See
+  // `lockToolbarConfig` for why.
+  const effectiveToolbarConfig = useMemo(
+    (): NodeToolbarConfig | undefined =>
+      toolbarConfig && isNodeReadOnly ? lockToolbarConfig(toolbarConfig) : toolbarConfig,
+    [toolbarConfig, isNodeReadOnly]
+  );
 
   // Adornments resolution: use default resolver, then override with props if provided
   const adornments: NodeAdornments = useMemo(() => {

--- a/packages/apollo-react/src/canvas/components/HierarchicalCanvas/HierarchicalCanvas.tsx
+++ b/packages/apollo-react/src/canvas/components/HierarchicalCanvas/HierarchicalCanvas.tsx
@@ -66,6 +66,8 @@ import { MiniCanvasNavigator } from '../MiniCanvasNavigator';
 
 interface HierarchicalCanvasProps {
   mode?: 'view' | 'design' | 'readonly';
+  /** Node ids to lock individually. Forwarded to BaseCanvas `readOnlyNodeIds`. */
+  readOnlyNodeIds?: ReadonlySet<string>;
   /**
    * Initial canvas data used to populate the store on mount.
    * Changes to this prop after mount are ignored - use onCanvasesChange to persist updates.
@@ -113,6 +115,7 @@ function isDefaultViewport(viewport: Viewport): boolean {
 
 export const HierarchicalCanvas: React.FC<HierarchicalCanvasProps> = ({
   mode = 'design',
+  readOnlyNodeIds,
   initialCanvases,
   initialPath,
   onCanvasesChange,
@@ -502,6 +505,7 @@ export const HierarchicalCanvas: React.FC<HierarchicalCanvasProps> = ({
         onInit={handleInit}
         onToolbarAction={handleToolbarAction}
         mode={mode}
+        readOnlyNodeIds={readOnlyNodeIds}
         defaultViewport={currentCanvas.viewport}
         fitView={shouldFitView}
         fitViewOptions={{ padding: 0.2, minZoom: 1, maxZoom: 1 }}

--- a/packages/apollo-react/src/canvas/components/LoopNode/LoopNode.test.tsx
+++ b/packages/apollo-react/src/canvas/components/LoopNode/LoopNode.test.tsx
@@ -4,23 +4,32 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { ValidationErrorSeverity } from '../../types/validation';
 import type { LoopNodeData, LoopNodeExecutionCountState } from './LoopNode.types';
 
-const { mockExecutionState, mockGetContainerResizeMinimums, mockManifest, mockValidationState } =
-  vi.hoisted(() => ({
-    mockExecutionState: { current: undefined as unknown },
-    mockGetContainerResizeMinimums: vi.fn(() => ({
-      left: 410,
-      right: 420,
-      top: 230,
-      bottom: 240,
-    })),
-    mockManifest: {
-      current: {
-        display: { label: 'Loop', icon: 'repeat', shape: 'container' },
-        handleConfiguration: [],
-      } as Record<string, unknown>,
-    },
-    mockValidationState: { current: undefined as unknown },
-  }));
+const {
+  mockExecutionState,
+  mockGetContainerResizeMinimums,
+  mockManifest,
+  mockNodeToolbar,
+  mockReadOnlyNodeIds,
+  mockValidationState,
+} = vi.hoisted(() => ({
+  mockExecutionState: { current: undefined as unknown },
+  mockGetContainerResizeMinimums: vi.fn(() => ({
+    left: 410,
+    right: 420,
+    top: 230,
+    bottom: 240,
+  })),
+  mockManifest: {
+    current: {
+      display: { label: 'Loop', icon: 'repeat', shape: 'container' },
+      handleConfiguration: [],
+    } as Record<string, unknown>,
+  },
+  // biome-ignore lint/suspicious/noExplicitAny: captures the toolbar props for assertions
+  mockNodeToolbar: vi.fn() as any,
+  mockReadOnlyNodeIds: { current: new Set<string>() as ReadonlySet<string> },
+  mockValidationState: { current: undefined as unknown },
+}));
 
 vi.mock('@uipath/apollo-react/canvas/xyflow/react', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@uipath/apollo-react/canvas/xyflow/react')>()),
@@ -103,6 +112,18 @@ vi.mock('../BaseCanvas/SelectionStateContext', () => ({
   useSelectionState: () => ({ multipleNodesSelected: false }),
 }));
 
+vi.mock('../BaseCanvas/ReadOnlyNodesContext', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../BaseCanvas/ReadOnlyNodesContext')>()),
+  useIsNodeReadOnly: (nodeId: string) => mockReadOnlyNodeIds.current.has(nodeId),
+}));
+
+vi.mock('../Toolbar', () => ({
+  NodeToolbar: (props: Record<string, unknown>) => {
+    mockNodeToolbar(props);
+    return null;
+  },
+}));
+
 import { LoopNode } from './LoopNode';
 
 const defaultProps: NodeProps<Node<LoopNodeData>> = {
@@ -140,6 +161,8 @@ function getResizeIndicators() {
 beforeEach(() => {
   mockExecutionState.current = undefined;
   mockGetContainerResizeMinimums.mockClear();
+  mockNodeToolbar.mockClear();
+  mockReadOnlyNodeIds.current = new Set<string>();
   mockManifest.current = {
     display: { label: 'Loop', icon: 'repeat', shape: 'container' },
     handleConfiguration: [],
@@ -394,5 +417,54 @@ describe('LoopNode localized labels', () => {
     renderLoopNode({ onAddFirstChild: vi.fn() });
 
     expect(screen.getByRole('button', { name: 'Add node to loop' })).toBeTruthy();
+  });
+});
+
+// A loop listed in BaseCanvas `readOnlyNodeIds` keeps its toolbar mounted with
+// every action disabled, matching BaseNode. NodeToolbar is module-mocked above,
+// so the contract is asserted on the props it receives.
+describe('LoopNode toolbar when the loop is locked', () => {
+  const NODE_ID = defaultProps.id;
+
+  const TOP_TOOLBAR = {
+    actions: [
+      { id: 'edit', icon: 'edit', label: 'Edit', onAction: vi.fn() },
+      { id: 'separator' },
+      { id: 'delete', icon: 'trash', label: 'Delete', onAction: vi.fn() },
+    ],
+    overflowActions: [{ id: 'rename', icon: 'pencil', label: 'Rename', onAction: vi.fn() }],
+    position: 'top' as const,
+  };
+
+  const toolbarConfig = () => mockNodeToolbar.mock.calls.at(-1)?.[0]?.config;
+
+  it('keeps the toolbar mounted but disables every action when the loop is locked', () => {
+    mockReadOnlyNodeIds.current = new Set([NODE_ID]);
+
+    renderLoopNode({ selected: true, toolbarConfig: TOP_TOOLBAR });
+
+    const config = toolbarConfig();
+    expect(config.actions).toEqual([
+      expect.objectContaining({ id: 'edit', disabled: true }),
+      { id: 'separator' },
+      expect.objectContaining({ id: 'delete', disabled: true }),
+    ]);
+    expect(config.overflowActions).toEqual([
+      expect.objectContaining({ id: 'rename', disabled: true }),
+    ]);
+  });
+
+  it('leaves the toolbar config untouched when the loop is not locked', () => {
+    renderLoopNode({ selected: true, toolbarConfig: TOP_TOOLBAR });
+
+    expect(toolbarConfig()).toBe(TOP_TOOLBAR);
+  });
+
+  it('renders no toolbar when the loop has no config', () => {
+    mockReadOnlyNodeIds.current = new Set([NODE_ID]);
+
+    renderLoopNode({ selected: true });
+
+    expect(mockNodeToolbar).not.toHaveBeenCalled();
   });
 });

--- a/packages/apollo-react/src/canvas/components/LoopNode/LoopNode.tsx
+++ b/packages/apollo-react/src/canvas/components/LoopNode/LoopNode.tsx
@@ -30,6 +30,7 @@ import { areNodePropsEqualIgnoringPosition } from '../../utils/nodePropsEqual';
 import { resolveToolbar } from '../../utils/toolbar-resolver';
 import { useBaseCanvasMode } from '../BaseCanvas/BaseCanvasModeProvider';
 import { useConnectedHandles } from '../BaseCanvas/ConnectedHandlesContext';
+import { useIsNodeReadOnly } from '../BaseCanvas/ReadOnlyNodesContext';
 import { useSelectionState } from '../BaseCanvas/SelectionStateContext';
 import type { NodeAdornments, NodeStatusContext } from '../BaseNode/BaseNode.types';
 import { BaseBadgeSlot } from '../BaseNode/BaseNodeBadgeSlot';
@@ -39,6 +40,7 @@ import type { HandleActionEvent } from '../ButtonHandle';
 import { ButtonHandles } from '../ButtonHandle';
 import { CanvasTooltip } from '../CanvasTooltip';
 import { NodeToolbar } from '../Toolbar';
+import { lockToolbarConfig } from '../Toolbar/NodeToolbar/NodeToolbar.utils';
 import { type ContainerHandleGroup, resolveContainerHandleGroups } from './LoopNode.helpers';
 import type { LoopNodeExecutionCountState, LoopNodeProps } from './LoopNode.types';
 import { LoopNodeExecutionCount } from './LoopNodeExecutionCount';
@@ -205,6 +207,8 @@ function LoopNodeComponent(props: LoopNodeProps) {
   const manifest = useMemo(() => nodeTypeRegistry?.getManifest(type), [nodeTypeRegistry, type]);
   const { mode } = useBaseCanvasMode();
   const isDesignMode = mode === 'design';
+  const isNodeReadOnly = useIsNodeReadOnly(id);
+  const canEditNode = isDesignMode && !isNodeReadOnly;
   const connectedHandleIds = useConnectedHandles(id);
   const { multipleNodesSelected } = useSelectionState();
   const isConnecting = useStore(selectIsConnecting);
@@ -281,6 +285,13 @@ function LoopNodeComponent(props: LoopNodeProps) {
     return manifest ? resolveToolbar(manifest, statusContext, data) : undefined;
   }, [data, manifest, statusContext, toolbarConfigProp]);
 
+  // Matches BaseNode: a locked loop keeps its toolbar with every action
+  // disabled rather than hiding it. See `lockToolbarConfig` for why.
+  const effectiveToolbarConfig = useMemo(
+    () => (toolbarConfig && isNodeReadOnly ? lockToolbarConfig(toolbarConfig) : toolbarConfig),
+    [toolbarConfig, isNodeReadOnly]
+  );
+
   const adornments: NodeAdornments = useMemo(
     () => ({
       ...resolveAdornments(statusContext, { hideExecutionStatusAdornment: true }),
@@ -337,8 +348,10 @@ function LoopNodeComponent(props: LoopNodeProps) {
 
   const shouldShowHandles = (isConnecting || selected || isHovered) && !dragging;
 
-  const showHandleAddButtons = isDesignMode && !multipleNodesSelected && !isConnecting && !dragging;
-  const showEmptyStateButton = isDesignMode && !hasChildNodes && !!onAddFirstChild;
+  // Resize stays enabled when locked: size, like position, is layout rather
+  // than content. Only the structural controls are gated.
+  const showHandleAddButtons = canEditNode && !multipleNodesSelected && !isConnecting && !dragging;
+  const showEmptyStateButton = canEditNode && !hasChildNodes && !!onAddFirstChild;
 
   const interactionState = resolveInteractionState(dragging, selected, isHovered);
   const activeStatus = suggestionType ?? validationState?.validationStatus ?? executionStatus;
@@ -347,7 +360,6 @@ function LoopNodeComponent(props: LoopNodeProps) {
 
   if (!manifest) {
     return (
-      // biome-ignore lint/a11y/noStaticElementInteractions: canvas node hover state is mouse-driven
       <div
         className="relative"
         style={nodeSizeStyle}
@@ -365,7 +377,6 @@ function LoopNodeComponent(props: LoopNodeProps) {
   }
 
   return (
-    // biome-ignore lint/a11y/noStaticElementInteractions: canvas node hover state is mouse-driven
     <div
       data-loop-container
       data-selected={selected ? 'true' : 'false'}
@@ -381,8 +392,8 @@ function LoopNodeComponent(props: LoopNodeProps) {
         statusBorder,
         isHovered && 'shadow-(--canvas-node-shadow-hover)',
         isHovered && !hasStatusBorder && 'border-border-hover',
-        selected && 'outline outline-2 outline-foreground-accent-muted',
-        isDropTarget && 'bg-surface-hover outline outline-2 outline-brand',
+        selected && 'outline-2 outline-foreground-accent-muted',
+        isDropTarget && 'bg-surface-hover outline-2 outline-brand',
         interactionState === 'drag' && 'cursor-grabbing shadow-(--canvas-node-shadow-lifted)'
       )}
       style={{
@@ -434,10 +445,10 @@ function LoopNodeComponent(props: LoopNodeProps) {
           <EmptyState label={addNodeToLoopLabel} onAddFirstChild={handleEmptyClick} />
         </div>
       ) : null}
-      {toolbarConfig && (
+      {effectiveToolbarConfig && (
         <NodeToolbar
           nodeId={id}
-          config={toolbarConfig}
+          config={effectiveToolbarConfig}
           expanded={selected || isHovered}
           hidden={dragging || multipleNodesSelected}
           portalToNodeOverlay

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.test.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.test.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { DAY, HOUR, MINUTE, SECOND } from '../../../test/durations';
 import { render, screen, waitFor } from '../../utils/testing';
+import { ReadOnlyNodesProvider } from '../BaseCanvas/ReadOnlyNodesContext';
 import type { ListItem } from '../Toolbox';
 import { StageNode } from './StageNode';
 import type { StageNodeProps, StageTaskItem, StageTaskStatus } from './StageNode.types';
@@ -223,6 +224,27 @@ const renderStageNode = (props: Partial<StageNodeProps> = {}) => {
     </ReactFlowProvider>
   );
 };
+
+function StageNodeWithReadOnlyIds({
+  props,
+  readOnlyNodeIds,
+}: {
+  props: Partial<StageNodeProps>;
+  readOnlyNodeIds?: ReadonlySet<string>;
+}) {
+  return (
+    <ReactFlowProvider>
+      <ReadOnlyNodesProvider readOnlyNodeIds={readOnlyNodeIds}>
+        <StageNode {...defaultProps} {...props} />
+      </ReadOnlyNodesProvider>
+    </ReactFlowProvider>
+  );
+}
+
+const renderStageNodeWithReadOnlyIds = (
+  props: Partial<StageNodeProps>,
+  readOnlyNodeIds?: ReadonlySet<string>
+) => render(<StageNodeWithReadOnlyIds props={props} readOnlyNodeIds={readOnlyNodeIds} />);
 
 describe('StageNode - Test Hooks', () => {
   it('renders a stable test id for the stage header', () => {
@@ -621,6 +643,76 @@ describe('StageNode - Replace Task Functionality', () => {
       // Only add task panel might exist if onAddTaskFromToolbox is provided
       expect(panels.length).toBeLessThanOrEqual(1);
     });
+  });
+});
+
+describe('StageNode toolboxes when the stage is locked', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('closes the add-task toolbox when the stage becomes locked', async () => {
+    const user = userEvent.setup();
+    const props = { onAddTaskFromToolbox: vi.fn() };
+    const view = renderStageNodeWithReadOnlyIds(props);
+
+    await user.click(screen.getByRole('button', { name: 'Add task' }));
+    expect(screen.getByTestId('toolbox')).toBeInTheDocument();
+
+    view.rerender(
+      <StageNodeWithReadOnlyIds props={props} readOnlyNodeIds={new Set(['stage-1'])} />
+    );
+
+    await waitFor(() => expect(screen.queryByTestId('toolbox')).not.toBeInTheDocument());
+    expect(screen.queryByRole('button', { name: 'Add task' })).not.toBeInTheDocument();
+  });
+
+  it('closes the replace-task toolbox and keeps it closed while locked', async () => {
+    const user = userEvent.setup();
+    const onReplaceTaskFromToolbox = vi.fn();
+    const props = { onReplaceTaskFromToolbox };
+    const view = renderStageNodeWithReadOnlyIds(props);
+
+    await user.click(screen.getByTestId('task-menu-button-task-1'));
+    await user.click(screen.getByTestId('menu-item-task-1-replace-task'));
+    expect(screen.getByTestId('toolbox')).toBeInTheDocument();
+
+    const lockedProps = {
+      onReplaceTaskFromToolbox,
+      pendingReplaceTask: true,
+      stageDetails: {
+        ...defaultProps.stageDetails,
+        selectedTaskId: 'task-1',
+      },
+    };
+    view.rerender(
+      <StageNodeWithReadOnlyIds props={lockedProps} readOnlyNodeIds={new Set(['stage-1'])} />
+    );
+
+    await waitFor(() => expect(screen.queryByTestId('toolbox')).not.toBeInTheDocument());
+    expect(screen.queryByTestId('task-menu-button-task-1')).not.toBeInTheDocument();
+  });
+});
+
+describe('StageNode host menu when the stage is locked', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const menuItems = [{ id: 'inspect', label: 'Inspect', onClick: vi.fn() }];
+
+  // Host-controlled, so it survives the lock: inspection and debug actions stay
+  // reachable. Stage-owned mutation affordances are gated separately.
+  it('keeps the host menu reachable on a locked stage', () => {
+    renderStageNodeWithReadOnlyIds({ menuItems }, new Set(['stage-1']));
+
+    expect(screen.getByTestId('node-context-menu')).toBeInTheDocument();
+  });
+
+  it('shows the same host menu when the stage is unlocked', () => {
+    renderStageNodeWithReadOnlyIds({ menuItems });
+
+    expect(screen.getByTestId('node-context-menu')).toBeInTheDocument();
   });
 });
 
@@ -1546,6 +1638,26 @@ describe('StageNode - Entry, exit and completion rules', () => {
     await user.click(screen.getByTestId('stage-rule-entry-1'));
 
     expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores rule clicks when the stage is locked', async () => {
+    const user = userEvent.setup();
+    const onClick = vi.fn();
+    renderStageNodeWithReadOnlyIds(
+      {
+        stageDetails: {
+          ...defaultProps.stageDetails,
+          entryRules: [{ id: 'entry-1', label: 'Amount > 1000', onClick }],
+        },
+      },
+      new Set(['stage-1'])
+    );
+
+    const rule = screen.getByTestId('stage-rule-entry-1');
+    await waitFor(() => expect(rule).not.toHaveAttribute('role', 'button'));
+    await user.click(rule);
+
+    expect(onClick).not.toHaveBeenCalled();
   });
 
   it('renders a collapsible entry rules header when a section state is provided', () => {

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.tsx
@@ -2,6 +2,7 @@ import { Spacing } from '@uipath/apollo-core';
 import { Column } from '@uipath/apollo-react/canvas/layouts';
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { areNodePropsEqualIgnoringPosition } from '../../utils/nodePropsEqual';
+import { useIsNodeReadOnly } from '../BaseCanvas/ReadOnlyNodesContext';
 import { FloatingCanvasPanel } from '../FloatingCanvasPanel';
 import { NodeContextMenu } from '../NodeContextMenu';
 import { useSetNodeSelection } from '../NodePropertiesPanel/hooks';
@@ -45,7 +46,8 @@ const StageNodeInner = (props: StageNodeProps) => {
   const allTasks = useMemo(() => stageDetails?.tasks || [], [stageDetails?.tasks]);
 
   const isException = stageDetails?.isException;
-  const isReadOnly = !!stageDetails?.isReadOnly;
+  // A per-node lock outranks the stage's own data flag.
+  const isReadOnly = useIsNodeReadOnly(id) || !!stageDetails?.isReadOnly;
   const selectedTaskId = stageDetails?.selectedTaskId;
   const status = execution?.stageStatus?.status;
 
@@ -63,7 +65,7 @@ const StageNodeInner = (props: StageNodeProps) => {
   const [isReplacingTask, setIsReplacingTask] = useState(false);
 
   useEffect(() => {
-    if (pendingReplaceTask) {
+    if (pendingReplaceTask && !isReadOnly) {
       const match = allTasks
         .flatMap((group, gi) => group.map((task, ti) => ({ task, groupIndex: gi, taskIndex: ti })))
         .find(({ task }) => task.id === selectedTaskId);
@@ -77,18 +79,21 @@ const StageNodeInner = (props: StageNodeProps) => {
         setIsReplacingTask(true);
       }
     }
-  }, [pendingReplaceTask, selectedTaskId, allTasks]);
+  }, [pendingReplaceTask, selectedTaskId, allTasks, isReadOnly]);
 
   useEffect(() => {
-    if (selected === false) {
+    if (selected === false || isReadOnly) {
       setIsAddingTask(false);
       setIsReplacingTask(false);
     }
-  }, [selected]);
+  }, [selected, isReadOnly]);
 
+  // Not gated on `isReadOnly`: these items are host-controlled, so inspection
+  // and debug actions stay reachable on a locked stage. The stage's own
+  // mutation affordances are gated individually below.
   const shouldShowMenu = useMemo(() => {
-    return menuItems && menuItems.length > 0 && (selected || isHovered) && !isReadOnly;
-  }, [menuItems, selected, isHovered, isReadOnly]);
+    return menuItems && menuItems.length > 0 && (selected || isHovered);
+  }, [menuItems, selected, isHovered]);
 
   const { setSelectedNodeId } = useSetNodeSelection();
   const handleStageClick = useCallback(() => {
@@ -98,6 +103,7 @@ const StageNodeInner = (props: StageNodeProps) => {
   const handleTaskAddClick = useCallback(
     (event: React.MouseEvent) => {
       event.stopPropagation();
+      if (isReadOnly) return;
       if (onTaskAdd) {
         onTaskAdd();
       } else if (onAddTaskFromToolbox) {
@@ -105,7 +111,7 @@ const StageNodeInner = (props: StageNodeProps) => {
       }
       setSelectedNodeId(id);
     },
-    [onTaskAdd, onAddTaskFromToolbox, setSelectedNodeId, id]
+    [onTaskAdd, onAddTaskFromToolbox, setSelectedNodeId, id, isReadOnly]
   );
 
   const handleAddTaskToolboxItemSelected = useCallback(
@@ -180,7 +186,7 @@ const StageNodeInner = (props: StageNodeProps) => {
       {/* Panels are mounted only while open: FloatingCanvasPanel subscribes to the
           node's internals (useInternalNode), so a permanently mounted panel re-renders
           on every drag/measure frame of the stage even though it renders nothing. */}
-      {onAddTaskFromToolbox && isAddingTask && (
+      {onAddTaskFromToolbox && isAddingTask && !isReadOnly && (
         <FloatingCanvasPanel nodeId={id} offset={15}>
           <Toolbox
             title={labels.addTask}
@@ -192,7 +198,7 @@ const StageNodeInner = (props: StageNodeProps) => {
         </FloatingCanvasPanel>
       )}
 
-      {onReplaceTaskFromToolbox && isReplacingTask && (
+      {onReplaceTaskFromToolbox && isReplacingTask && !isReadOnly && (
         <FloatingCanvasPanel nodeId={id} offset={15}>
           <Toolbox
             title={labels.replaceTask}

--- a/packages/apollo-react/src/canvas/components/StickyNoteNode/StickyNoteNode.test.tsx
+++ b/packages/apollo-react/src/canvas/components/StickyNoteNode/StickyNoteNode.test.tsx
@@ -1,4 +1,4 @@
-import { act, fireEvent, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { ReactFlowProvider } from '@uipath/apollo-react/canvas/xyflow/react';
 import type { Components } from 'react-markdown';
@@ -76,12 +76,23 @@ function renderStickyNoteNode(props: Partial<StickyNoteNodeProps> = {}) {
 type StickyNoteNodeCanvasProps = Readonly<{
   stickyNoteOptions: StickyNoteCanvasOptions;
   nodeProps?: Partial<StickyNoteNodeProps>;
+  readOnlyNodeIds?: ReadonlySet<string>;
 }>;
 
-function StickyNoteNodeCanvas({ stickyNoteOptions, nodeProps = {} }: StickyNoteNodeCanvasProps) {
+function StickyNoteNodeCanvas({
+  stickyNoteOptions,
+  nodeProps = {},
+  readOnlyNodeIds,
+}: StickyNoteNodeCanvasProps) {
   return (
     <ReactFlowProvider>
-      <BaseCanvas nodes={[]} edges={[]} nodeTypes={{}} stickyNoteOptions={stickyNoteOptions}>
+      <BaseCanvas
+        nodes={[]}
+        edges={[]}
+        nodeTypes={{}}
+        stickyNoteOptions={stickyNoteOptions}
+        readOnlyNodeIds={readOnlyNodeIds}
+      >
         <StickyNoteNode {...defaultProps} {...nodeProps} />
       </BaseCanvas>
     </ReactFlowProvider>
@@ -90,10 +101,15 @@ function StickyNoteNodeCanvas({ stickyNoteOptions, nodeProps = {} }: StickyNoteN
 
 function renderStickyNoteNodeInCanvas(
   stickyNoteOptions: StickyNoteCanvasOptions,
-  nodeProps: Partial<StickyNoteNodeProps> = {}
+  nodeProps: Partial<StickyNoteNodeProps> = {},
+  readOnlyNodeIds?: ReadonlySet<string>
 ) {
   return render(
-    <StickyNoteNodeCanvas stickyNoteOptions={stickyNoteOptions} nodeProps={nodeProps} />
+    <StickyNoteNodeCanvas
+      stickyNoteOptions={stickyNoteOptions}
+      nodeProps={nodeProps}
+      readOnlyNodeIds={readOnlyNodeIds}
+    />
   );
 }
 
@@ -110,6 +126,15 @@ beforeEach(() => {
 });
 
 describe('StickyNoteNode resize lifecycle', () => {
+  it('hides resize controls when the sticky note is locked', () => {
+    renderStickyNoteNodeInCanvas({ readOnly: false }, {}, new Set(['sticky-note-1']));
+
+    fireEvent.doubleClick(screen.getByText('Remember the resize lifecycle'));
+
+    expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('node-resize-control-bottom-right')).not.toBeInTheDocument();
+  });
+
   it('settles an active resize before removing controls when canvas options become read-only', async () => {
     const onResizeStart = vi.fn();
     const onResize = vi.fn();
@@ -466,6 +491,47 @@ describe('StickyNoteNode editor extensions', () => {
       content: 'Before draft media After',
     });
     expect(editor).toHaveValue('Before draft media After');
+  });
+
+  it('ignores formatting changes completed after the sticky note becomes locked', async () => {
+    let editorContext: StickyNoteEditorActionContext | undefined;
+    const onContentChange = vi.fn();
+    const formattingActions: readonly StickyNoteFormattingAction[] = [
+      {
+        id: 'deferred-action',
+        label: 'Deferred action',
+        icon: <span aria-hidden="true">D</span>,
+        onAction: (context) => {
+          editorContext = context;
+        },
+      },
+    ];
+    const nodeProps = { onContentChange, formattingActions };
+    const view = renderStickyNoteNodeInCanvas({ readOnly: false }, nodeProps);
+
+    startEditing();
+    fireEvent.click(screen.getByRole('button', { name: 'Deferred action' }));
+
+    view.rerender(
+      <StickyNoteNodeCanvas
+        stickyNoteOptions={{ readOnly: false }}
+        nodeProps={nodeProps}
+        readOnlyNodeIds={new Set(['sticky-note-1'])}
+      />
+    );
+    await waitFor(() => expect(screen.queryByRole('textbox')).not.toBeInTheDocument());
+
+    act(() => {
+      editorContext?.commit({
+        value: 'Late mutation',
+        selectionStart: 13,
+        selectionEnd: 13,
+      });
+    });
+
+    expect(onContentChange).not.toHaveBeenCalled();
+    expect(mockUpdateNodeData).not.toHaveBeenCalled();
+    expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
   });
 
   it('reads and resumes with externally updated content after the editor loses focus', () => {
@@ -909,5 +975,50 @@ describe('StickyNoteNode built-in media embedding', () => {
 
     expect(screen.queryByTitle('YouTube video')).not.toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Play video' })).toBeInTheDocument();
+  });
+});
+
+// A note listed in BaseCanvas `readOnlyNodeIds` keeps its toolbar with every
+// action disabled, matching BaseNode. The sticky-note-level `readOnly`
+// prop/option predates that contract and still hides the toolbar outright.
+describe('StickyNoteNode toolbar when the note is locked', () => {
+  const TOOLBAR_ACTION_NAMES = ['Delete', 'Edit', 'Color'];
+
+  it('keeps the toolbar mounted with every action disabled when the node is locked', () => {
+    renderStickyNoteNodeInCanvas(
+      { readOnly: false },
+      { selected: true },
+      new Set(['sticky-note-1'])
+    );
+
+    for (const name of TOOLBAR_ACTION_NAMES) {
+      expect(screen.getByRole('button', { name })).toBeDisabled();
+    }
+  });
+
+  it('leaves the toolbar actions enabled when the node is not locked', () => {
+    renderStickyNoteNodeInCanvas({ readOnly: false }, { selected: true });
+
+    for (const name of TOOLBAR_ACTION_NAMES) {
+      expect(screen.getByRole('button', { name })).toBeEnabled();
+    }
+  });
+
+  it('hides the toolbar when the sticky note itself is read-only', () => {
+    renderStickyNoteNodeInCanvas({ readOnly: true }, { selected: true });
+
+    for (const name of TOOLBAR_ACTION_NAMES) {
+      expect(screen.queryByRole('button', { name })).not.toBeInTheDocument();
+    }
+  });
+
+  it('blocks resizing while the node is locked', () => {
+    renderStickyNoteNodeInCanvas(
+      { readOnly: false },
+      { selected: true },
+      new Set(['sticky-note-1'])
+    );
+
+    expect(screen.queryAllByTestId(/^node-resize-control-/)).toHaveLength(0);
   });
 });

--- a/packages/apollo-react/src/canvas/components/StickyNoteNode/StickyNoteNode.tsx
+++ b/packages/apollo-react/src/canvas/components/StickyNoteNode/StickyNoteNode.tsx
@@ -13,10 +13,12 @@ import { useSafeLingui } from '../../../i18n';
 import { GRID_SPACING } from '../../constants';
 import { useLatestRef } from '../../hooks/useLatestRef';
 import { areNodePropsEqualIgnoringPosition } from '../../utils/nodePropsEqual';
+import { useIsNodeReadOnly } from '../BaseCanvas/ReadOnlyNodesContext';
 import { useSelectionState } from '../BaseCanvas/SelectionStateContext';
 import { NodeViewportOverlay } from '../NodeViewportOverlay';
 import type { ToolbarAction } from '../Toolbar';
 import { NodeToolbar } from '../Toolbar';
+import { lockToolbarConfig } from '../Toolbar/NodeToolbar/NodeToolbar.utils';
 import { FormattingToolbar } from './FormattingToolbar';
 import {
   type ActiveFormats,
@@ -111,7 +113,10 @@ const StickyNoteNodeComponent = ({
 }: StickyNoteNodeProps) => {
   const { _ } = useSafeLingui();
   const canvasOptions = useStickyNoteCanvasOptions();
-  const readOnly = readOnlyProp ?? canvasOptions.readOnly;
+  const isNodeReadOnly = useIsNodeReadOnly(id);
+  // Sticky-note-level only; node-level read-only is combined below.
+  const stickyNoteReadOnly = readOnlyProp ?? canvasOptions.readOnly;
+  const readOnly = isNodeReadOnly || stickyNoteReadOnly;
   const enableMediaEmbedding = enableMediaEmbeddingProp ?? canvasOptions.enableMediaEmbedding;
   const { updateNodeData, deleteElements } = useReactFlow();
   const { multipleNodesSelected } = useSelectionState();
@@ -125,6 +130,7 @@ const StickyNoteNodeComponent = ({
   const formattingToolbarRef = useRef<HTMLDivElement>(null);
   const skipBlurRef = useRef<string | null>(null);
   const resizeActiveRef = useRef(false);
+  const readOnlyRef = useLatestRef(readOnly);
   const resizeLifecycle = {
     content: data.content,
     id,
@@ -192,6 +198,7 @@ const StickyNoteNodeComponent = ({
   useEffect(() => {
     if (readOnly) {
       setIsEditing(false);
+      setIsColorPickerOpen(false);
       updateLocalContent(data.content || '');
     }
   }, [readOnly, data.content, updateLocalContent]);
@@ -267,6 +274,7 @@ const StickyNoteNodeComponent = ({
       let completed = false;
 
       const restoreSelection = (next: TextSelection) => {
+        if (readOnlyRef.current) return;
         setIsEditing(true);
         requestAnimationFrame(() => {
           const currentTextarea = textAreaRef.current;
@@ -282,6 +290,10 @@ const StickyNoteNodeComponent = ({
       const complete = (next: TextSelection, shouldPersist: boolean) => {
         if (completed) return;
         completed = true;
+        if (readOnlyRef.current) {
+          skipBlurRef.current = null;
+          return;
+        }
         skipBlurRef.current = shouldPersist ? next.value : null;
         setActiveFormats(detectActiveFormats(next));
         if (shouldPersist) {
@@ -312,7 +324,7 @@ const StickyNoteNodeComponent = ({
         throw error;
       }
     },
-    [id, onContentChange, updateLocalContent, updateNodeData]
+    [id, onContentChange, readOnlyRef, updateLocalContent, updateNodeData]
   );
 
   const openMediaDialog = useCallback((context: StickyNoteEditorActionContext) => {
@@ -484,17 +496,19 @@ const StickyNoteNodeComponent = ({
   // Color change handler
   const handleColorChange = useCallback(
     (newColor: StickyNoteColor) => {
+      if (readOnly) return;
       onColorChange?.(newColor);
       updateNodeData(id, { color: newColor });
       setIsColorPickerOpen(false);
     },
-    [id, updateNodeData, onColorChange]
+    [id, updateNodeData, onColorChange, readOnly]
   );
 
   // Toggle color picker
   const handleToggleColorPicker = useCallback(() => {
+    if (readOnly) return;
     setIsColorPickerOpen((prev) => !prev);
-  }, []);
+  }, [readOnly]);
 
   // Handle edit button click
   const handleEditClick = useCallback(() => {
@@ -509,8 +523,9 @@ const StickyNoteNodeComponent = ({
   }, [readOnly]);
 
   const handleDelete = useCallback(() => {
+    if (readOnly) return;
     deleteElements({ nodes: [{ id }] });
-  }, [id, deleteElements]);
+  }, [id, deleteElements, readOnly]);
 
   // Custom markdown components to handle link clicks properly in React Flow nodes
   const builtInMarkdownComponents = useMemo<Components>(
@@ -608,8 +623,16 @@ const StickyNoteNodeComponent = ({
     };
   }, [_, handleEditClick, handleToggleColorPicker, color, handleDelete]);
 
+  const effectiveToolbarConfig = useMemo(
+    () => (isNodeReadOnly ? lockToolbarConfig(toolbarConfig) : toolbarConfig),
+    [isNodeReadOnly, toolbarConfig]
+  );
+
+  // A per-node lock keeps the toolbar with every action disabled, matching
+  // BaseNode. The sticky-note-level `readOnly` prop/option predates that
+  // contract and still hides the toolbar outright.
   const shouldRenderToolbarOverlay =
-    !readOnly && selected && !dragging && !isResizing && !multipleNodesSelected;
+    !stickyNoteReadOnly && selected && !dragging && !isResizing && !multipleNodesSelected;
   // XYFlow's active D3 gesture owns external listeners, so keep its controls mounted until resize end.
   const shouldRenderResizeControls = !readOnly || isResizing;
 
@@ -752,7 +775,12 @@ const StickyNoteNodeComponent = ({
         </StickyNoteContainer>
 
         {shouldRenderToolbarOverlay && (
-          <NodeToolbar nodeId={id} config={toolbarConfig} expanded={true} portalToNodeOverlay />
+          <NodeToolbar
+            nodeId={id}
+            config={effectiveToolbarConfig}
+            expanded={true}
+            portalToNodeOverlay
+          />
         )}
         {shouldRenderToolbarOverlay && (
           <NodeViewportOverlay nodeId={id} layer="nodeToolbar">

--- a/packages/apollo-react/src/canvas/components/Toolbar/NodeToolbar/NodeToolbar.utils.ts
+++ b/packages/apollo-react/src/canvas/components/Toolbar/NodeToolbar/NodeToolbar.utils.ts
@@ -1,7 +1,26 @@
-import type { ExtendedToolbarAction, ToolbarSeparator } from '../shared';
+import type { ExtendedToolbarAction, ToolbarAction, ToolbarSeparator } from '../shared';
+import type { NodeToolbarConfig } from './NodeToolbar.types';
 
 export type ProcessedToolbarItem = ExtendedToolbarAction | ToolbarSeparator;
 
 export function isSeparator(item: ProcessedToolbarItem): item is ToolbarSeparator {
   return item.id === 'separator';
 }
+
+/**
+ * Returns the config with every action disabled, separators untouched. Locks a
+ * read-only node's toolbar instead of unmounting it: the greyed-out actions
+ * (with their tooltips intact) say "read-only", where a missing toolbar just
+ * reads as a node with nothing to offer. Disabling is also real enforcement,
+ * since a consumer's `onAction` never reaches the canvas-level delete veto.
+ */
+export function lockToolbarConfig(config: NodeToolbarConfig): NodeToolbarConfig {
+  return {
+    ...config,
+    actions: disableActions(config.actions),
+    ...(config.overflowActions && { overflowActions: disableActions(config.overflowActions) }),
+  };
+}
+
+const disableActions = (actions: ToolbarAction[]): ToolbarAction[] =>
+  actions.map((action) => (action.id === 'separator' ? action : { ...action, disabled: true }));

--- a/packages/apollo-react/src/canvas/storybook-utils/components/StoryPage.test.tsx
+++ b/packages/apollo-react/src/canvas/storybook-utils/components/StoryPage.test.tsx
@@ -1,0 +1,25 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it } from 'vitest';
+import { StoryTabs, type StoryTabsProps } from './StoryPage';
+
+describe('StoryTabs', () => {
+  it('shows the selected comparison when a node tab is activated', async () => {
+    const user = userEvent.setup();
+    const tabs: StoryTabsProps['tabs'] = [
+      { value: 'agent', label: 'AgentNode', content: 'Agent comparison' },
+      { value: 'loop', label: 'LoopNode', content: 'Loop comparison' },
+    ];
+
+    render(<StoryTabs label="Specialized node renderers" tabs={tabs} />);
+
+    expect(screen.getByRole('tablist', { name: 'Specialized node renderers' })).toBeInTheDocument();
+    expect(screen.getByRole('tabpanel')).toHaveTextContent('Agent comparison');
+
+    await user.click(screen.getByRole('tab', { name: 'LoopNode' }));
+
+    expect(screen.getByRole('tab', { name: 'LoopNode' })).toHaveAttribute('aria-selected', 'true');
+    expect(screen.getByRole('tabpanel')).toHaveTextContent('Loop comparison');
+    expect(screen.queryByText('Agent comparison')).not.toBeInTheDocument();
+  });
+});

--- a/packages/apollo-react/src/canvas/storybook-utils/components/StoryPage.tsx
+++ b/packages/apollo-react/src/canvas/storybook-utils/components/StoryPage.tsx
@@ -1,4 +1,4 @@
-import { cn } from '@uipath/apollo-wind';
+import { cn, Tabs, TabsContent, TabsList, TabsTrigger } from '@uipath/apollo-wind';
 import type { ReactNode } from 'react';
 import { CanvasIcon } from '../../utils/icon-registry';
 
@@ -109,13 +109,15 @@ export interface StoryCardProps {
   /** Value chip beside the title, e.g. the prop value this card illustrates. */
   code?: string;
   description: ReactNode;
+  /** Overrides the fixed anatomy-preview slot for larger live specimens. */
+  previewClassName?: string;
 }
 
 /** One entry in an anatomy gallery: a sample, a name, and what it is for. */
-export function StoryCard({ preview, title, code, description }: StoryCardProps) {
+export function StoryCard({ preview, title, code, description, previewClassName }: StoryCardProps) {
   return (
     <div className="flex flex-col gap-4 rounded-xl border border-border bg-card p-6">
-      <div className="flex h-24 items-center justify-center">{preview}</div>
+      <div className={cn('flex h-24 items-center justify-center', previewClassName)}>{preview}</div>
       <div className="flex flex-col gap-2">
         <div className="flex flex-wrap items-center gap-2">
           <span className="text-base font-semibold text-foreground">{title}</span>
@@ -124,6 +126,57 @@ export function StoryCard({ preview, title, code, description }: StoryCardProps)
         <p className="text-sm text-muted-foreground">{description}</p>
       </div>
     </div>
+  );
+}
+
+/** Lets a dense interactive surface use the viewport while surrounding prose stays readable. */
+export function StoryWideContent({ children }: { children?: ReactNode }) {
+  return (
+    <div className="relative left-1/2 w-[calc(100vw-2rem)] max-w-[1600px] -translate-x-1/2">
+      {children}
+    </div>
+  );
+}
+
+export interface StoryTab {
+  value: string;
+  label: string;
+  content: ReactNode;
+}
+
+export interface StoryTabsProps {
+  tabs: readonly StoryTab[];
+  /** Accessible name for the tab list. */
+  label?: string;
+}
+
+/** A documentation tab rail that keeps one dense comparison visible at a time. */
+export function StoryTabs({ tabs, label = 'Comparisons' }: StoryTabsProps) {
+  const firstTab = tabs[0];
+  if (!firstTab) return null;
+
+  return (
+    <Tabs defaultValue={firstTab.value} className="w-full">
+      <TabsList
+        aria-label={label}
+        className="h-auto w-full justify-start gap-1 overflow-x-auto rounded-none border-b border-border bg-transparent p-0"
+      >
+        {tabs.map((tab) => (
+          <TabsTrigger
+            key={tab.value}
+            value={tab.value}
+            className="h-10 shrink-0 rounded-none border-b-2 border-transparent px-4 text-sm font-medium text-muted-foreground shadow-none transition-colors hover:text-foreground data-[state=active]:border-primary data-[state=active]:bg-transparent data-[state=active]:text-foreground data-[state=active]:shadow-none"
+          >
+            {tab.label}
+          </TabsTrigger>
+        ))}
+      </TabsList>
+      {tabs.map((tab) => (
+        <TabsContent key={tab.value} value={tab.value} className="mt-6">
+          {tab.content}
+        </TabsContent>
+      ))}
+    </Tabs>
   );
 }
 

--- a/packages/apollo-react/src/canvas/types.ts
+++ b/packages/apollo-react/src/canvas/types.ts
@@ -268,6 +268,9 @@ export type SpanAttributes = Record<string, unknown>;
 export type AgentFlowProps = {
   mode: 'design' | 'view';
 
+  /** Node ids to lock individually. Forwarded to BaseCanvas `readOnlyNodeIds`. */
+  readOnlyNodeIds?: ReadonlySet<string>;
+
   // all modes
   definition: Record<string, unknown>;
   spans: IRawSpan[];


### PR DESCRIPTION
## Summary

Applies per-node read-only behavior to Apollo's specialized node renderers and forwards lock state through higher-level canvas consumers.

## Demo

https://github.com/user-attachments/assets/a8ddd7da-7d00-4e36-80ce-2d5baa493ece

## Scope

- `AgentNode`: hides resource/instruction editing controls
- `LoopNode`: hides structural controls while preserving resize behavior
- `StageNode`: disables task/rule mutations and closes add/replace toolboxes when locking activates
- `StickyNoteNode`: disables editing, deferred formatting commits, and resize controls
- `AgentFlow` and `HierarchicalCanvas`: forward `readOnlyNodeIds` to `BaseCanvas`

## Stack

Part 3 of 4. Depends on #1052. The final PR freezes edges wholly inside a locked region and adds the complete Storybook demo.

## Testing

- 6 focused renderer test files
- 232 tests passing
