### PR TITLE
feat(apollo-wind): update Value Field docs and controls

### DIFF
--- a/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.stories.tsx
@@ -2876,11 +2876,11 @@ function LockableValueFieldShowcase() {
         <p className="text-xs leading-4 text-foreground-muted">
           Uses component →{' '}
           <a
-            href="/?path=/docs/apollo-wind-components-uipath-value-field--docs"
+            href="/?path=/docs/apollo-wind-components-uipath-lockable-value-field--docs"
             target="_top"
             className="font-medium text-brand transition hover:text-brand-hover"
           >
-            Value Field
+            Lockable Value Field
           </a>
         </p>
       </div>

--- a/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.stories.tsx
@@ -2901,7 +2901,7 @@ function LockableValueFieldShowcase() {
               aria-label="Delete field"
               title="Delete field"
               disabled
-              className="grid size-7 shrink-0 place-items-center rounded-lg text-foreground-subtle transition hover:bg-surface-overlay hover:text-foreground"
+              className="grid size-7 shrink-0 place-items-center rounded-lg text-foreground-subtle transition hover:bg-surface-overlay hover:text-foreground disabled:pointer-events-none disabled:opacity-50"
             >
               <Trash2 size={14} />
             </button>
@@ -2941,7 +2941,7 @@ function LockableValueFieldShowcase() {
                 aria-label="Delete field"
                 title="Delete field"
                 disabled
-                className="grid size-7 shrink-0 place-items-center rounded-lg text-foreground-subtle transition hover:bg-surface-overlay hover:text-foreground"
+                className="grid size-7 shrink-0 place-items-center rounded-lg text-foreground-subtle transition hover:bg-surface-overlay hover:text-foreground disabled:pointer-events-none disabled:opacity-50"
               >
                 <Trash2 size={14} />
               </button>

--- a/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.stories.tsx
@@ -2876,7 +2876,7 @@ function LockableValueFieldShowcase() {
         <p className="text-xs leading-4 text-foreground-muted">
           Uses component →{' '}
           <a
-            href="/?path=/docs/apollo-wind-components-uipath-lockable-value-field--docs"
+            href="/?path=/docs/apollo-wind-components-uipath-value-field--docs"
             target="_top"
             className="font-medium text-brand transition hover:text-brand-hover"
           >
@@ -2900,6 +2900,7 @@ function LockableValueFieldShowcase() {
               type="button"
               aria-label="Delete field"
               title="Delete field"
+              disabled
               className="grid size-7 shrink-0 place-items-center rounded-lg text-foreground-subtle transition hover:bg-surface-overlay hover:text-foreground"
             >
               <Trash2 size={14} />
@@ -2939,6 +2940,7 @@ function LockableValueFieldShowcase() {
                 type="button"
                 aria-label="Delete field"
                 title="Delete field"
+                disabled
                 className="grid size-7 shrink-0 place-items-center rounded-lg text-foreground-subtle transition hover:bg-surface-overlay hover:text-foreground"
               >
                 <Trash2 size={14} />

--- a/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.stories.tsx
@@ -1358,7 +1358,6 @@ function InlineCaseRow({
       onModeChange={setMode}
       fieldType="string"
       variables={LOCKABLE_VARIABLES}
-      controlsVisibility="visible"
     />
   );
 }
@@ -2568,7 +2567,6 @@ function LockableCaseRow({
   fieldType,
   onFieldTypeChange,
   compact,
-  controlsVisibility,
   monacoTheme,
   insertBefore,
   insertAfter,
@@ -2588,7 +2586,6 @@ function LockableCaseRow({
   fieldType: LockableFieldType;
   onFieldTypeChange: (fieldType: LockableFieldType) => void;
   compact?: boolean;
-  controlsVisibility?: 'visible' | 'hover';
   monacoTheme: string;
   /** Shows the insertion line above this row (the dragged item would land here). */
   insertBefore?: boolean;
@@ -2666,13 +2663,9 @@ function LockableCaseRow({
               onClick={onDelete}
               aria-label="Delete field"
               title="Delete field"
-              className={cn(
-                'grid size-6 shrink-0 place-items-center rounded text-foreground-subtle transition hover:bg-surface-overlay hover:text-foreground',
-                controlsVisibility === 'hover' &&
-                  'opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 has-[[aria-expanded=true]]:opacity-100'
-              )}
+              className="grid size-6 shrink-0 place-items-center rounded text-foreground-subtle transition hover:bg-surface-overlay hover:text-foreground"
             >
-              <X size={12} />
+              <Trash2 size={12} />
             </button>
           }
           value={value}
@@ -2708,7 +2701,6 @@ function LockableCaseRow({
           onRequiredChange={onRequiredChange}
           variables={LOCKABLE_VARIABLES}
           compact={compact}
-          controlsVisibility={controlsVisibility}
         />
       </div>
       {insertAfter && (
@@ -2860,13 +2852,7 @@ function FieldDragOverlay({ caseItem }: { caseItem: LockableCase }) {
   );
 }
 
-function LockableValueFieldShowcase({
-  controlsVisibility,
-  onControlsVisibilityChange,
-}: {
-  controlsVisibility: 'visible' | 'hover';
-  onControlsVisibilityChange: (visibility: 'visible' | 'hover') => void;
-}) {
+function LockableValueFieldShowcase() {
   const fullViewId = useId();
   const compactViewId = useId();
   const [showcaseValue, setShowcaseValue] = useState('');
@@ -2888,34 +2874,15 @@ function LockableValueFieldShowcase({
       <div className="flex flex-col gap-1">
         <span className="text-sm font-semibold text-foreground">Demo controls</span>
         <p className="text-xs leading-4 text-foreground-muted">
-          Toggle Show/Hide to preview how field controls behave in the panel on the left. Uses
-          component →{' '}
+          Uses component →{' '}
           <a
             href="/?path=/docs/apollo-wind-components-uipath-lockable-value-field--docs"
             target="_top"
             className="font-medium text-brand transition hover:text-brand-hover"
           >
-            Lockable Value Field
+            Value Field
           </a>
         </p>
-      </div>
-      <div className="flex items-center justify-between border-t border-border-subtle pt-4">
-        <span className="text-[11px] font-medium uppercase tracking-wide text-foreground-subtle">
-          Controls
-        </span>
-        <ToggleGroup
-          type="single"
-          size="xs"
-          value={controlsVisibility}
-          onValueChange={(v) => v && onControlsVisibilityChange(v as 'visible' | 'hover')}
-        >
-          <ToggleGroupItem value="visible" className="!px-2.5 !text-xs">
-            Show
-          </ToggleGroupItem>
-          <ToggleGroupItem value="hover" className="!px-2.5 !text-xs">
-            Hide
-          </ToggleGroupItem>
-        </ToggleGroup>
       </div>
       <div className="flex flex-col gap-2">
         <span className="text-[11px] font-medium uppercase tracking-wide text-foreground-subtle">
@@ -2931,14 +2898,11 @@ function LockableValueFieldShowcase({
           headerActions={
             <button
               type="button"
-              aria-label="Close field"
-              className={cn(
-                'grid size-7 shrink-0 place-items-center rounded-lg text-foreground-subtle transition hover:bg-surface-overlay hover:text-foreground',
-                controlsVisibility === 'hover' &&
-                  'opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100 has-[[aria-expanded=true]]:opacity-100'
-              )}
+              aria-label="Delete field"
+              title="Delete field"
+              className="grid size-7 shrink-0 place-items-center rounded-lg text-foreground-subtle transition hover:bg-surface-overlay hover:text-foreground"
             >
-              <X size={14} />
+              <Trash2 size={14} />
             </button>
           }
           value={showcaseValue}
@@ -2952,7 +2916,6 @@ function LockableValueFieldShowcase({
           required={showcaseRequired}
           onRequiredChange={setShowcaseRequired}
           variables={LOCKABLE_VARIABLES}
-          controlsVisibility={controlsVisibility}
         />
       </div>
       <div className="flex flex-col gap-2 border-t border-border-subtle pt-4">
@@ -2974,14 +2937,11 @@ function LockableValueFieldShowcase({
             headerActions={
               <button
                 type="button"
-                aria-label="Close field"
-                className={cn(
-                  'grid size-7 shrink-0 place-items-center rounded-lg text-foreground-subtle transition hover:bg-surface-overlay hover:text-foreground',
-                  controlsVisibility === 'hover' &&
-                    'opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100 has-[[aria-expanded=true]]:opacity-100'
-                )}
+                aria-label="Delete field"
+                title="Delete field"
+                className="grid size-7 shrink-0 place-items-center rounded-lg text-foreground-subtle transition hover:bg-surface-overlay hover:text-foreground"
               >
-                <X size={14} />
+                <Trash2 size={14} />
               </button>
             }
             value={showcaseValue}
@@ -2995,7 +2955,6 @@ function LockableValueFieldShowcase({
             required={showcaseRequired}
             onRequiredChange={setShowcaseRequired}
             variables={LOCKABLE_VARIABLES}
-            controlsVisibility={controlsVisibility}
           />
         </div>
       </div>
@@ -3025,9 +2984,6 @@ export function QuickFormPanel({
   const [jsonDraft, setJsonDraft] = useState(() => JSON.stringify(DEFAULT_LOCKABLE_CASES, null, 2));
   const [jsonError, setJsonError] = useState<string | null>(null);
   const [jsonCopied, setJsonCopied] = useState(false);
-  const [showcaseControlsVisibility, setShowcaseControlsVisibility] = useState<'visible' | 'hover'>(
-    'visible'
-  );
   const [buttons, setButtons] = useState<FormButtonItem[]>(DEFAULT_FORM_BUTTONS);
   const nextButtonIdRef = useRef(3);
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -3347,7 +3303,6 @@ export function QuickFormPanel({
                                 onFieldTypeChange={(fieldType) =>
                                   updateCaseFieldType(c.id, fieldType)
                                 }
-                                controlsVisibility={showcaseControlsVisibility}
                                 monacoTheme={monacoTheme}
                                 insertBefore={isOver && activeIndex > index}
                                 insertAfter={isOver && activeIndex < index}
@@ -3454,10 +3409,7 @@ export function QuickFormPanel({
     <div className="flex items-start gap-8">
       <PanelFrame>{panel}</PanelFrame>
 
-      <LockableValueFieldShowcase
-        controlsVisibility={showcaseControlsVisibility}
-        onControlsVisibilityChange={setShowcaseControlsVisibility}
-      />
+      <LockableValueFieldShowcase />
     </div>
   );
 }
@@ -4377,7 +4329,6 @@ function PanelUIInventoryStory() {
                       required={compositionRequired}
                       onRequiredChange={setCompositionRequired}
                       variables={LOCKABLE_VARIABLES}
-                      controlsVisibility="visible"
                     />
                   </section>
                 </div>

--- a/packages/apollo-wind/src/components/ui/lockable-value-field/components/field-header.tsx
+++ b/packages/apollo-wind/src/components/ui/lockable-value-field/components/field-header.tsx
@@ -26,7 +26,6 @@ export function FieldHeader({
   fieldType,
   onFieldTypeChange,
   onRequiredChange,
-  controlsVisibility,
   compact,
   showFieldActions,
   value,
@@ -42,7 +41,6 @@ export function FieldHeader({
   fieldType: LockableFieldType;
   onFieldTypeChange?: (fieldType: LockableFieldType) => void;
   onRequiredChange?: (required: boolean) => void;
-  controlsVisibility: 'visible' | 'hover';
   compact?: boolean;
   showFieldActions: boolean;
   value: string;
@@ -70,13 +68,7 @@ export function FieldHeader({
       )}
       <TooltipProvider delayDuration={300}>
         <div className="ml-auto flex items-center gap-0.5">
-          <div
-            className={cn(
-              'flex items-center gap-0.5',
-              controlsVisibility === 'hover' &&
-                'opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100 has-[[aria-expanded=true]]:opacity-100'
-            )}
-          >
+          <div className="flex items-center gap-0.5">
             {onFieldTypeChange && (
               <DropdownMenu>
                 <Tooltip>

--- a/packages/apollo-wind/src/components/ui/lockable-value-field/lockable-value-field.stories.tsx
+++ b/packages/apollo-wind/src/components/ui/lockable-value-field/lockable-value-field.stories.tsx
@@ -299,7 +299,7 @@ function ReferenceExamplesDemo() {
 
 /** Reference layouts for assignment/binding fields used in node properties. */
 export const ReferenceExamples: Story = {
-  name: 'Assignment & Binding Examples',
+  name: 'Assignment & Binding',
   render: () => <ReferenceExamplesDemo />,
 };
 

--- a/packages/apollo-wind/src/components/ui/lockable-value-field/lockable-value-field.stories.tsx
+++ b/packages/apollo-wind/src/components/ui/lockable-value-field/lockable-value-field.stories.tsx
@@ -58,7 +58,7 @@ function DeleteFieldButton({ onDelete }: { onDelete?: () => void }) {
       disabled={!onDelete}
       aria-label="Delete field"
       title="Delete field"
-      className="grid size-7 shrink-0 place-items-center rounded-lg text-foreground-subtle transition hover:bg-surface-overlay hover:text-foreground"
+      className="grid size-7 shrink-0 place-items-center rounded-lg text-foreground-subtle transition hover:bg-surface-overlay hover:text-foreground disabled:pointer-events-none disabled:opacity-50"
     >
       <Trash2 size={14} />
     </button>

--- a/packages/apollo-wind/src/components/ui/lockable-value-field/lockable-value-field.stories.tsx
+++ b/packages/apollo-wind/src/components/ui/lockable-value-field/lockable-value-field.stories.tsx
@@ -6,7 +6,7 @@ import { LockableValueField } from './lockable-value-field';
 import { FIELD_TYPE_META, type LockableFieldType, type LockableValueFieldMode } from './types';
 
 const meta = {
-  title: 'Components/UiPath/Value Field',
+  title: 'Components/UiPath/Lockable Value Field',
   component: LockableValueField,
   parameters: {
     layout: 'centered',

--- a/packages/apollo-wind/src/components/ui/lockable-value-field/lockable-value-field.stories.tsx
+++ b/packages/apollo-wind/src/components/ui/lockable-value-field/lockable-value-field.stories.tsx
@@ -1,14 +1,12 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { X } from 'lucide-react';
+import { Trash2 } from 'lucide-react';
 import { useId, useRef, useState } from 'react';
-import { cn } from '@/lib';
 import { Label, RequiredIndicator } from '../label';
-import { ToggleGroup, ToggleGroupItem } from '../toggle-group';
 import { LockableValueField } from './lockable-value-field';
 import { FIELD_TYPE_META, type LockableFieldType, type LockableValueFieldMode } from './types';
 
 const meta = {
-  title: 'Components/UiPath/Lockable Value Field',
+  title: 'Components/UiPath/Value Field',
   component: LockableValueField,
   parameters: {
     layout: 'centered',
@@ -32,10 +30,8 @@ and (for scalar types) switched between a literal value and a JS expression.
   Insert-variable affordance for binding to upstream data. Both hidden via
   \`showFieldActions={false}\` for read-only reviewer contexts.
 - \`label\` accepts any ReactNode, so a consumer can compose its own
-  inline-editable title in place of the default text -- see **Controls**
-  below.
-- \`controlsVisibility\` decides whether the type/required/AI/insert/header
-  actions are always shown or only on hover -- see **Controls** below.
+  inline-editable title in place of the default text.
+- Header actions are shown at all times.
 - Header row is responsive (container query): the type, required,
   AI-assist, and insert-variable controls collapse to icon-only once the
   field gets too narrow for their labels. See **Responsive** below.
@@ -54,18 +50,16 @@ and (for scalar types) switched between a literal value and a JS expression.
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-function CloseFieldButton({ controlsVisibility }: { controlsVisibility: 'visible' | 'hover' }) {
+function DeleteFieldButton({ onDelete }: { onDelete?: () => void }) {
   return (
     <button
       type="button"
-      aria-label="Close field"
-      className={cn(
-        'grid size-7 shrink-0 place-items-center rounded-lg text-foreground-subtle transition hover:bg-surface-overlay hover:text-foreground',
-        controlsVisibility === 'hover' &&
-          'opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100 has-[[aria-expanded=true]]:opacity-100'
-      )}
+      onClick={onDelete}
+      aria-label="Delete field"
+      title="Delete field"
+      className="grid size-7 shrink-0 place-items-center rounded-lg text-foreground-subtle transition hover:bg-surface-overlay hover:text-foreground"
     >
-      <X size={14} />
+      <Trash2 size={14} />
     </button>
   );
 }
@@ -77,6 +71,7 @@ function DefaultDemo() {
   const [mode, setMode] = useState<LockableValueFieldMode>('fixed');
   const [fieldType, setFieldType] = useState<LockableFieldType>('string');
   const [required, setRequired] = useState(true);
+  const [deleted, setDeleted] = useState(false);
 
   const handleFieldTypeChange = (type: LockableFieldType) => {
     setFieldType(type);
@@ -85,6 +80,8 @@ function DefaultDemo() {
       setMode('fixed');
     }
   };
+
+  if (deleted) return null;
 
   return (
     <div className="w-80">
@@ -96,7 +93,7 @@ function DefaultDemo() {
             {required && <RequiredIndicator />}
           </Label>
         }
-        headerActions={<CloseFieldButton controlsVisibility="visible" />}
+        headerActions={<DeleteFieldButton onDelete={() => setDeleted(true)} />}
         value={value}
         onValueChange={setValue}
         locked={locked}
@@ -113,7 +110,44 @@ function DefaultDemo() {
 }
 
 export const Default: Story = {
+  name: 'Basic Value Field',
   render: () => <DefaultDemo />,
+};
+
+function ExpressionValueFieldDemo() {
+  const fieldId = useId();
+  const [value, setValue] = useState('');
+
+  return (
+    <div className="w-80">
+      <LockableValueField
+        id={fieldId}
+        label={<Label htmlFor={fieldId}>Expression</Label>}
+        value={value}
+        onValueChange={setValue}
+        locked={false}
+        mode="expression"
+        variables={[
+          { label: 'Customer name', value: '$input.customerName' },
+          { label: 'Invoice number', value: '$input.invoiceNumber' },
+          { label: 'User email', value: '$user.email' },
+        ]}
+      />
+    </div>
+  );
+}
+
+export const Expression: Story = {
+  name: 'Expression Value Field',
+  render: () => <ExpressionValueFieldDemo />,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A focused expression-writing example. Use the Insert variable action above the field to add an available variable to the expression.',
+      },
+    },
+  },
 };
 
 function EqualsAddon() {
@@ -264,7 +298,7 @@ function ReferenceExamplesDemo() {
 
 /** Reference layouts for assignment/binding fields used in node properties. */
 export const ReferenceExamples: Story = {
-  name: 'Reference examples (=)',
+  name: 'Assignment & Binding Examples',
   render: () => <ReferenceExamplesDemo />,
 };
 
@@ -350,70 +384,6 @@ function InlineEditableLabel({
   );
 }
 
-function ControlsPlayground() {
-  const [title, setTitle] = useState('Label');
-  const [value, setValue] = useState('');
-  const [locked, setLocked] = useState(true);
-  const [mode, setMode] = useState<LockableValueFieldMode>('fixed');
-  const [fieldType, setFieldType] = useState<LockableFieldType>('string');
-  const [required, setRequired] = useState(true);
-  const [controlsVisibility, setControlsVisibility] = useState<'visible' | 'hover'>('visible');
-
-  const handleFieldTypeChange = (type: LockableFieldType) => {
-    setFieldType(type);
-    setValue('');
-    if (!FIELD_TYPE_META[type].supportsExpression) {
-      setMode('fixed');
-    }
-  };
-
-  return (
-    <div className="flex w-80 flex-col gap-4">
-      <div className="flex items-center justify-between">
-        <span className="text-[11px] font-medium uppercase tracking-wide text-foreground-subtle">
-          Controls
-        </span>
-        <ToggleGroup
-          type="single"
-          size="xs"
-          value={controlsVisibility}
-          onValueChange={(v) => v && setControlsVisibility(v as 'visible' | 'hover')}
-        >
-          <ToggleGroupItem value="visible" className="!px-2.5 !text-xs">
-            Show
-          </ToggleGroupItem>
-          <ToggleGroupItem value="hover" className="!px-2.5 !text-xs">
-            Hide
-          </ToggleGroupItem>
-        </ToggleGroup>
-      </div>
-      <LockableValueField
-        label={
-          <div className="flex min-w-0 flex-1 items-center gap-1">
-            <InlineEditableLabel title={title} onTitleChange={setTitle} required={required} />
-          </div>
-        }
-        headerActions={<CloseFieldButton controlsVisibility={controlsVisibility} />}
-        value={value}
-        onValueChange={setValue}
-        locked={locked}
-        onLockedChange={setLocked}
-        mode={mode}
-        onModeChange={setMode}
-        fieldType={fieldType}
-        onFieldTypeChange={handleFieldTypeChange}
-        required={required}
-        onRequiredChange={setRequired}
-        controlsVisibility={controlsVisibility}
-      />
-    </div>
-  );
-}
-
-export const Controls: Story = {
-  render: () => <ControlsPlayground />,
-};
-
 function ResponsiveDemo() {
   const fullWidthId = useId();
   const narrowId = useId();
@@ -449,7 +419,7 @@ function ResponsiveDemo() {
           <LockableValueField
             id={fullWidthId}
             label={label(fullWidthId)}
-            headerActions={<CloseFieldButton controlsVisibility="visible" />}
+            headerActions={<DeleteFieldButton />}
             value={value}
             onValueChange={setValue}
             locked={locked}
@@ -471,7 +441,7 @@ function ResponsiveDemo() {
           <LockableValueField
             id={narrowId}
             label={label(narrowId)}
-            headerActions={<CloseFieldButton controlsVisibility="visible" />}
+            headerActions={<DeleteFieldButton />}
             value={value}
             onValueChange={setValue}
             locked={locked}
@@ -494,7 +464,7 @@ function ResponsiveDemo() {
             compact
             id={compactId}
             label={label(compactId)}
-            headerActions={<CloseFieldButton controlsVisibility="visible" />}
+            headerActions={<DeleteFieldButton />}
             value={value}
             onValueChange={setValue}
             locked={locked}

--- a/packages/apollo-wind/src/components/ui/lockable-value-field/lockable-value-field.stories.tsx
+++ b/packages/apollo-wind/src/components/ui/lockable-value-field/lockable-value-field.stories.tsx
@@ -31,7 +31,7 @@ and (for scalar types) switched between a literal value and a JS expression.
   \`showFieldActions={false}\` for read-only reviewer contexts.
 - \`label\` accepts any ReactNode, so a consumer can compose its own
   inline-editable title in place of the default text.
-- Header actions are shown at all times.
+- When provided, header actions are shown at all times.
 - Header row is responsive (container query): the type, required,
   AI-assist, and insert-variable controls collapse to icon-only once the
   field gets too narrow for their labels. See **Responsive** below.
@@ -55,6 +55,7 @@ function DeleteFieldButton({ onDelete }: { onDelete?: () => void }) {
     <button
       type="button"
       onClick={onDelete}
+      disabled={!onDelete}
       aria-label="Delete field"
       title="Delete field"
       className="grid size-7 shrink-0 place-items-center rounded-lg text-foreground-subtle transition hover:bg-surface-overlay hover:text-foreground"

--- a/packages/apollo-wind/src/components/ui/lockable-value-field/lockable-value-field.tsx
+++ b/packages/apollo-wind/src/components/ui/lockable-value-field/lockable-value-field.tsx
@@ -73,7 +73,6 @@ export function LockableValueField({
   fileUploadAriaLabel,
   headerActions,
   compact,
-  controlsVisibility = 'visible',
   showFieldActions = true,
   options = DEFAULT_SELECT_OPTIONS,
   onGenerateWithAi,
@@ -111,7 +110,6 @@ export function LockableValueField({
         fieldType={fieldType}
         onFieldTypeChange={onFieldTypeChange}
         onRequiredChange={onRequiredChange}
-        controlsVisibility={controlsVisibility}
         compact={compact}
         showFieldActions={showFieldActions}
         value={value}

--- a/packages/apollo-wind/src/components/ui/lockable-value-field/types.ts
+++ b/packages/apollo-wind/src/components/ui/lockable-value-field/types.ts
@@ -171,8 +171,6 @@ export interface LockableValueFieldProps {
   headerActions?: ReactNode;
   /** Forces the header row into its narrow-container icon-only layout, regardless of actual width. For demos/comparisons. */
   compact?: boolean;
-  /** Whether the field-type, AI-assist, and insert-variable controls are always shown or only on hover. Defaults to 'visible'. */
-  controlsVisibility?: 'visible' | 'hover';
   /** Whether the AI-assist and Insert-variable actions render at all. Set to false for read-only reviewer contexts where field configuration isn't editable. Defaults to true. */
   showFieldActions?: boolean;
   /** Options for 'single-select' / 'multi-select' field types. Defaults to a small set of demo options. */

--- a/packages/apollo-wind/src/components/ui/lockable-value-field/types.ts
+++ b/packages/apollo-wind/src/components/ui/lockable-value-field/types.ts
@@ -171,6 +171,8 @@ export interface LockableValueFieldProps {
   headerActions?: ReactNode;
   /** Forces the header row into its narrow-container icon-only layout, regardless of actual width. For demos/comparisons. */
   compact?: boolean;
+  /** @deprecated Controls are always visible. Retained as a no-op for backwards compatibility. */
+  controlsVisibility?: 'visible' | 'hover';
   /** Whether the AI-assist and Insert-variable actions render at all. Set to false for read-only reviewer contexts where field configuration isn't editable. Defaults to true. */
   showFieldActions?: boolean;
   /** Options for 'single-select' / 'multi-select' field types. Defaults to a small set of demo options. */


### PR DESCRIPTION
## Summary

- Keep the technical component/API name as LockableValueField while using Lockable Value Field as the Storybook component title.
- Organize the Storybook examples as Basic Value Field, Expression Value Field, Assignment & Binding, Inline Validation, and Responsive.
- Remove the Controls story and Show/Hide demo; controls are always visible in the documented examples.
- Retain controlsVisibility as a deprecated no-op for backwards compatibility.
- Replace header close icons with trash actions, including Delete field tooltip/aria labeling and a functional delete action in the basic demo.
- Add an expression-focused example with Insert variable support and interaction coverage for inserting a selected variable.
- Update the Node Property Panel showcase and Storybook links to match the final naming and behavior.

## Verification

- 1,413 apollo-wind tests passed.
- Full workspace typecheck passed.
- Biome checks passed.
- Storybook preview verified at http://localhost:6007/.
- Review feedback addressed and all review threads resolved.
