### PR TITLE
feat(apollo-react): add canvas takeover modal

### DIFF
--- a/packages/apollo-react/src/canvas/components/CanvasTakeoverModal/CanvasTakeoverModal.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/CanvasTakeoverModal/CanvasTakeoverModal.stories.tsx
@@ -1,0 +1,68 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Button } from '@uipath/apollo-wind';
+import { Plus } from 'lucide-react';
+import { useState } from 'react';
+import { CanvasTakeoverModal } from './CanvasTakeoverModal';
+
+const meta: Meta<typeof CanvasTakeoverModal> = {
+  title: 'Components/Controls/CanvasTakeoverModal',
+  component: CanvasTakeoverModal,
+  parameters: { layout: 'fullscreen' },
+  argTypes: {
+    children: { control: false },
+    sidebar: { control: false },
+    headerActions: { control: false },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof CanvasTakeoverModal>;
+
+function StoryCanvas({ withSidebar }: { withSidebar: boolean }) {
+  const [open, setOpen] = useState(true);
+
+  const sidebar = withSidebar ? (
+    <div className="p-2">
+      <div className="flex h-11 items-center justify-between px-2">
+        <span className="text-sm font-semibold">Title</span>
+        <button
+          type="button"
+          className="grid size-7 place-items-center rounded-md text-foreground-muted hover:bg-surface-hover hover:text-foreground"
+          aria-label="Add"
+        >
+          <Plus size={15} />
+        </button>
+      </div>
+    </div>
+  ) : undefined;
+
+  return (
+    <div className="relative h-screen min-h-[560px] overflow-hidden bg-surface">
+      <div className="grid h-full place-items-center bg-[radial-gradient(circle_at_center,var(--color-surface-overlay)_1px,transparent_1px)] bg-[length:20px_20px]">
+        {!open && <Button onClick={() => setOpen(true)}>Open takeover modal</Button>}
+      </div>
+      <CanvasTakeoverModal open={open} onOpenChange={setOpen} title="Modal title" sidebar={sidebar}>
+        <div className="flex h-full min-h-[360px] flex-col">
+          <div className="flex min-h-14 items-center justify-between border-b border-border-subtle px-5">
+            <div>
+              <p className="text-sm font-semibold">Title</p>
+              <p className="text-xs text-foreground-subtle">Subtext</p>
+            </div>
+            <Button variant="secondary" size="sm">
+              Action
+            </Button>
+          </div>
+          <div className="min-h-0 flex-1" />
+        </div>
+      </CanvasTakeoverModal>
+    </div>
+  );
+}
+
+export const WithSidebar: Story = {
+  render: () => <StoryCanvas withSidebar />,
+};
+
+export const WithoutSidebar: Story = {
+  render: () => <StoryCanvas withSidebar={false} />,
+};

--- a/packages/apollo-react/src/canvas/components/CanvasTakeoverModal/CanvasTakeoverModal.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/CanvasTakeoverModal/CanvasTakeoverModal.stories.tsx
@@ -27,7 +27,7 @@ function StoryCanvas({ withSidebar }: { withSidebar: boolean }) {
         <span className="text-sm font-semibold">Title</span>
         <button
           type="button"
-          className="grid size-7 place-items-center rounded-md text-foreground-muted hover:bg-surface-hover hover:text-foreground"
+          className="grid size-7 place-items-center rounded-md text-foreground-muted hover:bg-surface-hover hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-border-focus"
           aria-label="Add"
         >
           <Plus size={15} />

--- a/packages/apollo-react/src/canvas/components/CanvasTakeoverModal/CanvasTakeoverModal.test.tsx
+++ b/packages/apollo-react/src/canvas/components/CanvasTakeoverModal/CanvasTakeoverModal.test.tsx
@@ -1,0 +1,53 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { CanvasTakeoverModal } from './CanvasTakeoverModal';
+
+describe('CanvasTakeoverModal', () => {
+  it('renders an optional sidebar and toggles its expanded state', () => {
+    const onExpandedChange = vi.fn();
+    render(
+      <CanvasTakeoverModal
+        open
+        title="Manage datasets"
+        sidebar={<nav>Datasets</nav>}
+        onExpandedChange={onExpandedChange}
+      >
+        Datapoints
+      </CanvasTakeoverModal>
+    );
+
+    expect(screen.getByRole('navigation')).toHaveTextContent('Datasets');
+    expect(screen.getByRole('dialog')).toHaveAttribute('data-expanded', 'false');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Expand modal' }));
+
+    expect(screen.getByRole('dialog')).toHaveAttribute('data-expanded', 'true');
+    expect(onExpandedChange).toHaveBeenCalledWith(true);
+  });
+
+  it('requests close from Escape, the close button, and the backdrop', () => {
+    const onOpenChange = vi.fn();
+    render(
+      <CanvasTakeoverModal open title="Modal" onOpenChange={onOpenChange}>
+        Content
+      </CanvasTakeoverModal>
+    );
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+    fireEvent.click(screen.getByRole('button', { name: 'Close modal' }));
+    fireEvent.mouseDown(screen.getByTestId('canvas-takeover-backdrop'));
+
+    expect(onOpenChange).toHaveBeenCalledTimes(3);
+    expect(onOpenChange).toHaveBeenLastCalledWith(false);
+  });
+
+  it('does not render while closed', () => {
+    render(
+      <CanvasTakeoverModal open={false} title="Modal">
+        Content
+      </CanvasTakeoverModal>
+    );
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+});

--- a/packages/apollo-react/src/canvas/components/CanvasTakeoverModal/CanvasTakeoverModal.test.tsx
+++ b/packages/apollo-react/src/canvas/components/CanvasTakeoverModal/CanvasTakeoverModal.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import { CanvasTakeoverModal } from './CanvasTakeoverModal';
 
@@ -49,5 +49,50 @@ describe('CanvasTakeoverModal', () => {
     );
 
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('does not reserve sidebar space when sidebar is null', () => {
+    render(
+      <CanvasTakeoverModal open title="Modal" sidebar={null}>
+        Content
+      </CanvasTakeoverModal>
+    );
+
+    expect(screen.queryByRole('complementary')).not.toBeInTheDocument();
+  });
+
+  it('moves focus into the modal and restores it after closing', async () => {
+    const { rerender } = render(
+      <>
+        <button type="button">Open modal</button>
+        <CanvasTakeoverModal open={false} title="Modal">
+          Content
+        </CanvasTakeoverModal>
+      </>
+    );
+    const trigger = screen.getByRole('button', { name: 'Open modal' });
+    trigger.focus();
+
+    rerender(
+      <>
+        <button type="button">Open modal</button>
+        <CanvasTakeoverModal open title="Modal">
+          Content
+        </CanvasTakeoverModal>
+      </>
+    );
+
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Expand modal' })).toHaveFocus());
+
+    rerender(
+      <>
+        <button type="button">Open modal</button>
+        <CanvasTakeoverModal open={false} title="Modal">
+          Content
+        </CanvasTakeoverModal>
+      </>
+    );
+
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Open modal' })).toHaveFocus());
   });
 });

--- a/packages/apollo-react/src/canvas/components/CanvasTakeoverModal/CanvasTakeoverModal.tsx
+++ b/packages/apollo-react/src/canvas/components/CanvasTakeoverModal/CanvasTakeoverModal.tsx
@@ -1,0 +1,142 @@
+import { cn } from '@uipath/apollo-wind';
+import { Maximize2, Minimize2, X } from 'lucide-react';
+import { type MouseEvent, type ReactNode, useEffect, useId, useState } from 'react';
+
+export interface CanvasTakeoverModalProps {
+  /** Whether the takeover is visible. */
+  open: boolean;
+  /** Called when the takeover requests to open or close. */
+  onOpenChange?: (open: boolean) => void;
+  /** Accessible heading shown in the modal header. */
+  title: ReactNode;
+  /** Optional content rendered after the title. */
+  headerActions?: ReactNode;
+  /** Optional fixed-width navigation or supporting pane. */
+  sidebar?: ReactNode;
+  /** Main takeover content. */
+  children: ReactNode;
+  /** Controlled expanded state. */
+  expanded?: boolean;
+  /** Initial expanded state when uncontrolled. */
+  defaultExpanded?: boolean;
+  /** Called when the expanded state changes. */
+  onExpandedChange?: (expanded: boolean) => void;
+  /** Additional class names for the takeover surface. */
+  className?: string;
+  /** Additional class names for the optional sidebar. */
+  sidebarClassName?: string;
+  /** Close when the dimmed backdrop is pressed. @default true */
+  closeOnBackdropClick?: boolean;
+}
+
+/**
+ * A canvas-scoped modal for workflows that need substantially more room than a panel.
+ * The parent must establish a positioned containing block (for example, `position: relative`).
+ */
+export function CanvasTakeoverModal({
+  open,
+  onOpenChange,
+  title,
+  headerActions,
+  sidebar,
+  children,
+  expanded: controlledExpanded,
+  defaultExpanded = false,
+  onExpandedChange,
+  className,
+  sidebarClassName,
+  closeOnBackdropClick = true,
+}: CanvasTakeoverModalProps) {
+  const titleId = useId();
+  const [uncontrolledExpanded, setUncontrolledExpanded] = useState(defaultExpanded);
+  const expanded = controlledExpanded ?? uncontrolledExpanded;
+
+  useEffect(() => {
+    if (!open) return;
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') onOpenChange?.(false);
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [onOpenChange, open]);
+
+  if (!open) return null;
+
+  const setExpanded = (nextExpanded: boolean) => {
+    if (controlledExpanded === undefined) setUncontrolledExpanded(nextExpanded);
+    onExpandedChange?.(nextExpanded);
+  };
+
+  const handleBackdropClick = (event: MouseEvent<HTMLDivElement>) => {
+    if (closeOnBackdropClick && event.target === event.currentTarget) onOpenChange?.(false);
+  };
+
+  return (
+    <div
+      className={cn(
+        'absolute inset-0 z-50 flex items-center justify-center bg-ui-backdrop',
+        expanded ? 'p-0' : 'p-3'
+      )}
+      onMouseDown={handleBackdropClick}
+      data-testid="canvas-takeover-backdrop"
+    >
+      <section
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        data-expanded={expanded}
+        className={cn(
+          'flex min-h-0 flex-col overflow-hidden border border-border-subtle bg-surface-raised text-foreground shadow-xl transition-[width,height,border-radius] duration-200',
+          expanded ? 'h-full w-full rounded-none' : 'h-[95%] w-[95%] rounded-2xl',
+          className
+        )}
+      >
+        <header className="flex h-12 shrink-0 items-center gap-3 border-b border-border-subtle px-4">
+          <h2 id={titleId} className="min-w-0 flex-1 truncate text-sm font-semibold">
+            {title}
+          </h2>
+          {headerActions}
+          <div className="-mr-1 flex shrink-0 items-center gap-1">
+            <button
+              type="button"
+              onClick={() => setExpanded(!expanded)}
+              className="grid size-8 place-items-center rounded-md text-foreground-muted transition-colors hover:bg-surface-hover hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-border-focus"
+              aria-label={expanded ? 'Collapse modal' : 'Expand modal'}
+              title={expanded ? 'Collapse modal' : 'Expand modal'}
+            >
+              {expanded ? (
+                <Minimize2 size={16} strokeWidth={1.75} />
+              ) : (
+                <Maximize2 size={16} strokeWidth={1.75} />
+              )}
+            </button>
+            <button
+              type="button"
+              onClick={() => onOpenChange?.(false)}
+              className="grid size-8 place-items-center rounded-md text-foreground-muted transition-colors hover:bg-surface-hover hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-border-focus"
+              aria-label="Close modal"
+              title="Close modal"
+            >
+              <X size={16} strokeWidth={1.75} />
+            </button>
+          </div>
+        </header>
+        <div className="flex min-h-0 flex-1">
+          {sidebar !== undefined && (
+            <aside
+              className={cn(
+                'w-64 shrink-0 overflow-auto border-r border-border-subtle',
+                sidebarClassName
+              )}
+            >
+              {sidebar}
+            </aside>
+          )}
+          <main className="min-w-0 flex-1 overflow-auto">{children}</main>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/packages/apollo-react/src/canvas/components/CanvasTakeoverModal/CanvasTakeoverModal.tsx
+++ b/packages/apollo-react/src/canvas/components/CanvasTakeoverModal/CanvasTakeoverModal.tsx
@@ -1,6 +1,7 @@
 import { cn } from '@uipath/apollo-wind';
 import { Maximize2, Minimize2, X } from 'lucide-react';
-import { type MouseEvent, type ReactNode, useEffect, useId, useState } from 'react';
+import { type MouseEvent, type ReactNode, useEffect, useId, useRef, useState } from 'react';
+import FocusLock from 'react-focus-lock';
 
 export interface CanvasTakeoverModalProps {
   /** Whether the takeover is visible. */
@@ -48,18 +49,29 @@ export function CanvasTakeoverModal({
   closeOnBackdropClick = true,
 }: CanvasTakeoverModalProps) {
   const titleId = useId();
+  const expandButtonRef = useRef<HTMLButtonElement>(null);
+  const previouslyFocusedElementRef = useRef<HTMLElement | null>(null);
   const [uncontrolledExpanded, setUncontrolledExpanded] = useState(defaultExpanded);
   const expanded = controlledExpanded ?? uncontrolledExpanded;
 
   useEffect(() => {
     if (!open) return;
 
+    previouslyFocusedElementRef.current =
+      document.activeElement instanceof HTMLElement ? document.activeElement : null;
+    const animationFrame = requestAnimationFrame(() => expandButtonRef.current?.focus());
+
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key === 'Escape') onOpenChange?.(false);
     };
 
     document.addEventListener('keydown', handleKeyDown);
-    return () => document.removeEventListener('keydown', handleKeyDown);
+    return () => {
+      cancelAnimationFrame(animationFrame);
+      document.removeEventListener('keydown', handleKeyDown);
+      previouslyFocusedElementRef.current?.focus();
+      previouslyFocusedElementRef.current = null;
+    };
   }, [onOpenChange, open]);
 
   if (!open) return null;
@@ -82,61 +94,64 @@ export function CanvasTakeoverModal({
       onMouseDown={handleBackdropClick}
       data-testid="canvas-takeover-backdrop"
     >
-      <section
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby={titleId}
-        data-expanded={expanded}
-        className={cn(
-          'flex min-h-0 flex-col overflow-hidden border border-border-subtle bg-surface-raised text-foreground shadow-xl transition-[width,height,border-radius] duration-200',
-          expanded ? 'h-full w-full rounded-none' : 'h-[95%] w-[95%] rounded-2xl',
-          className
-        )}
-      >
-        <header className="flex h-12 shrink-0 items-center gap-3 border-b border-border-subtle px-4">
-          <h2 id={titleId} className="min-w-0 flex-1 truncate text-sm font-semibold">
-            {title}
-          </h2>
-          {headerActions}
-          <div className="-mr-1 flex shrink-0 items-center gap-1">
-            <button
-              type="button"
-              onClick={() => setExpanded(!expanded)}
-              className="grid size-8 place-items-center rounded-md text-foreground-muted transition-colors hover:bg-surface-hover hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-border-focus"
-              aria-label={expanded ? 'Collapse modal' : 'Expand modal'}
-              title={expanded ? 'Collapse modal' : 'Expand modal'}
-            >
-              {expanded ? (
-                <Minimize2 size={16} strokeWidth={1.75} />
-              ) : (
-                <Maximize2 size={16} strokeWidth={1.75} />
-              )}
-            </button>
-            <button
-              type="button"
-              onClick={() => onOpenChange?.(false)}
-              className="grid size-8 place-items-center rounded-md text-foreground-muted transition-colors hover:bg-surface-hover hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-border-focus"
-              aria-label="Close modal"
-              title="Close modal"
-            >
-              <X size={16} strokeWidth={1.75} />
-            </button>
-          </div>
-        </header>
-        <div className="flex min-h-0 flex-1">
-          {sidebar !== undefined && (
-            <aside
-              className={cn(
-                'w-64 shrink-0 overflow-auto border-r border-border-subtle',
-                sidebarClassName
-              )}
-            >
-              {sidebar}
-            </aside>
+      <FocusLock autoFocus={false} className="contents">
+        <section
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby={titleId}
+          data-expanded={expanded}
+          className={cn(
+            'flex min-h-0 flex-col overflow-hidden border border-border-subtle bg-surface-raised text-foreground shadow-xl transition-[width,height,border-radius] duration-200',
+            expanded ? 'h-full w-full rounded-none' : 'h-[95%] w-[95%] rounded-2xl',
+            className
           )}
-          <main className="min-w-0 flex-1 overflow-auto">{children}</main>
-        </div>
-      </section>
+        >
+          <header className="flex h-12 shrink-0 items-center gap-3 border-b border-border-subtle px-4">
+            <h2 id={titleId} className="min-w-0 flex-1 truncate text-sm font-semibold">
+              {title}
+            </h2>
+            {headerActions}
+            <div className="-mr-1 flex shrink-0 items-center gap-1">
+              <button
+                ref={expandButtonRef}
+                type="button"
+                onClick={() => setExpanded(!expanded)}
+                className="grid size-8 place-items-center rounded-md text-foreground-muted transition-colors hover:bg-surface-hover hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-border-focus"
+                aria-label={expanded ? 'Collapse modal' : 'Expand modal'}
+                title={expanded ? 'Collapse modal' : 'Expand modal'}
+              >
+                {expanded ? (
+                  <Minimize2 size={16} strokeWidth={1.75} />
+                ) : (
+                  <Maximize2 size={16} strokeWidth={1.75} />
+                )}
+              </button>
+              <button
+                type="button"
+                onClick={() => onOpenChange?.(false)}
+                className="grid size-8 place-items-center rounded-md text-foreground-muted transition-colors hover:bg-surface-hover hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-border-focus"
+                aria-label="Close modal"
+                title="Close modal"
+              >
+                <X size={16} strokeWidth={1.75} />
+              </button>
+            </div>
+          </header>
+          <div className="flex min-h-0 flex-1">
+            {sidebar != null && (
+              <aside
+                className={cn(
+                  'w-64 shrink-0 overflow-auto border-r border-border-subtle',
+                  sidebarClassName
+                )}
+              >
+                {sidebar}
+              </aside>
+            )}
+            <main className="min-w-0 flex-1 overflow-auto">{children}</main>
+          </div>
+        </section>
+      </FocusLock>
     </div>
   );
 }

--- a/packages/apollo-react/src/canvas/components/CanvasTakeoverModal/index.ts
+++ b/packages/apollo-react/src/canvas/components/CanvasTakeoverModal/index.ts
@@ -1,0 +1,2 @@
+export type { CanvasTakeoverModalProps } from './CanvasTakeoverModal';
+export { CanvasTakeoverModal } from './CanvasTakeoverModal';

--- a/packages/apollo-react/src/canvas/components/index.ts
+++ b/packages/apollo-react/src/canvas/components/index.ts
@@ -7,6 +7,7 @@ export * from './ButtonHandle';
 export * from './CanvasBottomPanel';
 export * from './CanvasModeToolbar';
 export * from './CanvasPositionControls';
+export * from './CanvasTakeoverModal';
 export * from './CanvasZoomControls';
 export * from './CaseFlow';
 export * from './CodedAgent';


### PR DESCRIPTION
## Summary

- add a reusable `CanvasTakeoverModal` for canvas-scoped workflows that need more space than an inline panel
- support optional sidebar and sidebar-free layouts
- support controlled or uncontrolled expand/collapse state
- handle Escape, backdrop, and close-button dismissal
- add neutral Storybook examples and focused interaction tests
- export the component from the Apollo React canvas package

<img width="1364" height="1114" alt="Screenshot 2026-08-13 at 2 45 52 PM" src="https://github.com/user-attachments/assets/eebca45d-f483-4bee-9794-157f86abda3a" />
<img width="1365" height="1115" alt="Screenshot 2026-08-13 at 2 45 44 PM" src="https://github.com/user-attachments/assets/1594cf8d-dca4-4ac2-a81e-1ee83191eeaa" />

## Why

Canvas consumers need a general takeover surface for complex workflows that require substantially more room while preserving the surrounding canvas context. This extracts the reusable modal shell from the prototype without coupling the component to dataset-specific content.

## Consumer impact

Consumers can compose their own sidebar, header actions, and main content while relying on the component for consistent sizing, modal semantics, dismissal behavior, and expand/collapse interactions.

## Validation

- `pnpm --filter @uipath/apollo-react exec biome check src/canvas/components/CanvasTakeoverModal src/canvas/components/index.ts`
- `pnpm --filter @uipath/apollo-react exec vitest --run src/canvas/components/CanvasTakeoverModal/CanvasTakeoverModal.test.tsx`
- Apollo React package build
- visually verified sidebar and sidebar-free Storybook layouts
- verified expand and collapse interactions in Storybook
