### PR TITLE
fix(apollo-vertex): gate group membership via checkGroupMembership

### DIFF
--- a/apps/apollo-vertex/registry/shell/use-is-group-member.ts
+++ b/apps/apollo-vertex/registry/shell/use-is-group-member.ts
@@ -1,5 +1,5 @@
-import { inArray, useLiveQuery } from "@tanstack/react-db";
-import { type GroupMember, useSolution } from "@uipath/vs-core";
+import { useQuery } from "@tanstack/react-query";
+import { useSolution } from "@uipath/vs-core";
 import { useAuth } from "./shell-auth-provider";
 
 export interface UseIsGroupMemberOptions {
@@ -16,21 +16,20 @@ export const useIsGroupMember = ({
 }: UseIsGroupMemberOptions): UseIsGroupMemberResult => {
   const { user } = useAuth();
   const solution = useSolution();
+  const checkGroupMembership =
+    solution?.api.collections.identity.checkGroupMembership;
+  const userId = user?.sub;
 
-  const { data, isLoading } = useLiveQuery<GroupMember>((q) =>
-    q
-      .from({ members: solution?.api.collections.identity.groupMembers })
-      .where(({ members }) => inArray(members.groupId, groupIds)),
-  );
+  const { data, isLoading } = useQuery({
+    queryKey: ["identity-group-membership", userId, [...groupIds].sort()],
+    queryFn: (): Promise<Record<string, boolean>> =>
+      checkGroupMembership && userId
+        ? checkGroupMembership(userId, groupIds)
+        : Promise.resolve({}),
+    enabled: Boolean(checkGroupMembership && userId && groupIds.length > 0),
+  });
 
-  if (!user) {
-    return { isMember: false, isLoading };
-  }
-
-  const userEmail = user.email.toLowerCase();
-  const isMember = (data ?? []).some(
-    (member) => member.email.toLowerCase() === userEmail,
-  );
+  const isMember = data ? groupIds.some((id) => data[id]) : false;
 
   return { isMember, isLoading };
 };

--- a/apps/apollo-vertex/types/optional-deps.d.ts
+++ b/apps/apollo-vertex/types/optional-deps.d.ts
@@ -121,6 +121,12 @@ declare module "@uipath/vs-core" {
         identity: {
           groups: unknown;
           groupMembers: unknown;
+          // Resolves group membership for a single user server-side (direct and
+          // transitive/AAD-inherited) in one call. Returns a groupId -> boolean map.
+          checkGroupMembership: (
+            userId: string,
+            groupIds: string[],
+          ) => Promise<Record<string, boolean>>;
         };
       };
     };


### PR DESCRIPTION
Reworks the group-membership gate (`useIsGroupMember`) to resolve membership through vs-core's `checkGroupMembership` (one server-side call) instead of enumerating the full `groupMembers` collection and matching users by email. This fixes AAD customers whose members are inherited via an assigned Azure AD group being wrongly denied, since the check endpoint resolves membership transitively. It also removes the brittle client-side email matching (and its null-email crash risk), fails closed when the check is unavailable, and adds the `checkGroupMembership` type to the vs-core stub.

👨 Generated with Kluijt Code