### PR TITLE
docs(storybook): field description vs. tooltip help guidance

### DIFF
--- a/apps/storybook/src/patterns/FieldGuidance.stories.tsx
+++ b/apps/storybook/src/patterns/FieldGuidance.stories.tsx
@@ -88,12 +88,13 @@ function InlineDescriptionExample() {
   );
 }
 
-function TooltipHelpExample() {
+function TooltipHelpExample({ idSuffix }: { idSuffix: string }) {
+  const inputId = `retention-period-${idSuffix}`;
   return (
     <TooltipProvider>
       <div className="grid gap-1.5">
         <div className="flex items-center gap-1">
-          <Label htmlFor="retention-period">Retention period</Label>
+          <Label htmlFor={inputId}>Retention period</Label>
           <Tooltip>
             <HelpTrigger fieldName="retention period" />
             <TooltipContent side="top" className="max-w-64">
@@ -101,7 +102,7 @@ function TooltipHelpExample() {
             </TooltipContent>
           </Tooltip>
         </div>
-        <Input id="retention-period" inputMode="numeric" placeholder="30 days" />
+        <Input id={inputId} inputMode="numeric" placeholder="30 days" />
       </div>
     </TooltipProvider>
   );
@@ -168,7 +169,7 @@ function FieldGuidancePage({ globalTheme }: { globalTheme: string }) {
               title="Tooltip help"
               description="Use for supplementary context that most people can complete the field without."
             >
-              <TooltipHelpExample />
+              <TooltipHelpExample idSuffix="pattern-card" />
             </PatternCard>
           </div>
         </section>
@@ -213,7 +214,7 @@ function FieldGuidancePage({ globalTheme }: { globalTheme: string }) {
                 <Check aria-hidden="true" className="size-4 text-primary" />
                 Do
               </div>
-              <TooltipHelpExample />
+              <TooltipHelpExample idSuffix="do-example" />
               <p className="mt-4 text-sm leading-6 text-muted-foreground">
                 Use a visible, focusable help button beside the label as the explicit target.
               </p>

--- a/apps/storybook/src/patterns/FieldGuidance.stories.tsx
+++ b/apps/storybook/src/patterns/FieldGuidance.stories.tsx
@@ -91,7 +91,7 @@ function InlineDescriptionExample() {
 function TooltipHelpExample({ idSuffix }: { idSuffix: string }) {
   const inputId = `retention-period-${idSuffix}`;
   return (
-    <TooltipProvider>
+    <TooltipProvider delayDuration={300}>
       <div className="grid gap-1.5">
         <div className="flex items-center gap-1">
           <Label htmlFor={inputId}>Retention period</Label>

--- a/apps/storybook/src/patterns/FieldGuidance.stories.tsx
+++ b/apps/storybook/src/patterns/FieldGuidance.stories.tsx
@@ -1,0 +1,314 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Check, CircleHelp, X } from 'lucide-react';
+import type * as React from 'react';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
+import { fontFamily } from '@/foundation/Future/typography';
+import { cn } from '@/lib';
+import { FullWorkbenchComposition } from '../../../../packages/apollo-react/src/canvas/stories/templates/Flow.stories';
+import { withCanvasProviders } from '../../../../packages/apollo-react/src/canvas/storybook-utils';
+
+const meta = {
+  title: 'Apollo Wind/Forms/Field guidance',
+  parameters: { layout: 'fullscreen' },
+} satisfies Meta;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+function SectionTitle({ children }: { children: React.ReactNode }) {
+  return <h2 className="mb-2 text-2xl font-bold tracking-tight text-foreground">{children}</h2>;
+}
+
+function SectionDescription({ children }: { children: React.ReactNode }) {
+  return <p className="mb-6 text-base leading-7 text-muted-foreground">{children}</p>;
+}
+
+function Divider() {
+  return <div className="my-10 h-px bg-border" />;
+}
+
+function InlineCode({ children }: { children: React.ReactNode }) {
+  return (
+    <code className="rounded bg-muted px-1.5 py-0.5 text-sm font-medium text-foreground">
+      {children}
+    </code>
+  );
+}
+
+function InfoCallout({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="rounded-lg border border-border bg-muted/50 p-4 text-sm leading-6 text-muted-foreground">
+      {children}
+    </div>
+  );
+}
+
+function GuidanceList({ children }: { children: React.ReactNode }) {
+  return <ul className="space-y-2 text-sm leading-6 text-muted-foreground">{children}</ul>;
+}
+
+function GuidanceItem({ children }: { children: React.ReactNode }) {
+  return (
+    <li className="flex gap-2">
+      <Check aria-hidden="true" className="mt-1 size-4 shrink-0 text-primary" />
+      <span>{children}</span>
+    </li>
+  );
+}
+
+function HelpTrigger({ fieldName }: { fieldName: string }) {
+  return (
+    <TooltipTrigger asChild>
+      <button
+        type="button"
+        aria-label={`Help for ${fieldName}`}
+        className="inline-flex size-5 cursor-help items-center justify-center rounded-sm text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+      >
+        <CircleHelp aria-hidden="true" className="size-3.5" />
+      </button>
+    </TooltipTrigger>
+  );
+}
+
+function InlineDescriptionExample() {
+  return (
+    <div className="grid gap-1.5">
+      <Label htmlFor="workspace-slug">Workspace URL</Label>
+      <Input
+        id="workspace-slug"
+        aria-describedby="workspace-slug-description"
+        placeholder="team-name"
+      />
+      <p id="workspace-slug-description" className="mt-1 text-xs leading-4 text-muted-foreground">
+        Use lowercase letters, numbers, and hyphens. You cannot change this later.
+      </p>
+    </div>
+  );
+}
+
+function TooltipHelpExample() {
+  return (
+    <TooltipProvider>
+      <div className="grid gap-1.5">
+        <div className="flex items-center gap-1">
+          <Label htmlFor="retention-period">Retention period</Label>
+          <Tooltip>
+            <HelpTrigger fieldName="retention period" />
+            <TooltipContent side="top" className="max-w-64">
+              How long completed jobs remain available before they are permanently deleted.
+            </TooltipContent>
+          </Tooltip>
+        </div>
+        <Input id="retention-period" inputMode="numeric" placeholder="30 days" />
+      </div>
+    </TooltipProvider>
+  );
+}
+
+function PatternCard({
+  eyebrow,
+  title,
+  description,
+  children,
+}: {
+  eyebrow: string;
+  title: string;
+  description: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="rounded-lg border border-border bg-card p-5">
+      <span className="mb-2 block text-xs font-medium uppercase tracking-wide text-muted-foreground">
+        {eyebrow}
+      </span>
+      <h3 className="mb-2 text-lg font-semibold text-foreground">{title}</h3>
+      <p className="mb-5 text-sm leading-6 text-muted-foreground">{description}</p>
+      {children}
+    </div>
+  );
+}
+
+function FieldGuidancePage({ globalTheme }: { globalTheme: string }) {
+  return (
+    <div
+      className={cn(globalTheme, 'min-h-screen w-full bg-background text-foreground')}
+      style={{ fontFamily: fontFamily.base }}
+    >
+      <main className="mx-auto max-w-3xl p-8">
+        <header>
+          <h1 className="text-[2rem] font-bold tracking-tight text-foreground">Field guidance</h1>
+          <p className="mt-2 text-base leading-7 text-muted-foreground">
+            Help people understand what a field expects and why the information is needed. Choose
+            inline descriptions or tooltip help according to how important that information is to
+            completing the task.
+          </p>
+        </header>
+
+        <Divider />
+
+        <section>
+          <SectionTitle>Choose the right pattern</SectionTitle>
+          <SectionDescription>
+            If someone needs the information to complete the field correctly, keep it visible.
+            Reserve tooltip help for optional context.
+          </SectionDescription>
+
+          <div className="grid gap-5 md:grid-cols-2">
+            <PatternCard
+              eyebrow="Persistent"
+              title="Inline description"
+              description="Use for requirements, constraints, consequences, or unfamiliar terms that are important to completing the field."
+            >
+              <InlineDescriptionExample />
+            </PatternCard>
+            <PatternCard
+              eyebrow="On demand"
+              title="Tooltip help"
+              description="Use for supplementary context that most people can complete the field without."
+            >
+              <TooltipHelpExample />
+            </PatternCard>
+          </div>
+        </section>
+
+        <Divider />
+
+        <section>
+          <SectionTitle>Inline descriptions</SectionTitle>
+          <SectionDescription>
+            Place persistent guidance below the field control so it remains available while someone
+            enters or reviews a value.
+          </SectionDescription>
+          <GuidanceList>
+            <GuidanceItem>
+              Explain the required format or constraints for a valid value.
+            </GuidanceItem>
+            <GuidanceItem>Describe consequences that may affect someone’s decision.</GuidanceItem>
+            <GuidanceItem>Clarify unfamiliar terminology needed by most people.</GuidanceItem>
+            <GuidanceItem>
+              Connect the description to the control with <InlineCode>aria-describedby</InlineCode>.
+            </GuidanceItem>
+          </GuidanceList>
+          <div className="mt-6">
+            <InfoCallout>
+              Do not put validation errors, required instructions, or critical consequences only in
+              a tooltip. Essential information must remain visible.
+            </InfoCallout>
+          </div>
+        </section>
+
+        <Divider />
+
+        <section>
+          <SectionTitle>Tooltip triggers</SectionTitle>
+          <SectionDescription>
+            Place a dedicated help icon immediately after the field label. The icon—not the label or
+            field control—is the tooltip trigger.
+          </SectionDescription>
+          <div className="grid gap-5 md:grid-cols-2">
+            <div className="rounded-lg border border-border bg-card p-5">
+              <div className="mb-4 flex items-center gap-2 text-sm font-semibold text-foreground">
+                <Check aria-hidden="true" className="size-4 text-primary" />
+                Do
+              </div>
+              <TooltipHelpExample />
+              <p className="mt-4 text-sm leading-6 text-muted-foreground">
+                Use a visible, focusable help button beside the label as the explicit target.
+              </p>
+            </div>
+            <div className="rounded-lg border border-border bg-card p-5">
+              <div className="mb-4 flex items-center gap-2 text-sm font-semibold text-foreground">
+                <X aria-hidden="true" className="size-4 text-destructive" />
+                Don’t
+              </div>
+              <div className="grid gap-1.5">
+                <Label htmlFor="whole-control-example">Retention period</Label>
+                <div className="rounded-md border border-dashed border-destructive/60 p-1">
+                  <Input id="whole-control-example" placeholder="30 days" />
+                </div>
+              </div>
+              <p className="mt-4 text-sm leading-6 text-muted-foreground">
+                Don’t make the input, select, label, or entire field an invisible hover target.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        <Divider />
+
+        <section>
+          <SectionTitle>Accessibility and interaction</SectionTitle>
+          <SectionDescription>
+            Tooltip help must not depend on pointer hover. Everyone needs an equivalent, explicit
+            way to discover and open it.
+          </SectionDescription>
+          <GuidanceList>
+            <GuidanceItem>
+              Render the trigger as a button with an accessible name such as “Help for retention
+              period.”
+            </GuidanceItem>
+            <GuidanceItem>Open the tooltip on both pointer hover and keyboard focus.</GuidanceItem>
+            <GuidanceItem>
+              Close it when hover or focus leaves, and allow <InlineCode>Escape</InlineCode> to
+              close it.
+            </GuidanceItem>
+            <GuidanceItem>Support activation on touch devices that do not have hover.</GuidanceItem>
+            <GuidanceItem>Keep the help trigger available when the field is disabled.</GuidanceItem>
+            <GuidanceItem>
+              Hide the decorative question-mark glyph from assistive technology.
+            </GuidanceItem>
+          </GuidanceList>
+        </section>
+
+        <Divider />
+
+        <section>
+          <SectionTitle>Recommendation</SectionTitle>
+          <SectionDescription>
+            Treat help as a field-level pattern rather than an Input feature. The same guidance
+            applies to inputs, selects, text areas, checkboxes, radio groups, and other controls.
+          </SectionDescription>
+          <div className="space-y-4">
+            <InfoCallout>
+              Prefer a composed <InlineCode>FieldLabel</InlineCode> that renders the native label
+              and a sibling help trigger. Avoid placing an interactive tooltip button inside a
+              native <InlineCode>&lt;label&gt;</InlineCode>, where it can create conflicting
+              activation behavior.
+            </InfoCallout>
+            <div className="overflow-x-auto rounded-lg border border-border bg-muted/50 p-4">
+              <pre className="text-sm leading-6 text-foreground">
+                <code style={{ fontFamily: fontFamily.monospace }}>{`<FieldLabel
+  htmlFor="retention"
+  helpText="How long completed jobs remain available."
+>
+  Retention period
+</FieldLabel>`}</code>
+              </pre>
+            </div>
+            <p className="text-sm leading-6 text-muted-foreground">
+              Keep persistent descriptions separate as a <InlineCode>FieldDescription</InlineCode>{' '}
+              or equivalent. This proposed API is a direction for review, not an implemented
+              component. Confirm terminology, icon, placement, touch behavior, and component
+              ownership with design before engineering implementation.
+            </p>
+          </div>
+        </section>
+      </main>
+    </div>
+  );
+}
+
+export const Documentation: Story = {
+  name: 'Documentation',
+  render: (_args, { globals }) => (
+    <FieldGuidancePage globalTheme={globals.theme || 'future-dark'} />
+  ),
+};
+
+export const Example: Story = {
+  name: 'Example',
+  decorators: [withCanvasProviders({ fullscreen: false })],
+  render: () => <FullWorkbenchComposition rightPanelVariant="field-help" />,
+};

--- a/apps/storybook/src/patterns/FieldGuidance.stories.tsx
+++ b/apps/storybook/src/patterns/FieldGuidance.stories.tsx
@@ -204,8 +204,8 @@ function FieldGuidancePage({ globalTheme }: { globalTheme: string }) {
         <section>
           <SectionTitle>Tooltip triggers</SectionTitle>
           <SectionDescription>
-            Place a dedicated help icon immediately after the field label. The icon—not the label or
-            field control—is the tooltip trigger.
+            Place a dedicated help icon immediately after the field label. The icon is the tooltip
+            trigger, not the label or field control.
           </SectionDescription>
           <div className="grid gap-5 md:grid-cols-2">
             <div className="rounded-lg border border-border bg-card p-5">

--- a/apps/storybook/src/patterns/FieldGuidance.stories.tsx
+++ b/apps/storybook/src/patterns/FieldGuidance.stories.tsx
@@ -64,7 +64,7 @@ function HelpTrigger({ fieldName }: { fieldName: string }) {
       <button
         type="button"
         aria-label={`Help for ${fieldName}`}
-        className="inline-flex size-5 cursor-help items-center justify-center rounded-sm text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+        className="inline-flex size-5 cursor-help items-center justify-center rounded-sm text-muted-foreground ring-offset-background hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
       >
         <CircleHelp aria-hidden="true" className="size-3.5" />
       </button>

--- a/packages/apollo-react/src/canvas/stories/templates/Flow.stories.tsx
+++ b/packages/apollo-react/src/canvas/stories/templates/Flow.stories.tsx
@@ -2761,7 +2761,7 @@ function FieldHelpPanel({ onClose }: { onClose: () => void }) {
       contentInset="0.875rem"
       className="h-full"
     >
-      <TooltipProvider>
+      <TooltipProvider delayDuration={300}>
         <div className="flex min-h-0 flex-1 flex-col gap-5 overflow-y-auto px-3 pb-4">
           <p className="text-xs leading-5 text-foreground-muted">
             The Forms/Field guidance patterns, shown in a real scroll-constrained panel next to tabs

--- a/packages/apollo-react/src/canvas/stories/templates/Flow.stories.tsx
+++ b/packages/apollo-react/src/canvas/stories/templates/Flow.stories.tsx
@@ -11,6 +11,9 @@ import {
   Card,
   CardContent,
   type FormSchema,
+  InputGroup,
+  InputGroupInput,
+  Label,
   type PanelImperativeHandle,
   ResizableHandle,
   ResizablePanel,
@@ -22,6 +25,10 @@ import {
   TabsTrigger,
   ToggleGroup,
   ToggleGroupItem,
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
 } from '@uipath/apollo-wind';
 import type { DockviewApi, DockviewReadyEvent, IDockviewPanelProps } from 'dockview-react';
 import { DockviewReact } from 'dockview-react';
@@ -32,6 +39,7 @@ import {
   Bug,
   ChevronDown,
   ChevronUp,
+  CircleHelp,
   Code2,
   FlaskConical,
   GitBranch,
@@ -2738,10 +2746,134 @@ function DapPanel({ onClose }: { onClose: () => void }) {
   );
 }
 
+function FieldHelpPanel({ onClose }: { onClose: () => void }) {
+  const [webhookUrl, setWebhookUrl] = useState('https://hooks.example.com/flows/finance-ops');
+  const [retryLimit, setRetryLimit] = useState('3');
+  const [signingSecret, setSigningSecret] = useState('whsec_8f2a1c9d4e7b3f60');
+
+  return (
+    <NodePropertyPanel
+      panelTitle="Properties"
+      nodeIcon={<Globe />}
+      nodeLabel="HTTP Webhook"
+      nodeCategory="Triggers · Field help pattern"
+      onClose={onClose}
+      contentInset="0.875rem"
+      className="h-full"
+    >
+      <TooltipProvider>
+        <div className="flex min-h-0 flex-1 flex-col gap-5 overflow-y-auto px-3 pb-4">
+          <p className="text-xs leading-5 text-foreground-muted">
+            The Forms/Field guidance patterns, shown in a real scroll-constrained panel next to tabs
+            and dense field stacks.
+          </p>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="field-help-url" className="text-xs">
+              Webhook URL <span className="text-error">*</span>
+            </Label>
+            <InputGroup className="h-9 bg-surface-overlay">
+              <InputGroupInput
+                id="field-help-url"
+                aria-describedby="field-help-url-description"
+                value={webhookUrl}
+                onChange={(event) => setWebhookUrl(event.target.value)}
+                className="text-xs"
+              />
+            </InputGroup>
+            <p
+              id="field-help-url-description"
+              className="text-[11px] leading-4 text-foreground-muted"
+            >
+              Must be publicly reachable over HTTPS. You cannot change this after the flow is
+              published.
+            </p>
+          </div>
+
+          <div className="space-y-1.5">
+            <div className="flex items-center gap-1">
+              <Label htmlFor="field-help-retry" className="text-xs">
+                Retry limit
+              </Label>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    type="button"
+                    aria-label="Help for retry limit"
+                    className="inline-flex size-5 cursor-help items-center justify-center rounded-sm text-foreground-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                  >
+                    <CircleHelp aria-hidden="true" className="size-3.5" />
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent side="top" className="max-w-56">
+                  How many times to retry a failed delivery before giving up.
+                </TooltipContent>
+              </Tooltip>
+            </div>
+            <InputGroup className="h-9 bg-surface-overlay">
+              <InputGroupInput
+                id="field-help-retry"
+                inputMode="numeric"
+                value={retryLimit}
+                onChange={(event) => setRetryLimit(event.target.value)}
+                className="text-xs"
+              />
+            </InputGroup>
+          </div>
+
+          <div className="space-y-1.5">
+            <div className="flex items-center gap-1">
+              <Label htmlFor="field-help-secret" className="text-xs">
+                Signing secret <span className="text-error">*</span>
+              </Label>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    type="button"
+                    aria-label="Help for signing secret"
+                    className="inline-flex size-5 cursor-help items-center justify-center rounded-sm text-foreground-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                  >
+                    <CircleHelp aria-hidden="true" className="size-3.5" />
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent side="top" className="max-w-56">
+                  Regenerating this secret invalidates any endpoints still using the old value.
+                </TooltipContent>
+              </Tooltip>
+            </div>
+            <InputGroup className="h-9 bg-surface-overlay">
+              <InputGroupInput
+                id="field-help-secret"
+                aria-describedby="field-help-secret-description"
+                value={signingSecret}
+                onChange={(event) => setSigningSecret(event.target.value)}
+                className="font-mono text-xs"
+              />
+            </InputGroup>
+            <p
+              id="field-help-secret-description"
+              className="text-[11px] leading-4 text-foreground-muted"
+            >
+              Used to verify webhook payloads came from this flow.
+            </p>
+          </div>
+        </div>
+      </TooltipProvider>
+    </NodePropertyPanel>
+  );
+}
+
 export function FullWorkbenchComposition({
   rightPanelVariant = 'properties',
 }: {
-  rightPanelVariant?: 'properties' | 'forms' | 'node' | 'rules' | 'variables' | 'dap';
+  rightPanelVariant?:
+    | 'properties'
+    | 'forms'
+    | 'node'
+    | 'rules'
+    | 'variables'
+    | 'dap'
+    | 'field-help';
 }) {
   const panelRef = useRef<PanelImperativeHandle | null>(null);
   const expandedBottomPanelHeight = useRef(368);
@@ -2809,7 +2941,9 @@ export function FullWorkbenchComposition({
       <div className="relative min-w-0 flex-1 overflow-hidden">
         <CanvasViewport
           workflowVariant={
-            rightPanelVariant === 'properties' || rightPanelVariant === 'dap'
+            rightPanelVariant === 'properties' ||
+            rightPanelVariant === 'dap' ||
+            rightPanelVariant === 'field-help'
               ? 'default'
               : rightPanelVariant
           }
@@ -2856,6 +2990,8 @@ export function FullWorkbenchComposition({
                 <VariableManagementPanel onClose={() => setRightPanelOpen(false)} />
               ) : rightPanelVariant === 'dap' ? (
                 <DapPanel onClose={() => setRightPanelOpen(false)} />
+              ) : rightPanelVariant === 'field-help' ? (
+                <FieldHelpPanel onClose={() => setRightPanelOpen(false)} />
               ) : rightPanelVariant === 'node' ? (
                 <SendEmailPropertiesPanel onClose={() => setRightPanelOpen(false)} />
               ) : (

--- a/packages/apollo-react/src/canvas/stories/templates/Flow.stories.tsx
+++ b/packages/apollo-react/src/canvas/stories/templates/Flow.stories.tsx
@@ -2801,7 +2801,7 @@ function FieldHelpPanel({ onClose }: { onClose: () => void }) {
                   <button
                     type="button"
                     aria-label="Help for retry limit"
-                    className="inline-flex size-5 cursor-help items-center justify-center rounded-sm text-foreground-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                    className="inline-flex size-5 cursor-help items-center justify-center rounded-sm text-foreground-muted ring-offset-background hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
                   >
                     <CircleHelp aria-hidden="true" className="size-3.5" />
                   </button>
@@ -2833,7 +2833,7 @@ function FieldHelpPanel({ onClose }: { onClose: () => void }) {
                   <button
                     type="button"
                     aria-label="Help for signing secret"
-                    className="inline-flex size-5 cursor-help items-center justify-center rounded-sm text-foreground-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                    className="inline-flex size-5 cursor-help items-center justify-center rounded-sm text-foreground-muted ring-offset-background hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
                   >
                     <CircleHelp aria-hidden="true" className="size-3.5" />
                   </button>

--- a/packages/apollo-react/src/canvas/stories/templates/Flow.stories.tsx
+++ b/packages/apollo-react/src/canvas/stories/templates/Flow.stories.tsx
@@ -2749,7 +2749,7 @@ function DapPanel({ onClose }: { onClose: () => void }) {
 function FieldHelpPanel({ onClose }: { onClose: () => void }) {
   const [webhookUrl, setWebhookUrl] = useState('https://hooks.example.com/flows/finance-ops');
   const [retryLimit, setRetryLimit] = useState('3');
-  const [signingSecret, setSigningSecret] = useState('whsec_8f2a1c9d4e7b3f60');
+  const [signingSecret, setSigningSecret] = useState('example-signing-secret-value');
 
   return (
     <NodePropertyPanel
@@ -2770,7 +2770,8 @@ function FieldHelpPanel({ onClose }: { onClose: () => void }) {
 
           <div className="space-y-1.5">
             <Label htmlFor="field-help-url" className="text-xs">
-              Webhook URL <span className="text-error">*</span>
+              Webhook URL <span aria-hidden="true">*</span>
+              <span className="sr-only"> (required)</span>
             </Label>
             <InputGroup className="h-9 bg-surface-overlay">
               <InputGroupInput
@@ -2824,7 +2825,8 @@ function FieldHelpPanel({ onClose }: { onClose: () => void }) {
           <div className="space-y-1.5">
             <div className="flex items-center gap-1">
               <Label htmlFor="field-help-secret" className="text-xs">
-                Signing secret <span className="text-error">*</span>
+                Signing secret <span aria-hidden="true">*</span>
+                <span className="sr-only"> (required)</span>
               </Label>
               <Tooltip>
                 <TooltipTrigger asChild>


### PR DESCRIPTION
## Summary

Adds a Storybook guidance page for a consistent field-help pattern, plus a working example inside a real docked properties panel.

- **Documentation** story: when to use a persistent inline description vs. tooltip help, an explicit help-icon trigger placed next to the field label (not the whole control) with a Do/Don't comparison, and accessibility/interaction requirements (keyboard focus, hover, `Escape`, touch, disabled state, `aria-hidden` glyph).
- Assesses native `Label` support for help text and proposes a `FieldLabel` `helpText` API as a **direction for design review** — explicitly flagged as not yet implemented, pending confirmation of terminology/icon/placement with design before engineering picks it up.
- **Example** story: the same pattern rendered inside `FullWorkbenchComposition`'s docked properties panel (scroll-constrained, next to tabs, 380px wide) — verifies the tooltip escapes the panel via portal instead of clipping, and that the pattern holds up outside an idealized isolated example.
<img width="1548" height="1052" alt="Screenshot 2026-08-27 at 7 38 58 AM" src="https://github.com/user-attachments/assets/7a9f9067-4978-4244-b6c7-95d707abfdc4" />
<img width="1558" height="1063" alt="Screenshot 2026-08-27 at 7 38 52 AM" src="https://github.com/user-attachments/assets/86aa27d5-1b3b-45fb-87f3-17ff2d236c24" />


## Acceptance criteria coverage

- [x] Storybook documents when to use inline descriptions vs. tooltips
- [x] Guidance discourages using the entire field control as the hover target (explicit Do/Don't)
- [x] Recommended trigger (help icon next to label) and placement are defined
- [x] Accessibility and interaction expectations documented, including keyboard focus and hover behavior
- [x] Native `Label` help-text support assessed; a recommended `FieldLabel.helpText` API is proposed for design review

## Follow-up (tracked separately)

The Documentation page's inline-description example currently hand-rolls a `<p className="text-xs leading-4 ...">` to match `Input`'s existing error-text convention. Once [#1091](https://github.com/UiPath/apollo-ui/pull/1091) lands its shared `FieldDescription`/`FieldError` primitives, this page should switch to the real component so it can't drift from `Input`'s styling again.

## Verification

- `tsc --noEmit` clean on `apollo-react`
- `biome check` clean on both changed files
- Verified in Storybook: Documentation and Example render correctly and in order (Documentation, then Example) under Apollo Wind → Forms → Field guidance; tooltip opens on hover/focus and portals outside the docked panel without clipping; axe a11y scan reports 0 violations on both stories; no console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)