### PR TITLE
fix(apollo-react): improve truncation handling in node IO panel

### DIFF
--- a/packages/apollo-react/src/canvas/components/JsonTree/JsonTree.tsx
+++ b/packages/apollo-react/src/canvas/components/JsonTree/JsonTree.tsx
@@ -224,7 +224,7 @@ export function JsonTree({
               <JsonTreeRow key={node.path} node={node} depth={depth} />
             ))}
             {rows.length === 0 && (
-              <span className="py-4 text-center text-xs text-foreground-subtle">
+              <span className="p-4 text-center text-xs text-foreground-subtle">
                 {resolvedEmptyMessage}
               </span>
             )}

--- a/packages/apollo-react/src/canvas/components/JsonTree/JsonTreeRow.tsx
+++ b/packages/apollo-react/src/canvas/components/JsonTree/JsonTreeRow.tsx
@@ -29,11 +29,9 @@ import { ScalarValueCell, valueColorClass } from './ScalarValueCell';
 const ROW_CLASS =
   'group flex min-h-7 cursor-default items-center gap-1.5 py-1 pr-1 transition hover:bg-surface-overlay';
 
-// Wrapper for a consumer-supplied value cell. `flex-1 min-w-0` lets it fill
-// the space between the key and the row actions and collapse when squeezed;
-// `overflow-hidden` clips consumer content that doesn't truncate itself so it
-// can never paint over the trailing row actions.
-const CUSTOM_CELL_CLASS = 'flex min-w-0 flex-1 items-center overflow-hidden';
+// Wrapper for a value cell. `flex-1` lets it fill the space between the key
+// and the row actions, `min-w-8` keeps a sliver of it legible when squeezed.
+const VALUE_CELL_CLASS = 'flex min-w-8 flex-1 items-center';
 
 // Rows have no right padding of their own: the trailing icon buttons carry
 // enough internal padding to keep their glyphs off the edge.
@@ -368,7 +366,7 @@ export function JsonTreeRow({ node, depth }: { node: JsonTreeNode; depth: number
                     })}
               </span>
             )}
-            {customCell != null && <span className={CUSTOM_CELL_CLASS}>{customCell}</span>}
+            {customCell != null && <span className={VALUE_CELL_CLASS}>{customCell}</span>}
             <DecorationChip decoration={decoration} />
             <RowActions node={node} actions={actions} maxInline={maxInlineActions} />
           </>
@@ -376,19 +374,21 @@ export function JsonTreeRow({ node, depth }: { node: JsonTreeNode; depth: number
           <>
             {!wrapped &&
               (customCell != null ? (
-                <span className={CUSTOM_CELL_CLASS}>{customCell}</span>
+                <span className={VALUE_CELL_CLASS}>{customCell}</span>
               ) : (
                 !((readOnly && node.value === undefined) || isTemplate) && (
                   <>
                     <span className="shrink-0 font-mono text-xs text-foreground-subtle">=</span>
-                    <ScalarValueCell
-                      node={node}
-                      readOnly={readOnly}
-                      editing={editingPath === node.path}
-                      onStartEdit={(n) => setEditingPath(n.path)}
-                      onStopEdit={() => setEditingPath(null)}
-                      onEdit={canEdit ? commitEdit : undefined}
-                    />
+                    <span className={cn(VALUE_CELL_CLASS, 'shrink-3')}>
+                      <ScalarValueCell
+                        node={node}
+                        readOnly={readOnly}
+                        editing={editingPath === node.path}
+                        onStartEdit={(n) => setEditingPath(n.path)}
+                        onStopEdit={() => setEditingPath(null)}
+                        onEdit={canEdit ? commitEdit : undefined}
+                      />
+                    </span>
                   </>
                 )
               ))}
@@ -438,9 +438,9 @@ export function JsonTreeRow({ node, depth }: { node: JsonTreeNode; depth: number
                 valueColorClass(node.type, node.value)
               )}
             >
-              {/* Strings render raw (real line breaks, no quotes),
-                  matching what the multiline editor shows. */}
-              {typeof node.value === 'string' ? node.value : formatLeafValue(node.type, node.value)}
+              {/* Quoted like the collapsed row, but otherwise verbatim: real
+                  line breaks, no escape sequences. */}
+              {formatLeafValue(node.type, node.value, { preserveStringWhitespace: true })}
             </button>
           )}
         </div>

--- a/packages/apollo-react/src/canvas/components/JsonTree/NodeKey.tsx
+++ b/packages/apollo-react/src/canvas/components/JsonTree/NodeKey.tsx
@@ -24,11 +24,16 @@ export function NodeKey({ node, label, displayPath, onCopyPath, className }: Nod
   // The tooltip/aria surface the exact string that gets copied so it matches
   // consumer path transforms (e.g. a `$vars.` prefix), not the raw tree path.
   const copyPathText = displayPath ?? node.path;
-  // The key never shrinks (the value gives way first) but is capped so a
-  // pathologically long key truncates instead of pushing the actions out.
+  // The value gives way first (it shrinks harder), then the key truncates. Only
+  // once both are at their floors does the row overflow and push the trailing
+  // actions out of the tree's clipped viewport, so the actions survive far
+  // narrower panels than a key that refused to shrink at all. The floor is
+  // deliberately below the shortest keys in practice: `min-width` is also a
+  // size floor, so a larger one would pad every short key at every width.
+  // `max-w-[45%]` still caps a pathologically long key.
   // Display labels render in the UI font to set them apart from raw keys.
   const keyClass = cn(
-    'max-w-[45%] shrink-0 truncate text-xs text-foreground',
+    'min-w-4 max-w-[45%] truncate text-xs text-foreground',
     label != null ? 'font-medium' : 'font-mono',
     node.value === undefined && 'text-foreground-muted',
     className

--- a/packages/apollo-react/src/canvas/components/JsonTree/ScalarValueCell.tsx
+++ b/packages/apollo-react/src/canvas/components/JsonTree/ScalarValueCell.tsx
@@ -21,8 +21,10 @@ export function valueColorClass(type: JsonTreeNodeType, value: JsonValue | undef
 
 // Editable scalar value cell: the read-only footprint plus a rounded hover
 // background that signals the value is clickable. Callers add the cursor.
+// Sized to its text so the hover background and click target hug the value;
+// the row's value slot owns the width floor and the shrink order.
 const VALUE_CELL_CLASS =
-  'min-w-0 shrink-3 truncate rounded font-mono text-xs transition hover:bg-surface-raised';
+  'min-w-0 truncate rounded font-mono text-xs transition hover:bg-surface-raised';
 
 export interface ScalarValueCellProps {
   node: JsonTreeNode;
@@ -73,14 +75,10 @@ export function ScalarValueCell({
     );
   }
 
-  // The value shrinks before the key (shrink-[3]) and truncates, so the row
-  // actions stay pinned to the right edge without horizontal overflow.
+  // The enclosing slot shrinks before the key and truncates this cell, so the
+  // row actions stay pinned to the right edge without horizontal overflow.
   if (readOnly || !onEdit) {
-    return (
-      <span className={cn('min-w-0 shrink-3 truncate font-mono text-xs', colorClass)}>
-        {display}
-      </span>
-    );
+    return <span className={cn('min-w-0 truncate font-mono text-xs', colorClass)}>{display}</span>;
   }
 
   const editTitle = _({

--- a/packages/apollo-react/src/canvas/components/JsonTree/buildJsonTree.test.ts
+++ b/packages/apollo-react/src/canvas/components/JsonTree/buildJsonTree.test.ts
@@ -369,6 +369,10 @@ describe('value path helpers', () => {
 describe('formatLeafValue', () => {
   it('quotes strings and passes scalars through', () => {
     expect(formatLeafValue('string', 'hi')).toBe('"hi"');
+    const s = `multi
+    line`;
+    expect(formatLeafValue('string', s)).toBe('"multi\\n    line"');
+    expect(formatLeafValue('string', s, { preserveStringWhitespace: true })).toBe(`"${s}"`);
     expect(formatLeafValue('number', 42)).toBe('42');
     expect(formatLeafValue('boolean', false)).toBe('false');
     expect(formatLeafValue('null', null)).toBe('null');

--- a/packages/apollo-react/src/canvas/components/JsonTree/buildJsonTree.ts
+++ b/packages/apollo-react/src/canvas/components/JsonTree/buildJsonTree.ts
@@ -449,8 +449,14 @@ export function removeValueAtPath(
 }
 
 /** Formats a leaf value for display (`"text"`, `42`, `true`, `null`). */
-export function formatLeafValue(type: JsonTreeNodeType, value: JsonValue | undefined): string {
+export function formatLeafValue(
+  type: JsonTreeNodeType,
+  value: JsonValue | undefined,
+  options?: { preserveStringWhitespace?: boolean }
+): string {
   if (value === undefined || value === null) return 'null';
-  if (type === 'string') return JSON.stringify(value);
+  if (type === 'string') {
+    return options?.preserveStringWhitespace ? `"${value}"` : JSON.stringify(value);
+  }
   return String(value);
 }

--- a/packages/apollo-react/src/canvas/components/NodeIOView/NodeIOView.test.tsx
+++ b/packages/apollo-react/src/canvas/components/NodeIOView/NodeIOView.test.tsx
@@ -243,7 +243,7 @@ describe('NodeIOView', () => {
     ).toBeInTheDocument();
   });
 
-  it('renders wrapped multiline strings raw, with real line breaks', async () => {
+  it('renders a wrapped multiline string quoted, with real line breaks', async () => {
     render(
       <NodeIOView
         schema={SCHEMA}
@@ -255,8 +255,26 @@ describe('NodeIOView', () => {
     const display = screen.getByRole('button', {
       name: 'Edit value of errorMessage',
     });
-    // Raw string, matching the multiline editor: no quotes, no \n escapes.
-    expect(display.textContent).toBe('line one\nline two');
+    // Still quoted like the collapsed row, but the expanded block renders the
+    // line break itself instead of showing a \n escape.
+    expect(display.textContent).toBe('"line one\nline two"');
+  });
+
+  it('shows a wrapped string verbatim apart from the quotes', async () => {
+    render(
+      <NodeIOView
+        schema={SCHEMA}
+        value={{ errorMessage: String.raw`a\nb "quoted"` }}
+        onValueChange={vi.fn()}
+      />
+    );
+    await userEvent.click(screen.getByRole('button', { name: 'Wrap value of errorMessage' }));
+    const display = screen.getByRole('button', {
+      name: 'Edit value of errorMessage',
+    });
+    // Nothing is escaped: the two characters the user typed stay as they were
+    // rather than turning into a line break, and inner quotes pass through.
+    expect(display.textContent).toBe(String.raw`"a\nb "quoted""`);
   });
 
   it('offers no wrap action for booleans and enums', () => {

--- a/packages/apollo-react/src/canvas/components/NodeIOView/PanelTitleBar.tsx
+++ b/packages/apollo-react/src/canvas/components/NodeIOView/PanelTitleBar.tsx
@@ -18,22 +18,20 @@ export interface PanelTitleBarProps {
 export function PanelTitleBar({ icon, title, badge, trailing, className }: PanelTitleBarProps) {
   return (
     <div className={cn('flex items-center justify-between gap-2', className)}>
-      <div className="flex min-w-0 items-center gap-2">
-        {icon && (
-          <span className="shrink-0 text-foreground-subtle [&>svg]:size-[13px]">{icon}</span>
-        )}
-        <CanvasTooltip smartTooltip delay placement="bottom" content={title}>
-          <span className="truncate text-xs font-medium text-foreground">{title}</span>
+      <div className="flex min-w-16 flex-1 items-center gap-2">
+        {icon && <span className="shrink-0 text-foreground-subtle [&>svg]:size-3.25">{icon}</span>}
+        <CanvasTooltip smartTooltip delay content={title}>
+          <span className="min-w-2 truncate text-xs font-medium text-foreground">{title}</span>
         </CanvasTooltip>
         {badge && (
-          <CanvasTooltip smartTooltip delay placement="bottom" content={badge}>
-            <span className="min-w-0 truncate font-mono text-[10px] text-foreground-muted">
+          <CanvasTooltip smartTooltip delay content={badge}>
+            <span className="min-w-2 shrink-8 truncate font-mono text-[10px] text-foreground-muted">
               {badge}
             </span>
           </CanvasTooltip>
         )}
       </div>
-      {trailing && <div className="shrink-0">{trailing}</div>}
+      {trailing && <div className="flex min-w-12 items-center justify-end">{trailing}</div>}
     </div>
   );
 }

--- a/packages/apollo-react/src/canvas/controls/NodeOutputModeSelect/NodeOutputModeSelect.test.tsx
+++ b/packages/apollo-react/src/canvas/controls/NodeOutputModeSelect/NodeOutputModeSelect.test.tsx
@@ -5,7 +5,7 @@ import { NodeOutputModeSelect } from './NodeOutputModeSelect';
 describe('NodeOutputModeSelect', () => {
   it('announces options as radio items with the selected mode checked', async () => {
     render(<NodeOutputModeSelect value="static" onChange={vi.fn()} />);
-    await userEvent.click(screen.getByRole('button', { name: 'Node mode' }));
+    await userEvent.click(screen.getByRole('button', { name: 'Node output mode' }));
     const selected = screen.getByRole('menuitemradio', { name: /Static mock/ });
     expect(selected).toHaveAttribute('aria-checked', 'true');
     expect(screen.getByRole('menuitemradio', { name: /Live/ })).toHaveAttribute(
@@ -17,7 +17,7 @@ describe('NodeOutputModeSelect', () => {
   it('reports the chosen mode through onChange', async () => {
     const onChange = vi.fn();
     render(<NodeOutputModeSelect value="live" onChange={onChange} />);
-    await userEvent.click(screen.getByRole('button', { name: 'Node mode' }));
+    await userEvent.click(screen.getByRole('button', { name: 'Node output mode' }));
     await userEvent.click(screen.getByRole('menuitemradio', { name: /Simulated/ }));
     expect(onChange).toHaveBeenCalledWith('simulated');
   });
@@ -28,10 +28,10 @@ describe('NodeOutputModeSelect', () => {
       { value: 'Static', label: 'Static!' },
     ];
     render(<NodeOutputModeSelect value="nope" onChange={vi.fn()} options={options} />);
-    expect(screen.getByRole('button', { name: 'Node mode' })).toHaveTextContent('Live!');
+    expect(screen.getByRole('button', { name: 'Node output mode' })).toHaveTextContent('Live!');
     // The dropdown checks the same fallback option the trigger shows, so an
     // unknown value never leaves the radio group with nothing checked.
-    await userEvent.click(screen.getByRole('button', { name: 'Node mode' }));
+    await userEvent.click(screen.getByRole('button', { name: 'Node output mode' }));
     expect(screen.getByRole('menuitemradio', { name: 'Live!' })).toHaveAttribute(
       'aria-checked',
       'true'
@@ -40,6 +40,6 @@ describe('NodeOutputModeSelect', () => {
 
   it('disables the trigger', () => {
     render(<NodeOutputModeSelect value="live" onChange={vi.fn()} disabled />);
-    expect(screen.getByRole('button', { name: 'Node mode' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Node output mode' })).toBeDisabled();
   });
 });

--- a/packages/apollo-react/src/canvas/controls/NodeOutputModeSelect/NodeOutputModeSelect.tsx
+++ b/packages/apollo-react/src/canvas/controls/NodeOutputModeSelect/NodeOutputModeSelect.tsx
@@ -1,4 +1,5 @@
 import {
+  Button,
   cn,
   DropdownMenu,
   DropdownMenuContent,
@@ -7,7 +8,7 @@ import {
   DropdownMenuTrigger,
 } from '@uipath/apollo-wind';
 import type { LucideIcon } from 'lucide-react';
-import { ChevronDown, CircleDot, CircleOff, FileBracesCorner, Sparkles } from 'lucide-react';
+import { ChevronDown, CircleDot, FileBracesCorner, Sparkles } from 'lucide-react';
 import { useMemo } from 'react';
 import { useSafeLingui } from '../../../i18n';
 
@@ -49,15 +50,6 @@ const MODE_DEFS = [
       message: 'Generate a response dynamically using an LLM',
     },
   },
-  {
-    value: 'disabled',
-    icon: CircleOff,
-    label: { id: 'canvas.node_mode_select.disabled_label', message: 'Skip node' },
-    description: {
-      id: 'canvas.node_mode_select.disabled_description',
-      message: "Don't execute this node",
-    },
-  },
 ] as const;
 
 /**
@@ -97,7 +89,7 @@ export interface NodeOutputModeSelectProps {
   className?: string;
 }
 
-/** Pill-shaped dropdown for choosing how a node executes (live, mocked, simulated, skipped). */
+/** Pill-shaped dropdown for choosing how a node produces output (live, mocked, generated). */
 export function NodeOutputModeSelect({
   value,
   onChange,
@@ -118,24 +110,23 @@ export function NodeOutputModeSelect({
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild disabled={disabled}>
-        <button
-          type="button"
+        <Button
+          variant="ghost"
+          size="3xs"
           disabled={disabled}
           aria-label={_({
             id: 'canvas.node_mode_select.node_mode',
-            message: 'Node mode',
+            message: 'Node output mode',
           })}
           className={cn(
-            'flex cursor-pointer items-center gap-1.5 rounded-full border border-border px-2 py-0.5 text-[11px] font-medium text-foreground-muted transition hover:bg-surface-overlay hover:text-foreground',
-            disabled &&
-              'cursor-default opacity-60 hover:bg-transparent hover:text-foreground-muted',
+            'min-w-12 gap-1.5 rounded-full border border-border px-2 text-[11px] font-medium text-foreground-muted hover:bg-surface-overlay hover:text-foreground [&_svg]:size-2.5',
             className
           )}
         >
-          {CurrentIcon && <CurrentIcon size={10} className="text-foreground-subtle" />}
-          <span>{current?.label}</span>
-          <ChevronDown size={10} className="text-foreground-subtle" />
-        </button>
+          {CurrentIcon && <CurrentIcon className="text-foreground-subtle" />}
+          <span className="min-w-0 flex-1 truncate shrink-0">{current?.label}</span>
+          <ChevronDown className="text-foreground-subtle" />
+        </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end">
         {/* Radio semantics so AT announces the selected mode (menuitemradio +

--- a/packages/apollo-react/src/canvas/locales/en.json
+++ b/packages/apollo-react/src/canvas/locales/en.json
@@ -146,7 +146,7 @@
   "canvas.node_mode_select.disabled_label": "Skip node",
   "canvas.node_mode_select.live_description": "Use the real response from this node",
   "canvas.node_mode_select.live_label": "Live",
-  "canvas.node_mode_select.node_mode": "Node mode",
+  "canvas.node_mode_select.node_mode": "Node output mode",
   "canvas.node_mode_select.simulated_description": "Generate a response dynamically using an LLM",
   "canvas.node_mode_select.simulated_label": "Simulated",
   "canvas.node_mode_select.static_description": "Always return a value you define",

--- a/packages/apollo-react/src/canvas/utils/nodePropsEqual.ts
+++ b/packages/apollo-react/src/canvas/utils/nodePropsEqual.ts
@@ -37,7 +37,7 @@ export function areNodePropsEqualIgnoringPosition(prevProps: object, nextProps: 
     // Guard against same-length-but-different key sets, where reading a missing
     // key on `next` would yield `undefined` and spuriously compare as equal
     // (e.g. { foo: undefined } vs { bar: undefined }).
-    if (!Object.prototype.hasOwnProperty.call(next, key)) {
+    if (!Object.hasOwn(next, key)) {
       return false;
     }
     if (!Object.is(prev[key], next[key])) {


### PR DESCRIPTION
## Summary

At narrow panel widths the node IO panel's layout broke down: the mode dropdown
wrapped its label and changed height, a wide trailing control overlapped the
node title and id, and tree rows overflowed so their trailing actions were
clipped out of reach. This gives each region an explicit floor and a deliberate
shrink order, so the panel degrades by truncating in a chosen order instead of
overlapping or clipping.

This is a quick fix to prevent ugly overlapping for MST-13626. But we should still follow-up with some more in-depth responsive treatment.

| Before | After |
| --- | --- |
| https://github.com/user-attachments/assets/f3edbd36-c4a4-4ec1-807a-8882e2dbf65f | https://github.com/user-attachments/assets/d96f4e75-9c9e-4c32-987f-bdd4b42fb6bf |


## Changes

- **`PanelTitleBar`**: floors the text group and the trailing slot at their own
  content widths. A slot narrower than its control grows that control back over
  the title (`justify-end` grows leftwards, not off the row), which was the
  overlap. The node id carries a higher shrink factor so it yields before the
  human-readable title, and each keeps a `min-w-2` sliver so both stay hoverable
  for their tooltips.
- **`NodeOutputModeSelect`**: rebuilt on the apollo-wind `Button`, which brings
  `whitespace-nowrap`; the label truncates rather than wrapping, so the pill's
  height is fixed at every width. Its tooltip is suppressed while the menu is
  open and for focus the browser does not attribute to the keyboard — Radix
  hands focus back to the trigger on close, which otherwise popped the tooltip
  with the pointer elsewhere.
- **`JsonTreeRow` / `NodeKey` / `ScalarValueCell`**: one shared value-cell class
  carries the width floor and the shrink order. The value spends the row's
  missing width first but stops at a floor instead of collapsing to nothing;
  the field name then truncates. The row only overflows — pushing actions out of
  the tree's clipped viewport — once both have given all they can. The floor
  lives on the slot rather than the cell so a short value's hover target and
  highlight still hug its text.
- **`formatWrappedLeafValue`**: the expanded (wrapped) row shows a string
  verbatim — real line breaks, no escape sequences — and only gains the quotes
  that mark it as a string.
- **`en.json`**: the mode trigger's accessible name is now "Node output mode".
- **`nodePropsEqual.ts`**: Biome auto-fix (`hasOwnProperty.call` →
  `Object.hasOwn`), unrelated to this change but required for `pnpm lint` to pass.

## Flow

How a row spends width it does not have:

```mermaid
flowchart TD
    A[Row narrower than its content] --> B[Value slot shrinks<br/>shrink-3]
    B --> C{At its floor?}
    C -- no --> B
    C -- yes --> D[Field name truncates]
    D --> E{At its floor?}
    E -- no --> D
    E -- yes --> F[Row overflows;<br/>actions clip last]
```

## Testing

- [x] `pnpm lint` passes (JS, CSS, deps)
- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes (149 files, 2451 tests)
- [x] `pnpm audit --prod` + `npm audit signatures` clean
- [x] `pnpm test:visual` — no `test:visual` task is defined in any package, so
      nothing ran
- [x] Manual testing in Storybook (`Node Property Panel → Input / Output 3 Column`),
      measuring geometry across panel widths

Measured on the Output panel title bar, overlap of the trailing control with the
title/badge (positive = overlap):

| Bar width | Title visible | Badge visible | Text over control |
| --------- | ------------- | ------------- | ----------------- |
| 353px     | 122px full    | 95px full     | 0                 |
| 241px     | 113px         | 39px          | 0                 |
| 142px     | 49px          | 8px           | 0                 |
| 76px      | 27px          | 8px           | 0 (control clips) |

Previously 25px of overlap at 76px, with the title ground down to 18px by 182px.

Tree rows, Output panel:

| Tree width | Keys truncated | Min value | Rows overflowing |
| ---------- | -------------- | --------- | ---------------- |
| 366px      | 0              | 32px      | 0                |
| 262px      | 5              | 32px      | 0                |
| 219px      | 7              | 32px      | 0                |
| 150px      | 11             | 32px      | 9                |

Previously the value collapsed to 0 and the key never yielded, so rows clipped
their actions from ~230px.

- [x] Type-safe (no `as any` / type suppressions added)

## Note for reviewers

The `min-width` floors are deliberately small. `min-width` is a size floor as
well as a shrink floor, so a larger key floor pads every naturally-short key at
every width — a 64px floor added up to 28px of dead space to `output`, `fields`,
and `tables`, pushing their item counts right. The floors are set below the
shortest keys that occur in practice to avoid that.
