### PR TITLE
fix(apollo-react): allow registry icons in node output mode dropdown [MST-13618]

### DIFF
--- a/packages/apollo-react/src/canvas/controls/NodeOutputModeSelect/NodeOutputModeSelect.test.tsx
+++ b/packages/apollo-react/src/canvas/controls/NodeOutputModeSelect/NodeOutputModeSelect.test.tsx
@@ -1,3 +1,4 @@
+import { FileBracesCorner } from 'lucide-react';
 import { describe, expect, it, vi } from 'vitest';
 import { render, screen, userEvent } from '../../utils/testing';
 import { NodeOutputModeSelect } from './NodeOutputModeSelect';
@@ -36,6 +37,55 @@ describe('NodeOutputModeSelect', () => {
       'aria-checked',
       'true'
     );
+  });
+
+  describe('icon shapes', () => {
+    // A registry name and a Lucide component must both work: Apollo's own icons
+    // (e.g. file-sparkles-corner) are not LucideIcons, so a name is the only way
+    // a consumer can select one here.
+    it('renders a registry icon name through CanvasIcon, in the trigger and the item', async () => {
+      const options = [{ value: 'simulated', label: 'Simulated', icon: 'file-sparkles-corner' }];
+      const { container } = render(
+        <NodeOutputModeSelect value="simulated" onChange={vi.fn()} options={options} />
+      );
+
+      // A registry miss would degrade to Lucide's Box, so assert the real glyph.
+      expect(container.querySelector('svg.file-sparkles-corner-icon')).toBeTruthy();
+
+      await userEvent.click(screen.getByRole('button', { name: 'Node output mode' }));
+      const item = screen.getByRole('menuitemradio', { name: /Simulated/ });
+      expect(item.querySelector('svg.file-sparkles-corner-icon')).toBeTruthy();
+    });
+
+    // The default Simulated mode uses the registry glyph, matching the canvas
+    // node adornment for the same state.
+    it('gives the default Simulated mode the file-sparkles-corner glyph', async () => {
+      const { container } = render(<NodeOutputModeSelect value="simulated" onChange={vi.fn()} />);
+      expect(container.querySelector('svg.file-sparkles-corner-icon')).toBeTruthy();
+
+      await userEvent.click(screen.getByRole('button', { name: 'Node output mode' }));
+      const item = screen.getByRole('menuitemradio', { name: /Simulated/ });
+      expect(item.querySelector('svg.file-sparkles-corner-icon')).toBeTruthy();
+    });
+
+    it('still renders a Lucide component icon', () => {
+      const options = [{ value: 'static', label: 'Static mock', icon: FileBracesCorner }];
+      const { container } = render(
+        <NodeOutputModeSelect value="static" onChange={vi.fn()} options={options} />
+      );
+      expect(container.querySelector('svg.lucide-file-braces-corner')).toBeTruthy();
+    });
+
+    it('carries the colour class for a name, which the registry icon inherits', () => {
+      const options = [{ value: 'simulated', label: 'Simulated', icon: 'file-sparkles-corner' }];
+      const { container } = render(
+        <NodeOutputModeSelect value="simulated" onChange={vi.fn()} options={options} />
+      );
+      // Registry icons ignore className and default to currentColor, so the
+      // class has to sit on a wrapper for the colour to reach the glyph.
+      const glyph = container.querySelector('svg.file-sparkles-corner-icon');
+      expect(glyph?.closest('.text-foreground-subtle')).toBeTruthy();
+    });
   });
 
   it('disables the trigger', () => {

--- a/packages/apollo-react/src/canvas/controls/NodeOutputModeSelect/NodeOutputModeSelect.tsx
+++ b/packages/apollo-react/src/canvas/controls/NodeOutputModeSelect/NodeOutputModeSelect.tsx
@@ -8,15 +8,53 @@ import {
   DropdownMenuTrigger,
 } from '@uipath/apollo-wind';
 import type { LucideIcon } from 'lucide-react';
-import { ChevronDown, CircleDot, FileBracesCorner, Sparkles } from 'lucide-react';
+import { ChevronDown, CircleDot, FileBracesCorner } from 'lucide-react';
 import { useMemo } from 'react';
 import { useSafeLingui } from '../../../i18n';
+import { CanvasIcon } from '../../utils/icon-registry';
+
+/**
+ * A mode's icon: either a Lucide component, or a canvas icon-registry name.
+ *
+ * Names exist because not every canvas icon is a Lucide one — Apollo's own
+ * registry entries (`file-sparkles-corner`, the project glyphs) are plain
+ * components taking `{ w, h, color }`, so they are not assignable to
+ * `LucideIcon`. Passing the name lets a consumer use the same identifier here
+ * that it passes to `CanvasIcon` elsewhere, instead of keeping a parallel
+ * component map that can drift from it.
+ */
+export type NodeOutputModeIcon = LucideIcon | string;
 
 export interface NodeOutputModeOption {
   value: string;
   label: string;
   description?: string;
-  icon?: LucideIcon;
+  icon?: NodeOutputModeIcon;
+}
+
+/**
+ * Renders either icon shape. Registry icons ignore `className` and default to
+ * `currentColor`, so a name goes in a span that carries the colour class for the
+ * glyph to inherit, rather than being handed the class directly.
+ */
+function ModeIcon({
+  icon,
+  size,
+  className,
+}: {
+  icon: NodeOutputModeIcon;
+  size?: number;
+  className?: string;
+}) {
+  if (typeof icon === 'string') {
+    return (
+      <span className={cn('inline-flex', className)}>
+        <CanvasIcon icon={icon} size={size} />
+      </span>
+    );
+  }
+  const Icon = icon;
+  return <Icon size={size} className={className} />;
 }
 
 // Single source of truth for the default modes: label/description carry the
@@ -42,8 +80,12 @@ const MODE_DEFS = [
     },
   },
   {
+    // The one registry name here: generated output has no Lucide equivalent, and
+    // this is the icon the canvas node adornment uses for the same state, so the
+    // dropdown and the node read as one family. The others stay components,
+    // which are typo-proof.
     value: 'simulated',
-    icon: Sparkles,
+    icon: 'file-sparkles-corner',
     label: { id: 'canvas.node_mode_select.simulated_label', message: 'Simulated' },
     description: {
       id: 'canvas.node_mode_select.simulated_description',
@@ -123,7 +165,9 @@ export function NodeOutputModeSelect({
             className
           )}
         >
-          {CurrentIcon && <CurrentIcon className="text-foreground-subtle" />}
+          {CurrentIcon && (
+            <ModeIcon icon={CurrentIcon} className="text-foreground-subtle" size={10} />
+          )}
           <span className="min-w-0 flex-1 truncate shrink-0">{current?.label}</span>
           <ChevronDown className="text-foreground-subtle" />
         </Button>
@@ -144,7 +188,9 @@ export function NodeOutputModeSelect({
                   selectedValue === option.value && 'text-foreground'
                 )}
               >
-                {Icon && <Icon size={13} className="shrink-0 text-foreground-subtle" />}
+                {Icon && (
+                  <ModeIcon icon={Icon} size={13} className="shrink-0 text-foreground-subtle" />
+                )}
                 <div className="flex min-w-0 flex-1 flex-col gap-0.5">
                   <span className="text-xs font-medium">{option.label}</span>
                   {option.description && (

--- a/packages/apollo-react/src/canvas/controls/NodeOutputModeSelect/index.ts
+++ b/packages/apollo-react/src/canvas/controls/NodeOutputModeSelect/index.ts
@@ -1,5 +1,6 @@
 export {
   DEFAULT_NODE_OUTPUT_MODES,
+  type NodeOutputModeIcon,
   type NodeOutputModeOption,
   NodeOutputModeSelect,
   type NodeOutputModeSelectProps,

--- a/packages/apollo-react/src/canvas/controls/index.ts
+++ b/packages/apollo-react/src/canvas/controls/index.ts
@@ -1,6 +1,7 @@
 export { Breadcrumb } from './Breadcrumb';
 export {
   DEFAULT_NODE_OUTPUT_MODES,
+  type NodeOutputModeIcon,
   type NodeOutputModeOption,
   NodeOutputModeSelect,
   type NodeOutputModeSelectProps,


### PR DESCRIPTION
## Summary

`NodeOutputModeOption.icon` only accepted a `LucideIcon`. Apollo's own registry icons are plain components taking `{ w, h, color }`, so they aren't assignable to that type — which meant `file-sparkles-corner`, added in [MST-13618](https://uipath.atlassian.net/browse/MST-13618) for output mocked by generation, was unreachable from the very control whose **Simulated** mode describes that state.

The prop now also accepts a registry **name**, resolved through `CanvasIcon`, and the default Simulated mode uses it.

## ⚠️ Visible change for consumers of the default modes

The Simulated mode's icon changes from Lucide `sparkles` to `file-sparkles-corner` — the file-with-sparkle that the canvas node adornment already shows for the same state, so the dropdown and the node now read as one family.

| | Before | After |
|---|---|---|
| Live | `circle-dot` | unchanged |
| Static mock | `file-braces-corner` | unchanged |
| Simulated | `sparkles` | **`file-sparkles-corner`** |

Consumers passing their own `options` are unaffected.

## Changes

- `NodeOutputModeOption.icon` is now `NodeOutputModeIcon = LucideIcon | string`. Backward compatible: existing `LucideIcon` values still receive `size`/`className` directly.
- New internal `ModeIcon` renders either shape. Names go inside a span carrying the colour class, because registry icons ignore `className` and default to `currentColor` — handing them the class directly would silently drop `text-foreground-subtle`.
- `MODE_DEFS.simulated.icon` → `'file-sparkles-corner'`. The other two stay components, which are typo-proof; the name is used only where there is no Lucide equivalent.
- `NodeOutputModeIcon` exported from the control and the `canvas/controls` barrel.

## Why a name rather than exporting the component

A consumer that wants its mode select to match its own node indicator already has the icon *name* — it passes the same string to `CanvasIcon` everywhere else. Accepting the name lets it use one identifier for both, instead of maintaining a parallel component map that can drift from the names. (This is the concrete problem on the Flow side: it currently keeps two maps and its dropdown disagrees with its node badge.)

## Testing

- [x] `turbo run test typecheck lint --filter=@uipath/apollo-react` — 165 files / 2582 tests pass, 5 tasks successful
- [x] `biome format` / `check` clean
- [x] Tests added

Four new cases: a registry name renders in both the trigger and the dropdown row; the default Simulated mode gets the new glyph; a Lucide component still works; and the colour class reaches the glyph. The icon assertions target `svg.file-sparkles-corner-icon` specifically — a registry miss degrades to Lucide's `Box`, so this proves the glyph rendered rather than merely that nothing threw.

Checked and unaffected: `NodePropertyPanel.stories.tsx` destructures `.icon` and renders it as a component, but its modes are a local `as const` array never annotated with `NodeOutputModeOption`, so the widened union doesn't reach it. `NodeOutputModeOption` has no other consumers in the repo, and `NodeIOView` only takes the select as an opaque slot.


[MST-13618]: https://uipath.atlassian.net/browse/MST-13618?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ