### PR TITLE
chore(apollo-ui-icons): sync version to the published 1.0.0 [PLT-109649]

### DIFF
--- a/packages/apollo-ui-icons/package.json
+++ b/packages/apollo-ui-icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uipath/apollo-ui-icons",
-  "version": "0.0.0",
+  "version": "1.0.0",
   "description": "UiPath Apollo icon set - tree-shakeable SVG exports",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",


### PR DESCRIPTION
## The problem

The release run for the icons extraction ([#1067](https://github.com/UiPath/apollo-ui/pull/1067)) **half-succeeded**:

- ✅ `@uipath/apollo-ui-icons@1.0.0` published to **both** registries
- ✅ tag `@uipath/apollo-ui-icons@1.0.0` created
- ❌ then a `409 Conflict` from GitHub Packages (`Cannot publish over existing version`) failed the step
- ❌ which skipped the **Commit version bump** job
- ❌ so `apollo-core@5.12.2` never published — `--workspace-concurrency=1 --sort` aborts the run at the first failure

Result: `packages/apollo-ui-icons/package.json` on `main` still says `0.0.0`, while the tag and both registries say `1.0.0`.

## Why this must be fixed before the next release run

apollo-core depends on the new package with `workspace:*`. **pnpm rewrites that at publish time using the dependency's `version` field in the workspace** — not the tag, not the registry.

On a re-run, semantic-release sees the `1.0.0` tag and no later commits touching `packages/apollo-ui-icons`, so it **skips** the package and leaves `package.json` at `0.0.0`. apollo-core then publishes 5.12.2 declaring:

```json
"dependencies": { "@uipath/apollo-ui-icons": "0.0.0" }
```

`@uipath/apollo-ui-icons@0.0.0` does not exist on either registry. That breaks `install` for **every apollo-core consumer**, which is a far worse outage than the rspack panic 5.12.2 is meant to fix.

This is not hypothetical — the dev-publish path already produced exactly that manifest, which is how the failure mode was spotted.

## The fix

Set the version to `1.0.0`, matching the tag and both registries. Precisely what the skipped job would have committed.

Verified with `pnpm pack` on apollo-core — the packed manifest now reads:

```json
"dependencies": { "@uipath/apollo-ui-icons": "1.0.0" }
```

## After merge

Merging pushes to `main` and re-triggers **Release** (no `[skip ci]`). Expected:

- **apollo-ui-icons** — skipped. The `chore` type cuts no release, so it stays at 1.0.0 and does not retry the 409.
- **apollo-core** — publishes **5.12.2** from the `fix(apollo-core)` commit, with a resolvable `1.0.0` dependency.

`5.12.2` satisfies the existing `^5.11.1` / `^5.12.1` ranges across the eight apollo-design-system packages plus apollo-react, apollo-wind and traceview, so consumers pick up the rspack fix with a lockfile refresh and no republishing.

## Worth a follow-up (not in this PR)

The underlying gap is that **`workspace:*` couples apollo-core's published manifest to a `package.json` field that a failed release can leave stale**. Two hardening options:

1. Have the release job commit version bumps even on partial failure, or make the publish step idempotent so a GHP 409 on an already-published version is not fatal.
2. Depend on `^1.0.0` explicitly instead of `workspace:*`, so a stale workspace version can never produce an unresolvable published dependency.

Also unresolved: the original `409` itself. The artifact reached GitHub Packages and the retry then collided — worth understanding before the next new-package release.
