### PR TITLE
chore(release): backfill apollo-react 6.29.0 version bump [skip ci]

### DIFF
--- a/packages/apollo-react/CHANGELOG.md
+++ b/packages/apollo-react/CHANGELOG.md
@@ -1,3 +1,13 @@
+## [@uipath/apollo-react-v6.29.0](https://github.com/UiPath/apollo-ui/compare/@uipath/apollo-react@6.28.0...@uipath/apollo-react@6.29.0) (2026-08-21)
+
+### Features
+
+* **apollo-react:** offer inline collapse on container nodes ([928ab13](https://github.com/UiPath/apollo-ui/commit/928ab13402e9adc0f15e00299f29c6cab9ccc287))
+
+### Bug Fixes
+
+* **apollo-react:** break the manifest/toolbar schema cycle ([5440cbd](https://github.com/UiPath/apollo-ui/commit/5440cbd11f17b6a360c727f712209ad06a0f3d75))
+
 ## [@uipath/apollo-react-v6.28.0](https://github.com/UiPath/apollo-ui/compare/@uipath/apollo-react@6.27.0...@uipath/apollo-react@6.28.0) (2026-08-21)
 
 ### Features

--- a/packages/apollo-react/package.json
+++ b/packages/apollo-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uipath/apollo-react",
-  "version": "6.28.0",
+  "version": "6.29.0",
   "description": "Apollo Design System - React component library with Material UI theming",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Backfills the `@uipath/apollo-react` 6.29.0 version bump and CHANGELOG entry that the release bot could not commit.

[Run 32478204410](https://github.com/UiPath/apollo-ui/actions/runs/32478204410) published 6.29.0 to npmjs.org and pushed the git tag, but then failed in the post-publish verification guard (false negative, see #1072), so the `commit-version-bump` job was skipped. Without this, the 6.29.0 changelog entry would be permanently missing: the next release only generates notes for commits after the 6.29.0 tag.

Contents mirror what the bot would have committed:
- `packages/apollo-react/package.json`: 6.28.0 → 6.29.0
- `packages/apollo-react/CHANGELOG.md`: 6.29.0 entry in semantic-release format (feat 928ab13, fix 5440cbd)

🤖 Generated with [Claude Code](https://claude.com/claude-code)