### PR TITLE
feat(apollo-react): rename conversations in chat history

### DIFF
--- a/packages/apollo-react/src/material/components/ap-chat/DOCS.md
+++ b/packages/apollo-react/src/material/components/ap-chat/DOCS.md
@@ -140,6 +140,7 @@ See [Usage Examples](#usage-examples) for complete setup details.
 | `appendOlderHistoryItems(items: AutopilotChatHistory[], done?: boolean)`      | (Only when `paginatedHistory` is enabled) Appends older history items when loading more. Set `done` to `true` when no more items are available (see [Pagination and Loading More History](#pagination-and-loading-more-history)) |
 | `toggleHistory(open?: boolean)`                                               | Toggles the history panel visibility                                                                                                                                                                                             |
 | `deleteConversation(conversationId: string)`                                  | Deletes a conversation from the history                                                                                                                                                                                          |
+| `renameConversation(conversationId: string, name: string)`                    | Renames a conversation.                                                                                        |
 | `openConversation(conversationId: string \| null, showLoadingState: boolean)` | Opens a specific conversation from the history, second parameter indicates if the chat should show loading spinner for conversation (defaults to true)                                                                           |
 
 ### Settings Management
@@ -282,6 +283,7 @@ Subscribes to chat events and returns an unsubscribe function. The handler will 
 - `SetConversation`: Emitted when the conversation is set
 - `SetHistory`: Emitted when the history is set
 - `DeleteConversation`: Emitted when a conversation is deleted from the history list
+- `RenameConversation`: Emitted when a conversation is renamed from the history list (see [Renaming Conversations](#renaming-conversations))
 - `OpenConversation`: Emitted when a conversation is opened (clicked on in the history list)
 - `Feedback`: Emitted when a feedback is sent (thumbs up or thumbs down)
 - `Copy`: Emitted when a message is copied
@@ -2375,6 +2377,23 @@ chatService.on(AutopilotChatEvent.DeleteConversation, (conversationId) => {
 });
 ```
 
+#### Renaming Conversations
+
+Users can rename a conversation inline from the history panel by clicking the edit icon
+on a row (revealed on hover). Consumers receive the `RenameConversation` event and are
+responsible for persisting the new name to their backend.
+
+```typescript
+// Rename a conversation in history
+chatService.renameConversation('conversation-2', 'Q3 planning notes');
+
+// Listen for rename events dispatched by the UI or by renameConversation()
+chatService.on(AutopilotChatEvent.RenameConversation, ({ conversationId, name }) => {
+  console.log('User renamed', conversationId, 'to', name);
+  // Persist to your backend
+});
+```
+
 #### Toggling the History Panel
 
 ```typescript
@@ -3071,6 +3090,7 @@ enum AutopilotChatMode {
  * @property copy - Whether the chat has copy button
  * @property audioStreaming - Whether to disable the always-on voice interaction button
  *                            (the feature requires the consumer to handle InputStream/OutputStream audio events)
+ * @property renameChat - Whether to disable the rename affordance on chat history items.
  */
 export interface AutopilotChatDisabledFeatures {
   resize?: boolean;
@@ -3089,6 +3109,7 @@ export interface AutopilotChatDisabledFeatures {
   fullHeight?: boolean;
   copy?: boolean;
   audioStreaming?: boolean;
+  renameChat?: boolean;
 }
 ```
 
@@ -3315,6 +3336,22 @@ export interface AutopilotChatHistory {
 }
 ```
 
+### AutopilotChatRenameConversationPayload
+
+```typescript
+/**
+ * Payload emitted with `AutopilotChatEvent.RenameConversation` and passed to the
+ * `AutopilotChatPreHookAction.RenameConversation` pre-hook.
+ *
+ * @property conversationId - The id of the conversation being renamed
+ * @property name - The new (trimmed, non-empty) name
+ */
+export interface AutopilotChatRenameConversationPayload {
+  conversationId: string;
+  name: string;
+}
+```
+
 ### AutopilotChatMessageRenderer
 
 ```typescript
@@ -3371,6 +3408,7 @@ export interface AutopilotChatActionPayload {
  * @property {string} CitationClick - Emitted when the user clicks on a citation
  * @property {string} Feedback - Emitted when the user clicks on the feedback buttons thumbs up/down
  * @property {string} DeleteConversation - Emitted when the user attempts to delete a conversation
+ * @property {string} RenameConversation - Emitted when the user attempts to rename a conversation
  */
 export enum AutopilotChatPreHookAction {
   NewChat = 'new-chat',
@@ -3380,7 +3418,8 @@ export enum AutopilotChatPreHookAction {
   CloseChat = 'close-chat',
   CitationClick = 'citation-click',
   Feedback = 'feedback',
-  DeleteConversation = 'delete-conversation'
+  DeleteConversation = 'delete-conversation',
+  RenameConversation = 'rename-conversation'
 }
 ```
 

--- a/packages/apollo-react/src/material/components/ap-chat/components/history/chat-history-item.tsx
+++ b/packages/apollo-react/src/material/components/ap-chat/components/history/chat-history-item.tsx
@@ -15,8 +15,8 @@ import {
 } from '../../service';
 import { AutopilotChatActionButton } from '../common/action-button';
 
-const GroupItem = styled('div')<{ isActive: boolean; showRemoveIcon: boolean }>(
-  ({ isActive, showRemoveIcon }) => ({
+const GroupItem = styled('div')<{ isActive: boolean; showActionButtons: boolean }>(
+  ({ isActive, showActionButtons }) => ({
     width: `calc(100% - 2 * ${token.Spacing.SpacingBase})`,
     padding: `0 calc(${token.Padding.PadL} + ${token.Spacing.SpacingBase})`,
     display: 'flex',
@@ -34,11 +34,14 @@ const GroupItem = styled('div')<{ isActive: boolean; showRemoveIcon: boolean }>(
       borderLeft: `4px solid var(--color-selection-indicator)`,
     }),
 
-    '& .delete-button-wrapper': {
-      opacity: showRemoveIcon ? 1 : 0,
+    '& .action-buttons-wrapper': {
+      opacity: showActionButtons ? 1 : 0,
       position: 'relative',
       left: token.Spacing.SpacingXs,
       marginRight: token.Spacing.SpacingBase,
+      display: 'flex',
+      alignItems: 'center',
+      gap: token.Spacing.SpacingXs,
     },
   })
 );
@@ -53,6 +56,25 @@ const GroupTitle = styled('div')(() => ({
   },
 }));
 
+const RenameInput = styled('input')(() => ({
+  width: '100%',
+  padding: 0,
+  margin: 0,
+  border: 'none',
+  background: 'transparent',
+  color: 'var(--color-foreground)',
+  fontFamily: 'inherit',
+  fontSize: 'inherit',
+  lineHeight: 'inherit',
+  outline: 'none',
+
+  '&:focus-visible': {
+    outline: `1px solid var(--color-focus-indicator)`,
+    outlineOffset: '2px',
+    borderRadius: token.Border.BorderRadiusS,
+  },
+}));
+
 interface AutopilotChatHistoryItemProps {
   item: AutopilotChatHistory;
   isHistoryOpen: boolean;
@@ -64,18 +86,31 @@ const AutopilotChatHistoryItemComponent: React.FC<AutopilotChatHistoryItemProps>
 }) => {
   const { _ } = useLingui();
   const chatService = useChatService();
-  const { spacing } = useChatState();
+  const { spacing, disabledFeatures } = useChatState();
+  const renameEnabled = !disabledFeatures.renameChat;
   const [isActive, setIsActive] = React.useState(chatService.activeConversationId === item.id);
   const { setWaitingResponse } = useLoading();
 
-  const [isRemoveIconVisible, setIsRemoveIconVisible] = React.useState(false);
+  const [isActionButtonsVisible, setIsActionButtonsVisible] = React.useState(false);
   const [isFocused, setIsFocused] = React.useState(false);
+  const [isEditing, setIsEditing] = React.useState(false);
+  const [draftName, setDraftName] = React.useState(item.name);
   const itemRef = React.useRef<HTMLDivElement>(null);
+  const inputRef = React.useRef<HTMLInputElement>(null);
   const lastMousePosition = React.useRef({
     x: 0,
     y: 0,
   });
-  const focusButtonRef = React.useRef<HTMLButtonElement>(null);
+  // Guards against double-commit when Enter triggers commit then the resulting
+  // unmount/blur fires again before state settles.
+  const isCommittingRef = React.useRef(false);
+
+  // Keep the draft in sync with parent-driven updates while not editing
+  React.useEffect(() => {
+    if (!isEditing) {
+      setDraftName(item.name);
+    }
+  }, [item.name, isEditing]);
 
   // Tooltip interferes with the onMouseEnter/onMouseLeave events, so we need to listen to mouse move events
   React.useEffect(() => {
@@ -98,7 +133,7 @@ const AutopilotChatHistoryItemComponent: React.FC<AutopilotChatHistoryItemProps>
           e.clientY >= rect.top &&
           e.clientY <= rect.bottom;
 
-        setIsRemoveIconVisible(isInside);
+        setIsActionButtonsVisible(isInside);
       }
     };
 
@@ -147,6 +182,61 @@ const AutopilotChatHistoryItemComponent: React.FC<AutopilotChatHistoryItemProps>
     };
   }, [chatService, item.id, isActive, setWaitingResponse]);
 
+  React.useEffect(() => {
+    if (isEditing) {
+      inputRef.current?.focus();
+      inputRef.current?.select();
+    }
+  }, [isEditing]);
+
+  const enterEditMode = React.useCallback(() => {
+    if (!isHistoryOpen) {
+      return;
+    }
+    isCommittingRef.current = false;
+    setDraftName(item.name);
+    setIsEditing(true);
+  }, [isHistoryOpen, item.name]);
+
+  const cancelRename = React.useCallback(() => {
+    isCommittingRef.current = false;
+    setDraftName(item.name);
+    setIsEditing(false);
+  }, [item.name]);
+
+  const commitRename = React.useCallback(() => {
+    if (isCommittingRef.current) {
+      return;
+    }
+    const trimmed = draftName.trim();
+
+    if (trimmed === '' || trimmed === item.name) {
+      cancelRename();
+      return;
+    }
+
+    if (!chatService) {
+      setIsEditing(false);
+      return;
+    }
+
+    isCommittingRef.current = true;
+    chatService
+      .getPreHook(AutopilotChatPreHookAction.RenameConversation)({
+        conversationId: item.id,
+        name: trimmed,
+      })
+      .then((proceed) => {
+        if (!proceed) {
+          cancelRename();
+          return;
+        }
+        chatService.renameConversation(item.id, trimmed);
+        setIsEditing(false);
+        isCommittingRef.current = false;
+      });
+  }, [draftName, item.id, item.name, chatService, cancelRename]);
+
   const handleDelete = React.useCallback(
     (
       ev: React.KeyboardEvent<HTMLButtonElement> | React.MouseEvent<HTMLButtonElement>,
@@ -171,33 +261,47 @@ const AutopilotChatHistoryItemComponent: React.FC<AutopilotChatHistoryItemProps>
     [chatService]
   );
 
+  const handleRename = React.useCallback(
+    (ev: React.KeyboardEvent<HTMLButtonElement> | React.MouseEvent<HTMLButtonElement>) => {
+      ev.stopPropagation();
+      setIsFocused(false);
+      enterEditMode();
+    },
+    [enterEditMode]
+  );
+
   const handleItemClick = React.useCallback(
     (itemId: string) => {
-      if (isActive) {
+      if (isEditing || isActive) {
         return;
       }
 
       chatService.openConversation(itemId);
       chatService.toggleHistory(false);
     },
-    [chatService, isActive]
+    [chatService, isActive, isEditing]
   );
 
-  React.useEffect(() => {
-    if (isFocused) {
-      focusButtonRef.current?.focus();
-    }
-  }, [isFocused]);
+  const renameLabel = _(msg({ id: 'autopilot-chat.history.rename', message: `Rename chat` }));
+  const renameInputLabel = _(
+    msg({ id: 'autopilot-chat.history.rename-input', message: `Chat name` })
+  );
+  const deleteLabel = _(msg({ id: 'autopilot-chat.history.delete', message: `Delete chat` }));
+  const showActionButtons = !isEditing && (isFocused || isActionButtonsVisible);
+  const tooltipVisible = showActionButtons && isHistoryOpen;
 
   return (
     <GroupItem
-      showRemoveIcon={isFocused || isRemoveIconVisible}
+      showActionButtons={showActionButtons}
       ref={itemRef}
-      tabIndex={isHistoryOpen ? 0 : -1}
+      tabIndex={isHistoryOpen && !isEditing ? 0 : -1}
       key={item.id}
       isActive={isActive}
       onClick={() => handleItemClick(item.id)}
       onKeyDown={(ev) => {
+        if (isEditing) {
+          return;
+        }
         if (ev.key === 'Enter' || ev.key === ' ') {
           handleItemClick(item.id);
         }
@@ -207,43 +311,93 @@ const AutopilotChatHistoryItemComponent: React.FC<AutopilotChatHistoryItemProps>
       aria-pressed={isActive}
     >
       <GroupTitle>
-        <ApTypography variant={spacing.primaryFontToken} color={'var(--color-foreground)'}>
-          {item.name}
-        </ApTypography>
+        {isEditing ? (
+          <RenameInput
+            ref={inputRef}
+            value={draftName}
+            aria-label={renameInputLabel}
+            data-testid="autopilot-chat-history-rename-input"
+            onChange={(ev) => setDraftName(ev.target.value)}
+            onClick={(ev) => ev.stopPropagation()}
+            onBlur={commitRename}
+            onKeyDown={(ev) => {
+              if (ev.key === 'Enter') {
+                ev.preventDefault();
+                ev.stopPropagation();
+                commitRename();
+              } else if (ev.key === 'Escape') {
+                ev.preventDefault();
+                ev.stopPropagation();
+                cancelRename();
+              } else {
+                // Prevent Space from bubbling to GroupItem's onKeyDown (which would open the conversation)
+                ev.stopPropagation();
+              }
+            }}
+          />
+        ) : (
+          <ApTypography variant={spacing.primaryFontToken} color={'var(--color-foreground)'}>
+            {item.name}
+          </ApTypography>
+        )}
       </GroupTitle>
 
-      <div className="delete-button-wrapper">
-        <AutopilotChatActionButton
-          disabled={!isHistoryOpen}
-          ref={focusButtonRef}
-          onClick={(ev) => handleDelete(ev, item.id)}
-          onFocus={() => {
-            setIsFocused(true);
-          }}
-          onBlur={() => {
-            setIsFocused(false);
-          }}
-          onKeyDown={(ev) => {
-            // Close modal if escape is pressed (propagate to Popover parent)
-            if (ev.key !== 'Escape') {
-              ev.stopPropagation();
-            }
+      {!isEditing && (
+        <div className="action-buttons-wrapper">
+          {renameEnabled && (
+          <AutopilotChatActionButton
+            disabled={!isHistoryOpen}
+            onClick={(ev) => handleRename(ev)}
+            onFocus={() => {
+              setIsFocused(true);
+            }}
+            onBlur={() => {
+              setIsFocused(false);
+            }}
+            onKeyDown={(ev) => {
+              // Close modal if escape is pressed (propagate to Popover parent)
+              if (ev.key !== 'Escape') {
+                ev.stopPropagation();
+              }
 
-            if (ev.key === 'Enter' || ev.key === ' ') {
-              handleDelete(ev, item.id);
-            }
-          }}
-          iconName="delete"
-          iconSize="16px"
-          tooltip={
-            (isRemoveIconVisible || isFocused) && isHistoryOpen
-              ? _(msg({ id: 'autopilot-chat.history.delete', message: `Delete chat` }))
-              : ''
-          }
-          data-testid="autopilot-chat-history-delete"
-          ariaLabel={_(msg({ id: 'autopilot-chat.history.delete', message: `Delete chat` }))}
-        />
-      </div>
+              if (ev.key === 'Enter' || ev.key === ' ') {
+                handleRename(ev);
+              }
+            }}
+            iconName="edit"
+            iconSize="16px"
+            tooltip={tooltipVisible ? renameLabel : ''}
+            data-testid="autopilot-chat-history-rename"
+            ariaLabel={renameLabel}
+          />
+          )}
+          <AutopilotChatActionButton
+            disabled={!isHistoryOpen}
+            onClick={(ev) => handleDelete(ev, item.id)}
+            onFocus={() => {
+              setIsFocused(true);
+            }}
+            onBlur={() => {
+              setIsFocused(false);
+            }}
+            onKeyDown={(ev) => {
+              // Close modal if escape is pressed (propagate to Popover parent)
+              if (ev.key !== 'Escape') {
+                ev.stopPropagation();
+              }
+
+              if (ev.key === 'Enter' || ev.key === ' ') {
+                handleDelete(ev, item.id);
+              }
+            }}
+            iconName="delete"
+            iconSize="16px"
+            tooltip={tooltipVisible ? deleteLabel : ''}
+            data-testid="autopilot-chat-history-delete"
+            ariaLabel={deleteLabel}
+          />
+        </div>
+      )}
     </GroupItem>
   );
 };

--- a/packages/apollo-react/src/material/components/ap-chat/components/history/chat-history-item.tsx
+++ b/packages/apollo-react/src/material/components/ap-chat/components/history/chat-history-item.tsx
@@ -234,6 +234,10 @@ const AutopilotChatHistoryItemComponent: React.FC<AutopilotChatHistoryItemProps>
         chatService.renameConversation(item.id, trimmed);
         setIsEditing(false);
         isCommittingRef.current = false;
+      })
+      .catch(() => {
+        // Pre-hook threw or rejected. Revert so the input doesn't stay stuck.
+        cancelRename();
       });
   }, [draftName, item.id, item.name, chatService, cancelRename]);
 
@@ -306,9 +310,11 @@ const AutopilotChatHistoryItemComponent: React.FC<AutopilotChatHistoryItemProps>
           handleItemClick(item.id);
         }
       }}
-      aria-label={item.name}
-      role="button"
-      aria-pressed={isActive}
+      // While editing, drop the button role so the nested <input> is exposed correctly
+      // to assistive tech (ARIA disallows interactive descendants of role="button").
+      aria-label={isEditing ? undefined : item.name}
+      role={isEditing ? undefined : 'button'}
+      aria-pressed={isEditing ? undefined : isActive}
     >
       <GroupTitle>
         {isEditing ? (
@@ -345,31 +351,31 @@ const AutopilotChatHistoryItemComponent: React.FC<AutopilotChatHistoryItemProps>
       {!isEditing && (
         <div className="action-buttons-wrapper">
           {renameEnabled && (
-          <AutopilotChatActionButton
-            disabled={!isHistoryOpen}
-            onClick={(ev) => handleRename(ev)}
-            onFocus={() => {
-              setIsFocused(true);
-            }}
-            onBlur={() => {
-              setIsFocused(false);
-            }}
-            onKeyDown={(ev) => {
-              // Close modal if escape is pressed (propagate to Popover parent)
-              if (ev.key !== 'Escape') {
-                ev.stopPropagation();
-              }
+            <AutopilotChatActionButton
+              disabled={!isHistoryOpen}
+              onClick={(ev) => handleRename(ev)}
+              onFocus={() => {
+                setIsFocused(true);
+              }}
+              onBlur={() => {
+                setIsFocused(false);
+              }}
+              onKeyDown={(ev) => {
+                // Close modal if escape is pressed (propagate to Popover parent)
+                if (ev.key !== 'Escape') {
+                  ev.stopPropagation();
+                }
 
-              if (ev.key === 'Enter' || ev.key === ' ') {
-                handleRename(ev);
-              }
-            }}
-            iconName="edit"
-            iconSize="16px"
-            tooltip={tooltipVisible ? renameLabel : ''}
-            data-testid="autopilot-chat-history-rename"
-            ariaLabel={renameLabel}
-          />
+                if (ev.key === 'Enter' || ev.key === ' ') {
+                  handleRename(ev);
+                }
+              }}
+              iconName="edit"
+              iconSize="16px"
+              tooltip={tooltipVisible ? renameLabel : ''}
+              data-testid="autopilot-chat-history-rename"
+              ariaLabel={renameLabel}
+            />
           )}
           <AutopilotChatActionButton
             disabled={!isHistoryOpen}

--- a/packages/apollo-react/src/material/components/ap-chat/locales/en.json
+++ b/packages/apollo-react/src/material/components/ap-chat/locales/en.json
@@ -17,6 +17,8 @@
   "autopilot-chat.message.actions.copy": "Copy",
   "autopilot-chat.message.code-block-copy": "Copy",
   "autopilot-chat.history.delete": "Delete",
+  "autopilot-chat.history.rename": "Rename chat",
+  "autopilot-chat.history.rename-input": "Chat name",
   "autopilot-chat.dropzone.overlay-title": "Drop your files here to add them to your prompt",
   "autopilot-chat.message.expand": "Expand",
   "autopilot-chat.header.actions.expand": "Expand",

--- a/packages/apollo-react/src/material/components/ap-chat/service/ChatModel.ts
+++ b/packages/apollo-react/src/material/components/ap-chat/service/ChatModel.ts
@@ -191,6 +191,7 @@ export interface AutopilotChatError {
  * @property {string} SetConversation - Emitted when the conversation is set
  * @property {string} SetHistory - Emitted when the history is set
  * @property {string} DeleteConversation - Emitted when a conversation is deleted from the history list
+ * @property {string} RenameConversation - Emitted when a conversation is renamed from the history list
  * @property {string} OpenConversation - Emitted when a conversation is opened (clicked on in the history list)
  * @property {string} Feedback - Emitted when a feedback is sent (thumbs up or thumbs down)
  * @property {string} Copy - Emitted when a message is copied
@@ -234,6 +235,7 @@ export enum AutopilotChatEvent {
   SetConversation = 'setConversation',
   SetHistory = 'setHistory',
   DeleteConversation = 'deleteConversation',
+  RenameConversation = 'renameConversation',
   OpenConversation = 'openConversation',
   Feedback = 'feedback',
   Copy = 'copy',
@@ -422,6 +424,7 @@ export interface PdfCitation extends Citation {
  * @property htmlPreview - Whether the chat has HTML preview for code blocks
  * @property audioStreaming - Whether to disable the always-on voice interaction button
  *                            (the feature requires the consumer to handle InputStream/OutputStream audio events)
+ * @property renameChat - Whether to disable the rename affordance on chat history items.
  */
 export interface AutopilotChatDisabledFeatures {
   resize?: boolean;
@@ -441,6 +444,7 @@ export interface AutopilotChatDisabledFeatures {
   copy?: boolean;
   htmlPreview?: boolean;
   audioStreaming?: boolean;
+  renameChat?: boolean;
 }
 
 /**
@@ -468,6 +472,8 @@ export interface AutopilotChatOverrideLabels {
  * @property {string} CloseChat - Emitted when the user attemps to close the chat
  * @property {string} CitationClick - Emitted when the user clicks on a citation
  * @property {string} Feedback - Emitted when the user clicks on feedback thumbs up or down
+ * @property {string} DeleteConversation - Emitted when the user attempts to delete a conversation
+ * @property {string} RenameConversation - Emitted when the user attempts to rename a conversation
  */
 export enum AutopilotChatPreHookAction {
   NewChat = 'new-chat',
@@ -478,6 +484,7 @@ export enum AutopilotChatPreHookAction {
   CitationClick = 'citation-click',
   Feedback = 'feedback',
   DeleteConversation = 'delete-conversation',
+  RenameConversation = 'rename-conversation',
 }
 
 /**
@@ -589,6 +596,18 @@ export interface AutopilotChatHistory {
   id: string;
   name: string;
   timestamp: string;
+}
+
+/**
+ * Payload emitted with `AutopilotChatEvent.RenameConversation` and passed to the
+ * `AutopilotChatPreHookAction.RenameConversation` pre-hook.
+ *
+ * @property conversationId - The id of the conversation being renamed
+ * @property name - The new (trimmed, non-empty) name
+ */
+export interface AutopilotChatRenameConversationPayload {
+  conversationId: string;
+  name: string;
 }
 
 /**

--- a/packages/apollo-react/src/material/components/ap-chat/service/ChatService.ts
+++ b/packages/apollo-react/src/material/components/ap-chat/service/ChatService.ts
@@ -62,6 +62,7 @@ export class AutopilotChatService {
     // AudioStreaming (always-on voice interaction) will be disabled by default since each consumer needs to wire InputStream/OutputStream events
     // FullHeight will be disabled by default since most of the consumers will have the portal-shell header
     // HtmlPreview will be disabled by default
+    // RenameChat is disabled by default since consumers must wire up persistence for renames
     disabledFeatures: {
       settings: true,
       headerSeparator: true,
@@ -69,6 +70,7 @@ export class AutopilotChatService {
       audioStreaming: true,
       fullHeight: true,
       htmlPreview: true,
+      renameChat: true,
     },
     settingsRenderer: () => {},
     models: undefined,
@@ -139,6 +141,7 @@ export class AutopilotChatService {
     this.toggleHistory = this.toggleHistory.bind(this);
     this.toggleSettings = this.toggleSettings.bind(this);
     this.deleteConversation = this.deleteConversation.bind(this);
+    this.renameConversation = this.renameConversation.bind(this);
     this.openConversation = this.openConversation.bind(this);
     this.setAllowedAttachments = this.setAllowedAttachments.bind(this);
     this.toggleAutoScroll = this.toggleAutoScroll.bind(this);
@@ -932,6 +935,19 @@ export class AutopilotChatService {
     }
 
     this._eventBus.publish(AutopilotChatEvent.DeleteConversation, conversationId);
+  }
+
+  /**
+   * Renames a conversation in the chat service.
+   *
+   * @param conversationId - The conversation ID to rename
+   * @param name - The new name
+   */
+  renameConversation(conversationId: string, name: string) {
+    this._eventBus.publish(AutopilotChatEvent.RenameConversation, {
+      conversationId,
+      name,
+    });
   }
 
   /**

--- a/packages/apollo-react/src/material/components/ap-chat/service/LocalHistory.ts
+++ b/packages/apollo-react/src/material/components/ap-chat/service/LocalHistory.ts
@@ -249,6 +249,36 @@ export class LocalHistoryService {
   }
 
   /**
+   * Renames an existing conversation in place.
+   */
+  public static async renameConversation(
+    conversationId: string,
+    name: string
+  ): Promise<void> {
+    const db = await LocalHistoryService.getConversationsDb();
+    const existing = await LocalHistoryService.getConversation(conversationId);
+
+    if (!existing) {
+      return;
+    }
+
+    const data: Conversation = {
+      ...existing,
+      name,
+      lastUpdated: Date.now(),
+    };
+
+    return new Promise((resolve, reject) => {
+      const transaction = db.transaction('conversations', 'readwrite');
+      const store = transaction.objectStore('conversations');
+      const request = store.put(data, conversationId);
+
+      request.onerror = () => reject(request.error);
+      request.onsuccess = () => resolve();
+    });
+  }
+
+  /**
    * Deletes a conversation and all associated messages for a conversation.
    */
   public static async deleteConversation(conversationId: string): Promise<void> {
@@ -416,6 +446,14 @@ export class LocalHistoryService {
           }
         );
 
+        const unsubscribeRenameConversation = chatService.on(
+          AutopilotChatEvent.RenameConversation,
+          async (payload: { conversationId: string; name: string }) => {
+            await LocalHistoryService.renameConversation(payload.conversationId, payload.name);
+            chatService.setHistory(await LocalHistoryService.getAllConversations());
+          }
+        );
+
         cleanup();
         LocalHistoryService.UNSUBSCRIBE_CALLBACKS.set('setHistory', unsubscribeSetHistory);
         LocalHistoryService.UNSUBSCRIBE_CALLBACKS.set(
@@ -425,6 +463,10 @@ export class LocalHistoryService {
         LocalHistoryService.UNSUBSCRIBE_CALLBACKS.set(
           'deleteConversation',
           unsubscribeDeleteConversation
+        );
+        LocalHistoryService.UNSUBSCRIBE_CALLBACKS.set(
+          'renameConversation',
+          unsubscribeRenameConversation
         );
         LocalHistoryService.UNSUBSCRIBE_CALLBACKS.set('request', unsubscribeRequest);
         LocalHistoryService.UNSUBSCRIBE_CALLBACKS.set('response', unsubscribeResponse);

--- a/packages/apollo-react/src/material/components/ap-chat/service/LocalHistory.ts
+++ b/packages/apollo-react/src/material/components/ap-chat/service/LocalHistory.ts
@@ -251,10 +251,7 @@ export class LocalHistoryService {
   /**
    * Renames an existing conversation in place.
    */
-  public static async renameConversation(
-    conversationId: string,
-    name: string
-  ): Promise<void> {
+  public static async renameConversation(conversationId: string, name: string): Promise<void> {
     const db = await LocalHistoryService.getConversationsDb();
     const existing = await LocalHistoryService.getConversation(conversationId);
 

--- a/packages/apollo-react/src/material/stories/chat-story-support.tsx
+++ b/packages/apollo-react/src/material/stories/chat-story-support.tsx
@@ -257,6 +257,7 @@ export function ChatShowcaseDemo({
     audio: false, // STT dictate (mic) button - disabled by default
     audioStreaming: false, // Always-on voice interaction button - disabled by default
     htmlPreview: true,
+    renameChat: true, // Rename affordance on history items - disabled by default
     headerSeparator: false, // Disabled by default (like HTML)
     fullHeight: true, // Enabled by default
     resize: true,
@@ -560,6 +561,7 @@ export function ChatShowcaseDemo({
           close: !features.close,
           feedback: !features.feedback,
           copy: !features.copy,
+          renameChat: !features.renameChat,
         },
         settingsRenderer: createSettingsRenderer(),
       },
@@ -701,6 +703,16 @@ export function ChatShowcaseDemo({
       // biome-ignore lint/suspicious/noExplicitAny: Event not in enum
       service.on('stopResponse' as any, () => {
         console.log('Stop response event');
+      })
+    );
+
+    unsubscribes.push(
+      service.on(AutopilotChatEvent.RenameConversation, (payload: unknown) => {
+        const { conversationId, name } = payload as {
+          conversationId: string;
+          name: string;
+        };
+        console.log(`[Rename] conversation ${conversationId} renamed to "${name}"`);
       })
     );
 
@@ -938,6 +950,7 @@ export function ChatShowcaseDemo({
     features.headerSeparator,
     features.history,
     features.htmlPreview,
+    features.renameChat,
     features.resize,
     features.settings,
     features.readOnly,
@@ -972,6 +985,7 @@ export function ChatShowcaseDemo({
           close: !features.close,
           feedback: !features.feedback,
           copy: !features.copy,
+          renameChat: !features.renameChat,
         },
         settingsRenderer: createSettingsRenderer(),
         ...(chatMode === AutopilotChatMode.Embedded &&
@@ -1537,7 +1551,14 @@ console.log(processUserData(exampleUser, { source: 'web', ipAddress: '192.168.1.
   };
 
   const setPreHook = () => {
-    const actions = ['new-chat', 'toggle-history', 'toggle-chat', 'close-chat', 'feedback'];
+    const actions = [
+      'new-chat',
+      'toggle-history',
+      'toggle-chat',
+      'close-chat',
+      'feedback',
+      'rename-conversation',
+    ];
     actions.forEach((action) => {
       // biome-ignore lint/suspicious/noExplicitAny: setPreHook action parameter not fully typed
       chatService?.setPreHook(action as any, async () => {
@@ -2150,6 +2171,16 @@ console.log(processUserData(exampleUser, { source: 'web', ipAddress: '192.168.1.
               />
             }
             label="History"
+          />
+          <FormControlLabel
+            control={
+              <Checkbox
+                size="small"
+                checked={features.renameChat}
+                onChange={() => toggleFeature('renameChat')}
+              />
+            }
+            label="Rename Chat"
           />
           <FormControlLabel
             control={


### PR DESCRIPTION
## Summary

Adds the ability to rename conversations in the chat-history. 

Adds an inline Rename Button each chat history item, plus a new `AutopilotChatEvent.RenameConversation` event that SDK consumers can subscribe to for persistence.

Gated behind `disabledFeatures.renameChat` (defaults to `true`), so **existing consumers see no change until they opt in.**


## Demo
(storybook, so persistence of rename is not wired up)

https://github.com/user-attachments/assets/c46fb2c1-04dc-4f6e-bc16-66de62d67c44


## How consumers use it

**Local-history consumers** (`useLocalHistory: true`) get end-to-end persistence for free — just opt in:

```ts
chatService.setDisabledFeatures({ renameChat: false });
```

**Consumers with a custom history backend** must (1) opt in and (2) subscribe to the event:

```ts
chatService.setDisabledFeatures({ renameChat: false });

chatService.on(AutopilotChatEvent.RenameConversation, async ({ conversationId, name }) => {
  await api.renameConversation(conversationId, name);
  chatService.setHistory(await api.getHistory());
});
```

**Optional: validate before commit** via the pre-hook (rejects the rename in the UI without persisting):

```ts
chatService.setPreHook(AutopilotChatPreHookAction.RenameConversation, async ({ name }) => {
  if (name.length > 80) return false;
  return true;
});
```

Full API docs: `packages/apollo-react/src/material/components/ap-chat/DOCS.md` (Renaming Conversations section).

