### PR TITLE
fix(apollo-wind): keep plain section chevron on the trailing edge [MST-14024]

### DIFF
--- a/packages/apollo-wind/src/components/forms/metadata-form.test.tsx
+++ b/packages/apollo-wind/src/components/forms/metadata-form.test.tsx
@@ -597,33 +597,4 @@ describe('MetadataForm', () => {
       expect(screen.queryByRole('tab', { name: 'Conditional' })).not.toBeInTheDocument();
     });
   });
-
-  describe('collapsible sections', () => {
-    const collapsibleSchema: FormSchema = {
-      id: 'collapsible-form',
-      title: 'Collapsible Form',
-      sections: [
-        {
-          id: 'advanced',
-          title: 'Advanced',
-          collapsible: true,
-          fields: [{ name: 'field1', type: 'text', label: 'Field 1' }],
-        },
-      ],
-    };
-
-    // The chevron belongs on the trailing edge in both variants, so an
-    // expandable section's affordance never moves depending on how the host
-    // framed it.
-    it.each([
-      'card',
-      'plain',
-    ] as const)('keeps the %s chevron on the trailing edge', (sectionVariant) => {
-      render(<MetadataForm schema={collapsibleSchema} sectionVariant={sectionVariant} />);
-
-      const trigger = screen.getByRole('button', { name: 'Advanced' });
-      expect(trigger).not.toHaveClass('justify-start');
-      expect(trigger.lastElementChild?.tagName).toBe('svg');
-    });
-  });
 });

--- a/packages/apollo-wind/src/components/forms/metadata-form.test.tsx
+++ b/packages/apollo-wind/src/components/forms/metadata-form.test.tsx
@@ -597,4 +597,33 @@ describe('MetadataForm', () => {
       expect(screen.queryByRole('tab', { name: 'Conditional' })).not.toBeInTheDocument();
     });
   });
+
+  describe('collapsible sections', () => {
+    const collapsibleSchema: FormSchema = {
+      id: 'collapsible-form',
+      title: 'Collapsible Form',
+      sections: [
+        {
+          id: 'advanced',
+          title: 'Advanced',
+          collapsible: true,
+          fields: [{ name: 'field1', type: 'text', label: 'Field 1' }],
+        },
+      ],
+    };
+
+    // The chevron belongs on the trailing edge in both variants, so an
+    // expandable section's affordance never moves depending on how the host
+    // framed it.
+    it.each([
+      'card',
+      'plain',
+    ] as const)('keeps the %s chevron on the trailing edge', (sectionVariant) => {
+      render(<MetadataForm schema={collapsibleSchema} sectionVariant={sectionVariant} />);
+
+      const trigger = screen.getByRole('button', { name: 'Advanced' });
+      expect(trigger).not.toHaveClass('justify-start');
+      expect(trigger.lastElementChild?.tagName).toBe('svg');
+    });
+  });
 });

--- a/packages/apollo-wind/src/components/forms/metadata-form.tsx
+++ b/packages/apollo-wind/src/components/forms/metadata-form.tsx
@@ -614,13 +614,14 @@ function FormSection({
   // Accordion's first child) so `first:` resolves against the sibling list.
   const dividerClassName = 'border-t first:border-t-0';
   const wrapperClassName = isPlain ? 'border-b-0' : 'border rounded-lg px-3';
-  // Plain: the chevron sits immediately right of the title (packed left with a
-  // small gap) rather than pushed to the far edge, and the header no longer
-  // underlines on hover — it reads as a section label, not a link. Semibold
-  // (vs the field labels' medium) keeps the header distinguishable from its own
-  // fields even when the collapse chevron is absent.
+  // Plain: the header no longer underlines on hover — it reads as a section
+  // label, not a link. Semibold (vs the field labels' medium) keeps the header
+  // distinguishable from its own fields even when the collapse chevron is
+  // absent. The chevron stays on the trailing edge (AccordionTrigger's own
+  // `justify-between`) so it lands in the same place in every expandable
+  // section, card or plain.
   const triggerClassName = isPlain
-    ? 'justify-start gap-2 py-4 text-sm font-semibold hover:no-underline'
+    ? 'py-4 text-sm font-semibold hover:no-underline'
     : 'text-sm font-medium';
 
   const fieldsGrid = (


### PR DESCRIPTION
[MST-14024](https://uipath.atlassian.net/browse/MST-14024) — from the Flow UX audit (Aug 2026): expand/collapse carets in the Flow property panels sit in inconsistent places, and the caret is the thing users aim at.

<img width="1079" height="735" alt="2026-08-25 16 34 48" src="https://github.com/user-attachments/assets/9d44c86f-7848-406e-838c-1643a33881b1" />

## Testing

- [x] Manual verification
- [x] `metadata-form.test.tsx` — 27 passed.
- [x] `biome check`, `tsc --noEmit` clean

[MST-14024]: https://uipath.atlassian.net/browse/MST-14024?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ