### PR TITLE
ci(repo): fail the release when a publish misses npmjs.org [PLT-109649]

### DIFF
--- a/.github/workflows/monitor-npm-publishes.yml
+++ b/.github/workflows/monitor-npm-publishes.yml
@@ -42,7 +42,7 @@ jobs:
             # Fetch all active dist-tag versions (not just latest) so publishes under
             # beta/next/rc tags are also caught. Use if ! to capture non-zero exit before
             # bash -e can terminate the step (GitHub Actions runs scripts with set -e).
-            if ! dist_tags=$(npm view "$pkg" dist-tags --json --registry https://registry.npmjs.org 2>/dev/null) \
+            if ! dist_tags=$(npm view "$pkg" dist-tags --json --@uipath:registry=https://registry.npmjs.org 2>/dev/null) \
                 || [ -z "$dist_tags" ] || [ "$dist_tags" = "null" ]; then
               echo "::warning::Could not fetch dist-tags for $pkg — skipping (will not auto-close alerts)"
               FETCH_ERRORS=$((FETCH_ERRORS + 1))

--- a/scripts/publish-to-registries.sh
+++ b/scripts/publish-to-registries.sh
@@ -58,14 +58,57 @@ done
 
 TAG="${TAG_NAME:-latest}"
 
+PKG_NAME=$(node -p "require('./package.json').name")
+PKG_VERSION=$(node -p "require('./package.json').version")
+
+# Confirm the version is actually retrievable from npmjs.org.
+#
+# `pnpm publish` exits 0 in cases where nothing reached npmjs.org at all (see the
+# OIDC note below), so the only trustworthy signal is asking the registry. Use the
+# version document rather than the packument: for a brand-new package name the
+# packument stays 404 for several minutes after the version endpoint is live.
+verify_on_npmjs() {
+  local url="https://registry.npmjs.org/${PKG_NAME//\//%2F}/${PKG_VERSION}"
+  for _ in $(seq 1 18); do
+    # 404s are expected while a fresh publish propagates; stay quiet until we give up
+    if curl -fsS -o /dev/null "$url" 2>/dev/null; then
+      return 0
+    fi
+    sleep 10
+  done
+  return 1
+}
+
 echo "📦 Publishing to npm.org (OIDC trusted publisher)..."
 # --provenance: binds artifact to GitHub Actions source via Sigstore. npmjs.org-only.
-# --@uipath:registry: scope-specific registry override. For scoped packages, this
-# beats both .npmrc's `@uipath:registry=` line and the plain `--registry=` flag
-pnpm publish "${filtered_args[@]}" --tag "$TAG" --provenance \
-  --@uipath:registry=https://registry.npmjs.org
+#
+# The `--@uipath:registry` override only holds while OIDC succeeds. When the token
+# exchange fails — which it does for any package with no Trusted Publisher on
+# npmjs.com, and a new package cannot have one before it exists — pnpm logs
+# "Skipped OIDC", silently falls back to the ambient registry (GHP), publishes
+# there and still exits 0. That shipped @uipath/apollo-core@5.13.0 and
+# @uipath/apollo-react@6.23.1 to npmjs.org depending on an @uipath/apollo-ui-icons
+# that was never published there, breaking installs for every consumer. Treat the
+# warning as fatal and verify the outcome.
+npm_log=$(mktemp)
+trap 'rm -f "$npm_log"' EXIT
 
-echo "✓ Published to npm.org"
+pnpm publish "${filtered_args[@]}" --tag "$TAG" --provenance \
+  --@uipath:registry=https://registry.npmjs.org 2>&1 | tee "$npm_log"
+
+if grep -q "Skipped OIDC" "$npm_log"; then
+  echo "::error::OIDC token exchange failed for ${PKG_NAME}, so pnpm did not publish to npmjs.org." >&2
+  echo "Add a Trusted Publisher for ${PKG_NAME} on npmjs.com (UiPath/apollo-ui, workflow release.yml, no environment, action: npm publish)." >&2
+  exit 1
+fi
+
+if ! verify_on_npmjs; then
+  echo "::error::${PKG_NAME}@${PKG_VERSION} is not retrievable from npmjs.org after publishing." >&2
+  echo "The publish reported success but the artifact is not there — check which registry it actually went to." >&2
+  exit 1
+fi
+
+echo "✓ Published to npm.org (verified retrievable)"
 echo ""
 echo "📦 Publishing to GitHub Package Registry..."
 NODE_AUTH_TOKEN="$GH_NPM_REGISTRY_TOKEN" \


### PR DESCRIPTION
## Why

`pnpm publish` exits **0** in cases where nothing reaches npmjs.org at all.

When the OIDC token exchange fails — which it does for any package with no Trusted Publisher on npmjs.com, and **a new package cannot have one before it exists** — pnpm logs `Skipped OIDC`, silently falls back to the ambient registry (GitHub Packages), publishes there, and still succeeds. `set -euo pipefail` never fires, and the script prints `✓ Published to npm.org`.

This is what that looked like in the run that shipped the icons extraction:

```
📦 Publishing to npm.org (OIDC trusted publisher)...
[WARN] Skipped OIDC: ERR_PNPM_AUTH_TOKEN_EXCHANGE ... (status code 404)
📦 @uipath/apollo-ui-icons@1.0.0 → https://npm.pkg.github.com/     ← wrong registry
✅ Published package @uipath/apollo-ui-icons@1.0.0
✓ Published to npm.org                                             ← false
📦 Publishing to GitHub Package Registry...
[E409] Cannot publish over existing version                        ← collides with the line above
```

The 409 was self-inflicted and pointed at the wrong registry entirely, which sent the investigation off in the wrong direction.

**The damage landed on the next run.** With the tag already created, semantic-release skipped the package — so no OIDC attempt at all — and published `@uipath/apollo-core@5.13.0` and `@uipath/apollo-react@6.23.1` to npmjs.org, each depending on an `@uipath/apollo-ui-icons` that was not there:

```
npm error 404  The requested resource '@uipath/apollo-ui-icons@1.0.0'
               could not be found or you do not have permission to access it.
```

`npm install` of either package failed for every consumer resolving from npmjs.org until the missing package was published by hand. GitHub Packages was fine throughout, which is why internal repos and CI stayed green and nobody noticed.

## What this changes

Two guards after the npm.org publish:

1. **`Skipped OIDC` is fatal.** The error names the package and exactly what to configure.
2. **Ask the registry whether the version is actually retrievable.** Outcome-based, so it also catches a wrong registry, a silent no-op, or a revoked publisher — not just the one symptom we happened to observe.

The retrieval check polls the **version document**, not the packument: a brand-new package name stays 404 on the packument for several minutes after `/{name}/{version}` is already live. Up to 3 minutes, quiet during propagation.

Also fixes the same class of bug in the monitor. It queried npmjs.org with a plain `--registry`, which does **not** override a scoped `@uipath:registry` — the very precedence rule that made this incident hard to see. It works today only because the repo `.npmrc` deliberately omits that line; if a runner ever picks one up, the daily audit would silently read GitHub Packages and report everything healthy.

## Verification

- `shellcheck` clean, `bash -n` clean
- The `Skipped OIDC` guard fires on the exact CI output above, and does **not** fire on a clean log
- The retrieval check finds `apollo-ui-icons@1.0.0` and `apollo-core@5.13.0`, and correctly rejects `apollo-core@99.99.99`
- URL encoding verified: `@uipath/apollo-core` → `https://registry.npmjs.org/@uipath%2Fapollo-core/5.13.0`
- `pipefail` still propagates a failing publish through the added `tee`

## Scope note

This does not add a check for the GitHub Packages publish. That path already fails loudly — the 409 above — so the silent-success problem is npm.org-specific.

## Related follow-up

The structural gap remains: a Trusted Publisher cannot be created before the package exists, so **the first release of every new package** hits this. With this PR that is now a loud, safe failure rather than a public breakage. A dry-run OIDC verification job (`pnpm publish --dry-run --provenance` under `id-token: write`) would let us confirm a new publisher's config before the first real release — happy to add it here or separately.
