### PR TITLE
fix: keep CanvasModeToolbar centered on the visible canvas area

### DIFF
--- a/apps/storybook/src/patterns/LayoutPatterns.stories.tsx
+++ b/apps/storybook/src/patterns/LayoutPatterns.stories.tsx
@@ -235,6 +235,7 @@ function CanvasViewport({
   const { getNodes, getNodesBounds, setEdges, setNodes, setViewport } = useReactFlow();
   const nodesInitialized = useNodesInitialized();
   const viewportContainerRef = useRef<HTMLDivElement>(null);
+  const occupiedRight = Math.max(0, rightControlsOffset - 16);
 
   const fitWorkflow = useCallback(
     (duration: number) => {
@@ -242,7 +243,6 @@ function CanvasViewport({
       const nodes = getNodes();
       if (!container || nodes.length === 0) return;
       const bounds = getNodesBounds(nodes);
-      const occupiedRight = Math.max(0, rightControlsOffset - 16);
       const occupiedBottom = Math.max(0, bottomControlsOffset - 20);
       const availableWidth = container.clientWidth - occupiedRight;
       const availableHeight = container.clientHeight - occupiedBottom;
@@ -263,7 +263,7 @@ function CanvasViewport({
         { duration }
       );
     },
-    [bottomControlsOffset, getNodes, getNodesBounds, rightControlsOffset, setViewport]
+    [bottomControlsOffset, getNodes, getNodesBounds, occupiedRight, setViewport]
   );
 
   useEffect(() => {
@@ -294,8 +294,8 @@ function CanvasViewport({
         {trigger ?? <PanelTrigger />}
       </div>
       <div
-        className="absolute left-1/2 z-20 -translate-x-1/2"
-        style={{ bottom: bottomControlsOffset }}
+        className="absolute z-20 -translate-x-1/2"
+        style={{ left: `calc(50% - ${occupiedRight / 2}px)`, bottom: bottomControlsOffset }}
       >
         <CanvasNavigationControls />
       </div>

--- a/packages/apollo-react/src/canvas/stories/templates/Flow.stories.tsx
+++ b/packages/apollo-react/src/canvas/stories/templates/Flow.stories.tsx
@@ -678,6 +678,7 @@ function CanvasViewport({
   const { getNodes, getNodesBounds, getViewport, setEdges, setNodes, setViewport } = useReactFlow();
   const nodesInitialized = useNodesInitialized();
   const viewportContainerRef = useRef<HTMLDivElement>(null);
+  const occupiedRight = Math.max(0, rightControlsOffset - 16);
 
   const centerWorkflow = useCallback(
     (duration: number) => {
@@ -686,7 +687,6 @@ function CanvasViewport({
       if (!container || nodes.length === 0) return;
       const bounds = getNodesBounds(nodes);
       const viewport = getViewport();
-      const occupiedRight = Math.max(0, rightControlsOffset - 16);
       const occupiedBottom = Math.max(0, bottomControlsOffset - 20);
       const availableCenterX = (container.clientWidth - occupiedRight) / 2;
       const availableCenterY = (container.clientHeight - occupiedBottom) / 2;
@@ -699,7 +699,7 @@ function CanvasViewport({
         { duration }
       );
     },
-    [bottomControlsOffset, getNodes, getNodesBounds, getViewport, rightControlsOffset, setViewport]
+    [bottomControlsOffset, getNodes, getNodesBounds, getViewport, occupiedRight, setViewport]
   );
 
   useEffect(() => {
@@ -723,8 +723,8 @@ function CanvasViewport({
         {trigger ?? <PanelTrigger />}
       </div>
       <div
-        className="absolute left-1/2 z-20 -translate-x-1/2"
-        style={{ bottom: bottomControlsOffset }}
+        className="absolute z-20 -translate-x-1/2"
+        style={{ left: `calc(50% - ${occupiedRight / 2}px)`, bottom: bottomControlsOffset }}
       >
         <CanvasNavigationControls />
       </div>


### PR DESCRIPTION
## Summary

- `CanvasModeToolbar` used `left-1/2 -translate-x-1/2`, which centers on the full canvas width, not the visible area
- The right properties panel is absolutely positioned over the canvas, so opening/closing it never shifted the toolbar. it stayed pinned to the full-width center
- Fix: reuse the existing `occupiedRight` offset (already used to recenter the flow diagram itself) so the toolbar centers on the same visible region as the diagram

<img width="1348" height="985" alt="Screenshot 2026-08-27 at 5 34 48 AM" src="https://github.com/user-attachments/assets/8398d128-a4b8-4db2-b8c6-ebee470d7fd8" />

## Files

- `packages/apollo-react/.../Flow.stories.tsx` — shared `CanvasViewport` used by all Flow Standalone templates (Full Workbench, w/ Panel Right, etc.)
- `apps/storybook/src/patterns/LayoutPatterns.stories.tsx` — UX Error and Validation pattern, same duplicated `CanvasViewport`

## Test plan

- [x] Full Workbench story: toolbar center matches visible canvas center, panel open and closed (verified via DOM measurement)
- [x] UX Error and Validation story: same exact-match result
- [x] `biome check` + `tsc --noEmit`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)