### PR TITLE
feat(apollo-wind): unify field label styling and required indicator

### DIFF
--- a/packages/apollo-react/src/canvas/components/JsonTree/JsonContainerEditor.tsx
+++ b/packages/apollo-react/src/canvas/components/JsonTree/JsonContainerEditor.tsx
@@ -1,4 +1,4 @@
-import { cn } from '@uipath/apollo-wind';
+import { cn, FormFieldError } from '@uipath/apollo-wind';
 import { useState } from 'react';
 import { useSafeLingui } from '../../../i18n';
 import { EditorActions, EditorTextarea } from './EditorChrome';
@@ -89,7 +89,7 @@ export function JsonContainerEditor({
           })}
         />
       )}
-      {error && <p className="text-xs leading-4 text-error">{error}</p>}
+      <FormFieldError>{error}</FormFieldError>
       <EditorActions onApply={apply} onCancel={onCancel} />
     </div>
   );

--- a/packages/apollo-react/src/canvas/components/JsonTree/JsonTreeRow.tsx
+++ b/packages/apollo-react/src/canvas/components/JsonTree/JsonTreeRow.tsx
@@ -1,4 +1,4 @@
-import { cn } from '@uipath/apollo-wind';
+import { cn, RequiredIndicator } from '@uipath/apollo-wind';
 import { ChevronDown, CircleCheck, Copy, Pencil, WrapText } from 'lucide-react';
 import { createContext, type MouseEvent, type ReactNode, useContext } from 'react';
 import { useSafeLingui } from '../../../i18n';
@@ -336,18 +336,16 @@ export function JsonTreeRow({ node, depth }: { node: JsonTreeNode; depth: number
             {decoration.sublabel}
           </span>
         )}
-        {/* `*` is presentational; the sr-only span carries the semantic so
-            screen readers don't announce a bare asterisk. */}
+        {/* Explicit color: the row establishes none, so an inherited indicator
+            would fall back to black. `ml-0` because the row already gaps. */}
         {node.required && (
-          <span className="shrink-0 text-[10px] text-error">
-            <span aria-hidden="true">*</span>
-            <span className="sr-only">
-              {_({
-                id: 'canvas.json_value_panel.required_marker',
-                message: 'required',
-              })}
-            </span>
-          </span>
+          <RequiredIndicator
+            className="ml-0 shrink-0 text-[10px] text-foreground"
+            srLabel={_({
+              id: 'canvas.json_value_panel.required_marker',
+              message: 'required',
+            })}
+          />
         )}
         {isContainer ? (
           <>

--- a/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.stories.tsx
@@ -45,6 +45,9 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
   FIELD_TYPE_META,
+  FormField,
+  FormFieldDescription,
+  FormFieldLabel,
   HoverCard,
   HoverCardContent,
   HoverCardTrigger,
@@ -126,6 +129,7 @@ import {
 } from 'lucide-react';
 import type { CSSProperties, ReactElement, ReactNode } from 'react';
 import {
+  cloneElement,
   createContext,
   lazy,
   Suspense,
@@ -157,7 +161,6 @@ import { isJsonObject } from '../JsonTree';
 import { NodeIOView, type NodeIOViewTab } from '../NodeIOView';
 import { NodePropertyPanel } from './NodePropertyPanel';
 import { NodePropertyPanelLayout } from './NodePropertyPanelLayout';
-import { PanelField, PanelFieldLabel } from './PanelField';
 
 // @monaco-editor/react uses a CJS build without an `exports` field, which
 // causes Rolldown (Vite 8 production bundler) to resolve the default import as
@@ -707,7 +710,7 @@ function FullEditorStory() {
             </div>
             <TabsContent value="parameters" className="mt-0 flex min-h-0 flex-1 flex-col">
               <div className="flex shrink-0 items-center justify-between py-2 [padding-inline:var(--mf-content-inset,0.875rem)]">
-                <PanelFieldLabel className="leading-4">Path</PanelFieldLabel>
+                <FormFieldLabel className="leading-4">Path</FormFieldLabel>
                 <div className="flex items-center gap-0.5">
                   <button
                     type="button"
@@ -940,7 +943,7 @@ function CasePanel({
               setEditingTitle(true);
               setTimeout(() => titleRef.current?.select(), 0);
             }}
-            className="flex-1 truncate rounded px-1 py-0.5 text-left text-xs font-medium text-foreground transition hover:bg-surface-overlay"
+            className="flex min-w-0 flex-1 items-center rounded px-1 py-0.5 text-left text-xs font-medium text-foreground transition hover:bg-surface-overlay"
           >
             {caseTitle}
           </button>
@@ -967,7 +970,7 @@ function CasePanel({
         <>
           {/* Condition label + buttons */}
           <div className="flex items-center justify-between border-t border-border-subtle px-3 py-2">
-            <PanelFieldLabel className="leading-4">Condition</PanelFieldLabel>
+            <FormFieldLabel className="leading-4">Condition</FormFieldLabel>
             <div className="flex items-center gap-0.5">
               <button
                 type="button"
@@ -1358,6 +1361,7 @@ function InlineCaseRow({
       onModeChange={setMode}
       fieldType="string"
       variables={LOCKABLE_VARIABLES}
+      controlsVisibility="visible"
     />
   );
 }
@@ -2567,6 +2571,7 @@ function LockableCaseRow({
   fieldType,
   onFieldTypeChange,
   compact,
+  controlsVisibility,
   monacoTheme,
   insertBefore,
   insertAfter,
@@ -2586,6 +2591,7 @@ function LockableCaseRow({
   fieldType: LockableFieldType;
   onFieldTypeChange: (fieldType: LockableFieldType) => void;
   compact?: boolean;
+  controlsVisibility?: 'visible' | 'hover';
   monacoTheme: string;
   /** Shows the insertion line above this row (the dragged item would land here). */
   insertBefore?: boolean;
@@ -2649,10 +2655,14 @@ function LockableCaseRow({
                     setEditingTitle(true);
                     setTimeout(() => titleRef.current?.select(), 0);
                   }}
-                  className="truncate rounded px-1 py-0.5 text-left text-xs font-medium text-foreground transition hover:bg-surface-overlay"
+                  title={caseTitle}
+                  className="flex min-w-0 items-center rounded px-1 py-0.5 text-left text-xs font-medium text-foreground transition hover:bg-surface-overlay"
                 >
-                  {caseTitle}
-                  {required && <RequiredIndicator />}
+                  {/* Single-line header row, so the title ellipsizes. The
+                      indicator sits outside the truncated run so the ellipsis
+                      cannot swallow it. */}
+                  <span className="truncate">{caseTitle}</span>
+                  {required && <RequiredIndicator className="shrink-0" />}
                 </button>
               )}
             </div>
@@ -2663,9 +2673,13 @@ function LockableCaseRow({
               onClick={onDelete}
               aria-label="Delete field"
               title="Delete field"
-              className="grid size-6 shrink-0 place-items-center rounded text-foreground-subtle transition hover:bg-surface-overlay hover:text-foreground"
+              className={cn(
+                'grid size-6 shrink-0 place-items-center rounded text-foreground-subtle transition hover:bg-surface-overlay hover:text-foreground',
+                controlsVisibility === 'hover' &&
+                  'opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 has-[[aria-expanded=true]]:opacity-100'
+              )}
             >
-              <Trash2 size={12} />
+              <X size={12} />
             </button>
           }
           value={value}
@@ -2701,6 +2715,7 @@ function LockableCaseRow({
           onRequiredChange={onRequiredChange}
           variables={LOCKABLE_VARIABLES}
           compact={compact}
+          controlsVisibility={controlsVisibility}
         />
       </div>
       {insertAfter && (
@@ -2839,20 +2854,29 @@ function FieldDragOverlay({ caseItem }: { caseItem: LockableCase }) {
   const meta = FIELD_TYPE_META[caseItem.fieldType];
   return (
     <div
-      className="flex items-center gap-2 rounded-lg border border-border-subtle bg-surface-raised px-3 py-2 shadow-lg"
+      className="flex max-w-56 items-center gap-2 rounded-lg border border-border-subtle bg-surface-raised px-3 py-2 shadow-lg"
       style={{ cursor: 'grabbing' }}
     >
       <GripVertical size={12} className="shrink-0 text-foreground-subtle" />
       <meta.icon size={12} className="shrink-0 text-foreground-subtle" />
-      <span className="truncate text-xs font-medium text-foreground">
-        {caseItem.title}
-        {caseItem.required && <RequiredIndicator />}
+      <span
+        title={caseItem.title}
+        className="flex min-w-0 items-center text-xs font-medium text-foreground"
+      >
+        <span className="truncate">{caseItem.title}</span>
+        {caseItem.required && <RequiredIndicator className="shrink-0" />}
       </span>
     </div>
   );
 }
 
-function LockableValueFieldShowcase() {
+function LockableValueFieldShowcase({
+  controlsVisibility,
+  onControlsVisibilityChange,
+}: {
+  controlsVisibility: 'visible' | 'hover';
+  onControlsVisibilityChange: (visibility: 'visible' | 'hover') => void;
+}) {
   const fullViewId = useId();
   const compactViewId = useId();
   const [showcaseValue, setShowcaseValue] = useState('');
@@ -2874,7 +2898,8 @@ function LockableValueFieldShowcase() {
       <div className="flex flex-col gap-1">
         <span className="text-sm font-semibold text-foreground">Demo controls</span>
         <p className="text-xs leading-4 text-foreground-muted">
-          Uses component →{' '}
+          Toggle Show/Hide to preview how field controls behave in the panel on the left. Uses
+          component →{' '}
           <a
             href="/?path=/docs/apollo-wind-components-uipath-lockable-value-field--docs"
             target="_top"
@@ -2884,6 +2909,24 @@ function LockableValueFieldShowcase() {
           </a>
         </p>
       </div>
+      <div className="flex items-center justify-between border-t border-border-subtle pt-4">
+        <span className="text-[11px] font-medium uppercase tracking-wide text-foreground-subtle">
+          Controls
+        </span>
+        <ToggleGroup
+          type="single"
+          size="xs"
+          value={controlsVisibility}
+          onValueChange={(v) => v && onControlsVisibilityChange(v as 'visible' | 'hover')}
+        >
+          <ToggleGroupItem value="visible" className="!px-2.5 !text-xs">
+            Show
+          </ToggleGroupItem>
+          <ToggleGroupItem value="hover" className="!px-2.5 !text-xs">
+            Hide
+          </ToggleGroupItem>
+        </ToggleGroup>
+      </div>
       <div className="flex flex-col gap-2">
         <span className="text-[11px] font-medium uppercase tracking-wide text-foreground-subtle">
           Full view
@@ -2891,19 +2934,21 @@ function LockableValueFieldShowcase() {
         <LockableValueField
           id={fullViewId}
           label={
-            <PanelFieldLabel htmlFor={fullViewId} required={showcaseRequired} className="leading-4">
+            <FormFieldLabel htmlFor={fullViewId} required={showcaseRequired} className="leading-4">
               Label
-            </PanelFieldLabel>
+            </FormFieldLabel>
           }
           headerActions={
             <button
               type="button"
-              aria-label="Delete field"
-              title="Delete field"
-              disabled
-              className="grid size-7 shrink-0 place-items-center rounded-lg text-foreground-subtle transition hover:bg-surface-overlay hover:text-foreground disabled:pointer-events-none disabled:opacity-50"
+              aria-label="Close field"
+              className={cn(
+                'grid size-7 shrink-0 place-items-center rounded-lg text-foreground-subtle transition hover:bg-surface-overlay hover:text-foreground',
+                controlsVisibility === 'hover' &&
+                  'opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100 has-[[aria-expanded=true]]:opacity-100'
+              )}
             >
-              <Trash2 size={14} />
+              <X size={14} />
             </button>
           }
           value={showcaseValue}
@@ -2917,6 +2962,7 @@ function LockableValueFieldShowcase() {
           required={showcaseRequired}
           onRequiredChange={setShowcaseRequired}
           variables={LOCKABLE_VARIABLES}
+          controlsVisibility={controlsVisibility}
         />
       </div>
       <div className="flex flex-col gap-2 border-t border-border-subtle pt-4">
@@ -2927,23 +2973,25 @@ function LockableValueFieldShowcase() {
           <LockableValueField
             id={compactViewId}
             label={
-              <PanelFieldLabel
+              <FormFieldLabel
                 htmlFor={compactViewId}
                 required={showcaseRequired}
                 className="leading-4"
               >
                 Label
-              </PanelFieldLabel>
+              </FormFieldLabel>
             }
             headerActions={
               <button
                 type="button"
-                aria-label="Delete field"
-                title="Delete field"
-                disabled
-                className="grid size-7 shrink-0 place-items-center rounded-lg text-foreground-subtle transition hover:bg-surface-overlay hover:text-foreground disabled:pointer-events-none disabled:opacity-50"
+                aria-label="Close field"
+                className={cn(
+                  'grid size-7 shrink-0 place-items-center rounded-lg text-foreground-subtle transition hover:bg-surface-overlay hover:text-foreground',
+                  controlsVisibility === 'hover' &&
+                    'opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100 has-[[aria-expanded=true]]:opacity-100'
+                )}
               >
-                <Trash2 size={14} />
+                <X size={14} />
               </button>
             }
             value={showcaseValue}
@@ -2957,6 +3005,7 @@ function LockableValueFieldShowcase() {
             required={showcaseRequired}
             onRequiredChange={setShowcaseRequired}
             variables={LOCKABLE_VARIABLES}
+            controlsVisibility={controlsVisibility}
           />
         </div>
       </div>
@@ -2986,6 +3035,9 @@ export function QuickFormPanel({
   const [jsonDraft, setJsonDraft] = useState(() => JSON.stringify(DEFAULT_LOCKABLE_CASES, null, 2));
   const [jsonError, setJsonError] = useState<string | null>(null);
   const [jsonCopied, setJsonCopied] = useState(false);
+  const [showcaseControlsVisibility, setShowcaseControlsVisibility] = useState<'visible' | 'hover'>(
+    'visible'
+  );
   const [buttons, setButtons] = useState<FormButtonItem[]>(DEFAULT_FORM_BUTTONS);
   const nextButtonIdRef = useRef(3);
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -3139,7 +3191,7 @@ export function QuickFormPanel({
           {/* Quick form */}
           <div className="flex flex-col gap-2">
             <div className="flex items-center justify-between">
-              <span className="text-xs font-medium text-foreground-muted">Quick form</span>
+              <Label>Quick form</Label>
               <div className="flex items-center gap-2">
                 <Popover>
                   <TooltipProvider delayDuration={300}>
@@ -3305,6 +3357,7 @@ export function QuickFormPanel({
                                 onFieldTypeChange={(fieldType) =>
                                   updateCaseFieldType(c.id, fieldType)
                                 }
+                                controlsVisibility={showcaseControlsVisibility}
                                 monacoTheme={monacoTheme}
                                 insertBefore={isOver && activeIndex > index}
                                 insertAfter={isOver && activeIndex < index}
@@ -3411,7 +3464,10 @@ export function QuickFormPanel({
     <div className="flex items-start gap-8">
       <PanelFrame>{panel}</PanelFrame>
 
-      <LockableValueFieldShowcase />
+      <LockableValueFieldShowcase
+        controlsVisibility={showcaseControlsVisibility}
+        onControlsVisibilityChange={setShowcaseControlsVisibility}
+      />
     </div>
   );
 }
@@ -3430,10 +3486,15 @@ function InventoryField({
   description?: string;
   children: ReactElement;
 }) {
+  const generatedId = useId();
+  const controlId = children.props.id ?? generatedId;
+  const descriptionId = description ? `${controlId}-description` : undefined;
   return (
-    <PanelField label={label} description={description}>
-      {children}
-    </PanelField>
+    <FormField>
+      <FormFieldLabel htmlFor={controlId}>{label}</FormFieldLabel>
+      {cloneElement(children, { id: controlId, 'aria-describedby': descriptionId })}
+      <FormFieldDescription id={descriptionId}>{description}</FormFieldDescription>
+    </FormField>
   );
 }
 
@@ -3568,11 +3629,11 @@ function InventorySubContainer({
             </InventoryField>
             <InventoryField label="Processing mode">
               <RadioGroup defaultValue="automatic" className="grid gap-2">
-                <Label className="flex items-center gap-2 font-normal">
+                <Label variant="muted" className="flex items-center gap-2">
                   <RadioGroupItem value="automatic" />
                   Automatic
                 </Label>
-                <Label className="flex items-center gap-2 font-normal">
+                <Label variant="muted" className="flex items-center gap-2">
                   <RadioGroupItem value="manual" />
                   Manual review
                 </Label>
@@ -3584,14 +3645,12 @@ function InventorySubContainer({
                 checked={checked}
                 onCheckedChange={(value) => setChecked(value === true)}
               />
-              <Label htmlFor="sub-container-save-output" className="text-xs">
+              <Label variant="muted" htmlFor="sub-container-save-output">
                 Save output for later steps
               </Label>
             </div>
             <div className="flex items-center justify-between gap-4">
-              <Label htmlFor="sub-container-enabled" className="text-xs">
-                Enabled
-              </Label>
+              <Label htmlFor="sub-container-enabled">Enabled</Label>
               <Switch id="sub-container-enabled" checked={enabled} onCheckedChange={setEnabled} />
             </div>
             <InventoryField label="Confidence threshold" description="Current value: 75%">
@@ -3841,9 +3900,7 @@ function PanelUIInventoryStory() {
                     </InventoryField>
                     <div className="flex items-center justify-between gap-4">
                       <div>
-                        <Label htmlFor="flat-pattern-enabled" className="text-xs">
-                          Enabled
-                        </Label>
+                        <Label htmlFor="flat-pattern-enabled">Enabled</Label>
                         <p className="text-xs text-foreground-muted">
                           Run this node in the workflow.
                         </p>
@@ -3909,11 +3966,11 @@ function PanelUIInventoryStory() {
                       </InventoryField>
                       <InventoryField label="Processing mode">
                         <RadioGroup defaultValue="automatic" className="grid gap-2">
-                          <Label className="flex items-center gap-2 font-normal">
+                          <Label variant="muted" className="flex items-center gap-2">
                             <RadioGroupItem value="automatic" />
                             Automatic
                           </Label>
-                          <Label className="flex items-center gap-2 font-normal">
+                          <Label variant="muted" className="flex items-center gap-2">
                             <RadioGroupItem value="manual" />
                             Manual review
                           </Label>
@@ -3926,9 +3983,7 @@ function PanelUIInventoryStory() {
                           onCheckedChange={(value) => setChecked(value === true)}
                         />
                         <div className="grid gap-0.5">
-                          <Label htmlFor="save-output" className="text-xs">
-                            Save output to storage
-                          </Label>
+                          <Label htmlFor="save-output">Save output to storage</Label>
                           <p className="text-xs text-foreground-muted">
                             Makes the result available to later steps.
                           </p>
@@ -3936,9 +3991,7 @@ function PanelUIInventoryStory() {
                       </div>
                       <div className="flex items-center justify-between gap-4">
                         <div>
-                          <Label htmlFor="enabled-switch" className="text-xs">
-                            Enabled
-                          </Label>
+                          <Label htmlFor="enabled-switch">Enabled</Label>
                           <p className="text-xs text-foreground-muted">
                             Run this node in the workflow.
                           </p>
@@ -4305,13 +4358,13 @@ function PanelUIInventoryStory() {
                     <LockableValueField
                       id={compositionFieldId}
                       label={
-                        <PanelFieldLabel
+                        <FormFieldLabel
                           htmlFor={compositionFieldId}
                           required={compositionRequired}
                           className="leading-4"
                         >
                           Invoice value
-                        </PanelFieldLabel>
+                        </FormFieldLabel>
                       }
                       headerActions={
                         <CanvasTooltip content="Remove field">
@@ -4331,6 +4384,7 @@ function PanelUIInventoryStory() {
                       required={compositionRequired}
                       onRequiredChange={setCompositionRequired}
                       variables={LOCKABLE_VARIABLES}
+                      controlsVisibility="visible"
                     />
                   </section>
                 </div>
@@ -4467,7 +4521,7 @@ function CompactResponsivePanelStory() {
             <TabsContent
               key={step.id}
               value={step.id}
-              className="mt-0 min-h-0 flex-1 overflow-y-auto [&_[data-slot=form-description]]:text-xs [&_[data-slot=form-description]]:leading-4 [&_[data-slot=form-description]]:text-foreground-muted [&_[data-slot=form-label]]:text-xs [&_[data-slot=form-label]]:font-medium [&_[data-slot=form-label]]:leading-4 [&_[data-slot=form-label]]:text-foreground"
+              className="mt-0 min-h-0 flex-1 overflow-y-auto"
             >
               <MetadataForm
                 schema={flatSchema}

--- a/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.tsx
+++ b/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.tsx
@@ -146,12 +146,7 @@ export function NodePropertyPanel({
         // the header. This wrapper is a height-filling flex column, NOT the
         // scroll container — the form's inset/padding move inside TabbedStepForm.
         <div className="flex min-h-0 flex-1 flex-col">
-          <div
-            className={cn(
-              'flex min-h-0 flex-1 flex-col [&_[data-slot=form-description]]:text-xs [&_[data-slot=form-description]]:leading-4 [&_[data-slot=form-description]]:text-foreground-muted [&_[data-slot=form-label]]:text-xs [&_[data-slot=form-label]]:font-medium [&_[data-slot=form-label]]:leading-4 [&_[data-slot=form-label]]:text-foreground',
-              SURFACE_REMAP
-            )}
-          >
+          <div className={cn('flex min-h-0 flex-1 flex-col', SURFACE_REMAP)}>
             <MetadataForm
               key={resetKey}
               schema={formSchema}
@@ -171,12 +166,7 @@ export function NodePropertyPanel({
         // Single-page schema: classic behavior — this wrapper scrolls the whole
         // form. No stepVariant: it only applies to step-based schemas.
         <div className="min-h-0 flex-1 overflow-auto">
-          <div
-            className={cn(
-              '[&_[data-slot=form-description]]:text-xs [&_[data-slot=form-description]]:leading-4 [&_[data-slot=form-description]]:text-foreground-muted [&_[data-slot=form-label]]:text-xs [&_[data-slot=form-label]]:font-medium [&_[data-slot=form-label]]:leading-4 [&_[data-slot=form-label]]:text-foreground',
-              SURFACE_REMAP
-            )}
-          >
+          <div className={SURFACE_REMAP}>
             <MetadataForm
               key={resetKey}
               schema={formSchema}

--- a/packages/apollo-react/src/canvas/components/NodePropertyPanel/PanelField.tsx
+++ b/packages/apollo-react/src/canvas/components/NodePropertyPanel/PanelField.tsx
@@ -1,4 +1,11 @@
-import { cn, Label, type LabelProps, RequiredIndicator } from '@uipath/apollo-wind';
+import {
+  cn,
+  FormFieldDescription,
+  FormFieldError,
+  Label,
+  type LabelProps,
+  RequiredIndicator,
+} from '@uipath/apollo-wind';
 import {
   cloneElement,
   forwardRef,
@@ -31,19 +38,20 @@ export interface PanelFieldProps {
 }
 
 export interface PanelFieldLabelProps extends LabelProps {
-  /** Displays the panel-standard required indicator after the label. */
+  /** Appends the panel-standard required indicator after the label text. */
   required?: boolean;
 }
 
-/** Panel-scoped label treatment for controls that own their field layout. */
+/**
+ * Panel-scoped label treatment for controls that own their field layout.
+ *
+ * @deprecated Use `FormFieldLabel` from `@uipath/apollo-wind`. It renders the
+ * same label and required indicator at the same size, so nothing
+ * panel-specific is lost. This wrapper will be removed in the next major.
+ */
 export const PanelFieldLabel = forwardRef<HTMLLabelElement, PanelFieldLabelProps>(
-  ({ children, className, required = false, ...props }, ref) => (
-    <Label
-      ref={ref}
-      data-slot="panel-field-label"
-      className={cn('text-xs font-medium text-foreground', className)}
-      {...props}
-    >
+  ({ children, required = false, ...props }, ref) => (
+    <Label ref={ref} data-slot="panel-field-label" {...props}>
       {children}
       {required && <RequiredIndicator />}
     </Label>
@@ -56,6 +64,15 @@ PanelFieldLabel.displayName = 'PanelFieldLabel';
  * PanelField standardizes the label, spacing, supporting text, and validation
  * treatment used by inputs inside a NodePropertyPanel. It composes existing
  * controls without changing their own size, styling, or behavior.
+ *
+ * @deprecated Compose `FormField`, `FormFieldLabel`, `FormFieldDescription`,
+ * and `FormFieldError` from `@uipath/apollo-wind` instead. Those are the same
+ * parts the metadata form renderer is built from, so a hand-built panel field
+ * and a manifest-driven one stay identical by construction.
+ *
+ * The one thing they do not do for you is the id and aria wiring below, so
+ * generate a control id and pass `aria-describedby` yourself. This wrapper
+ * will be removed in the next major.
  */
 export function PanelField({
   label,
@@ -87,24 +104,12 @@ export function PanelField({
         {label}
       </PanelFieldLabel>
       {control}
-      {description && (
-        <p
-          id={descriptionId}
-          data-slot="panel-field-description"
-          className="text-xs leading-4 text-foreground-muted"
-        >
-          {description}
-        </p>
-      )}
-      {error && (
-        <p
-          id={errorId}
-          data-slot="panel-field-error"
-          className="text-xs leading-4 text-destructive"
-        >
-          {error}
-        </p>
-      )}
+      <FormFieldDescription id={descriptionId} data-slot="panel-field-description">
+        {description}
+      </FormFieldDescription>
+      <FormFieldError id={errorId} data-slot="panel-field-error">
+        {error}
+      </FormFieldError>
     </div>
   );
 }

--- a/packages/apollo-react/src/canvas/components/StickyNoteNode/StickyNoteMediaDialog.tsx
+++ b/packages/apollo-react/src/canvas/components/StickyNoteNode/StickyNoteMediaDialog.tsx
@@ -135,13 +135,13 @@ export function StickyNoteMediaDialog({
               >
                 <div className="flex items-center gap-2">
                   <RadioGroupItem value="image" id={imageTypeId} />
-                  <Label htmlFor={imageTypeId}>
+                  <Label variant="muted" htmlFor={imageTypeId}>
                     {_({ id: 'sticky-note.media.dialog.image-option', message: 'Image' })}
                   </Label>
                 </div>
                 <div className="flex items-center gap-2">
                   <RadioGroupItem value="video" id={videoTypeId} />
-                  <Label htmlFor={videoTypeId}>
+                  <Label variant="muted" htmlFor={videoTypeId}>
                     {_({ id: 'sticky-note.media.dialog.video-option', message: 'Video' })}
                   </Label>
                 </div>
@@ -221,7 +221,7 @@ export function StickyNoteMediaDialog({
                 className="mt-0.5"
               />
               <div className="flex flex-col gap-0.5">
-                <Label htmlFor={fullWidthId} className="text-sm font-medium leading-none">
+                <Label htmlFor={fullWidthId}>
                   {_({
                     id: 'sticky-note.media.dialog.full-width-label',
                     message: 'Make full width',

--- a/packages/apollo-wind/src/components/forms/field-renderer.tsx
+++ b/packages/apollo-wind/src/components/forms/field-renderer.tsx
@@ -1,17 +1,19 @@
-import React, { useEffect, useState, useMemo, useRef } from 'react';
-import { useFormContext, Controller } from 'react-hook-form';
-import type {
-  FieldMetadata,
-  FormContext,
-  FieldOption,
-  CustomFieldComponentProps,
-  SliderFieldMetadata,
-} from './form-schema';
-import { hasOptions, isCustomField } from './form-schema';
-import { RulesEngine } from './rules-engine';
-import { DataFetcher } from './data-fetcher';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { Controller, useFormContext } from 'react-hook-form';
+import { Checkbox } from '@/components/ui/checkbox';
+import { DatePicker } from '@/components/ui/date-picker';
+import { DateTimePicker } from '@/components/ui/datetime-picker';
+import { FileUpload } from '@/components/ui/file-upload';
+import {
+  FormField,
+  FormFieldDescription,
+  FormFieldError,
+  FormFieldLabel,
+} from '@/components/ui/form-field';
 import { Input } from '@/components/ui/input';
-import { Textarea } from '@/components/ui/textarea';
+import { Label } from '@/components/ui/label';
+import { MultiSelect } from '@/components/ui/multi-select';
+import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
 import {
   Select,
   SelectContent,
@@ -19,16 +21,20 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
-import { MultiSelect } from '@/components/ui/multi-select';
-import { Checkbox } from '@/components/ui/checkbox';
-import { Switch } from '@/components/ui/switch';
-import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
 import { Slider } from '@/components/ui/slider';
-import { Label, RequiredIndicator } from '@/components/ui/label';
-import { DatePicker } from '@/components/ui/date-picker';
-import { DateTimePicker } from '@/components/ui/datetime-picker';
-import { FileUpload } from '@/components/ui/file-upload';
-import { cn, deepEqual } from '@/lib';
+import { Switch } from '@/components/ui/switch';
+import { Textarea } from '@/components/ui/textarea';
+import { deepEqual } from '@/lib';
+import { DataFetcher } from './data-fetcher';
+import type {
+  CustomFieldComponentProps,
+  FieldMetadata,
+  FieldOption,
+  FormContext,
+  SliderFieldMetadata,
+} from './form-schema';
+import { hasOptions, isCustomField } from './form-schema';
+import { RulesEngine } from './rules-engine';
 
 /**
  * Field Renderer - Connects metadata to actual UI components
@@ -328,7 +334,7 @@ function FieldByType({ field, formField, error, disabled, required, options }: F
     case 'email':
       return (
         <FormField>
-          <FormLabel required={required}>{field.label}</FormLabel>
+          <FormFieldLabel required={required}>{field.label}</FormFieldLabel>
           <Input
             value={formField.value as string | undefined}
             onChange={(e) => formField.onChange(e.target.value)}
@@ -340,15 +346,15 @@ function FieldByType({ field, formField, error, disabled, required, options }: F
             disabled={disabled}
             aria-label={field.ariaLabel}
           />
-          <FormDescription>{field.description}</FormDescription>
-          <FormError>{error}</FormError>
+          <FormFieldDescription>{field.description}</FormFieldDescription>
+          <FormFieldError>{error}</FormFieldError>
         </FormField>
       );
 
     case 'number':
       return (
         <FormField>
-          <FormLabel required={required}>{field.label}</FormLabel>
+          <FormFieldLabel required={required}>{field.label}</FormFieldLabel>
           <Input
             value={formField.value as number | undefined}
             onBlur={formField.onBlur}
@@ -362,15 +368,15 @@ function FieldByType({ field, formField, error, disabled, required, options }: F
             disabled={disabled}
             onChange={(e) => formField.onChange(parseFloat(e.target.value))}
           />
-          <FormDescription>{field.description}</FormDescription>
-          <FormError>{error}</FormError>
+          <FormFieldDescription>{field.description}</FormFieldDescription>
+          <FormFieldError>{error}</FormFieldError>
         </FormField>
       );
 
     case 'textarea':
       return (
         <FormField>
-          <FormLabel required={required}>{field.label}</FormLabel>
+          <FormFieldLabel required={required}>{field.label}</FormFieldLabel>
           <Textarea
             value={formField.value as string | undefined}
             onChange={(e) => formField.onChange(e.target.value)}
@@ -381,15 +387,15 @@ function FieldByType({ field, formField, error, disabled, required, options }: F
             disabled={disabled}
             rows={field.rows || 4}
           />
-          <FormDescription>{field.description}</FormDescription>
-          <FormError>{error}</FormError>
+          <FormFieldDescription>{field.description}</FormFieldDescription>
+          <FormFieldError>{error}</FormFieldError>
         </FormField>
       );
 
     case 'select':
       return (
         <FormField>
-          <FormLabel required={required}>{field.label}</FormLabel>
+          <FormFieldLabel required={required}>{field.label}</FormFieldLabel>
           <Select
             value={formField.value as string | undefined}
             onValueChange={formField.onChange}
@@ -410,15 +416,15 @@ function FieldByType({ field, formField, error, disabled, required, options }: F
               ))}
             </SelectContent>
           </Select>
-          <FormDescription>{field.description}</FormDescription>
-          <FormError>{error}</FormError>
+          <FormFieldDescription>{field.description}</FormFieldDescription>
+          <FormFieldError>{error}</FormFieldError>
         </FormField>
       );
 
     case 'multiselect':
       return (
         <FormField>
-          <FormLabel required={required}>{field.label}</FormLabel>
+          <FormFieldLabel required={required}>{field.label}</FormFieldLabel>
           <MultiSelect
             selected={(formField.value as string[]) || []}
             onChange={formField.onChange}
@@ -432,8 +438,8 @@ function FieldByType({ field, formField, error, disabled, required, options }: F
             searchPlaceholder="Search..."
             maxSelected={field.maxSelected}
           />
-          <FormDescription>{field.description}</FormDescription>
-          <FormError>{error}</FormError>
+          <FormFieldDescription>{field.description}</FormFieldDescription>
+          <FormFieldError>{error}</FormFieldError>
         </FormField>
       );
 
@@ -448,13 +454,13 @@ function FieldByType({ field, formField, error, disabled, required, options }: F
               id={field.name}
             />
             <div className="space-y-1 leading-none">
-              <FormLabel htmlFor={field.name} className="font-normal">
+              <FormFieldLabel htmlFor={field.name} className="font-normal">
                 {field.label}
-              </FormLabel>
-              <FormDescription>{field.description}</FormDescription>
+              </FormFieldLabel>
+              <FormFieldDescription>{field.description}</FormFieldDescription>
             </div>
           </div>
-          <FormError>{error}</FormError>
+          <FormFieldError>{error}</FormFieldError>
         </FormField>
       );
 
@@ -463,8 +469,8 @@ function FieldByType({ field, formField, error, disabled, required, options }: F
         <FormField>
           <div className="flex items-center justify-between">
             <div className="space-y-0.5">
-              <FormLabel>{field.label}</FormLabel>
-              <FormDescription>{field.description}</FormDescription>
+              <FormFieldLabel>{field.label}</FormFieldLabel>
+              <FormFieldDescription>{field.description}</FormFieldDescription>
             </div>
             <Switch
               checked={formField.value === true}
@@ -472,14 +478,14 @@ function FieldByType({ field, formField, error, disabled, required, options }: F
               disabled={disabled}
             />
           </div>
-          <FormError>{error}</FormError>
+          <FormFieldError>{error}</FormFieldError>
         </FormField>
       );
 
     case 'radio':
       return (
         <FormField>
-          <FormLabel required={required}>{field.label}</FormLabel>
+          <FormFieldLabel required={required}>{field.label}</FormFieldLabel>
           <RadioGroup
             value={formField.value as string | null | undefined}
             onValueChange={formField.onChange}
@@ -492,12 +498,14 @@ function FieldByType({ field, formField, error, disabled, required, options }: F
                   id={`${field.name}-${option.value}`}
                   disabled={'disabled' in option ? Boolean(option.disabled) : false}
                 />
-                <Label htmlFor={`${field.name}-${option.value}`}>{option.label}</Label>
+                <Label variant="muted" htmlFor={`${field.name}-${option.value}`}>
+                  {option.label}
+                </Label>
               </div>
             ))}
           </RadioGroup>
-          <FormDescription>{field.description}</FormDescription>
-          <FormError>{error}</FormError>
+          <FormFieldDescription>{field.description}</FormFieldDescription>
+          <FormFieldError>{error}</FormFieldError>
         </FormField>
       );
 
@@ -515,22 +523,22 @@ function FieldByType({ field, formField, error, disabled, required, options }: F
     case 'date':
       return (
         <FormField>
-          <FormLabel required={required}>{field.label}</FormLabel>
+          <FormFieldLabel required={required}>{field.label}</FormFieldLabel>
           <DatePicker
             value={formField.value as Date | undefined}
             onValueChange={formField.onChange}
             disabled={disabled}
             placeholder={field.placeholder}
           />
-          <FormDescription>{field.description}</FormDescription>
-          <FormError>{error}</FormError>
+          <FormFieldDescription>{field.description}</FormFieldDescription>
+          <FormFieldError>{error}</FormFieldError>
         </FormField>
       );
 
     case 'datetime':
       return (
         <FormField>
-          <FormLabel required={required}>{field.label}</FormLabel>
+          <FormFieldLabel required={required}>{field.label}</FormFieldLabel>
           <DateTimePicker
             value={formField.value as Date | undefined}
             onValueChange={formField.onChange}
@@ -538,15 +546,15 @@ function FieldByType({ field, formField, error, disabled, required, options }: F
             placeholder={field.placeholder}
             use12Hour={field.use12Hour}
           />
-          <FormDescription>{field.description}</FormDescription>
-          <FormError>{error}</FormError>
+          <FormFieldDescription>{field.description}</FormFieldDescription>
+          <FormFieldError>{error}</FormFieldError>
         </FormField>
       );
 
     case 'file':
       return (
         <FormField>
-          <FormLabel required={required}>{field.label}</FormLabel>
+          <FormFieldLabel required={required}>{field.label}</FormFieldLabel>
           <FileUpload
             accept={field.accept}
             multiple={field.multiple}
@@ -557,8 +565,8 @@ function FieldByType({ field, formField, error, disabled, required, options }: F
               formField.onChange(field.multiple ? files : files[0]);
             }}
           />
-          <FormDescription>{field.description}</FormDescription>
-          <FormError>{error}</FormError>
+          <FormFieldDescription>{field.description}</FormFieldDescription>
+          <FormFieldError>{error}</FormFieldError>
         </FormField>
       );
 
@@ -570,53 +578,6 @@ function FieldByType({ field, formField, error, disabled, required, options }: F
 // ============================================================================
 // Form Field Wrapper Components
 // ============================================================================
-
-function FormField({
-  children,
-  className = '',
-}: {
-  children: React.ReactNode;
-  className?: string;
-}) {
-  return (
-    <div data-slot="form-field" className={cn('grid gap-1.5', className)}>
-      {children}
-    </div>
-  );
-}
-
-function FormLabel({
-  children,
-  required,
-  htmlFor,
-  className = '',
-}: {
-  children?: React.ReactNode;
-  required?: boolean;
-  htmlFor?: string;
-  className?: string;
-}) {
-  return (
-    <Label data-slot="form-label" htmlFor={htmlFor} className={className}>
-      {children}
-      {required && <RequiredIndicator className="ml-1" />}
-    </Label>
-  );
-}
-
-function FormDescription({ children }: { children?: React.ReactNode }) {
-  if (!children) return null;
-  return (
-    <p data-slot="form-description" className="text-sm text-muted-foreground">
-      {children}
-    </p>
-  );
-}
-
-function FormError({ children }: { children?: React.ReactNode }) {
-  if (!children) return null;
-  return <p className="text-sm text-destructive">{children}</p>;
-}
 
 // ============================================================================
 // Slider field — extracted so it can subscribe to another form field via
@@ -664,7 +625,7 @@ function SliderField({ field, formField, error, disabled, required }: SliderFiel
   return (
     <FormField>
       <div className="flex justify-between">
-        <FormLabel required={required}>{field.label}</FormLabel>
+        <FormFieldLabel required={required}>{field.label}</FormFieldLabel>
         <span className="text-sm text-muted-foreground">{displayValue as React.ReactNode}</span>
       </div>
       <Slider
@@ -675,8 +636,8 @@ function SliderField({ field, formField, error, disabled, required }: SliderFiel
         step={field.step || 1}
         disabled={disabled}
       />
-      <FormDescription>{field.description}</FormDescription>
-      <FormError>{error}</FormError>
+      <FormFieldDescription>{field.description}</FormFieldDescription>
+      <FormFieldError>{error}</FormFieldError>
     </FormField>
   );
 }

--- a/packages/apollo-wind/src/components/ui/component-gallery.stories.tsx
+++ b/packages/apollo-wind/src/components/ui/component-gallery.stories.tsx
@@ -497,13 +497,13 @@ const components: ComponentInfo[] = [
       <RadioGroup defaultValue="option1" className="gap-2">
         <div className="flex items-center gap-2">
           <RadioGroupItem value="option1" id="rg-preview-1" />
-          <Label htmlFor="rg-preview-1" className="text-xs font-normal">
+          <Label variant="muted" htmlFor="rg-preview-1">
             Option 1
           </Label>
         </div>
         <div className="flex items-center gap-2">
           <RadioGroupItem value="option2" id="rg-preview-2" />
-          <Label htmlFor="rg-preview-2" className="text-xs font-normal">
+          <Label variant="muted" htmlFor="rg-preview-2">
             Option 2
           </Label>
         </div>

--- a/packages/apollo-wind/src/components/ui/form-field.test.tsx
+++ b/packages/apollo-wind/src/components/ui/form-field.test.tsx
@@ -1,0 +1,64 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { FormField, FormFieldDescription, FormFieldError, FormFieldLabel } from './form-field';
+
+describe('FormField', () => {
+  it('composes the field anatomy without any form context', () => {
+    render(
+      <FormField>
+        <FormFieldLabel htmlFor="endpoint" required>
+          Endpoint
+        </FormFieldLabel>
+        <input id="endpoint" />
+        <FormFieldDescription>The URL to call.</FormFieldDescription>
+        <FormFieldError>Endpoint is required.</FormFieldError>
+      </FormField>
+    );
+
+    expect(screen.getByLabelText(/Endpoint/)).toBeInTheDocument();
+    expect(screen.getByText('The URL to call.')).toBeInTheDocument();
+    expect(screen.getByText('Endpoint is required.')).toBeInTheDocument();
+  });
+});
+
+describe('FormFieldLabel', () => {
+  it('appends the required indicator', () => {
+    render(<FormFieldLabel required>Endpoint</FormFieldLabel>);
+    expect(screen.getByText('*')).toBeInTheDocument();
+  });
+
+  it('omits the indicator by default', () => {
+    render(<FormFieldLabel>Endpoint</FormFieldLabel>);
+    expect(screen.queryByText('*')).not.toBeInTheDocument();
+  });
+});
+
+describe('FormFieldDescription', () => {
+  it('matches the label size and muted color', () => {
+    render(<FormFieldDescription>The URL to call.</FormFieldDescription>);
+    expect(screen.getByText('The URL to call.')).toHaveClass(
+      'text-xs',
+      'leading-4',
+      'text-foreground-muted'
+    );
+  });
+
+  it('renders nothing without children', () => {
+    const { container } = render(<FormFieldDescription />);
+    expect(container).toBeEmptyDOMElement();
+  });
+});
+
+describe('FormFieldError', () => {
+  it('uses the error token and announces politely', () => {
+    render(<FormFieldError>Endpoint is required.</FormFieldError>);
+    const error = screen.getByText('Endpoint is required.');
+    expect(error).toHaveClass('text-xs', 'leading-4', 'text-error');
+    expect(error).toHaveAttribute('aria-live', 'polite');
+  });
+
+  it('renders nothing without children', () => {
+    const { container } = render(<FormFieldError />);
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/packages/apollo-wind/src/components/ui/form-field.tsx
+++ b/packages/apollo-wind/src/components/ui/form-field.tsx
@@ -1,0 +1,84 @@
+import * as React from 'react';
+
+import { Label, RequiredIndicator } from '@/components/ui/label';
+import { cn } from '@/lib/index';
+
+export type FormFieldProps = React.ComponentPropsWithoutRef<'div'>;
+
+/**
+ * Vertical field anatomy: label, control, supporting text, validation message.
+ *
+ * These parts are presentational and hold no form state, so they compose the
+ * same way inside a metadata-driven form as they do in hand-built panels.
+ */
+const FormField = React.forwardRef<HTMLDivElement, FormFieldProps>(
+  ({ children, className, ...props }, ref) => (
+    <div ref={ref} data-slot="form-field" className={cn('grid gap-1.5', className)} {...props}>
+      {children}
+    </div>
+  )
+);
+FormField.displayName = 'FormField';
+
+export interface FormFieldLabelProps extends React.ComponentPropsWithoutRef<typeof Label> {
+  /** Appends the required indicator after the label text. */
+  required?: boolean;
+}
+
+/** Names the field. Pair with a control via `htmlFor`. */
+const FormFieldLabel = React.forwardRef<HTMLLabelElement, FormFieldLabelProps>(
+  ({ children, required = false, ...props }, ref) => (
+    <Label ref={ref} data-slot="form-field-label" {...props}>
+      {children}
+      {required && <RequiredIndicator />}
+    </Label>
+  )
+);
+FormFieldLabel.displayName = 'FormFieldLabel';
+
+export type FormFieldDescriptionProps = React.ComponentPropsWithoutRef<'p'>;
+
+/** Supporting guidance rendered below a field control. */
+const FormFieldDescription = React.forwardRef<HTMLParagraphElement, FormFieldDescriptionProps>(
+  ({ children, className, ...props }, ref) => {
+    if (!children) return null;
+    return (
+      <p
+        ref={ref}
+        data-slot="form-field-description"
+        className={cn('text-xs leading-4 text-foreground-muted', className)}
+        {...props}
+      >
+        {children}
+      </p>
+    );
+  }
+);
+FormFieldDescription.displayName = 'FormFieldDescription';
+
+export type FormFieldErrorProps = React.ComponentPropsWithoutRef<'p'>;
+
+/**
+ * Validation message rendered below a field control. Uses the `error` token
+ * rather than `destructive`, which some themes resolve to a different color.
+ */
+const FormFieldError = React.forwardRef<HTMLParagraphElement, FormFieldErrorProps>(
+  ({ children, className, ...props }, ref) => {
+    if (!children) return null;
+    return (
+      <p
+        ref={ref}
+        data-slot="form-field-error"
+        aria-live="polite"
+        aria-atomic="true"
+        className={cn('text-xs leading-4 text-error', className)}
+        {...props}
+      >
+        {children}
+      </p>
+    );
+  }
+);
+FormFieldError.displayName = 'FormFieldError';
+
+export { FormField, FormFieldDescription, FormFieldError, FormFieldLabel };

--- a/packages/apollo-wind/src/components/ui/index.ts
+++ b/packages/apollo-wind/src/components/ui/index.ts
@@ -23,6 +23,7 @@ export * from './drawer';
 export * from './dropdown-menu';
 export * from './editable-cell';
 export * from './empty-state';
+export * from './form-field';
 export * from './file-upload';
 export * from './hover-card';
 export * from './input';

--- a/packages/apollo-wind/src/components/ui/input-group.tsx
+++ b/packages/apollo-wind/src/components/ui/input-group.tsx
@@ -4,6 +4,7 @@ import { Button, type ButtonProps } from '@/components/ui/button';
 import { Input, type InputProps } from '@/components/ui/input';
 import { Textarea, type TextareaProps } from '@/components/ui/textarea';
 import { cn } from '@/lib';
+import { FormFieldError } from './form-field';
 
 interface InputGroupValidationContextValue {
   error?: React.ReactNode;
@@ -53,17 +54,9 @@ const InputGroup = React.forwardRef<HTMLDivElement, InputGroupProps>(
           )}
           {...props}
         />
-        {error && (
-          <p
-            id={validationId}
-            data-slot="input-group-error"
-            aria-live="polite"
-            aria-atomic="true"
-            className="mt-1 text-xs leading-4 text-error"
-          >
-            {error}
-          </p>
-        )}
+        <FormFieldError id={validationId} data-slot="input-group-error" className="mt-1">
+          {error}
+        </FormFieldError>
       </InputGroupValidationContext.Provider>
     );
   }

--- a/packages/apollo-wind/src/components/ui/input.tsx
+++ b/packages/apollo-wind/src/components/ui/input.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { cn } from '@/lib/utils';
+import { FormFieldError } from './form-field';
 
 export interface InputProps extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 'size'> {
   variant?: 'default' | 'ghost';
@@ -64,17 +65,9 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
           )}
           ref={ref}
         />
-        {error && (
-          <p
-            id={validationId}
-            data-slot="input-error"
-            aria-live="polite"
-            aria-atomic="true"
-            className="mt-1 text-xs leading-4 text-error"
-          >
-            {error}
-          </p>
-        )}
+        <FormFieldError id={validationId} data-slot="input-error" className="mt-1">
+          {error}
+        </FormFieldError>
       </>
     );
   }

--- a/packages/apollo-wind/src/components/ui/label.stories.tsx
+++ b/packages/apollo-wind/src/components/ui/label.stories.tsx
@@ -1,6 +1,8 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { FormFieldDescription } from '../..';
 import { Input } from './input';
 import { Label, RequiredIndicator } from './label';
+import { RadioGroup, RadioGroupItem } from './radio-group';
 
 const meta = {
   title: 'Components/Core/Label',
@@ -29,12 +31,13 @@ export const WithInput = {
   ),
 } satisfies Story;
 
+/** The required indicator inherits the label color, so it reads as an attribute of the field. */
 export const Required = {
   render: () => (
     <div className="grid w-full max-w-sm items-center gap-1.5">
       <Label htmlFor="required">
-        {'Username'}
-        <RequiredIndicator className="ml-0" />
+        Username
+        <RequiredIndicator />
       </Label>
       <Input id="required" required placeholder="Enter username" />
     </div>
@@ -56,12 +59,83 @@ export const Required = {
   },
 } satisfies Story;
 
+/**
+ * `default` names the field itself. Use it whenever the label names the whole
+ * field, including one driven by a single switch or checkbox.
+ *
+ * `muted` de-emphasizes a label that names one option among several inside a
+ * field, such as a radio or checkbox option.
+ */
+export const Variants = {
+  render: () => (
+    <div className="grid w-full max-w-sm gap-4">
+      <div className="grid gap-1.5">
+        <Label htmlFor="variant-default">
+          Notification email
+          <RequiredIndicator />
+        </Label>
+        <Input id="variant-default" placeholder="you@example.com" />
+      </div>
+      <div className="grid gap-1.5">
+        <Label>Delivery frequency</Label>
+        <RadioGroup defaultValue="daily" className="grid gap-2">
+          <div className="flex items-center gap-2">
+            <RadioGroupItem value="daily" id="variant-daily" />
+            <Label variant="muted" htmlFor="variant-daily">
+              Daily digest
+            </Label>
+          </div>
+          <div className="flex items-center gap-2">
+            <RadioGroupItem value="weekly" id="variant-weekly" />
+            <Label variant="muted" htmlFor="variant-weekly">
+              Weekly summary
+            </Label>
+          </div>
+        </RadioGroup>
+      </div>
+    </div>
+  ),
+} satisfies Story;
+
 export const WithDescription = {
   render: () => (
     <div className="grid w-full max-w-sm items-center gap-1.5">
       <Label htmlFor="password">Password</Label>
       <Input type="password" id="password" />
-      <p className="text-sm text-muted-foreground">Must be at least 8 characters long</p>
+      <FormFieldDescription>Must be at least 8 characters long</FormFieldDescription>
+    </div>
+  ),
+} satisfies Story;
+
+/**
+ * Long labels wrap. Do not put `truncate` on the label itself: the required
+ * indicator shares the ellipsized run, so a long label hides it.
+ *
+ * Where a single-line row genuinely cannot grow, make the label a flex
+ * container and truncate the text alone, as the second example does. Pair that
+ * with `title`, since clipped text is otherwise unreadable.
+ */
+export const LongText = {
+  render: () => (
+    <div className="grid w-56 gap-4">
+      <div className="grid gap-1.5">
+        <Label htmlFor="wrapping">
+          Conversation identifier from the previous step
+          <RequiredIndicator />
+        </Label>
+        <Input id="wrapping" placeholder="Wraps" />
+      </div>
+      <div className="grid gap-1.5">
+        <Label
+          htmlFor="constrained"
+          title="Conversation identifier from the previous step"
+          className="flex min-w-0 items-center"
+        >
+          <span className="truncate">Conversation identifier from the previous step</span>
+          <RequiredIndicator className="shrink-0" />
+        </Label>
+        <Input id="constrained" placeholder="Truncates the text only" />
+      </div>
     </div>
   ),
 } satisfies Story;

--- a/packages/apollo-wind/src/components/ui/label.test.tsx
+++ b/packages/apollo-wind/src/components/ui/label.test.tsx
@@ -13,7 +13,10 @@ describe('Label', () => {
   it('has no accessibility violations', async () => {
     const { container } = render(
       <div>
-        <Label htmlFor="username">Username</Label>
+        <Label htmlFor="username">
+          Username
+          <RequiredIndicator />
+        </Label>
         <Input id="username" />
       </div>
     );
@@ -21,10 +24,50 @@ describe('Label', () => {
     expect(results).toHaveNoViolations();
   });
 
-  it('applies base classes', () => {
+  it('applies the default treatment', () => {
     render(<Label>Email</Label>);
-    const label = screen.getByText('Email');
-    expect(label).toHaveClass('text-xs', 'font-medium');
+    expect(screen.getByText('Email')).toHaveClass('text-xs', 'font-medium', 'text-foreground');
+  });
+
+  it('applies the muted treatment for labels that name a single option', () => {
+    render(<Label variant="muted">Email me updates</Label>);
+    expect(screen.getByText('Email me updates')).toHaveClass(
+      'text-xs',
+      'font-normal',
+      'text-foreground-muted'
+    );
+  });
+
+  it('keeps both variants on one type scale', () => {
+    const { rerender } = render(<Label>Label</Label>);
+    expect(screen.getByText('Label')).toHaveClass('text-xs');
+    rerender(<Label variant="muted">Label</Label>);
+    expect(screen.getByText('Label')).toHaveClass('text-xs');
+  });
+
+  it('exposes the variant so consumers can target it', () => {
+    const { rerender } = render(<Label>Endpoint</Label>);
+    expect(screen.getByText('Endpoint')).toHaveAttribute('data-variant', 'default');
+    rerender(<Label variant="muted">Endpoint</Label>);
+    expect(screen.getByText('Endpoint')).toHaveAttribute('data-variant', 'muted');
+  });
+
+  it('renders children verbatim so callers can truncate the text alone', () => {
+    render(
+      <Label>
+        <span className="truncate">Endpoint</span>
+        <RequiredIndicator />
+      </Label>
+    );
+
+    const text = screen.getByText('Endpoint');
+    expect(text).toHaveClass('truncate');
+    expect(text).not.toContainElement(screen.getByText('*'));
+  });
+
+  it('adds no indicator of its own', () => {
+    render(<Label>Email</Label>);
+    expect(screen.queryByText('*')).not.toBeInTheDocument();
   });
 
   it('accepts htmlFor attribute', () => {
@@ -37,6 +80,11 @@ describe('Label', () => {
     expect(screen.getByText('Custom')).toHaveClass('custom-label');
   });
 
+  it('lets callers rename the slot they are targeted by', () => {
+    const { container } = render(<Label data-slot="panel-field-label">Email</Label>);
+    expect(container.querySelector('[data-slot="panel-field-label"]')).not.toBeNull();
+  });
+
   it('forwards ref correctly', () => {
     const ref = { current: null };
     render(<Label ref={ref}>Label</Label>);
@@ -45,6 +93,19 @@ describe('Label', () => {
 });
 
 describe('RequiredIndicator', () => {
+  it('takes the foreground color rather than an error color', () => {
+    render(
+      <Label htmlFor="name">
+        Name
+        <RequiredIndicator />
+      </Label>
+    );
+    const indicator = screen.getByText('*').parentElement;
+    expect(indicator).toHaveClass('text-foreground');
+    expect(indicator).not.toHaveClass('text-destructive');
+    expect(indicator).not.toHaveClass('text-error');
+  });
+
   it('hides the asterisk glyph from assistive tech but announces it via sr-only text', () => {
     render(
       <Label htmlFor="name">
@@ -54,6 +115,17 @@ describe('RequiredIndicator', () => {
     );
     expect(screen.getByText('*')).toHaveAttribute('aria-hidden', 'true');
     expect(screen.getByText('(required)')).toHaveClass('sr-only');
+  });
+
+  it('lets a localized surface supply its own announced text', () => {
+    render(
+      <Label htmlFor="name">
+        Name
+        <RequiredIndicator srLabel="requis" />
+      </Label>
+    );
+    expect(screen.getByText('requis')).toHaveClass('sr-only');
+    expect(screen.queryByText('(required)')).not.toBeInTheDocument();
   });
 
   it('announces the requirement even when the paired control has no required/aria-required', async () => {

--- a/packages/apollo-wind/src/components/ui/label.tsx
+++ b/packages/apollo-wind/src/components/ui/label.tsx
@@ -4,19 +4,44 @@ import * as React from 'react';
 
 import { cn } from '@/lib/index';
 
-const labelVariants = cva(
-  'text-xs font-medium peer-disabled:cursor-not-allowed peer-disabled:opacity-70'
-);
+const labelVariants = cva('text-xs peer-disabled:cursor-not-allowed peer-disabled:opacity-70', {
+  variants: {
+    variant: {
+      /** Names a field: the header above an input, select, or editor. */
+      default: 'font-medium text-foreground',
+      /** De-emphasized, for a label that names one option inside a field. */
+      muted: 'font-normal text-foreground-muted',
+    },
+  },
+  defaultVariants: {
+    variant: 'default',
+  },
+});
 
-export type LabelProps = React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root> &
-  VariantProps<typeof labelVariants>;
+/** Variant props, for consumers that forward a variant through to `Label`. */
+export type LabelVariants = VariantProps<typeof labelVariants>;
 
+export type LabelProps = React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root> & LabelVariants;
+
+/**
+ * Compose `RequiredIndicator` as the last child to mark a field required.
+ *
+ * Long labels wrap. Do not ellipsize one with `truncate`: the indicator shares
+ * the label's inline run, so the ellipsis swallows it, and a clipped field name
+ * is unreadable anyway.
+ *
+ * `data-variant` exposes the variant so a container can restyle every label of
+ * one kind at once rather than reaching for each slot by name. Target it as
+ * `label[data-variant=default]`: callers rename `data-slot`, and `data-variant`
+ * alone is a convention other components share.
+ */
 const Label = React.forwardRef<React.ElementRef<typeof LabelPrimitive.Root>, LabelProps>(
-  ({ className, ...props }, ref) => (
+  ({ className, variant = 'default', ...props }, ref) => (
     <LabelPrimitive.Root
       ref={ref}
       data-slot="label"
-      className={cn(labelVariants(), className)}
+      data-variant={variant}
+      className={cn(labelVariants({ variant }), className)}
       {...props}
     />
   )
@@ -24,7 +49,13 @@ const Label = React.forwardRef<React.ElementRef<typeof LabelPrimitive.Root>, Lab
 Label.displayName = LabelPrimitive.Root.displayName;
 
 export interface RequiredIndicatorProps
-  extends Omit<React.HTMLAttributes<HTMLSpanElement>, 'children' | 'aria-hidden'> {}
+  extends Omit<React.HTMLAttributes<HTMLSpanElement>, 'children' | 'aria-hidden'> {
+  /**
+   * Visually hidden text announced in place of the asterisk. apollo-wind ships
+   * no i18n, so localized consumers pass their own translated string here.
+   */
+  srLabel?: string;
+}
 
 /**
  * Marks a field as required. Place it right after the label text.
@@ -35,13 +66,14 @@ export interface RequiredIndicatorProps
  * glyph is `aria-hidden` since it's a visual affordance, not the thing that
  * makes the field required to assistive tech; a `sr-only` "(required)" is
  * included alongside it so the label still announces the requirement even if
- * the field's own control is missing `required`/`aria-required`.
+ * the field's own control is missing `required`/`aria-required`. That text is
+ * English by default; pass `srLabel` to localize it.
  */
 const RequiredIndicator = React.forwardRef<HTMLSpanElement, RequiredIndicatorProps>(
-  ({ className, ...props }, ref) => (
+  ({ className, srLabel = ' (required)', ...props }, ref) => (
     <span ref={ref} {...props} className={cn('ml-0.5', className, 'text-foreground')}>
       <span aria-hidden="true">*</span>
-      <span className="sr-only"> (required)</span>
+      <span className="sr-only">{srLabel}</span>
     </span>
   )
 );

--- a/packages/apollo-wind/src/components/ui/lockable-value-field/lockable-value-field.tsx
+++ b/packages/apollo-wind/src/components/ui/lockable-value-field/lockable-value-field.tsx
@@ -7,6 +7,7 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { FileUpload } from '@/components/ui/file-upload';
+import { FormFieldError } from '@/components/ui/form-field';
 import { Input } from '@/components/ui/input';
 import {
   InputGroup,
@@ -350,16 +351,10 @@ export function LockableValueField({
         </div>
       )}
 
-      {error && !typeMeta.supportsExpression && (
-        <p
-          id={validationId}
-          data-slot="lockable-value-field-error"
-          aria-live="polite"
-          aria-atomic="true"
-          className="mt-1 text-xs leading-4 text-error"
-        >
+      {!typeMeta.supportsExpression && (
+        <FormFieldError id={validationId} data-slot="lockable-value-field-error" className="mt-1">
           {error}
-        </p>
+        </FormFieldError>
       )}
 
       {belowValue}

--- a/packages/apollo-wind/src/components/ui/radio-group.stories.tsx
+++ b/packages/apollo-wind/src/components/ui/radio-group.stories.tsx
@@ -17,15 +17,21 @@ export const Default = {
     <RadioGroup defaultValue="comfortable">
       <Row gap={2} align="center">
         <RadioGroupItem value="default" id="r1" />
-        <Label htmlFor="r1">Default</Label>
+        <Label variant="muted" htmlFor="r1">
+          Default
+        </Label>
       </Row>
       <Row gap={2} align="center">
         <RadioGroupItem value="comfortable" id="r2" />
-        <Label htmlFor="r2">Comfortable</Label>
+        <Label variant="muted" htmlFor="r2">
+          Comfortable
+        </Label>
       </Row>
       <Row gap={2} align="center">
         <RadioGroupItem value="compact" id="r3" />
-        <Label htmlFor="r3">Compact</Label>
+        <Label variant="muted" htmlFor="r3">
+          Compact
+        </Label>
       </Row>
     </RadioGroup>
   ),

--- a/packages/apollo-wind/src/index.ts
+++ b/packages/apollo-wind/src/index.ts
@@ -74,7 +74,20 @@ export { Textarea } from './components/ui/textarea';
 export type { TextareaProps } from './components/ui/textarea';
 
 export { Label, RequiredIndicator } from './components/ui/label';
-export type { LabelProps, RequiredIndicatorProps } from './components/ui/label';
+export type { LabelProps, LabelVariants, RequiredIndicatorProps } from './components/ui/label';
+
+export {
+  FormField,
+  FormFieldDescription,
+  FormFieldError,
+  FormFieldLabel,
+} from './components/ui/form-field';
+export type {
+  FormFieldDescriptionProps,
+  FormFieldErrorProps,
+  FormFieldLabelProps,
+  FormFieldProps,
+} from './components/ui/form-field';
 
 export { Checkbox } from './components/ui/checkbox';
 export type { CheckboxProps } from './components/ui/checkbox';

--- a/packages/apollo-wind/src/templates/Forms/form-builder-example.tsx
+++ b/packages/apollo-wind/src/templates/Forms/form-builder-example.tsx
@@ -233,12 +233,7 @@ export function FormBuilderExample() {
                             checked={formData.newsletter}
                             onCheckedChange={(checked) => updateField('newsletter', !!checked)}
                           />
-                          <Label
-                            htmlFor="newsletter"
-                            className="text-sm font-normal leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
-                          >
-                            Subscribe to newsletter
-                          </Label>
+                          <Label htmlFor="newsletter">Subscribe to newsletter</Label>
                         </Row>
                       </CardContent>
                     </Card>
@@ -259,19 +254,19 @@ export function FormBuilderExample() {
                           >
                             <Row gap={2} align="center">
                               <RadioGroupItem value="public" id="public" />
-                              <Label htmlFor="public" className="font-normal">
+                              <Label variant="muted" htmlFor="public" className="font-normal">
                                 Public - Anyone can see your profile
                               </Label>
                             </Row>
                             <Row gap={2} align="center">
                               <RadioGroupItem value="private" id="private" />
-                              <Label htmlFor="private" className="font-normal">
+                              <Label variant="muted" htmlFor="private" className="font-normal">
                                 Private - Only you can see your profile
                               </Label>
                             </Row>
                             <Row gap={2} align="center">
                               <RadioGroupItem value="friends" id="friends" />
-                              <Label htmlFor="friends" className="font-normal">
+                              <Label variant="muted" htmlFor="friends" className="font-normal">
                                 Friends - Only friends can see your profile
                               </Label>
                             </Row>
@@ -318,10 +313,7 @@ export function FormBuilderExample() {
                                       }
                                     }}
                                   />
-                                  <Label
-                                    htmlFor={interest}
-                                    className="text-sm font-normal leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
-                                  >
+                                  <Label variant="muted" htmlFor={interest} className="font-normal">
                                     {interest}
                                   </Label>
                                 </Row>


### PR DESCRIPTION
Closes [MST-14020](https://uipath.atlassian.net/browse/MST-14020) on the design-system side. MST-14021 and a separate label-unification series both landed on main while this was open; the branch is rebased on them and adopts their decisions rather than duplicating them.

## What main already settled

`Label` is `text-xs font-medium` with no variants, and `RequiredIndicator` renders an `aria-hidden` asterisk plus `sr-only` "(required)" in the foreground colour. This PR takes all of that as-is and builds on it.

## One set of parts

`ui/form-field.tsx` now holds the whole field anatomy, all exported:

```tsx
<FormField>
  <FormFieldLabel htmlFor={id} required>Endpoint</FormFieldLabel>
  <Input id={id} aria-describedby={descriptionId} />
  <FormFieldDescription id={descriptionId}>The URL to call.</FormFieldDescription>
  <FormFieldError>{error}</FormFieldError>
</FormField>
```

`FormField` and `FormFieldLabel` were private inside `field-renderer`; `FormDescription` and `FormError` are gone, since they were one-line pass-throughs that only added a `data-slot`. None of the parts hold form state, so they compose the same way in a hand-built panel as inside a metadata-driven form. `Input`, `InputGroup`, `LockableValueField`, and the renderer all route through them instead of re-implementing the description and error text inline.

They live under `ui/` rather than beside the renderer because `Input`, `InputGroup`, and `LockableValueField` all render the error part. A `forms/` home would make those primitives depend on the forms subsystem, inverting a layering that is currently strictly one-way.

## Two label variants

`Label` gains `default` (unchanged from main) and `muted`, for a label naming one option among several inside a field:

```tsx
<Label htmlFor="freq">Delivery frequency</Label>
<Label variant="muted" htmlFor="daily">Daily digest</Label>
```

A switch or standalone checkbox drives its whole field, so those labels stay on `default`. `LabelVariants` is exported for consumers forwarding a variant through, and `data-variant` is emitted so a container can restyle every label of one kind at once rather than reaching for each slot by name.

No density override is needed anywhere: main's `text-xs` default is already the panel size, and `text-xs` carries `line-height: 1rem`, so the panel root now styles nothing label-related.

## `RequiredIndicator` gains `srLabel`

An `srLabel?: string` prop for the visually hidden text, defaulting to the existing `" (required)"`. The text was hard-coded English, so localized surfaces had to keep hand-rolling the asterisk to preserve their translated string. apollo-wind carries no i18n of its own and is not the place to introduce it, so the string comes from the caller:

```tsx
<RequiredIndicator srLabel={_({ id: 'canvas.json_value_panel.required_marker', message: 'required' })} />
```

Purely additive, default unchanged, and the original `children` omit is preserved.

## `PanelField` is deprecated, not removed

`PanelField` and `PanelFieldLabel` duplicated this anatomy, but they are released public API, so removing them would force a major. They are marked `@deprecated` with exports intact, and every use inside the repo moves to the shared parts. The panel stories compose `FormField` directly, which is also the more honest documentation: it shows the id and `aria-describedby` wiring a caller has to do, rather than hiding it behind a wrapper only this panel had.

## Also folded in

- JSON tree required marker dropped `text-error` (a required key read as a key in an error state) and composes `RequiredIndicator`, passing its existing translated string through `srLabel`. Its colour stays explicit because the tree row establishes no text colour, so an inherited indicator falls back to black.
- JSON container editor's parse error routes through `FormFieldError`, gaining the live region it never had.
- The editable case-title no longer nests a `<label>` inside a `<button>`.

## Heads-up: slot names changed

`form-label` → `form-field-label`, `form-description` → `form-field-description`, `field-error` → `form-field-error`. Nothing in-repo targets the old names, but the canvas repo's MST-14021 stopgap CSS keys on `[data-slot="form-label"]` and will stop matching. That stopgap should be deleted anyway now the asterisk colour is fixed upstream.

## Known follow-ups, not in scope

- `TaskContent` still hand-rolls its required asterisk with no `aria-hidden` or `sr-only`, so screen readers announce a bare "star" on required stage tasks.
- In `InventoryField`, a Radix `Select` child swallows the generated `id`, so that one label associates with nothing. Pre-existing, identical under the old `PanelField`.
- 8 sites in `checkbox.stories.tsx` keep `future:`-prefixed overrides rather than `variant="muted"`, since converting would change that theme's colour.

## Verification

- apollo-wind: 1428 tests / 93 files, tsc clean
- apollo-react: 2593 tests / 166 files, tsc clean, built against fresh apollo-wind
- `turbo run lint` and `format:check` passing
- Verified in Storybook: panel labels unchanged at 12px/16px after removing the override, `muted` at 12px/400/muted, indicator carrying its `sr-only` text, label and description aria wiring intact after the `PanelField` migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[MST-14020]: https://uipath.atlassian.net/browse/MST-14020?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ