### PR TITLE
feat(apollo-wind): default lucide icon stroke to 1.4

### DIFF
--- a/packages/apollo-react/package.json
+++ b/packages/apollo-react/package.json
@@ -166,6 +166,7 @@
     "access": "public"
   },
   "peerDependencies": {
+    "lucide-react": ">=0.577.0 <2",
     "react": ">=18.3.0",
     "react-dom": ">=18.3.0"
   },
@@ -223,7 +224,6 @@
     "katex": "^0.16.27",
     "lexical": "0.42.0",
     "lodash": "^4.18.1",
-    "lucide-react": "^0.577.0",
     "luxon": "^3.7.1",
     "mermaid": "^11.16.1",
     "motion": "^13.1.0",
@@ -284,6 +284,7 @@
     "esbuild": "^0.28.1",
     "glob": "^13.0.0",
     "happy-dom": "^20.0.0",
+    "lucide-react": "^0.577.0",
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "typescript": "^5.9.3",

--- a/packages/apollo-wind/package.json
+++ b/packages/apollo-wind/package.json
@@ -76,6 +76,7 @@
     "clean": "rm -rf dist"
   },
   "peerDependencies": {
+    "lucide-react": ">=0.577.0 <2",
     "react": ">=18.0.0",
     "react-dom": ">=18.0.0"
   },
@@ -127,7 +128,6 @@
     "framer-motion": "^13.1.0",
     "jsep": "^1.4.0",
     "lexical": "0.42.0",
-    "lucide-react": "^0.577.0",
     "marked": "^17.0.6",
     "next-themes": "^0.4.6",
     "react-day-picker": "^9.13.0",
@@ -172,6 +172,7 @@
     "globals": "^16.5.0",
     "jest-axe": "^10.0.0",
     "jsdom": "^27.2.0",
+    "lucide-react": "^0.577.0",
     "monaco-editor": "^0.55.1",
     "postcss": "^8.5.6",
     "postcss-import": "^16.1.1",

--- a/packages/apollo-wind/src/styles/tailwind.consumer.css
+++ b/packages/apollo-wind/src/styles/tailwind.consumer.css
@@ -763,6 +763,14 @@ body.canvas, .canvas {
   --color-gradient-human-end: var(--color-gradient-human-end);
 }
 
+/* `stroke-2` is the documented way to opt out of the icon-weight default in
+ * @layer base below. Tailwind only emits utilities it finds while scanning
+ * source, and nothing here writes `stroke-2`, so it would be missing from the
+ * prebuilt `styles.css` — the escape hatch has to exist for consumers who ship
+ * that file rather than building from `tailwind.css` with their own @source.
+ * Only 2 needs this; any other weight is still reachable via the prop. */
+@source inline("stroke-2");
+
 @layer base {
   * {
     border-color: var(--color-border-de-emp);
@@ -770,6 +778,29 @@ body.canvas, .canvas {
 
   body {
     @apply bg-background text-foreground;
+  }
+
+  /* Icon weight — lucide ships a 2px stroke, which reads too heavy against
+   * Apollo's type. 1.4 is the design-system default.
+   *
+   * lucide has no theming API (no provider, no context — `Icon` hard-codes
+   * `strokeWidth = 2` as a default parameter), so CSS is the only lever, and a
+   * stylesheet outranks the presentation attribute the prop compiles to. The
+   * selector therefore matches lucide's default only: every other
+   * `strokeWidth` still works, including the `strokeWidth={0}` filled glyphs
+   * rely on. Only the value 2 is indistinguishable from "no opinion", so
+   * `strokeWidth={2}` meaning "keep this bold" is the one case CSS would
+   * silently thin — write `className="stroke-2"` for that instead. Utilities
+   * sit in the `utilities` layer, which the cascade resolves after `base`
+   * whatever the specificity, so they win.
+   *
+   * This is a stopgap. lucide 1.x adds <LucideProvider strokeWidth={1.4}>,
+   * which makes 1.4 a real React default that props override cleanly, with no
+   * ambiguity around the value 2. Once consumers are on 1.x, replace this rule
+   * with the provider rather than running both — under a provider a deliberate
+   * strokeWidth={2} renders as 2 and would be thinned here all over again. */
+  svg.lucide[stroke-width="2"] {
+    stroke-width: 1.4;
   }
 }
 

--- a/packages/apollo-wind/src/styles/tailwind.consumer.test.ts
+++ b/packages/apollo-wind/src/styles/tailwind.consumer.test.ts
@@ -82,3 +82,78 @@ describe('dark variant selector behaviour', () => {
     expect(matches('<span id="target"></span>')).toBe(false);
   });
 });
+
+describe('tailwind.consumer.css icon stroke default', () => {
+  it('thins lucide icons to the design-system weight', () => {
+    expect(css).toMatch(/svg\.lucide\[stroke-width="2"\]\s*\{\s*stroke-width:\s*1\.4;/);
+  });
+
+  it('declares the rule inside @layer base so utilities outrank it', () => {
+    // stroke-* lands in `utilities`, which the cascade resolves after `base`
+    // regardless of specificity — that is what makes stroke-2 an escape hatch.
+    // Brace-match the block rather than compare offsets, so the assertion means
+    // "contained in" and not merely "appears somewhere after".
+    const open = css.indexOf('@layer base {');
+    expect(open).toBeGreaterThan(-1);
+    let depth = 0;
+    let end = -1;
+    for (let i = css.indexOf('{', open); i < css.length; i++) {
+      if (css[i] === '{') depth++;
+      else if (css[i] === '}' && --depth === 0) {
+        end = i;
+        break;
+      }
+    }
+    expect(end).toBeGreaterThan(open);
+    const rule = css.indexOf('svg.lucide[stroke-width="2"]');
+    expect(rule).toBeGreaterThan(open);
+    expect(rule).toBeLessThan(end);
+  });
+
+  it('safelists stroke-2 so the escape hatch survives into the prebuilt css', () => {
+    // Tailwind only emits utilities it finds while scanning source, and nothing
+    // here writes stroke-2. Without this, consumers shipping the prebuilt
+    // styles.css would have no way to keep an icon at weight 2.
+    expect(css).toContain('@source inline("stroke-2");');
+  });
+});
+
+describe('icon stroke selector behaviour', () => {
+  // Parsed from the stylesheet so these cases can't drift from what ships.
+  const selector = /(svg\.lucide\[stroke-width="2"\])\s*\{/.exec(css)?.[1];
+
+  const matches = (html: string) => {
+    document.body.innerHTML = html;
+    const target = document.querySelector('#target');
+    if (!target || !selector) throw new Error('missing target or selector');
+    return target.matches(selector);
+  };
+
+  it('matches a lucide icon left at the default weight', () => {
+    expect(matches('<svg id="target" class="lucide lucide-plus" stroke-width="2"></svg>')).toBe(
+      true
+    );
+  });
+
+  it('leaves a deliberate strokeWidth={0} alone', () => {
+    // Filled glyphs set 0 and would grow an outline if the rule caught them.
+    expect(matches('<svg id="target" class="lucide lucide-square" stroke-width="0"></svg>')).toBe(
+      false
+    );
+  });
+
+  it('leaves other deliberate weights alone', () => {
+    for (const weight of ['1', '1.5', '2.5', '3']) {
+      expect(
+        matches(`<svg id="target" class="lucide lucide-check" stroke-width="${weight}"></svg>`)
+      ).toBe(false);
+    }
+  });
+
+  it('ignores svgs that are not lucide icons', () => {
+    // recharts series, edge handles and hand-authored icons all carry
+    // stroke-width="2" and default to 1 without it — they must not be caught.
+    expect(matches('<svg id="target" stroke-width="2"></svg>')).toBe(false);
+    expect(matches('<svg id="target" class="recharts-line" stroke-width="2"></svg>')).toBe(false);
+  });
+});

--- a/packages/apollo-wind/src/templates/Patterns/ideas-AnimatedGradientText.tsx
+++ b/packages/apollo-wind/src/templates/Patterns/ideas-AnimatedGradientText.tsx
@@ -55,7 +55,6 @@ export function AnimatedGradientIcon({
       <Sparkles
         stroke={`url(#${gradientId})`}
         className="size-full"
-        strokeWidth={2}
         strokeLinecap="round"
         strokeLinejoin="round"
         aria-hidden

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -134,10 +134,10 @@ importers:
         version: 0.4.6(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       nextra:
         specifier: ^4.6.1
-        version: 4.6.1(next@16.2.11(@opentelemetry/api@1.9.1)(@types/node@24.10.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
+        version: 4.6.1(next@16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@types/node@24.10.1)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
       nextra-theme-docs:
         specifier: ^4.6.1
-        version: 4.6.1(@types/react@19.2.8)(next@16.2.11(@opentelemetry/api@1.9.1)(@types/node@24.10.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(nextra@4.6.1(next@16.2.11(@opentelemetry/api@1.9.1)(@types/node@24.10.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(use-sync-external-store@1.6.0(react@19.2.3))
+        version: 4.6.1(@types/react@19.2.8)(next@16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@types/node@24.10.1)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(nextra@4.6.1(next@16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@types/node@24.10.1)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(use-sync-external-store@1.6.0(react@19.2.3))
       postcss:
         specifier: ^8.5.23
         version: 8.5.23
@@ -342,10 +342,10 @@ importers:
         version: 0.4.6(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       nextra:
         specifier: ^4.6.1
-        version: 4.6.1(next@16.2.11(@opentelemetry/api@1.9.1)(@types/node@24.10.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
+        version: 4.6.1(next@16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@types/node@24.10.1)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
       nextra-theme-docs:
         specifier: ^4.6.1
-        version: 4.6.1(@types/react@19.2.8)(next@16.2.11(@opentelemetry/api@1.9.1)(@types/node@24.10.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(nextra@4.6.1(next@16.2.11(@opentelemetry/api@1.9.1)(@types/node@24.10.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(use-sync-external-store@1.6.0(react@19.2.3))
+        version: 4.6.1(@types/react@19.2.8)(next@16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@types/node@24.10.1)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(nextra@4.6.1(next@16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@types/node@24.10.1)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(use-sync-external-store@1.6.0(react@19.2.3))
       pkce-challenge:
         specifier: ^6.0.0
         version: 6.0.0
@@ -736,9 +736,6 @@ importers:
       lodash:
         specifier: ^4.18.1
         version: 4.18.1
-      lucide-react:
-        specifier: ^0.577.0
-        version: 0.577.0(react@19.2.3)
       luxon:
         specifier: ^3.7.1
         version: 3.7.2
@@ -914,6 +911,9 @@ importers:
       happy-dom:
         specifier: ^20.0.0
         version: 20.8.9
+      lucide-react:
+        specifier: ^0.577.0
+        version: 0.577.0(react@19.2.3)
       react:
         specifier: 19.2.3
         version: 19.2.3
@@ -1091,9 +1091,6 @@ importers:
       lexical:
         specifier: 0.42.0
         version: 0.42.0
-      lucide-react:
-        specifier: ^0.577.0
-        version: 0.577.0(react@19.2.3)
       marked:
         specifier: ^17.0.6
         version: 17.0.6
@@ -1221,6 +1218,9 @@ importers:
       jsdom:
         specifier: ^27.2.0
         version: 27.3.0
+      lucide-react:
+        specifier: ^0.577.0
+        version: 0.577.0(react@19.2.3)
       monaco-editor:
         specifier: ^0.55.1
         version: 0.55.1
@@ -23440,13 +23440,13 @@ snapshots:
       - '@types/node'
       - babel-plugin-macros
 
-  nextra-theme-docs@4.6.1(@types/react@19.2.8)(next@16.2.11(@opentelemetry/api@1.9.1)(@types/node@24.10.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(nextra@4.6.1(next@16.2.11(@opentelemetry/api@1.9.1)(@types/node@24.10.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(use-sync-external-store@1.6.0(react@19.2.3)):
+  nextra-theme-docs@4.6.1(@types/react@19.2.8)(next@16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@types/node@24.10.1)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(nextra@4.6.1(next@16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@types/node@24.10.1)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(use-sync-external-store@1.6.0(react@19.2.3)):
     dependencies:
       '@headlessui/react': 2.2.9(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       clsx: 2.1.1
       next: 16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@types/node@24.10.1)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       next-themes: 0.4.6(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      nextra: 4.6.1(next@16.2.11(@opentelemetry/api@1.9.1)(@types/node@24.10.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
+      nextra: 4.6.1(next@16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@types/node@24.10.1)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
       react: 19.2.3
       react-compiler-runtime: 19.1.0-rc.3(react@19.2.3)
       react-dom: 19.2.3(react@19.2.3)
@@ -23458,7 +23458,7 @@ snapshots:
       - immer
       - use-sync-external-store
 
-  nextra@4.6.1(next@16.2.11(@opentelemetry/api@1.9.1)(@types/node@24.10.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3):
+  nextra@4.6.1(next@16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@types/node@24.10.1)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3):
     dependencies:
       '@formatjs/intl-localematcher': 0.6.2
       '@headlessui/react': 2.2.9(react-dom@19.2.3(react@19.2.3))(react@19.2.3)


### PR DESCRIPTION
Sets lucide's icon stroke to **1.4** for every consumer of the apollo-wind styles, and moves `lucide-react` to a peer dependency so consumers share a single copy.

Design confirmed 1.4 as the system-wide default. Filed from the Flow UX Audit (MST-14019), but the fix belongs here rather than in a consumer: apollo-wind renders its own lucide icons (accordion chevrons, select carets), which a downstream rule can't reach cleanly.

## Why CSS, and why the selector looks like that

On the version range we support today, lucide has **no theming API** — `Icon` hard-codes `strokeWidth = 2` as a default parameter and spreads it onto the SVG. So CSS is the only lever. (1.x changes this — see the last section.)

The catch is that a stylesheet outranks the presentation attribute the prop compiles to, so a blanket `svg.lucide { stroke-width: 1.4 }` would silently break *every* `strokeWidth` prop in every consumer. I verified this in Chromium rather than trusting the spec — **cascade layers do not change it**; a layered rule still beat `stroke-width="3"` and `stroke-width="0"`.

So the rule matches lucide's default value only:

```css
svg.lucide[stroke-width="2"] { stroke-width: 1.4; }
```

| call site | result |
|---|---|
| default icon | 1.4 ✅ |
| `strokeWidth={0}` (filled glyphs) | 0 ✅ |
| `strokeWidth={3}` | 3 ✅ |
| `className="stroke-2"` | 2 ✅ |

Only the value `2` is indistinguishable from "no opinion", so a `strokeWidth={2}` meaning *keep this bold* is the one case that would be silently thinned. `stroke-2` is the documented opt-out — it lands in the `utilities` layer, which the cascade resolves after `base` regardless of specificity, so it wins.

`@source inline("stroke-2")` safelists it. Tailwind only emits utilities it finds while scanning source, and nothing in apollo-wind writes `stroke-2` — without the safelist the escape hatch would be missing from the prebuilt `styles.css` for consumers who ship that file instead of building from `tailwind.css`. Verified against the real built artifact, both before and after.

## lucide-react as a peer dependency

`lucide-react` was a hard `dependency` of apollo-wind and apollo-react, so consumers ended up with a second copy. It's also already part of the public type surface — `NodeOutputModeIcon` is a `LucideIcon`, as is `LockableValueField`'s `icon` prop — so a consumer passing its own icon is passing a type from a different module instance.

Range is `>=0.577.0 <2` — deliberately spanning both current majors, since everything apollo uses (`Icon`, `createLucideIcon`, `LucideIcon`, `LucideProps`, the named icons) is present in both. Both packages keep it as a `devDependency`. Released as a **minor**, not a major: the range is permissive and auto-install-peers is the default in npm 7+, pnpm 8+, and yarn berry.

## Follow-up: `LucideProvider` should eventually replace this rule

Worth recording, since it changes how the CSS above should be maintained rather than merely extended.

lucide **1.x** (latest is 1.34.0; we're on 0.577.0) adds `LucideProvider`, and `Icon` now resolves `strokeWidth ?? contextStrokeWidth`. Nullish coalescing means `strokeWidth={0}` survives *and* `strokeWidth={2}` is genuinely honored — it makes 1.4 a real React default and removes the ambiguity this PR works around, with no selector and no safelist.

**Important:** the two mechanisms don't compose. Under a provider a deliberate `strokeWidth={2}` renders as `2` and this rule would thin it all over again. Replace the rule with the provider; don't run both. The CSS comment says the same thing in-place.

### Why this isn't bundled here

Adopting the provider means a peer floor of `>=1`, which is a genuinely breaking change for every consumer — and a provider only covers the React tree it wraps. apollo-wind has no root provider to host it, so each consuming app would mount its own, and consumers with multiple React roots (flow-workbench's `<ui-flow-canvas>` web components, Studio Web's module federation) would need per-root coverage verified. The CSS rule needs zero consumer code and works on 0.x and 1.x alike.

### What a `>=1` floor would actually force

The icon set loses **29 keys** from the runtime `icons` map (1703 → 1777; +103, −29). They split into three tiers with very different consequences:

| tier | count | `import { X }` | `icons['X']` lookup |
|---|---|---|---|
| Brand logos — Github, Figma, Slack, Twitter, Youtube, Gitlab, Linkedin, Instagram, Facebook, Trello, Twitch, Framer, Dribbble, Codepen, Codesandbox, Pocket, Chromium, RailSymbol | 18 | ❌ gone | ❌ gone |
| Canonically renamed, alias retained | 11 | ✅ still works | ❌ **silently gone** |
| Everything else, plus 103 new | 1777 | ✅ | ✅ |

The renamed 11: `History→RotateCcwClock`, `Waves→WavesHorizontal`, `Smile→FaceSlightlySmiling`, `Frown→FaceSlightlyFrowning`, `Meh→FaceNeutral`, `Angry→FaceAngry`, `Annoyed→FaceExpressionless`, `Laugh→FaceGrinning`, `SmilePlus→FaceSlightlySmilingPlus`, `Podcast→MicSignal`, `TextSelect→SquareDashedText`.

**The compile-time surface is small** — 18 brand icons, and neither apollo-ui nor flow-workbench imports any of them. `LucideIcon`/`LucideProps` are intact, aliases like `AlertTriangle → TriangleAlert` are preserved, and 1.x still emits `class="lucide"`, so this PR's rule stays valid either way.

**The hazard is the data-driven path.** The `icons` map holds canonical names only, so `icons['History']` is now `undefined` for all 29. `apollo-react/src/canvas/utils/icon-registry.tsx` does exactly that lookup and **falls back to `Box`** — no error, no crash, no log. flow-workbench feeds it `display.icon`, typed `z.string().optional()` and resolved from **server-fetched connector manifests**. A Slack or GitHub connector icon would silently render as a generic box in production, and because the data isn't in the repo, **no grep can clear it**.

**Cheap mitigation, worth landing ahead of any upgrade:** a ~30-line alias map in `icon-registry.tsx` translating the 29 legacy ids to their new canonical names *before* the `Box` fallback. That turns the silent tier into a non-event and is harmless on 0.x.

### Packaging changes in 1.x

- ESM entry `dist/esm/lucide-react.js` → **`.mjs`**. Neither repo deep-imports, so it's a non-issue here; it breaks anyone who does.
- **`unpkg` and `main:umd` removed** — no UMD/CDN build.
- **`"use client"` added** to `Icon` and `context`. Benign for Vite/rsbuild; relevant for RSC consumers and may surface directive warnings in some Rollup setups.
- React peer **unchanged** (`^16.5.1 || ^17 || ^18 || ^19`).

Net: the cost isn't "fix 18 imports", it's "audit runtime manifest data across every consumer, including connector icons we don't control" — a coordination problem with Studio Web and the connector teams, not an apollo-local change.

## Scope notes for review

- **One redundant prop removed** — `<Sparkles strokeWidth={2}>` in `ideas-AnimatedGradientText.tsx`. I swept all 43 `strokeWidth=2` sites in the repo and classified each by enclosing tag; this is the only one on a lucide icon. The rest are recharts (`Line`/`Pie`/`Radar`), raw SVG primitives, and hand-authored icon components — all of which would drop to **1**, not 1.4, if the prop were removed. They're untouched.
- **`token-icon-markup.ts` thins**, correctly — it hand-builds markup carrying `class="lucide"` precisely to mirror lucide's output. The `strokeWidth={2}` in `tree-view.tsx` and `TokenPill.tsx` are hand-rolled `<svg><path>` with no `lucide` class and are unaffected.
- **apollo-vertex is deliberately untouched.** It has no dependency on apollo-wind — not in `package.json`, not in `globals.css` — so it never receives this rule, and `DESIGN-CONTEXT.md` documents it as a distinct design system. Its icon catalogue hard-codes 1.5; whether Vertex tracks 1.4 is a Vertex design call, not this PR's.

## Testing

`typecheck`, `build`, `lint`, `format:check` green; 1409 (wind) + 2585 (react) unit tests pass.

New coverage in `src/styles/tailwind.consumer.test.ts`, following the file's existing pattern of parsing the selector out of the stylesheet so the cases can't drift from what ships: the rule is brace-matched to be *inside* `@layer base`, the safelist is asserted, and the selector is exercised against real elements — a default lucide icon matches, while `stroke-width` 0 / 1 / 1.5 / 2.5 / 3 and non-lucide svgs (recharts series, edge handles, hand-authored icons) do not.

Mutation-checked rather than assumed — each guard was confirmed to fail when the CSS is broken:

| mutation | tests failed |
|---|---|
| drop `@source inline("stroke-2")` | 1 |
| blanket `svg.lucide` selector | **6** |
| rule hoisted out of `@layer base` | 1 |
| weight changed to 1.5 | 1 |

⚠️ **`test:visual` snapshots will need a wholesale update** — this moves nearly every icon in the system by design. I deliberately have not run or approved them; that's a reviewer/design judgement.

