### PR TITLE
feat(apollo-react): offer inline collapse on container nodes

### DIFF
--- a/packages/apollo-react/src/canvas/schema/node-definition/index.ts
+++ b/packages/apollo-react/src/canvas/schema/node-definition/index.ts
@@ -24,12 +24,12 @@ export {
 export type {
   NodeDisplayManifest,
   NodeManifest,
-  NodeShape,
   RuntimeConstraints,
 } from './node-manifest';
 export {
   nodeDisplayManifestSchema,
   nodeManifestSchema,
   nodeRuntimeConstraintsManifestSchema,
-  nodeShapeSchema,
 } from './node-manifest';
+export type { NodeShape } from './shape';
+export { nodeShapeSchema } from './shape';

--- a/packages/apollo-react/src/canvas/schema/node-definition/node-manifest.ts
+++ b/packages/apollo-react/src/canvas/schema/node-definition/node-manifest.ts
@@ -8,11 +8,7 @@ import type { FormSchema } from '@uipath/apollo-wind';
 import { z } from 'zod';
 import { toolbarConfigurationSchema } from '../toolbar';
 import { handleGroupManifestSchema } from './handle';
-
-/**
- * Node shape for display
- */
-export const nodeShapeSchema = z.enum(['circle', 'square', 'rectangle', 'container']);
+import { nodeShapeSchema } from './shape';
 
 /**
  * Debug configuration for a node
@@ -153,7 +149,6 @@ export const nodeManifestSchema = z.object({
 });
 
 // Export inferred types
-export type NodeShape = z.infer<typeof nodeShapeSchema>;
 export type NodeDisplayManifest = z.infer<typeof nodeDisplayManifestSchema>;
 export type NodeManifest = z.infer<typeof nodeManifestSchema>;
 export type RuntimeConstraints = z.infer<typeof nodeRuntimeConstraintsManifestSchema>;

--- a/packages/apollo-react/src/canvas/schema/node-definition/shape.ts
+++ b/packages/apollo-react/src/canvas/schema/node-definition/shape.ts
@@ -1,0 +1,7 @@
+// Leaf module: node-manifest and toolbar both need this, and they import each other.
+
+import { z } from 'zod';
+
+export const nodeShapeSchema = z.enum(['circle', 'square', 'rectangle', 'container']);
+
+export type NodeShape = z.infer<typeof nodeShapeSchema>;

--- a/packages/apollo-react/src/canvas/schema/node-instance/base.ts
+++ b/packages/apollo-react/src/canvas/schema/node-instance/base.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { nodeShapeSchema } from '../node-definition/node-manifest';
+import { nodeShapeSchema } from '../node-definition/shape';
 
 /**
  * Unique identifier for nodes, types, and workflows

--- a/packages/apollo-react/src/canvas/schema/toolbar.ts
+++ b/packages/apollo-react/src/canvas/schema/toolbar.ts
@@ -5,7 +5,7 @@
  */
 
 import { z } from 'zod';
-import { nodeShapeSchema } from './node-definition/node-manifest';
+import { nodeShapeSchema } from './node-definition/shape';
 
 /**
  * Toolbar action definition

--- a/packages/apollo-react/src/canvas/schema/toolbar.ts
+++ b/packages/apollo-react/src/canvas/schema/toolbar.ts
@@ -5,6 +5,7 @@
  */
 
 import { z } from 'zod';
+import { nodeShapeSchema } from './node-definition/node-manifest';
 
 /**
  * Toolbar action definition
@@ -33,6 +34,9 @@ export const toolbarActionSchema = z.object({
 
       /** Show only for specific node types */
       nodeTypes: z.array(z.string()).optional(),
+
+      /** Show only for manifests drawn in one of these shapes */
+      shapes: z.array(nodeShapeSchema).optional(),
 
       /** Show only if node has handles defined in its manifest */
       handles: z

--- a/packages/apollo-react/src/canvas/utils/manifest-resolver.test.ts
+++ b/packages/apollo-react/src/canvas/utils/manifest-resolver.test.ts
@@ -281,9 +281,89 @@ describe('resolveHandles', () => {
       expect(result[0]!.handles[0]!.visible).toBe(false);
       expect(result[1]!.handles[0]!.visible).toBe(true);
     });
+
+    it('hides inner-boundary handles when collapsed, keeps outer handles visible', () => {
+      const result = resolveHandles(
+        [
+          {
+            position: 'left',
+            boundary: 'inner',
+            handles: [{ id: 'start', type: 'source', handleType: 'output' }],
+          },
+          {
+            position: 'left',
+            boundary: 'outer',
+            handles: [{ id: 'in', type: 'target', handleType: 'input' }],
+          },
+          {
+            position: 'right',
+            handles: [{ id: 'out', type: 'source', handleType: 'output' }],
+          },
+        ],
+        { isCollapsed: true }
+      );
+
+      expect(result[0]!.handles[0]!.visible).toBe(false);
+      expect(result[1]!.handles[0]!.visible).toBe(true);
+      expect(result[2]!.handles[0]!.visible).toBe(true);
+    });
+
+    it('keeps inner-boundary handles visible when expanded', () => {
+      const group = firstGroup(
+        [
+          {
+            position: 'left',
+            boundary: 'inner',
+            handles: [{ id: 'start', type: 'source', handleType: 'output' }],
+          },
+        ],
+        {}
+      );
+
+      expect(group.handles[0]!.visible).toBe(true);
+    });
+
+    it('hides repeat-generated inner-boundary handles when collapsed', () => {
+      const group = firstGroup(
+        [
+          {
+            position: 'right',
+            boundary: 'inner',
+            handles: [
+              {
+                id: 'case-{index}',
+                type: 'source',
+                handleType: 'output',
+                repeat: 'inputs.cases',
+                indexVar: 'index',
+              },
+            ],
+          },
+        ],
+        { isCollapsed: true, inputs: { cases: [{}, {}] } }
+      );
+
+      expect(group.handles).toHaveLength(2);
+      expect(group.handles.every((handle) => handle.visible === false)).toBe(true);
+    });
   });
 
   describe('group visibility when collapsed', () => {
+    it('hides an inner-boundary group when collapsed', () => {
+      const group = firstGroup(
+        [
+          {
+            position: 'left',
+            visible: true,
+            boundary: 'inner',
+            handles: [{ id: 'start', type: 'source', handleType: 'output' }],
+          },
+        ],
+        { isCollapsed: true }
+      );
+      expect(group.visible).toBe(false);
+    });
+
     it('hides group when collapsed and all handles are hidden', () => {
       const group = firstGroup(
         [

--- a/packages/apollo-react/src/canvas/utils/manifest-resolver.ts
+++ b/packages/apollo-react/src/canvas/utils/manifest-resolver.ts
@@ -275,11 +275,14 @@ export function resolveHandles(
   const isCollapsed = context?.isCollapsed ?? false;
 
   return handleGroups.map((group) => {
+    // Inner handles wire a container's body, which a collapsed node isn't showing.
+    const hidesGroup = isCollapsed && group.boundary === 'inner';
+
     const handles: ResolvedHandle[] = group.handles.flatMap((handle) => {
-      // Hide artifact handles when node is collapsed
       const isArtifactHandle = handle.handleType === 'artifact';
       const handleBaseVisible = resolveVisibility(handle.visible, context);
-      const handleVisible = isCollapsed && isArtifactHandle ? false : handleBaseVisible;
+      const handleVisible =
+        hidesGroup || (isCollapsed && isArtifactHandle) ? false : handleBaseVisible;
 
       // Handle repeat (dynamic handles from array)
       if (handle.repeat) {

--- a/packages/apollo-react/src/canvas/utils/toolbar-resolver.test.tsx
+++ b/packages/apollo-react/src/canvas/utils/toolbar-resolver.test.tsx
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest';
+import type { NodeStatusContext } from '../components/BaseNode/BaseNode.types';
+import type { NodeManifest } from '../schema/node-definition';
+import { resolveToolbar } from './toolbar-resolver';
+
+const context: NodeStatusContext = { nodeId: 'n1' };
+
+const containerManifest = {
+  nodeType: 'loop',
+  display: { label: 'Loop', icon: 'repeat', shape: 'container' },
+  handleConfiguration: [
+    {
+      position: 'left',
+      boundary: 'outer',
+      handles: [{ id: 'in', type: 'target', handleType: 'input' }],
+    },
+    {
+      position: 'left',
+      boundary: 'inner',
+      handles: [{ id: 'start', type: 'source', handleType: 'output' }],
+    },
+  ],
+} as NodeManifest;
+
+const artifactManifest = {
+  nodeType: 'agent',
+  display: { label: 'Agent', icon: 'bot', shape: 'square' },
+  handleConfiguration: [
+    {
+      position: 'bottom',
+      handles: [{ id: 'tools', type: 'source', handleType: 'artifact' }],
+    },
+  ],
+} as NodeManifest;
+
+const plainManifest = {
+  nodeType: 'script',
+  display: { label: 'Script', icon: 'code', shape: 'square' },
+  handleConfiguration: [
+    {
+      position: 'left',
+      handles: [{ id: 'in', type: 'target', handleType: 'input' }],
+    },
+  ],
+} as NodeManifest;
+
+const actionIds = (manifest: NodeManifest) =>
+  (resolveToolbar(manifest, context)?.actions ?? []).map((action) => action.id);
+
+describe('resolveToolbar', () => {
+  describe('collapse action', () => {
+    it('offers collapse on a container manifest', () => {
+      expect(actionIds(containerManifest)).toContain('collapse');
+    });
+
+    it('offers collapse on a manifest with an artifact source handle', () => {
+      expect(actionIds(artifactManifest)).toContain('collapse');
+    });
+
+    it('withholds collapse from a node with neither a body nor artifacts', () => {
+      expect(actionIds(plainManifest)).not.toContain('collapse');
+    });
+
+    it('offers collapse once when a manifest qualifies both ways', () => {
+      const bothManifest = {
+        ...containerManifest,
+        handleConfiguration: [
+          ...containerManifest.handleConfiguration,
+          {
+            position: 'bottom',
+            handles: [{ id: 'tools', type: 'source', handleType: 'artifact' }],
+          },
+        ],
+      } as NodeManifest;
+
+      expect(actionIds(bothManifest).filter((id) => id === 'collapse')).toHaveLength(1);
+    });
+
+    it('honours suppressDefaultToolbarActions', () => {
+      const suppressed = {
+        ...containerManifest,
+        suppressDefaultToolbarActions: { design: ['collapse'] },
+      } as NodeManifest;
+
+      expect(actionIds(suppressed)).not.toContain('collapse');
+    });
+  });
+
+  describe('duplicate action ids', () => {
+    it('lets a manifest extension override a default of the same id', () => {
+      const extended = {
+        ...plainManifest,
+        toolbarExtensions: {
+          design: {
+            actions: [{ id: 'delete', icon: 'trash', label: 'Remove forever' }],
+          },
+        },
+      } as NodeManifest;
+
+      const actions = resolveToolbar(extended, context)?.actions ?? [];
+      const deletes = actions.filter((action) => action.id === 'delete');
+
+      expect(deletes).toHaveLength(1);
+      expect(deletes[0]!.label).toBe('Remove forever');
+    });
+  });
+});

--- a/packages/apollo-react/src/canvas/utils/toolbar-resolver.test.tsx
+++ b/packages/apollo-react/src/canvas/utils/toolbar-resolver.test.tsx
@@ -87,6 +87,23 @@ describe('resolveToolbar', () => {
   });
 
   describe('duplicate action ids', () => {
+    it('moves a default into the overflow menu when an extension declares it there', () => {
+      const extended = {
+        ...plainManifest,
+        toolbarExtensions: {
+          design: {
+            actions: [],
+            overflowActions: [{ id: 'delete', icon: 'trash', label: 'Remove forever' }],
+          },
+        },
+      } as NodeManifest;
+
+      const toolbar = resolveToolbar(extended, context);
+
+      expect((toolbar?.actions ?? []).map((action) => action.id)).not.toContain('delete');
+      expect((toolbar?.overflowActions ?? []).map((action) => action.id)).toEqual(['delete']);
+    });
+
     it('lets a manifest extension override a default of the same id', () => {
       const extended = {
         ...plainManifest,

--- a/packages/apollo-react/src/canvas/utils/toolbar-resolver.tsx
+++ b/packages/apollo-react/src/canvas/utils/toolbar-resolver.tsx
@@ -20,12 +20,19 @@ interface ExtendedNodeContext extends NodeStatusContext {
   permissions?: string[];
 }
 
+// Condition predicates are conjunctive, so artifact and container collapse need an entry each.
 const DEFAULT_ACTIONS_FOR_ALL_MODES: ModeToolbarConfig['actions'] = [
   {
     id: 'collapse',
     icon: 'chevrons-down-up',
     label: 'Toggle collapse',
     condition: { handles: [{ handleType: 'artifact', type: 'source' }] },
+  },
+  {
+    id: 'collapse',
+    icon: 'chevrons-down-up',
+    label: 'Toggle collapse',
+    condition: { shapes: ['container'] },
   },
 ];
 
@@ -88,6 +95,12 @@ function evaluateCondition(
     return false;
   }
 
+  // Check node shape
+  if (condition.shapes?.length) {
+    const shape = manifest.display?.shape;
+    if (!shape || !condition.shapes.includes(shape)) return false;
+  }
+
   // Check if node has matching handles
   if (condition.handles?.length) {
     const manifestHandles = manifest.handleConfiguration.flatMap(
@@ -133,6 +146,13 @@ function convertToNodeAction(
       });
     },
   };
+}
+
+/** Keeps each id once, at its first slot, carrying the last definition. */
+function dedupeById(actions: ToolbarActionSchema[]): ToolbarActionSchema[] {
+  const byId = new Map<string, ToolbarActionSchema>();
+  for (const action of actions) byId.set(action.id, action);
+  return [...byId.values()];
 }
 
 /**
@@ -188,13 +208,13 @@ export function resolveToolbar(
   const merged = mergeToolbarConfigs(modeDefaults, nodeExtensions);
 
   // Step 4: Filter actions based on conditions and convert to node actions
-  const filteredActions = merged.actions
-    .filter((action) => evaluateCondition(manifest, action, nodeType, context))
-    .map((action) => convertToNodeAction(action, mode, nodeData));
+  const resolveActions = (actions: ToolbarActionSchema[]) =>
+    dedupeById(
+      actions.filter((action) => evaluateCondition(manifest, action, nodeType, context))
+    ).map((action) => convertToNodeAction(action, mode, nodeData));
 
-  const filteredOverflow = (merged.overflowActions ?? [])
-    .filter((action) => evaluateCondition(manifest, action, nodeType, context))
-    .map((action) => convertToNodeAction(action, mode, nodeData));
+  const filteredActions = resolveActions(merged.actions);
+  const filteredOverflow = resolveActions(merged.overflowActions ?? []);
 
   // Return undefined if no actions
   if (filteredActions.length === 0 && filteredOverflow.length === 0) {

--- a/packages/apollo-react/src/canvas/utils/toolbar-resolver.tsx
+++ b/packages/apollo-react/src/canvas/utils/toolbar-resolver.tsx
@@ -95,7 +95,6 @@ function evaluateCondition(
     return false;
   }
 
-  // Check node shape
   if (condition.shapes?.length) {
     const shape = manifest.display?.shape;
     if (!shape || !condition.shapes.includes(shape)) return false;
@@ -166,9 +165,18 @@ function mergeToolbarConfigs(
   if (!base) return extension!;
   if (!extension) return base;
 
+  // An extension owns every id it declares, so overriding a default into overflow moves it.
+  const extensionIds = new Set(
+    [...extension.actions, ...(extension.overflowActions ?? [])].map((action) => action.id)
+  );
+  const notOverridden = (action: ToolbarActionSchema) => !extensionIds.has(action.id);
+
   return {
-    actions: [...base.actions, ...extension.actions],
-    overflowActions: [...(base.overflowActions ?? []), ...(extension.overflowActions ?? [])],
+    actions: [...base.actions.filter(notOverridden), ...extension.actions],
+    overflowActions: [
+      ...(base.overflowActions ?? []).filter(notOverridden),
+      ...(extension.overflowActions ?? []),
+    ],
   };
 }
 


### PR DESCRIPTION
Apollo-side groundwork for collapsing a container Loop in place: expanded it is a loop frame, collapsed it is a base node. This PR carries the two pieces apollo owns. The component switch and the node/edge filtering live in the host and are not part of this change.

## Handles

`resolveHandles` already hides `handleType: 'artifact'` handles on a collapsed node. It now also hides handles in a group with `boundary: 'inner'`, which is how a container declares the rails that wire its body. The pre-existing rule that hides a group once all its handles are hidden takes care of the group, and `LoopNode.tsx:706` already skips groups marked invisible, so `resolveContainerHandleGroups` needed no change.

Outer groups are untouched, so a collapsed container stays wired into its sequence.

This is also the whole guard against editing a collapsed body: every route into a container hangs off an inner handle or the body geometry, so hiding the inner handles closes all of them.

## Toolbar

The default `collapse` action qualifies a node by its artifact source handle. A container has none, so it needs a second way in.

- `schema/toolbar.ts` gains a `shapes` predicate on the action condition, a sibling to `nodeTypes` and `handles`.
- `evaluateCondition` matches it against `manifest.display.shape`.
- A second default `collapse` entry qualifies `shapes: ['container']`.

`shapes: ['container']` is exactly `isContainerNodeManifest`, which is what decides whether a loop frame renders at all, so the affordance and the render decision key off one fact and cannot drift.

Predicates inside one condition are conjunctive, so the artifact and container cases cannot share an entry. `mergeToolbarConfigs` concatenates without deduplicating, so the resolver now keeps one action per id after condition filtering, last entry winning. Nothing matches both conditions today, but that same concat already meant a manifest extension re-declaring `delete` rendered two Delete buttons; that is fixed here too.

A container type that should not collapse can still decline through the existing `suppressDefaultToolbarActions`.

## Not in this PR

- The `LoopNode` -> `BaseNode` switch. It belongs in the host: `useFlowNodeConfig` supplies `handleConfigurations` and `onActionNeeded` that only `FlowBaseNode` forwards, so a switch inside `LoopNode` would render a collapsed loop with ungated add-buttons.
- Hiding the children, the size override, persistence, drag/delete/duplicate, and layout.
- Shape rewriting. `resolveDisplay` is untouched; a collapsed container keeps `shape: 'container'` and lands on the square treatment because `getContainerWidth` and `BaseNodeContainer` both branch only on `rectangle`.

## Testing

- `manifest-resolver.test.ts`: inner handles hidden when collapsed and visible when not, outer handles unaffected, repeat-generated inner handles covered, inner group hidden.
- `toolbar-resolver.test.tsx` (new): collapse offered on a container manifest and on an artifact manifest, withheld from a node with neither, offered once when a manifest qualifies both ways, `suppressDefaultToolbarActions` honoured, and a manifest extension overriding a default of the same id.

`pnpm run test` in `apollo-react`: 2580 pass, 1 fail. The failure is `formatDuration` "keeps the cap in other locales", which fails identically on `main` with this branch stashed. It is an ICU locale-data difference, unrelated.

Typecheck and biome are clean.
