### PR TITLE
chore(apollo-vertex): update vs-core to 4.2.0 in registry [AGVSOL-6207]

### DIFF
--- a/apps/apollo-vertex/registry.json
+++ b/apps/apollo-vertex/registry.json
@@ -2303,7 +2303,7 @@
         "sonner",
         "@mantine/hooks@^9.0.0",
         "@tanstack/react-db",
-        "@uipath/vs-core@^1.2.2"
+        "@uipath/vs-core@^4.2.0"
       ],
       "registryDependencies": [
         "button",
@@ -2495,7 +2495,7 @@
       "dependencies": [
         "@tanstack/react-table@^8.21.0",
         "@tanstack/react-db",
-        "@uipath/vs-core@^1.2.2"
+        "@uipath/vs-core@^4.2.0"
       ],
       "registryDependencies": ["@uipath/use-data-table", "@uipath/data-table"],
       "files": [
@@ -3024,7 +3024,7 @@
         "@tanstack/react-query@^5.90.0",
         "@tanstack/react-table@^8.21.0",
         "@tanstack/react-router",
-        "@uipath/vs-core@^2.0.6",
+        "@uipath/vs-core@^4.2.0",
         "@uipath/uipath-typescript@^1.5.4",
         "react-i18next",
         "recharts@2.15.4",

--- a/apps/apollo-vertex/registry/shell/use-is-group-member.ts
+++ b/apps/apollo-vertex/registry/shell/use-is-group-member.ts
@@ -1,5 +1,5 @@
-import { inArray, useLiveQuery } from "@tanstack/react-db";
-import { type GroupMember, useSolution } from "@uipath/vs-core";
+import { useQuery } from "@tanstack/react-query";
+import { useSolution } from "@uipath/vs-core";
 import { useAuth } from "./shell-auth-provider";
 
 export interface UseIsGroupMemberOptions {
@@ -16,21 +16,19 @@ export const useIsGroupMember = ({
 }: UseIsGroupMemberOptions): UseIsGroupMemberResult => {
   const { user } = useAuth();
   const solution = useSolution();
+  const checkGroupMembership = solution?.api.identity.checkGroupMembership;
+  const userId = user?.sub;
 
-  const { data, isLoading } = useLiveQuery<GroupMember>((q) =>
-    q
-      .from({ members: solution?.api.collections.identity.groupMembers })
-      .where(({ members }) => inArray(members.groupId, groupIds)),
-  );
+  const { data, isLoading } = useQuery({
+    queryKey: ["identity-group-membership", userId, groupIds.toSorted()],
+    queryFn: (): Promise<Record<string, boolean>> =>
+      checkGroupMembership != null && userId != null
+        ? checkGroupMembership(userId, groupIds)
+        : Promise.resolve({}),
+    enabled: userId != null && groupIds.length > 0,
+  });
 
-  if (!user) {
-    return { isMember: false, isLoading };
-  }
-
-  const userEmail = user.email.toLowerCase();
-  const isMember = (data ?? []).some(
-    (member) => member.email.toLowerCase() === userEmail,
-  );
+  const isMember = data ? groupIds.some((id) => data[id]) : false;
 
   return { isMember, isLoading };
 };

--- a/apps/apollo-vertex/types/optional-deps.d.ts
+++ b/apps/apollo-vertex/types/optional-deps.d.ts
@@ -123,6 +123,13 @@ declare module "@uipath/vs-core" {
           groupMembers: unknown;
         };
       };
+      identity: {
+        // Resolves each requested groupId to whether `userId` is a member.
+        checkGroupMembership: (
+          userId: string,
+          groupIds: string[],
+        ) => Promise<Record<string, boolean>>;
+      };
     };
   } | null;
 }


### PR DESCRIPTION
## Summary

This is a follow up to https://github.com/UiPath/vertical-solutions/pull/268. It switches the group membership check to a different endpoint so we don't have to rely on checking a list of all group members which didn't include AD members before. This endpoint does work in such a case.