### PR TITLE
fix(apollo-wind, apollo-react): add field asterisk and update chip color

### DIFF
--- a/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.stories.tsx
@@ -57,6 +57,7 @@ import {
   PopoverTrigger,
   RadioGroup,
   RadioGroupItem,
+  RequiredIndicator,
   ScrollableTabsList,
   Select,
   SelectContent,
@@ -2654,7 +2655,7 @@ function LockableCaseRow({
                   className="truncate rounded px-1 py-0.5 text-left text-xs font-medium text-foreground transition hover:bg-surface-overlay"
                 >
                   {caseTitle}
-                  {required && <span className="ml-0.5 text-destructive">*</span>}
+                  {required && <RequiredIndicator />}
                 </button>
               )}
             </div>
@@ -2853,7 +2854,7 @@ function FieldDragOverlay({ caseItem }: { caseItem: LockableCase }) {
       <meta.icon size={12} className="shrink-0 text-foreground-subtle" />
       <span className="truncate text-xs font-medium text-foreground">
         {caseItem.title}
-        {caseItem.required && <span className="ml-0.5 text-destructive">*</span>}
+        {caseItem.required && <RequiredIndicator />}
       </span>
     </div>
   );

--- a/packages/apollo-react/src/canvas/components/NodePropertyPanel/PanelField.tsx
+++ b/packages/apollo-react/src/canvas/components/NodePropertyPanel/PanelField.tsx
@@ -1,4 +1,4 @@
-import { cn, Label, type LabelProps } from '@uipath/apollo-wind';
+import { cn, Label, type LabelProps, RequiredIndicator } from '@uipath/apollo-wind';
 import {
   cloneElement,
   forwardRef,
@@ -45,7 +45,7 @@ export const PanelFieldLabel = forwardRef<HTMLLabelElement, PanelFieldLabelProps
       {...props}
     >
       {children}
-      {required && <span className="ml-0.5 text-destructive">*</span>}
+      {required && <RequiredIndicator />}
     </Label>
   )
 );

--- a/packages/apollo-react/src/material/components/ap-chat/components/input/tiptap/resource-chip-node-view.tsx
+++ b/packages/apollo-react/src/material/components/ap-chat/components/input/tiptap/resource-chip-node-view.tsx
@@ -14,8 +14,8 @@ const ChipContent = styled('span')<{ readonly?: boolean }>(({ readonly }) => ({
   display: 'inline-flex',
   alignItems: 'center',
   padding: `0 ${token.Padding.PadS}`,
-  backgroundColor: 'var(--color-primary-lighter)',
-  color: 'var(--color-foreground)',
+  backgroundColor: 'var(--color-info-background)',
+  color: 'var(--color-info-text)',
   borderRadius: `calc(${token.Border.BorderRadiusL} * 2)`,
   verticalAlign: 'middle',
   ...(!readonly && {
@@ -49,7 +49,7 @@ const ChipDeleteContainer = styled('span')<{ visible: boolean; compactMode: bool
     transform: 'translateY(-50%)',
     display: 'flex',
     alignItems: 'center',
-    backgroundColor: 'var(--color-primary-lighter)',
+    backgroundColor: 'var(--color-info-background)',
     borderRadius: `calc(${token.Border.BorderRadiusL} * 2)`,
     transition: 'opacity 0.15s ease-in-out',
 

--- a/packages/apollo-wind/src/components/forms/field-renderer.tsx
+++ b/packages/apollo-wind/src/components/forms/field-renderer.tsx
@@ -24,7 +24,7 @@ import { Checkbox } from '@/components/ui/checkbox';
 import { Switch } from '@/components/ui/switch';
 import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
 import { Slider } from '@/components/ui/slider';
-import { Label } from '@/components/ui/label';
+import { Label, RequiredIndicator } from '@/components/ui/label';
 import { DatePicker } from '@/components/ui/date-picker';
 import { DateTimePicker } from '@/components/ui/datetime-picker';
 import { FileUpload } from '@/components/ui/file-upload';
@@ -599,7 +599,7 @@ function FormLabel({
   return (
     <Label data-slot="form-label" htmlFor={htmlFor} className={className}>
       {children}
-      {required && <span className="text-destructive ml-1">*</span>}
+      {required && <RequiredIndicator className="ml-1" />}
     </Label>
   );
 }

--- a/packages/apollo-wind/src/components/forms/form-designer.tsx
+++ b/packages/apollo-wind/src/components/forms/form-designer.tsx
@@ -13,7 +13,7 @@ import { schemaToJson } from './schema-serializer';
 import { MetadataForm } from './metadata-form';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
+import { Label, RequiredIndicator } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
 import {
   Select,
@@ -1187,7 +1187,7 @@ export function FormDesigner() {
                           <div className="flex items-center gap-1">
                             <span className="text-xs font-medium truncate">{field.label}</span>
                             {field.rules?.some((r) => r.effects.required) && (
-                              <span className="text-[10px] text-destructive">*</span>
+                              <RequiredIndicator className="ml-0 text-[10px]" />
                             )}
                           </div>
                           <div className="text-[9px] text-muted-foreground">{field.type}</div>

--- a/packages/apollo-wind/src/components/ui/label.stories.tsx
+++ b/packages/apollo-wind/src/components/ui/label.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { Input } from './input';
-import { Label } from './label';
+import { Label, RequiredIndicator } from './label';
 
 const meta = {
   title: 'Components/Core/Label',
@@ -33,11 +33,27 @@ export const Required = {
   render: () => (
     <div className="grid w-full max-w-sm items-center gap-1.5">
       <Label htmlFor="required">
-        Username <span className="text-destructive">*</span>
+        {'Username'}
+        <RequiredIndicator className="ml-0" />
       </Label>
-      <Input id="required" placeholder="Enter username" />
+      <Input id="required" required placeholder="Enter username" />
     </div>
   ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Use `RequiredIndicator` after the label text for a required field. It inherits the ' +
+          "surrounding text color instead of an error color: the field isn't in an error state " +
+          "just because it's empty, so a red asterisk overstates it and can be mistaken for a " +
+          "validation failure. The asterisk glyph is `aria-hidden`, since it isn't reliably " +
+          'announced by assistive tech on its own, and a `sr-only` "(required)" is included ' +
+          'alongside it so the label still announces the requirement on its own. Still put ' +
+          "`required` (or `aria-required`) on the field's own control so the requirement is " +
+          'enforced, not just announced.',
+      },
+    },
+  },
 } satisfies Story;
 
 export const WithDescription = {

--- a/packages/apollo-wind/src/components/ui/label.test.tsx
+++ b/packages/apollo-wind/src/components/ui/label.test.tsx
@@ -2,7 +2,7 @@ import { render, screen } from '@testing-library/react';
 import { axe } from 'jest-axe';
 import { describe, expect, it } from 'vitest';
 import { Input } from './input';
-import { Label } from './label';
+import { Label, RequiredIndicator } from './label';
 
 describe('Label', () => {
   it('renders label with text', () => {
@@ -41,5 +41,33 @@ describe('Label', () => {
     const ref = { current: null };
     render(<Label ref={ref}>Label</Label>);
     expect(ref.current).toBeInstanceOf(HTMLLabelElement);
+  });
+});
+
+describe('RequiredIndicator', () => {
+  it('hides the asterisk glyph from assistive tech but announces it via sr-only text', () => {
+    render(
+      <Label htmlFor="name">
+        Name
+        <RequiredIndicator />
+      </Label>
+    );
+    expect(screen.getByText('*')).toHaveAttribute('aria-hidden', 'true');
+    expect(screen.getByText('(required)')).toHaveClass('sr-only');
+  });
+
+  it('announces the requirement even when the paired control has no required/aria-required', async () => {
+    const { container } = render(
+      <div>
+        <Label htmlFor="name">
+          Name
+          <RequiredIndicator />
+        </Label>
+        <Input id="name" />
+      </div>
+    );
+    expect(screen.getByLabelText(/Name\*?\s*\(required\)/)).toBeInTheDocument();
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
   });
 });

--- a/packages/apollo-wind/src/components/ui/label.tsx
+++ b/packages/apollo-wind/src/components/ui/label.tsx
@@ -23,4 +23,28 @@ const Label = React.forwardRef<React.ElementRef<typeof LabelPrimitive.Root>, Lab
 );
 Label.displayName = LabelPrimitive.Root.displayName;
 
-export { Label };
+export interface RequiredIndicatorProps
+  extends Omit<React.HTMLAttributes<HTMLSpanElement>, 'children' | 'aria-hidden'> {}
+
+/**
+ * Marks a field as required. Place it right after the label text.
+ *
+ * Uses `text-current` rather than an error/destructive color: an untouched
+ * required field isn't in an error state, so coloring the asterisk red reads
+ * as a validation failure before the person has done anything. The asterisk
+ * glyph is `aria-hidden` since it's a visual affordance, not the thing that
+ * makes the field required to assistive tech; a `sr-only` "(required)" is
+ * included alongside it so the label still announces the requirement even if
+ * the field's own control is missing `required`/`aria-required`.
+ */
+const RequiredIndicator = React.forwardRef<HTMLSpanElement, RequiredIndicatorProps>(
+  ({ className, ...props }, ref) => (
+    <span ref={ref} {...props} className={cn('ml-0.5 text-current', className)}>
+      <span aria-hidden="true">*</span>
+      <span className="sr-only"> (required)</span>
+    </span>
+  )
+);
+RequiredIndicator.displayName = 'RequiredIndicator';
+
+export { Label, RequiredIndicator };

--- a/packages/apollo-wind/src/components/ui/lockable-value-field/components/field-header.tsx
+++ b/packages/apollo-wind/src/components/ui/lockable-value-field/components/field-header.tsx
@@ -8,7 +8,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
-import { Label } from '@/components/ui/label';
+import { Label, RequiredIndicator } from '@/components/ui/label';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { Switch } from '@/components/ui/switch';
 import { Textarea } from '@/components/ui/textarea';
@@ -65,7 +65,7 @@ export function FieldHeader({
       {label ?? (
         <Label htmlFor={fieldId} className="text-xs font-medium text-foreground-muted">
           {fieldLabel}
-          {required && <span className="ml-0.5 text-destructive">*</span>}
+          {required && <RequiredIndicator />}
         </Label>
       )}
       <TooltipProvider delayDuration={300}>

--- a/packages/apollo-wind/src/components/ui/lockable-value-field/lockable-value-field.stories.tsx
+++ b/packages/apollo-wind/src/components/ui/lockable-value-field/lockable-value-field.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { X } from 'lucide-react';
 import { useId, useRef, useState } from 'react';
 import { cn } from '@/lib';
-import { Label } from '../label';
+import { Label, RequiredIndicator } from '../label';
 import { ToggleGroup, ToggleGroupItem } from '../toggle-group';
 import { LockableValueField } from './lockable-value-field';
 import { FIELD_TYPE_META, type LockableFieldType, type LockableValueFieldMode } from './types';
@@ -93,7 +93,7 @@ function DefaultDemo() {
         label={
           <Label htmlFor={fieldId} className="text-xs font-medium text-foreground-muted">
             Label
-            {required && <span className="ml-0.5 text-destructive">*</span>}
+            {required && <RequiredIndicator />}
           </Label>
         }
         headerActions={<CloseFieldButton controlsVisibility="visible" />}
@@ -179,7 +179,7 @@ function InlineEditableLabel({
       className="truncate rounded px-1 py-0.5 text-left text-xs font-medium text-foreground-muted transition hover:bg-surface-overlay hover:text-foreground"
     >
       {title}
-      {required && <span className="ml-0.5 text-destructive">*</span>}
+      {required && <RequiredIndicator />}
     </button>
   );
 }
@@ -269,7 +269,7 @@ function ResponsiveDemo() {
   const label = (fieldId: string) => (
     <Label htmlFor={fieldId} className="text-xs font-medium text-foreground-muted">
       Label
-      {required && <span className="ml-0.5 text-destructive">*</span>}
+      {required && <RequiredIndicator />}
     </Label>
   );
 

--- a/packages/apollo-wind/src/components/ui/prompt-editor/components/MarkdownPreview.tsx
+++ b/packages/apollo-wind/src/components/ui/prompt-editor/components/MarkdownPreview.tsx
@@ -36,8 +36,8 @@ const MARKDOWN_PREVIEW_STYLES = `
 .prompt-editor-preview th { font-weight: 600; background-color: var(--color-muted); }
 .prompt-editor-preview strong { font-weight: 700; }
 .prompt-editor-preview em { font-style: italic; }
-.prompt-editor-preview .token-pill { display: inline-flex; align-items: center; gap: 3px; height: 20px; padding: 0 4px; border-radius: 4px; font-size: 13px; line-height: 20px; vertical-align: middle; background: var(--color-primary-lighter); color: var(--color-foreground); }
-.prompt-editor-preview .token-pill svg { display: block; flex-shrink: 0; color: var(--color-primary); width: 14px; height: 14px; }
+.prompt-editor-preview .token-pill { display: inline-flex; align-items: center; gap: 3px; height: 20px; padding: 0 4px; border-radius: 4px; font-size: 13px; line-height: 20px; vertical-align: middle; background: var(--color-info-background); color: var(--color-info-text); }
+.prompt-editor-preview .token-pill svg { display: block; flex-shrink: 0; color: var(--color-info-icon); width: 14px; height: 14px; }
 `;
 
 export interface MarkdownPreviewProps {

--- a/packages/apollo-wind/src/components/ui/prompt-editor/prompt-editor.test.tsx
+++ b/packages/apollo-wind/src/components/ui/prompt-editor/prompt-editor.test.tsx
@@ -4,7 +4,12 @@ import { createRef, useState } from 'react';
 import { describe, expect, it, vi } from 'vitest';
 import { VARIABLE_DRAG_MIME } from './plugins/VariableDropPlugin';
 import { PromptEditor, type PromptEditorRef } from './prompt-editor';
-import type { PromptEditorAutoCompleteOption, PromptEditorMode, PromptEditorToken } from './types';
+import {
+  getPromptEditorTokenColors,
+  type PromptEditorAutoCompleteOption,
+  type PromptEditorMode,
+  type PromptEditorToken,
+} from './types';
 
 const OPTIONS: PromptEditorAutoCompleteOption[] = [
   { type: 'input', value: 'vars.firstName' },
@@ -12,6 +17,23 @@ const OPTIONS: PromptEditorAutoCompleteOption[] = [
 ];
 
 describe('PromptEditor', () => {
+  it('uses semantic info and error tokens for token colors', () => {
+    expect(getPromptEditorTokenColors()).toEqual({
+      valid: {
+        background: 'var(--color-info-background)',
+        border: 'var(--color-info-icon)',
+        text: 'var(--color-info-text)',
+        icon: 'var(--color-info-icon)',
+      },
+      invalid: {
+        background: 'var(--color-error-background)',
+        border: 'var(--color-error-icon)',
+        text: 'var(--color-error-text)',
+        icon: 'var(--color-error-icon)',
+      },
+    });
+  });
+
   describe('rendering', () => {
     it('renders an editable textbox with the given aria-label', () => {
       render(<PromptEditor ariaLabel="Prompt" />);

--- a/packages/apollo-wind/src/components/ui/prompt-editor/types.ts
+++ b/packages/apollo-wind/src/components/ui/prompt-editor/types.ts
@@ -77,14 +77,14 @@ export const getPromptEditorTokenColors = (): Record<
   PromptEditorTokenColorConfig
 > => ({
   valid: {
-    background: 'var(--color-primary-lighter)',
-    border: 'var(--color-primary)',
-    text: 'var(--color-foreground)',
-    icon: 'var(--color-primary)',
+    background: 'var(--color-info-background)',
+    border: 'var(--color-info-icon)',
+    text: 'var(--color-info-text)',
+    icon: 'var(--color-info-icon)',
   },
   invalid: {
     background: 'var(--color-error-background)',
-    border: 'var(--color-error)',
+    border: 'var(--color-error-icon)',
     text: 'var(--color-error-text)',
     icon: 'var(--color-error-icon)',
   },

--- a/packages/apollo-wind/src/index.ts
+++ b/packages/apollo-wind/src/index.ts
@@ -73,8 +73,8 @@ export type {
 export { Textarea } from './components/ui/textarea';
 export type { TextareaProps } from './components/ui/textarea';
 
-export { Label } from './components/ui/label';
-export type { LabelProps } from './components/ui/label';
+export { Label, RequiredIndicator } from './components/ui/label';
+export type { LabelProps, RequiredIndicatorProps } from './components/ui/label';
 
 export { Checkbox } from './components/ui/checkbox';
 export type { CheckboxProps } from './components/ui/checkbox';


### PR DESCRIPTION
## Summary
- Adds `RequiredIndicator` to apollo-wind's `Label` and migrates all 9 hand-rolled `text-destructive` asterisk usages (apollo-wind forms/lockable-value-field, apollo-react canvas NodePropertyPanel) to it. The asterisk now inherits the surrounding text color instead of red, since an untouched required field isn't in an error state, and is `aria-hidden` (pair with `required`/`aria-required` on the control). Documented with usage guidance on the Label Storybook docs page.
- Fixes variable/resource chips rendering in a neon cyan (`--color-primary-lighter` resolves to `#53eafd` in the dark/canvas theme) by swapping the prompt editor's "valid" token palette and ap-chat's resource chip to the info-color tokens, mirroring the fix already validated on `codex/fix-templates-part-3`.

<img width="959" height="510" alt="Screenshot 2026-08-26 at 6 25 50 PM" src="https://github.com/user-attachments/assets/ff437915-4890-4736-8113-d0346e884754" />
<img width="1005" height="534" alt="Screenshot 2026-08-26 at 6 40 08 PM" src="https://github.com/user-attachments/assets/05b115b0-abb3-457c-bafe-9997331cec8b" />
<img width="1004" height="594" alt="Screenshot 2026-08-26 at 6 26 03 PM" src="https://github.com/user-attachments/assets/ce4697b4-6cc0-47d4-975c-afd2e00da566" />
705d7d" />


## Test plan
- [x] `tsc --noEmit` passes for apollo-wind and apollo-react (rebuilt apollo-wind first so apollo-react picks up the new `RequiredIndicator` export)
- [x] Verified in Storybook (Future Dark theme): Label "Required" story shows the asterisk in the label's own color with 0 accessibility violations; Prompt Editor "With Tokens" story and the ap-chat Showcase mention-chip both render the muted info-background instead of neon cyan
- [ ] Visual regression / Chromatic (if applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)