### PR TITLE
feat(storybook): add Flow UX layout patterns

### DIFF
--- a/apps/storybook/.storybook/main.ts
+++ b/apps/storybook/.storybook/main.ts
@@ -34,6 +34,10 @@ const config: StorybookConfig = {
       files: '**/*.stories.@(tsx|ts|jsx|js|mdx)',
     },
     {
+      directory: '../src/patterns',
+      files: '**/*.stories.@(tsx|ts|jsx|js|mdx)',
+    },
+    {
       directory: '../src/core',
       files: '**/*.stories.@(tsx|ts|jsx|js|mdx)',
       titlePrefix: 'Apollo Core',

--- a/apps/storybook/src/patterns/LayoutPatterns.stories.tsx
+++ b/apps/storybook/src/patterns/LayoutPatterns.stories.tsx
@@ -3,7 +3,6 @@ import {
   AgentExperienceComposition,
   FullWorkbenchComposition,
   mapTemplateThemeToChat,
-  NodeInventoryComposition,
 } from '../../../../packages/apollo-react/src/canvas/stories/templates/Flow.stories';
 import { withCanvasProviders } from '../../../../packages/apollo-react/src/canvas/storybook-utils';
 
@@ -36,11 +35,6 @@ export const VariableSelect: Story = {
 export const Rule: Story = {
   name: 'UX Rule',
   render: () => <FullWorkbenchComposition rightPanelVariant="rules" />,
-};
-
-export const Nodes: Story = {
-  name: 'UX Nodes',
-  render: () => <NodeInventoryComposition />,
 };
 
 export const Dap: Story = {

--- a/apps/storybook/src/patterns/LayoutPatterns.stories.tsx
+++ b/apps/storybook/src/patterns/LayoutPatterns.stories.tsx
@@ -3,6 +3,7 @@ import {
   AgentExperienceComposition,
   FullWorkbenchComposition,
   mapTemplateThemeToChat,
+  ResponsiveWorkbenchComposition,
 } from '../../../../packages/apollo-react/src/canvas/stories/templates/Flow.stories';
 import { withCanvasProviders } from '../../../../packages/apollo-react/src/canvas/storybook-utils';
 
@@ -35,6 +36,16 @@ export const VariableSelect: Story = {
 export const Rule: Story = {
   name: 'UX Rule',
   render: () => <FullWorkbenchComposition rightPanelVariant="rules" />,
+};
+
+export const CollectionFilter: Story = {
+  name: 'UX Variable collection',
+  render: () => <FullWorkbenchComposition rightPanelVariant="collection" />,
+};
+
+export const ResponsiveBehaviors: Story = {
+  name: 'UX Responsive behaviors',
+  render: () => <ResponsiveWorkbenchComposition />,
 };
 
 export const Dap: Story = {

--- a/apps/storybook/src/patterns/LayoutPatterns.stories.tsx
+++ b/apps/storybook/src/patterns/LayoutPatterns.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useCallback, useEffect, useRef } from 'react';
 import {
   AgentExperienceComposition,
   FullWorkbenchComposition,
@@ -6,6 +7,7 @@ import {
   ResponsiveWorkbenchComposition,
 } from '../../../../packages/apollo-react/src/canvas/stories/templates/Flow.stories';
 import { withCanvasProviders } from '../../../../packages/apollo-react/src/canvas/storybook-utils';
+import variablesResearchHtml from './variables-field-guide.html?raw';
 
 const meta = {
   title: 'Apollo Wind/Patterns/Layout Patterns',
@@ -18,9 +20,67 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
+const RESEARCH_THEME_TOKENS = {
+  '--bg': '--surface',
+  '--surface': '--surface-raised',
+  '--surface-alt': '--surface-overlay',
+  '--ink': '--foreground',
+  '--ink-muted': '--foreground-muted',
+  '--ink-faint': '--foreground-subtle',
+  '--line': '--border-subtle',
+  '--line-strong': '--ap-wind-border',
+  '--accent': '--brand',
+  '--accent-ink': '--foreground-accent',
+  '--accent-soft': '--brand-subtle',
+  '--dir-in': '--info',
+  '--dir-in-soft': '--info-background',
+  '--dir-out': '--success',
+  '--dir-out-soft': '--success-background',
+  '--dir-inout': '--brand',
+  '--dir-inout-soft': '--brand-subtle',
+  '--dir-node': '--warning',
+  '--dir-node-soft': '--warning-background',
+} as const;
+
+function VariablesResearchPage() {
+  const iframeRef = useRef<HTMLIFrameElement>(null);
+
+  const syncTheme = useCallback(() => {
+    const researchRoot = iframeRef.current?.contentDocument?.documentElement;
+    if (!researchRoot) return;
+    const sourceStyles = getComputedStyle(document.body);
+    for (const [researchToken, apolloToken] of Object.entries(RESEARCH_THEME_TOKENS)) {
+      const value = sourceStyles.getPropertyValue(apolloToken).trim();
+      if (value) researchRoot.style.setProperty(researchToken, value);
+    }
+  }, []);
+
+  useEffect(() => {
+    const observer = new MutationObserver(syncTheme);
+    observer.observe(document.documentElement, { attributes: true });
+    observer.observe(document.body, { attributes: true });
+    return () => observer.disconnect();
+  }, [syncTheme]);
+
+  return (
+    <iframe
+      ref={iframeRef}
+      title="Variables research field guide"
+      srcDoc={variablesResearchHtml}
+      onLoad={syncTheme}
+      className="block h-screen w-full border-0 bg-surface"
+    />
+  );
+}
+
 export const Form: Story = {
-  name: 'UX Form',
+  name: 'UX HITL',
   render: () => <FullWorkbenchComposition rightPanelVariant="forms" />,
+};
+
+export const VariablesResearch: Story = {
+  name: 'Variables research',
+  render: () => <VariablesResearchPage />,
 };
 
 export const Variables: Story = {
@@ -31,11 +91,6 @@ export const Variables: Story = {
 export const VariableSelect: Story = {
   name: 'UX Variables select',
   render: () => <FullWorkbenchComposition rightPanelVariant="variables" />,
-};
-
-export const Rule: Story = {
-  name: 'UX Rule',
-  render: () => <FullWorkbenchComposition rightPanelVariant="rules" />,
 };
 
 export const CollectionFilter: Story = {
@@ -51,6 +106,16 @@ export const ResponsiveBehaviors: Story = {
 export const Dap: Story = {
   name: 'UX DAP',
   render: () => <FullWorkbenchComposition rightPanelVariant="dap" />,
+};
+
+export const ErrorAndValidation: Story = {
+  name: 'UX Error and Validation',
+  render: () => <FullWorkbenchComposition rightPanelVariant="validation" />,
+};
+
+export const Rule: Story = {
+  name: 'UX Rule',
+  render: () => <FullWorkbenchComposition rightPanelVariant="rules" />,
 };
 
 export const Agent: Story = {

--- a/apps/storybook/src/patterns/LayoutPatterns.stories.tsx
+++ b/apps/storybook/src/patterns/LayoutPatterns.stories.tsx
@@ -1,15 +1,14 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-
-import { withCanvasProviders } from '../../storybook-utils';
 import {
   AgentExperienceComposition,
   FullWorkbenchComposition,
   mapTemplateThemeToChat,
   NodeInventoryComposition,
-} from './Flow.stories';
+} from '../../../../packages/apollo-react/src/canvas/stories/templates/Flow.stories';
+import { withCanvasProviders } from '../../../../packages/apollo-react/src/canvas/storybook-utils';
 
 const meta = {
-  title: 'Templates/Flow Standalone',
+  title: 'Apollo Wind/Patterns/Layout Patterns',
   parameters: {
     layout: 'fullscreen',
   },
@@ -19,32 +18,37 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const WorkbenchWithForms: Story = {
+export const Form: Story = {
   name: 'UX Form',
   render: () => <FullWorkbenchComposition rightPanelVariant="forms" />,
 };
 
-export const WorkbenchWithNode: Story = {
+export const Variables: Story = {
   name: 'UX Variables',
   render: () => <FullWorkbenchComposition rightPanelVariant="node" />,
 };
 
-export const RuleBuilding: Story = {
+export const VariableSelect: Story = {
+  name: 'UX Variables select',
+  render: () => <FullWorkbenchComposition rightPanelVariant="variables" />,
+};
+
+export const Rule: Story = {
   name: 'UX Rule',
   render: () => <FullWorkbenchComposition rightPanelVariant="rules" />,
 };
 
-export const VariableManagement: Story = {
+export const Nodes: Story = {
   name: 'UX Nodes',
   render: () => <NodeInventoryComposition />,
 };
 
-export const DapUX: Story = {
+export const Dap: Story = {
   name: 'UX DAP',
   render: () => <FullWorkbenchComposition rightPanelVariant="dap" />,
 };
 
-export const AgentExperience: Story = {
+export const Agent: Story = {
   name: 'UX Agent',
   render: (_args, context) => (
     <AgentExperienceComposition theme={mapTemplateThemeToChat(context.globals.theme)} />

--- a/apps/storybook/src/patterns/NodePatterns.stories.tsx
+++ b/apps/storybook/src/patterns/NodePatterns.stories.tsx
@@ -1,0 +1,114 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { NodePatternComposition } from '../../../../packages/apollo-react/src/canvas/stories/templates/Flow.stories';
+import { withCanvasProviders } from '../../../../packages/apollo-react/src/canvas/storybook-utils';
+
+const meta = {
+  title: 'Apollo Wind/Patterns/Node Patterns',
+  parameters: { layout: 'fullscreen' },
+  decorators: [withCanvasProviders({ fullscreen: false })],
+} satisfies Meta;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const nodePattern = (nodeId: string, name: string): Story => ({
+  name,
+  render: () => <NodePatternComposition nodeId={nodeId} />,
+});
+
+export const AutonomousAgent = nodePattern('autonomous-agent', 'Agents · Autonomous agent');
+export const ConversationalAgent = nodePattern(
+  'conversational-agent',
+  'Agents · Conversational agent'
+);
+export const VoiceAgent = nodePattern('voice-agent', 'Agents · Voice agent');
+
+export const Escalation = nodePattern('escalation', 'Agent resources · Escalation');
+export const QuickFormEscalation = nodePattern(
+  'quick-form-escalation',
+  'Agent resources · Quick Form escalation'
+);
+export const ActionAppEscalation = nodePattern(
+  'action-app-escalation',
+  'Agent resources · Action App escalation'
+);
+
+export const HttpRequest = nodePattern('http-request-v2', 'Connectors · HTTP Request');
+export const SlackSendMessage = nodePattern('slack-send', 'Connectors · Send Message');
+
+export const BatchTransform = nodePattern('batch-transform', 'Data · Batch transform');
+export const Filter = nodePattern('filter', 'Data · Filter');
+export const GroupBy = nodePattern('group-by', 'Data · Group by');
+export const DataMap = nodePattern('map', 'Data · Map');
+export const Transform = nodePattern('transform', 'Data · Transform');
+export const ReadEntity = nodePattern('read-entity', 'Data · Read entity');
+export const UpdateEntity = nodePattern('update-entity', 'Data · Update entity');
+
+export const Summarize = nodePattern('summarize', 'Document · Summarize');
+export const Extract = nodePattern('extract', 'Document · Extract');
+export const Classify = nodePattern('classify', 'Document · Classify');
+export const DocumentValidation = nodePattern(
+  'document-validation',
+  'Document · Document Validation'
+);
+export const AnalyzeFiles = nodePattern('analyze-files', 'Document · Analyze Files');
+
+export const QuickForm = nodePattern('quick-form', 'Human · Quick Form');
+export const ActionApp = nodePattern('action-app', 'Human · Action App');
+export const HumanTask = nodePattern('human-task', 'Human · Human Task');
+
+export const Mock = nodePattern('mock', 'Control · Mock');
+export const Decision = nodePattern('decision', 'Control · Decision');
+export const Switch = nodePattern('switch', 'Control · Switch');
+export const Merge = nodePattern('merge', 'Control · Merge');
+export const End = nodePattern('end', 'Control · End');
+export const Terminate = nodePattern('terminate', 'Control · Terminate');
+export const DoWhile = nodePattern('do-while', 'Control · Do while');
+export const Loop = nodePattern('loop', 'Control · Loop');
+
+export const Script = nodePattern('script', 'Tool · Script');
+export const WaitForMessage = nodePattern('wait-message', 'Tool · Wait for message');
+export const GetConversationContext = nodePattern(
+  'conversation-context',
+  'Tool · Get conversation context'
+);
+export const SendMessage = nodePattern('send-message', 'Tool · Send message');
+export const CreateQueueItem = nodePattern('queue-create', 'Tool · Create queue item');
+export const CreateAndWaitForQueueItem = nodePattern(
+  'queue-create-wait',
+  'Tool · Create and wait for queue item'
+);
+export const CreateOutgoingCall = nodePattern('outgoing-call', 'Tool · Create outgoing call');
+export const EndCall = nodePattern('end-call', 'Tool · End call');
+export const ClientSideTool = nodePattern('client-side-tool', 'Tool · Client-side tool');
+
+export const ManualTrigger = nodePattern('manual-trigger', 'Triggers · Manual trigger');
+export const ScheduledTrigger = nodePattern('scheduled-trigger', 'Triggers · Scheduled trigger');
+export const SlackMessageReceived = nodePattern(
+  'slack-trigger',
+  'Triggers · Message Received in Slack'
+);
+export const HttpWebhook = nodePattern('http-webhook', 'Triggers · HTTP Webhook');
+export const IncomingCall = nodePattern('incoming-call', 'Triggers · Incoming call');
+export const ConversationTrigger = nodePattern(
+  'conversation-trigger',
+  'Triggers · Conversation trigger'
+);
+export const FormTrigger = nodePattern('form-trigger', 'Triggers · Form trigger');
+
+export const Delay = nodePattern('delay', 'Wait for event · Delay');
+export const HttpWebhookCallback = nodePattern(
+  'webhook-wait',
+  'Wait for event · HTTP Webhook callback'
+);
+export const EmailReceivedWait = nodePattern(
+  'email-wait',
+  'Wait for event · Email Received (Wait)'
+);
+
+export const Subflow = nodePattern('subflow', 'UiPath · Subflow');
+export const Flow = nodePattern('flow', 'UiPath · Flow');
+export const Bpmn = nodePattern('bpmn', 'UiPath · BPMN');
+export const Case = nodePattern('case', 'UiPath · Case');
+export const RpaWorkflow = nodePattern('rpa-workflow', 'UiPath · RPA Workflow');
+export const ApiWorkflow = nodePattern('api-workflow', 'UiPath · API Workflow');

--- a/apps/storybook/src/patterns/variables-field-guide.html
+++ b/apps/storybook/src/patterns/variables-field-guide.html
@@ -1,0 +1,937 @@
+<title>Variables Field Guide</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500;600&display=swap">
+
+<style>
+  :root {
+    --bg: #f5f6fa;
+    --surface: #ffffff;
+    --surface-alt: #ecedf4;
+    --ink: #171a23;
+    --ink-muted: #4b5165;
+    --ink-faint: #7d829a;
+    --line: #dcdee7;
+    --line-strong: #c3c6d6;
+    --accent: #0f8a82;
+    --accent-ink: #066159;
+    --accent-soft: #d9f0ed;
+
+    --dir-in: #2f6fed;
+    --dir-in-soft: #e3ecff;
+    --dir-out: #16a34a;
+    --dir-out-soft: #e0f6e8;
+    --dir-inout: #9333ea;
+    --dir-inout-soft: #f2e4fc;
+    --dir-node: #c2760a;
+    --dir-node-soft: #fbeed7;
+
+    --font-mono: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    --font-body: "Inter", -apple-system, "Segoe UI", Helvetica, Arial, sans-serif;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    :root:not([data-theme="light"]) {
+      --bg: #12131a;
+      --surface: #191b24;
+      --surface-alt: #20222d;
+      --ink: #e9eaf2;
+      --ink-muted: #a4a8bd;
+      --ink-faint: #767b93;
+      --line: #2c2f3d;
+      --line-strong: #3a3e50;
+      --accent: #33bdb2;
+      --accent-ink: #7fe0d6;
+      --accent-soft: #163431;
+
+      --dir-in: #6f97f7;
+      --dir-in-soft: #1c2740;
+      --dir-out: #4ade80;
+      --dir-out-soft: #163524;
+      --dir-inout: #c084fc;
+      --dir-inout-soft: #2c1f42;
+      --dir-node: #f0a93d;
+      --dir-node-soft: #3a2b12;
+    }
+  }
+
+  :root[data-theme="dark"] {
+    --bg: #12131a;
+    --surface: #191b24;
+    --surface-alt: #20222d;
+    --ink: #e9eaf2;
+    --ink-muted: #a4a8bd;
+    --ink-faint: #767b93;
+    --line: #2c2f3d;
+    --line-strong: #3a3e50;
+    --accent: #33bdb2;
+    --accent-ink: #7fe0d6;
+    --accent-soft: #163431;
+
+    --dir-in: #6f97f7;
+    --dir-in-soft: #1c2740;
+    --dir-out: #4ade80;
+    --dir-out-soft: #163524;
+    --dir-inout: #c084fc;
+    --dir-inout-soft: #2c1f42;
+    --dir-node: #f0a93d;
+    --dir-node-soft: #3a2b12;
+  }
+
+  * { box-sizing: border-box; }
+  html { scroll-behavior: smooth; }
+  @media (prefers-reduced-motion: reduce) {
+    html { scroll-behavior: auto; }
+    * { animation-duration: 0.01ms !important; transition-duration: 0.01ms !important; }
+  }
+
+  body {
+    margin: 0;
+    background: var(--bg);
+    color: var(--ink);
+    font-family: var(--font-body);
+    font-size: 16px;
+    line-height: 1.6;
+    -webkit-font-smoothing: antialiased;
+  }
+
+  a { color: var(--accent-ink); text-decoration: none; border-bottom: 1px solid currentColor; }
+  a:hover { opacity: 0.8; }
+  a:focus-visible, button:focus-visible, .navlink:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
+    border-radius: 3px;
+  }
+
+  code, .mono { font-family: var(--font-mono); }
+
+  .shell {
+    max-width: 1180px;
+    margin: 0 auto;
+    padding: 0 24px 96px;
+    display: grid;
+    grid-template-columns: 220px minmax(0, 1fr);
+    gap: 56px;
+  }
+  @media (max-width: 900px) {
+    .shell { grid-template-columns: 1fr; gap: 0; }
+  }
+
+  /* ---------- Masthead ---------- */
+  .masthead {
+    grid-column: 1 / -1;
+    padding: 64px 0 40px;
+    border-bottom: 1px solid var(--line);
+    margin-bottom: 8px;
+  }
+  .eyebrow {
+    font-family: var(--font-mono);
+    font-size: 12px;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: var(--accent-ink);
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    margin-bottom: 18px;
+  }
+  .eyebrow::before {
+    content: "";
+    width: 8px; height: 8px;
+    background: var(--accent);
+    border-radius: 1px;
+    display: inline-block;
+    transform: rotate(45deg);
+  }
+  h1.title {
+    font-family: var(--font-mono);
+    font-weight: 600;
+    font-size: clamp(2.6rem, 6vw, 4rem);
+    letter-spacing: -0.01em;
+    margin: 0 0 18px;
+    text-wrap: balance;
+  }
+  .dek {
+    max-width: 62ch;
+    font-size: 1.15rem;
+    color: var(--ink-muted);
+    margin: 0 0 28px;
+    text-wrap: pretty;
+  }
+  .meta-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+  }
+  .meta-chip {
+    font-family: var(--font-mono);
+    font-size: 12px;
+    color: var(--ink-muted);
+    background: var(--surface-alt);
+    border: 1px solid var(--line);
+    border-radius: 5px;
+    padding: 5px 10px;
+  }
+
+  /* ---------- Nav rail ---------- */
+  nav.rail {
+    padding-top: 48px;
+  }
+  nav.rail .rail-inner {
+    position: sticky;
+    top: 32px;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+  nav.rail .navlabel {
+    font-family: var(--font-mono);
+    font-size: 11px;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: var(--ink-faint);
+    margin-bottom: 10px;
+  }
+  .navlink {
+    font-size: 13.5px;
+    color: var(--ink-muted);
+    border-bottom: none;
+    padding: 7px 10px;
+    border-radius: 6px;
+    border-left: 2px solid transparent;
+  }
+  .navlink:hover { color: var(--ink); background: var(--surface-alt); }
+  @media (max-width: 900px) {
+    nav.rail {
+      padding-top: 24px;
+      overflow-x: auto;
+    }
+    nav.rail .rail-inner {
+      position: static;
+      flex-direction: row;
+      gap: 6px;
+      padding-bottom: 20px;
+      border-bottom: 1px solid var(--line);
+      margin-bottom: 20px;
+    }
+    nav.rail .navlabel { display: none; }
+    .navlink { white-space: nowrap; background: var(--surface-alt); }
+  }
+
+  /* ---------- Main column ---------- */
+  main { padding-top: 48px; min-width: 0; }
+  section { margin-bottom: 76px; scroll-margin-top: 24px; }
+  section:last-child { margin-bottom: 0; }
+
+  .sec-head { margin-bottom: 24px; }
+  .sec-num {
+    font-family: var(--font-mono);
+    font-size: 12px;
+    color: var(--ink-faint);
+    letter-spacing: 0.08em;
+    margin-bottom: 8px;
+    display: block;
+  }
+  h2 {
+    font-family: var(--font-mono);
+    font-weight: 600;
+    font-size: clamp(1.5rem, 3vw, 1.9rem);
+    margin: 0 0 10px;
+    text-wrap: balance;
+  }
+  .sec-intro {
+    max-width: 66ch;
+    color: var(--ink-muted);
+    font-size: 1.02rem;
+  }
+  h3 {
+    font-family: var(--font-mono);
+    font-size: 1rem;
+    font-weight: 600;
+    margin: 36px 0 12px;
+    color: var(--ink);
+  }
+  p { max-width: 68ch; }
+  p.wide { max-width: none; }
+
+  /* ---------- Direction legend ---------- */
+  .legend {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 12px;
+    margin: 18px 0 8px;
+  }
+  .legend-item {
+    display: flex;
+    gap: 12px;
+    align-items: flex-start;
+    background: var(--surface);
+    border: 1px solid var(--line);
+    border-radius: 10px;
+    padding: 14px 16px;
+  }
+  .legend-swatch {
+    width: 28px; height: 28px;
+    border-radius: 7px;
+    flex-shrink: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-family: var(--font-mono);
+    font-size: 13px;
+    font-weight: 600;
+    margin-top: 1px;
+  }
+  .legend-swatch.in { background: var(--dir-in-soft); color: var(--dir-in); }
+  .legend-swatch.out { background: var(--dir-out-soft); color: var(--dir-out); }
+  .legend-swatch.inout { background: var(--dir-inout-soft); color: var(--dir-inout); }
+  .legend-swatch.node { background: var(--dir-node-soft); color: var(--dir-node); }
+  .legend-body .legend-title {
+    font-family: var(--font-mono);
+    font-size: 13.5px;
+    font-weight: 600;
+    margin-bottom: 3px;
+  }
+  .legend-body .legend-title .direction-tag.in { color: var(--dir-in); }
+  .legend-body .legend-title .direction-tag.out { color: var(--dir-out); }
+  .legend-body .legend-title .direction-tag.inout { color: var(--dir-inout); }
+  .legend-body .legend-title .direction-tag.node { color: var(--dir-node); }
+  .legend-body p { margin: 0; font-size: 13.5px; color: var(--ink-muted); max-width: none; }
+
+  /* ---------- Data model table ---------- */
+  .table-wrap { overflow-x: auto; border: 1px solid var(--line); border-radius: 10px; margin: 18px 0; }
+  table { width: 100%; border-collapse: collapse; font-size: 14px; background: var(--surface); }
+  th, td { text-align: left; padding: 11px 14px; border-bottom: 1px solid var(--line); vertical-align: top; }
+  th {
+    font-family: var(--font-mono);
+    font-size: 11px;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--ink-faint);
+    background: var(--surface-alt);
+    white-space: nowrap;
+  }
+  tr:last-child td { border-bottom: none; }
+  td .fieldname { font-family: var(--font-mono); font-size: 13px; color: var(--accent-ink); font-weight: 500; }
+  td.muted { color: var(--ink-muted); }
+
+  /* ---------- Card grid (touchpoint map) ---------- */
+  .group-label {
+    font-family: var(--font-mono);
+    font-size: 12px;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--accent-ink);
+    margin: 32px 0 14px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+  }
+  .group-label:first-of-type { margin-top: 20px; }
+  .group-label::after { content: ""; flex: 1; height: 1px; background: var(--line); }
+
+  .card-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 12px;
+  }
+  .touch-card {
+    background: var(--surface);
+    border: 1px solid var(--line);
+    border-radius: 10px;
+    padding: 16px 18px;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+  .touch-card .comp {
+    font-family: var(--font-mono);
+    font-size: 13.5px;
+    font-weight: 600;
+    color: var(--ink);
+  }
+  .touch-card .trigger {
+    font-family: var(--font-mono);
+    font-size: 11px;
+    color: var(--accent-ink);
+    background: var(--accent-soft);
+    display: inline-block;
+    padding: 2px 7px;
+    border-radius: 4px;
+    align-self: flex-start;
+  }
+  .touch-card p { margin: 0; font-size: 13.5px; color: var(--ink-muted); max-width: none; }
+
+  /* ---------- User paths ---------- */
+  .path-list { display: flex; flex-direction: column; gap: 16px; margin-top: 24px; }
+  .path-card {
+    background: var(--surface);
+    border: 1px solid var(--line);
+    border-radius: 12px;
+    padding: 18px;
+  }
+  .path-header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 16px;
+    margin-bottom: 16px;
+  }
+  .path-title { font-family: var(--font-mono); font-size: 14px; font-weight: 600; }
+  .path-intent { margin-top: 3px; color: var(--ink-muted); font-size: 13px; }
+  .path-badge {
+    flex-shrink: 0;
+    border-radius: 999px;
+    background: var(--accent-soft);
+    color: var(--accent-ink);
+    padding: 3px 9px;
+    font-family: var(--font-mono);
+    font-size: 10px;
+    font-weight: 600;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+  }
+  .path-steps {
+    display: flex;
+    align-items: stretch;
+    gap: 8px;
+    overflow-x: auto;
+    padding-bottom: 4px;
+  }
+  .path-step {
+    position: relative;
+    min-width: 132px;
+    flex: 1 0 132px;
+    border-radius: 9px;
+    background: var(--surface-alt);
+    border: 1px solid var(--line);
+    padding: 11px 12px;
+  }
+  .path-step:not(:last-child)::after {
+    content: ">";
+    position: absolute;
+    right: -8px;
+    top: 50%;
+    z-index: 2;
+    width: 15px;
+    height: 20px;
+    display: grid;
+    place-items: center;
+    transform: translateY(-50%);
+    border-radius: 999px;
+    background: var(--surface);
+    color: var(--ink-faint);
+    font-family: var(--font-mono);
+    font-size: 11px;
+    font-weight: 600;
+  }
+  .path-step-num {
+    display: block;
+    margin-bottom: 5px;
+    color: var(--accent-ink);
+    font-family: var(--font-mono);
+    font-size: 10px;
+  }
+  .path-step strong { display: block; font-size: 12.5px; line-height: 1.35; }
+  .path-step span:last-child {
+    display: block;
+    margin-top: 4px;
+    color: var(--ink-muted);
+    font-size: 11.5px;
+    line-height: 1.4;
+  }
+  .path-question {
+    margin: 14px 0 0;
+    border-left: 2px solid var(--accent);
+    padding-left: 10px;
+    color: var(--ink-muted);
+    font-size: 12.5px;
+    font-style: italic;
+  }
+
+  /* ---------- Panel anatomy ---------- */
+  .anatomy {
+    border: 1px solid var(--line);
+    border-radius: 12px;
+    overflow: hidden;
+    background: var(--surface);
+    margin: 20px 0;
+  }
+  .anatomy-row {
+    display: grid;
+    grid-template-columns: 190px minmax(0,1fr);
+    border-bottom: 1px solid var(--line);
+  }
+  .anatomy-row:last-child { border-bottom: none; }
+  .anatomy-tag {
+    font-family: var(--font-mono);
+    font-size: 12px;
+    color: var(--accent-ink);
+    background: var(--surface-alt);
+    padding: 14px 16px;
+    border-right: 1px solid var(--line);
+  }
+  .anatomy-desc { padding: 14px 18px; font-size: 13.75px; color: var(--ink-muted); }
+  .anatomy-desc strong { color: var(--ink); font-weight: 600; }
+  @media (max-width: 640px) {
+    .anatomy-row { grid-template-columns: 1fr; }
+    .anatomy-tag { border-right: none; border-bottom: 1px solid var(--line); }
+  }
+
+  /* ---------- Callout (in-flight redesign) ---------- */
+  .callout {
+    border: 1px solid var(--accent);
+    background: var(--accent-soft);
+    border-radius: 12px;
+    padding: 22px 24px;
+    margin: 22px 0;
+  }
+  .callout-label {
+    font-family: var(--font-mono);
+    font-size: 11px;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--accent-ink);
+    margin-bottom: 10px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+  .callout-label .pulse {
+    width: 6px; height: 6px; border-radius: 50%;
+    background: var(--accent);
+    box-shadow: 0 0 0 3px var(--accent-soft);
+  }
+  .callout p { max-width: none; color: var(--ink); font-size: 14.5px; }
+  .callout ul { margin: 10px 0 0; padding-left: 20px; }
+  .callout li { margin-bottom: 8px; font-size: 14.5px; }
+  .callout code { font-size: 13px; background: var(--surface); padding: 1px 5px; border-radius: 4px; border: 1px solid var(--line); }
+
+  /* ---------- Threads (numbered prompts) ---------- */
+  .thread-list { display: flex; flex-direction: column; gap: 16px; margin-top: 18px; }
+  .thread {
+    display: grid;
+    grid-template-columns: 40px minmax(0,1fr);
+    gap: 16px;
+    padding: 16px 0;
+    border-top: 1px solid var(--line);
+  }
+  .thread:first-child { border-top: none; padding-top: 0; }
+  .thread-num {
+    font-family: var(--font-mono);
+    font-size: 13px;
+    color: var(--ink-faint);
+    padding-top: 2px;
+  }
+  .thread-body p { margin: 0; max-width: 62ch; font-size: 14.5px; }
+  .thread-body .thread-title { font-weight: 600; margin-bottom: 4px; display: block; font-size: 15px; }
+
+  /* ---------- Source map ---------- */
+  .src-table td .path { font-family: var(--font-mono); font-size: 12.5px; color: var(--ink); word-break: break-all; }
+  .src-table td .role { font-size: 13px; }
+
+  footer {
+    grid-column: 1 / -1;
+    margin-top: 40px;
+    padding-top: 24px;
+    border-top: 1px solid var(--line);
+    font-size: 12.5px;
+    color: var(--ink-faint);
+    font-family: var(--font-mono);
+  }
+</style>
+
+<div class="shell">
+  <header class="masthead">
+    <div class="eyebrow">Research brief — canvas package</div>
+    <h1 class="title">Variables</h1>
+    <p class="dek">What a "variable" actually means in the flow editor, every place a builder currently runs into one, and how each of those places renders it today — compiled as raw material for concepting, not a proposal.</p>
+    <div class="meta-row">
+      <span class="meta-chip">scope: @flow/canvas</span>
+      <span class="meta-chip">branch: codex/MST-11724</span>
+      <span class="meta-chip">compiled 2026-08-26</span>
+    </div>
+  </header>
+
+  <nav class="rail">
+    <div class="rail-inner">
+      <span class="navlabel">Contents</span>
+      <a class="navlink" href="#model">01 · The mental model</a>
+      <a class="navlink" href="#touchpoints">02 · Where people touch them</a>
+      <a class="navlink" href="#paths">03 · User paths</a>
+      <a class="navlink" href="#presentation">04 · How they're shown today</a>
+      <a class="navlink" href="#inflight">05 · Live in this branch</a>
+      <a class="navlink" href="#threads">06 · Threads worth pulling</a>
+      <a class="navlink" href="#sourcemap">07 · Source map</a>
+    </div>
+  </nav>
+
+  <main>
+
+    <section id="model">
+      <div class="sec-head">
+        <span class="sec-num">01</span>
+        <h2>The mental model</h2>
+        <p class="sec-intro">"Variable" is an umbrella over four genuinely different things. They share one storage shape and one reference syntax, but a builder meets them under different names, in different places, created by different actors.</p>
+      </div>
+
+      <div class="legend">
+        <div class="legend-item">
+          <div class="legend-swatch in">↓</div>
+          <div class="legend-body">
+            <div class="legend-title"><span class="direction-tag in">in</span> — Input</div>
+            <p>Data the caller provides when the workflow starts. Grouped under whichever trigger node it belongs to; a connector trigger's inputs come pre-shaped from its manifest and can't be edited.</p>
+          </div>
+        </div>
+        <div class="legend-item">
+          <div class="legend-swatch out">↑</div>
+          <div class="legend-body">
+            <div class="legend-title"><span class="direction-tag out">out</span> — Output</div>
+            <p>Data the workflow hands back on completion. Declared once at the workflow boundary; its value is whatever the author wires to it, or a literal default.</p>
+          </div>
+        </div>
+        <div class="legend-item">
+          <div class="legend-swatch inout">⛁</div>
+          <div class="legend-body">
+            <div class="legend-title"><span class="direction-tag inout">inout</span> — Variable (state)</div>
+            <p>Internal, mutable, lives for the run. The only kind a node can write to mid-flow, via a per-node list of "variable updates" — an id plus an expression.</p>
+          </div>
+        </div>
+        <div class="legend-item">
+          <div class="legend-swatch node">▢</div>
+          <div class="legend-body">
+            <div class="legend-title"><span class="direction-tag node">node output</span> — informal</div>
+            <p>Not declared by the author at all — it's whatever a node's own output definition says it produces. Becomes referenceable the moment the node exists; this is the largest category in most real workflows.</p>
+          </div>
+        </div>
+      </div>
+
+      <h3>Storage shape — <code>WorkflowVariable</code></h3>
+      <p>Every declared variable (in / out / inout — not node outputs, which come from the node's own manifest) is the same Zod shape, defined once in <code>flow-schema</code>:</p>
+      <div class="table-wrap">
+        <table>
+          <thead><tr><th>field</th><th>purpose</th></tr></thead>
+          <tbody>
+            <tr><td><span class="fieldname">id</span></td><td>Unique identifier, referenced in expressions as <code>$vars.{id}</code>.</td></tr>
+            <tr><td><span class="fieldname">direction</span></td><td><code>'in' | 'out' | 'inout'</code> — see legend above.</td></tr>
+            <tr><td><span class="fieldname">type</span></td><td>String tag — <code>string</code> / <code>number</code> / <code>boolean</code> / <code>object</code> / <code>array</code> / <code>file</code>.</td></tr>
+            <tr><td><span class="fieldname">subType</span></td><td>Optional refinement (e.g. array item type).</td></tr>
+            <tr><td><span class="fieldname">schema</span></td><td>Full JSON Schema for <code>object</code>/<code>array</code> — authored via the visual Schema panel or a raw JSON toggle.</td></tr>
+            <tr><td><span class="fieldname">defaultValue</span></td><td>Only meaningful for <code>in</code> and <code>inout</code>.</td></tr>
+            <tr><td><span class="fieldname">description</span></td><td>Free text — doubles as intellisense hint text and (for agent outputs) as guidance to the model.</td></tr>
+            <tr><td><span class="fieldname">triggerNodeId</span></td><td>Present only on root-level <code>in</code> variables — ties an input to the specific trigger node it belongs to.</td></tr>
+          </tbody>
+        </table>
+      </div>
+
+      <h3>Scoping is graph-shaped, not text-ordered</h3>
+      <p class="wide">What's "available" at a node is computed fresh from the graph every time — <code>getUpstreamNodes</code> walks backward through edges (skipping loop-terminal edges so a loop body can't see its own future iteration), then <code>getAvailableVariables</code> collects every upstream node's outputs. Consequences a builder feels but rarely sees explained: a container (loop) node creates a nested scope — sibling loops at the same level can't see each other's variables, but a loop nested inside another loop still sees the parent loop's; a gateway's synthetic branch outputs are suppressed from every node except the one they were generated for; an <code>error</code> output only enters scope once a real edge is drawn from that node's error handle.</p>
+
+      <h3>Two adjacent concepts that are <em>not</em> <code>WorkflowVariable</code></h3>
+      <p class="wide"><strong>Environment variables</strong> are project-scoped, not workflow-scoped — a flat key/value set for coded agents, backed by an <code>EnvironmentVariablesService</code> that the VS Code host swaps for a real on-disk <code>.env</code> file. <strong>File-type variables</strong> aren't a distinct direction, but every file variable gets a canonical shape silently backfilled (<code>{ ID, FullName, MimeType, Metadata }</code>) so its tree row renders consistently no matter where it was declared.</p>
+    </section>
+
+    <section id="touchpoints">
+      <div class="sec-head">
+        <span class="sec-num">02</span>
+        <h2>Where people actually touch them</h2>
+        <p class="sec-intro">Thirteen distinct surfaces, none of which is "the" variables feature — a builder assembles their understanding out of whichever ones they happen to hit.</p>
+      </div>
+
+      <div class="group-label">Declare &amp; manage</div>
+      <div class="card-grid">
+        <div class="touch-card">
+          <span class="comp">Variables panel</span>
+          <span class="trigger">docked panel, always mounted</span>
+          <p>The one place that lists everything at once — inputs by trigger, outputs, state variables, then one collapsible group per node that produces output. A "Selected node" toggle scopes the whole list down to what that node can actually see.</p>
+        </div>
+        <div class="touch-card">
+          <span class="comp">Add / edit variable dialog</span>
+          <span class="trigger">"+" on any section header</span>
+          <p>Name, type, description, a type-appropriate default-value field, and — for object/array — a visual schema builder or raw JSON toggle.</p>
+        </div>
+        <div class="touch-card">
+          <span class="comp">Rename dialog</span>
+          <span class="trigger">pencil icon next to a locked ID</span>
+          <p>Renaming is gated behind its own dialog because it has to rewrite every expression that references the old id — the dialog surfaces a live reference count before you commit.</p>
+        </div>
+        <div class="touch-card">
+          <span class="comp">Schema panel</span>
+          <span class="trigger">"Define schema" on an object/array variable</span>
+          <p>Simple/Advanced JSON Schema editor, shared with node input/output definitions — not variable-specific, but variables are one of its biggest consumers.</p>
+        </div>
+      </div>
+
+      <div class="group-label">Reference in an expression</div>
+      <div class="card-grid">
+        <div class="touch-card">
+          <span class="comp">Variable picker</span>
+          <span class="trigger">type <code class="mono">$</code> in any code field</span>
+          <p>Virtualized, keyboard-navigable tree grouped by prefix — <code>$vars</code> starts open, <code>$self</code> and <code>$metadata</code> start collapsed. Filtering force-expands whatever still matches. Data Fabric live references carry a <strong>LIVE QUERY</strong> badge with a tooltip summarizing the entity + query behind it.</p>
+        </div>
+        <div class="touch-card">
+          <span class="comp">Prompt editor</span>
+          <span class="trigger">Lexical-based, agent prompt fields</span>
+          <p>Variables render as pills inline in the prompt text rather than raw <code>$vars.x</code> strings — its own plugin model, not interchangeable with the CodeMirror/Monaco fields used elsewhere.</p>
+        </div>
+        <div class="touch-card">
+          <span class="comp">Code editor variable highlighting</span>
+          <span class="trigger">ambient, while typing</span>
+          <p>A CodeMirror decoration plugin colors <code>$vars.x</code> tokens distinctly from surrounding script — the only place a variable reference gets a visual identity outside the picker itself.</p>
+        </div>
+      </div>
+
+      <div class="group-label">Assign a value</div>
+      <div class="card-grid">
+        <div class="touch-card">
+          <span class="comp">Variable update editor</span>
+          <span class="trigger">on a node, one row per assignment</span>
+          <p>The only place a node writes to state. Pick an existing <code>inout</code> variable or create one inline; the expression field defaults to a type-appropriate stub (<code>0</code>, <code>[]</code>, <code>true</code>...) so it opens already in the right mode.</p>
+        </div>
+        <div class="touch-card">
+          <span class="comp">Output default-value field</span>
+          <span class="trigger">inside the add/edit dialog, direction = out</span>
+          <p>A workflow output's fallback value when nothing else maps to it — type-switches its own input control (text / number / switch / JSON textarea).</p>
+        </div>
+      </div>
+
+      <div class="group-label">Configure a node's own I/O</div>
+      <div class="card-grid">
+        <div class="touch-card">
+          <span class="comp">Output variables editor</span>
+          <span class="trigger">agent / subflow node properties</span>
+          <p>Edits a node's own <code>outputs</code> definition — reuses the same add/edit dialog, with an extra "Required" switch for agent outputs (round-trips into <code>outputSchema.required[]</code>).</p>
+        </div>
+        <div class="touch-card">
+          <span class="comp">Subflow input / output editor</span>
+          <span class="trigger">on the subflow node, from the parent level</span>
+          <p>Renders in the parent's properties panel but writes into the child level it drills into — a deliberate break of the usual one-form-one-level rule.</p>
+        </div>
+        <div class="touch-card">
+          <span class="comp">HITL variable remapping</span>
+          <span class="trigger">human-in-the-loop task debug</span>
+          <p>Lets a reviewer re-point a task's inputs to different variables at debug time, without editing the node.</p>
+        </div>
+      </div>
+
+      <div class="group-label">Adjacent surfaces</div>
+      <div class="card-grid">
+        <div class="touch-card">
+          <span class="comp">Input variables dialog</span>
+          <span class="trigger">just before starting a debug run</span>
+          <p>One field per entry-point input, including file upload — uploads happen out of band and the dialog only ever holds a reference to the result, never the file bytes.</p>
+        </div>
+        <div class="touch-card">
+          <span class="comp">Environment variables editor</span>
+          <span class="trigger">coded-agent project settings</span>
+          <p>Flat key/value list, deliberately outside the workflow-variable system described above.</p>
+        </div>
+      </div>
+    </section>
+
+    <section id="paths">
+      <div class="sec-head">
+        <span class="sec-num">03</span>
+        <h2>User paths through variables</h2>
+        <p class="sec-intro">Concrete journeys from intent to outcome. Each path highlights the surfaces a builder crosses and the design question that transition creates.</p>
+      </div>
+
+      <div class="path-list">
+        <article class="path-card">
+          <div class="path-header">
+            <div><div class="path-title">Use an existing value</div><div class="path-intent">“I need data from an earlier step in this field.”</div></div>
+            <span class="path-badge">reference</span>
+          </div>
+          <div class="path-steps">
+            <div class="path-step"><span class="path-step-num">01</span><strong>Open workflow</strong><span>Enter the canvas editor.</span></div>
+            <div class="path-step"><span class="path-step-num">02</span><strong>Select a node</strong><span>Open its properties.</span></div>
+            <div class="path-step"><span class="path-step-num">03</span><strong>Choose a field</strong><span>Fixed value or expression?</span></div>
+            <div class="path-step"><span class="path-step-num">04</span><strong>Insert variable</strong><span>Open the scoped picker.</span></div>
+            <div class="path-step"><span class="path-step-num">05</span><strong>Find upstream data</strong><span>Browse or search by meaning.</span></div>
+            <div class="path-step"><span class="path-step-num">06</span><strong>Insert and verify</strong><span>See a token and resolved type.</span></div>
+          </div>
+          <p class="path-question">Design question: can users understand why some values are available here—and why others are not—without learning the graph-scoping model?</p>
+        </article>
+
+        <article class="path-card">
+          <div class="path-header">
+            <div><div class="path-title">Create reusable workflow state</div><div class="path-intent">“I need to save this value and use it later.”</div></div>
+            <span class="path-badge">create</span>
+          </div>
+          <div class="path-steps">
+            <div class="path-step"><span class="path-step-num">01</span><strong>Open workflow</strong><span>Enter the canvas editor.</span></div>
+            <div class="path-step"><span class="path-step-num">02</span><strong>Open Variables</strong><span>Use the left sidebar.</span></div>
+            <div class="path-step"><span class="path-step-num">03</span><strong>Add variable</strong><span>Choose state direction.</span></div>
+            <div class="path-step"><span class="path-step-num">04</span><strong>Define it</strong><span>Name, type, description, default.</span></div>
+            <div class="path-step"><span class="path-step-num">05</span><strong>Save</strong><span>Confirm its reference path.</span></div>
+            <div class="path-step"><span class="path-step-num">06</span><strong>Use in a node</strong><span>Find it through Insert variable.</span></div>
+          </div>
+          <p class="path-question">Design question: should creation begin in the Variables panel, or happen inline at the moment the user realizes they need persistent state?</p>
+        </article>
+
+        <article class="path-card">
+          <div class="path-header">
+            <div><div class="path-title">Change a variable when a node runs</div><div class="path-intent">“When this step completes, update workflow state.”</div></div>
+            <span class="path-badge">assign</span>
+          </div>
+          <div class="path-steps">
+            <div class="path-step"><span class="path-step-num">01</span><strong>Select a node</strong><span>Open its combined panel.</span></div>
+            <div class="path-step"><span class="path-step-num">02</span><strong>Find Changes</strong><span>Locate run-time assignments.</span></div>
+            <div class="path-step"><span class="path-step-num">03</span><strong>Choose a variable</strong><span>Only writable state appears.</span></div>
+            <div class="path-step"><span class="path-step-num">04</span><strong>Set expression</strong><span>Map output or enter a value.</span></div>
+            <div class="path-step"><span class="path-step-num">05</span><strong>Add more changes</strong><span>Review assignment order.</span></div>
+            <div class="path-step"><span class="path-step-num">06</span><strong>Run and inspect</strong><span>Confirm the resulting state.</span></div>
+          </div>
+          <p class="path-question">Design question: how clearly do we distinguish “read this variable” from “write to this variable” when both use similar field controls?</p>
+        </article>
+
+        <article class="path-card">
+          <div class="path-header">
+            <div><div class="path-title">Debug an unexpected value</div><div class="path-intent">“This node received the wrong data. Where did it come from?”</div></div>
+            <span class="path-badge">trace</span>
+          </div>
+          <div class="path-steps">
+            <div class="path-step"><span class="path-step-num">01</span><strong>Run workflow</strong><span>Observe a failed result.</span></div>
+            <div class="path-step"><span class="path-step-num">02</span><strong>Select the node</strong><span>Inspect parameters and outputs.</span></div>
+            <div class="path-step"><span class="path-step-num">03</span><strong>Open Variables</strong><span>Scope the tree to this node.</span></div>
+            <div class="path-step"><span class="path-step-num">04</span><strong>Trace the reference</strong><span>Find producer and writers.</span></div>
+            <div class="path-step"><span class="path-step-num">05</span><strong>Inspect runtime value</strong><span>Compare expected and actual.</span></div>
+            <div class="path-step"><span class="path-step-num">06</span><strong>Correct and rerun</strong><span>Edit the binding or assignment.</span></div>
+          </div>
+          <p class="path-question">Design question: can the product reveal lineage—who produced or last changed a value—without making users manually inspect every node?</p>
+        </article>
+      </div>
+    </section>
+
+    <section id="presentation">
+      <div class="sec-head">
+        <span class="sec-num">04</span>
+        <h2>How they're shown today</h2>
+        <p class="sec-intro">The panel is one component doing five jobs — filter, browse, disambiguate scope, create, and mutate — stacked in a fixed vertical order.</p>
+      </div>
+
+      <h3>Panel anatomy, top to bottom</h3>
+      <div class="anatomy">
+        <div class="anatomy-row">
+          <div class="anatomy-tag">header</div>
+          <div class="anatomy-desc">Either <strong>"Variables"</strong> or, when scoped, <strong>"Scope: {node label}"</strong> — plus the <strong>Selected node</strong> switch that toggles scoping on.</div>
+        </div>
+        <div class="anatomy-row">
+          <div class="anatomy-tag">search</div>
+          <div class="anatomy-desc">Free-text filter across id, name, type, and description — matches force sections and trigger sub-groups open and re-derive every count shown next to a header.</div>
+        </div>
+        <div class="anatomy-row">
+          <div class="anatomy-tag">Inputs</div>
+          <div class="anatomy-desc">Sub-grouped one level deeper, per trigger node — each trigger shows its own icon, label, and node id, with a nested tree for its input shape.</div>
+        </div>
+        <div class="anatomy-row">
+          <div class="anatomy-tag">Outputs</div>
+          <div class="anatomy-desc">Flat list of workflow-level <code>out</code> variables. Always rendered, even empty, so the "+" stays reachable.</div>
+        </div>
+        <div class="anatomy-row">
+          <div class="anatomy-tag">Variables</div>
+          <div class="anatomy-desc">Flat list of <code>inout</code> state variables. Same always-visible treatment.</div>
+        </div>
+        <div class="anatomy-row">
+          <div class="anatomy-tag">per-node groups</div>
+          <div class="anatomy-desc">One collapsible section per node that produces output — icon and label pulled live from the canvas, with a "focus" action that pans/zooms the canvas to that node and selects it.</div>
+        </div>
+      </div>
+
+      <h3>Row anatomy</h3>
+      <p class="wide">Every row shares one primitive (<code>VariableItem</code> / <code>VariableTreeRow</code>): a chevron if it has children, left-padding keyed to nesting depth, the value's type badge, and — only on hover — edit/delete actions so the resting state stays quiet. Object and array variables expand into a recursive schema tree in place, rather than opening a second surface.</p>
+
+      <h3>Add/edit dialog</h3>
+      <p class="wide">Name field validates against an identifier pattern live, with a same-tick check against every existing node id and variable id (collisions are illegal, not just discouraged). The instant the name is valid, a hint line appears showing exactly how it'll resolve in an expression — <code>$vars.name</code> for a plain global, <code>$vars.{node}.output.{name}</code> for anything tied to a trigger or an output node. Changing the data type resets the default value and — for anything other than object/array — silently drops any schema that had been drawn, so the dialog can never save a type/schema mismatch.</p>
+    </section>
+
+    <section id="inflight">
+      <div class="sec-head">
+        <span class="sec-num">05</span>
+        <h2>Live in this branch, right now</h2>
+        <p class="sec-intro">Worth knowing before sketching anything new: this exact area is mid-rework, uncommitted, on this branch.</p>
+      </div>
+
+      <div class="callout">
+        <div class="callout-label"><span class="pulse"></span>uncommitted working-tree changes</div>
+        <p>The team's own next move is already sitting in the working tree — a real signal of where their thinking is headed, not a hypothetical:</p>
+        <ul>
+          <li><strong>The separate "Variables" tab is gone.</strong> It no longer sits beside Properties as its own tab or its own dockable panel — <code>VariablesPanel</code> now renders stacked directly beneath <code>PropertiesPanel</code> inside one scrolling column, divided by a plain border.</li>
+          <li><strong>A new "Changes when this node runs" block</strong> appears above the variables list whenever exactly one node is selected — the <code>VariableUpdateEditor</code> is now generic and always available there, replacing the old approach of registering it per node-type as a form contributor (the <code>update-variable</code> contributor was just removed from the registry).</li>
+          <li><strong>Search was just added</strong> to the panel itself — a plain text input filtering ids, names, types, and descriptions across every section at once, with per-section counts updating live to match.</li>
+        </ul>
+      </div>
+    </section>
+
+    <section id="threads">
+      <div class="sec-head">
+        <span class="sec-num">06</span>
+        <h2>Threads worth pulling</h2>
+        <p class="sec-intro">Observations, not recommendations — things that stood out while mapping the above that seem worth interrogating during concepting.</p>
+      </div>
+
+      <div class="thread-list">
+        <div class="thread">
+          <span class="thread-num">01</span>
+          <div class="thread-body">
+            <span class="thread-title">One list, four mental models.</span>
+            <p>Declared inputs, declared outputs, internal state, and node-produced values all live in the same flat panel today, distinguished only by section and a small color-coded icon. As workflows lean more agentic — more nodes producing more of their own outputs — that fourth, undeclared category keeps growing while the other three stay roughly fixed in size.</p>
+          </div>
+        </div>
+        <div class="thread">
+          <span class="thread-num">02</span>
+          <div class="thread-body">
+            <span class="thread-title">The reference syntax is the interface.</span>
+            <p><code>$vars.x</code> shows up as the literal hint text in the add dialog, the placeholder text in the update editor, and the label in the picker. It's precise, but it's also implementation vocabulary surfacing everywhere a less technical builder looks for help.</p>
+          </div>
+        </div>
+        <div class="thread">
+          <span class="thread-num">03</span>
+          <div class="thread-body">
+            <span class="thread-title">No trace of "who wrote this last."</span>
+            <p>A state variable can be updated by any number of nodes scattered across the graph. Nothing in the panel today answers "which nodes write to this one" — you'd have to open every node's properties and check its update list individually.</p>
+          </div>
+        </div>
+        <div class="thread">
+          <span class="thread-num">04</span>
+          <div class="thread-body">
+            <span class="thread-title">Three editors, one underlying shape.</span>
+            <p>Workflow inputs, trigger inputs, and subflow inputs are all the same <code>WorkflowVariable</code> with <code>direction: 'in'</code>, but a builder meets them through three differently-shaped editors depending on which boundary they're standing at.</p>
+          </div>
+        </div>
+        <div class="thread">
+          <span class="thread-num">05</span>
+          <div class="thread-body">
+            <span class="thread-title">Scale has no story yet.</span>
+            <p>The picker is virtualized because expression-time lookups can get long; the panel itself is not — every section renders in full. Search just landed as a first answer, but a workflow with a few hundred variables would still be a very long scroll.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section id="sourcemap">
+      <div class="sec-head">
+        <span class="sec-num">07</span>
+        <h2>Source map</h2>
+        <p class="sec-intro">For anyone who wants to go straight to the code.</p>
+      </div>
+      <div class="table-wrap src-table">
+        <table>
+          <thead><tr><th>path</th><th>what's there</th></tr></thead>
+          <tbody>
+            <tr><td><span class="path">packages/flow-schema/src/workflow-core.ts</span></td><td class="role">Canonical <code>workflowVariableSchema</code> + variable-update schema.</td></tr>
+            <tr><td><span class="path">packages/canvas/src/components/variables-panel/</span></td><td class="role">The panel itself, plus the add/edit/rename dialogs, tree rows, and pure helpers (<code>save-variable.ts</code>, <code>variable-helpers.ts</code>).</td></tr>
+            <tr><td><span class="path">packages/canvas/src/components/properties-panel/VariableUpdateEditor.tsx</span></td><td class="role">The "Set Variable" list editor for a single node.</td></tr>
+            <tr><td><span class="path">packages/canvas/src/components/properties-panel/VariablePicker.tsx</span></td><td class="role">The <code>$</code>-triggered autocomplete tree.</td></tr>
+            <tr><td><span class="path">packages/canvas/src/services/ScopeService.ts</span></td><td class="role"><code>getUpstreamNodes</code>, <code>getAvailableVariables</code>, <code>getNodeOutputVariables</code> — the scoping engine.</td></tr>
+            <tr><td><span class="path">packages/canvas/src/context/VariablesContext.tsx</span></td><td class="role">Enrichment + the hooks (<code>useWritableVariables</code>, <code>useNodeVariableUpdates</code>, …) that everything above reads from.</td></tr>
+            <tr><td><span class="path">packages/canvas/src/components/hierarchical-canvas/panel-layout/</span></td><td class="role">Where the panel gets docked/seeded — currently mid-change, see §04.</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+
+  </main>
+
+  <footer>compiled from repo state on codex/MST-11724 — 2026-08-26 — for internal concepting use</footer>
+</div>

--- a/apps/storybook/src/raw-html.d.ts
+++ b/apps/storybook/src/raw-html.d.ts
@@ -1,0 +1,4 @@
+declare module '*.html?raw' {
+  const source: string;
+  export default source;
+}

--- a/packages/apollo-react/src/canvas/components/HierarchicalCanvas/HierarchicalCanvas.tsx
+++ b/packages/apollo-react/src/canvas/components/HierarchicalCanvas/HierarchicalCanvas.tsx
@@ -50,7 +50,8 @@ import {
 import { viewportManager } from '../../stores/viewportManager';
 import { DefaultCanvasTranslations } from '../../types';
 import type { CanvasLevel } from '../../types/canvas.types';
-import { type CanvasHandleActionEvent, isContainerNodeManifest } from '../../utils';
+import type { CanvasHandleActionEvent } from '../../utils/CanvasEventBus';
+import { isContainerNodeManifest } from '../../utils/container';
 import { isPreviewEdge } from '../../utils/createPreviewNode';
 import { CanvasIcon } from '../../utils/icon-registry';
 import { prefersReducedMotion } from '../../utils/transitions';
@@ -58,7 +59,7 @@ import { AddNodeManager } from '../AddNodePanel/AddNodeManager';
 import { AddNodePreview } from '../AddNodePanel/AddNodePreview';
 import { createAddNodePreview } from '../AddNodePanel/createAddNodePreview';
 import { BaseCanvas, type BaseCanvasRef } from '../BaseCanvas';
-import { BaseNode } from '../BaseNode';
+import { BaseNode } from '../BaseNode/BaseNode';
 import { BlankCanvasNode } from '../BlankCanvasNode';
 import { CanvasPositionControls } from '../CanvasPositionControls';
 import { LoopCanvasNode } from '../LoopNode';

--- a/packages/apollo-react/src/canvas/components/TriggerNode/TriggerNode.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/TriggerNode/TriggerNode.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { CanvasIcon } from '@uipath/apollo-react/canvas';
 import type {
   Connection,
   Edge,
@@ -12,7 +13,6 @@ import {
   applyNodeChanges,
   ReactFlowProvider,
 } from '@uipath/apollo-react/canvas/xyflow/react';
-import { CanvasIcon } from '@uipath/apollo-react/canvas';
 import { useCallback, useState } from 'react';
 import { BaseCanvas } from '../BaseCanvas';
 import { TriggerNode } from './TriggerNode';
@@ -222,4 +222,113 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
   render: () => <TriggerNodeStory />,
+};
+
+const DefaultEntryPointStory = () => {
+  const [nodes, setNodes] = useState<Node[]>([
+    {
+      id: 'manual-trigger',
+      type: 'trigger',
+      position: { x: 96, y: 144 },
+      width: 96,
+      height: 96,
+      data: {
+        details: {
+          tooltip: 'Manual trigger',
+          icon: <CanvasIcon icon="mouse-pointer-click" size={28} />,
+        },
+      },
+    },
+    {
+      id: 'schedule-trigger',
+      type: 'trigger',
+      position: { x: 288, y: 144 },
+      width: 96,
+      height: 96,
+      data: {
+        details: {
+          tooltip: 'Schedule trigger — default entry point',
+          icon: <CanvasIcon icon="clock" size={28} />,
+          isDefaultEntryPoint: true,
+        },
+      },
+    },
+    {
+      id: 'webhook-trigger',
+      type: 'trigger',
+      position: { x: 480, y: 144 },
+      width: 96,
+      height: 96,
+      data: {
+        details: {
+          tooltip: 'Webhook trigger',
+          icon: <CanvasIcon icon="webhook" size={28} />,
+        },
+      },
+    },
+  ]);
+
+  const onNodesChange = useCallback(
+    (changes: NodeChange[]) => setNodes((currentNodes) => applyNodeChanges(changes, currentNodes)),
+    []
+  );
+
+  return (
+    <BaseCanvas
+      nodes={nodes}
+      edges={[]}
+      nodeTypes={nodeTypes}
+      onNodesChange={onNodesChange}
+      mode="design"
+    />
+  );
+};
+
+/**
+ * The star marks the trigger used by toolbar Run and Debug actions when a flow
+ * has multiple triggers. Do not set `isDefaultEntryPoint` for a single-trigger
+ * flow: that trigger is implicitly the default.
+ */
+export const DefaultEntryPoint: Story = {
+  name: 'Default entry point',
+  render: () => <DefaultEntryPointStory />,
+};
+
+const ImplicitDefaultEntryPointStory = () => {
+  const [nodes, setNodes] = useState<Node[]>([
+    {
+      id: 'single-trigger',
+      type: 'trigger',
+      position: { x: 192, y: 144 },
+      width: 96,
+      height: 96,
+      data: {
+        details: {
+          tooltip: 'The only trigger is implicitly the default entry point',
+          icon: <CanvasIcon icon="clock" size={28} />,
+        },
+      },
+    },
+  ]);
+
+  const onNodesChange = useCallback(
+    (changes: NodeChange[]) => setNodes((currentNodes) => applyNodeChanges(changes, currentNodes)),
+    []
+  );
+
+  return (
+    <BaseCanvas
+      nodes={nodes}
+      edges={[]}
+      nodeTypes={nodeTypes}
+      onNodesChange={onNodesChange}
+      mode="design"
+    />
+  );
+};
+
+/** A single trigger is implicitly the default, so Flow omits the visual marker. */
+export const ImplicitDefaultEntryPoint: Story = {
+  name: 'Implicit default (single trigger)',
+  render: () => <ImplicitDefaultEntryPointStory />,
 };

--- a/packages/apollo-react/src/canvas/components/TriggerNode/TriggerNode.styles.ts
+++ b/packages/apollo-react/src/canvas/components/TriggerNode/TriggerNode.styles.ts
@@ -109,3 +109,21 @@ export const TriggerIconWrapper = styled.div<{ status?: TriggerStatus; nodeHeigh
     }};
   }
 `;
+
+export const TriggerBottomAdornment = styled.div`
+  position: absolute;
+  z-index: 1;
+  bottom: -8px;
+  left: 50%;
+  display: flex;
+  width: 24px;
+  height: 24px;
+  align-items: center;
+  justify-content: center;
+  transform: translateX(-50%);
+  color: var(--canvas-background);
+  background: var(--canvas-primary);
+  border: 2px solid var(--canvas-background);
+  border-radius: 50%;
+  box-shadow: var(--shadow-sm);
+`;

--- a/packages/apollo-react/src/canvas/components/TriggerNode/TriggerNode.test.tsx
+++ b/packages/apollo-react/src/canvas/components/TriggerNode/TriggerNode.test.tsx
@@ -1,0 +1,11 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { DefaultEntryPointIndicator } from './TriggerNode';
+
+describe('DefaultEntryPointIndicator', () => {
+  it('renders an accessible default entry point marker', () => {
+    render(<DefaultEntryPointIndicator />);
+
+    expect(screen.getByLabelText('Default entry point')).toBeInTheDocument();
+  });
+});

--- a/packages/apollo-react/src/canvas/components/TriggerNode/TriggerNode.tsx
+++ b/packages/apollo-react/src/canvas/components/TriggerNode/TriggerNode.tsx
@@ -6,12 +6,22 @@ import { areNodePropsEqualIgnoringPosition } from '../../utils/nodePropsEqual';
 import { useConnectedHandles } from '../BaseCanvas/ConnectedHandlesContext';
 import { useButtonHandles } from '../ButtonHandle/useButtonHandles';
 import { CanvasTooltip } from '../CanvasTooltip';
-import { TriggerContainer, TriggerIconWrapper } from './TriggerNode.styles';
+import { TriggerBottomAdornment, TriggerContainer, TriggerIconWrapper } from './TriggerNode.styles';
 import type { TriggerNodeProps } from './TriggerNode.types';
+
+export function DefaultEntryPointIndicator() {
+  return (
+    <CanvasTooltip content="Default entry point" placement="bottom">
+      <TriggerBottomAdornment aria-label="Default entry point">
+        <CanvasIcon icon="star" size={14} fill="currentColor" />
+      </TriggerBottomAdornment>
+    </CanvasTooltip>
+  );
+}
 
 const TriggerNodeComponent = (props: TriggerNodeProps) => {
   const { selected, id, details = {} } = props;
-  const { tooltip, icon, status } = details;
+  const { tooltip, icon, status, isDefaultEntryPoint, bottomAdornment } = details;
 
   const [isHovered, setIsHovered] = useState(false);
 
@@ -65,6 +75,12 @@ const TriggerNodeComponent = (props: TriggerNodeProps) => {
       ) : (
         triggerContent
       )}
+
+      {bottomAdornment ? (
+        <TriggerBottomAdornment>{bottomAdornment}</TriggerBottomAdornment>
+      ) : isDefaultEntryPoint ? (
+        <DefaultEntryPointIndicator />
+      ) : null}
 
       {handleElements}
     </div>

--- a/packages/apollo-react/src/canvas/components/TriggerNode/TriggerNode.types.ts
+++ b/packages/apollo-react/src/canvas/components/TriggerNode/TriggerNode.types.ts
@@ -14,9 +14,17 @@ enum ElementStatusValues {
 export type TriggerStatus = `${ElementStatusValues}`;
 
 export interface TriggerNodeProps extends NodeProps {
-  details: {
+  details?: {
     tooltip?: string;
     icon?: React.ReactElement;
     status?: TriggerStatus;
+    /**
+     * Marks this trigger as the entry point used by toolbar Run and Debug actions.
+     * Consumers should only set this when the flow has multiple eligible triggers;
+     * a single trigger is implicitly the default and does not need an adornment.
+     */
+    isDefaultEntryPoint?: boolean;
+    /** Overrides the standard default-entry-point treatment with custom content. */
+    bottomAdornment?: React.ReactNode;
   };
 }

--- a/packages/apollo-react/src/canvas/stories/templates/Flow.stories.tsx
+++ b/packages/apollo-react/src/canvas/stories/templates/Flow.stories.tsx
@@ -13,6 +13,7 @@ import {
   AccordionTrigger,
   Alert,
   AlertDescription,
+  AlertTitle,
   Button,
   Card,
   CardContent,
@@ -24,6 +25,7 @@ import {
   InputGroupButton,
   InputGroupInput,
   Label,
+  LockableValueField,
   type PanelImperativeHandle,
   PromptEditor,
   type PromptEditorAutoCompleteOption,
@@ -48,13 +50,13 @@ import {
   ToggleGroup,
   ToggleGroupItem,
   VARIABLE_DRAG_MIME,
-  VariablePicker,
   type VariablePickerItem,
 } from '@uipath/apollo-wind';
 import type { DockviewApi, DockviewReadyEvent, IDockviewPanelProps } from 'dockview-react';
 import { DockviewReact } from 'dockview-react';
 import 'dockview-react/dist/styles/dockview.css';
 import {
+  AlertCircle,
   AtSign,
   Blocks,
   Bold,
@@ -132,7 +134,9 @@ import {
   NodePropertyTrigger,
   type NodePropertyTriggerLayout,
 } from '../../controls/NodePropertyTrigger';
+import { ValidationStatusContext } from '../../hooks';
 import { createNode, useCanvasStory, withCanvasProviders } from '../../storybook-utils';
+import { ValidationErrorSeverity } from '../../types/validation';
 import { CanvasIcon } from '../../utils/icon-registry';
 import './Flow.stories.css';
 
@@ -164,7 +168,7 @@ type Story = StoryObj<typeof meta>;
 // Sample Canvas Data
 // ============================================================================
 
-type WorkflowVariant = 'default' | 'forms' | 'node' | 'rules' | 'variables';
+type WorkflowVariant = 'default' | 'forms' | 'node' | 'rules' | 'variables' | 'validation';
 
 function createFlowGraph(variant: WorkflowVariant): {
   nodes: Node<BaseNodeData>[];
@@ -365,6 +369,50 @@ function createFlowGraph(variant: WorkflowVariant): {
     };
   }
 
+  if (variant === 'validation') {
+    const nodes = [
+      createNode({
+        id: 'trigger',
+        type: 'uipath.manual-trigger',
+        position: { x: 80, y: 200 },
+        display: { label: 'Invoice received', subLabel: 'Document trigger' },
+      }),
+      createNode({
+        id: 'extract',
+        type: 'uipath.blank-node',
+        position: { x: 340, y: 200 },
+        display: { label: 'Extract invoice details', subLabel: 'Document understanding' },
+      }),
+      createNode({
+        id: 'approver',
+        type: 'uipath.blank-node',
+        position: { x: 600, y: 200 },
+        display: { label: 'Get approver', subLabel: 'Directory lookup' },
+      }),
+      createNode({
+        id: 'email',
+        type: 'uipath.blank-node',
+        position: { x: 860, y: 200 },
+        selected: true,
+        display: { label: 'Send email', subLabel: 'Gmail' },
+      }),
+    ];
+    return {
+      nodes,
+      edges: [
+        ['trigger', 'extract'],
+        ['extract', 'approver'],
+        ['approver', 'email'],
+      ].map(([source, target]) => ({
+        id: `e-${source}-${target}`,
+        source,
+        target,
+        sourceHandle: 'output',
+        targetHandle: 'input',
+      })),
+    };
+  }
+
   const nodes = [
     createNode({
       id: 'trigger',
@@ -493,7 +541,7 @@ function PanelTrigger({
         onPanelToggle?.(id, enabled);
         setMenuOpen(false);
       }}
-      onPropertiesClick={onPropertiesClick}
+      onPropertiesClick={onPropertiesClick ?? (() => onPanelToggle?.('properties', true))}
     />
   );
 }
@@ -607,6 +655,7 @@ function StandaloneRightPropertiesComposition({
   return (
     <div className="relative h-screen overflow-hidden bg-surface">
       <CanvasViewport
+        leftControlsOffset={rightPanelOpen && panelZone === 'left' ? 412 : 16}
         rightControlsOffset={rightPanelOpen && panelZone === 'right' ? 412 : 16}
         bottomControlsOffset={rightPanelOpen && panelZone === 'bottom' ? 380 : 20}
         trigger={
@@ -715,6 +764,7 @@ function CanvasViewport({
   trigger,
   children,
   bottomControlsOffset = 20,
+  leftControlsOffset = 16,
   rightControlsOffset = 16,
   workflowVariant = 'default',
   onNodeSelect,
@@ -722,6 +772,7 @@ function CanvasViewport({
   trigger?: ReactNode;
   children?: ReactNode;
   bottomControlsOffset?: number;
+  leftControlsOffset?: number;
   rightControlsOffset?: number;
   workflowVariant?: WorkflowVariant;
   onNodeSelect?: (nodeId: string) => void;
@@ -736,9 +787,10 @@ function CanvasViewport({
       const nodes = getNodes();
       if (!container || nodes.length === 0) return;
       const bounds = getNodesBounds(nodes);
+      const occupiedLeft = Math.max(0, leftControlsOffset - 16);
       const occupiedRight = Math.max(0, rightControlsOffset - 16);
       const occupiedBottom = Math.max(0, bottomControlsOffset - 20);
-      const availableWidth = container.clientWidth - occupiedRight;
+      const availableWidth = container.clientWidth - occupiedLeft - occupiedRight;
       const availableHeight = container.clientHeight - occupiedBottom;
       const padding = 48;
       const zoom = Math.min(
@@ -746,7 +798,7 @@ function CanvasViewport({
         Math.max(0.1, (availableWidth - padding * 2) / bounds.width),
         Math.max(0.1, (availableHeight - padding * 2) / bounds.height)
       );
-      const availableCenterX = availableWidth / 2;
+      const availableCenterX = occupiedLeft + availableWidth / 2;
       const availableCenterY = availableHeight / 2;
       void setViewport(
         {
@@ -757,7 +809,14 @@ function CanvasViewport({
         { duration }
       );
     },
-    [bottomControlsOffset, getNodes, getNodesBounds, rightControlsOffset, setViewport]
+    [
+      bottomControlsOffset,
+      getNodes,
+      getNodesBounds,
+      leftControlsOffset,
+      rightControlsOffset,
+      setViewport,
+    ]
   );
 
   useEffect(() => {
@@ -790,7 +849,11 @@ function CanvasViewport({
       </div>
       <div
         className="absolute left-1/2 z-20 -translate-x-1/2"
-        style={{ bottom: bottomControlsOffset }}
+        style={{
+          bottom: bottomControlsOffset,
+          marginLeft:
+            (Math.max(0, leftControlsOffset - 16) - Math.max(0, rightControlsOffset - 16)) / 2,
+        }}
       >
         <CanvasNavigationControls />
       </div>
@@ -874,6 +937,7 @@ function BottomPropertiesComposition() {
     >
       <CanvasViewport
         bottomControlsOffset={bottomPanels.length > 0 ? panelHeight + 20 : 20}
+        leftControlsOffset={dockedPanels('left').length > 0 ? 412 : 16}
         rightControlsOffset={dockedPanels('right').length > 0 ? 412 : 16}
         trigger={
           <PanelTrigger
@@ -1219,37 +1283,16 @@ function ExpressionField({
   value,
   placeholder,
   variables = [],
-  onInsertVariable,
   onValueChange,
 }: {
   label?: string;
   value?: string;
   placeholder?: string;
   variables?: VariablePickerItem[];
-  onInsertVariable?: (variable: VariablePickerItem) => void;
   onValueChange?: (value: string) => void;
 }) {
-  const [isVariableDragging, setIsVariableDragging] = useState(false);
-  const [isDragOver, setIsDragOver] = useState(false);
-
-  useEffect(() => {
-    const handleDragStart = (event: globalThis.DragEvent) => {
-      if (event.dataTransfer?.types.includes(VARIABLE_DRAG_MIME)) setIsVariableDragging(true);
-    };
-    const handleDragEnd = () => {
-      setIsVariableDragging(false);
-      setIsDragOver(false);
-    };
-    window.addEventListener('dragstart', handleDragStart);
-    window.addEventListener('dragend', handleDragEnd);
-    window.addEventListener('drop', handleDragEnd);
-    return () => {
-      window.removeEventListener('dragstart', handleDragStart);
-      window.removeEventListener('dragend', handleDragEnd);
-      window.removeEventListener('drop', handleDragEnd);
-    };
-  }, []);
-
+  const [locked, setLocked] = useState(false);
+  const [mode, setMode] = useState<'fixed' | 'expression'>('expression');
   const tokens = useMemo(() => expressionValueToTokens(value ?? ''), [value]);
 
   const autoCompleteOptions = useMemo<PromptEditorAutoCompleteOption[]>(() => {
@@ -1268,74 +1311,40 @@ function ExpressionField({
   }, [variables, tokens]);
 
   return (
-    <div className="space-y-1.5">
-      {label && (
-        <div className="flex items-center justify-between gap-2">
-          <p className="text-xs font-medium text-foreground">{label}</p>
-          <VariablePicker
-            items={variables}
-            onSelect={(variable) => onInsertVariable?.(variable)}
-            disabled={!onInsertVariable || variables.length === 0}
-            triggerLabel="Select variable"
-            triggerAriaLabel={`Select variable for ${label}`}
-          />
-        </div>
-      )}
-      <div
-        onDragEnter={(event) => {
-          if (!event.dataTransfer.types.includes(VARIABLE_DRAG_MIME)) return;
-          setIsDragOver(true);
-        }}
-        onDragOver={(event) => {
-          if (!event.dataTransfer.types.includes(VARIABLE_DRAG_MIME)) return;
-          event.dataTransfer.dropEffect = onValueChange ? 'copy' : 'none';
-        }}
-        onDragLeave={(event) => {
-          if (!event.currentTarget.contains(event.relatedTarget as globalThis.Node | null)) {
-            setIsDragOver(false);
-          }
-        }}
-        onDrop={() => setIsDragOver(false)}
-        className={`relative flex min-h-9 items-center gap-1.5 rounded-lg border bg-surface-overlay px-2.5 text-xs transition-[border-color,box-shadow,background-color] focus-within:border-border-focus focus-within:ring-1 focus-within:ring-border-focus ${
-          isDragOver && onValueChange
-            ? 'border-brand bg-brand-subtle/40 ring-2 ring-brand/30'
-            : isDragOver
-              ? 'border-error/60 bg-error/5'
-              : isVariableDragging && onValueChange
-                ? 'border-brand/60 bg-brand-subtle/20'
-                : isVariableDragging
-                  ? 'border-border-subtle opacity-60'
-                  : 'border-border-subtle'
-        }`}
-      >
-        <span className="shrink-0 font-mono text-foreground-accent" aria-hidden="true">
-          ƒx
-        </span>
+    <LockableValueField
+      label={
+        label ? (
+          <Label className="text-xs font-medium text-foreground-muted">{label}</Label>
+        ) : undefined
+      }
+      value={value}
+      locked={locked}
+      onLockedChange={setLocked}
+      mode={mode}
+      onModeChange={setMode}
+      fieldType="string"
+      showFieldActions
+      variables={variables.map((variable) => ({
+        label: variable.label,
+        value: variable.value ?? variable.label,
+      }))}
+      onValueChange={onValueChange}
+      renderExpressionEditor={({ id, onBlur, readOnly }) => (
         <PromptEditor
+          id={id}
           value={tokens}
           onChange={(nextTokens) => onValueChange?.(expressionTokensToValue(nextTokens))}
+          onBlur={onBlur}
           autoCompleteOptions={autoCompleteOptions}
           multiline={false}
           borderless
-          disabled={!onValueChange}
+          disabled={readOnly}
           placeholder={placeholder}
           ariaLabel={label ? `${label} expression` : 'Expression'}
           mapVarDropToToken={(insertPath) => ({ type: 'output', value: insertPath })}
         />
-        <SlidersHorizontal className="ml-auto size-4 shrink-0 text-foreground-muted" />
-        {isVariableDragging && (
-          <span
-            className={`pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 rounded px-1.5 py-0.5 text-[10px] font-medium ${
-              onValueChange
-                ? 'bg-brand text-foreground-on-accent'
-                : 'bg-surface-raised text-foreground-muted'
-            }`}
-          >
-            {onValueChange ? (isDragOver ? 'Drop to insert' : 'Drop variable') : 'Unavailable'}
-          </span>
-        )}
-      </div>
-    </div>
+      )}
+    />
   );
 }
 
@@ -1378,7 +1387,6 @@ function KeywordExpressionField({
   value,
   caption,
   variables = [],
-  onInsertVariable,
   onValueChange,
 }: {
   label: string;
@@ -1386,9 +1394,9 @@ function KeywordExpressionField({
   value?: string;
   caption?: string;
   variables?: VariablePickerItem[];
-  onInsertVariable?: (variable: VariablePickerItem) => void;
   onValueChange?: (value: string) => void;
 }) {
+  const [mode, setMode] = useState<'fixed' | 'expression'>('expression');
   const tokens = useMemo(() => keywordValueToTokens(value ?? ''), [value]);
 
   const autoCompleteOptions = useMemo<PromptEditorAutoCompleteOption[]>(() => {
@@ -1405,31 +1413,49 @@ function KeywordExpressionField({
 
   return (
     <div className="space-y-1.5">
-      <div className="flex items-center justify-between gap-2">
-        <p className="text-sm font-semibold text-foreground">
-          {label}
-          {required && <span className="ml-0.5 text-error">*</span>}
-        </p>
-        <VariablePicker
-          items={variables}
-          onSelect={(variable) => onInsertVariable?.(variable)}
-          disabled={!onInsertVariable || variables.length === 0}
-        />
-      </div>
-      <div className="flex min-h-11 items-center gap-2 rounded-lg border border-border-subtle bg-surface px-3">
-        <span className="shrink-0 font-mono text-sm text-foreground-muted">=</span>
-        <PromptEditor
-          value={tokens}
-          onChange={(nextTokens) => onValueChange?.(keywordTokensToValue(nextTokens))}
-          autoCompleteOptions={autoCompleteOptions}
-          multiline={false}
-          borderless
-          disabled={!onValueChange}
-          ariaLabel={`${label} expression`}
-          mapVarDropToToken={(insertPath) => ({ type: 'input', value: insertPath })}
-        />
-      </div>
-      {caption && <p className="text-xs text-foreground-muted">{caption}</p>}
+      <LockableValueField
+        label={
+          <Label className="text-xs font-medium text-foreground-muted">
+            {label}
+            {required && <span className="ml-0.5 text-error">*</span>}
+          </Label>
+        }
+        required={required}
+        value={value}
+        locked={false}
+        leadingAddon={
+          <span
+            className="font-mono text-sm font-semibold text-foreground-accent"
+            aria-hidden="true"
+          >
+            =
+          </span>
+        }
+        mode={mode}
+        onModeChange={setMode}
+        fieldType="string"
+        showFieldActions
+        variables={variables.map((variable) => ({
+          label: variable.label,
+          value: variable.value ?? variable.label,
+        }))}
+        onValueChange={onValueChange}
+        renderExpressionEditor={({ id, onBlur, readOnly }) => (
+          <PromptEditor
+            id={id}
+            value={tokens}
+            onChange={(nextTokens) => onValueChange?.(keywordTokensToValue(nextTokens))}
+            onBlur={onBlur}
+            autoCompleteOptions={autoCompleteOptions}
+            multiline={false}
+            borderless
+            disabled={readOnly}
+            ariaLabel={`${label} expression`}
+            mapVarDropToToken={(insertPath) => ({ type: 'input', value: insertPath })}
+          />
+        )}
+      />
+      {caption && <p className="text-[11px] leading-4 text-foreground-muted">{caption}</p>}
     </div>
   );
 }
@@ -1478,12 +1504,6 @@ function SendEmailForm({
       value={fieldValues[key]}
       placeholder={placeholder}
       variables={pickerItems}
-      onInsertVariable={(variable) =>
-        setFieldValues((current) => ({
-          ...current,
-          [key]: `${current[key]}${variable.value ?? variable.label}`,
-        }))
-      }
       onValueChange={(nextValue) => setFieldValues((current) => ({ ...current, [key]: nextValue }))}
     />
   );
@@ -2377,9 +2397,6 @@ function CollectionFilterPanel({
           value={collectionValue}
           caption="Conditions are applied to this collection."
           variables={pickerItems}
-          onInsertVariable={(variable) =>
-            setCollectionValue((current) => `${current}${variable.value ?? variable.label}`)
-          }
           onValueChange={setCollectionValue}
         />
 
@@ -3264,6 +3281,17 @@ const VARIABLE_CONCEPT_SIDEBAR_ITEMS = CANVAS_LEFT_SIDEBAR_DEFAULT_PRIMARY_ITEMS
     : [item]
 );
 
+const withErrorDot = (icon: ReactNode) => (
+  <span className="relative grid size-5 place-items-center">
+    {icon}
+    <span className="absolute -right-0.5 -top-0.5 size-2 rounded-full bg-error ring-2 ring-surface-raised" />
+  </span>
+);
+
+const VALIDATION_SIDEBAR_ITEMS = CANVAS_LEFT_SIDEBAR_DEFAULT_PRIMARY_ITEMS.map((item) =>
+  item.id === 'variables' ? { ...item, icon: withErrorDot(item.icon) } : item
+);
+
 const VARIABLE_TAB_LIST_CLASS =
   'mx-3 h-auto justify-start gap-0.5 overflow-x-auto rounded-lg bg-transparent p-0.5 text-muted-foreground [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden';
 const VARIABLE_TAB_TRIGGER_CLASS =
@@ -3469,9 +3497,6 @@ function UnifiedVariablesPanel({
                       label={parameter.label}
                       value={value}
                       variables={variablePickerItems}
-                      onInsertVariable={(variable) =>
-                        onParameterValueChange(parameterKey, variable.value ?? variable.label)
-                      }
                       onValueChange={(nextValue) => onParameterValueChange(parameterKey, nextValue)}
                     />
                   ) : (
@@ -4685,6 +4710,7 @@ function DapValueField({
   value,
   placeholder,
   required,
+  error,
   onChange,
 }: {
   id: string;
@@ -4692,6 +4718,7 @@ function DapValueField({
   value: string;
   placeholder: string;
   required?: boolean;
+  error?: ReactNode;
   onChange: (value: string) => void;
 }) {
   return (
@@ -4700,7 +4727,7 @@ function DapValueField({
         {label}
         {required && <span className="text-error"> *</span>}
       </Label>
-      <InputGroup className="h-9 bg-surface-overlay">
+      <InputGroup className="h-9 bg-surface-overlay" error={error}>
         <InputGroupInput
           id={id}
           value={value}
@@ -4988,6 +5015,175 @@ function DapPanel({ onClose }: { onClose: () => void }) {
   );
 }
 
+function ValidationTabLabel({ label, count }: { label: string; count?: number }) {
+  if (!count) return <>{label}</>;
+  return (
+    <span className="inline-flex items-center gap-1.5">
+      <span>{label}</span>
+      <span
+        title={`${count} issue${count === 1 ? '' : 's'}`}
+        className="grid h-4 min-w-4 place-items-center rounded-full bg-error px-1 text-[10px] font-semibold leading-none text-foreground-on-accent"
+      >
+        <span aria-hidden="true">{count}</span>
+        <span className="sr-only">{`${count} issue${count === 1 ? '' : 's'}`}</span>
+      </span>
+    </span>
+  );
+}
+
+function DapValidationPanel({ onClose }: { onClose: () => void }) {
+  const [subject, setSubject] = useState('Invoice approval required');
+  const [recipient, setRecipient] = useState('');
+  const [body, setBody] = useState(
+    'Hi $vars.approverName,\n\nPlease review invoice $vars.invoiceNumber.'
+  );
+  const [errorHandlingEnabled, setErrorHandlingEnabled] = useState(true);
+  const [retryCount, setRetryCount] = useState('8');
+
+  return (
+    <NodePropertyPanel
+      panelTitle="Properties"
+      nodeIcon={<Mail />}
+      nodeLabel="Send email"
+      nodeCategory="Gmail · DAP layout"
+      onClose={onClose}
+      contentInset="0.875rem"
+      className="h-full"
+    >
+      <Tabs defaultValue="parameters" className="flex h-full min-h-0 flex-col">
+        <TabsList className={VARIABLE_TAB_LIST_CLASS}>
+          <TabsTrigger value="parameters" className={VARIABLE_TAB_TRIGGER_CLASS}>
+            <ValidationTabLabel label="Parameters" count={1} />
+          </TabsTrigger>
+          <TabsTrigger value="error-handling" className={VARIABLE_TAB_TRIGGER_CLASS}>
+            <ValidationTabLabel label="Error handling" count={1} />
+          </TabsTrigger>
+          <TabsTrigger value="variables" className={VARIABLE_TAB_TRIGGER_CLASS}>
+            Variables
+          </TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="parameters" className="mt-0 min-h-0 flex-1 overflow-y-auto p-3">
+          <div className="space-y-5">
+            <Alert variant="destructive">
+              <AlertCircle />
+              <AlertTitle>Resolve 2 issues before running this node</AlertTitle>
+              <AlertDescription>
+                Fix the highlighted fields in Parameters and Error handling before you run or
+                publish this workflow.
+              </AlertDescription>
+            </Alert>
+
+            <section className="space-y-3">
+              <p className="text-xs font-semibold text-foreground">Connection</p>
+              <Select defaultValue="gmail-finance">
+                <SelectTrigger className="h-9 w-full bg-surface-overlay text-xs">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="gmail-finance">Gmail · Finance operations</SelectItem>
+                  <SelectItem value="gmail-personal">Gmail · Personal</SelectItem>
+                </SelectContent>
+              </Select>
+            </section>
+
+            <Separator />
+
+            <section className="space-y-4">
+              <p className="text-xs font-semibold text-foreground">Message</p>
+              <DapValueField
+                id="dap-validation-recipient"
+                label="To"
+                value={recipient}
+                placeholder="Recipient email address"
+                required
+                error="This field is required. Enter a recipient or bind a variable."
+                onChange={setRecipient}
+              />
+              <DapValueField
+                id="dap-validation-subject"
+                label="Subject"
+                value={subject}
+                placeholder="The subject of the email"
+                required
+                onChange={setSubject}
+              />
+              <div className="space-y-1.5">
+                <Label htmlFor="dap-validation-body" className="text-xs">
+                  Body <span className="text-error">*</span>
+                </Label>
+                <Textarea
+                  id="dap-validation-body"
+                  value={body}
+                  onChange={(event) => setBody(event.target.value)}
+                  className="min-h-24 resize-none bg-surface-overlay text-xs"
+                />
+              </div>
+            </section>
+          </div>
+        </TabsContent>
+
+        <TabsContent value="error-handling" className="mt-0 min-h-0 flex-1 overflow-y-auto p-3">
+          <div className="space-y-4">
+            <div className="flex items-center justify-between gap-4">
+              <div>
+                <Label htmlFor="dap-validation-error-handling" className="text-xs">
+                  Enable error handling
+                </Label>
+                <p className="text-xs text-foreground-muted">
+                  Add an error output handle on the node to catch and handle failures.
+                </p>
+              </div>
+              <Switch
+                id="dap-validation-error-handling"
+                checked={errorHandlingEnabled}
+                onCheckedChange={setErrorHandlingEnabled}
+              />
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="dap-validation-retry-count" className="text-xs">
+                Retry count
+              </Label>
+              <Input
+                id="dap-validation-retry-count"
+                value={retryCount}
+                onChange={(event) => setRetryCount(event.target.value)}
+                error="Retry count must be between 0 and 5."
+                className="bg-surface-overlay text-xs"
+              />
+            </div>
+          </div>
+        </TabsContent>
+
+        <TabsContent value="variables" className="mt-0 min-h-0 flex-1 overflow-y-auto p-3">
+          <div className="space-y-4">
+            <p className="text-xs leading-5 text-foreground-muted">
+              Values available to the connector fields and produced when this activity runs.
+            </p>
+            {[
+              ['$vars.approverEmail', 'Text · Input'],
+              ['$vars.approverName', 'Text · Input'],
+              ['$vars.invoiceNumber', 'Text · Input'],
+              ['$output.messageId', 'Text · Output'],
+            ].map(([name, metadata]) => (
+              <div
+                key={name}
+                className="flex items-center gap-3 rounded-lg border border-border-subtle bg-surface-overlay px-3 py-2.5"
+              >
+                <Blocks className="size-4 shrink-0 text-foreground-subtle" />
+                <div className="min-w-0 flex-1">
+                  <p className="truncate font-mono text-xs font-medium">{name}</p>
+                  <p className="mt-0.5 text-[11px] text-foreground-muted">{metadata}</p>
+                </div>
+              </div>
+            ))}
+          </div>
+        </TabsContent>
+      </Tabs>
+    </NodePropertyPanel>
+  );
+}
+
 export function FullWorkbenchComposition({
   rightPanelVariant = 'properties',
 }: {
@@ -4998,6 +5194,7 @@ export function FullWorkbenchComposition({
     | 'rules'
     | 'variables'
     | 'dap'
+    | 'validation'
     | 'collection';
 }) {
   const panelRef = useRef<PanelImperativeHandle | null>(null);
@@ -5037,7 +5234,11 @@ export function FullWorkbenchComposition({
       id: 'execution',
       label: (
         <>
-          <Bug className="size-3" /> Executions
+          <Bug className="size-3" />{' '}
+          <ValidationTabLabel
+            label="Executions"
+            count={rightPanelVariant === 'validation' ? 2 : undefined}
+          />
         </>
       ),
       group: 'debug',
@@ -5072,13 +5273,21 @@ export function FullWorkbenchComposition({
       <CanvasLeftSidebar
         title={sidebarLabels[activeSidebarItem]}
         variant="default"
-        primaryItems={VARIABLE_CONCEPT_SIDEBAR_ITEMS}
+        primaryItems={
+          rightPanelVariant === 'validation'
+            ? VALIDATION_SIDEBAR_ITEMS
+            : VARIABLE_CONCEPT_SIDEBAR_ITEMS
+        }
         isExpanded={sidebarExpanded}
         onExpandedChange={setSidebarExpanded}
         activeItemId={activeSidebarItem}
         onItemSelect={setActiveSidebarItem}
       >
-        {activeSidebarItem === 'variables' ? (
+        {rightPanelVariant === 'validation' ? (
+          <div className="py-6 text-center text-xs text-foreground-muted">
+            {sidebarLabels[activeSidebarItem]} content
+          </div>
+        ) : activeSidebarItem === 'variables' ? (
           <WorkflowVariablesSidebar
             variables={editableWorkflowVariables}
             onVariablesChange={setEditableWorkflowVariables}
@@ -5100,42 +5309,62 @@ export function FullWorkbenchComposition({
         )}
       </CanvasLeftSidebar>
       <div className="relative min-w-0 flex-1 overflow-hidden">
-        <CanvasViewport
-          workflowVariant={
-            rightPanelVariant === 'properties' ||
-            rightPanelVariant === 'dap' ||
-            rightPanelVariant === 'collection'
-              ? 'default'
-              : rightPanelVariant
-          }
-          bottomControlsOffset={canvasBottomOffset}
-          rightControlsOffset={rightPanelOpen ? 412 : 16}
-          onNodeSelect={
-            rightPanelVariant === 'variables'
-              ? (nodeId) => {
-                  setSelectedVariableNodeId(nodeId);
-                  setRightPanelOpen(true);
-                }
-              : undefined
-          }
-          trigger={
-            <PanelTrigger
-              layout={rightPanelOpen ? 'right' : 'closed'}
-              panels={[
-                { id: 'input', label: 'Input', enabled: false },
-                { id: 'properties', label: 'Properties', enabled: rightPanelOpen },
-                { id: 'output', label: 'Output', enabled: false },
-              ]}
-              onPanelToggle={(id, enabled) => {
-                if (id === 'properties') setRightPanelOpen(enabled);
-              }}
-              onLayoutChange={(layout) => {
-                if (layout === 'right') setRightPanelOpen(true);
-              }}
-              onPropertiesClick={() => setRightPanelOpen(true)}
-            />
-          }
-        />
+        <ValidationStatusContext.Provider
+          value={{
+            getElementValidationState:
+              rightPanelVariant === 'validation'
+                ? (elementId) =>
+                    elementId === 'email'
+                      ? {
+                          validationStatus: ValidationErrorSeverity.ERROR,
+                          validationError: {
+                            code: 'MISSING_REQUIRED_FIELDS',
+                            message: 'Resolve 2 issues before running this node.',
+                            description: 'Resolve 2 issues before running this node.',
+                            severity: ValidationErrorSeverity.ERROR,
+                          },
+                        }
+                      : undefined
+                : () => undefined,
+          }}
+        >
+          <CanvasViewport
+            workflowVariant={
+              rightPanelVariant === 'properties' ||
+              rightPanelVariant === 'dap' ||
+              rightPanelVariant === 'collection'
+                ? 'default'
+                : rightPanelVariant
+            }
+            bottomControlsOffset={canvasBottomOffset}
+            rightControlsOffset={rightPanelOpen ? 412 : 16}
+            onNodeSelect={
+              rightPanelVariant === 'variables'
+                ? (nodeId) => {
+                    setSelectedVariableNodeId(nodeId);
+                    setRightPanelOpen(true);
+                  }
+                : undefined
+            }
+            trigger={
+              <PanelTrigger
+                layout={rightPanelOpen ? 'right' : 'closed'}
+                panels={[
+                  { id: 'input', label: 'Input', enabled: false },
+                  { id: 'properties', label: 'Properties', enabled: rightPanelOpen },
+                  { id: 'output', label: 'Output', enabled: false },
+                ]}
+                onPanelToggle={(id, enabled) => {
+                  if (id === 'properties') setRightPanelOpen(enabled);
+                }}
+                onLayoutChange={(layout) => {
+                  if (layout === 'right') setRightPanelOpen(true);
+                }}
+                onPropertiesClick={() => setRightPanelOpen(true)}
+              />
+            }
+          />
+        </ValidationStatusContext.Provider>
 
         {rightPanelOpen && (
           <div
@@ -5168,6 +5397,8 @@ export function FullWorkbenchComposition({
                 />
               ) : rightPanelVariant === 'dap' ? (
                 <DapPanel onClose={() => setRightPanelOpen(false)} />
+              ) : rightPanelVariant === 'validation' ? (
+                <DapValidationPanel onClose={() => setRightPanelOpen(false)} />
               ) : rightPanelVariant === 'node' ? (
                 <SendEmailPropertiesPanel
                   onClose={() => setRightPanelOpen(false)}

--- a/packages/apollo-react/src/canvas/stories/templates/Flow.stories.tsx
+++ b/packages/apollo-react/src/canvas/stories/templates/Flow.stories.tsx
@@ -3398,11 +3398,11 @@ function InventoryPanelField({ field }: { field: InventoryField }) {
     <div className="space-y-1.5">
       <Label className="text-xs">
         {field.label}
-        {field.required && <span className="text-foreground-danger"> *</span>}
+        {field.required && <span className="text-error"> *</span>}
       </Label>
       {field.kind === 'select' ? (
         <Select defaultValue="current">
-          <SelectTrigger className="w-full">
+          <SelectTrigger className="h-9 w-full bg-surface-overlay text-xs">
             <SelectValue />
           </SelectTrigger>
           <SelectContent>
@@ -3410,7 +3410,10 @@ function InventoryPanelField({ field }: { field: InventoryField }) {
           </SelectContent>
         </Select>
       ) : field.kind === 'textarea' ? (
-        <Textarea defaultValue={field.value} className="min-h-24 resize-none text-xs" />
+        <Textarea
+          defaultValue={field.value}
+          className="min-h-24 resize-none bg-surface-overlay text-xs"
+        />
       ) : field.kind === 'expression' ? (
         <div className="flex items-center rounded-lg border border-border-subtle bg-surface-overlay px-2 focus-within:border-border-focus">
           <span className="mr-1.5 font-mono text-xs text-foreground-subtle">=</span>
@@ -3420,7 +3423,7 @@ function InventoryPanelField({ field }: { field: InventoryField }) {
           />
         </div>
       ) : (
-        <Input defaultValue={field.value} className="text-xs" />
+        <Input defaultValue={field.value} className="h-9 bg-surface-overlay text-xs" />
       )}
       {field.helper && <p className="text-[11px] text-foreground-muted">{field.helper}</p>}
     </div>
@@ -3436,45 +3439,69 @@ function NodeInventoryPanel({ item, onClose }: { item: NodeInventoryItem; onClos
       nodeLabel={item.label}
       nodeCategory={item.category}
       onClose={onClose}
+      contentInset="0.875rem"
       className="h-full"
     >
       <div className="flex min-h-0 flex-1 flex-col overflow-y-auto">
         <Tabs defaultValue="parameters" className="flex min-h-0 flex-1 flex-col">
-          <TabsList className="mx-4 mt-3 w-fit">
-            <TabsTrigger value="parameters">Parameters</TabsTrigger>
-            <TabsTrigger value="errors">Error handling</TabsTrigger>
-            <TabsTrigger value="advanced">Advanced</TabsTrigger>
+          <TabsList className={VARIABLE_TAB_LIST_CLASS}>
+            <TabsTrigger value="parameters" className={VARIABLE_TAB_TRIGGER_CLASS}>
+              Parameters
+            </TabsTrigger>
+            <TabsTrigger value="errors" className={VARIABLE_TAB_TRIGGER_CLASS}>
+              Error handling
+            </TabsTrigger>
+            <TabsTrigger value="advanced" className={VARIABLE_TAB_TRIGGER_CLASS}>
+              Advanced
+            </TabsTrigger>
           </TabsList>
-          <TabsContent value="parameters" className="mt-0 space-y-4 p-4">
-            {spec?.section && (
-              <p className="text-xs font-semibold text-foreground">{spec.section}</p>
-            )}
-            {spec?.description && (
-              <p className="text-xs leading-5 text-foreground-muted">{spec.description}</p>
-            )}
-            {spec?.empty && (
-              <p className="text-xs text-foreground-muted">No available parameters</p>
-            )}
-            {spec?.fields?.map((field) => (
-              <InventoryPanelField key={field.label} field={field} />
-            ))}
-            {spec?.action && (
-              <Button variant="outline" className="w-full">
-                <Plus size={14} />
-                {spec.action}
-              </Button>
-            )}
-            {!spec && (
-              <p className="text-xs text-foreground-muted">
-                No Figma reference is available for this node yet.
+          <TabsContent value="parameters" className="mt-0 min-h-0 flex-1 overflow-auto p-3">
+            <div className="space-y-4">
+              <p className="text-xs leading-5 text-foreground-muted">
+                Configure what this node does when the workflow runs.
               </p>
-            )}
+              {spec?.section && (
+                <p className="text-xs font-semibold text-foreground">{spec.section}</p>
+              )}
+              {spec?.description && (
+                <p className="text-xs leading-5 text-foreground-muted">{spec.description}</p>
+              )}
+              {spec?.empty && (
+                <p className="text-xs text-foreground-muted">No available parameters</p>
+              )}
+              {spec?.fields?.map((field) => (
+                <InventoryPanelField key={field.label} field={field} />
+              ))}
+              {spec?.action && (
+                <Button
+                  size="sm"
+                  variant={spec.action.startsWith('Add') ? 'ghost' : 'outline'}
+                  className={
+                    spec.action.startsWith('Add')
+                      ? 'h-7 px-2 text-xs font-semibold text-brand hover:text-brand'
+                      : 'h-8 text-xs'
+                  }
+                >
+                  {spec.action.startsWith('Add') && <Plus size={14} />}
+                  {spec.action}
+                </Button>
+              )}
+              {!spec && (
+                <p className="text-xs text-foreground-muted">
+                  No Figma reference is available for this node yet.
+                </p>
+              )}
+            </div>
           </TabsContent>
-          <TabsContent value="errors" className="mt-0 p-4 text-xs text-foreground-muted">
-            Configure retry, timeout, and error continuation behavior for this node.
+          <TabsContent value="errors" className="mt-0 min-h-0 flex-1 overflow-auto p-3">
+            <p className="text-xs leading-5 text-foreground-muted">
+              Configure retry, timeout, and error continuation behavior for this node.
+            </p>
           </TabsContent>
-          <TabsContent value="advanced" className="mt-0 p-4 text-xs text-foreground-muted">
-            Advanced execution settings are available when supported by this node.
+          <TabsContent value="advanced" className="mt-0 min-h-0 flex-1 overflow-auto p-3">
+            <p className="text-xs leading-5 text-foreground-muted">
+              Advanced execution settings are available when supported by this node.
+            </p>
           </TabsContent>
         </Tabs>
       </div>

--- a/packages/apollo-react/src/canvas/stories/templates/Flow.stories.tsx
+++ b/packages/apollo-react/src/canvas/stories/templates/Flow.stories.tsx
@@ -3017,8 +3017,10 @@ const inventoryNodeTypes = {
 
 function NodeInventoryCanvas({
   onItemSelect,
+  rightPanelOpen,
 }: {
   onItemSelect: (item: NodeInventoryItem) => void;
+  rightPanelOpen: boolean;
 }) {
   const inventoryNodes = useMemo(createNodeInventoryNodes, []);
   const { fitView } = useReactFlow();
@@ -3047,10 +3049,16 @@ function NodeInventoryCanvas({
           if (item) onItemSelect(item);
         }}
       />
-      <div className="absolute bottom-5 left-1/2 z-20 -translate-x-1/2">
+      <div
+        className="absolute bottom-5 z-20 -translate-x-1/2 transition-[left] duration-200"
+        style={{ left: rightPanelOpen ? 'calc(50% - 198px)' : '50%' }}
+      >
         <CanvasNavigationControls />
       </div>
-      <div className="absolute bottom-5 right-4 z-20">
+      <div
+        className="absolute bottom-5 z-20 transition-[right] duration-200"
+        style={{ right: rightPanelOpen ? 412 : 16 }}
+      >
         <CanvasZoomControls
           orientation="vertical"
           onOrganize={() => void fitView({ padding: 0.12, duration: 200, maxZoom: 0.85 })}
@@ -3492,6 +3500,7 @@ export function NodeInventoryComposition() {
       />
       <div className="relative min-w-0 flex-1 overflow-hidden">
         <NodeInventoryCanvas
+          rightPanelOpen={rightPanelOpen}
           onItemSelect={(item) => {
             setSelectedItem(item);
             setRightPanelOpen(true);

--- a/packages/apollo-react/src/canvas/stories/templates/Flow.stories.tsx
+++ b/packages/apollo-react/src/canvas/stories/templates/Flow.stories.tsx
@@ -44,6 +44,7 @@ import {
   Textarea,
   ToggleGroup,
   ToggleGroupItem,
+  VARIABLE_DRAG_MIME,
   VariablePicker,
   type VariablePickerItem,
 } from '@uipath/apollo-wind';
@@ -61,14 +62,18 @@ import {
   FlaskConical,
   GitBranch,
   Globe,
+  GripVertical,
   Italic,
   List,
   ListOrdered,
+  ListTree,
   Mail,
   Maximize2,
+  Pencil,
   Play,
   Plus,
   Redo2,
+  Search,
   SlidersHorizontal,
   Sparkles,
   StickyNote,
@@ -103,6 +108,7 @@ import { BaseCanvas } from '../../components/BaseCanvas';
 import type { BaseNodeData } from '../../components/BaseNode/BaseNode.types';
 import { CanvasBottomPanel, type CanvasBottomPanelTab } from '../../components/CanvasBottomPanel';
 import {
+  CANVAS_LEFT_SIDEBAR_DEFAULT_PRIMARY_ITEMS,
   CanvasLeftSidebar,
   type CanvasLeftSidebarItemId,
 } from '../../components/CanvasLeftSidebar';
@@ -1196,6 +1202,40 @@ function ExpressionField({
   onInsertVariable?: (variable: VariablePickerItem) => void;
   onValueChange?: (value: string) => void;
 }) {
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const [isVariableDragging, setIsVariableDragging] = useState(false);
+  const [isDragOver, setIsDragOver] = useState(false);
+
+  useEffect(() => {
+    const handleDragStart = (event: globalThis.DragEvent) => {
+      if (event.dataTransfer?.types.includes(VARIABLE_DRAG_MIME)) setIsVariableDragging(true);
+    };
+    const handleDragEnd = () => {
+      setIsVariableDragging(false);
+      setIsDragOver(false);
+    };
+    window.addEventListener('dragstart', handleDragStart);
+    window.addEventListener('dragend', handleDragEnd);
+    window.addEventListener('drop', handleDragEnd);
+    return () => {
+      window.removeEventListener('dragstart', handleDragStart);
+      window.removeEventListener('dragend', handleDragEnd);
+      window.removeEventListener('drop', handleDragEnd);
+    };
+  }, []);
+
+  const insertDroppedVariable = (path: string) => {
+    if (!onValueChange || !path) return;
+    const token = `$${path.replace(/^\$/, '')}`;
+    const currentValue = value ?? '';
+    const cursor = inputRef.current?.selectionStart ?? currentValue.length;
+    onValueChange(`${currentValue.slice(0, cursor)}${token}${currentValue.slice(cursor)}`);
+    requestAnimationFrame(() => {
+      inputRef.current?.focus();
+      inputRef.current?.setSelectionRange(cursor + token.length, cursor + token.length);
+    });
+  };
+
   return (
     <div className="space-y-1.5">
       {label && (
@@ -1210,11 +1250,50 @@ function ExpressionField({
           />
         </div>
       )}
-      <div className="flex min-h-9 items-center gap-1.5 rounded-lg border border-border-subtle bg-surface-overlay px-2.5 text-xs focus-within:border-border-focus focus-within:ring-1 focus-within:ring-border-focus">
+      <div
+        onDragEnter={(event) => {
+          if (!event.dataTransfer.types.includes(VARIABLE_DRAG_MIME)) return;
+          if (onValueChange) event.preventDefault();
+          setIsDragOver(true);
+        }}
+        onDragOver={(event) => {
+          if (!event.dataTransfer.types.includes(VARIABLE_DRAG_MIME)) return;
+          if (onValueChange) {
+            event.preventDefault();
+            event.dataTransfer.dropEffect = 'copy';
+          } else {
+            event.dataTransfer.dropEffect = 'none';
+          }
+        }}
+        onDragLeave={(event) => {
+          if (!event.currentTarget.contains(event.relatedTarget as globalThis.Node | null)) {
+            setIsDragOver(false);
+          }
+        }}
+        onDrop={(event) => {
+          const path = event.dataTransfer.getData(VARIABLE_DRAG_MIME);
+          if (!path || !onValueChange) return;
+          event.preventDefault();
+          insertDroppedVariable(path);
+          setIsDragOver(false);
+        }}
+        className={`relative flex min-h-9 items-center gap-1.5 rounded-lg border bg-surface-overlay px-2.5 text-xs transition-[border-color,box-shadow,background-color] focus-within:border-border-focus focus-within:ring-1 focus-within:ring-border-focus ${
+          isDragOver && onValueChange
+            ? 'border-brand bg-brand-subtle/40 ring-2 ring-brand/30'
+            : isDragOver
+              ? 'border-error/60 bg-error/5'
+              : isVariableDragging && onValueChange
+                ? 'border-brand/60 bg-brand-subtle/20'
+                : isVariableDragging
+                  ? 'border-border-subtle opacity-60'
+                  : 'border-border-subtle'
+        }`}
+      >
         <span className="shrink-0 font-mono text-foreground-accent" aria-hidden="true">
           ƒx
         </span>
         <input
+          ref={inputRef}
           value={value ?? ''}
           onChange={(event) => onValueChange?.(event.target.value)}
           readOnly={!onValueChange}
@@ -1223,6 +1302,17 @@ function ExpressionField({
           className="h-8 min-w-0 flex-1 bg-transparent font-mono text-xs text-foreground-accent outline-none placeholder:font-sans placeholder:text-foreground-subtle read-only:cursor-default"
         />
         <SlidersHorizontal className="ml-auto size-4 shrink-0 text-foreground-muted" />
+        {isVariableDragging && (
+          <span
+            className={`pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 rounded px-1.5 py-0.5 text-[10px] font-medium ${
+              onValueChange
+                ? 'bg-brand text-foreground-on-accent'
+                : 'bg-surface-raised text-foreground-muted'
+            }`}
+          >
+            {onValueChange ? (isDragOver ? 'Drop to insert' : 'Drop variable') : 'Unavailable'}
+          </span>
+        )}
       </div>
     </div>
   );
@@ -1247,7 +1337,40 @@ function BooleanField({ label }: { label: string }) {
   );
 }
 
-function SendEmailForm({ spacious = false }: { spacious?: boolean }) {
+function SendEmailForm({
+  spacious = false,
+  variables = [],
+}: {
+  spacious?: boolean;
+  variables?: EditableWorkflowVariable[];
+}) {
+  const [fieldValues, setFieldValues] = useState({
+    to: '$vars.executeQuerySynchronously1.output[0].assignee_email',
+    subject: '$vars.recordUpdated1.output.Subject',
+    attachment: '',
+    replyTo: '',
+  });
+  const pickerItems = variables.map((variable) => ({
+    id: variable.id,
+    label: variable.name,
+    value: `$vars.${variable.name}`,
+    type: variable.type.toLowerCase(),
+  }));
+  const field = (key: keyof typeof fieldValues, label: string, placeholder?: string) => (
+    <ExpressionField
+      label={label}
+      value={fieldValues[key]}
+      placeholder={placeholder}
+      variables={pickerItems}
+      onInsertVariable={(variable) =>
+        setFieldValues((current) => ({
+          ...current,
+          [key]: `${current[key]}${variable.value ?? variable.label}`,
+        }))
+      }
+      onValueChange={(nextValue) => setFieldValues((current) => ({ ...current, [key]: nextValue }))}
+    />
+  );
   return (
     <div className={spacious ? 'mx-auto w-full max-w-[760px] p-6' : 'p-3'}>
       <div className="mb-5 flex items-center gap-1 border-b border-border-subtle pb-2">
@@ -1281,14 +1404,8 @@ function SendEmailForm({ spacious = false }: { spacious?: boolean }) {
           </div>
         </div>
         <BooleanField label="Save as draft" />
-        <div>
-          <p className="mb-2 text-xs font-medium">To *</p>
-          <ExpressionField value="$vars.executeQuerySynchronously1.output[0].assignee_email" />
-        </div>
-        <div>
-          <p className="mb-2 text-xs font-medium">Subject</p>
-          <ExpressionField value="$vars.recordUpdated1.output.Subject" />
-        </div>
+        {field('to', 'To *')}
+        {field('subject', 'Subject')}
         <div>
           <p className="mb-2 text-xs font-medium">Body</p>
           <div className="rounded-lg border border-border-subtle bg-surface-overlay">
@@ -1317,10 +1434,7 @@ function SendEmailForm({ spacious = false }: { spacious?: boolean }) {
             </div>
           </div>
         </div>
-        <div>
-          <p className="mb-2 text-xs font-medium">Attachment</p>
-          <ExpressionField placeholder="The file to attach to the email" />
-        </div>
+        {field('attachment', 'Attachment', 'The file to attach to the email')}
         <BooleanField label="Include message details" />
         <button
           type="button"
@@ -1329,10 +1443,7 @@ function SendEmailForm({ spacious = false }: { spacious?: boolean }) {
           <Plus className="size-4" /> Manage Properties
         </button>
         <div className="rounded-lg bg-surface-overlay px-3 py-2 text-xs font-semibold">Options</div>
-        <div>
-          <p className="mb-2 text-xs font-medium">Reply to</p>
-          <ExpressionField placeholder="Email addresses to use when replying" />
-        </div>
+        {field('replyTo', 'Reply to', 'Email addresses to use when replying')}
       </div>
     </div>
   );
@@ -1341,9 +1452,11 @@ function SendEmailForm({ spacious = false }: { spacious?: boolean }) {
 function SendEmailPropertiesPanel({
   onClose,
   onOpenTakeover,
+  variables,
 }: {
   onClose: () => void;
   onOpenTakeover: () => void;
+  variables?: EditableWorkflowVariable[];
 }) {
   return (
     <NodePropertyPanel
@@ -1360,7 +1473,7 @@ function SendEmailPropertiesPanel({
       className="h-full"
     >
       <div className="min-h-0 flex-1 overflow-auto">
-        <SendEmailForm />
+        <SendEmailForm variables={variables} />
       </div>
     </NodePropertyPanel>
   );
@@ -1659,7 +1772,7 @@ function DockedDataPanels({
   );
 }
 
-function SendEmailTakeoverPanels() {
+function SendEmailTakeoverPanels({ variables = [] }: { variables?: EditableWorkflowVariable[] }) {
   return (
     <NodePropertyPanelLayout
       className="h-full"
@@ -1699,7 +1812,7 @@ function SendEmailTakeoverPanels() {
           className="h-full"
         >
           <div className="min-h-0 flex-1 overflow-auto">
-            <SendEmailForm spacious />
+            <SendEmailForm spacious variables={variables} />
           </div>
         </NodePropertyPanel>
       }
@@ -2260,6 +2373,639 @@ type EditableWorkflowVariable = {
   type: string;
   value: string;
 };
+
+function WorkflowVariablesSidebar({
+  variables,
+  onVariablesChange,
+}: {
+  variables: EditableWorkflowVariable[];
+  onVariablesChange: (variables: EditableWorkflowVariable[]) => void;
+}) {
+  const [query, setQuery] = useState('');
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const visibleVariables = variables.filter((variable) =>
+    `${variable.name} ${variable.type} ${variable.value}`
+      .toLowerCase()
+      .includes(query.toLowerCase())
+  );
+  const updateVariable = (id: string, updates: Partial<EditableWorkflowVariable>) => {
+    onVariablesChange(
+      variables.map((variable) => (variable.id === id ? { ...variable, ...updates } : variable))
+    );
+  };
+  const addVariable = () => {
+    const id = `variable-${Date.now()}`;
+    onVariablesChange([...variables, { id, name: 'newVariable', type: 'Text', value: '' }]);
+    setEditingId(id);
+  };
+
+  return (
+    <div className="flex h-full min-h-0 flex-col">
+      <div className="relative">
+        <Search className="pointer-events-none absolute left-2.5 top-1/2 size-3.5 -translate-y-1/2 text-foreground-muted" />
+        <Input
+          value={query}
+          onChange={(event) => setQuery(event.target.value)}
+          placeholder="Filter variables"
+          aria-label="Filter variables"
+          className="h-8 pl-8 text-xs"
+        />
+      </div>
+      <div className="mt-3 flex items-center justify-between">
+        <div>
+          <p className="text-xs font-semibold text-foreground">Workflow scope</p>
+          <p className="mt-0.5 text-[11px] text-foreground-muted">
+            Drag a variable into a supported field.
+          </p>
+        </div>
+        <Button
+          size="sm"
+          variant="ghost"
+          className="h-7 px-2 text-xs font-semibold text-brand hover:text-brand"
+          onClick={addVariable}
+        >
+          <Plus size={14} /> Add
+        </Button>
+      </div>
+      <div className="mt-3 min-h-0 flex-1 space-y-2 overflow-auto">
+        {visibleVariables.map((variable) =>
+          editingId === variable.id ? (
+            <div
+              key={variable.id}
+              className="space-y-3 rounded-xl border border-border-focus bg-surface-raised p-3 shadow-sm"
+            >
+              <div className="grid grid-cols-[minmax(0,1fr)_96px] gap-2">
+                <Input
+                  value={variable.name}
+                  onChange={(event) => updateVariable(variable.id, { name: event.target.value })}
+                  aria-label="Variable name"
+                  className="h-8 text-xs"
+                />
+                <Select
+                  value={variable.type}
+                  onValueChange={(type) => updateVariable(variable.id, { type })}
+                >
+                  <SelectTrigger className="h-8 text-xs" aria-label="Variable type">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {['Text', 'Number', 'Boolean', 'Object'].map((type) => (
+                      <SelectItem key={type} value={type}>
+                        {type}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              <Input
+                value={variable.value}
+                onChange={(event) => updateVariable(variable.id, { value: event.target.value })}
+                placeholder="Default value"
+                aria-label="Default value"
+                className="h-8 text-xs"
+              />
+              <div className="flex justify-between">
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  className="h-7 px-2 text-xs text-destructive"
+                  onClick={() => {
+                    onVariablesChange(variables.filter((item) => item.id !== variable.id));
+                    setEditingId(null);
+                  }}
+                >
+                  <Trash2 size={13} /> Delete
+                </Button>
+                <Button size="sm" className="h-7 text-xs" onClick={() => setEditingId(null)}>
+                  Done
+                </Button>
+              </div>
+            </div>
+          ) : (
+            <div
+              key={variable.id}
+              draggable
+              onDragStart={(event) => {
+                event.dataTransfer.effectAllowed = 'copy';
+                event.dataTransfer.setData(
+                  'application/x-variable',
+                  JSON.stringify({ id: variable.id, name: variable.name, type: variable.type })
+                );
+                event.dataTransfer.setData(VARIABLE_DRAG_MIME, `vars.${variable.name}`);
+                event.dataTransfer.setData('text/plain', `$vars.${variable.name}`);
+              }}
+              className="group flex cursor-grab items-center gap-2 rounded-lg border border-border-subtle bg-surface-overlay px-2 py-2 active:cursor-grabbing"
+            >
+              <GripVertical className="size-3.5 shrink-0 text-foreground-subtle" />
+              <Code2 className="size-4 shrink-0 text-brand" />
+              <div className="min-w-0 flex-1">
+                <p className="truncate font-mono text-xs font-medium">{variable.name}</p>
+                <p className="mt-0.5 truncate text-[11px] text-foreground-muted">
+                  {variable.type} · {variable.value || 'No default value'}
+                </p>
+              </div>
+              <Button
+                size="3xs"
+                icon
+                variant="ghost"
+                aria-label={`Edit ${variable.name}`}
+                className="opacity-0 group-hover:opacity-100 group-focus-within:opacity-100"
+                onClick={() => setEditingId(variable.id)}
+              >
+                <Pencil size={13} />
+              </Button>
+            </div>
+          )
+        )}
+        {visibleVariables.length === 0 && (
+          <p className="px-2 py-6 text-center text-xs text-foreground-muted">
+            No variables match this filter.
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}
+
+const TREE_OUTPUT_VARIABLES = [
+  { id: 'record-description', name: 'recordUpdated1.output.Description', type: 'Text' },
+  { id: 'account-name', name: 'getAccountDetails.output.AccountName', type: 'Text' },
+];
+
+function VariableTreeRow({
+  name,
+  type,
+  selected,
+  onSelect,
+}: {
+  name: string;
+  type: string;
+  selected?: boolean;
+  onSelect?: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      draggable
+      onClick={onSelect}
+      onDragStart={(event) => {
+        event.dataTransfer.effectAllowed = 'copy';
+        event.dataTransfer.setData(VARIABLE_DRAG_MIME, name.replace(/^\$/, ''));
+        event.dataTransfer.setData('text/plain', name.startsWith('$') ? name : `$vars.${name}`);
+      }}
+      className={`group flex h-8 w-full cursor-grab items-center gap-2 rounded-md px-2 text-left transition active:cursor-grabbing ${
+        selected ? 'bg-surface-overlay text-foreground' : 'hover:bg-surface-hover'
+      }`}
+    >
+      <GripVertical className="size-3 shrink-0 text-foreground-subtle opacity-0 group-hover:opacity-100" />
+      <Code2 className="size-3.5 shrink-0 text-brand" />
+      <span className="min-w-0 flex-1 truncate font-mono text-xs">{name}</span>
+      <span className="text-[10px] text-foreground-subtle">{type}</span>
+    </button>
+  );
+}
+
+function WorkflowVariablesTreeSidebar({
+  variables,
+  onVariablesChange,
+}: {
+  variables: EditableWorkflowVariable[];
+  onVariablesChange: (variables: EditableWorkflowVariable[]) => void;
+}) {
+  const [query, setQuery] = useState('');
+  const [selectedId, setSelectedId] = useState<string | null>(variables[0]?.id ?? null);
+  const [expanded, setExpanded] = useState({ flow: true, outputs: true });
+  const selectedVariable = variables.find((variable) => variable.id === selectedId);
+  const visibleVariables = variables.filter((variable) =>
+    variable.name.toLowerCase().includes(query.toLowerCase())
+  );
+  const updateSelected = (updates: Partial<EditableWorkflowVariable>) => {
+    if (!selectedId) return;
+    onVariablesChange(
+      variables.map((variable) =>
+        variable.id === selectedId ? { ...variable, ...updates } : variable
+      )
+    );
+  };
+  const addVariable = () => {
+    const id = `variable-${Date.now()}`;
+    onVariablesChange([...variables, { id, name: 'newVariable', type: 'Text', value: '' }]);
+    setSelectedId(id);
+    setExpanded((current) => ({ ...current, flow: true }));
+  };
+
+  const section = (id: 'flow' | 'outputs', label: string, count: number, children: ReactNode) => (
+    <section>
+      <button
+        type="button"
+        className="flex h-8 w-full items-center gap-2 rounded-md px-1 text-left hover:bg-surface-hover"
+        onClick={() => setExpanded((current) => ({ ...current, [id]: !current[id] }))}
+      >
+        <ChevronDown
+          className={`size-3.5 text-foreground-subtle transition-transform ${
+            expanded[id] ? '' : '-rotate-90'
+          }`}
+        />
+        <span className="flex-1 text-xs font-semibold text-foreground">{label}</span>
+        <span className="text-[10px] text-foreground-muted">{count}</span>
+      </button>
+      {expanded[id] && <div className="ml-2 border-l border-border-subtle pl-2">{children}</div>}
+    </section>
+  );
+
+  return (
+    <div className="flex h-full min-h-0 flex-col">
+      <div className="relative">
+        <Search className="pointer-events-none absolute left-2.5 top-1/2 size-3.5 -translate-y-1/2 text-foreground-muted" />
+        <Input
+          value={query}
+          onChange={(event) => setQuery(event.target.value)}
+          placeholder="Filter variables"
+          aria-label="Filter tree variables"
+          className="h-8 pl-8 text-xs"
+        />
+      </div>
+      <div className="mt-3 flex items-center justify-between">
+        <p className="text-[11px] text-foreground-muted">Select to edit · drag to bind</p>
+        <Button
+          size="2xs"
+          variant="ghost"
+          className="text-brand hover:text-brand"
+          onClick={addVariable}
+        >
+          <Plus size={13} /> Add
+        </Button>
+      </div>
+      <div className="mt-2 min-h-0 flex-1 space-y-1 overflow-auto">
+        {section(
+          'flow',
+          'Flow scope',
+          visibleVariables.length,
+          visibleVariables.map((variable) => (
+            <VariableTreeRow
+              key={variable.id}
+              name={variable.name}
+              type={variable.type}
+              selected={selectedId === variable.id}
+              onSelect={() => setSelectedId(variable.id)}
+            />
+          ))
+        )}
+        {section(
+          'outputs',
+          'Node outputs',
+          TREE_OUTPUT_VARIABLES.length,
+          TREE_OUTPUT_VARIABLES.map((variable) => (
+            <VariableTreeRow key={variable.id} name={`$${variable.name}`} type={variable.type} />
+          ))
+        )}
+      </div>
+      {selectedVariable && (
+        <div className="mt-3 shrink-0 space-y-2 border-t border-border-subtle pt-3">
+          <div className="flex items-center justify-between">
+            <p className="text-xs font-semibold">Variable details</p>
+            <Button
+              size="3xs"
+              icon
+              variant="ghost"
+              aria-label={`Delete ${selectedVariable.name}`}
+              onClick={() => {
+                onVariablesChange(variables.filter((variable) => variable.id !== selectedId));
+                setSelectedId(null);
+              }}
+            >
+              <Trash2 size={13} />
+            </Button>
+          </div>
+          <div className="grid grid-cols-[minmax(0,1fr)_96px] gap-2">
+            <Input
+              value={selectedVariable.name}
+              onChange={(event) => updateSelected({ name: event.target.value })}
+              aria-label="Tree variable name"
+              className="h-8 text-xs"
+            />
+            <Select
+              value={selectedVariable.type}
+              onValueChange={(type) => updateSelected({ type })}
+            >
+              <SelectTrigger className="h-8 text-xs" aria-label="Tree variable type">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {['Text', 'Number', 'Boolean', 'Object'].map((type) => (
+                  <SelectItem key={type} value={type}>
+                    {type}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          <Input
+            value={selectedVariable.value}
+            onChange={(event) => updateSelected({ value: event.target.value })}
+            placeholder="Default value"
+            aria-label="Tree variable default value"
+            className="h-8 text-xs"
+          />
+        </div>
+      )}
+    </div>
+  );
+}
+
+function VariableSchemaBadge({ type }: { type: string }) {
+  const labels: Record<string, string> = { Text: 'T', Number: '#', Boolean: '?', Object: '{}' };
+  return (
+    <span className="inline-flex h-[18px] min-w-[18px] shrink-0 items-center justify-center rounded border border-border bg-surface-overlay px-0.5 font-mono text-[9px] font-semibold leading-none text-foreground-muted">
+      {labels[type] ?? 'T'}
+    </span>
+  );
+}
+
+function WorkflowVariablesSchemaSidebar({
+  variables,
+  onVariablesChange,
+}: {
+  variables: EditableWorkflowVariable[];
+  onVariablesChange: (variables: EditableWorkflowVariable[]) => void;
+}) {
+  const [query, setQuery] = useState('');
+  const [searchOpen, setSearchOpen] = useState(false);
+  const [collapsed, setCollapsed] = useState({ flow: false, outputs: false });
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editingValueId, setEditingValueId] = useState<string | null>(null);
+  const visibleVariables = variables.filter((variable) =>
+    `${variable.name} ${variable.value}`.toLowerCase().includes(query.toLowerCase())
+  );
+  const updateVariable = (id: string, updates: Partial<EditableWorkflowVariable>) => {
+    onVariablesChange(
+      variables.map((variable) => (variable.id === id ? { ...variable, ...updates } : variable))
+    );
+  };
+  const addVariable = () => {
+    const id = `variable-${Date.now()}`;
+    onVariablesChange([...variables, { id, name: 'newVariable', type: 'Text', value: '' }]);
+    setCollapsed((current) => ({ ...current, flow: false }));
+    setEditingId(id);
+  };
+  const allCollapsed = collapsed.flow && collapsed.outputs;
+  const containerRow = (
+    id: 'flow' | 'outputs',
+    label: string,
+    count: number,
+    children: ReactNode
+  ) => (
+    <>
+      <div className="group flex cursor-default items-center gap-2 py-1 pl-2 pr-3.5 transition hover:bg-surface-overlay">
+        <button
+          type="button"
+          onClick={() => setCollapsed((current) => ({ ...current, [id]: !current[id] }))}
+          aria-label={collapsed[id] ? `Expand ${label}` : `Collapse ${label}`}
+          className="grid size-3 shrink-0 cursor-pointer place-items-center text-foreground-subtle transition hover:text-foreground"
+        >
+          <ChevronDown
+            size={10}
+            className={`transition-transform duration-100 ${collapsed[id] ? '-rotate-90' : ''}`}
+          />
+        </button>
+        <VariableSchemaBadge type="Object" />
+        <span className="flex-1 truncate font-mono text-xs text-foreground">{label}</span>
+        <span className="shrink-0 font-mono text-[10px] text-foreground-muted">
+          {count} {count === 1 ? 'key' : 'keys'}
+        </span>
+      </div>
+      {!collapsed[id] && children}
+    </>
+  );
+
+  return (
+    <div className="flex h-full min-h-0 flex-col">
+      <div className="flex shrink-0 items-center gap-1.5 pb-1 pt-1">
+        <button
+          type="button"
+          className="flex cursor-pointer items-center gap-1.5 rounded-md px-2 py-1 text-xs font-medium text-foreground-muted transition hover:bg-surface-overlay hover:text-foreground"
+        >
+          Filter: All <ChevronDown size={10} className="text-foreground-subtle" />
+        </button>
+        <div className="flex-1" />
+        {searchOpen ? (
+          <div className="relative flex items-center">
+            <Search
+              size={12}
+              className="pointer-events-none absolute left-2 text-foreground-subtle"
+            />
+            <Input
+              autoFocus
+              variant="ghost"
+              size="xs"
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+              aria-label="Search variable schema"
+              placeholder="Search variables..."
+              className="w-36 pl-6 pr-6 text-foreground focus-visible:ring-0"
+            />
+            <button
+              type="button"
+              onClick={() => {
+                setQuery('');
+                setSearchOpen(false);
+              }}
+              aria-label="Clear variable search"
+              className="absolute right-1.5 grid size-4 place-items-center text-foreground-subtle hover:text-foreground"
+            >
+              ×
+            </button>
+          </div>
+        ) : (
+          <Button
+            variant="ghost"
+            size="4xs"
+            icon
+            onClick={() => setSearchOpen(true)}
+            aria-label="Search variable fields"
+            className="rounded text-foreground-subtle hover:bg-surface-overlay hover:text-foreground"
+          >
+            <Search size={12} />
+          </Button>
+        )}
+        <Button
+          variant="ghost"
+          size="4xs"
+          icon
+          onClick={() => setCollapsed({ flow: !allCollapsed, outputs: !allCollapsed })}
+          aria-label={allCollapsed ? 'Expand all variable fields' : 'Collapse all variable fields'}
+          className="rounded text-foreground-subtle hover:bg-surface-overlay hover:text-foreground"
+        >
+          <ListTree size={12} />
+        </Button>
+      </div>
+      <div className="mt-1 min-h-0 flex-1 overflow-hidden rounded-xl border border-surface-overlay bg-surface-overlay/40 pb-0">
+        <div className="h-full overflow-y-auto pt-1.5">
+          {containerRow(
+            'flow',
+            'flow',
+            visibleVariables.length,
+            visibleVariables.map((variable) => (
+              <div
+                key={variable.id}
+                draggable={editingId !== variable.id}
+                onDragStart={(event) => {
+                  event.dataTransfer.effectAllowed = 'copy';
+                  event.dataTransfer.setData(VARIABLE_DRAG_MIME, `vars.${variable.name}`);
+                  event.dataTransfer.setData('text/plain', `$vars.${variable.name}`);
+                }}
+                className="group flex min-h-7 cursor-grab items-center gap-2 py-1 pl-7 pr-2 transition hover:bg-surface-overlay active:cursor-grabbing"
+              >
+                <div className="size-3 shrink-0" />
+                <VariableSchemaBadge type={variable.type} />
+                {editingId === variable.id ? (
+                  <div className="flex min-w-0 flex-1 items-center gap-1.5">
+                    <input
+                      value={variable.name}
+                      onChange={(event) =>
+                        updateVariable(variable.id, { name: event.target.value })
+                      }
+                      aria-label="Schema variable name"
+                      className="h-6 min-w-0 flex-1 rounded bg-transparent px-1 font-mono text-xs outline-none ring-1 ring-brand"
+                    />
+                    <Button size="4xs" variant="ghost" onClick={() => setEditingId(null)}>
+                      Done
+                    </Button>
+                  </div>
+                ) : (
+                  <>
+                    <span className="shrink-0 font-mono text-xs text-foreground">
+                      {variable.name}
+                    </span>
+                    <span className="shrink-0 font-mono text-xs text-foreground-subtle">=</span>
+                    {editingValueId === variable.id ? (
+                      <input
+                        value={variable.value}
+                        onChange={(event) =>
+                          updateVariable(variable.id, { value: event.target.value })
+                        }
+                        onBlur={() => setEditingValueId(null)}
+                        onKeyDown={(event) => {
+                          if (event.key === 'Enter' || event.key === 'Escape') {
+                            setEditingValueId(null);
+                          }
+                        }}
+                        aria-label={`Edit value for ${variable.name}`}
+                        className="h-5 min-w-0 flex-1 rounded bg-transparent px-1 font-mono text-xs text-success outline-none ring-1 ring-brand"
+                      />
+                    ) : (
+                      <button
+                        type="button"
+                        onClick={() => setEditingValueId(variable.id)}
+                        className={`min-w-0 flex-1 truncate text-left font-mono text-xs ${
+                          variable.type === 'Number'
+                            ? 'text-info'
+                            : variable.type === 'Boolean'
+                              ? variable.value === 'true'
+                                ? 'text-success'
+                                : 'text-error'
+                              : variable.value
+                                ? 'text-success'
+                                : 'text-foreground-subtle'
+                        }`}
+                      >
+                        {variable.value
+                          ? variable.type === 'Text'
+                            ? `&quot;${variable.value}&quot;`
+                            : variable.value
+                          : 'null'}
+                      </button>
+                    )}
+                    <Button
+                      size="4xs"
+                      icon
+                      variant="ghost"
+                      aria-label={`Edit schema variable ${variable.name}`}
+                      className="opacity-0 group-hover:opacity-100"
+                      onClick={() => setEditingId(variable.id)}
+                    >
+                      <Pencil size={11} />
+                    </Button>
+                    <Button
+                      size="4xs"
+                      icon
+                      variant="ghost"
+                      aria-label={`Delete schema variable ${variable.name}`}
+                      className="opacity-0 group-hover:opacity-100"
+                      onClick={() =>
+                        onVariablesChange(variables.filter((item) => item.id !== variable.id))
+                      }
+                    >
+                      <Trash2 size={11} />
+                    </Button>
+                  </>
+                )}
+              </div>
+            ))
+          )}
+          {containerRow(
+            'outputs',
+            'nodeOutputs',
+            TREE_OUTPUT_VARIABLES.length,
+            TREE_OUTPUT_VARIABLES.map((variable) => (
+              <div
+                key={variable.id}
+                draggable
+                onDragStart={(event) => {
+                  event.dataTransfer.effectAllowed = 'copy';
+                  event.dataTransfer.setData(VARIABLE_DRAG_MIME, variable.name);
+                  event.dataTransfer.setData('text/plain', `$${variable.name}`);
+                }}
+                className="group flex min-h-7 cursor-grab items-center gap-2 py-1 pl-7 pr-3.5 transition hover:bg-surface-overlay active:cursor-grabbing"
+              >
+                <div className="size-3 shrink-0" />
+                <VariableSchemaBadge type={variable.type} />
+                <span className="min-w-0 flex-1 truncate font-mono text-xs text-foreground">
+                  {variable.name}
+                </span>
+                <span className="shrink-0 font-mono text-[10px] text-foreground-muted">
+                  {variable.type.toLowerCase()}
+                </span>
+              </div>
+            ))
+          )}
+        </div>
+      </div>
+      <button
+        type="button"
+        onClick={addVariable}
+        className="flex cursor-pointer items-center gap-1.5 py-3 text-xs text-brand transition hover:text-brand-hover"
+      >
+        <Plus size={12} /> Add variable
+      </button>
+    </div>
+  );
+}
+
+const withDiscoveryDot = (icon: ReactNode) => (
+  <span className="relative grid size-5 place-items-center">
+    {icon}
+    <span className="absolute -right-0.5 -top-0.5 size-2 rounded-full bg-brand ring-2 ring-surface-raised" />
+  </span>
+);
+
+const VARIABLE_CONCEPT_SIDEBAR_ITEMS = CANVAS_LEFT_SIDEBAR_DEFAULT_PRIMARY_ITEMS.flatMap((item) =>
+  item.id === 'variables'
+    ? [
+        { ...item, icon: withDiscoveryDot(item.icon) },
+        {
+          id: 'variables-tree',
+          label: 'Variables tree',
+          icon: withDiscoveryDot(<ListTree strokeWidth={1.75} />),
+        },
+        {
+          id: 'variables-schema',
+          label: 'Variables schema tree',
+          icon: withDiscoveryDot(<Code2 strokeWidth={1.75} />),
+        },
+      ]
+    : [item]
+);
 
 const VARIABLE_TAB_LIST_CLASS =
   'mx-3 h-auto justify-start gap-0.5 overflow-x-auto rounded-lg bg-transparent p-0.5 text-muted-foreground [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden';
@@ -3992,7 +4738,7 @@ export function FullWorkbenchComposition({
 }) {
   const panelRef = useRef<PanelImperativeHandle | null>(null);
   const expandedBottomPanelHeight = useRef(368);
-  const [sidebarExpanded, setSidebarExpanded] = useState(false);
+  const [sidebarExpanded, setSidebarExpanded] = useState(rightPanelVariant === 'node');
   const [activeSidebarItem, setActiveSidebarItem] = useState<CanvasLeftSidebarItemId>('variables');
   const [rightPanelOpen, setRightPanelOpen] = useState(true);
   const [takeoverOpen, setTakeoverOpen] = useState(false);
@@ -4015,6 +4761,8 @@ export function FullWorkbenchComposition({
     'coding-agent': 'Coding agent',
     files: 'Files',
     variables: 'Variables',
+    'variables-tree': 'Variables tree',
+    'variables-schema': 'Variables schema tree',
     connections: 'Connections',
     'run-history': 'Run history',
     'whats-new': "What's new",
@@ -4060,11 +4808,33 @@ export function FullWorkbenchComposition({
       <CanvasLeftSidebar
         title={sidebarLabels[activeSidebarItem]}
         variant="default"
+        primaryItems={VARIABLE_CONCEPT_SIDEBAR_ITEMS}
         isExpanded={sidebarExpanded}
         onExpandedChange={setSidebarExpanded}
         activeItemId={activeSidebarItem}
         onItemSelect={setActiveSidebarItem}
-      />
+      >
+        {activeSidebarItem === 'variables' ? (
+          <WorkflowVariablesSidebar
+            variables={editableWorkflowVariables}
+            onVariablesChange={setEditableWorkflowVariables}
+          />
+        ) : activeSidebarItem === 'variables-tree' ? (
+          <WorkflowVariablesTreeSidebar
+            variables={editableWorkflowVariables}
+            onVariablesChange={setEditableWorkflowVariables}
+          />
+        ) : activeSidebarItem === 'variables-schema' ? (
+          <WorkflowVariablesSchemaSidebar
+            variables={editableWorkflowVariables}
+            onVariablesChange={setEditableWorkflowVariables}
+          />
+        ) : (
+          <div className="py-6 text-center text-xs text-foreground-muted">
+            {sidebarLabels[activeSidebarItem]} content
+          </div>
+        )}
+      </CanvasLeftSidebar>
       <div className="relative min-w-0 flex-1 overflow-hidden">
         <CanvasViewport
           workflowVariant={
@@ -4131,6 +4901,7 @@ export function FullWorkbenchComposition({
                 <SendEmailPropertiesPanel
                   onClose={() => setRightPanelOpen(false)}
                   onOpenTakeover={() => setTakeoverOpen(true)}
+                  variables={editableWorkflowVariables}
                 />
               ) : (
                 <PropertiesPanel className="h-full" onClose={() => setRightPanelOpen(false)} />
@@ -4197,7 +4968,7 @@ export function FullWorkbenchComposition({
             </Button>
           }
         >
-          <SendEmailTakeoverPanels />
+          <SendEmailTakeoverPanels variables={editableWorkflowVariables} />
         </CanvasTakeoverModal>
       )}
       {rightPanelVariant === 'variables' && (

--- a/packages/apollo-react/src/canvas/stories/templates/Flow.stories.tsx
+++ b/packages/apollo-react/src/canvas/stories/templates/Flow.stories.tsx
@@ -10,18 +10,30 @@ import {
   Button,
   Card,
   CardContent,
+  Checkbox,
   type FormSchema,
+  Input,
+  Label,
   type PanelImperativeHandle,
   ResizableHandle,
   ResizablePanel,
   ResizablePanelGroup,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
   Separator,
+  Switch,
   Tabs,
   TabsContent,
   TabsList,
   TabsTrigger,
+  Textarea,
   ToggleGroup,
   ToggleGroupItem,
+  VariablePicker,
+  type VariablePickerItem,
 } from '@uipath/apollo-wind';
 import type { DockviewApi, DockviewReadyEvent, IDockviewPanelProps } from 'dockview-react';
 import { DockviewReact } from 'dockview-react';
@@ -40,6 +52,7 @@ import {
   List,
   ListOrdered,
   Mail,
+  Maximize2,
   Play,
   Plus,
   Redo2,
@@ -391,14 +404,26 @@ function createFlowGraph(variant: WorkflowVariant): {
 // Canvas content component (must be inside ReactFlowProvider)
 // ============================================================================
 
-function FlowCanvas({ workflowVariant = 'default' }: { workflowVariant?: WorkflowVariant }) {
+function FlowCanvas({
+  workflowVariant = 'default',
+  onNodeSelect,
+}: {
+  workflowVariant?: WorkflowVariant;
+  onNodeSelect?: (nodeId: string) => void;
+}) {
   const graph = useMemo(() => createFlowGraph(workflowVariant), [workflowVariant]);
   const { canvasProps } = useCanvasStory({
     initialNodes: graph.nodes,
     initialEdges: graph.edges,
   });
 
-  return <BaseCanvas {...canvasProps} mode="design" />;
+  return (
+    <BaseCanvas
+      {...canvasProps}
+      mode="design"
+      onNodeClick={(_event, node) => onNodeSelect?.(node.id)}
+    />
+  );
 }
 
 const panelBehaviorOptions = [
@@ -668,45 +693,62 @@ function CanvasViewport({
   bottomControlsOffset = 20,
   rightControlsOffset = 16,
   workflowVariant = 'default',
+  onNodeSelect,
 }: {
   trigger?: ReactNode;
   children?: ReactNode;
   bottomControlsOffset?: number;
   rightControlsOffset?: number;
   workflowVariant?: WorkflowVariant;
+  onNodeSelect?: (nodeId: string) => void;
 }) {
   const { getNodes, getNodesBounds, getViewport, setEdges, setNodes, setViewport } = useReactFlow();
   const nodesInitialized = useNodesInitialized();
   const viewportContainerRef = useRef<HTMLDivElement>(null);
 
-  const centerWorkflow = useCallback(
+  const fitWorkflow = useCallback(
     (duration: number) => {
       const container = viewportContainerRef.current;
       const nodes = getNodes();
       if (!container || nodes.length === 0) return;
       const bounds = getNodesBounds(nodes);
-      const viewport = getViewport();
       const occupiedRight = Math.max(0, rightControlsOffset - 16);
       const occupiedBottom = Math.max(0, bottomControlsOffset - 20);
-      const availableCenterX = (container.clientWidth - occupiedRight) / 2;
-      const availableCenterY = (container.clientHeight - occupiedBottom) / 2;
+      const availableWidth = container.clientWidth - occupiedRight;
+      const availableHeight = container.clientHeight - occupiedBottom;
+      const padding = 48;
+      const zoom = Math.min(
+        0.85,
+        Math.max(0.1, (availableWidth - padding * 2) / bounds.width),
+        Math.max(0.1, (availableHeight - padding * 2) / bounds.height)
+      );
+      const availableCenterX = availableWidth / 2;
+      const availableCenterY = availableHeight / 2;
       void setViewport(
         {
-          ...viewport,
-          x: availableCenterX - (bounds.x + bounds.width / 2) * viewport.zoom,
-          y: availableCenterY - (bounds.y + bounds.height / 2) * viewport.zoom,
+          zoom,
+          x: availableCenterX - (bounds.x + bounds.width / 2) * zoom,
+          y: availableCenterY - (bounds.y + bounds.height / 2) * zoom,
         },
         { duration }
       );
     },
-    [bottomControlsOffset, getNodes, getNodesBounds, getViewport, rightControlsOffset, setViewport]
+    [bottomControlsOffset, getNodes, getNodesBounds, rightControlsOffset, setViewport]
   );
 
   useEffect(() => {
     if (!nodesInitialized) return;
-    const timeout = window.setTimeout(() => centerWorkflow(200), 100);
+    const timeout = window.setTimeout(() => fitWorkflow(200), 100);
     return () => window.clearTimeout(timeout);
-  }, [centerWorkflow, nodesInitialized]);
+  }, [fitWorkflow, nodesInitialized]);
+
+  useEffect(() => {
+    const container = viewportContainerRef.current;
+    if (!container || !nodesInitialized) return;
+    const resizeObserver = new ResizeObserver(() => fitWorkflow(0));
+    resizeObserver.observe(container);
+    return () => resizeObserver.disconnect();
+  }, [fitWorkflow, nodesInitialized]);
 
   const tidy = useCallback(() => {
     const graph = createFlowGraph(workflowVariant);
@@ -717,7 +759,7 @@ function CanvasViewport({
 
   return (
     <div ref={viewportContainerRef} className="relative h-full min-h-0 min-w-0 overflow-hidden">
-      <FlowCanvas workflowVariant={workflowVariant} />
+      <FlowCanvas workflowVariant={workflowVariant} onNodeSelect={onNodeSelect} />
       {children}
       <div className="absolute top-4 z-20" style={{ right: rightControlsOffset }}>
         {trigger ?? <PanelTrigger />}
@@ -1125,17 +1167,49 @@ function QuickFormPropertiesPanel({ onClose }: { onClose: () => void }) {
   return <QuickFormPanel embedded onClose={onClose} className="h-full" />;
 }
 
-function ExpressionField({ value, placeholder }: { value?: string; placeholder?: string }) {
+function ExpressionField({
+  label,
+  value,
+  placeholder,
+  variables = [],
+  onInsertVariable,
+  onValueChange,
+}: {
+  label?: string;
+  value?: string;
+  placeholder?: string;
+  variables?: VariablePickerItem[];
+  onInsertVariable?: (variable: VariablePickerItem) => void;
+  onValueChange?: (value: string) => void;
+}) {
   return (
-    <div className="flex min-h-9 items-center rounded-lg border border-border-subtle bg-surface-overlay px-2.5 text-xs">
-      {value ? (
-        <span className="max-w-full truncate rounded-md bg-brand-subtle px-2 py-1 font-mono text-foreground-accent">
-          ƒx {value}
-        </span>
-      ) : (
-        <span className="truncate text-foreground-subtle">{placeholder}</span>
+    <div className="space-y-1.5">
+      {label && (
+        <div className="flex items-center justify-between gap-2">
+          <p className="text-xs font-medium text-foreground">{label}</p>
+          <VariablePicker
+            items={variables}
+            onSelect={(variable) => onInsertVariable?.(variable)}
+            disabled={!onInsertVariable || variables.length === 0}
+            triggerLabel="Select variable"
+            triggerAriaLabel={`Select variable for ${label}`}
+          />
+        </div>
       )}
-      <SlidersHorizontal className="ml-auto size-4 shrink-0 text-foreground-muted" />
+      <div className="flex min-h-9 items-center gap-1.5 rounded-lg border border-border-subtle bg-surface-overlay px-2.5 text-xs focus-within:border-border-focus focus-within:ring-1 focus-within:ring-border-focus">
+        <span className="shrink-0 font-mono text-foreground-accent" aria-hidden="true">
+          ƒx
+        </span>
+        <input
+          value={value ?? ''}
+          onChange={(event) => onValueChange?.(event.target.value)}
+          readOnly={!onValueChange}
+          placeholder={placeholder}
+          aria-label={label ? `${label} expression` : 'Expression'}
+          className="h-8 min-w-0 flex-1 bg-transparent font-mono text-xs text-foreground-accent outline-none placeholder:font-sans placeholder:text-foreground-subtle read-only:cursor-default"
+        />
+        <SlidersHorizontal className="ml-auto size-4 shrink-0 text-foreground-muted" />
+      </div>
     </div>
   );
 }
@@ -1250,7 +1324,13 @@ function SendEmailForm({ spacious = false }: { spacious?: boolean }) {
   );
 }
 
-function SendEmailPropertiesPanel({ onClose }: { onClose: () => void }) {
+function SendEmailPropertiesPanel({
+  onClose,
+  onOpenTakeover,
+}: {
+  onClose: () => void;
+  onOpenTakeover: () => void;
+}) {
   return (
     <NodePropertyPanel
       panelTitle="Properties"
@@ -1258,8 +1338,8 @@ function SendEmailPropertiesPanel({ onClose }: { onClose: () => void }) {
       nodeLabel="Send Email"
       nodeCategory="Microsoft Outlook 365"
       action={
-        <Button size="sm">
-          <Play size={14} /> Run node
+        <Button size="sm" onClick={onOpenTakeover}>
+          Node Takeover
         </Button>
       }
       onClose={onClose}
@@ -2158,28 +2238,383 @@ function RuleBuildingPanel({ onClose }: { onClose: () => void }) {
   );
 }
 
-function VariableManagementPanel({ onClose }: { onClose: () => void }) {
+type VariableDemoTab = 'parameters' | 'variables';
+
+type EditableWorkflowVariable = {
+  id: string;
+  name: string;
+  type: string;
+  value: string;
+};
+
+const VARIABLE_TAB_LIST_CLASS =
+  'mx-3 h-auto justify-start gap-0.5 overflow-x-auto rounded-lg bg-transparent p-0.5 text-muted-foreground [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden';
+const VARIABLE_TAB_TRIGGER_CLASS =
+  'inline-flex h-6 shrink-0 items-center whitespace-nowrap rounded-md px-2.5 text-xs font-medium text-muted-foreground shadow-none transition-colors hover:text-foreground data-[state=active]:bg-surface-overlay data-[state=active]:text-foreground data-[state=active]:shadow-sm';
+
+type VariableDemoNode = {
+  label: string;
+  category: string;
+  icon: ReactNode;
+  parameters: { label: string; value: string; expression?: boolean }[];
+  inputs: { name: string; type: string; required?: boolean }[];
+  outputs: { name: string; type: string }[];
+  updates?: { name: string; value: string }[];
+};
+
+const VARIABLE_DEMO_NODES: Record<string, VariableDemoNode> = {
+  trigger: {
+    label: 'Start workflow',
+    category: 'Manual trigger',
+    icon: <Play />,
+    parameters: [
+      { label: 'Trigger type', value: 'Manual' },
+      { label: 'Allow API invocation', value: 'Enabled' },
+      { label: 'Default invoice ID', value: '$vars.currentInvoice.id', expression: true },
+    ],
+    inputs: [
+      { name: 'invoiceId', type: 'Text', required: true },
+      { name: 'priority', type: 'Number' },
+    ],
+    outputs: [{ name: 'requestedBy', type: 'Text' }],
+  },
+  initialize: {
+    label: 'Initialize variables',
+    category: 'Workflow scope',
+    icon: <Code2 />,
+    parameters: [
+      { label: 'Invoice ID', value: '$vars.startWorkflow.output.invoiceId', expression: true },
+      { label: 'Initial status', value: 'Pending review' },
+    ],
+    inputs: [{ name: 'invoiceId', type: 'Text', required: true }],
+    outputs: [
+      { name: 'invoice', type: 'Object' },
+      { name: 'approvalStatus', type: 'Text' },
+    ],
+    updates: [
+      { name: 'currentInvoice', value: '$result.invoice' },
+      { name: 'approvalStatus', value: 'Pending review' },
+    ],
+  },
+  transform: {
+    label: 'Transform invoice data',
+    category: 'Expressions',
+    icon: <Sparkles />,
+    parameters: [
+      { label: 'Source', value: '$vars.currentInvoice', expression: true },
+      { label: 'Transformation', value: 'Normalize invoice fields' },
+    ],
+    inputs: [{ name: 'currentInvoice', type: 'Object', required: true }],
+    outputs: [{ name: 'normalizedInvoice', type: 'Object' }],
+  },
+  assign: {
+    label: 'Assign approval state',
+    category: 'Variables',
+    icon: <SlidersHorizontal />,
+    parameters: [
+      { label: 'Condition', value: '$vars.currentInvoice.total > 10000', expression: true },
+      { label: 'Approval state', value: 'Manager review' },
+    ],
+    inputs: [
+      { name: 'currentInvoice', type: 'Object', required: true },
+      { name: 'approvalStatus', type: 'Text' },
+    ],
+    outputs: [{ name: 'requiresApproval', type: 'Boolean' }],
+    updates: [{ name: 'approvalStatus', value: 'Manager review' }],
+  },
+  output: {
+    label: 'Publish outputs',
+    category: 'Workflow results',
+    icon: <Upload />,
+    parameters: [
+      { label: 'Invoice', value: '$vars.normalizedInvoice', expression: true },
+      { label: 'Status', value: '$vars.approvalStatus', expression: true },
+    ],
+    inputs: [
+      { name: 'normalizedInvoice', type: 'Object', required: true },
+      { name: 'approvalStatus', type: 'Text', required: true },
+    ],
+    outputs: [
+      { name: 'invoice', type: 'Object' },
+      { name: 'status', type: 'Text' },
+    ],
+  },
+};
+
+function VariableRow({ name, type, required }: { name: string; type: string; required?: boolean }) {
+  return (
+    <div className="flex items-center gap-3 rounded-lg border border-border-subtle bg-surface-overlay px-3 py-2.5">
+      <Code2 className="size-4 shrink-0 text-foreground-subtle" />
+      <div className="min-w-0 flex-1">
+        <p className="truncate font-mono text-xs font-medium text-foreground">{name}</p>
+        <p className="mt-0.5 text-[11px] text-foreground-muted">
+          {type}
+          {required ? ' · Required' : ''}
+        </p>
+      </div>
+    </div>
+  );
+}
+
+function UnifiedVariablesPanel({
+  nodeId,
+  activeTab,
+  onActiveTabChange,
+  onClose,
+  onExpand,
+  workflowVariables,
+  onWorkflowVariablesChange,
+  parameterValues,
+  onParameterValueChange,
+  columnMode,
+}: {
+  nodeId: string;
+  activeTab: VariableDemoTab;
+  onActiveTabChange: (tab: VariableDemoTab) => void;
+  onClose?: () => void;
+  onExpand?: () => void;
+  workflowVariables: EditableWorkflowVariable[];
+  onWorkflowVariablesChange: (variables: EditableWorkflowVariable[]) => void;
+  parameterValues: Record<string, string>;
+  onParameterValueChange: (key: string, value: string) => void;
+  columnMode?: VariableDemoTab;
+}) {
+  const node = VARIABLE_DEMO_NODES[nodeId] ?? VARIABLE_DEMO_NODES.trigger;
+  const [editingVariableId, setEditingVariableId] = useState<string | null>(null);
+  const variablePickerItems = workflowVariables.map((variable) => ({
+    id: variable.id,
+    label: variable.name,
+    value: `$vars.${variable.name}`,
+    type: variable.type.toLowerCase(),
+  }));
+  const updateWorkflowVariable = (
+    variableId: string,
+    updates: Partial<EditableWorkflowVariable>
+  ) => {
+    onWorkflowVariablesChange(
+      workflowVariables.map((variable) =>
+        variable.id === variableId ? { ...variable, ...updates } : variable
+      )
+    );
+  };
   return (
     <NodePropertyPanel
-      panelTitle="Variables"
-      nodeIcon={<Code2 />}
-      nodeLabel="Workflow variables"
-      nodeCategory="Manage values used throughout this workflow"
+      panelTitle={
+        columnMode ? (columnMode === 'parameters' ? 'Parameters' : 'Variables') : 'Properties'
+      }
+      nodeIcon={columnMode ? undefined : node.icon}
+      nodeLabel={columnMode ? undefined : node.label}
+      nodeCategory={columnMode ? undefined : node.category}
       onClose={onClose}
+      headerExtra={
+        onExpand ? (
+          <button
+            type="button"
+            onClick={onExpand}
+            aria-label="Expand configuration"
+            title="Expand configuration"
+            className="grid size-6 place-items-center rounded text-foreground-muted transition hover:bg-surface-overlay hover:text-foreground"
+          >
+            <Maximize2 size={14} />
+          </button>
+        ) : undefined
+      }
       contentInset="0.875rem"
       className="h-full"
     >
-      <div className="flex min-h-0 flex-1 flex-col p-3">
-        <div className="grid min-h-52 flex-1 place-items-center rounded-xl border border-dashed border-border-subtle bg-surface-overlay/30 p-6 text-center">
-          <div className="max-w-56">
-            <Code2 className="mx-auto size-6 text-foreground-subtle" />
-            <p className="mt-3 text-sm font-semibold text-foreground">Variable management</p>
-            <p className="mt-1 text-xs leading-5 text-foreground-muted">
-              Add the variable list, editor, and scope controls here.
+      <Tabs
+        value={columnMode ?? activeTab}
+        onValueChange={(value) => onActiveTabChange(value as VariableDemoTab)}
+        className="flex h-full min-h-0 flex-col"
+      >
+        {!columnMode && (
+          <TabsList className={VARIABLE_TAB_LIST_CLASS}>
+            <TabsTrigger value="parameters" className={VARIABLE_TAB_TRIGGER_CLASS}>
+              Parameters
+            </TabsTrigger>
+            <TabsTrigger value="variables" className={VARIABLE_TAB_TRIGGER_CLASS}>
+              Variables
+            </TabsTrigger>
+          </TabsList>
+        )}
+        <TabsContent value="parameters" className="min-h-0 flex-1 overflow-auto p-3">
+          <div className="space-y-4">
+            <p className="text-xs leading-5 text-foreground-muted">
+              Configure what this node does when the workflow runs.
             </p>
+            {node.parameters.map((parameter) => {
+              const parameterKey = `${nodeId}:${parameter.label}`;
+              const value = parameterValues[parameterKey] ?? parameter.value;
+              return (
+                <div key={parameter.label}>
+                  {parameter.expression ? (
+                    <ExpressionField
+                      label={parameter.label}
+                      value={value}
+                      variables={variablePickerItems}
+                      onInsertVariable={(variable) =>
+                        onParameterValueChange(parameterKey, variable.value ?? variable.label)
+                      }
+                      onValueChange={(nextValue) => onParameterValueChange(parameterKey, nextValue)}
+                    />
+                  ) : (
+                    <>
+                      <p className="mb-1.5 text-xs font-medium text-foreground">
+                        {parameter.label}
+                      </p>
+                      <div className="flex min-h-9 items-center rounded-lg border border-border-subtle bg-surface-overlay px-2.5 text-xs text-foreground">
+                        {value}
+                      </div>
+                    </>
+                  )}
+                </div>
+              );
+            })}
           </div>
-        </div>
-      </div>
+        </TabsContent>
+        <TabsContent value="variables" className="min-h-0 flex-1 overflow-auto p-3">
+          <div className="space-y-5">
+            <p className="text-xs leading-5 text-foreground-muted">
+              See the values this node receives, creates, and changes.
+            </p>
+            <section>
+              <div className="mb-2 flex items-center justify-between">
+                <p className="text-xs font-semibold text-foreground">Inputs</p>
+                <span className="text-[11px] text-foreground-muted">Available to this node</span>
+              </div>
+              <div className="space-y-2">
+                {node.inputs.map((variable) => (
+                  <VariableRow key={variable.name} {...variable} />
+                ))}
+              </div>
+            </section>
+            <section>
+              <div className="mb-2 flex items-center justify-between">
+                <p className="text-xs font-semibold text-foreground">Outputs</p>
+                <span className="text-[11px] text-foreground-muted">Created by this node</span>
+              </div>
+              <div className="space-y-2">
+                {node.outputs.map((variable) => (
+                  <VariableRow key={variable.name} {...variable} />
+                ))}
+              </div>
+            </section>
+            {node.updates && (
+              <section>
+                <p className="mb-2 text-xs font-semibold text-foreground">
+                  Changes when this node runs
+                </p>
+                <div className="space-y-2">
+                  {node.updates.map((update) => (
+                    <div
+                      key={update.name}
+                      className="rounded-lg border border-border-subtle px-3 py-2.5"
+                    >
+                      <p className="font-mono text-xs font-medium">{update.name}</p>
+                      <p className="mt-1 truncate font-mono text-[11px] text-foreground-muted">
+                        {update.value}
+                      </p>
+                    </div>
+                  ))}
+                </div>
+              </section>
+            )}
+            <section className="border-t border-border-subtle pt-4">
+              <div className="mb-2 flex items-center justify-between gap-3">
+                <div>
+                  <p className="text-xs font-semibold text-foreground">Workflow variables</p>
+                  <p className="mt-0.5 text-[11px] text-foreground-muted">
+                    Reusable across every node
+                  </p>
+                </div>
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  className="h-7 px-2 text-xs font-semibold text-brand hover:text-brand"
+                  onClick={() => {
+                    const id = `variable-${Date.now()}`;
+                    onWorkflowVariablesChange([
+                      ...workflowVariables,
+                      { id, name: 'newVariable', type: 'Text', value: '' },
+                    ]);
+                    setEditingVariableId(id);
+                  }}
+                >
+                  <Plus size={14} /> Add variable
+                </Button>
+              </div>
+              <div className="space-y-2">
+                {workflowVariables.map((variable) =>
+                  editingVariableId === variable.id ? (
+                    <div
+                      key={variable.id}
+                      className="space-y-2 rounded-lg border border-border-focus bg-surface-overlay p-3"
+                    >
+                      <div className="grid grid-cols-[1fr_92px] gap-2">
+                        <input
+                          value={variable.name}
+                          onChange={(event) =>
+                            updateWorkflowVariable(variable.id, { name: event.target.value })
+                          }
+                          aria-label="Variable name"
+                          className="h-8 min-w-0 rounded-md border border-border-subtle bg-surface px-2 text-xs outline-none focus:border-border-focus"
+                        />
+                        <select
+                          value={variable.type}
+                          onChange={(event) =>
+                            updateWorkflowVariable(variable.id, { type: event.target.value })
+                          }
+                          aria-label="Variable type"
+                          className="h-8 rounded-md border border-border-subtle bg-surface px-2 text-xs outline-none focus:border-border-focus"
+                        >
+                          <option>Text</option>
+                          <option>Number</option>
+                          <option>Boolean</option>
+                          <option>Object</option>
+                        </select>
+                      </div>
+                      <input
+                        value={variable.value}
+                        onChange={(event) =>
+                          updateWorkflowVariable(variable.id, { value: event.target.value })
+                        }
+                        placeholder="Default value"
+                        aria-label="Default value"
+                        className="h-8 w-full rounded-md border border-border-subtle bg-surface px-2 text-xs outline-none focus:border-border-focus"
+                      />
+                      <div className="flex justify-end">
+                        <Button size="sm" onClick={() => setEditingVariableId(null)}>
+                          Done
+                        </Button>
+                      </div>
+                    </div>
+                  ) : (
+                    <div
+                      key={variable.id}
+                      className="flex items-center gap-3 rounded-lg border border-border-subtle bg-surface-overlay px-3 py-2.5"
+                    >
+                      <Code2 className="size-4 shrink-0 text-foreground-subtle" />
+                      <div className="min-w-0 flex-1">
+                        <p className="truncate font-mono text-xs font-medium">{variable.name}</p>
+                        <p className="mt-0.5 truncate text-[11px] text-foreground-muted">
+                          {variable.type} · {variable.value || 'No default value'}
+                        </p>
+                      </div>
+                      <Button
+                        size="sm"
+                        variant="ghost"
+                        onClick={() => setEditingVariableId(variable.id)}
+                      >
+                        Edit
+                      </Button>
+                    </div>
+                  )
+                )}
+              </div>
+            </section>
+          </div>
+        </TabsContent>
+      </Tabs>
     </NodePropertyPanel>
   );
 }
@@ -2629,7 +3064,367 @@ function NodeInventoryCanvas({
   );
 }
 
+type InventoryField = {
+  label: string;
+  value?: string;
+  helper?: string;
+  kind?: 'expression' | 'select' | 'textarea' | 'toggle' | 'checkbox';
+  required?: boolean;
+};
+
+type InventoryPanelSpec = {
+  section?: string;
+  description?: string;
+  fields?: InventoryField[];
+  action?: string;
+  empty?: boolean;
+};
+
+const NODE_PANEL_SPECS: Record<string, InventoryPanelSpec> = {
+  'autonomous-agent': {
+    section: 'Agent settings',
+    fields: [
+      { label: 'Harness', value: 'Standard harness', kind: 'select' },
+      { label: 'Model', value: 'anthropic.claude-sonnet-5', kind: 'select', required: true },
+      {
+        label: 'System prompt',
+        value: 'You are an agentic assistant.',
+        kind: 'textarea',
+        required: true,
+      },
+      {
+        label: 'User prompt',
+        value: 'What is the current date?',
+        kind: 'textarea',
+        required: true,
+      },
+    ],
+    action: 'Add output variable',
+  },
+  'conversational-agent': {
+    section: 'Agent settings',
+    fields: [
+      { label: 'Model', value: 'anthropic.claude-sonnet-5', kind: 'select' },
+      { label: 'System prompt', value: "You're an agent", kind: 'textarea' },
+      { label: 'Conversation context', value: '$vars.flowTest', kind: 'expression' },
+      {
+        label: 'End exchange',
+        helper: 'End the conversation exchange after this response.',
+        kind: 'checkbox',
+      },
+    ],
+    action: 'Add output variable',
+  },
+  'voice-agent': {
+    section: 'Agent settings',
+    fields: [
+      { label: 'Model', value: 'gemini-3.1-flash-live-preview', kind: 'select' },
+      { label: 'Persona', value: 'Aoede', kind: 'select' },
+      { label: 'System prompt', value: '', kind: 'textarea' },
+      { label: 'Call context', value: '$metadata.FolderKey', kind: 'expression' },
+    ],
+    action: 'Add output variable',
+  },
+  'http-request-v2': {
+    fields: [
+      { label: 'Authentication', value: 'Manual authentication', kind: 'select', required: true },
+      { label: 'Method', value: 'POST', kind: 'select', required: true },
+      { label: 'URL', value: 'https://catfact.ninja/fact', kind: 'expression', required: true },
+      { label: 'Body', value: '', kind: 'textarea' },
+    ],
+    action: 'Add header or query pair',
+  },
+  'slack-send': {
+    fields: [
+      { label: 'Slack connection', value: 'carl.schultze', kind: 'select', required: true },
+      {
+        label: 'Channel name/ID',
+        value: 'carl-design - C0HBZDNJKPT',
+        kind: 'expression',
+        required: true,
+      },
+      { label: 'Message', value: 'Test', kind: 'expression', required: true },
+      { label: 'Send as', value: 'Bot', kind: 'select', required: true },
+      { label: 'Button actions', value: '', kind: 'expression' },
+      { label: 'Image URL', value: '', kind: 'expression' },
+    ],
+  },
+  'batch-transform': {
+    section: 'Data source',
+    fields: [
+      { label: 'Attachment', value: '$vars.flowTest', kind: 'expression', required: true },
+      { label: 'Prompt', value: 'Transform the data', kind: 'textarea', required: true },
+      { label: 'Enable web search grounding', kind: 'checkbox' },
+      { label: 'Output column', value: 'OutputColumn1' },
+      {
+        label: 'Description',
+        value: 'Describe what this new column should contain',
+        kind: 'textarea',
+      },
+    ],
+    action: 'Add column',
+  },
+  filter: {
+    fields: [
+      { label: 'Collection', value: '$vars.flowArray', kind: 'expression', required: true },
+      { label: 'Condition', value: 'Equals', kind: 'select' },
+      { label: 'Value', value: '1' },
+    ],
+    action: 'Add condition',
+  },
+  'group-by': {
+    fields: [
+      { label: 'Collection', value: '$vars.flowArray', kind: 'expression', required: true },
+      { label: 'Operation', value: 'Count', kind: 'select', required: true },
+      { label: 'Output name', value: 'count', required: true },
+    ],
+    action: 'Add aggregation',
+  },
+  map: {
+    fields: [
+      { label: 'Collection', value: '$vars.flowArray', kind: 'expression', required: true },
+      { label: 'Transformation', value: 'Trim whitespace', kind: 'select' },
+    ],
+    action: 'Add field',
+  },
+  transform: {
+    description: 'Build a visual transformation from input to output.',
+    action: 'Edit transformation',
+  },
+  'read-entity': {
+    fields: [
+      { label: 'Data Fabric entity', value: 'Account', kind: 'select' },
+      { label: 'Filter field', value: 'Field', kind: 'select' },
+      { label: 'Filter value', value: '$vars.flowTest', kind: 'expression' },
+    ],
+    action: 'Add AND or OR filter',
+  },
+  'update-entity': {
+    section: 'How to identify the record',
+    fields: [
+      { label: 'Data Fabric entity', value: 'Account', kind: 'select' },
+      { label: 'Record ID', value: '1', kind: 'expression' },
+      { label: 'Field to update', value: 'AnotherThing', kind: 'select' },
+      { label: 'New value', value: '1', kind: 'expression' },
+    ],
+    action: 'Add field',
+  },
+  summarize: {
+    section: 'Data source',
+    fields: [
+      { label: 'Attachment', value: '$vars.flowTest', kind: 'expression', required: true },
+      { label: 'Prompt', value: 'Summarize this', kind: 'textarea', required: true },
+    ],
+  },
+  extract: {
+    section: 'Model config',
+    fields: [
+      { label: 'Model family', value: 'Gemini', kind: 'select' },
+      { label: 'Model version', value: '2.5 Flash', kind: 'select' },
+      { label: 'Execution mode', value: 'Standard', kind: 'select' },
+      { label: 'File', value: '$vars.flowTest', kind: 'expression', required: true },
+      {
+        label: 'Overall extraction instructions',
+        value: 'Context relevant across the whole schema...',
+        kind: 'textarea',
+      },
+    ],
+    action: 'Add field group',
+  },
+  'quick-form': {
+    section: 'Task delivery',
+    fields: [
+      { label: 'Delivery channel', value: 'Slack', kind: 'select' },
+      { label: 'Assignment criteria', value: 'All users', kind: 'select' },
+      { label: 'Form title', value: 'Quick Approval' },
+      { label: 'New field', value: '', kind: 'expression' },
+    ],
+    action: 'Add outcome',
+  },
+  'action-app': {
+    section: 'Task delivery',
+    fields: [
+      { label: 'Delivery channel', value: 'Slack', kind: 'select' },
+      { label: 'Assignment criteria', value: 'Single User', kind: 'select' },
+      { label: 'Assignee', value: 'carl.schultze@uipath.com' },
+      { label: 'Action App', value: 'Select a coded action app', kind: 'select' },
+    ],
+  },
+  mock: { empty: true },
+  merge: { empty: true },
+  flow: { empty: true },
+  'rpa-workflow': { empty: true },
+  decision: {
+    fields: [
+      { label: 'Condition', value: '$vars.flowBoolean', kind: 'expression', required: true },
+      { label: 'True branch label', value: 'True' },
+      { label: 'False branch label', value: 'False' },
+    ],
+  },
+  switch: {
+    section: 'Switch cases',
+    fields: [
+      { label: 'Case 1', value: '$vars.flowBoolean', kind: 'expression' },
+      { label: 'Other', value: '$vars.flowBoolean', kind: 'expression' },
+    ],
+    action: 'Add case',
+  },
+  end: { action: 'Add output variable' },
+  terminate: { empty: true },
+  loop: {
+    fields: [
+      { label: 'Collection', value: '$vars.flowArray', kind: 'expression', required: true },
+      { label: 'Parallel', helper: 'Run iterations at the same time.', kind: 'toggle' },
+      { label: 'Break on condition', value: '$vars.flowBoolean', kind: 'expression' },
+      { label: 'Show break handle', kind: 'toggle' },
+    ],
+  },
+  script: { fields: [{ label: 'Code', value: '//', kind: 'textarea', required: true }] },
+  'wait-message': {
+    fields: [
+      { label: 'Conversation ID', value: '$vars.flowTest', kind: 'expression', required: true },
+      { label: 'From', value: 'User', kind: 'select' },
+      { label: 'Number of exchanges', value: '20' },
+    ],
+  },
+  'conversation-context': {
+    fields: [
+      { label: 'Conversation ID', value: '$vars.flowTest', kind: 'expression', required: true },
+      { label: 'Exchange limit', value: '20' },
+    ],
+  },
+  'send-message': {
+    fields: [
+      { label: 'Conversation ID', value: '$vars.flowTest', kind: 'expression', required: true },
+      { label: 'Exchange ID', value: '$vars.flowTest', kind: 'expression', required: true },
+      { label: 'End exchange after writing', kind: 'checkbox' },
+      { label: 'Content', value: '$vars.flowTest', kind: 'expression', required: true },
+      { label: 'Mimetype', value: 'text/markdown' },
+    ],
+  },
+  'queue-create': {
+    fields: [{ label: 'Queue', value: 'Select a queue', kind: 'select', required: true }],
+  },
+  'queue-create-wait': {
+    fields: [{ label: 'Queue', value: 'Select a queue', kind: 'select', required: true }],
+  },
+  'outgoing-call': {
+    fields: [
+      { label: 'From', value: 'Select a connected number...', kind: 'select', required: true },
+      { label: 'To', value: '$vars.flowTest', kind: 'expression', required: true },
+    ],
+  },
+  'end-call': {
+    fields: [
+      { label: 'Call context', value: '$vars.flowTest', kind: 'expression', required: true },
+    ],
+  },
+  'manual-trigger': {
+    description: 'Define input arguments provided when this trigger starts the flow.',
+    action: 'Add input argument',
+  },
+  'scheduled-trigger': {
+    fields: [
+      { label: 'Frequency', value: 'Hourly', kind: 'select', required: true },
+      { label: 'Every', value: '1' },
+      { label: 'At minute', value: '0', kind: 'select' },
+    ],
+  },
+  'slack-trigger': {
+    fields: [{ label: 'Slack connection', value: 'carl.schultze', kind: 'select', required: true }],
+  },
+  'http-webhook': {
+    fields: [
+      { label: 'HTTP Webhook connection', value: 'Flow Test', kind: 'select', required: true },
+    ],
+  },
+  'incoming-call': { empty: true },
+  'conversation-trigger': { empty: true },
+  delay: {
+    fields: [
+      { label: 'Type', value: 'Duration', kind: 'select', required: true },
+      { label: 'Duration', value: '15 minutes', kind: 'select', required: true },
+    ],
+  },
+  'webhook-wait': {
+    fields: [
+      { label: 'HTTP Webhook connection', value: 'Flow Test', kind: 'select', required: true },
+    ],
+  },
+  'email-wait': {
+    fields: [
+      { label: 'Gmail connection', value: 'Select a connection', kind: 'select', required: true },
+    ],
+  },
+  subflow: {
+    section: 'Inputs',
+    description:
+      'Define input variables for this subflow and map expressions from the parent scope.',
+    action: 'Add input variable',
+  },
+  bpmn: { empty: true },
+  case: {
+    fields: [
+      {
+        label: 'Enable fire and forget',
+        helper: 'Start the run without waiting for it to finish.',
+        kind: 'toggle',
+      },
+    ],
+  },
+  'api-workflow': { empty: true },
+};
+
+function InventoryPanelField({ field }: { field: InventoryField }) {
+  if (field.kind === 'toggle' || field.kind === 'checkbox') {
+    return (
+      <div className="flex items-start justify-between gap-3 py-1">
+        <div>
+          <Label className="text-xs">{field.label}</Label>
+          {field.helper && (
+            <p className="mt-0.5 text-[11px] text-foreground-muted">{field.helper}</p>
+          )}
+        </div>
+        {field.kind === 'toggle' ? <Switch /> : <Checkbox aria-label={field.label} />}
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-1.5">
+      <Label className="text-xs">
+        {field.label}
+        {field.required && <span className="text-foreground-danger"> *</span>}
+      </Label>
+      {field.kind === 'select' ? (
+        <Select defaultValue="current">
+          <SelectTrigger className="w-full">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="current">{field.value}</SelectItem>
+          </SelectContent>
+        </Select>
+      ) : field.kind === 'textarea' ? (
+        <Textarea defaultValue={field.value} className="min-h-24 resize-none text-xs" />
+      ) : field.kind === 'expression' ? (
+        <div className="flex items-center rounded-lg border border-border-subtle bg-surface-overlay px-2 focus-within:border-border-focus">
+          <span className="mr-1.5 font-mono text-xs text-foreground-subtle">=</span>
+          <Input
+            defaultValue={field.value}
+            className="border-0 bg-transparent px-0 font-mono text-xs text-foreground-accent shadow-none focus-visible:ring-0"
+          />
+        </div>
+      ) : (
+        <Input defaultValue={field.value} className="text-xs" />
+      )}
+      {field.helper && <p className="text-[11px] text-foreground-muted">{field.helper}</p>}
+    </div>
+  );
+}
+
 function NodeInventoryPanel({ item, onClose }: { item: NodeInventoryItem; onClose: () => void }) {
+  const spec = NODE_PANEL_SPECS[item.id];
   return (
     <NodePropertyPanel
       panelTitle="Properties"
@@ -2639,22 +3434,45 @@ function NodeInventoryPanel({ item, onClose }: { item: NodeInventoryItem; onClos
       onClose={onClose}
       className="h-full"
     >
-      <div className="flex min-h-0 flex-1 flex-col gap-4 p-4">
-        <div className="rounded-xl border border-border-subtle bg-surface-overlay p-3">
-          <p className="text-[10px] font-semibold uppercase tracking-wide text-foreground-subtle">
-            Node type
-          </p>
-          <p className="mt-1 break-all font-mono text-xs text-foreground-muted">{item.nodeType}</p>
-        </div>
-        <div className="grid min-h-52 flex-1 place-items-center rounded-xl border border-dashed border-border-subtle p-6 text-center">
-          <div className="max-w-56">
-            <CanvasIcon icon={item.icon} size={24} />
-            <p className="mt-3 text-sm font-semibold">{item.label} panel experience</p>
-            <p className="mt-1 text-xs leading-5 text-foreground-muted">
-              Add the source-of-truth fields and interactions for this node here.
-            </p>
-          </div>
-        </div>
+      <div className="flex min-h-0 flex-1 flex-col overflow-y-auto">
+        <Tabs defaultValue="parameters" className="flex min-h-0 flex-1 flex-col">
+          <TabsList className="mx-4 mt-3 w-fit">
+            <TabsTrigger value="parameters">Parameters</TabsTrigger>
+            <TabsTrigger value="errors">Error handling</TabsTrigger>
+            <TabsTrigger value="advanced">Advanced</TabsTrigger>
+          </TabsList>
+          <TabsContent value="parameters" className="mt-0 space-y-4 p-4">
+            {spec?.section && (
+              <p className="text-xs font-semibold text-foreground">{spec.section}</p>
+            )}
+            {spec?.description && (
+              <p className="text-xs leading-5 text-foreground-muted">{spec.description}</p>
+            )}
+            {spec?.empty && (
+              <p className="text-xs text-foreground-muted">No available parameters</p>
+            )}
+            {spec?.fields?.map((field) => (
+              <InventoryPanelField key={field.label} field={field} />
+            ))}
+            {spec?.action && (
+              <Button variant="outline" className="w-full">
+                <Plus size={14} />
+                {spec.action}
+              </Button>
+            )}
+            {!spec && (
+              <p className="text-xs text-foreground-muted">
+                No Figma reference is available for this node yet.
+              </p>
+            )}
+          </TabsContent>
+          <TabsContent value="errors" className="mt-0 p-4 text-xs text-foreground-muted">
+            Configure retry, timeout, and error continuation behavior for this node.
+          </TabsContent>
+          <TabsContent value="advanced" className="mt-0 p-4 text-xs text-foreground-muted">
+            Advanced execution settings are available when supported by this node.
+          </TabsContent>
+        </Tabs>
       </div>
     </NodePropertyPanel>
   );
@@ -2748,7 +3566,19 @@ export function FullWorkbenchComposition({
   const [sidebarExpanded, setSidebarExpanded] = useState(false);
   const [activeSidebarItem, setActiveSidebarItem] = useState<CanvasLeftSidebarItemId>('variables');
   const [rightPanelOpen, setRightPanelOpen] = useState(true);
-  const [takeoverOpen, setTakeoverOpen] = useState(rightPanelVariant === 'node');
+  const [takeoverOpen, setTakeoverOpen] = useState(false);
+  const [selectedVariableNodeId, setSelectedVariableNodeId] = useState('trigger');
+  const [variableDemoTab, setVariableDemoTab] = useState<VariableDemoTab>('parameters');
+  const [editableWorkflowVariables, setEditableWorkflowVariables] = useState<
+    EditableWorkflowVariable[]
+  >([
+    { id: 'current-invoice', name: 'currentInvoice', type: 'Object', value: '{}' },
+    { id: 'approval-status', name: 'approvalStatus', type: 'Text', value: 'Pending review' },
+    { id: 'review-threshold', name: 'reviewThreshold', type: 'Number', value: '10000' },
+  ]);
+  const [variableParameterValues, setVariableParameterValues] = useState<Record<string, string>>(
+    {}
+  );
   const [activeTabId, setActiveTabId] = useState('execution');
   const [isBottomPanelCollapsed, setIsBottomPanelCollapsed] = useState(true);
   const [bottomPanelHeight, setBottomPanelHeight] = useState(80);
@@ -2815,6 +3645,14 @@ export function FullWorkbenchComposition({
           }
           bottomControlsOffset={canvasBottomOffset}
           rightControlsOffset={rightPanelOpen ? 412 : 16}
+          onNodeSelect={
+            rightPanelVariant === 'variables'
+              ? (nodeId) => {
+                  setSelectedVariableNodeId(nodeId);
+                  setRightPanelOpen(true);
+                }
+              : undefined
+          }
           trigger={
             <PanelTrigger
               layout={rightPanelOpen ? 'right' : 'closed'}
@@ -2832,15 +3670,7 @@ export function FullWorkbenchComposition({
               onPropertiesClick={() => setRightPanelOpen(true)}
             />
           }
-        >
-          {rightPanelVariant === 'node' && !takeoverOpen && (
-            <div className="pointer-events-none absolute inset-0 z-10 grid place-items-center">
-              <Button className="pointer-events-auto" onClick={() => setTakeoverOpen(true)}>
-                Open node takeover
-              </Button>
-            </div>
-          )}
-        </CanvasViewport>
+        />
 
         {rightPanelOpen && (
           <div
@@ -2853,11 +3683,26 @@ export function FullWorkbenchComposition({
               ) : rightPanelVariant === 'rules' ? (
                 <RuleBuildingPanel onClose={() => setRightPanelOpen(false)} />
               ) : rightPanelVariant === 'variables' ? (
-                <VariableManagementPanel onClose={() => setRightPanelOpen(false)} />
+                <UnifiedVariablesPanel
+                  nodeId={selectedVariableNodeId}
+                  activeTab={variableDemoTab}
+                  onActiveTabChange={setVariableDemoTab}
+                  onClose={() => setRightPanelOpen(false)}
+                  onExpand={() => setTakeoverOpen(true)}
+                  workflowVariables={editableWorkflowVariables}
+                  onWorkflowVariablesChange={setEditableWorkflowVariables}
+                  parameterValues={variableParameterValues}
+                  onParameterValueChange={(key, value) =>
+                    setVariableParameterValues((current) => ({ ...current, [key]: value }))
+                  }
+                />
               ) : rightPanelVariant === 'dap' ? (
                 <DapPanel onClose={() => setRightPanelOpen(false)} />
               ) : rightPanelVariant === 'node' ? (
-                <SendEmailPropertiesPanel onClose={() => setRightPanelOpen(false)} />
+                <SendEmailPropertiesPanel
+                  onClose={() => setRightPanelOpen(false)}
+                  onOpenTakeover={() => setTakeoverOpen(true)}
+                />
               ) : (
                 <PropertiesPanel className="h-full" onClose={() => setRightPanelOpen(false)} />
               )}
@@ -2924,6 +3769,40 @@ export function FullWorkbenchComposition({
           }
         >
           <SendEmailTakeoverPanels />
+        </CanvasTakeoverModal>
+      )}
+      {rightPanelVariant === 'variables' && (
+        <CanvasTakeoverModal
+          open={takeoverOpen}
+          onOpenChange={setTakeoverOpen}
+          title={VARIABLE_DEMO_NODES[selectedVariableNodeId]?.label ?? 'Node configuration'}
+        >
+          <div className="grid h-full min-h-0 grid-cols-2 divide-x divide-border-subtle overflow-hidden">
+            <UnifiedVariablesPanel
+              nodeId={selectedVariableNodeId}
+              activeTab={variableDemoTab}
+              onActiveTabChange={setVariableDemoTab}
+              workflowVariables={editableWorkflowVariables}
+              onWorkflowVariablesChange={setEditableWorkflowVariables}
+              parameterValues={variableParameterValues}
+              onParameterValueChange={(key, value) =>
+                setVariableParameterValues((current) => ({ ...current, [key]: value }))
+              }
+              columnMode="parameters"
+            />
+            <UnifiedVariablesPanel
+              nodeId={selectedVariableNodeId}
+              activeTab={variableDemoTab}
+              onActiveTabChange={setVariableDemoTab}
+              workflowVariables={editableWorkflowVariables}
+              onWorkflowVariablesChange={setEditableWorkflowVariables}
+              parameterValues={variableParameterValues}
+              onParameterValueChange={(key, value) =>
+                setVariableParameterValues((current) => ({ ...current, [key]: value }))
+              }
+              columnMode="variables"
+            />
+          </div>
         </CanvasTakeoverModal>
       )}
     </div>

--- a/packages/apollo-react/src/canvas/stories/templates/Flow.stories.tsx
+++ b/packages/apollo-react/src/canvas/stories/templates/Flow.stories.tsx
@@ -137,6 +137,7 @@ const meta = {
     'DraggablePanelLayout',
     'FullWorkbenchComposition',
     'NodeInventoryComposition',
+    'NodePatternComposition',
     'AgentExperienceComposition',
     'mapTemplateThemeToChat',
   ],
@@ -3443,7 +3444,7 @@ function InventoryPanelField({ field }: { field: InventoryField }) {
   );
 }
 
-function NodeInventoryPanel({ item, onClose }: { item: NodeInventoryItem; onClose: () => void }) {
+function NodeInventoryPanel({ item, onClose }: { item: NodeInventoryItem; onClose?: () => void }) {
   const spec = NODE_PANEL_SPECS[item.id];
   return (
     <NodePropertyPanel
@@ -3571,6 +3572,106 @@ export function NodeInventoryComposition() {
           </div>
         </div>
       )}
+    </div>
+  );
+}
+
+function SingleNodePatternCanvas({ item }: { item: NodeInventoryItem }) {
+  const nodes = useMemo(
+    () => [
+      createNode({
+        id: item.id,
+        type: 'uipath.blank-node',
+        position: { x: 0, y: 0 },
+        selected: true,
+        display: {
+          label: item.label,
+          subLabel: item.category,
+          icon: item.icon,
+        },
+        data: {
+          inventoryNodeType: item.nodeType,
+          inventoryItem: true,
+        },
+      }),
+    ],
+    [item]
+  );
+  const { fitView, getViewport, setViewport } = useReactFlow();
+  const nodesInitialized = useNodesInitialized();
+  const { canvasProps } = useCanvasStory({ initialNodes: nodes, initialEdges: [] });
+
+  const fitNode = useCallback(
+    async (duration: number) => {
+      await fitView({ padding: 0.42, maxZoom: 1, duration });
+      const viewport = getViewport();
+      await setViewport({ ...viewport, x: viewport.x - 198 }, { duration: 0 });
+    },
+    [fitView, getViewport, setViewport]
+  );
+
+  useEffect(() => {
+    if (!nodesInitialized) return;
+    void fitNode(0);
+  }, [fitNode, nodesInitialized]);
+
+  return (
+    <div className="relative h-full min-h-0 overflow-hidden">
+      <BaseCanvas {...canvasProps} mode="view" />
+      <div
+        className="absolute bottom-5 z-20 -translate-x-1/2"
+        style={{ left: 'calc(50% - 198px)' }}
+      >
+        <CanvasNavigationControls />
+      </div>
+      <div className="absolute bottom-5 right-[412px] z-20">
+        <CanvasZoomControls orientation="vertical" onOrganize={() => void fitNode(200)} />
+      </div>
+    </div>
+  );
+}
+
+export function NodePatternComposition({ nodeId }: { nodeId: string }) {
+  const item = NODE_INVENTORY_ITEMS.find((candidate) => candidate.id === nodeId);
+  const [sidebarExpanded, setSidebarExpanded] = useState(false);
+  const [activeSidebarItem, setActiveSidebarItem] = useState<CanvasLeftSidebarItemId>('variables');
+
+  if (!item) {
+    return (
+      <div className="grid h-screen place-items-center bg-surface p-8 text-sm text-foreground-muted">
+        Node pattern “{nodeId}” was not found.
+      </div>
+    );
+  }
+
+  return (
+    <div className="relative flex h-screen bg-surface">
+      <CanvasLeftSidebar
+        title="Variables"
+        variant="default"
+        isExpanded={sidebarExpanded}
+        onExpandedChange={setSidebarExpanded}
+        activeItemId={activeSidebarItem}
+        onItemSelect={setActiveSidebarItem}
+      />
+      <div className="relative min-w-0 flex-1 overflow-hidden">
+        <SingleNodePatternCanvas item={item} />
+        <div className="absolute right-[412px] top-4 z-20">
+          <PanelTrigger
+            layout="right"
+            panels={[
+              { id: 'input', label: 'Input', enabled: false },
+              { id: 'properties', label: 'Properties', enabled: true },
+              { id: 'output', label: 'Output', enabled: false },
+            ]}
+          />
+        </div>
+      </div>
+      <div className="absolute inset-y-0 right-0 z-20 p-4 pl-0">
+        <div className="h-full w-[380px] overflow-hidden rounded-2xl border border-border-subtle shadow-lg">
+          <NodeInventoryPanel item={item} />
+        </div>
+      </div>
     </div>
   );
 }

--- a/packages/apollo-react/src/canvas/stories/templates/Flow.stories.tsx
+++ b/packages/apollo-react/src/canvas/stories/templates/Flow.stories.tsx
@@ -25,6 +25,9 @@ import {
   InputGroupInput,
   Label,
   type PanelImperativeHandle,
+  PromptEditor,
+  type PromptEditorAutoCompleteOption,
+  type PromptEditorToken,
   RadioGroup,
   RadioGroupItem,
   ResizableHandle,
@@ -89,6 +92,7 @@ import {
   Fragment,
   type PointerEvent,
   type ReactNode,
+  type RefObject,
   useCallback,
   useContext,
   useEffect,
@@ -722,7 +726,7 @@ function CanvasViewport({
   workflowVariant?: WorkflowVariant;
   onNodeSelect?: (nodeId: string) => void;
 }) {
-  const { getNodes, getNodesBounds, getViewport, setEdges, setNodes, setViewport } = useReactFlow();
+  const { getNodes, getNodesBounds, setEdges, setNodes, setViewport } = useReactFlow();
   const nodesInitialized = useNodesInitialized();
   const viewportContainerRef = useRef<HTMLDivElement>(null);
 
@@ -774,8 +778,8 @@ function CanvasViewport({
     const graph = createFlowGraph(workflowVariant);
     setNodes(graph.nodes);
     setEdges(graph.edges);
-    window.setTimeout(() => centerWorkflow(200), 100);
-  }, [centerWorkflow, setEdges, setNodes, workflowVariant]);
+    window.setTimeout(() => fitWorkflow(200), 100);
+  }, [fitWorkflow, setEdges, setNodes, workflowVariant]);
 
   return (
     <div ref={viewportContainerRef} className="relative h-full min-h-0 min-w-0 overflow-hidden">
@@ -1187,6 +1191,29 @@ function QuickFormPropertiesPanel({ onClose }: { onClose: () => void }) {
   return <QuickFormPanel embedded onClose={onClose} className="h-full" />;
 }
 
+/** Matches a `$vars.foo.bar[0].baz`-style reference so it can be lifted into its own token. */
+const VARIABLE_REFERENCE_PATTERN = /\$vars(?:\.[a-zA-Z_$][\w$]*|\[\d+\])+/g;
+
+/** Splits a flat expression string into PromptEditor tokens, isolating each `$vars....` reference. */
+function expressionValueToTokens(value: string): PromptEditorToken[] {
+  if (!value) return [];
+  const tokens: PromptEditorToken[] = [];
+  let lastIndex = 0;
+  for (const match of value.matchAll(VARIABLE_REFERENCE_PATTERN)) {
+    const index = match.index ?? 0;
+    if (index > lastIndex) tokens.push({ type: 'text', value: value.slice(lastIndex, index) });
+    tokens.push({ type: 'output', value: match[0].slice(1) });
+    lastIndex = index + match[0].length;
+  }
+  if (lastIndex < value.length) tokens.push({ type: 'text', value: value.slice(lastIndex) });
+  return tokens;
+}
+
+/** Inverse of {@link expressionValueToTokens} — rejoins tokens back into a flat expression string. */
+function expressionTokensToValue(tokens: PromptEditorToken[]): string {
+  return tokens.map((token) => (token.type === 'text' ? token.value : `$${token.value}`)).join('');
+}
+
 function ExpressionField({
   label,
   value,
@@ -1202,7 +1229,6 @@ function ExpressionField({
   onInsertVariable?: (variable: VariablePickerItem) => void;
   onValueChange?: (value: string) => void;
 }) {
-  const inputRef = useRef<HTMLInputElement | null>(null);
   const [isVariableDragging, setIsVariableDragging] = useState(false);
   const [isDragOver, setIsDragOver] = useState(false);
 
@@ -1224,17 +1250,22 @@ function ExpressionField({
     };
   }, []);
 
-  const insertDroppedVariable = (path: string) => {
-    if (!onValueChange || !path) return;
-    const token = `$${path.replace(/^\$/, '')}`;
-    const currentValue = value ?? '';
-    const cursor = inputRef.current?.selectionStart ?? currentValue.length;
-    onValueChange(`${currentValue.slice(0, cursor)}${token}${currentValue.slice(cursor)}`);
-    requestAnimationFrame(() => {
-      inputRef.current?.focus();
-      inputRef.current?.setSelectionRange(cursor + token.length, cursor + token.length);
-    });
-  };
+  const tokens = useMemo(() => expressionValueToTokens(value ?? ''), [value]);
+
+  const autoCompleteOptions = useMemo<PromptEditorAutoCompleteOption[]>(() => {
+    const options = new Map<string, PromptEditorAutoCompleteOption>();
+    for (const variable of variables) {
+      const path = (variable.value ?? '').replace(/^\$/, '');
+      if (path) options.set(path, { type: 'output', value: path });
+    }
+    // Deep node-output paths already present in the value (e.g. `vars.recordUpdated1.output.Subject`)
+    // are legitimate upstream references even though they aren't in the workflow-scope variable list
+    // above — recognize them too so they don't render as "not found" on first paint.
+    for (const token of tokens) {
+      if (token.type !== 'text') options.set(token.value, { type: token.type, value: token.value });
+    }
+    return [...options.values()];
+  }, [variables, tokens]);
 
   return (
     <div className="space-y-1.5">
@@ -1253,30 +1284,18 @@ function ExpressionField({
       <div
         onDragEnter={(event) => {
           if (!event.dataTransfer.types.includes(VARIABLE_DRAG_MIME)) return;
-          if (onValueChange) event.preventDefault();
           setIsDragOver(true);
         }}
         onDragOver={(event) => {
           if (!event.dataTransfer.types.includes(VARIABLE_DRAG_MIME)) return;
-          if (onValueChange) {
-            event.preventDefault();
-            event.dataTransfer.dropEffect = 'copy';
-          } else {
-            event.dataTransfer.dropEffect = 'none';
-          }
+          event.dataTransfer.dropEffect = onValueChange ? 'copy' : 'none';
         }}
         onDragLeave={(event) => {
           if (!event.currentTarget.contains(event.relatedTarget as globalThis.Node | null)) {
             setIsDragOver(false);
           }
         }}
-        onDrop={(event) => {
-          const path = event.dataTransfer.getData(VARIABLE_DRAG_MIME);
-          if (!path || !onValueChange) return;
-          event.preventDefault();
-          insertDroppedVariable(path);
-          setIsDragOver(false);
-        }}
+        onDrop={() => setIsDragOver(false)}
         className={`relative flex min-h-9 items-center gap-1.5 rounded-lg border bg-surface-overlay px-2.5 text-xs transition-[border-color,box-shadow,background-color] focus-within:border-border-focus focus-within:ring-1 focus-within:ring-border-focus ${
           isDragOver && onValueChange
             ? 'border-brand bg-brand-subtle/40 ring-2 ring-brand/30'
@@ -1292,14 +1311,16 @@ function ExpressionField({
         <span className="shrink-0 font-mono text-foreground-accent" aria-hidden="true">
           ƒx
         </span>
-        <input
-          ref={inputRef}
-          value={value ?? ''}
-          onChange={(event) => onValueChange?.(event.target.value)}
-          readOnly={!onValueChange}
+        <PromptEditor
+          value={tokens}
+          onChange={(nextTokens) => onValueChange?.(expressionTokensToValue(nextTokens))}
+          autoCompleteOptions={autoCompleteOptions}
+          multiline={false}
+          borderless
+          disabled={!onValueChange}
           placeholder={placeholder}
-          aria-label={label ? `${label} expression` : 'Expression'}
-          className="h-8 min-w-0 flex-1 bg-transparent font-mono text-xs text-foreground-accent outline-none placeholder:font-sans placeholder:text-foreground-subtle read-only:cursor-default"
+          ariaLabel={label ? `${label} expression` : 'Expression'}
+          mapVarDropToToken={(insertPath) => ({ type: 'output', value: insertPath })}
         />
         <SlidersHorizontal className="ml-auto size-4 shrink-0 text-foreground-muted" />
         {isVariableDragging && (
@@ -1314,6 +1335,101 @@ function ExpressionField({
           </span>
         )}
       </div>
+    </div>
+  );
+}
+
+/** Matches a leading `$vars`/`$state`/`$in`/`$out` keyword so only the namespace itself is pilled. */
+const KEYWORD_REFERENCE_PATTERN = /^\$(vars|state|in|out)\b/;
+
+/**
+ * Splits a flat expression string into PromptEditor tokens the same way {@link expressionValueToTokens}
+ * does, except only the leading `$vars`-style namespace keyword becomes a token — the remainder of the
+ * path (`.flowArray`) stays as plain editable text. Used by fields that reference a whole collection
+ * rather than a single resolved value, where highlighting the full path as one chip would be misleading.
+ */
+function keywordValueToTokens(value: string): PromptEditorToken[] {
+  if (!value) return [];
+  const match = value.match(KEYWORD_REFERENCE_PATTERN);
+  if (!match) return [{ type: 'text', value }];
+  const rest = value.slice(match[0].length);
+  return rest
+    ? [
+        { type: 'input', value: match[0].slice(1) },
+        { type: 'text', value: rest },
+      ]
+    : [{ type: 'input', value: match[0].slice(1) }];
+}
+
+/** Inverse of {@link keywordValueToTokens} — rejoins tokens back into a flat expression string. */
+function keywordTokensToValue(tokens: PromptEditorToken[]): string {
+  return tokens.map((token) => (token.type === 'text' ? token.value : `$${token.value}`)).join('');
+}
+
+/**
+ * Expression field for "operate on this whole collection" contexts (e.g. a Filter's source array),
+ * as opposed to {@link ExpressionField}'s "insert a value into this field" contexts. Only the leading
+ * namespace keyword is pilled — the rest of the path renders as plain syntax-colored text — and the
+ * insert control sits in the field's label row rather than beside the value.
+ */
+function KeywordExpressionField({
+  label,
+  required,
+  value,
+  caption,
+  variables = [],
+  onInsertVariable,
+  onValueChange,
+}: {
+  label: string;
+  required?: boolean;
+  value?: string;
+  caption?: string;
+  variables?: VariablePickerItem[];
+  onInsertVariable?: (variable: VariablePickerItem) => void;
+  onValueChange?: (value: string) => void;
+}) {
+  const tokens = useMemo(() => keywordValueToTokens(value ?? ''), [value]);
+
+  const autoCompleteOptions = useMemo<PromptEditorAutoCompleteOption[]>(() => {
+    const options = new Map<string, PromptEditorAutoCompleteOption>();
+    for (const variable of variables) {
+      const path = (variable.value ?? '').replace(/^\$/, '');
+      if (path) options.set(path, { type: 'input', value: path });
+    }
+    for (const token of tokens) {
+      if (token.type !== 'text') options.set(token.value, { type: token.type, value: token.value });
+    }
+    return [...options.values()];
+  }, [variables, tokens]);
+
+  return (
+    <div className="space-y-1.5">
+      <div className="flex items-center justify-between gap-2">
+        <p className="text-sm font-semibold text-foreground">
+          {label}
+          {required && <span className="ml-0.5 text-error">*</span>}
+        </p>
+        <VariablePicker
+          items={variables}
+          onSelect={(variable) => onInsertVariable?.(variable)}
+          disabled={!onInsertVariable || variables.length === 0}
+        />
+      </div>
+      <div className="flex min-h-11 items-center gap-2 rounded-lg border border-border-subtle bg-surface px-3">
+        <span className="shrink-0 font-mono text-sm text-foreground-muted">=</span>
+        <PromptEditor
+          value={tokens}
+          onChange={(nextTokens) => onValueChange?.(keywordTokensToValue(nextTokens))}
+          autoCompleteOptions={autoCompleteOptions}
+          multiline={false}
+          borderless
+          disabled={!onValueChange}
+          ariaLabel={`${label} expression`}
+          mapVarDropToToken={(insertPath) => ({ type: 'input', value: insertPath })}
+        />
+      </div>
+      {caption && <p className="text-xs text-foreground-muted">{caption}</p>}
     </div>
   );
 }
@@ -1438,7 +1554,7 @@ function SendEmailForm({
         <BooleanField label="Include message details" />
         <button
           type="button"
-          className="mx-auto flex items-center gap-2 text-xs font-semibold text-brand"
+          className="flex w-fit items-center gap-2 text-xs font-semibold text-brand"
         >
           <Plus className="size-4" /> Manage Properties
         </button>
@@ -2207,6 +2323,147 @@ function LeftSidebarComposition() {
         </div>
       )}
     </div>
+  );
+}
+
+type CollectionFilterCondition = { id: number; operator: string; value: string };
+
+/**
+ * Filters a collection down to items matching a set of conditions. Unlike {@link RuleBuildingPanel},
+ * conditions here apply to each item of the `Collection` field above rather than to separately named
+ * fields, so a condition row only needs an operator and a value.
+ */
+function CollectionFilterPanel({
+  onClose,
+  variables,
+}: {
+  onClose: () => void;
+  variables: EditableWorkflowVariable[];
+}) {
+  const [collectionValue, setCollectionValue] = useState('$vars.flowArray');
+  const [matchMode, setMatchMode] = useState<'all' | 'any'>('all');
+  const [conditions, setConditions] = useState<CollectionFilterCondition[]>([
+    { id: 1, operator: 'Equals', value: '1' },
+  ]);
+  const nextConditionId = useRef(2);
+
+  const pickerItems = variables.map((variable) => ({
+    id: variable.id,
+    label: variable.name,
+    value: `$vars.${variable.name}`,
+    type: variable.type.toLowerCase(),
+  }));
+
+  const updateCondition = (id: number, patch: Partial<CollectionFilterCondition>) =>
+    setConditions((current) =>
+      current.map((condition) => (condition.id === id ? { ...condition, ...patch } : condition))
+    );
+
+  return (
+    <NodePropertyPanel
+      panelTitle="Filter array"
+      nodeIcon={<ListTree />}
+      nodeLabel="Filter array"
+      nodeCategory="Keep items in a collection that match conditions"
+      action={<Button size="sm">Save</Button>}
+      onClose={onClose}
+      contentInset="0.875rem"
+      className="h-full"
+    >
+      <div className="flex min-h-0 flex-1 flex-col gap-4 overflow-auto px-3 pb-4 pt-3">
+        <KeywordExpressionField
+          label="Collection"
+          required
+          value={collectionValue}
+          caption="Conditions are applied to this collection."
+          variables={pickerItems}
+          onInsertVariable={(variable) =>
+            setCollectionValue((current) => `${current}${variable.value ?? variable.label}`)
+          }
+          onValueChange={setCollectionValue}
+        />
+
+        <div className="flex items-center justify-between">
+          <span className="text-xs font-medium text-foreground-muted">Match</span>
+          <ToggleGroup
+            type="single"
+            size="xs"
+            value={matchMode}
+            onValueChange={(value) => value && setMatchMode(value as 'all' | 'any')}
+          >
+            <ToggleGroupItem value="all" className="!px-2.5 !text-xs">
+              All (AND)
+            </ToggleGroupItem>
+            <ToggleGroupItem value="any" className="!px-2.5 !text-xs">
+              Any (OR)
+            </ToggleGroupItem>
+          </ToggleGroup>
+        </div>
+
+        <div className="relative ml-3 border-l-2 border-brand/40 pl-4">
+          <span className="absolute -left-[13px] top-0 rounded-md border border-brand/30 bg-surface-raised px-1.5 py-0.5 text-[9px] font-bold uppercase tracking-wide text-brand">
+            {matchMode === 'all' ? 'AND' : 'OR'}
+          </span>
+          <div className="space-y-3 pt-7">
+            {conditions.map((condition, index) => (
+              <Card key={condition.id} className="relative">
+                <CardContent className="space-y-2 p-3">
+                  <div className="flex items-center justify-between">
+                    <span className="text-[10px] font-semibold uppercase tracking-wide text-foreground-muted">
+                      Condition {index + 1}
+                    </span>
+                    <button
+                      type="button"
+                      aria-label={`Remove condition ${index + 1}`}
+                      onClick={() =>
+                        setConditions((current) => current.filter(({ id }) => id !== condition.id))
+                      }
+                      className="grid size-6 place-items-center rounded text-foreground-subtle transition hover:bg-surface-overlay hover:text-destructive"
+                    >
+                      <Trash2 size={13} />
+                    </button>
+                  </div>
+                  <div className="grid grid-cols-[minmax(0,1fr)_minmax(0,1.2fr)] gap-2">
+                    <select
+                      value={condition.operator}
+                      onChange={(event) =>
+                        updateCondition(condition.id, { operator: event.target.value })
+                      }
+                      className="h-8 min-w-0 rounded-lg border border-border-subtle bg-surface-overlay px-2 text-xs"
+                    >
+                      <option>Equals</option>
+                      <option>Does not equal</option>
+                      <option>Contains</option>
+                      <option>Is greater than</option>
+                      <option>Is less than</option>
+                    </select>
+                    <input
+                      value={condition.value}
+                      onChange={(event) =>
+                        updateCondition(condition.id, { value: event.target.value })
+                      }
+                      aria-label={`Condition ${index + 1} value`}
+                      className="h-8 min-w-0 rounded-lg border border-border-subtle bg-surface-overlay px-2 text-xs outline-none focus:border-border-focus"
+                    />
+                  </div>
+                </CardContent>
+              </Card>
+            ))}
+            <Button
+              size="sm"
+              variant="ghost"
+              onClick={() => {
+                const id = nextConditionId.current++;
+                setConditions((current) => [...current, { id, operator: 'Equals', value: '' }]);
+              }}
+              className="w-full border border-dashed border-border-subtle"
+            >
+              <Plus size={14} /> Add condition
+            </Button>
+          </div>
+        </div>
+      </div>
+    </NodePropertyPanel>
   );
 }
 
@@ -4734,7 +4991,14 @@ function DapPanel({ onClose }: { onClose: () => void }) {
 export function FullWorkbenchComposition({
   rightPanelVariant = 'properties',
 }: {
-  rightPanelVariant?: 'properties' | 'forms' | 'node' | 'rules' | 'variables' | 'dap';
+  rightPanelVariant?:
+    | 'properties'
+    | 'forms'
+    | 'node'
+    | 'rules'
+    | 'variables'
+    | 'dap'
+    | 'collection';
 }) {
   const panelRef = useRef<PanelImperativeHandle | null>(null);
   const expandedBottomPanelHeight = useRef(368);
@@ -4838,7 +5102,9 @@ export function FullWorkbenchComposition({
       <div className="relative min-w-0 flex-1 overflow-hidden">
         <CanvasViewport
           workflowVariant={
-            rightPanelVariant === 'properties' || rightPanelVariant === 'dap'
+            rightPanelVariant === 'properties' ||
+            rightPanelVariant === 'dap' ||
+            rightPanelVariant === 'collection'
               ? 'default'
               : rightPanelVariant
           }
@@ -4881,6 +5147,11 @@ export function FullWorkbenchComposition({
                 <QuickFormPropertiesPanel onClose={() => setRightPanelOpen(false)} />
               ) : rightPanelVariant === 'rules' ? (
                 <RuleBuildingPanel onClose={() => setRightPanelOpen(false)} />
+              ) : rightPanelVariant === 'collection' ? (
+                <CollectionFilterPanel
+                  onClose={() => setRightPanelOpen(false)}
+                  variables={editableWorkflowVariables}
+                />
               ) : rightPanelVariant === 'variables' ? (
                 <UnifiedVariablesPanel
                   nodeId={selectedVariableNodeId}
@@ -5005,6 +5276,244 @@ export function FullWorkbenchComposition({
           </div>
         </CanvasTakeoverModal>
       )}
+    </div>
+  );
+}
+
+/** Tracks an element's border-box width via ResizeObserver. Null until the first measurement lands. */
+function useContainerWidth(ref: RefObject<HTMLElement | null>) {
+  const [width, setWidth] = useState<number | null>(null);
+
+  useEffect(() => {
+    const element = ref.current;
+    if (!element) return;
+    const observer = new ResizeObserver((entries) => {
+      const entry = entries[0];
+      if (entry) setWidth(entry.contentRect.width);
+    });
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, [ref]);
+
+  return width;
+}
+
+// Below this container width the left sidebar auto-collapses to its icon rail, reclaiming space for
+// the canvas. Chosen wider than the right panel's threshold so the sidebar gives way first.
+const RESPONSIVE_SIDEBAR_COLLAPSE_WIDTH = 1180;
+// Below this container width the right panel auto-closes entirely (reopenable via the panel trigger),
+// since by this point the canvas needs the room more than a docked panel does.
+const RESPONSIVE_RIGHT_PANEL_COLLAPSE_WIDTH = 860;
+const RESPONSIVE_RIGHT_PANEL_MIN_WIDTH = 320;
+const RESPONSIVE_RIGHT_PANEL_MAX_WIDTH = 480;
+const RESPONSIVE_RIGHT_PANEL_DEFAULT_WIDTH = 380;
+
+/**
+ * Explores what the workbench should do as its container narrows: the left sidebar collapses to its
+ * icon rail first (wider breakpoint), the right panel closes second (narrower breakpoint), prioritizing
+ * canvas space. Both thresholds only ever force a collapse, never force a re-expand — once narrowed,
+ * re-opening either panel is left to the user via their normal manual controls. The right panel is also
+ * manually resizable within a fixed min/max range via the handle on its leading edge.
+ */
+export function ResponsiveWorkbenchComposition() {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const containerWidth = useContainerWidth(containerRef);
+  const panelRef = useRef<PanelImperativeHandle | null>(null);
+
+  const [sidebarExpanded, setSidebarExpanded] = useState(true);
+  const [activeSidebarItem, setActiveSidebarItem] = useState<CanvasLeftSidebarItemId>('variables');
+  const [rightPanelOpen, setRightPanelOpen] = useState(true);
+  const [rightPanelWidth, setRightPanelWidth] = useState(RESPONSIVE_RIGHT_PANEL_DEFAULT_WIDTH);
+  const [activeTabId, setActiveTabId] = useState('execution');
+  const [isBottomPanelCollapsed, setIsBottomPanelCollapsed] = useState(true);
+  const [bottomPanelHeight, setBottomPanelHeight] = useState(80);
+
+  useEffect(() => {
+    if (containerWidth !== null && containerWidth < RESPONSIVE_SIDEBAR_COLLAPSE_WIDTH) {
+      setSidebarExpanded(false);
+    }
+  }, [containerWidth]);
+
+  useEffect(() => {
+    if (containerWidth !== null && containerWidth < RESPONSIVE_RIGHT_PANEL_COLLAPSE_WIDTH) {
+      setRightPanelOpen(false);
+    }
+  }, [containerWidth]);
+
+  const handleResizeHandlePointerDown = (event: PointerEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    const startX = event.clientX;
+    const startWidth = rightPanelWidth;
+
+    const handlePointerMove = (moveEvent: globalThis.PointerEvent) => {
+      const nextWidth = startWidth + (startX - moveEvent.clientX);
+      setRightPanelWidth(
+        Math.min(
+          RESPONSIVE_RIGHT_PANEL_MAX_WIDTH,
+          Math.max(RESPONSIVE_RIGHT_PANEL_MIN_WIDTH, nextWidth)
+        )
+      );
+    };
+    const handlePointerUp = () => {
+      window.removeEventListener('pointermove', handlePointerMove);
+      window.removeEventListener('pointerup', handlePointerUp);
+    };
+    window.addEventListener('pointermove', handlePointerMove);
+    window.addEventListener('pointerup', handlePointerUp);
+  };
+
+  const setBottomPanelCollapsed = (collapsed: boolean) => {
+    setIsBottomPanelCollapsed(collapsed);
+    if (collapsed) panelRef.current?.collapse();
+    else panelRef.current?.expand();
+  };
+
+  const tabs: CanvasBottomPanelTab[] = [
+    {
+      id: 'execution',
+      label: (
+        <>
+          <Bug className="size-3" /> Executions
+        </>
+      ),
+      group: 'debug',
+      content: <DebugPanelContent />,
+    },
+    { id: 'datasets', label: 'Datasets', content: <EvaluatePanelContent /> },
+    { id: 'evaluators', label: 'Evaluators', content: <EvaluatePanelContent /> },
+  ];
+
+  return (
+    <div ref={containerRef} className="relative flex h-screen bg-surface">
+      <CanvasLeftSidebar
+        title="Variables"
+        variant="default"
+        primaryItems={VARIABLE_CONCEPT_SIDEBAR_ITEMS}
+        isExpanded={sidebarExpanded}
+        onExpandedChange={setSidebarExpanded}
+        activeItemId={activeSidebarItem}
+        onItemSelect={setActiveSidebarItem}
+      />
+      <div className="relative min-w-0 flex-1 overflow-hidden">
+        <CanvasViewport
+          bottomControlsOffset={bottomPanelHeight + 20}
+          rightControlsOffset={rightPanelOpen ? rightPanelWidth + 32 : 16}
+          trigger={
+            <PanelTrigger
+              panels={[
+                { id: 'input', label: 'Input', enabled: false },
+                { id: 'properties', label: 'Properties', enabled: rightPanelOpen },
+                { id: 'output', label: 'Output', enabled: false },
+              ]}
+              onPanelToggle={(id, enabled) => {
+                if (id === 'properties') setRightPanelOpen(enabled);
+              }}
+            />
+          }
+        />
+
+        <div className="pointer-events-none absolute left-3 top-3 z-30 rounded-lg border border-border-subtle bg-surface-raised/95 px-3 py-2 text-[11px] leading-5 text-foreground-muted shadow-lg backdrop-blur">
+          <p className="font-semibold text-foreground">
+            Container {containerWidth ? Math.round(containerWidth) : '—'}px
+          </p>
+          <p>
+            Sidebar {sidebarExpanded ? 'expanded' : 'collapsed'} · collapses under{' '}
+            {RESPONSIVE_SIDEBAR_COLLAPSE_WIDTH}px
+          </p>
+          <p>
+            Right panel {rightPanelOpen ? `open, ${rightPanelWidth}px` : 'closed'} · closes under{' '}
+            {RESPONSIVE_RIGHT_PANEL_COLLAPSE_WIDTH}px
+          </p>
+          <p>
+            Right panel range {RESPONSIVE_RIGHT_PANEL_MIN_WIDTH}–{RESPONSIVE_RIGHT_PANEL_MAX_WIDTH}
+            px
+          </p>
+        </div>
+
+        {rightPanelOpen && (
+          <div
+            className="absolute right-0 top-0 z-20 flex p-4 pl-0"
+            style={{ bottom: bottomPanelHeight - 12 }}
+          >
+            {/* biome-ignore lint/a11y/useSemanticElements: an <hr> can't carry pointer/keyboard drag handlers or a live aria-valuenow — this is an interactive resize handle, not a static divider. */}
+            <div
+              onPointerDown={handleResizeHandlePointerDown}
+              onKeyDown={(event) => {
+                const step = event.shiftKey ? 32 : 8;
+                if (event.key === 'ArrowLeft') {
+                  event.preventDefault();
+                  setRightPanelWidth((current) =>
+                    Math.min(RESPONSIVE_RIGHT_PANEL_MAX_WIDTH, current + step)
+                  );
+                } else if (event.key === 'ArrowRight') {
+                  event.preventDefault();
+                  setRightPanelWidth((current) =>
+                    Math.max(RESPONSIVE_RIGHT_PANEL_MIN_WIDTH, current - step)
+                  );
+                }
+              }}
+              role="separator"
+              tabIndex={0}
+              aria-orientation="vertical"
+              aria-label="Resize properties panel"
+              aria-valuenow={rightPanelWidth}
+              aria-valuemin={RESPONSIVE_RIGHT_PANEL_MIN_WIDTH}
+              aria-valuemax={RESPONSIVE_RIGHT_PANEL_MAX_WIDTH}
+              className="mr-1 w-1.5 shrink-0 cursor-col-resize rounded-full transition hover:bg-brand/40 active:bg-brand/60 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-border-focus"
+            />
+            <div
+              className="h-full shrink-0 overflow-hidden rounded-2xl border border-border-subtle shadow-lg"
+              style={{ width: rightPanelWidth }}
+            >
+              <RuleBuildingPanel onClose={() => setRightPanelOpen(false)} />
+            </div>
+          </div>
+        )}
+
+        <ResizablePanelGroup
+          orientation="vertical"
+          className="pointer-events-none absolute inset-y-0 left-0 z-30"
+          style={{ right: rightPanelOpen ? rightPanelWidth + 16 : 0 }}
+        >
+          <ResizablePanel defaultSize="55%" minSize="30%" className="pointer-events-none" />
+          {!isBottomPanelCollapsed && (
+            <ResizableHandle
+              withHandle
+              className="pointer-events-auto z-20 mx-8 translate-y-3 bg-transparent aria-[orientation=horizontal]:w-[calc(100%-4rem)]"
+            />
+          )}
+          <ResizablePanel
+            panelRef={panelRef}
+            collapsible
+            collapsedSize={80}
+            defaultSize={80}
+            minSize={368}
+            onResize={({ inPixels }) => setBottomPanelHeight(inPixels)}
+            className="pointer-events-auto min-h-0 px-4 pb-4 pt-3"
+          >
+            <CanvasBottomPanel
+              variant="floating"
+              className="h-full"
+              tabs={tabs}
+              activeTabId={activeTabId}
+              onTabChange={(tabId) => {
+                setActiveTabId(tabId);
+                if (isBottomPanelCollapsed) setBottomPanelCollapsed(false);
+              }}
+              isCollapsed={isBottomPanelCollapsed}
+              onCollapsedChange={setBottomPanelCollapsed}
+              headerActions={
+                <ToolbarButton
+                  label={isBottomPanelCollapsed ? 'Expand panel' : 'Collapse panel'}
+                  onClick={() => setBottomPanelCollapsed(!isBottomPanelCollapsed)}
+                >
+                  {isBottomPanelCollapsed ? <ChevronUp /> : <ChevronDown />}
+                </ToolbarButton>
+              }
+            />
+          </ResizablePanel>
+        </ResizablePanelGroup>
+      </div>
     </div>
   );
 }

--- a/packages/apollo-react/src/canvas/stories/templates/Flow.stories.tsx
+++ b/packages/apollo-react/src/canvas/stories/templates/Flow.stories.tsx
@@ -7,14 +7,26 @@ import {
   useReactFlow,
 } from '@uipath/apollo-react/canvas/xyflow/react';
 import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+  Alert,
+  AlertDescription,
   Button,
   Card,
   CardContent,
   Checkbox,
   type FormSchema,
   Input,
+  InputGroup,
+  InputGroupAddon,
+  InputGroupButton,
+  InputGroupInput,
   Label,
   type PanelImperativeHandle,
+  RadioGroup,
+  RadioGroupItem,
   ResizableHandle,
   ResizablePanel,
   ResizablePanelGroup,
@@ -39,6 +51,7 @@ import type { DockviewApi, DockviewReadyEvent, IDockviewPanelProps } from 'dockv
 import { DockviewReact } from 'dockview-react';
 import 'dockview-react/dist/styles/dockview.css';
 import {
+  AtSign,
   Blocks,
   Bold,
   Bug,
@@ -3562,28 +3575,311 @@ export function NodeInventoryComposition() {
   );
 }
 
+function DapValueField({
+  id,
+  label,
+  value,
+  placeholder,
+  required,
+  onChange,
+}: {
+  id: string;
+  label: string;
+  value: string;
+  placeholder: string;
+  required?: boolean;
+  onChange: (value: string) => void;
+}) {
+  return (
+    <div className="space-y-1.5">
+      <Label htmlFor={id} className="text-xs">
+        {label}
+        {required && <span className="text-error"> *</span>}
+      </Label>
+      <InputGroup className="h-9 bg-surface-overlay">
+        <InputGroupInput
+          id={id}
+          value={value}
+          placeholder={placeholder}
+          onChange={(event) => onChange(event.target.value)}
+          className="text-xs"
+        />
+        <InputGroupAddon align="inline-end" className="-my-1 gap-0 self-stretch">
+          <InputGroupButton
+            icon
+            aria-label={`Insert variable for ${label}`}
+            title="Insert variable"
+            className="h-full rounded-none border-l px-2.5"
+            onClick={() => onChange(`${value}$vars.`)}
+          >
+            <AtSign size={14} />
+          </InputGroupButton>
+          <InputGroupButton
+            icon
+            aria-label={`Configure value for ${label}`}
+            title="Configure value"
+            className="h-full rounded-none border-l px-2.5"
+          >
+            <SlidersHorizontal size={14} />
+          </InputGroupButton>
+        </InputGroupAddon>
+      </InputGroup>
+    </div>
+  );
+}
+
 function DapPanel({ onClose }: { onClose: () => void }) {
+  const [subject, setSubject] = useState('Invoice approval required');
+  const [recipient, setRecipient] = useState('$vars.approverEmail');
+  const [body, setBody] = useState(
+    'Hi $vars.approverName,\n\nPlease review invoice $vars.invoiceNumber.'
+  );
+  const [attachment, setAttachment] = useState('$vars.invoicePdf');
+  const [replyTo, setReplyTo] = useState('finance-ops@example.com');
+  const [includeDetails, setIncludeDetails] = useState('true');
+  const [selectedProperties, setSelectedProperties] = useState(['Subject', 'Body', 'Importance']);
+
+  const toggleProperty = (property: string) => {
+    setSelectedProperties((current) =>
+      current.includes(property)
+        ? current.filter((candidate) => candidate !== property)
+        : [...current, property]
+    );
+  };
+
   return (
     <NodePropertyPanel
-      panelTitle="DAP"
-      nodeIcon={<Blocks />}
-      nodeLabel="DAP components"
-      nodeCategory="Component display and interaction guidance"
+      panelTitle="Properties"
+      nodeIcon={<Mail />}
+      nodeLabel="Send email"
+      nodeCategory="Gmail · DAP layout"
       onClose={onClose}
       contentInset="0.875rem"
       className="h-full"
     >
-      <div className="flex min-h-0 flex-1 flex-col p-3">
-        <div className="grid min-h-52 flex-1 place-items-center rounded-xl border border-dashed border-border-subtle bg-surface-overlay/30 p-6 text-center">
-          <div className="max-w-56">
-            <Blocks className="mx-auto size-6 text-foreground-subtle" />
-            <p className="mt-3 text-sm font-semibold text-foreground">DAP UX</p>
-            <p className="mt-1 text-xs leading-5 text-foreground-muted">
-              Add DAP components and their interaction guidance here.
+      <Tabs defaultValue="parameters" className="flex h-full min-h-0 flex-col">
+        <TabsList className={VARIABLE_TAB_LIST_CLASS}>
+          <TabsTrigger value="parameters" className={VARIABLE_TAB_TRIGGER_CLASS}>
+            Parameters
+          </TabsTrigger>
+          <TabsTrigger value="variables" className={VARIABLE_TAB_TRIGGER_CLASS}>
+            Variables
+          </TabsTrigger>
+        </TabsList>
+        <TabsContent value="parameters" className="mt-0 min-h-0 flex-1 overflow-y-auto p-3">
+          <div className="space-y-5">
+            <p className="text-xs leading-5 text-foreground-muted">
+              Configure a connector activity using reusable DAP field and value-source patterns.
             </p>
+
+            <section className="space-y-3">
+              <div className="flex items-center justify-between gap-3">
+                <p className="text-xs font-semibold text-foreground">Connection</p>
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  className="h-7 px-2 text-xs font-semibold text-brand hover:text-brand"
+                >
+                  Refresh schema
+                </Button>
+              </div>
+              <Select defaultValue="gmail-finance">
+                <SelectTrigger className="h-9 w-full bg-surface-overlay text-xs">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="gmail-finance">Gmail · Finance operations</SelectItem>
+                  <SelectItem value="gmail-personal">Gmail · Personal</SelectItem>
+                </SelectContent>
+              </Select>
+              <Alert className="border-brand/30 bg-brand-subtle/30 py-2.5">
+                <AlertDescription className="text-[11px] leading-4">
+                  Schema is current. Nine configurable message properties are available.
+                </AlertDescription>
+              </Alert>
+            </section>
+
+            <Separator />
+
+            <section className="space-y-4">
+              <p className="text-xs font-semibold text-foreground">Message</p>
+              <DapValueField
+                id="dap-recipient"
+                label="To"
+                value={recipient}
+                placeholder="Recipient email address"
+                required
+                onChange={setRecipient}
+              />
+              <DapValueField
+                id="dap-subject"
+                label="Subject"
+                value={subject}
+                placeholder="The subject of the email"
+                required
+                onChange={setSubject}
+              />
+              <div className="space-y-1.5">
+                <div className="flex items-center justify-between gap-2">
+                  <Label htmlFor="dap-body" className="text-xs">
+                    Body <span className="text-error">*</span>
+                  </Label>
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    className="h-7 px-2 text-xs text-brand hover:text-brand"
+                    onClick={() => setBody(`${body}$vars.`)}
+                  >
+                    <AtSign size={13} /> Insert variable
+                  </Button>
+                </div>
+                <div className="overflow-hidden rounded-lg border border-border-subtle bg-surface-overlay focus-within:border-border-focus">
+                  <div className="flex h-8 items-center gap-1 border-b border-border-subtle px-2">
+                    <Button size="sm" variant="ghost" className="size-6 p-0" aria-label="Bold">
+                      <Bold size={13} />
+                    </Button>
+                    <Button
+                      size="sm"
+                      variant="ghost"
+                      className="size-6 p-0"
+                      aria-label="Bulleted list"
+                    >
+                      <List size={13} />
+                    </Button>
+                    <span className="ml-auto text-[10px] text-foreground-muted">Rich text</span>
+                  </div>
+                  <Textarea
+                    id="dap-body"
+                    value={body}
+                    onChange={(event) => setBody(event.target.value)}
+                    className="min-h-28 resize-none rounded-none border-0 bg-transparent text-xs shadow-none focus-visible:ring-0"
+                  />
+                </div>
+              </div>
+              <DapValueField
+                id="dap-attachment"
+                label="Attachment"
+                value={attachment}
+                placeholder="The file to attach"
+                onChange={setAttachment}
+              />
+            </section>
+
+            <Accordion type="multiple" defaultValue={['options']} className="space-y-2">
+              <AccordionItem
+                value="options"
+                className="rounded-lg border border-border-subtle px-3"
+              >
+                <AccordionTrigger className="py-3 text-xs font-semibold hover:no-underline">
+                  Options
+                </AccordionTrigger>
+                <AccordionContent className="space-y-4 pb-3">
+                  <div className="space-y-2">
+                    <Label className="text-xs">Include message details</Label>
+                    <RadioGroup
+                      value={includeDetails}
+                      onValueChange={setIncludeDetails}
+                      className="flex gap-5"
+                    >
+                      <label className="flex items-center gap-2 text-xs" htmlFor="dap-details-true">
+                        <RadioGroupItem id="dap-details-true" value="true" /> True
+                      </label>
+                      <label
+                        className="flex items-center gap-2 text-xs"
+                        htmlFor="dap-details-false"
+                      >
+                        <RadioGroupItem id="dap-details-false" value="false" /> False
+                      </label>
+                    </RadioGroup>
+                  </div>
+                  <DapValueField
+                    id="dap-reply-to"
+                    label="Reply to"
+                    value={replyTo}
+                    placeholder="Reply-to address"
+                    onChange={setReplyTo}
+                  />
+                  <div className="space-y-1.5">
+                    <Label className="text-xs">Importance</Label>
+                    <Select defaultValue="normal">
+                      <SelectTrigger className="h-9 w-full bg-surface-overlay text-xs">
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="low">Low</SelectItem>
+                        <SelectItem value="normal">Normal</SelectItem>
+                        <SelectItem value="high">High</SelectItem>
+                      </SelectContent>
+                    </Select>
+                  </div>
+                </AccordionContent>
+              </AccordionItem>
+
+              <AccordionItem
+                value="properties"
+                className="rounded-lg border border-border-subtle px-3"
+              >
+                <AccordionTrigger className="py-3 text-xs font-semibold hover:no-underline">
+                  Manage properties
+                </AccordionTrigger>
+                <AccordionContent className="space-y-3 pb-3">
+                  <p className="text-[11px] leading-4 text-foreground-muted">
+                    Choose the optional fields shown for this connector activity.
+                  </p>
+                  {['Subject', 'Body', 'Reply to', 'Importance', 'Attachment'].map((property) => (
+                    <div
+                      key={property}
+                      className="flex cursor-pointer items-center gap-2.5 rounded-md px-1 py-1 text-xs"
+                    >
+                      <Checkbox
+                        id={`dap-property-${property.toLowerCase().replaceAll(' ', '-')}`}
+                        checked={selectedProperties.includes(property)}
+                        onCheckedChange={() => toggleProperty(property)}
+                      />
+                      <Label
+                        htmlFor={`dap-property-${property.toLowerCase().replaceAll(' ', '-')}`}
+                        className="flex-1 cursor-pointer text-xs font-normal"
+                      >
+                        {property}
+                      </Label>
+                      <span className="text-[10px] text-foreground-muted">String</span>
+                    </div>
+                  ))}
+                  <Button size="sm" variant="outline" className="h-8 w-full text-xs">
+                    Update fields
+                  </Button>
+                </AccordionContent>
+              </AccordionItem>
+            </Accordion>
           </div>
-        </div>
-      </div>
+        </TabsContent>
+
+        <TabsContent value="variables" className="mt-0 min-h-0 flex-1 overflow-y-auto p-3">
+          <div className="space-y-4">
+            <p className="text-xs leading-5 text-foreground-muted">
+              Values available to the connector fields and produced when this activity runs.
+            </p>
+            {[
+              ['$vars.approverEmail', 'Text · Input'],
+              ['$vars.approverName', 'Text · Input'],
+              ['$vars.invoiceNumber', 'Text · Input'],
+              ['$vars.invoicePdf', 'File · Input'],
+              ['$output.messageId', 'Text · Output'],
+            ].map(([name, metadata]) => (
+              <div
+                key={name}
+                className="flex items-center gap-3 rounded-lg border border-border-subtle bg-surface-overlay px-3 py-2.5"
+              >
+                <Blocks className="size-4 shrink-0 text-foreground-subtle" />
+                <div className="min-w-0 flex-1">
+                  <p className="truncate font-mono text-xs font-medium">{name}</p>
+                  <p className="mt-0.5 text-[11px] text-foreground-muted">{metadata}</p>
+                </div>
+              </div>
+            ))}
+          </div>
+        </TabsContent>
+      </Tabs>
     </NodePropertyPanel>
   );
 }

--- a/packages/apollo-react/src/canvas/stories/templates/Flow.stories.tsx
+++ b/packages/apollo-react/src/canvas/stories/templates/Flow.stories.tsx
@@ -2976,17 +2976,6 @@ function InventoryCategoryNode({ data }: NodeProps<Node<BaseNodeData>>) {
   );
 }
 
-function InventoryItemNode({ data }: NodeProps<Node<BaseNodeData>>) {
-  return (
-    <div className="flex w-40 cursor-pointer flex-col items-center gap-2 text-center text-foreground">
-      <div className="grid size-16 place-items-center rounded-2xl border border-border-subtle bg-surface shadow-sm transition-shadow hover:shadow-md">
-        <CanvasIcon icon={data.display?.icon} size={28} />
-      </div>
-      <span className="max-w-40 text-xs font-medium leading-4">{data.display?.label}</span>
-    </div>
-  );
-}
-
 function createNodeInventoryNodes(): Node<BaseNodeData>[] {
   return NODE_INVENTORY_GROUPS.flatMap((group, rowIndex) => {
     const y = rowIndex * 150;
@@ -2997,26 +2986,33 @@ function createNodeInventoryNodes(): Node<BaseNodeData>[] {
       display: { label: group.category },
       data: { inventoryCategory: true },
     });
-    const itemNodes = group.items.map((item, columnIndex) =>
-      createNode({
+    const itemNodes = group.items.map((item, columnIndex) => {
+      const hasPanelMockup = NODE_PANEL_SPECS[item.id] !== undefined;
+      return createNode({
         id: item.id,
-        type: 'inventory-item',
+        type: 'uipath.blank-node',
         position: { x: 190 + columnIndex * 245, y: y + 8 },
         display: {
           label: item.label,
-          subLabel: item.source === 'dynamic' ? 'Dynamic catalog example' : group.category,
+          subLabel: hasPanelMockup
+            ? '🟢 Panel mockup'
+            : item.source === 'dynamic'
+              ? 'Dynamic catalog example'
+              : group.category,
           icon: item.icon,
         },
-        data: { nodeType: item.nodeType, inventoryItem: true },
-      })
-    );
+        data: {
+          inventoryNodeType: item.nodeType,
+          inventoryItem: true,
+        },
+      });
+    });
     return [categoryNode, ...itemNodes];
   });
 }
 
 const inventoryNodeTypes = {
   'inventory-category': InventoryCategoryNode,
-  'inventory-item': InventoryItemNode,
 };
 
 function NodeInventoryCanvas({

--- a/packages/apollo-react/src/canvas/stories/templates/FlowUX.stories.tsx
+++ b/packages/apollo-react/src/canvas/stories/templates/FlowUX.stories.tsx
@@ -1,0 +1,52 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { withCanvasProviders } from '../../storybook-utils';
+import {
+  AgentExperienceComposition,
+  FullWorkbenchComposition,
+  mapTemplateThemeToChat,
+  NodeInventoryComposition,
+} from './Flow.stories';
+
+const meta = {
+  title: 'Templates/Flow Standalone',
+  parameters: {
+    layout: 'fullscreen',
+  },
+  decorators: [withCanvasProviders({ fullscreen: false })],
+} satisfies Meta;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const WorkbenchWithForms: Story = {
+  name: 'UX Form',
+  render: () => <FullWorkbenchComposition rightPanelVariant="forms" />,
+};
+
+export const WorkbenchWithNode: Story = {
+  name: 'UX Variables',
+  render: () => <FullWorkbenchComposition rightPanelVariant="node" />,
+};
+
+export const RuleBuilding: Story = {
+  name: 'UX Rule',
+  render: () => <FullWorkbenchComposition rightPanelVariant="rules" />,
+};
+
+export const VariableManagement: Story = {
+  name: 'UX Nodes',
+  render: () => <NodeInventoryComposition />,
+};
+
+export const DapUX: Story = {
+  name: 'UX DAP',
+  render: () => <FullWorkbenchComposition rightPanelVariant="dap" />,
+};
+
+export const AgentExperience: Story = {
+  name: 'UX Agent',
+  render: (_args, context) => (
+    <AgentExperienceComposition theme={mapTemplateThemeToChat(context.globals.theme)} />
+  ),
+};

--- a/packages/apollo-wind/src/components/forms/field-guidance.stories.tsx
+++ b/packages/apollo-wind/src/components/forms/field-guidance.stories.tsx
@@ -1,0 +1,305 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Check, CircleHelp, X } from 'lucide-react';
+import type * as React from 'react';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
+import { fontFamily } from '@/foundation/Future/typography';
+import { cn } from '@/lib';
+
+const meta = {
+  title: 'Forms/Field guidance',
+  parameters: { layout: 'fullscreen' },
+} satisfies Meta;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+function SectionTitle({ children }: { children: React.ReactNode }) {
+  return <h2 className="mb-2 text-2xl font-bold tracking-tight text-foreground">{children}</h2>;
+}
+
+function SectionDescription({ children }: { children: React.ReactNode }) {
+  return <p className="mb-6 text-base leading-7 text-muted-foreground">{children}</p>;
+}
+
+function Divider() {
+  return <div className="my-10 h-px bg-border" />;
+}
+
+function InlineCode({ children }: { children: React.ReactNode }) {
+  return (
+    <code className="rounded bg-muted px-1.5 py-0.5 text-sm font-medium text-foreground">
+      {children}
+    </code>
+  );
+}
+
+function InfoCallout({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="rounded-lg border border-border bg-muted/50 p-4 text-sm leading-6 text-muted-foreground">
+      {children}
+    </div>
+  );
+}
+
+function GuidanceList({ children }: { children: React.ReactNode }) {
+  return <ul className="space-y-2 text-sm leading-6 text-muted-foreground">{children}</ul>;
+}
+
+function GuidanceItem({ children }: { children: React.ReactNode }) {
+  return (
+    <li className="flex gap-2">
+      <Check aria-hidden="true" className="mt-1 size-4 shrink-0 text-primary" />
+      <span>{children}</span>
+    </li>
+  );
+}
+
+function HelpTrigger({ fieldName }: { fieldName: string }) {
+  return (
+    <TooltipTrigger asChild>
+      <button
+        type="button"
+        aria-label={`Help for ${fieldName}`}
+        className="inline-flex size-5 cursor-help items-center justify-center rounded-sm text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+      >
+        <CircleHelp aria-hidden="true" className="size-3.5" />
+      </button>
+    </TooltipTrigger>
+  );
+}
+
+function InlineDescriptionExample() {
+  return (
+    <div className="grid gap-1.5">
+      <Label htmlFor="workspace-slug">Workspace URL</Label>
+      <Input
+        id="workspace-slug"
+        aria-describedby="workspace-slug-description"
+        placeholder="team-name"
+      />
+      <p id="workspace-slug-description" className="text-sm text-muted-foreground">
+        Use lowercase letters, numbers, and hyphens. You cannot change this later.
+      </p>
+    </div>
+  );
+}
+
+function TooltipHelpExample() {
+  return (
+    <TooltipProvider>
+      <div className="grid gap-1.5">
+        <div className="flex items-center gap-1">
+          <Label htmlFor="retention-period">Retention period</Label>
+          <Tooltip>
+            <HelpTrigger fieldName="retention period" />
+            <TooltipContent side="top" className="max-w-64">
+              How long completed jobs remain available before they are permanently deleted.
+            </TooltipContent>
+          </Tooltip>
+        </div>
+        <Input id="retention-period" inputMode="numeric" placeholder="30 days" />
+      </div>
+    </TooltipProvider>
+  );
+}
+
+function PatternCard({
+  eyebrow,
+  title,
+  description,
+  children,
+}: {
+  eyebrow: string;
+  title: string;
+  description: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="rounded-lg border border-border bg-card p-5">
+      <span className="mb-2 block text-xs font-medium uppercase tracking-wide text-muted-foreground">
+        {eyebrow}
+      </span>
+      <h3 className="mb-2 text-lg font-semibold text-foreground">{title}</h3>
+      <p className="mb-5 text-sm leading-6 text-muted-foreground">{description}</p>
+      {children}
+    </div>
+  );
+}
+
+function FieldGuidancePage({ globalTheme }: { globalTheme: string }) {
+  return (
+    <div
+      className={cn(globalTheme, 'min-h-screen w-full bg-background text-foreground')}
+      style={{ fontFamily: fontFamily.base }}
+    >
+      <main className="mx-auto max-w-3xl p-8">
+        <header>
+          <h1 className="text-[2rem] font-bold tracking-tight text-foreground">Field guidance</h1>
+          <p className="mt-2 text-base leading-7 text-muted-foreground">
+            Help people understand what a field expects and why the information is needed. Choose
+            inline descriptions or tooltip help according to how important that information is to
+            completing the task.
+          </p>
+        </header>
+
+        <Divider />
+
+        <section>
+          <SectionTitle>Choose the right pattern</SectionTitle>
+          <SectionDescription>
+            If someone needs the information to complete the field correctly, keep it visible.
+            Reserve tooltip help for optional context.
+          </SectionDescription>
+
+          <div className="grid gap-5 md:grid-cols-2">
+            <PatternCard
+              eyebrow="Persistent"
+              title="Inline description"
+              description="Use for requirements, constraints, consequences, or unfamiliar terms that are important to completing the field."
+            >
+              <InlineDescriptionExample />
+            </PatternCard>
+            <PatternCard
+              eyebrow="On demand"
+              title="Tooltip help"
+              description="Use for supplementary context that most people can complete the field without."
+            >
+              <TooltipHelpExample />
+            </PatternCard>
+          </div>
+        </section>
+
+        <Divider />
+
+        <section>
+          <SectionTitle>Inline descriptions</SectionTitle>
+          <SectionDescription>
+            Place persistent guidance below the field control so it remains available while someone
+            enters or reviews a value.
+          </SectionDescription>
+          <GuidanceList>
+            <GuidanceItem>
+              Explain the required format or constraints for a valid value.
+            </GuidanceItem>
+            <GuidanceItem>Describe consequences that may affect someone’s decision.</GuidanceItem>
+            <GuidanceItem>Clarify unfamiliar terminology needed by most people.</GuidanceItem>
+            <GuidanceItem>
+              Connect the description to the control with <InlineCode>aria-describedby</InlineCode>.
+            </GuidanceItem>
+          </GuidanceList>
+          <div className="mt-6">
+            <InfoCallout>
+              Do not put validation errors, required instructions, or critical consequences only in
+              a tooltip. Essential information must remain visible.
+            </InfoCallout>
+          </div>
+        </section>
+
+        <Divider />
+
+        <section>
+          <SectionTitle>Tooltip triggers</SectionTitle>
+          <SectionDescription>
+            Place a dedicated help icon immediately after the field label. The icon—not the label or
+            field control—is the tooltip trigger.
+          </SectionDescription>
+          <div className="grid gap-5 md:grid-cols-2">
+            <div className="rounded-lg border border-border bg-card p-5">
+              <div className="mb-4 flex items-center gap-2 text-sm font-semibold text-foreground">
+                <Check aria-hidden="true" className="size-4 text-primary" />
+                Do
+              </div>
+              <TooltipHelpExample />
+              <p className="mt-4 text-sm leading-6 text-muted-foreground">
+                Use a visible, focusable help button beside the label as the explicit target.
+              </p>
+            </div>
+            <div className="rounded-lg border border-border bg-card p-5">
+              <div className="mb-4 flex items-center gap-2 text-sm font-semibold text-foreground">
+                <X aria-hidden="true" className="size-4 text-destructive" />
+                Don’t
+              </div>
+              <div className="grid gap-1.5">
+                <Label htmlFor="whole-control-example">Retention period</Label>
+                <div className="rounded-md border border-dashed border-destructive/60 p-1">
+                  <Input id="whole-control-example" placeholder="30 days" />
+                </div>
+              </div>
+              <p className="mt-4 text-sm leading-6 text-muted-foreground">
+                Don’t make the input, select, label, or entire field an invisible hover target.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        <Divider />
+
+        <section>
+          <SectionTitle>Accessibility and interaction</SectionTitle>
+          <SectionDescription>
+            Tooltip help must not depend on pointer hover. Everyone needs an equivalent, explicit
+            way to discover and open it.
+          </SectionDescription>
+          <GuidanceList>
+            <GuidanceItem>
+              Render the trigger as a button with an accessible name such as “Help for retention
+              period.”
+            </GuidanceItem>
+            <GuidanceItem>Open the tooltip on both pointer hover and keyboard focus.</GuidanceItem>
+            <GuidanceItem>
+              Close it when hover or focus leaves, and allow <InlineCode>Escape</InlineCode> to
+              close it.
+            </GuidanceItem>
+            <GuidanceItem>Support activation on touch devices that do not have hover.</GuidanceItem>
+            <GuidanceItem>Keep the help trigger available when the field is disabled.</GuidanceItem>
+            <GuidanceItem>
+              Hide the decorative question-mark glyph from assistive technology.
+            </GuidanceItem>
+          </GuidanceList>
+        </section>
+
+        <Divider />
+
+        <section>
+          <SectionTitle>Recommendation</SectionTitle>
+          <SectionDescription>
+            Treat help as a field-level pattern rather than an Input feature. The same guidance
+            applies to inputs, selects, text areas, checkboxes, radio groups, and other controls.
+          </SectionDescription>
+          <div className="space-y-4">
+            <InfoCallout>
+              Prefer a composed <InlineCode>FieldLabel</InlineCode> that renders the native label
+              and a sibling help trigger. Avoid placing an interactive tooltip button inside a
+              native <InlineCode>&lt;label&gt;</InlineCode>, where it can create conflicting
+              activation behavior.
+            </InfoCallout>
+            <div className="overflow-x-auto rounded-lg border border-border bg-muted/50 p-4">
+              <pre className="text-sm leading-6 text-foreground">
+                <code style={{ fontFamily: fontFamily.monospace }}>{`<FieldLabel
+  htmlFor="retention"
+  helpText="How long completed jobs remain available."
+>
+  Retention period
+</FieldLabel>`}</code>
+              </pre>
+            </div>
+            <p className="text-sm leading-6 text-muted-foreground">
+              Keep persistent descriptions separate as a <InlineCode>FieldDescription</InlineCode>{' '}
+              or equivalent. This proposed API is a direction for review, not an implemented
+              component. Confirm terminology, icon, placement, touch behavior, and component
+              ownership with design before engineering implementation.
+            </p>
+          </div>
+        </section>
+      </main>
+    </div>
+  );
+}
+
+export const Default: Story = {
+  render: (_args, { globals }) => (
+    <FieldGuidancePage globalTheme={globals.theme || 'future-dark'} />
+  ),
+};

--- a/packages/apollo-wind/src/components/ui/lockable-value-field/lockable-value-field.stories.tsx
+++ b/packages/apollo-wind/src/components/ui/lockable-value-field/lockable-value-field.stories.tsx
@@ -20,6 +20,11 @@ and (for scalar types) switched between a literal value and a JS expression.
 
 - Left lock icon toggles Editable / Read-only. Read-only fields show plain
   text, not a disabled control.
+- Use the default lock control when a user can intentionally freeze or unlock
+  a configurable form value. For assignment/binding fields that should remain
+  editable, use the leadingAddon prop to replace the lock with a semantic
+  prefix such as an equals sign, and set locked to false. The addon changes presentation only; it
+  does not change editability.
 - Right value-mode icon switches between Fixed value and Expression,
   updating the value styling. Only shown for types an expression can
   produce.
@@ -137,6 +142,43 @@ export const InlineValidation: Story = {
       },
     },
   },
+};
+
+function AssignmentExpressionDemo() {
+  const [value, setValue] = useState('$vars.flowArray');
+  const [mode, setMode] = useState<LockableValueFieldMode>('expression');
+
+  return (
+    <div className="w-80">
+      <LockableValueField
+        label="Collection"
+        value={value}
+        onValueChange={setValue}
+        locked={false}
+        leadingAddon={
+          <span
+            className="font-mono text-sm font-semibold text-foreground-accent"
+            aria-hidden="true"
+          >
+            =
+          </span>
+        }
+        mode={mode}
+        onModeChange={setMode}
+        variables={[{ label: 'Flow array', value: '$vars.flowArray' }]}
+      />
+    </div>
+  );
+}
+
+/**
+ * Assignment and binding fields are continuously editable, so `=` communicates
+ * expression assignment more clearly than a lock/unlock action. `leadingAddon`
+ * replaces only the visual control; `locked={false}` provides the editable state.
+ */
+export const AssignmentExpression: Story = {
+  name: 'Assignment expression (=)',
+  render: () => <AssignmentExpressionDemo />,
 };
 
 /**

--- a/packages/apollo-wind/src/components/ui/lockable-value-field/lockable-value-field.tsx
+++ b/packages/apollo-wind/src/components/ui/lockable-value-field/lockable-value-field.tsx
@@ -57,6 +57,7 @@ export function LockableValueField({
   onValueBlur,
   locked = true,
   onLockedChange,
+  leadingAddon,
   mode = 'fixed',
   onModeChange,
   renderExpressionEditor,
@@ -121,7 +122,7 @@ export function LockableValueField({
       {typeMeta.supportsExpression ? (
         <InputGroup error={error} errorId={validationId}>
           <InputGroupAddon align="inline-start">
-            <LockToggleButton locked={locked} onLockedChange={onLockedChange} />
+            {leadingAddon ?? <LockToggleButton locked={locked} onLockedChange={onLockedChange} />}
           </InputGroupAddon>
 
           {effectiveMode === 'expression' ? (

--- a/packages/apollo-wind/src/components/ui/lockable-value-field/types.ts
+++ b/packages/apollo-wind/src/components/ui/lockable-value-field/types.ts
@@ -107,6 +107,11 @@ export interface LockableValueFieldProps {
   locked?: boolean;
   /** Called when the user toggles the lock. */
   onLockedChange?: (locked: boolean) => void;
+  /**
+   * Replaces the leading lock toggle with a semantic prefix such as `=`. This is presentational:
+   * consumers must also set `locked={false}` when the replacement field should remain editable.
+   */
+  leadingAddon?: ReactNode;
   /** Fixed value vs. JS expression. Defaults to 'fixed'. Ignored for types that don't support expressions. */
   mode?: LockableValueFieldMode;
   /** Called when the user switches modes. */

--- a/packages/apollo-wind/src/components/ui/prompt-editor/components/TokenPill.tsx
+++ b/packages/apollo-wind/src/components/ui/prompt-editor/components/TokenPill.tsx
@@ -84,7 +84,7 @@ const TokenPillBase = ({
         <Icon className="h-3.5 w-3.5" />
       </span>
       <span
-        className="font-normal whitespace-nowrap"
+        className="inline-block max-w-[200px] truncate align-bottom font-normal"
         style={{ color: colors.text, fontFamily: "'Noto Sans', sans-serif" }}
       >
         {value}

--- a/packages/apollo-wind/src/components/ui/prompt-editor/types.ts
+++ b/packages/apollo-wind/src/components/ui/prompt-editor/types.ts
@@ -77,14 +77,14 @@ export const getPromptEditorTokenColors = (): Record<
   PromptEditorTokenColorConfig
 > => ({
   valid: {
-    background: 'var(--color-primary-lighter)',
-    border: 'var(--color-primary)',
-    text: 'var(--color-foreground)',
-    icon: 'var(--color-primary)',
+    background: 'var(--color-info-background)',
+    border: 'var(--color-info-icon)',
+    text: 'var(--color-info-text)',
+    icon: 'var(--color-info-icon)',
   },
   invalid: {
     background: 'var(--color-error-background)',
-    border: 'var(--color-error)',
+    border: 'var(--color-error-icon)',
     text: 'var(--color-error-text)',
     icon: 'var(--color-error-icon)',
   },


### PR DESCRIPTION
## Summary
- move Flow UX demonstrations under Apollo Wind > Patterns > Layout Patterns
- add unified parameters and variables panel demonstrations, including variable insertion and takeover layouts
- add Figma-informed node property panel layouts for the UX Nodes experience
- keep the core Flow standalone template stories focused on reusable layouts

## Validation
- pnpm exec biome check packages/apollo-react/src/canvas/stories/templates/Flow.stories.tsx
- pnpm --filter @uipath/apollo-react exec tsc --noEmit --pretty false
- git diff --check
- verified representative UX Nodes states in Storybook