### PR TITLE
feat(apollo-wind): extend Lockable Value Field bindings

### DIFF
--- a/packages/apollo-wind/src/components/ui/lockable-value-field/components/field-header.tsx
+++ b/packages/apollo-wind/src/components/ui/lockable-value-field/components/field-header.tsx
@@ -63,7 +63,7 @@ export function FieldHeader({
   return (
     <div className="flex items-center gap-1">
       {label ?? (
-        <Label htmlFor={fieldId} className="text-xs font-medium text-foreground-muted">
+        <Label htmlFor={fieldId} className="text-xs font-medium text-foreground">
           {fieldLabel}
           {required && <span className="ml-0.5 text-destructive">*</span>}
         </Label>

--- a/packages/apollo-wind/src/components/ui/lockable-value-field/lockable-value-field.stories.tsx
+++ b/packages/apollo-wind/src/components/ui/lockable-value-field/lockable-value-field.stories.tsx
@@ -116,6 +116,172 @@ export const Default: Story = {
   render: () => <DefaultDemo />,
 };
 
+function EqualsAddon() {
+  return (
+    <span className="font-mono text-sm font-semibold text-foreground-accent" aria-hidden="true">
+      =
+    </span>
+  );
+}
+
+function RequiredExpressionLabel({
+  children,
+  htmlFor,
+  required = true,
+}: {
+  children: string;
+  htmlFor: string;
+  required?: boolean;
+}) {
+  return (
+    <Label htmlFor={htmlFor} className="text-xs font-medium text-foreground">
+      {children}
+      {required && <span className="ml-0.5 text-destructive">*</span>}
+    </Label>
+  );
+}
+
+function ReferenceExamplesDemo() {
+  const idPrefix = useId();
+  const [collection, setCollection] = useState('$vars.flowArray');
+  const [attachment, setAttachment] = useState('$vars.flowTest');
+  const [context, setContext] = useState('$vars.flowTest');
+  const [endExchange, setEndExchange] = useState(true);
+  const [file, setFile] = useState('$vars.flowTest');
+  const [conversationId, setConversationId] = useState('$vars.flowTest');
+  const [exchangeId, setExchangeId] = useState('$vars.flowTest');
+
+  return (
+    <div className="flex w-[620px] flex-col gap-8">
+      <LockableValueField
+        id={`${idPrefix}-collection`}
+        label={
+          <RequiredExpressionLabel htmlFor={`${idPrefix}-collection`}>
+            Collection
+          </RequiredExpressionLabel>
+        }
+        fieldType="object"
+        value={collection}
+        onValueChange={setCollection}
+        locked={false}
+        leadingAddon={<EqualsAddon />}
+        mode="expression"
+        variables={[{ label: 'Flow array', value: '$vars.flowArray' }]}
+      />
+      <LockableValueField
+        id={`${idPrefix}-attachment`}
+        label={
+          <RequiredExpressionLabel htmlFor={`${idPrefix}-attachment`}>
+            Attachment
+          </RequiredExpressionLabel>
+        }
+        fieldType="file"
+        value={attachment}
+        onValueChange={setAttachment}
+        locked={false}
+        leadingAddon={<EqualsAddon />}
+        mode="expression"
+      />
+      <LockableValueField
+        id={`${idPrefix}-conversation-context`}
+        label={
+          <RequiredExpressionLabel htmlFor={`${idPrefix}-conversation-context`} required={false}>
+            Conversation context
+          </RequiredExpressionLabel>
+        }
+        fieldType="object"
+        value={context}
+        onValueChange={setContext}
+        locked={false}
+        leadingAddon={<EqualsAddon />}
+        mode="expression"
+        belowValue={
+          <label className="flex items-start gap-2 pl-1 text-sm text-foreground">
+            <input
+              type="checkbox"
+              checked={endExchange}
+              onChange={(event) => setEndExchange(event.target.checked)}
+              className="mt-0.5 size-4 accent-brand"
+            />
+            <span>
+              <span className="block font-medium">End exchange</span>
+              <span className="block text-xs leading-4 text-foreground-muted">
+                When checked, the conversation exchange will be ended and the user will be able to
+                send another message. Leave unchecked if later node(s) should continue responding as
+                part of the process&apos;s turn.
+              </span>
+            </span>
+          </label>
+        }
+      />
+      <LockableValueField
+        id={`${idPrefix}-file`}
+        label={<RequiredExpressionLabel htmlFor={`${idPrefix}-file`}>File</RequiredExpressionLabel>}
+        fieldType="file"
+        value={file}
+        onValueChange={setFile}
+        locked={false}
+        leadingAddon={<EqualsAddon />}
+        mode="expression"
+        belowValue={<p className="text-xs text-foreground-muted">File to extract data from</p>}
+      />
+      <LockableValueField
+        id={`${idPrefix}-conversation-id`}
+        label={
+          <RequiredExpressionLabel htmlFor={`${idPrefix}-conversation-id`}>
+            Conversation ID
+          </RequiredExpressionLabel>
+        }
+        value={conversationId}
+        onValueChange={setConversationId}
+        locked={false}
+        leadingAddon={<EqualsAddon />}
+        mode="expression"
+        trailingAddon={<FunctionAddon />}
+      />
+      <LockableValueField
+        id={`${idPrefix}-exchange-id`}
+        label={
+          <RequiredExpressionLabel htmlFor={`${idPrefix}-exchange-id`}>
+            Exchange ID
+          </RequiredExpressionLabel>
+        }
+        value={exchangeId}
+        onValueChange={setExchangeId}
+        locked={false}
+        leadingAddon={<EqualsAddon />}
+        mode="expression"
+        trailingAddon={<FunctionAddon />}
+        belowValue={
+          <p className="text-xs text-foreground-muted">
+            The message will be added to this existing exchange.
+          </p>
+        }
+      />
+    </div>
+  );
+}
+
+/** Reference layouts for assignment/binding fields used in node properties. */
+export const ReferenceExamples: Story = {
+  name: 'Reference examples (=)',
+  render: () => <ReferenceExamplesDemo />,
+};
+
+function FunctionAddon() {
+  return (
+    <button
+      type="button"
+      aria-label="Open expression editor"
+      className="grid size-7 place-items-center border-l border-border text-foreground-subtle transition hover:bg-surface-overlay hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+    >
+      <span className="rounded border border-current px-0.5 font-mono text-[10px] leading-3">
+        ƒ
+      </span>
+    </button>
+  );
+}
+
 export const InlineValidation: Story = {
   render: () => (
     <div className="w-80">

--- a/packages/apollo-wind/src/components/ui/lockable-value-field/lockable-value-field.test.tsx
+++ b/packages/apollo-wind/src/components/ui/lockable-value-field/lockable-value-field.test.tsx
@@ -181,6 +181,24 @@ describe('LockableValueField', () => {
     expect(screen.getByRole('button', { name: 'Choose value type' })).toBeInTheDocument();
   });
 
+  it('allows null addons to suppress the default controls', () => {
+    const { container } = render(
+      <LockableValueField
+        locked={false}
+        leadingAddon={null}
+        trailingAddon={null}
+        onLockedChange={vi.fn()}
+        onModeChange={vi.fn()}
+      />
+    );
+
+    expect(screen.queryByRole('button', { name: /Editable/ })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Choose value type' })).not.toBeInTheDocument();
+    expect(
+      container.querySelector('[role="group"].bg-surface-overlay > [role="group"]')
+    ).not.toBeInTheDocument();
+  });
+
   it('renders headerActions content after the built-in controls', () => {
     render(
       <LockableValueField
@@ -255,8 +273,56 @@ describe('LockableValueField', () => {
   });
 
   it('renders a file upload control for file fields when unlocked', () => {
-    render(<LockableValueField locked={false} fieldType="file" />);
+    const { container } = render(<LockableValueField locked={false} fieldType="file" />);
     expect(screen.getByText(/drag/i, { exact: false })).toBeInTheDocument();
+    expect(container.querySelector('[role="group"].bg-surface-overlay')).toHaveClass(
+      'h-auto',
+      'items-stretch'
+    );
+  });
+
+  it('keeps locked file fields in the compact read-only layout', () => {
+    const { container } = render(
+      <LockableValueField locked fieldType="file" value="invoice.pdf" />
+    );
+    expect(container.querySelector('[role="group"].bg-surface-overlay')).not.toHaveClass(
+      'h-auto',
+      'items-stretch'
+    );
+  });
+
+  it('allows expression values for file and object fields', () => {
+    const onValueChange = vi.fn();
+    const { rerender } = render(
+      <LockableValueField
+        fieldType="file"
+        mode="expression"
+        value="$vars.flowTest"
+        locked={false}
+        onValueChange={onValueChange}
+        leadingAddon={<span>=</span>}
+      />
+    );
+
+    expect(screen.getByDisplayValue('$vars.flowTest')).toBeInTheDocument();
+    expect(screen.getByText('=')).toBeInTheDocument();
+
+    rerender(
+      <LockableValueField
+        fieldType="object"
+        mode="expression"
+        value="$vars.flowTest"
+        locked={false}
+        onValueChange={onValueChange}
+        leadingAddon={<span>=</span>}
+      />
+    );
+    expect(screen.getByDisplayValue('$vars.flowTest')).toHaveClass('font-mono');
+  });
+
+  it('renders content below the value control', () => {
+    render(<LockableValueField belowValue={<span>End exchange</span>} />);
+    expect(screen.getByText('End exchange')).toBeInTheDocument();
   });
 
   it('disables the file upload control when unlocked but onValueChange is not provided', () => {

--- a/packages/apollo-wind/src/components/ui/lockable-value-field/lockable-value-field.tsx
+++ b/packages/apollo-wind/src/components/ui/lockable-value-field/lockable-value-field.tsx
@@ -57,6 +57,8 @@ export function LockableValueField({
   onValueBlur,
   locked = true,
   onLockedChange,
+  leadingAddon,
+  trailingAddon,
   mode = 'fixed',
   onModeChange,
   renderExpressionEditor,
@@ -67,6 +69,7 @@ export function LockableValueField({
   label,
   error,
   errorId,
+  belowValue,
   fileUploadAriaLabel,
   headerActions,
   compact,
@@ -119,10 +122,23 @@ export function LockableValueField({
       />
 
       {typeMeta.supportsExpression ? (
-        <InputGroup error={error} errorId={validationId}>
-          <InputGroupAddon align="inline-start">
-            <LockToggleButton locked={locked} onLockedChange={onLockedChange} />
-          </InputGroupAddon>
+        <InputGroup
+          error={error}
+          errorId={validationId}
+          className={cn(
+            'bg-surface-overlay',
+            fieldType === 'file' && !locked && effectiveMode === 'fixed' && 'h-auto items-stretch'
+          )}
+        >
+          {leadingAddon !== null && (
+            <InputGroupAddon align="inline-start">
+              {leadingAddon !== undefined ? (
+                leadingAddon
+              ) : (
+                <LockToggleButton locked={locked} onLockedChange={onLockedChange} />
+              )}
+            </InputGroupAddon>
+          )}
 
           {effectiveMode === 'expression' ? (
             renderExpressionEditor ? (
@@ -206,6 +222,18 @@ export function LockableValueField({
                 />
               </PopoverContent>
             </Popover>
+          ) : fieldType === 'file' ? (
+            <FileUpload
+              id={fieldId}
+              ariaLabel={fileUploadAriaLabel ?? (typeof label === 'string' ? label : fieldLabel)}
+              className="flex-1"
+              onFilesChange={(files) => onValueChange?.(files.map((f) => f.name).join(', '))}
+              disabled={!onValueChange}
+              onBlur={onValueBlur}
+              aria-invalid={error ? true : undefined}
+              aria-describedby={error ? validationId : undefined}
+              aria-errormessage={error ? validationId : undefined}
+            />
           ) : (
             <InputGroupInput
               id={fieldId}
@@ -218,40 +246,53 @@ export function LockableValueField({
             />
           )}
 
-          <InputGroupAddon align="inline-end">
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <InputGroupButton
-                  icon
-                  size="3xs"
-                  disabled={!onModeChange}
-                  aria-label="Choose value type"
-                >
-                  {effectiveMode === 'expression' ? <Code2 /> : <Type />}
-                </InputGroupButton>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="end" className="w-56">
-                <ModeMenuItem
-                  icon={Type}
-                  label={typeMeta.fixedLabel}
-                  description={typeMeta.fixedDescription}
-                  active={effectiveMode === 'fixed'}
-                  onClick={() => onModeChange?.('fixed')}
-                />
-                <ModeMenuItem
-                  icon={Code2}
-                  label="Expression"
-                  description="Use a JS expression"
-                  active={effectiveMode === 'expression'}
-                  onClick={() => onModeChange?.('expression')}
-                />
-              </DropdownMenuContent>
-            </DropdownMenu>
-          </InputGroupAddon>
+          {trailingAddon !== null && (
+            <InputGroupAddon
+              align="inline-end"
+              className={trailingAddon != null ? 'cursor-default' : undefined}
+            >
+              {trailingAddon !== undefined ? (
+                trailingAddon
+              ) : (
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <InputGroupButton
+                      icon
+                      size="3xs"
+                      disabled={!onModeChange}
+                      aria-label="Choose value type"
+                    >
+                      {effectiveMode === 'expression' ? <Code2 /> : <Type />}
+                    </InputGroupButton>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align="end" className="w-56">
+                    <ModeMenuItem
+                      icon={Type}
+                      label={typeMeta.fixedLabel}
+                      description={typeMeta.fixedDescription}
+                      active={effectiveMode === 'fixed'}
+                      onClick={() => onModeChange?.('fixed')}
+                    />
+                    <ModeMenuItem
+                      icon={Code2}
+                      label="Expression"
+                      description="Use a JS expression"
+                      active={effectiveMode === 'expression'}
+                      onClick={() => onModeChange?.('expression')}
+                    />
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              )}
+            </InputGroupAddon>
+          )}
         </InputGroup>
       ) : (
         <div className="flex items-center gap-2">
-          <LockToggleButton locked={locked} onLockedChange={onLockedChange} />
+          {leadingAddon !== undefined ? (
+            leadingAddon
+          ) : (
+            <LockToggleButton locked={locked} onLockedChange={onLockedChange} />
+          )}
 
           {locked ? (
             <Input
@@ -307,21 +348,7 @@ export function LockableValueField({
               aria-describedby={error ? validationId : undefined}
               aria-errormessage={error ? validationId : undefined}
             />
-          ) : (
-            fieldType === 'file' && (
-              <FileUpload
-                id={fieldId}
-                ariaLabel={fileUploadAriaLabel ?? (typeof label === 'string' ? label : fieldLabel)}
-                className="flex-1"
-                onFilesChange={(files) => onValueChange?.(files.map((f) => f.name).join(', '))}
-                disabled={!onValueChange}
-                onBlur={onValueBlur}
-                aria-invalid={error ? true : undefined}
-                aria-describedby={error ? validationId : undefined}
-                aria-errormessage={error ? validationId : undefined}
-              />
-            )
-          )}
+          ) : null}
         </div>
       )}
 
@@ -336,6 +363,8 @@ export function LockableValueField({
           {error}
         </p>
       )}
+
+      {belowValue}
     </div>
   );
 }

--- a/packages/apollo-wind/src/components/ui/lockable-value-field/types.ts
+++ b/packages/apollo-wind/src/components/ui/lockable-value-field/types.ts
@@ -1,5 +1,6 @@
 import {
   ALargeSmall,
+  Braces,
   Calendar as CalendarIcon,
   File as FileIcon,
   Hash,
@@ -19,7 +20,8 @@ export type LockableFieldType =
   | 'boolean'
   | 'single-select'
   | 'multi-select'
-  | 'file';
+  | 'file'
+  | 'object';
 
 interface FieldTypeMeta {
   label: string;
@@ -75,9 +77,16 @@ export const FIELD_TYPE_META: Record<LockableFieldType, FieldTypeMeta> = {
   file: {
     label: 'File',
     icon: FileIcon,
-    supportsExpression: false,
+    supportsExpression: true,
     fixedLabel: 'Fixed value',
     fixedDescription: 'Upload a file',
+  },
+  object: {
+    label: 'Object',
+    icon: Braces,
+    supportsExpression: true,
+    fixedLabel: 'Fixed value',
+    fixedDescription: 'Use a literal object value',
   },
 };
 
@@ -89,6 +98,7 @@ export const FIELD_TYPE_ORDER: LockableFieldType[] = [
   'single-select',
   'multi-select',
   'file',
+  'object',
 ];
 
 export interface LockableValueFieldOption {
@@ -107,6 +117,17 @@ export interface LockableValueFieldProps {
   locked?: boolean;
   /** Called when the user toggles the lock. */
   onLockedChange?: (locked: boolean) => void;
+  /**
+   * Replaces the leading lock toggle with a semantic prefix such as `=`.
+   * Pass `null` to suppress the built-in toggle; omitting the prop preserves it.
+   */
+  leadingAddon?: ReactNode;
+  /**
+   * Replaces the trailing fixed/expression menu with a consumer-provided action
+   * for expression-capable field types. Pass `null` to suppress the built-in
+   * menu; omitting the prop preserves it.
+   */
+  trailingAddon?: ReactNode;
   /** Fixed value vs. JS expression. Defaults to 'fixed'. Ignored for types that don't support expressions. */
   mode?: LockableValueFieldMode;
   /** Called when the user switches modes. */
@@ -142,6 +163,8 @@ export interface LockableValueFieldProps {
   error?: ReactNode;
   /** Optional id for the inline validation message. */
   errorId?: string;
+  /** Content rendered below the value control, such as a related checkbox or help text. */
+  belowValue?: ReactNode;
   /** Accessible name for the file-upload dropzone. Defaults to a string `label`, then the computed field label. */
   fileUploadAriaLabel?: string;
   /** Extra content rendered after the built-in AI assist / Insert variable buttons (e.g. a delete button). */


### PR DESCRIPTION
## Summary

- Add composable leading addons for assignment/binding fields, including the `=` pattern.
- Support expression-backed file and object values while preserving fixed file uploads.
- Add a below-value slot for related controls such as “End exchange”.
- Add Storybook reference examples and coverage for the new behavior.
<img width="1411" height="1088" alt="Screenshot 2026-08-27 at 9 16 58 AM" src="https://github.com/user-attachments/assets/8938abca-54e1-44ca-8ab8-8b58b83eea06" />

## Verification

- `pnpm --filter @uipath/apollo-wind test -- --run src/components/ui/lockable-value-field/lockable-value-field.test.tsx`
- 1,408 tests passing
- TypeScript and Biome checks passing

Preview: http://localhost:6008/