### PR TITLE
fix(apollo-react): disable stage move options at list ends instead of hiding [MST-13609]

### DIFF
--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.test.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.test.tsx
@@ -117,10 +117,10 @@ vi.mock('./tasks/DraggableTask', () => ({
     isDragDisabled?: boolean;
     getContextMenuItems?: (
       task: StageTaskItem
-    ) => Array<{ id?: string; label?: string; onClick?: () => void }>;
+    ) => Array<{ id?: string; label?: string; onClick?: () => void; disabled?: boolean }>;
   }) => {
     const [menuItems, setMenuItems] = React.useState<
-      Array<{ id?: string; label?: string; onClick?: () => void }>
+      Array<{ id?: string; label?: string; onClick?: () => void; disabled?: boolean }>
     >([]);
     return (
       <div
@@ -146,6 +146,7 @@ vi.mock('./tasks/DraggableTask', () => ({
                 key={item.id || index}
                 type="button"
                 data-testid={`menu-item-${task.id}-${item.id || index}`}
+                disabled={item.disabled}
                 onClick={item.onClick}
               >
                 {item.label}
@@ -766,7 +767,7 @@ describe('StageNode - hideParallelOptions', () => {
     ).not.toBeInTheDocument();
   });
 
-  it('should show only delete for a single task when hideParallelOptions is true', async () => {
+  it('should show delete plus disabled move options for a single task when hideParallelOptions is true', async () => {
     const user = userEvent.setup();
     const onTaskGroupModification = vi.fn();
     const tasks: StageTaskItem[][] = [[createTask('task-1', 'Task 1')]];
@@ -780,9 +781,15 @@ describe('StageNode - hideParallelOptions', () => {
     await user.click(screen.getByTestId('task-menu-button-task-1'));
 
     const menuItems = screen.getByTestId('task-menu-items-task-1');
-    const buttons = menuItems.querySelectorAll('button');
-    expect(buttons).toHaveLength(1);
-    expect(buttons[0]).toHaveTextContent('Delete task');
+    // The lone task has nowhere to move, but the options stay listed rather than disappearing.
+    expect(menuItems.querySelector('[data-testid="menu-item-task-1-move-up"]')).toBeDisabled();
+    expect(menuItems.querySelector('[data-testid="menu-item-task-1-move-down"]')).toBeDisabled();
+    expect(
+      menuItems.querySelector('[data-testid="menu-item-task-1-remove-task"]')
+    ).toHaveTextContent('Delete task');
+    expect(
+      menuItems.querySelector('[data-testid="menu-item-task-1-group-with-up"]')
+    ).not.toBeInTheDocument();
   });
 });
 

--- a/packages/apollo-react/src/canvas/components/StageNode/tasks/StageNodeTaskUtilities.ts
+++ b/packages/apollo-react/src/canvas/components/StageNode/tasks/StageNodeTaskUtilities.ts
@@ -43,19 +43,27 @@ export const getContextMenuItems = ({
   labels: StageContextMenuLabels;
 }): NodeMenuItem[] => {
   const CONTEXT_MENU_ITEMS = {
-    MOVE_UP: getMenuItem('move-up', labels.moveUp, () =>
-      reGroupTaskFunction(
-        GroupModificationType.TASK_GROUP_UP,
-        groupIndexInAllTasks,
-        taskIndexInAllTasks
-      )
+    MOVE_UP: getMenuItem(
+      'move-up',
+      labels.moveUp,
+      () =>
+        reGroupTaskFunction(
+          GroupModificationType.TASK_GROUP_UP,
+          groupIndexInAllTasks,
+          taskIndexInAllTasks
+        ),
+      groupIndex === 0
     ),
-    MOVE_DOWN: getMenuItem('move-down', labels.moveDown, () =>
-      reGroupTaskFunction(
-        GroupModificationType.TASK_GROUP_DOWN,
-        groupIndexInAllTasks,
-        taskIndexInAllTasks
-      )
+    MOVE_DOWN: getMenuItem(
+      'move-down',
+      labels.moveDown,
+      () =>
+        reGroupTaskFunction(
+          GroupModificationType.TASK_GROUP_DOWN,
+          groupIndexInAllTasks,
+          taskIndexInAllTasks
+        ),
+      groupIndex === tasksLength - 1
     ),
     UNGROUP_ALL: getMenuItem('ungroup', labels.ungroupParallelTasks, () =>
       reGroupTaskFunction(
@@ -130,10 +138,9 @@ export const getContextMenuItems = ({
 
   const items: NodeMenuItem[] = [];
 
-  if (groupIndex > 0) items.push(CONTEXT_MENU_ITEMS.MOVE_UP);
-  if (groupIndex < tasksLength - 1) items.push(CONTEXT_MENU_ITEMS.MOVE_DOWN);
-
-  if (items.length) items.push(CONTEXT_MENU_ITEMS.DIVIDER);
+  // Both moves are always listed, disabled at the ends of the list rather than dropped: a task
+  // that silently loses its reorder entries reads as "reordering is gone" (MST-13609).
+  items.push(CONTEXT_MENU_ITEMS.MOVE_UP, CONTEXT_MENU_ITEMS.MOVE_DOWN, CONTEXT_MENU_ITEMS.DIVIDER);
 
   if (isParallelGroup && !hideParallelOptions) {
     items.push(
@@ -144,6 +151,8 @@ export const getContextMenuItems = ({
       CONTEXT_MENU_ITEMS.REMOVE_TASK
     );
   } else if (!isParallelGroup && !hideParallelOptions) {
+    const parallelOptionsStart = items.length;
+
     if (groupIndex > 0) {
       items.push(
         isAboveParallel
@@ -160,7 +169,9 @@ export const getContextMenuItems = ({
       );
     }
 
-    if (items.length) items.push(CONTEXT_MENU_ITEMS.DIVIDER);
+    // Only when a parallel option was actually added — the move entries above already end in a
+    // divider, so an unconditional one would double up on a single-task stage.
+    if (items.length > parallelOptionsStart) items.push(CONTEXT_MENU_ITEMS.DIVIDER);
 
     items.push(CONTEXT_MENU_ITEMS.REMOVE_TASK);
   } else {


### PR DESCRIPTION
## Summary

Split out of #1058 at review request — this is the menu-item disabling change on its own, so it can be reviewed independently of the reordering work.

A task's ⋮ menu used to **omit** Move up on the first group and Move down on the last. A user who saw a task lose both entries read it as "reordering is gone", which is what prompted [MST-13609](https://uipath.atlassian.net/browse/MST-13609). Both entries are now always listed and simply disabled at the ends of the list.

## Demo

<img width="1128" height="646" alt="image" src="https://github.com/user-attachments/assets/742ff80b-1485-43d8-84c1-b487db12fdd7" />
<img width="1170" height="714" alt="image" src="https://github.com/user-attachments/assets/936032ce-3417-4284-a24d-9fc33143fad5" />
<img width="1468" height="928" alt="image" src="https://github.com/user-attachments/assets/11885af7-42ea-4cb2-bd23-bfaf7c951023" />


## Changes

- `getContextMenuItems` always pushes `MOVE_UP` / `MOVE_DOWN`, passing `disabled` (`groupIndex === 0` and `groupIndex === tasksLength - 1`) rather than conditionally omitting them. `getMenuItem` already took a disabled flag and `NodeMenuItem.disabled` was already honoured by `CanvasDropdownMenu` → Radix, which blocks `onSelect` in JS as well as via `pointer-events`.
- The divider after the parallel options became conditional (`items.length > parallelOptionsStart`). Without that, a single-task stage rendered two dividers in a row, since the move entries above now always contribute one.

## Testing

- [x] `vitest` — 24 files, 323 tests
- [x] Unit test updated: a single-task stage with `hideParallelOptions` now asserts both move entries are present-but-disabled alongside Delete task, instead of asserting the menu had exactly one button
- [x] Type-safe (`tsc --noEmit` clean)

## Notes

Scope is deliberately only the **sequential** section's menu — that is the one `getContextMenuItems` builds. The equivalent entries for the event-triggered and manually-triggered sections arrive with the reordering feature in #1058, since those sections have no move options at all today.


[MST-13609]: https://uipath.atlassian.net/browse/MST-13609?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ