### PR TITLE
feat(apollo-react): allow some toolbar options to stay enabled during node lock

### DIFF
--- a/packages/apollo-react/src/canvas/components/Toolbar/NodeToolbar/NodeToolbar.utils.test.ts
+++ b/packages/apollo-react/src/canvas/components/Toolbar/NodeToolbar/NodeToolbar.utils.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { ToolbarAction, ToolbarActionItem } from '../shared';
+import type { NodeToolbarConfig } from './NodeToolbar.types';
+import { lockToolbarConfig } from './NodeToolbar.utils';
+
+const action = (id: string, extra: Partial<ToolbarActionItem> = {}): ToolbarActionItem => ({
+  id,
+  icon: 'edit',
+  label: id,
+  onAction: vi.fn(),
+  ...extra,
+});
+
+const byId = (actions: ToolbarAction[] | undefined, id: string) =>
+  actions?.find((item) => item.id === id) as ToolbarActionItem | undefined;
+
+describe('lockToolbarConfig', () => {
+  it('disables every action that does not opt out', () => {
+    const config: NodeToolbarConfig = {
+      actions: [action('edit'), action('delete')],
+      overflowActions: [action('cut')],
+    };
+
+    const locked = lockToolbarConfig(config);
+
+    expect(byId(locked.actions, 'edit')?.disabled).toBe(true);
+    expect(byId(locked.actions, 'delete')?.disabled).toBe(true);
+    expect(byId(locked.overflowActions, 'cut')?.disabled).toBe(true);
+  });
+
+  it('leaves an action marked allowWhenReadOnly enabled, in both the bar and the overflow', () => {
+    const config: NodeToolbarConfig = {
+      actions: [action('drill-into', { allowWhenReadOnly: true }), action('delete')],
+      overflowActions: [action('copy', { allowWhenReadOnly: true }), action('cut')],
+    };
+
+    const locked = lockToolbarConfig(config);
+
+    expect(byId(locked.actions, 'drill-into')?.disabled).toBeUndefined();
+    expect(byId(locked.overflowActions, 'copy')?.disabled).toBeUndefined();
+    expect(byId(locked.actions, 'delete')?.disabled).toBe(true);
+    expect(byId(locked.overflowActions, 'cut')?.disabled).toBe(true);
+  });
+
+  it('keeps an action already disabled by the consumer disabled even when it opts out', () => {
+    const config: NodeToolbarConfig = {
+      actions: [action('paste', { allowWhenReadOnly: true, disabled: true })],
+    };
+
+    expect(byId(lockToolbarConfig(config).actions, 'paste')?.disabled).toBe(true);
+  });
+
+  it('leaves separators untouched', () => {
+    const config: NodeToolbarConfig = { actions: [action('edit'), { id: 'separator' }] };
+
+    expect(lockToolbarConfig(config).actions[1]).toEqual({ id: 'separator' });
+  });
+
+  it('omits overflowActions when the source config has none', () => {
+    const locked = lockToolbarConfig({ actions: [action('edit')] });
+
+    expect(locked).not.toHaveProperty('overflowActions');
+  });
+
+  it('does not mutate the config it is given', () => {
+    const original = action('delete');
+    const config: NodeToolbarConfig = { actions: [original] };
+
+    lockToolbarConfig(config);
+
+    expect(original.disabled).toBeUndefined();
+  });
+});

--- a/packages/apollo-react/src/canvas/components/Toolbar/NodeToolbar/NodeToolbar.utils.test.ts
+++ b/packages/apollo-react/src/canvas/components/Toolbar/NodeToolbar/NodeToolbar.utils.test.ts
@@ -28,10 +28,10 @@ describe('lockToolbarConfig', () => {
     expect(byId(locked.overflowActions, 'cut')?.disabled).toBe(true);
   });
 
-  it('leaves an action marked allowWhenReadOnly enabled, in both the bar and the overflow', () => {
+  it('leaves an action marked allowWhenLocked enabled, in both the bar and the overflow', () => {
     const config: NodeToolbarConfig = {
-      actions: [action('drill-into', { allowWhenReadOnly: true }), action('delete')],
-      overflowActions: [action('copy', { allowWhenReadOnly: true }), action('cut')],
+      actions: [action('drill-into', { allowWhenLocked: true }), action('delete')],
+      overflowActions: [action('copy', { allowWhenLocked: true }), action('cut')],
     };
 
     const locked = lockToolbarConfig(config);
@@ -44,7 +44,7 @@ describe('lockToolbarConfig', () => {
 
   it('keeps an action already disabled by the consumer disabled even when it opts out', () => {
     const config: NodeToolbarConfig = {
-      actions: [action('paste', { allowWhenReadOnly: true, disabled: true })],
+      actions: [action('paste', { allowWhenLocked: true, disabled: true })],
     };
 
     expect(byId(lockToolbarConfig(config).actions, 'paste')?.disabled).toBe(true);

--- a/packages/apollo-react/src/canvas/components/Toolbar/NodeToolbar/NodeToolbar.utils.ts
+++ b/packages/apollo-react/src/canvas/components/Toolbar/NodeToolbar/NodeToolbar.utils.ts
@@ -8,11 +8,17 @@ export function isSeparator(item: ProcessedToolbarItem): item is ToolbarSeparato
 }
 
 /**
- * Returns the config with every action disabled, separators untouched. Locks a
- * read-only node's toolbar instead of unmounting it: the greyed-out actions
- * (with their tooltips intact) say "read-only", where a missing toolbar just
- * reads as a node with nothing to offer. Disabling is also real enforcement,
- * since a consumer's `onAction` never reaches the canvas-level delete veto.
+ * Returns the config with every mutating action disabled, separators and
+ * actions marked `allowWhenReadOnly` untouched. Locks a read-only node's
+ * toolbar instead of unmounting it: the greyed-out actions (with their tooltips
+ * intact) say "read-only", where a missing toolbar just reads as a node with
+ * nothing to offer. Disabling is also real enforcement, since a consumer's
+ * `onAction` never reaches the canvas-level delete veto.
+ *
+ * Opting out is per action rather than per node because a single toolbar mixes
+ * both kinds: Copy and Drill into are safe on a locked node, Cut and Delete are
+ * not. An action that says nothing is disabled, so the safe default survives
+ * new actions.
  */
 export function lockToolbarConfig(config: NodeToolbarConfig): NodeToolbarConfig {
   return {
@@ -23,4 +29,14 @@ export function lockToolbarConfig(config: NodeToolbarConfig): NodeToolbarConfig 
 }
 
 const disableActions = (actions: ToolbarAction[]): ToolbarAction[] =>
-  actions.map((action) => (action.id === 'separator' ? action : { ...action, disabled: true }));
+  actions.map((action) => {
+    if (isSeparatorAction(action) || action.allowWhenReadOnly) return action;
+    return { ...action, disabled: true };
+  });
+
+/**
+ * `ToolbarActionItem.id` is a plain string, so comparing it to `'separator'`
+ * cannot narrow the union on its own — a predicate can.
+ */
+const isSeparatorAction = (action: ToolbarAction): action is ToolbarSeparator =>
+  action.id === 'separator';

--- a/packages/apollo-react/src/canvas/components/Toolbar/NodeToolbar/NodeToolbar.utils.ts
+++ b/packages/apollo-react/src/canvas/components/Toolbar/NodeToolbar/NodeToolbar.utils.ts
@@ -9,7 +9,7 @@ export function isSeparator(item: ToolbarAction): item is ToolbarSeparator {
 
 /**
  * Returns the config with every mutating action disabled, separators and
- * actions marked `allowWhenReadOnly` untouched. Locks a read-only node's
+ * actions marked `allowWhenLocked` untouched. Locks a read-only node's
  * toolbar instead of unmounting it: the greyed-out actions (with their tooltips
  * intact) say "read-only", where a missing toolbar just reads as a node with
  * nothing to offer. Disabling is also real enforcement, since a consumer's
@@ -30,6 +30,6 @@ export function lockToolbarConfig(config: NodeToolbarConfig): NodeToolbarConfig 
 
 const disableActions = (actions: ToolbarAction[]): ToolbarAction[] =>
   actions.map((action) => {
-    if (isSeparator(action) || action.allowWhenReadOnly) return action;
+    if (isSeparator(action) || action.allowWhenLocked) return action;
     return { ...action, disabled: true };
   });

--- a/packages/apollo-react/src/canvas/components/Toolbar/NodeToolbar/NodeToolbar.utils.ts
+++ b/packages/apollo-react/src/canvas/components/Toolbar/NodeToolbar/NodeToolbar.utils.ts
@@ -3,7 +3,7 @@ import type { NodeToolbarConfig } from './NodeToolbar.types';
 
 export type ProcessedToolbarItem = ExtendedToolbarAction | ToolbarSeparator;
 
-export function isSeparator(item: ProcessedToolbarItem | ToolbarAction): item is ToolbarSeparator {
+export function isSeparator(item: ToolbarAction): item is ToolbarSeparator {
   return item.id === 'separator';
 }
 

--- a/packages/apollo-react/src/canvas/components/Toolbar/NodeToolbar/NodeToolbar.utils.ts
+++ b/packages/apollo-react/src/canvas/components/Toolbar/NodeToolbar/NodeToolbar.utils.ts
@@ -3,7 +3,7 @@ import type { NodeToolbarConfig } from './NodeToolbar.types';
 
 export type ProcessedToolbarItem = ExtendedToolbarAction | ToolbarSeparator;
 
-export function isSeparator(item: ProcessedToolbarItem): item is ToolbarSeparator {
+export function isSeparator(item: ProcessedToolbarItem | ToolbarAction): item is ToolbarSeparator {
   return item.id === 'separator';
 }
 
@@ -30,13 +30,6 @@ export function lockToolbarConfig(config: NodeToolbarConfig): NodeToolbarConfig 
 
 const disableActions = (actions: ToolbarAction[]): ToolbarAction[] =>
   actions.map((action) => {
-    if (isSeparatorAction(action) || action.allowWhenReadOnly) return action;
+    if (isSeparator(action) || action.allowWhenReadOnly) return action;
     return { ...action, disabled: true };
   });
-
-/**
- * `ToolbarActionItem.id` is a plain string, so comparing it to `'separator'`
- * cannot narrow the union on its own — a predicate can.
- */
-const isSeparatorAction = (action: ToolbarAction): action is ToolbarSeparator =>
-  action.id === 'separator';

--- a/packages/apollo-react/src/canvas/components/Toolbar/shared/toolbar.types.ts
+++ b/packages/apollo-react/src/canvas/components/Toolbar/shared/toolbar.types.ts
@@ -11,12 +11,7 @@ export interface ToolbarActionItem {
   isToggled?: boolean;
   /** Custom color for the button icon and underline when toggled */
   color?: string;
-  /**
-   * Keeps this action enabled on a read-only node, where `lockToolbarConfig`
-   * disables everything else. Set it on actions that only read the node — copy,
-   * inspect, navigate — and leave it off for anything that mutates the flow, so
-   * an action added later is locked by default.
-   */
+  /** Keeps this action enabled when a node is locked. */
   allowWhenReadOnly?: boolean;
   onAction: (nodeId: string) => void;
 }

--- a/packages/apollo-react/src/canvas/components/Toolbar/shared/toolbar.types.ts
+++ b/packages/apollo-react/src/canvas/components/Toolbar/shared/toolbar.types.ts
@@ -12,7 +12,7 @@ export interface ToolbarActionItem {
   /** Custom color for the button icon and underline when toggled */
   color?: string;
   /** Keeps this action enabled when a node is locked. */
-  allowWhenReadOnly?: boolean;
+  allowWhenLocked?: boolean;
   onAction: (nodeId: string) => void;
 }
 

--- a/packages/apollo-react/src/canvas/components/Toolbar/shared/toolbar.types.ts
+++ b/packages/apollo-react/src/canvas/components/Toolbar/shared/toolbar.types.ts
@@ -11,7 +11,7 @@ export interface ToolbarActionItem {
   isToggled?: boolean;
   /** Custom color for the button icon and underline when toggled */
   color?: string;
-  /** Keeps this action enabled when a node is locked. */
+  /** Prevents lockToolbarConfig from force-disabling this action when a node is locked. */
   allowWhenLocked?: boolean;
   onAction: (nodeId: string) => void;
 }

--- a/packages/apollo-react/src/canvas/components/Toolbar/shared/toolbar.types.ts
+++ b/packages/apollo-react/src/canvas/components/Toolbar/shared/toolbar.types.ts
@@ -11,6 +11,13 @@ export interface ToolbarActionItem {
   isToggled?: boolean;
   /** Custom color for the button icon and underline when toggled */
   color?: string;
+  /**
+   * Keeps this action enabled on a read-only node, where `lockToolbarConfig`
+   * disables everything else. Set it on actions that only read the node — copy,
+   * inspect, navigate — and leave it off for anything that mutates the flow, so
+   * an action added later is locked by default.
+   */
+  allowWhenReadOnly?: boolean;
   onAction: (nodeId: string) => void;
 }
 


### PR DESCRIPTION
## Problem

`lockToolbarConfig` disables **every** action on a read-only node:

```ts
const disableActions = (actions) =>
  actions.map((a) => (a.id === 'separator' ? a : { ...a, disabled: true }));
```

## Change

Add an optional flag to `ToolbarActionItem`:

```ts
/**
 * Keeps this action enabled on a read-only node, where `lockToolbarConfig`
 * disables everything else. …
 */
allowWhenLocked?: boolean;
```

and honour it in `disableActions`.

**Per action, not per node**, because the distinction is a property of the action, not of the consumer's lock semantics — and a single toolbar needs both answers at once.

## Demo

**Before:** all menu items were indiscriminately disabled.

<img width="649" height="266" alt="image" src="https://github.com/user-attachments/assets/19d800ec-d464-4f05-9c6a-b46364a78414" />