### PR TITLE
feat(apollo-wind): update alert states and validation patterns

### DIFF
--- a/packages/apollo-wind/src/components/ui/alert.stories.tsx
+++ b/packages/apollo-wind/src/components/ui/alert.stories.tsx
@@ -1,20 +1,21 @@
-import { useState } from 'react';
 import type { Meta } from '@storybook/react-vite';
 import {
   AlertCircle,
+  AlertTriangle,
   CheckCircle2,
+  ExternalLink,
   Info,
+  Rocket,
   ShieldAlert,
   Terminal,
-  Rocket,
-  X,
-  ExternalLink,
-  AlertTriangle,
   Wifi,
   WifiOff,
+  X,
 } from 'lucide-react';
+import { useState } from 'react';
 import { Alert, AlertDescription, AlertTitle } from './alert';
 import { Button } from './button';
+import { Tabs, TabsList, TabsTrigger } from './tabs';
 
 const meta: Meta<typeof Alert> = {
   title: 'Components/Feedback/Alert',
@@ -33,16 +34,17 @@ export const BasicAlert = {
   render: () => (
     <div className="flex flex-col gap-4 max-w-xl">
       <Alert>
-        <AlertTitle>Default Alert</AlertTitle>
+        <AlertTitle>Neutral message</AlertTitle>
         <AlertDescription>
-          This is a default alert — use it for general information.
+          Use the default style for guidance that does not communicate a system state.
         </AlertDescription>
       </Alert>
 
-      <Alert variant="destructive">
-        <AlertTitle>Destructive Alert</AlertTitle>
+      <Alert variant="info">
+        <Info />
+        <AlertTitle>Information message</AlertTitle>
         <AlertDescription>
-          This is a destructive alert — use it for errors or critical warnings.
+          Use semantic variants when the message communicates a result or validation state.
         </AlertDescription>
       </Alert>
     </div>
@@ -57,13 +59,13 @@ export const AlertWithIcons = {
   name: 'Alert with Icons',
   render: () => (
     <div className="flex flex-col gap-4 max-w-xl">
-      <Alert>
+      <Alert variant="info">
         <Terminal className="h-4 w-4" />
         <AlertTitle>Terminal</AlertTitle>
         <AlertDescription>You can add components to your app using the CLI.</AlertDescription>
       </Alert>
 
-      <Alert>
+      <Alert variant="info">
         <Info className="h-4 w-4" />
         <AlertTitle>Information</AlertTitle>
         <AlertDescription>
@@ -71,13 +73,13 @@ export const AlertWithIcons = {
         </AlertDescription>
       </Alert>
 
-      <Alert>
+      <Alert variant="success">
         <CheckCircle2 className="h-4 w-4" />
         <AlertTitle>Success</AlertTitle>
         <AlertDescription>Your changes have been saved successfully.</AlertDescription>
       </Alert>
 
-      <Alert>
+      <Alert variant="warning">
         <AlertTriangle className="h-4 w-4" />
         <AlertTitle>Warning</AlertTitle>
         <AlertDescription>
@@ -90,6 +92,93 @@ export const AlertWithIcons = {
         <AlertTitle>Error</AlertTitle>
         <AlertDescription>Your session has expired. Please log in again.</AlertDescription>
       </Alert>
+    </div>
+  ),
+};
+
+// ============================================================================
+// Patterns — Section Messages
+// ============================================================================
+
+export const SectionMessages = {
+  name: 'Pattern: Section Messages',
+  render: () => (
+    <div className="flex max-w-md flex-col gap-3">
+      <Alert variant="info">
+        <Info />
+        <AlertTitle>Configuration guidance</AlertTitle>
+        <AlertDescription>
+          <p>This node uses the connection selected for the current folder.</p>
+          <p>Change the folder context to use a different connection.</p>
+        </AlertDescription>
+      </Alert>
+
+      <Alert variant="success">
+        <CheckCircle2 />
+        <AlertTitle>Configuration is valid</AlertTitle>
+        <AlertDescription>
+          <p>All required fields have been completed.</p>
+          <p>This node is ready to run.</p>
+        </AlertDescription>
+      </Alert>
+
+      <Alert variant="warning">
+        <AlertTriangle />
+        <AlertTitle>Review recommended</AlertTitle>
+        <AlertDescription>
+          <p>The request timeout is higher than the recommended value.</p>
+          <p>Review the timeout before publishing this workflow.</p>
+        </AlertDescription>
+      </Alert>
+
+      <Alert variant="destructive">
+        <AlertCircle />
+        <AlertTitle>Connection required</AlertTitle>
+        <AlertDescription>
+          <p>No valid connection is configured for this node.</p>
+          <p>Select a connection before running this node.</p>
+        </AlertDescription>
+      </Alert>
+    </div>
+  ),
+};
+
+function ValidationCount({ count }: { count: number }) {
+  return (
+    <span
+      title={`${count} issue${count === 1 ? '' : 's'}`}
+      className="grid h-4 min-w-4 place-items-center rounded-full bg-error px-1 text-[10px] font-semibold leading-none text-foreground-on-accent"
+    >
+      <span aria-hidden="true">{count}</span>
+      <span className="sr-only">{`${count} issue${count === 1 ? '' : 's'}`}</span>
+    </span>
+  );
+}
+
+export const NavigationValidation = {
+  name: 'Pattern: Navigation Validation',
+  render: () => (
+    <div className="w-full max-w-md space-y-4">
+      <Alert variant="destructive">
+        <AlertCircle />
+        <AlertTitle>Resolve 3 issues before publishing</AlertTitle>
+        <AlertDescription>
+          Error counts identify the sections that need attention, including hidden content.
+        </AlertDescription>
+      </Alert>
+      <Tabs defaultValue="parameters">
+        <TabsList className="h-auto w-full justify-start gap-0.5 rounded-lg bg-transparent p-0.5">
+          <TabsTrigger value="parameters" className="h-7 gap-1.5 px-2.5 text-xs">
+            Parameters <ValidationCount count={1} />
+          </TabsTrigger>
+          <TabsTrigger value="error-handling" className="h-7 gap-1.5 px-2.5 text-xs">
+            Error handling <ValidationCount count={2} />
+          </TabsTrigger>
+          <TabsTrigger value="advanced" className="h-7 px-2.5 text-xs">
+            Advanced
+          </TabsTrigger>
+        </TabsList>
+      </Tabs>
     </div>
   ),
 };

--- a/packages/apollo-wind/src/components/ui/alert.test.tsx
+++ b/packages/apollo-wind/src/components/ui/alert.test.tsx
@@ -54,7 +54,22 @@ describe('Alert', () => {
       </Alert>
     );
     const alert = screen.getByRole('alert');
-    expect(alert).toHaveClass('bg-background');
+    expect(alert).toHaveClass('border-border-subtle', 'bg-surface');
+  });
+
+  it.each([
+    ['info', 'border-info/30', 'bg-info-background/10'],
+    ['success', 'border-success/50', 'bg-success-background/25'],
+    ['warning', 'border-warning/50', 'bg-warning-background/25'],
+  ] as const)('applies %s variant classes', (variant, borderClass, backgroundClass) => {
+    render(
+      <Alert variant={variant}>
+        <AlertTitle>Title</AlertTitle>
+        <AlertDescription>Description</AlertDescription>
+      </Alert>
+    );
+
+    expect(screen.getByRole('alert')).toHaveClass(borderClass, backgroundClass);
   });
 
   it('applies destructive variant classes', () => {
@@ -65,7 +80,7 @@ describe('Alert', () => {
       </Alert>
     );
     const alert = screen.getByRole('alert');
-    expect(alert).toHaveClass('border-destructive/50');
+    expect(alert).toHaveClass('border-error/50', 'bg-error-background/25');
   });
 
   it('renders with icon', () => {

--- a/packages/apollo-wind/src/components/ui/alert.tsx
+++ b/packages/apollo-wind/src/components/ui/alert.tsx
@@ -4,13 +4,15 @@ import * as React from 'react';
 import { cn } from '@/lib';
 
 const alertVariants = cva(
-  'relative w-full rounded-lg border p-4 [&>svg~*]:pl-7 [&>svg+div]:translate-y-[-3px] [&>svg]:absolute [&>svg]:left-4 [&>svg]:top-4 [&>svg]:text-foreground',
+  'relative w-full rounded-xl border p-3 text-foreground [&>svg~*]:pl-6 [&>svg]:absolute [&>svg]:left-3 [&>svg]:top-3.5 [&>svg]:size-3.5',
   {
     variants: {
       variant: {
-        default: 'bg-background text-foreground',
-        destructive:
-          'border-destructive/50 text-destructive dark:border-destructive [&>svg]:text-destructive',
+        default: 'border-border-subtle bg-surface [&>svg]:text-foreground-muted',
+        info: 'border-info/30 bg-info-background/10 [&>svg]:text-info',
+        success: 'border-success/50 bg-success-background/25 [&>svg]:text-success',
+        warning: 'border-warning/50 bg-warning-background/25 [&>svg]:text-warning',
+        destructive: 'border-error/50 bg-error-background/25 [&>svg]:text-error',
       },
     },
     defaultVariants: {
@@ -27,23 +29,25 @@ const Alert = React.forwardRef<
 ));
 Alert.displayName = 'Alert';
 
-const AlertTitle = React.forwardRef<HTMLParagraphElement, React.HTMLAttributes<HTMLHeadingElement>>(
+const AlertTitle = React.forwardRef<HTMLHeadingElement, React.HTMLAttributes<HTMLHeadingElement>>(
   ({ className, ...props }, ref) => (
-    <h5
-      ref={ref}
-      className={cn('mb-1 font-medium leading-none tracking-tight', className)}
-      {...props}
-    />
+    <h5 ref={ref} className={cn('text-xs font-semibold leading-4', className)} {...props} />
   )
 );
 AlertTitle.displayName = 'AlertTitle';
 
-const AlertDescription = React.forwardRef<
-  HTMLParagraphElement,
-  React.HTMLAttributes<HTMLParagraphElement>
->(({ className, ...props }, ref) => (
-  <div ref={ref} className={cn('text-sm [&_p]:leading-relaxed', className)} {...props} />
-));
+const AlertDescription = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div
+      ref={ref}
+      className={cn(
+        'mt-1 text-xs leading-4 text-foreground-muted [&_p+p]:mt-1 [&_p]:leading-4',
+        className
+      )}
+      {...props}
+    />
+  )
+);
 AlertDescription.displayName = 'AlertDescription';
 
 export { Alert, AlertTitle, AlertDescription };


### PR DESCRIPTION
## What changed
- align the Apollo Wind Alert primitive with the established panel section-message visual language
- add semantic info, success, and warning variants while preserving default and destructive
- add Section Messages and Navigation Validation pattern stories
- expand variant coverage and correct Alert ref typings

<img width="1294" height="975" alt="Screenshot 2026-08-14 at 11 14 46 AM" src="https://github.com/user-attachments/assets/9c6fb75e-db76-44ee-97e7-3714ddbac088" />
<img width="1299" height="997" alt="Screenshot 2026-08-14 at 11 15 02 AM" src="https://github.com/user-attachments/assets/68d9fbb9-87f4-477d-8acb-485ee2b73e01" />

## Why
Canvas panel patterns already use compact semantic messages and tab-level validation indicators. Moving that visual and behavioral direction into Apollo Wind makes it reusable and consistent across products.

## Impact
Consumers can use semantic Alert variants for persistent section feedback and follow the accompanying navigation-validation pattern for hidden errors.

## Validation
- pnpm --filter @uipath/apollo-wind exec vitest run src/components/ui/alert.test.tsx
- pnpm --filter @uipath/apollo-wind build
- Biome checks for changed files
- local Storybook visual verification