### PR TITLE
feat(apollo-react): add canvas left sidebar

### DIFF
--- a/packages/apollo-react/src/canvas/components/CanvasLeftSidebar/CanvasLeftSidebar.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/CanvasLeftSidebar/CanvasLeftSidebar.stories.tsx
@@ -1,0 +1,58 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { cn, TooltipProvider } from '@uipath/apollo-wind';
+import { useState } from 'react';
+import { CanvasLeftSidebar, type CanvasLeftSidebarItemId } from './CanvasLeftSidebar';
+
+const meta = {
+  title: 'Components/Controls/CanvasLeftSidebar',
+  component: CanvasLeftSidebar,
+  parameters: { layout: 'fullscreen' },
+  args: { title: 'Variables' },
+  decorators: [
+    (Story) => (
+      <TooltipProvider>
+        <Story />
+      </TooltipProvider>
+    ),
+  ],
+} satisfies Meta<typeof CanvasLeftSidebar>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+function SidebarStory({ variant }: { variant: 'default' | 'floating' }) {
+  const [isExpanded, setIsExpanded] = useState(false);
+  const [activeItemId, setActiveItemId] = useState<CanvasLeftSidebarItemId>('variables');
+  const labels: Record<CanvasLeftSidebarItemId, string> = {
+    'coding-agent': 'Coding agent',
+    files: 'Files',
+    variables: 'Variables',
+    connections: 'Connections',
+    'run-history': 'Run history',
+    'whats-new': "What's new",
+    account: 'Account',
+  };
+
+  return (
+    <div className={cn('h-screen bg-surface', variant === 'floating' && 'p-6')}>
+      <CanvasLeftSidebar
+        title={labels[activeItemId]}
+        variant={variant}
+        isExpanded={isExpanded}
+        onExpandedChange={setIsExpanded}
+        activeItemId={activeItemId}
+        onItemSelect={setActiveItemId}
+      />
+    </div>
+  );
+}
+
+export const DefaultSidebar: Story = {
+  name: 'Default Sidebar',
+  render: () => <SidebarStory variant="default" />,
+};
+
+export const FloatingSidebar: Story = {
+  name: 'Floating Sidebar',
+  render: () => <SidebarStory variant="floating" />,
+};

--- a/packages/apollo-react/src/canvas/components/CanvasLeftSidebar/CanvasLeftSidebar.test.tsx
+++ b/packages/apollo-react/src/canvas/components/CanvasLeftSidebar/CanvasLeftSidebar.test.tsx
@@ -53,7 +53,7 @@ describe('CanvasLeftSidebar', () => {
   it('renders persistent primary and utility rail actions', () => {
     render(<CanvasLeftSidebar title="Variables" isExpanded={false} onExpandedChange={vi.fn()} />);
 
-    expect(screen.getByRole('button', { name: 'Home' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Home' })).not.toBeInTheDocument();
     for (const label of [
       'Coding agent',
       'Files',
@@ -65,6 +65,21 @@ describe('CanvasLeftSidebar', () => {
     ]) {
       expect(screen.getByRole('button', { name: label })).toBeInTheDocument();
     }
+  });
+
+  it('makes the logo actionable only when a click handler is provided', async () => {
+    const onLogoClick = vi.fn();
+    render(
+      <CanvasLeftSidebar
+        title="Variables"
+        isExpanded={false}
+        onExpandedChange={vi.fn()}
+        onLogoClick={onLogoClick}
+      />
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: 'Home' }));
+    expect(onLogoClick).toHaveBeenCalledOnce();
   });
 
   it('supports consumer-defined navigation and exposes the active item', () => {

--- a/packages/apollo-react/src/canvas/components/CanvasLeftSidebar/CanvasLeftSidebar.test.tsx
+++ b/packages/apollo-react/src/canvas/components/CanvasLeftSidebar/CanvasLeftSidebar.test.tsx
@@ -1,0 +1,85 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  CANVAS_LEFT_SIDEBAR_COLLAPSED_WIDTH,
+  CANVAS_LEFT_SIDEBAR_RAIL_WIDTH,
+  CANVAS_LEFT_SIDEBAR_WIDTH,
+  CanvasLeftSidebar,
+} from './CanvasLeftSidebar';
+
+describe('CanvasLeftSidebar', () => {
+  it('renders its title and content when expanded', () => {
+    render(
+      <CanvasLeftSidebar title="Variables" isExpanded onExpandedChange={vi.fn()}>
+        Sidebar content
+      </CanvasLeftSidebar>
+    );
+
+    expect(screen.getByRole('heading', { name: 'Variables' })).toBeInTheDocument();
+    expect(screen.getByText('Sidebar content')).toBeInTheDocument();
+    expect(screen.getByTestId('canvas-left-sidebar')).toHaveStyle({
+      width: `${CANVAS_LEFT_SIDEBAR_RAIL_WIDTH + CANVAS_LEFT_SIDEBAR_WIDTH}px`,
+    });
+  });
+
+  it('requests collapse from the expanded state', async () => {
+    const onExpandedChange = vi.fn();
+    render(<CanvasLeftSidebar title="Variables" isExpanded onExpandedChange={onExpandedChange} />);
+
+    await userEvent.click(screen.getByRole('button', { name: 'Collapse sidebar' }));
+    expect(onExpandedChange).toHaveBeenCalledWith(false);
+  });
+
+  it('hides content and requests expansion from the collapsed state', async () => {
+    const onExpandedChange = vi.fn();
+    render(
+      <CanvasLeftSidebar title="Variables" isExpanded={false} onExpandedChange={onExpandedChange}>
+        Sidebar content
+      </CanvasLeftSidebar>
+    );
+
+    const contentPanel = screen.getByText('Variables').closest('[aria-hidden]');
+    expect(contentPanel).toHaveAttribute('aria-hidden', 'true');
+    expect(contentPanel).toHaveAttribute('inert');
+    expect(screen.getByTestId('canvas-left-sidebar')).toHaveStyle({
+      width: `${CANVAS_LEFT_SIDEBAR_COLLAPSED_WIDTH}px`,
+    });
+
+    await userEvent.click(screen.getByRole('button', { name: 'Variables' }));
+    expect(onExpandedChange).toHaveBeenCalledWith(true);
+  });
+
+  it('renders persistent primary and utility rail actions', () => {
+    render(<CanvasLeftSidebar title="Variables" isExpanded={false} onExpandedChange={vi.fn()} />);
+
+    expect(screen.getByRole('button', { name: 'Home' })).toBeInTheDocument();
+    for (const label of [
+      'Coding agent',
+      'Files',
+      'Variables',
+      'Connections',
+      'Run history',
+      "What's new",
+      'Account',
+    ]) {
+      expect(screen.getByRole('button', { name: label })).toBeInTheDocument();
+    }
+  });
+
+  it('supports consumer-defined navigation and exposes the active item', () => {
+    render(
+      <CanvasLeftSidebar
+        title="Search"
+        isExpanded
+        onExpandedChange={vi.fn()}
+        activeItemId="search"
+        primaryItems={[{ id: 'search', label: 'Search', icon: <span>Icon</span> }]}
+        bottomItems={[]}
+      />
+    );
+
+    expect(screen.getByRole('button', { name: 'Search' })).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.queryByRole('button', { name: "What's new" })).not.toBeInTheDocument();
+  });
+});

--- a/packages/apollo-react/src/canvas/components/CanvasLeftSidebar/CanvasLeftSidebar.tsx
+++ b/packages/apollo-react/src/canvas/components/CanvasLeftSidebar/CanvasLeftSidebar.tsx
@@ -147,14 +147,20 @@ export const CanvasLeftSidebar = memo(function CanvasLeftSidebar({
         className="flex h-full shrink-0 select-none flex-col items-center border-r border-border-subtle py-3"
         style={{ width: CANVAS_LEFT_SIDEBAR_RAIL_WIDTH }}
       >
-        <ToolbarButton
-          label="Home"
-          tooltipSide="right"
-          onClick={onLogoClick}
-          className="mb-2 size-9 shrink-0 overflow-hidden rounded-lg p-0 transition-transform hover:opacity-90 active:scale-95 [&_svg]:!size-9"
-        >
-          {logo ?? <UiPathLogo />}
-        </ToolbarButton>
+        {onLogoClick ? (
+          <ToolbarButton
+            label="Home"
+            tooltipSide="right"
+            onClick={onLogoClick}
+            className="mb-2 size-9 shrink-0 overflow-hidden rounded-lg p-0 transition-transform hover:opacity-90 active:scale-95 [&_svg]:!size-9"
+          >
+            {logo ?? <UiPathLogo />}
+          </ToolbarButton>
+        ) : (
+          <div className="mb-2 size-9 shrink-0 overflow-hidden rounded-lg [&_svg]:!size-9">
+            {logo ?? <UiPathLogo />}
+          </div>
+        )}
 
         <div className="flex flex-1 flex-col items-center gap-1 pt-2">
           {primaryItems.map((item) => (

--- a/packages/apollo-react/src/canvas/components/CanvasLeftSidebar/CanvasLeftSidebar.tsx
+++ b/packages/apollo-react/src/canvas/components/CanvasLeftSidebar/CanvasLeftSidebar.tsx
@@ -1,0 +1,212 @@
+import { cn } from '@uipath/apollo-wind';
+import {
+  Files,
+  History,
+  MessageCircle,
+  Network,
+  Newspaper,
+  PanelLeftClose,
+  User,
+  Variable,
+} from 'lucide-react';
+import { memo, type ReactNode } from 'react';
+import { ToolbarButton } from '../ToolbarButton';
+
+export const CANVAS_LEFT_SIDEBAR_RAIL_WIDTH = 60;
+export const CANVAS_LEFT_SIDEBAR_WIDTH = 288;
+export const CANVAS_LEFT_SIDEBAR_COLLAPSED_WIDTH = CANVAS_LEFT_SIDEBAR_RAIL_WIDTH;
+
+export type CanvasLeftSidebarItemId = string;
+
+export interface CanvasLeftSidebarItem {
+  id: CanvasLeftSidebarItemId;
+  label: string;
+  icon: ReactNode;
+  disabled?: boolean;
+}
+
+export interface CanvasLeftSidebarProps {
+  /** Text displayed in the expanded sidebar header. */
+  title: ReactNode;
+  /** Reusable sidebar content. Hidden while the sidebar is collapsed. */
+  children?: ReactNode;
+  /** Whether the content panel next to the navigation rail is visible. */
+  isExpanded: boolean;
+  /** Called when the content panel is expanded or collapsed. */
+  onExpandedChange: (isExpanded: boolean) => void;
+  /** Currently selected rail item. */
+  activeItemId?: CanvasLeftSidebarItemId;
+  /** Called when a rail item is selected. */
+  onItemSelect?: (itemId: CanvasLeftSidebarItemId) => void;
+  /** Called when the UiPath logo is selected. */
+  onLogoClick?: () => void;
+  /** Custom logo artwork. Defaults to the UiPath mark. */
+  logo?: ReactNode;
+  /** Primary actions rendered below the logo. Defaults to the Flow navigation actions. */
+  primaryItems?: readonly CanvasLeftSidebarItem[];
+  /** Utility actions pinned to the bottom. Defaults to What's new and Account. */
+  bottomItems?: readonly CanvasLeftSidebarItem[];
+  /** Additional controls rendered before the collapse button in the panel header. */
+  headerActions?: ReactNode;
+  /** Docked sidebars are square; floating sidebars use rounded, elevated chrome. */
+  variant?: 'default' | 'floating';
+  className?: string;
+}
+
+export const CANVAS_LEFT_SIDEBAR_DEFAULT_PRIMARY_ITEMS: readonly CanvasLeftSidebarItem[] = [
+  { id: 'coding-agent', label: 'Coding agent', icon: <MessageCircle strokeWidth={1.75} /> },
+  { id: 'files', label: 'Files', icon: <Files strokeWidth={1.75} /> },
+  { id: 'variables', label: 'Variables', icon: <Variable strokeWidth={1.75} /> },
+  { id: 'connections', label: 'Connections', icon: <Network strokeWidth={1.75} /> },
+  { id: 'run-history', label: 'Run history', icon: <History strokeWidth={1.75} /> },
+];
+
+export const CANVAS_LEFT_SIDEBAR_DEFAULT_BOTTOM_ITEMS: readonly CanvasLeftSidebarItem[] = [
+  { id: 'whats-new', label: "What's new", icon: <Newspaper strokeWidth={1.75} /> },
+  { id: 'account', label: 'Account', icon: <User strokeWidth={1.75} /> },
+];
+
+function UiPathLogo() {
+  return (
+    <svg aria-hidden="true" width="36" height="36" viewBox="0 0 36 36" fill="none">
+      <rect width="36" height="36" rx="8" fill="#0092B8" />
+      <g transform="translate(6 6)" fill="#FAFAFA">
+        <path d="M18.57 11.4h-.297c-.959 0-1.555.601-1.555 1.568v9.465c0 .967.596 1.567 1.555 1.567h.297c.959 0 1.555-.6 1.555-1.567v-9.465c0-.967-.596-1.568-1.555-1.568Z" />
+        <path d="M22.689 5.541c-2.168-.348-3.878-2.057-4.226-4.222-.007-.041-.06-.041-.066 0-.348 2.165-2.059 3.874-4.226 4.222-.041.006-.041.059 0 .066 2.167.348 3.878 2.056 4.226 4.221.006.041.059.041.066 0 .348-2.165 2.058-3.873 4.226-4.221.041-.007.041-.06 0-.066Z" />
+        <path d="M23.985 2.159C22.9 2.333 22.046 3.187 21.872 4.27c-.004.02-.03.02-.034 0-.174-1.083-1.029-1.937-2.112-2.111-.021-.003-.021-.03 0-.033 1.083-.174 1.938-1.028 2.112-2.111.003-.02.03-.02.034 0 .174 1.083 1.029 1.937 2.113 2.111.02.003.02.03 0 .033Z" />
+        <path d="M12.765 6.859h-.359c-.936 0-1.517.578-1.517 1.509v7.485c0 3.549-1.086 4.996-3.748 4.996s-3.748-1.454-3.748-5.018V8.368c0-.931-.581-1.509-1.517-1.509h-.359C.581 6.859 0 7.437 0 8.368v7.485C0 21.259 2.403 24 7.141 24s7.141-2.741 7.141-8.147V8.368c0-.931-.581-1.509-1.517-1.509Z" />
+      </g>
+    </svg>
+  );
+}
+
+function RailButton({
+  item,
+  activeItemId,
+  onSelect,
+}: {
+  item: CanvasLeftSidebarItem;
+  activeItemId?: CanvasLeftSidebarItemId;
+  onSelect: (id: CanvasLeftSidebarItemId) => void;
+}) {
+  const isActive = activeItemId === item.id;
+  return (
+    <ToolbarButton
+      label={item.label}
+      tooltipSide="right"
+      onClick={() => onSelect(item.id)}
+      disabled={item.disabled}
+      ariaPressed={isActive}
+      className={cn(
+        'size-9 rounded-lg text-foreground-muted transition-colors hover:bg-surface-hover hover:text-foreground [&_svg]:size-5',
+        isActive && 'bg-surface-overlay text-foreground'
+      )}
+    >
+      {item.icon}
+    </ToolbarButton>
+  );
+}
+
+export const CanvasLeftSidebar = memo(function CanvasLeftSidebar({
+  title,
+  children,
+  isExpanded,
+  onExpandedChange,
+  activeItemId,
+  onItemSelect,
+  onLogoClick,
+  logo,
+  primaryItems = CANVAS_LEFT_SIDEBAR_DEFAULT_PRIMARY_ITEMS,
+  bottomItems = CANVAS_LEFT_SIDEBAR_DEFAULT_BOTTOM_ITEMS,
+  headerActions,
+  variant = 'default',
+  className,
+}: CanvasLeftSidebarProps) {
+  const selectItem = (itemId: CanvasLeftSidebarItemId) => {
+    onItemSelect?.(itemId);
+    onExpandedChange(activeItemId === itemId ? !isExpanded : true);
+  };
+
+  return (
+    <aside
+      data-testid="canvas-left-sidebar"
+      data-expanded={isExpanded}
+      className={cn(
+        'flex h-full shrink-0 overflow-hidden border border-border-subtle bg-surface-raised text-foreground transition-[width] duration-150 ease-[cubic-bezier(0.2,0,0,1)] motion-reduce:transition-none',
+        variant === 'floating' && 'rounded-2xl shadow-lg',
+        className
+      )}
+      style={{
+        width: isExpanded
+          ? CANVAS_LEFT_SIDEBAR_RAIL_WIDTH + CANVAS_LEFT_SIDEBAR_WIDTH
+          : CANVAS_LEFT_SIDEBAR_COLLAPSED_WIDTH,
+      }}
+    >
+      <nav
+        aria-label="Canvas navigation"
+        className="flex h-full shrink-0 select-none flex-col items-center border-r border-border-subtle py-3"
+        style={{ width: CANVAS_LEFT_SIDEBAR_RAIL_WIDTH }}
+      >
+        <ToolbarButton
+          label="Home"
+          tooltipSide="right"
+          onClick={onLogoClick}
+          className="mb-2 size-9 shrink-0 overflow-hidden rounded-lg p-0 transition-transform hover:opacity-90 active:scale-95 [&_svg]:!size-9"
+        >
+          {logo ?? <UiPathLogo />}
+        </ToolbarButton>
+
+        <div className="flex flex-1 flex-col items-center gap-1 pt-2">
+          {primaryItems.map((item) => (
+            <RailButton
+              key={item.id}
+              item={item}
+              activeItemId={activeItemId}
+              onSelect={selectItem}
+            />
+          ))}
+        </div>
+
+        <div className="flex flex-col items-center gap-2 pt-2">
+          {bottomItems.map((item) => (
+            <RailButton
+              key={item.id}
+              item={item}
+              activeItemId={activeItemId}
+              onSelect={selectItem}
+            />
+          ))}
+        </div>
+      </nav>
+
+      <div
+        aria-hidden={!isExpanded}
+        inert={!isExpanded}
+        className={cn(
+          'flex h-full shrink-0 flex-col transition-[opacity,transform] duration-150 ease-[cubic-bezier(0.2,0,0,1)] motion-reduce:transition-none',
+          isExpanded ? 'translate-x-0 opacity-100' : 'invisible -translate-x-1 opacity-0'
+        )}
+        style={{ width: CANVAS_LEFT_SIDEBAR_WIDTH }}
+      >
+        <header className="flex h-12 shrink-0 items-center justify-between gap-3 px-4">
+          <h2 className="min-w-0 truncate text-sm font-semibold tracking-[-0.35px]">{title}</h2>
+          <div className="flex shrink-0 items-center gap-1">
+            {headerActions}
+            <ToolbarButton
+              label="Collapse sidebar"
+              tooltipSide="right"
+              onClick={() => onExpandedChange(false)}
+              className="shrink-0 text-foreground-muted hover:bg-surface-hover hover:text-foreground [&_svg]:size-4"
+            >
+              <PanelLeftClose />
+            </ToolbarButton>
+          </div>
+        </header>
+
+        <div className="min-h-0 flex-1 overflow-auto border-t border-border-subtle p-3">
+          {children}
+        </div>
+      </div>
+    </aside>
+  );
+});

--- a/packages/apollo-react/src/canvas/components/CanvasLeftSidebar/index.ts
+++ b/packages/apollo-react/src/canvas/components/CanvasLeftSidebar/index.ts
@@ -1,0 +1,13 @@
+export type {
+  CanvasLeftSidebarItem,
+  CanvasLeftSidebarItemId,
+  CanvasLeftSidebarProps,
+} from './CanvasLeftSidebar';
+export {
+  CANVAS_LEFT_SIDEBAR_COLLAPSED_WIDTH,
+  CANVAS_LEFT_SIDEBAR_DEFAULT_BOTTOM_ITEMS,
+  CANVAS_LEFT_SIDEBAR_DEFAULT_PRIMARY_ITEMS,
+  CANVAS_LEFT_SIDEBAR_RAIL_WIDTH,
+  CANVAS_LEFT_SIDEBAR_WIDTH,
+  CanvasLeftSidebar,
+} from './CanvasLeftSidebar';

--- a/packages/apollo-react/src/canvas/components/ToolbarButton.tsx
+++ b/packages/apollo-react/src/canvas/components/ToolbarButton.tsx
@@ -1,6 +1,6 @@
-import { forwardRef } from 'react';
-import type { MouseEventHandler, ReactNode } from 'react';
 import { Button, Tooltip, TooltipContent, TooltipTrigger } from '@uipath/apollo-wind';
+import type { MouseEventHandler, ReactNode } from 'react';
+import { forwardRef } from 'react';
 
 interface ToolbarButtonProps {
   label: string;
@@ -8,6 +8,7 @@ interface ToolbarButtonProps {
   testId?: string;
   onClick?: MouseEventHandler<HTMLButtonElement>;
   disabled?: boolean;
+  ariaPressed?: boolean;
   className?: string;
   tooltipSide?: 'top' | 'right' | 'bottom' | 'left';
   children: ReactNode;
@@ -15,7 +16,7 @@ interface ToolbarButtonProps {
 
 export const ToolbarButton = forwardRef<HTMLButtonElement, ToolbarButtonProps>(
   function ToolbarButton(
-    { label, tooltip, testId, onClick, disabled, className, tooltipSide, children },
+    { label, tooltip, testId, onClick, disabled, ariaPressed, className, tooltipSide, children },
     ref
   ) {
     return (
@@ -25,6 +26,7 @@ export const ToolbarButton = forwardRef<HTMLButtonElement, ToolbarButtonProps>(
             ref={ref}
             data-testid={testId}
             aria-label={label}
+            aria-pressed={ariaPressed}
             variant="ghost"
             size="xs"
             icon

--- a/packages/apollo-react/src/canvas/components/ToolbarButton.tsx
+++ b/packages/apollo-react/src/canvas/components/ToolbarButton.tsx
@@ -1,5 +1,5 @@
 import { Button, Tooltip, TooltipContent, TooltipTrigger } from '@uipath/apollo-wind';
-import type { MouseEventHandler, ReactNode } from 'react';
+import type { AriaAttributes, MouseEventHandler, ReactNode } from 'react';
 import { forwardRef } from 'react';
 
 interface ToolbarButtonProps {
@@ -8,7 +8,7 @@ interface ToolbarButtonProps {
   testId?: string;
   onClick?: MouseEventHandler<HTMLButtonElement>;
   disabled?: boolean;
-  ariaPressed?: boolean;
+  ariaPressed?: AriaAttributes['aria-pressed'];
   className?: string;
   tooltipSide?: 'top' | 'right' | 'bottom' | 'left';
   children: ReactNode;

--- a/packages/apollo-react/src/canvas/components/index.ts
+++ b/packages/apollo-react/src/canvas/components/index.ts
@@ -5,6 +5,7 @@ export * from './BaseCanvas';
 export * from './BaseNode';
 export * from './ButtonHandle';
 export * from './CanvasBottomPanel';
+export * from './CanvasLeftSidebar';
 export * from './CanvasModeToolbar';
 export * from './CanvasPositionControls';
 export * from './CanvasZoomControls';


### PR DESCRIPTION
## Summary

- Add a reusable `CanvasLeftSidebar` with docked and floating Storybook examples.
- Provide a persistent, prototype-aligned navigation rail with the UiPath logo, five primary actions, What's new, and Account.
- Support controlled expand/collapse and active-item behavior with smooth, reduced-motion-aware transitions.
- Allow consumers to configure the logo, primary actions, bottom actions, header actions, and reusable panel content.
- Export layout constants and default navigation collections for consistent canvas integration.

<img width="1360" height="1111" alt="Screenshot 2026-08-13 at 2 20 37 PM" src="https://github.com/user-attachments/assets/c74fc114-01fb-43e0-9370-7ad58c8995cc" />
<img width="1366" height="1116" alt="Screenshot 2026-08-13 at 2 20 28 PM" src="https://github.com/user-attachments/assets/88c28dd8-0da2-4956-bd29-b708f73640a5" />

## Why

Canvas consumers need a consistent left navigation and reusable content region that can sit alongside existing canvas controls while supporting docked and floating layouts.

## Consumer impact

The default variant is anchored without external spacing, while the floating variant provides rounded, elevated chrome. Consumers can use the prototype-aligned defaults or provide custom navigation items and slots.

## Feedback requested

- Do the default 60px rail and 288px content width work across expected canvas layouts?
- Does the 150ms expansion feel appropriately responsive?
- Does the configurable navigation API provide enough flexibility while preserving consistent defaults?

## Validation

- Biome checks pass.
- TypeScript check passes for `@uipath/apollo-react`.
- Focused `CanvasLeftSidebar` Vitest suite passes: 5 tests.
