### PR TITLE
Add inline validation to core field components

### DIFF
--- a/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.stories.tsx
@@ -4089,7 +4089,6 @@ function PanelUIInventoryStory() {
                       <div>
                         <Input
                           defaultValue="Existing node"
-                          aria-invalid="true"
                           error={
                             <>
                               <span className="block">This node name is already in use.</span>

--- a/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.stories.tsx
@@ -4090,11 +4090,14 @@ function PanelUIInventoryStory() {
                         <Input
                           defaultValue="Existing node"
                           aria-invalid="true"
-                          className="!border !border-error"
-                        />
-                        <InlineValidationMessage
-                          message="This node name is already in use."
-                          action="Enter a unique name before saving."
+                          error={
+                            <>
+                              <span className="block">This node name is already in use.</span>
+                              <span className="mt-0.5 block text-foreground-muted">
+                                Enter a unique name before saving.
+                              </span>
+                            </>
+                          }
                         />
                       </div>
                     </InventoryField>

--- a/packages/apollo-wind/src/components/ui/file-upload.tsx
+++ b/packages/apollo-wind/src/components/ui/file-upload.tsx
@@ -32,6 +32,9 @@ export interface FileUploadProps {
   /** External errors keyed by filename. Use this to set errors from outside (e.g., upload failures). */
   errors?: Record<string, string>;
   onBlur?: React.FocusEventHandler<HTMLFieldSetElement>;
+  'aria-invalid'?: React.AriaAttributes['aria-invalid'];
+  'aria-describedby'?: string;
+  'aria-errormessage'?: string;
 }
 
 export const FileUpload = React.forwardRef<HTMLFieldSetElement, FileUploadProps>(
@@ -48,6 +51,9 @@ export const FileUpload = React.forwardRef<HTMLFieldSetElement, FileUploadProps>
       showPreview = false,
       errors,
       onBlur,
+      'aria-invalid': ariaInvalid,
+      'aria-describedby': ariaDescribedBy,
+      'aria-errormessage': ariaErrorMessage,
     },
     ref
   ) {
@@ -258,12 +264,18 @@ export const FileUpload = React.forwardRef<HTMLFieldSetElement, FileUploadProps>
           // accessible-name computation, so only set it when there's no id for a
           // consumer's label to target (same pattern as MultiSelect).
           aria-label={id ? undefined : (ariaLabel ?? 'File upload')}
+          aria-invalid={ariaInvalid}
+          aria-describedby={ariaDescribedBy}
+          aria-errormessage={ariaErrorMessage}
         />
         {/** biome-ignore lint/a11y/useSemanticElements: A div avoids invalid nested buttons when uploaded files have remove actions. */}
         <div
           role="button"
           aria-label={ariaLabel ?? 'File upload area'}
           aria-disabled={disabled}
+          aria-invalid={ariaInvalid}
+          aria-describedby={ariaDescribedBy}
+          aria-errormessage={ariaErrorMessage}
           tabIndex={disabled ? -1 : 0}
           className={cn(
             // Base styles (all themes)

--- a/packages/apollo-wind/src/components/ui/input-group.stories.tsx
+++ b/packages/apollo-wind/src/components/ui/input-group.stories.tsx
@@ -134,6 +134,28 @@ export const WithLabel: Story = {
   ),
 };
 
+export const WithInlineValidation: Story = {
+  render: () => (
+    <div className="grid w-72 items-center gap-1.5">
+      <Label htmlFor="group-node-name">Node name</Label>
+      <InputGroup error="This node name is already in use. Enter a unique name before saving.">
+        <InputGroupAddon align="inline-start">
+          <Lock className="text-muted-foreground" />
+        </InputGroupAddon>
+        <InputGroupInput id="group-node-name" value="Invoice processor" readOnly />
+      </InputGroup>
+    </div>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Input group controls use the same inline validation behavior as Input. The message remains below the grouped control while the group border communicates the invalid state.',
+      },
+    },
+  },
+};
+
 export const Compact: Story = {
   render: () => (
     <InputGroup size="xs" className="w-72">

--- a/packages/apollo-wind/src/components/ui/input-group.test.tsx
+++ b/packages/apollo-wind/src/components/ui/input-group.test.tsx
@@ -123,7 +123,7 @@ describe('InputGroup', () => {
       </InputGroup>
     );
 
-    expect(screen.getByRole('alert')).toHaveTextContent('Enter a unique name before saving.');
+    expect(screen.getByRole('status')).toHaveTextContent('Enter a unique name before saving.');
     expect(screen.getByRole('textbox')).toHaveAttribute('aria-invalid', 'true');
     expect(screen.getByRole('textbox')).toHaveClass('!border-0');
     expect(screen.getByRole('textbox')).toHaveClass('!ring-0');

--- a/packages/apollo-wind/src/components/ui/input-group.test.tsx
+++ b/packages/apollo-wind/src/components/ui/input-group.test.tsx
@@ -45,7 +45,7 @@ describe('InputGroup', () => {
     expect(group).toHaveClass('bg-surface-overlay');
     expect(group).not.toHaveClass('border-input');
     // The input's own border is always zeroed, regardless of the group's variant.
-    expect(screen.getByPlaceholderText('Ghost')).toHaveClass('border-0');
+    expect(screen.getByPlaceholderText('Ghost')).toHaveClass('!border-0');
   });
 
   it('applies xs size classes to the wrapper', () => {
@@ -114,6 +114,25 @@ describe('InputGroup', () => {
       </InputGroup>
     );
     expect(screen.getByPlaceholderText('Disabled')).toBeDisabled();
+  });
+
+  it('stacks inline validation below the grouped input', () => {
+    render(
+      <InputGroup data-testid="group" error="Enter a unique name before saving.">
+        <InputGroupInput id="node-name" />
+      </InputGroup>
+    );
+
+    expect(screen.getByRole('alert')).toHaveTextContent('Enter a unique name before saving.');
+    expect(screen.getByRole('textbox')).toHaveAttribute('aria-invalid', 'true');
+    expect(screen.getByRole('textbox')).toHaveClass('!border-0');
+    expect(screen.getByRole('textbox')).toHaveClass('!ring-0');
+    expect(screen.getByTestId('group')).toHaveClass(
+      'has-[[data-slot][aria-invalid=true]]:border-error'
+    );
+    expect(screen.getByTestId('group')).toHaveClass(
+      'future:has-[[data-slot][aria-invalid=true]]:ring-1'
+    );
   });
 
   it('supports a textarea control', () => {

--- a/packages/apollo-wind/src/components/ui/input-group.test.tsx
+++ b/packages/apollo-wind/src/components/ui/input-group.test.tsx
@@ -123,7 +123,7 @@ describe('InputGroup', () => {
       </InputGroup>
     );
 
-    expect(screen.getByRole('status')).toHaveTextContent('Enter a unique name before saving.');
+    expect(screen.getByText('Enter a unique name before saving.')).toBeInTheDocument();
     expect(screen.getByRole('textbox')).toHaveAttribute('aria-invalid', 'true');
     expect(screen.getByRole('textbox')).toHaveClass('!border-0');
     expect(screen.getByRole('textbox')).toHaveClass('!ring-0');

--- a/packages/apollo-wind/src/components/ui/input-group.tsx
+++ b/packages/apollo-wind/src/components/ui/input-group.tsx
@@ -5,38 +5,64 @@ import { Input, type InputProps } from '@/components/ui/input';
 import { Textarea, type TextareaProps } from '@/components/ui/textarea';
 import { cn } from '@/lib';
 
+interface InputGroupValidationContextValue {
+  error?: React.ReactNode;
+  errorId?: string;
+}
+
+const InputGroupValidationContext = React.createContext<InputGroupValidationContextValue>({});
+
 export interface InputGroupProps extends React.HTMLAttributes<HTMLDivElement> {
   variant?: 'default' | 'ghost';
   size?: 'default' | 'xs';
+  /** Field-specific validation feedback rendered below the grouped control. */
+  error?: React.ReactNode;
+  /** Optional id for the inline validation message. */
+  errorId?: string;
 }
 
 const InputGroup = React.forwardRef<HTMLDivElement, InputGroupProps>(
-  ({ className, variant = 'default', size = 'default', ...props }, ref) => {
+  ({ className, error, errorId, variant = 'default', size = 'default', ...props }, ref) => {
+    const generatedId = React.useId();
+    const validationId = errorId ?? `input-group-${generatedId.replace(/:/g, '')}-error`;
+
     return (
-      // biome-ignore lint/a11y/useSemanticElements: input groups need role="group" to convey relationship between the field and its addons
-      <div
-        ref={ref}
-        role="group"
-        className={cn(
-          'group/input-group relative flex w-full items-center gap-2 transition-colors has-[>textarea]:h-auto has-[>textarea]:items-start',
-          // Size (mirrors Input's own size scale, since Input's box chrome moves up to this wrapper)
-          size === 'default' &&
-            'h-9 rounded-md px-3 py-1 future:h-10 future:rounded-xl future:py-2',
-          size === 'xs' && 'h-6 gap-1 rounded px-2',
-          // Variant (mirrors Input's own variant treatment exactly)
-          variant === 'default' &&
-            'border border-input bg-transparent future:border-0 future:bg-surface-overlay',
-          variant === 'ghost' && 'border-0 bg-surface-overlay',
-          // Focus state, forwarded from the inner control
-          'has-[[data-slot=input-group-control]:focus-visible]:ring-2 has-[[data-slot=input-group-control]:focus-visible]:ring-ring future:has-[[data-slot=input-group-control]:focus-visible]:ring-offset-2 future:has-[[data-slot=input-group-control]:focus-visible]:ring-offset-background',
-          // Error state
-          'has-[[data-slot][aria-invalid=true]]:border-destructive has-[[data-slot][aria-invalid=true]]:ring-destructive/20',
-          // Disabled state
-          'has-[[data-slot=input-group-control]:disabled]:cursor-not-allowed has-[[data-slot=input-group-control]:disabled]:opacity-50',
-          className
+      <InputGroupValidationContext.Provider value={{ error, errorId: validationId }}>
+        {/* biome-ignore lint/a11y/useSemanticElements: input groups need role="group" to convey relationship between the field and its addons */}
+        <div
+          ref={ref}
+          role="group"
+          className={cn(
+            'group/input-group relative flex w-full items-center gap-2 transition-colors has-[>textarea]:h-auto has-[>textarea]:items-start',
+            // Size (mirrors Input's own size scale, since Input's box chrome moves up to this wrapper)
+            size === 'default' &&
+              'h-9 rounded-md px-3 py-1 future:h-10 future:rounded-xl future:py-2',
+            size === 'xs' && 'h-6 gap-1 rounded px-2',
+            // Variant (mirrors Input's own variant treatment exactly)
+            variant === 'default' &&
+              'border border-input bg-transparent future:border-0 future:bg-surface-overlay',
+            variant === 'ghost' && 'border-0 bg-surface-overlay',
+            // Focus state, forwarded from the inner control
+            'has-[[data-slot=input-group-control]:focus-visible]:ring-2 has-[[data-slot=input-group-control]:focus-visible]:ring-ring future:has-[[data-slot=input-group-control]:focus-visible]:ring-offset-2 future:has-[[data-slot=input-group-control]:focus-visible]:ring-offset-background',
+            // Error state
+            'has-[[data-slot][aria-invalid=true]]:border-error has-[[data-slot][aria-invalid=true]]:ring-error/20 future:has-[[data-slot][aria-invalid=true]]:ring-1 future:has-[[data-slot][aria-invalid=true]]:ring-error/40',
+            // Disabled state
+            'has-[[data-slot=input-group-control]:disabled]:cursor-not-allowed has-[[data-slot=input-group-control]:disabled]:opacity-50',
+            className
+          )}
+          {...props}
+        />
+        {error && (
+          <p
+            id={validationId}
+            data-slot="input-group-error"
+            role="alert"
+            className="mt-1 text-xs leading-4 text-error"
+          >
+            {error}
+          </p>
         )}
-        {...props}
-      />
+      </InputGroupValidationContext.Provider>
     );
   }
 );
@@ -123,20 +149,33 @@ const InputGroupText = React.forwardRef<HTMLSpanElement, InputGroupTextProps>(
 );
 InputGroupText.displayName = 'InputGroupText';
 
-export interface InputGroupInputProps extends Omit<InputProps, 'variant' | 'size'> {}
+export interface InputGroupInputProps
+  extends Omit<InputProps, 'variant' | 'size' | 'error' | 'errorId'> {}
 
 const InputGroupInput = React.forwardRef<HTMLInputElement, InputGroupInputProps>(
-  ({ className, ...props }, ref) => {
+  (
+    { 'aria-describedby': ariaDescribedBy, 'aria-invalid': ariaInvalid, className, ...props },
+    ref
+  ) => {
+    const validation = React.useContext(InputGroupValidationContext);
+    const describedBy = [ariaDescribedBy, validation.error ? validation.errorId : undefined]
+      .filter(Boolean)
+      .join(' ');
+
     return (
-      <Input
-        ref={ref}
-        data-slot="input-group-control"
-        className={cn(
-          'h-full flex-1 rounded-none border-0 bg-transparent p-0 shadow-none focus-visible:ring-0 focus-visible:ring-offset-0 future:h-full future:rounded-none future:border-0 future:bg-transparent future:p-0 future:focus-visible:ring-offset-0',
-          className
-        )}
-        {...props}
-      />
+      <div className="min-w-0 flex-1">
+        <Input
+          ref={ref}
+          data-slot="input-group-control"
+          aria-describedby={describedBy || undefined}
+          aria-invalid={validation.error ? true : ariaInvalid}
+          className={cn(
+            'h-full w-full rounded-none !border-0 !ring-0 bg-transparent p-0 shadow-none focus-visible:ring-0 focus-visible:ring-offset-0 future:h-full future:rounded-none future:border-0 future:bg-transparent future:p-0 future:focus-visible:ring-offset-0',
+            className
+          )}
+          {...props}
+        />
+      </div>
     );
   }
 );
@@ -145,13 +184,23 @@ InputGroupInput.displayName = 'InputGroupInput';
 export interface InputGroupTextareaProps extends Omit<TextareaProps, 'variant'> {}
 
 const InputGroupTextarea = React.forwardRef<HTMLTextAreaElement, InputGroupTextareaProps>(
-  ({ className, ...props }, ref) => {
+  (
+    { 'aria-describedby': ariaDescribedBy, 'aria-invalid': ariaInvalid, className, ...props },
+    ref
+  ) => {
+    const validation = React.useContext(InputGroupValidationContext);
+    const describedBy = [ariaDescribedBy, validation.error ? validation.errorId : undefined]
+      .filter(Boolean)
+      .join(' ');
+
     return (
       <Textarea
         ref={ref}
         data-slot="input-group-control"
+        aria-describedby={describedBy || undefined}
+        aria-invalid={validation.error ? true : ariaInvalid}
         className={cn(
-          'min-h-0 flex-1 resize-none rounded-none border-0 bg-transparent p-0 py-2 shadow-none focus-visible:ring-0 focus-visible:ring-offset-0 future:rounded-none future:border-0 future:bg-transparent future:focus-visible:ring-offset-0',
+          'min-h-0 flex-1 resize-none rounded-none !border-0 !ring-0 bg-transparent p-0 py-2 shadow-none focus-visible:ring-0 focus-visible:ring-offset-0 future:rounded-none future:border-0 future:bg-transparent future:focus-visible:ring-offset-0',
           className
         )}
         {...props}

--- a/packages/apollo-wind/src/components/ui/input-group.tsx
+++ b/packages/apollo-wind/src/components/ui/input-group.tsx
@@ -154,7 +154,13 @@ export interface InputGroupInputProps
 
 const InputGroupInput = React.forwardRef<HTMLInputElement, InputGroupInputProps>(
   (
-    { 'aria-describedby': ariaDescribedBy, 'aria-invalid': ariaInvalid, className, ...props },
+    {
+      'aria-describedby': ariaDescribedBy,
+      'aria-errormessage': ariaErrorMessage,
+      'aria-invalid': ariaInvalid,
+      className,
+      ...props
+    },
     ref
   ) => {
     const validation = React.useContext(InputGroupValidationContext);
@@ -168,6 +174,7 @@ const InputGroupInput = React.forwardRef<HTMLInputElement, InputGroupInputProps>
           ref={ref}
           data-slot="input-group-control"
           aria-describedby={describedBy || undefined}
+          aria-errormessage={validation.error ? validation.errorId : ariaErrorMessage}
           aria-invalid={validation.error ? true : ariaInvalid}
           className={cn(
             'h-full w-full rounded-none !border-0 !ring-0 bg-transparent p-0 shadow-none focus-visible:ring-0 focus-visible:ring-offset-0 future:h-full future:rounded-none future:border-0 future:bg-transparent future:p-0 future:focus-visible:ring-offset-0',
@@ -185,7 +192,13 @@ export interface InputGroupTextareaProps extends Omit<TextareaProps, 'variant'> 
 
 const InputGroupTextarea = React.forwardRef<HTMLTextAreaElement, InputGroupTextareaProps>(
   (
-    { 'aria-describedby': ariaDescribedBy, 'aria-invalid': ariaInvalid, className, ...props },
+    {
+      'aria-describedby': ariaDescribedBy,
+      'aria-errormessage': ariaErrorMessage,
+      'aria-invalid': ariaInvalid,
+      className,
+      ...props
+    },
     ref
   ) => {
     const validation = React.useContext(InputGroupValidationContext);
@@ -198,6 +211,7 @@ const InputGroupTextarea = React.forwardRef<HTMLTextAreaElement, InputGroupTexta
         ref={ref}
         data-slot="input-group-control"
         aria-describedby={describedBy || undefined}
+        aria-errormessage={validation.error ? validation.errorId : ariaErrorMessage}
         aria-invalid={validation.error ? true : ariaInvalid}
         className={cn(
           'min-h-0 flex-1 resize-none rounded-none !border-0 !ring-0 bg-transparent p-0 py-2 shadow-none focus-visible:ring-0 focus-visible:ring-offset-0 future:rounded-none future:border-0 future:bg-transparent future:focus-visible:ring-offset-0',

--- a/packages/apollo-wind/src/components/ui/input-group.tsx
+++ b/packages/apollo-wind/src/components/ui/input-group.tsx
@@ -46,6 +46,7 @@ const InputGroup = React.forwardRef<HTMLDivElement, InputGroupProps>(
             'has-[[data-slot=input-group-control]:focus-visible]:ring-2 has-[[data-slot=input-group-control]:focus-visible]:ring-ring future:has-[[data-slot=input-group-control]:focus-visible]:ring-offset-2 future:has-[[data-slot=input-group-control]:focus-visible]:ring-offset-background',
             // Error state
             'has-[[data-slot][aria-invalid=true]]:border-error has-[[data-slot][aria-invalid=true]]:ring-error/20 future:has-[[data-slot][aria-invalid=true]]:ring-1 future:has-[[data-slot][aria-invalid=true]]:ring-error/40',
+            error && 'border-error ring-error/20 future:ring-1 future:ring-error/40',
             // Disabled state
             'has-[[data-slot=input-group-control]:disabled]:cursor-not-allowed has-[[data-slot=input-group-control]:disabled]:opacity-50',
             className

--- a/packages/apollo-wind/src/components/ui/input-group.tsx
+++ b/packages/apollo-wind/src/components/ui/input-group.tsx
@@ -56,7 +56,6 @@ const InputGroup = React.forwardRef<HTMLDivElement, InputGroupProps>(
           <p
             id={validationId}
             data-slot="input-group-error"
-            role="status"
             aria-live="polite"
             aria-atomic="true"
             className="mt-1 text-xs leading-4 text-error"

--- a/packages/apollo-wind/src/components/ui/input-group.tsx
+++ b/packages/apollo-wind/src/components/ui/input-group.tsx
@@ -56,7 +56,9 @@ const InputGroup = React.forwardRef<HTMLDivElement, InputGroupProps>(
           <p
             id={validationId}
             data-slot="input-group-error"
-            role="alert"
+            role="status"
+            aria-live="polite"
+            aria-atomic="true"
             className="mt-1 text-xs leading-4 text-error"
           >
             {error}

--- a/packages/apollo-wind/src/components/ui/input.stories.tsx
+++ b/packages/apollo-wind/src/components/ui/input.stories.tsx
@@ -6,10 +6,16 @@ import { Label } from './label';
 const meta = {
   title: 'Components/Core/Input',
   component: Input,
+  tags: ['autodocs'],
   parameters: {
     layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'Use inline validation when feedback belongs to one field. Pass `error` to keep the message beside the input; explain what went wrong and the action needed to resolve it. Use `aria-describedby` for additional guidance, not as a replacement for the visible error. See the [Node Property Panel UI Inventory](https://engdogfood.staging.uipath.host/apollo-design/?path=/story/apollo-react-canvas-components-panels-node-property-panel--panel-ui-inventory) for the reference state pattern.',
+      },
+    },
   },
-  tags: ['autodocs'],
   argTypes: {
     variant: {
       control: 'select',
@@ -42,6 +48,28 @@ export const WithLabel = {
     </div>
   ),
 } satisfies Story;
+
+export const WithInlineValidation: Story = {
+  render: () => (
+    <div className="grid w-full max-w-sm items-center gap-1.5">
+      <Label htmlFor="node-name">Node name</Label>
+      <Input
+        id="node-name"
+        value="Invoice processor"
+        error="This node name is already in use. Enter a unique name before saving."
+        readOnly
+      />
+    </div>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Inline validation stays beside the control so the issue and resolution are clear in context. The input exposes `aria-invalid` and associates the visible message with `aria-describedby` and `aria-errormessage` automatically.',
+      },
+    },
+  },
+};
 
 export const Disabled: Story = {
   args: {

--- a/packages/apollo-wind/src/components/ui/input.test.tsx
+++ b/packages/apollo-wind/src/components/ui/input.test.tsx
@@ -52,7 +52,7 @@ describe('Input', () => {
   it('renders inline validation and associates it with the input', () => {
     render(<Input id="node-name" error="Enter a unique name before saving." />);
     const input = screen.getByRole('textbox');
-    const message = screen.getByRole('alert');
+    const message = screen.getByRole('status');
 
     expect(input).toHaveAttribute('aria-invalid', 'true');
     expect(input).toHaveAttribute('aria-describedby', 'node-name-error');

--- a/packages/apollo-wind/src/components/ui/input.test.tsx
+++ b/packages/apollo-wind/src/components/ui/input.test.tsx
@@ -49,6 +49,33 @@ describe('Input', () => {
     expect(screen.getByRole('textbox')).toHaveClass('custom-input');
   });
 
+  it('renders inline validation and associates it with the input', () => {
+    render(<Input id="node-name" error="Enter a unique name before saving." />);
+    const input = screen.getByRole('textbox');
+    const message = screen.getByRole('alert');
+
+    expect(input).toHaveAttribute('aria-invalid', 'true');
+    expect(input).toHaveAttribute('aria-describedby', 'node-name-error');
+    expect(input).toHaveAttribute('aria-errormessage', 'node-name-error');
+    expect(message).toHaveAttribute('id', 'node-name-error');
+    expect(message).toHaveTextContent('Enter a unique name before saving.');
+    expect(message).toHaveClass('text-xs', 'leading-4', 'text-error');
+  });
+
+  it('preserves existing descriptions when rendering inline validation', () => {
+    render(
+      <>
+        <p id="name-help">Use a unique node name.</p>
+        <Input id="node-name" aria-describedby="name-help" error="Name is already in use." />
+      </>
+    );
+
+    expect(screen.getByRole('textbox')).toHaveAttribute(
+      'aria-describedby',
+      'name-help node-name-error'
+    );
+  });
+
   it('forwards ref correctly', () => {
     const ref = { current: null };
     render(<Input ref={ref} />);

--- a/packages/apollo-wind/src/components/ui/input.test.tsx
+++ b/packages/apollo-wind/src/components/ui/input.test.tsx
@@ -52,7 +52,7 @@ describe('Input', () => {
   it('renders inline validation and associates it with the input', () => {
     render(<Input id="node-name" error="Enter a unique name before saving." />);
     const input = screen.getByRole('textbox');
-    const message = screen.getByRole('status');
+    const message = screen.getByText('Enter a unique name before saving.');
 
     expect(input).toHaveAttribute('aria-invalid', 'true');
     expect(input).toHaveAttribute('aria-describedby', 'node-name-error');

--- a/packages/apollo-wind/src/components/ui/input.tsx
+++ b/packages/apollo-wind/src/components/ui/input.tsx
@@ -67,7 +67,6 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
           <p
             id={validationId}
             data-slot="input-error"
-            role="status"
             aria-live="polite"
             aria-atomic="true"
             className="mt-1 text-xs leading-4 text-error"

--- a/packages/apollo-wind/src/components/ui/input.tsx
+++ b/packages/apollo-wind/src/components/ui/input.tsx
@@ -4,33 +4,76 @@ import { cn } from '@/lib/utils';
 export interface InputProps extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 'size'> {
   variant?: 'default' | 'ghost';
   size?: 'default' | 'xs';
+  /**
+   * Field-specific feedback rendered immediately below the input.
+   * Keep the message focused on what went wrong and how to resolve it.
+   */
+  error?: React.ReactNode;
+  /** Optional id for the inline validation message. */
+  errorId?: string;
 }
 
 const Input = React.forwardRef<HTMLInputElement, InputProps>(
-  ({ className, type, variant = 'default', size = 'default', ...props }, ref) => {
+  (
+    {
+      'aria-describedby': ariaDescribedBy,
+      'aria-invalid': ariaInvalid,
+      className,
+      error,
+      errorId,
+      id,
+      type,
+      variant = 'default',
+      size = 'default',
+      ...props
+    },
+    ref
+  ) => {
+    const generatedId = React.useId();
+    const validationId = errorId ?? `${id ?? `input-${generatedId.replace(/:/g, '')}`}-error`;
+    const describedBy = [ariaDescribedBy, error ? validationId : undefined]
+      .filter(Boolean)
+      .join(' ');
+
     return (
-      <input
-        type={type}
-        data-slot="input"
-        className={cn(
-          // Base styles (all themes)
-          'flex w-full transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50',
-          // Size
-          size === 'default' &&
-            'h-9 rounded-md px-3 py-1 text-base placeholder:text-muted-foreground md:text-sm',
-          size === 'xs' && 'h-6 rounded px-2 text-xs placeholder:text-muted-foreground',
-          // Variant
-          variant === 'default' && 'border border-input bg-transparent',
-          variant === 'ghost' && 'border-0 bg-surface-overlay',
-          // Future theme overrides apply only to the default variant + default size
-          variant === 'default' &&
+      <>
+        <input
+          type={type}
+          data-slot="input"
+          id={id}
+          aria-describedby={describedBy || undefined}
+          aria-errormessage={error ? validationId : undefined}
+          aria-invalid={error ? true : ariaInvalid}
+          className={cn(
+            // Base styles (all themes)
+            'flex w-full transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-error aria-invalid:focus-visible:ring-error',
+            // Size
             size === 'default' &&
-            'future:h-10 future:rounded-xl future:border-0 future:bg-surface-overlay future:py-2 future:text-sm future:placeholder:text-foreground-muted future:placeholder:font-normal future:focus-visible:ring-offset-2 future:focus-visible:ring-offset-background',
-          className
+              'h-9 rounded-md px-3 py-1 text-base placeholder:text-muted-foreground md:text-sm',
+            size === 'xs' && 'h-6 rounded px-2 text-xs placeholder:text-muted-foreground',
+            // Variant
+            variant === 'default' && 'border border-input bg-transparent',
+            variant === 'ghost' && 'border-0 bg-surface-overlay',
+            // Future theme overrides apply only to the default variant + default size
+            variant === 'default' &&
+              size === 'default' &&
+              'future:h-10 future:rounded-xl future:border-0 future:bg-surface-overlay future:py-2 future:text-sm future:placeholder:text-foreground-muted future:placeholder:font-normal future:focus-visible:ring-offset-2 future:focus-visible:ring-offset-background future:aria-invalid:ring-1 future:aria-invalid:ring-error/40',
+            className
+          )}
+          ref={ref}
+          {...props}
+        />
+        {error && (
+          <p
+            id={validationId}
+            data-slot="input-error"
+            role="alert"
+            className="mt-1 text-xs leading-4 text-error"
+          >
+            {error}
+          </p>
         )}
-        ref={ref}
-        {...props}
-      />
+      </>
     );
   }
 );

--- a/packages/apollo-wind/src/components/ui/input.tsx
+++ b/packages/apollo-wind/src/components/ui/input.tsx
@@ -67,7 +67,9 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
           <p
             id={validationId}
             data-slot="input-error"
-            role="alert"
+            role="status"
+            aria-live="polite"
+            aria-atomic="true"
             className="mt-1 text-xs leading-4 text-error"
           >
             {error}

--- a/packages/apollo-wind/src/components/ui/input.tsx
+++ b/packages/apollo-wind/src/components/ui/input.tsx
@@ -17,6 +17,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
   (
     {
       'aria-describedby': ariaDescribedBy,
+      'aria-errormessage': ariaErrorMessage,
       'aria-invalid': ariaInvalid,
       className,
       error,
@@ -41,8 +42,9 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
           type={type}
           data-slot="input"
           id={id}
+          {...props}
           aria-describedby={describedBy || undefined}
-          aria-errormessage={error ? validationId : undefined}
+          aria-errormessage={error ? validationId : ariaErrorMessage}
           aria-invalid={error ? true : ariaInvalid}
           className={cn(
             // Base styles (all themes)
@@ -61,7 +63,6 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
             className
           )}
           ref={ref}
-          {...props}
         />
         {error && (
           <p

--- a/packages/apollo-wind/src/components/ui/lockable-value-field/lockable-value-field.stories.tsx
+++ b/packages/apollo-wind/src/components/ui/lockable-value-field/lockable-value-field.stories.tsx
@@ -39,6 +39,8 @@ and (for scalar types) switched between a literal value and a JS expression.
 - Header row is responsive (container query): the type, required,
   AI-assist, and insert-variable controls collapse to icon-only once the
   field gets too narrow for their labels. See **Responsive** below.
+- Inline validation stays immediately below the active control and explains
+  both the issue and the action needed to resolve it. See **Inline validation** below.
 - Built on \`InputGroup\` for the scalar types that support expressions; see
   Input Group's \`LockedFieldWithPopover\` story for a lighter-weight recipe
   using only \`InputGroup\` primitives.
@@ -112,6 +114,29 @@ function DefaultDemo() {
 
 export const Default: Story = {
   render: () => <DefaultDemo />,
+};
+
+export const InlineValidation: Story = {
+  render: () => (
+    <div className="w-80">
+      <LockableValueField
+        id="lockable-node-name"
+        label={<Label htmlFor="lockable-node-name">Node name</Label>}
+        value="Invoice processor"
+        error="This node name is already in use. Enter a unique name before saving."
+        locked
+        showFieldActions={false}
+      />
+    </div>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Use the field-level `error` prop for validation that belongs to the active value. The message stays below the lockable control and the built-in input is marked invalid for assistive technology.',
+      },
+    },
+  },
 };
 
 /**

--- a/packages/apollo-wind/src/components/ui/lockable-value-field/lockable-value-field.test.tsx
+++ b/packages/apollo-wind/src/components/ui/lockable-value-field/lockable-value-field.test.tsx
@@ -16,6 +16,24 @@ describe('LockableValueField', () => {
     expect(screen.getByPlaceholderText('String value')).not.toHaveAttribute('readonly');
   });
 
+  it('renders inline validation below the active value control', () => {
+    render(
+      <LockableValueField
+        id="node-name"
+        value="Invoice processor"
+        error="Enter a unique name before saving."
+        locked
+      />
+    );
+
+    expect(screen.getByRole('alert')).toHaveTextContent('Enter a unique name before saving.');
+    expect(screen.getByPlaceholderText('String value')).toHaveAttribute('aria-invalid', 'true');
+    expect(screen.getByPlaceholderText('String value')).toHaveAttribute(
+      'aria-describedby',
+      'node-name-error'
+    );
+  });
+
   it('renders a read-only input when unlocked but onValueChange is not provided', () => {
     render(<LockableValueField value="" locked={false} />);
     expect(screen.getByPlaceholderText('String value')).toHaveAttribute('readonly');

--- a/packages/apollo-wind/src/components/ui/lockable-value-field/lockable-value-field.test.tsx
+++ b/packages/apollo-wind/src/components/ui/lockable-value-field/lockable-value-field.test.tsx
@@ -26,7 +26,7 @@ describe('LockableValueField', () => {
       />
     );
 
-    expect(screen.getByRole('alert')).toHaveTextContent('Enter a unique name before saving.');
+    expect(screen.getByRole('status')).toHaveTextContent('Enter a unique name before saving.');
     expect(screen.getByPlaceholderText('String value')).toHaveAttribute('aria-invalid', 'true');
     expect(screen.getByPlaceholderText('String value')).toHaveAttribute(
       'aria-describedby',

--- a/packages/apollo-wind/src/components/ui/lockable-value-field/lockable-value-field.test.tsx
+++ b/packages/apollo-wind/src/components/ui/lockable-value-field/lockable-value-field.test.tsx
@@ -26,7 +26,7 @@ describe('LockableValueField', () => {
       />
     );
 
-    expect(screen.getByRole('status')).toHaveTextContent('Enter a unique name before saving.');
+    expect(screen.getByText('Enter a unique name before saving.')).toBeInTheDocument();
     expect(screen.getByPlaceholderText('String value')).toHaveAttribute('aria-invalid', 'true');
     expect(screen.getByPlaceholderText('String value')).toHaveAttribute(
       'aria-describedby',

--- a/packages/apollo-wind/src/components/ui/lockable-value-field/lockable-value-field.tsx
+++ b/packages/apollo-wind/src/components/ui/lockable-value-field/lockable-value-field.tsx
@@ -140,6 +140,7 @@ export function LockableValueField({
                 id={fieldId}
                 aria-invalid={error ? true : undefined}
                 aria-describedby={error ? validationId : undefined}
+                aria-errormessage={error ? validationId : undefined}
                 readOnly={!editableOnValueChange}
                 value={value}
                 onChange={(e) => editableOnValueChange?.(e.target.value)}
@@ -153,6 +154,7 @@ export function LockableValueField({
               id={fieldId}
               aria-invalid={error ? true : undefined}
               aria-describedby={error ? validationId : undefined}
+              aria-errormessage={error ? validationId : undefined}
               readOnly
               value={lockedDisplayValue}
               placeholder={fieldLabel}
@@ -206,6 +208,7 @@ export function LockableValueField({
               type={fieldType === 'integer' ? 'number' : 'text'}
               aria-invalid={error ? true : undefined}
               aria-describedby={error ? validationId : undefined}
+              aria-errormessage={error ? validationId : undefined}
               readOnly={!onValueChange}
               value={value}
               onChange={(e) => onValueChange?.(e.target.value)}
@@ -254,6 +257,7 @@ export function LockableValueField({
               id={fieldId}
               aria-invalid={error ? true : undefined}
               aria-describedby={error ? validationId : undefined}
+              aria-errormessage={error ? validationId : undefined}
               readOnly
               value={lockedDisplayValue}
               placeholder={fieldLabel}

--- a/packages/apollo-wind/src/components/ui/lockable-value-field/lockable-value-field.tsx
+++ b/packages/apollo-wind/src/components/ui/lockable-value-field/lockable-value-field.tsx
@@ -78,7 +78,7 @@ export function LockableValueField({
   id,
   className,
 }: LockableValueFieldProps) {
-  const generatedId = useId();
+  const generatedId = useId().replace(/:/g, '');
   const [datePopoverOpen, setDatePopoverOpen] = useState(false);
   const [selectOpen, setSelectOpen] = useState(false);
   const fieldId = id ?? generatedId;

--- a/packages/apollo-wind/src/components/ui/lockable-value-field/lockable-value-field.tsx
+++ b/packages/apollo-wind/src/components/ui/lockable-value-field/lockable-value-field.tsx
@@ -65,6 +65,8 @@ export function LockableValueField({
   required,
   onRequiredChange,
   label,
+  error,
+  errorId,
   fileUploadAriaLabel,
   headerActions,
   compact,
@@ -80,6 +82,7 @@ export function LockableValueField({
   const [datePopoverOpen, setDatePopoverOpen] = useState(false);
   const [selectOpen, setSelectOpen] = useState(false);
   const fieldId = id ?? generatedId;
+  const validationId = errorId ?? `${fieldId}-error`;
   const typeMeta = FIELD_TYPE_META[fieldType];
   const effectiveMode = typeMeta.supportsExpression ? mode : 'fixed';
   const editableOnValueChange = locked ? undefined : onValueChange;
@@ -135,6 +138,8 @@ export function LockableValueField({
             ) : (
               <InputGroupInput
                 id={fieldId}
+                aria-invalid={error ? true : undefined}
+                aria-describedby={error ? validationId : undefined}
                 readOnly={!editableOnValueChange}
                 value={value}
                 onChange={(e) => editableOnValueChange?.(e.target.value)}
@@ -146,6 +151,8 @@ export function LockableValueField({
           ) : locked ? (
             <InputGroupInput
               id={fieldId}
+              aria-invalid={error ? true : undefined}
+              aria-describedby={error ? validationId : undefined}
               readOnly
               value={lockedDisplayValue}
               placeholder={fieldLabel}
@@ -197,6 +204,8 @@ export function LockableValueField({
             <InputGroupInput
               id={fieldId}
               type={fieldType === 'integer' ? 'number' : 'text'}
+              aria-invalid={error ? true : undefined}
+              aria-describedby={error ? validationId : undefined}
               readOnly={!onValueChange}
               value={value}
               onChange={(e) => onValueChange?.(e.target.value)}
@@ -243,6 +252,8 @@ export function LockableValueField({
           {locked ? (
             <Input
               id={fieldId}
+              aria-invalid={error ? true : undefined}
+              aria-describedby={error ? validationId : undefined}
               readOnly
               value={lockedDisplayValue}
               placeholder={fieldLabel}
@@ -295,6 +306,17 @@ export function LockableValueField({
             )
           )}
         </div>
+      )}
+
+      {error && (
+        <p
+          id={validationId}
+          data-slot="lockable-value-field-error"
+          role="alert"
+          className="text-xs leading-4 text-error"
+        >
+          {error}
+        </p>
       )}
     </div>
   );

--- a/packages/apollo-wind/src/components/ui/lockable-value-field/lockable-value-field.tsx
+++ b/packages/apollo-wind/src/components/ui/lockable-value-field/lockable-value-field.tsx
@@ -134,6 +134,10 @@ export function LockableValueField({
                 readOnly: !editableOnValueChange,
                 placeholder: fieldLabel,
                 fieldType,
+                'aria-invalid': error ? true : undefined,
+                'aria-describedby': error ? validationId : undefined,
+                'aria-errormessage': error ? validationId : undefined,
+                'data-slot': 'input-group-control',
               })
             ) : (
               <InputGroupInput

--- a/packages/apollo-wind/src/components/ui/lockable-value-field/lockable-value-field.tsx
+++ b/packages/apollo-wind/src/components/ui/lockable-value-field/lockable-value-field.tsx
@@ -325,7 +325,9 @@ export function LockableValueField({
         <p
           id={validationId}
           data-slot="lockable-value-field-error"
-          role="alert"
+          role="status"
+          aria-live="polite"
+          aria-atomic="true"
           className="mt-1 text-xs leading-4 text-error"
         >
           {error}

--- a/packages/apollo-wind/src/components/ui/lockable-value-field/lockable-value-field.tsx
+++ b/packages/apollo-wind/src/components/ui/lockable-value-field/lockable-value-field.tsx
@@ -317,7 +317,7 @@ export function LockableValueField({
           id={validationId}
           data-slot="lockable-value-field-error"
           role="alert"
-          className="text-xs leading-4 text-error"
+          className="mt-1 text-xs leading-4 text-error"
         >
           {error}
         </p>

--- a/packages/apollo-wind/src/components/ui/lockable-value-field/lockable-value-field.tsx
+++ b/packages/apollo-wind/src/components/ui/lockable-value-field/lockable-value-field.tsx
@@ -119,7 +119,7 @@ export function LockableValueField({
       />
 
       {typeMeta.supportsExpression ? (
-        <InputGroup>
+        <InputGroup error={error} errorId={validationId}>
           <InputGroupAddon align="inline-start">
             <LockToggleButton locked={locked} onLockedChange={onLockedChange} />
           </InputGroupAddon>
@@ -138,9 +138,6 @@ export function LockableValueField({
             ) : (
               <InputGroupInput
                 id={fieldId}
-                aria-invalid={error ? true : undefined}
-                aria-describedby={error ? validationId : undefined}
-                aria-errormessage={error ? validationId : undefined}
                 readOnly={!editableOnValueChange}
                 value={value}
                 onChange={(e) => editableOnValueChange?.(e.target.value)}
@@ -152,9 +149,6 @@ export function LockableValueField({
           ) : locked ? (
             <InputGroupInput
               id={fieldId}
-              aria-invalid={error ? true : undefined}
-              aria-describedby={error ? validationId : undefined}
-              aria-errormessage={error ? validationId : undefined}
               readOnly
               value={lockedDisplayValue}
               placeholder={fieldLabel}
@@ -164,6 +158,9 @@ export function LockableValueField({
             <div className="flex h-full flex-1 items-center px-3">
               <Switch
                 id={fieldId}
+                aria-invalid={error ? true : undefined}
+                aria-describedby={error ? validationId : undefined}
+                aria-errormessage={error ? validationId : undefined}
                 checked={value === 'true'}
                 onCheckedChange={(checked) => onValueChange?.(String(checked))}
                 onBlur={onValueBlur}
@@ -183,6 +180,9 @@ export function LockableValueField({
                   type="button"
                   id={fieldId}
                   data-slot="input-group-control"
+                  aria-invalid={error ? true : undefined}
+                  aria-describedby={error ? validationId : undefined}
+                  aria-errormessage={error ? validationId : undefined}
                   disabled={!onValueChange}
                   className="flex h-full flex-1 items-center text-left text-sm text-foreground outline-none disabled:cursor-not-allowed disabled:opacity-50"
                 >
@@ -206,9 +206,6 @@ export function LockableValueField({
             <InputGroupInput
               id={fieldId}
               type={fieldType === 'integer' ? 'number' : 'text'}
-              aria-invalid={error ? true : undefined}
-              aria-describedby={error ? validationId : undefined}
-              aria-errormessage={error ? validationId : undefined}
               readOnly={!onValueChange}
               value={value}
               onChange={(e) => onValueChange?.(e.target.value)}
@@ -275,7 +272,13 @@ export function LockableValueField({
               onValueChange={onValueChange}
               disabled={!onValueChange}
             >
-              <SelectTrigger id={fieldId} className="flex-1">
+                <SelectTrigger
+                  id={fieldId}
+                  className="flex-1"
+                  aria-invalid={error ? true : undefined}
+                  aria-describedby={error ? validationId : undefined}
+                  aria-errormessage={error ? validationId : undefined}
+                >
                 <SelectValue placeholder="Select an option" />
               </SelectTrigger>
               <SelectContent>
@@ -296,6 +299,9 @@ export function LockableValueField({
               placeholder="Select options..."
               disabled={!onValueChange}
               onBlur={onValueBlur}
+              aria-invalid={error ? true : undefined}
+              aria-describedby={error ? validationId : undefined}
+              aria-errormessage={error ? validationId : undefined}
             />
           ) : (
             fieldType === 'file' && (
@@ -306,13 +312,16 @@ export function LockableValueField({
                 onFilesChange={(files) => onValueChange?.(files.map((f) => f.name).join(', '))}
                 disabled={!onValueChange}
                 onBlur={onValueBlur}
+                aria-invalid={error ? true : undefined}
+                aria-describedby={error ? validationId : undefined}
+                aria-errormessage={error ? validationId : undefined}
               />
             )
           )}
         </div>
       )}
 
-      {error && (
+      {error && !typeMeta.supportsExpression && (
         <p
           id={validationId}
           data-slot="lockable-value-field-error"

--- a/packages/apollo-wind/src/components/ui/lockable-value-field/lockable-value-field.tsx
+++ b/packages/apollo-wind/src/components/ui/lockable-value-field/lockable-value-field.tsx
@@ -272,13 +272,13 @@ export function LockableValueField({
               onValueChange={onValueChange}
               disabled={!onValueChange}
             >
-                <SelectTrigger
-                  id={fieldId}
-                  className="flex-1"
-                  aria-invalid={error ? true : undefined}
-                  aria-describedby={error ? validationId : undefined}
-                  aria-errormessage={error ? validationId : undefined}
-                >
+              <SelectTrigger
+                id={fieldId}
+                className="flex-1"
+                aria-invalid={error ? true : undefined}
+                aria-describedby={error ? validationId : undefined}
+                aria-errormessage={error ? validationId : undefined}
+              >
                 <SelectValue placeholder="Select an option" />
               </SelectTrigger>
               <SelectContent>
@@ -325,7 +325,6 @@ export function LockableValueField({
         <p
           id={validationId}
           data-slot="lockable-value-field-error"
-          role="status"
           aria-live="polite"
           aria-atomic="true"
           className="mt-1 text-xs leading-4 text-error"

--- a/packages/apollo-wind/src/components/ui/lockable-value-field/types.ts
+++ b/packages/apollo-wind/src/components/ui/lockable-value-field/types.ts
@@ -8,7 +8,7 @@ import {
   type LucideIcon,
   ToggleLeft,
 } from 'lucide-react';
-import type { ReactNode } from 'react';
+import type { AriaAttributes, ReactNode } from 'react';
 
 export type LockableValueFieldMode = 'fixed' | 'expression';
 
@@ -123,7 +123,7 @@ export interface LockableValueFieldProps {
     readOnly: boolean;
     placeholder: string;
     fieldType: LockableFieldType;
-    'aria-invalid'?: boolean;
+    'aria-invalid'?: AriaAttributes['aria-invalid'];
     'aria-describedby'?: string;
     'aria-errormessage'?: string;
     'data-slot'?: string;

--- a/packages/apollo-wind/src/components/ui/lockable-value-field/types.ts
+++ b/packages/apollo-wind/src/components/ui/lockable-value-field/types.ts
@@ -134,6 +134,10 @@ export interface LockableValueFieldProps {
   onRequiredChange?: (required: boolean) => void;
   /** Overrides the default mode-based label (e.g. a field name instead of "String value"). */
   label?: ReactNode;
+  /** Field-specific validation feedback rendered immediately below the active control. */
+  error?: ReactNode;
+  /** Optional id for the inline validation message. */
+  errorId?: string;
   /** Accessible name for the file-upload dropzone. Defaults to a string `label`, then the computed field label. */
   fileUploadAriaLabel?: string;
   /** Extra content rendered after the built-in AI assist / Insert variable buttons (e.g. a delete button). */

--- a/packages/apollo-wind/src/components/ui/lockable-value-field/types.ts
+++ b/packages/apollo-wind/src/components/ui/lockable-value-field/types.ts
@@ -123,6 +123,10 @@ export interface LockableValueFieldProps {
     readOnly: boolean;
     placeholder: string;
     fieldType: LockableFieldType;
+    'aria-invalid'?: boolean;
+    'aria-describedby'?: string;
+    'aria-errormessage'?: string;
+    'data-slot'?: string;
   }) => ReactNode;
   /** The field's data type. Defaults to 'string'. Determines which control renders the value. */
   fieldType?: LockableFieldType;

--- a/packages/apollo-wind/src/components/ui/multi-select.tsx
+++ b/packages/apollo-wind/src/components/ui/multi-select.tsx
@@ -29,6 +29,9 @@ export interface MultiSelectProps {
   clearAllText?: string | ((count: number) => string);
   /** Called when the multi-select popover closes after being opened. */
   onBlur?: () => void;
+  'aria-invalid'?: React.AriaAttributes['aria-invalid'];
+  'aria-describedby'?: string;
+  'aria-errormessage'?: string;
 }
 
 const MultiSelect = React.forwardRef<HTMLDivElement, MultiSelectProps>(
@@ -46,6 +49,9 @@ const MultiSelect = React.forwardRef<HTMLDivElement, MultiSelectProps>(
       searchPlaceholder = 'Search...',
       clearAllText,
       onBlur,
+      'aria-invalid': ariaInvalid,
+      'aria-describedby': ariaDescribedBy,
+      'aria-errormessage': ariaErrorMessage,
     },
     ref
   ) => {
@@ -85,6 +91,9 @@ const MultiSelect = React.forwardRef<HTMLDivElement, MultiSelectProps>(
               variant="outline"
               role="combobox"
               aria-expanded={open}
+              aria-invalid={ariaInvalid}
+              aria-describedby={ariaDescribedBy}
+              aria-errormessage={ariaErrorMessage}
               // aria-label always wins over a `<label htmlFor>` association in the
               // accessible-name computation, so only set it when there's no id for a
               // consumer's label to target -- otherwise the label's own text names


### PR DESCRIPTION
## Summary

Adds a consistent inline-validation pattern across core Apollo Wind field components and aligns the panel UI Inventory example with the shared implementation.

### What changed

- Added `error` and `errorId` support to `Input`, including visible field-level feedback and accessible `aria-invalid`, `aria-describedby`, and `aria-errormessage` wiring.
- Added the same behavior to `InputGroup`, `InputGroupInput`, and `InputGroupTextarea`; validation renders outside the grouped field while the outer group owns the error outline.
- Added field-level validation to `LockableValueField` and kept the inner control borderless so the composite field owns the outline.
- Standardized semantic error color, typography, and the Future-theme 1px outer ring.
- Added Storybook documentation/examples for Input, Input Group, and Lockable Value Field.
- Updated Node Property Panel UI Inventory to use the shared `Input` validation API and linked it as the reference pattern.

<img width="1065" height="846" alt="Screenshot 2026-08-26 at 1 23 07 PM" src="https://github.com/user-attachments/assets/bce8fd11-450c-4948-a92b-7e91ec7f53c1" />
<img width="1043" height="847" alt="Screenshot 2026-08-26 at 1 23 18 PM" src="https://github.com/user-attachments/assets/5ea84f8c-c2f0-4435-aee3-8377a400753d" />
<img width="1039" height="710" alt="Screenshot 2026-08-26 at 1 23 31 PM" src="https://github.com/user-attachments/assets/0016c81b-f227-4304-bd61-978b1b77becf" />
<img width="1069" height="860" alt="Screenshot 2026-08-26 at 1 23 52 PM" src="https://github.com/user-attachments/assets/29ee41b8-91ea-4ccd-957d-832108934555" />


## Validation

- `pnpm --filter @uipath/apollo-wind test` — 1,406 tests passed
- `pnpm --filter @uipath/apollo-wind build`
- Apollo React Storybook story Biome check and TypeScript check
- Focused component tests: 80 passed

## Reference

[Node Property Panel UI Inventory](https://engdogfood.staging.uipath.host/apollo-design/?path=/story/apollo-react-canvas-components-panels-node-property-panel--panel-ui-inventory)