### PR TITLE
fix(storybook): use white pattern required labels

### DIFF
--- a/apps/storybook/src/patterns/LayoutPatterns.stories.tsx
+++ b/apps/storybook/src/patterns/LayoutPatterns.stories.tsx
@@ -346,13 +346,18 @@ function DapValueField({
     <div className="space-y-1.5">
       <Label htmlFor={id} className="text-xs">
         {label}
-        {required && <span className="text-foreground"> *</span>}
+        {required && (
+          <span aria-hidden="true" className="text-foreground">
+            {' *'}
+          </span>
+        )}
       </Label>
       <InputGroup className="h-9 bg-surface-overlay" error={error}>
         <InputGroupInput
           id={id}
           value={value}
           placeholder={placeholder}
+          required={required}
           onChange={(event) => onChange(event.target.value)}
           className="text-xs"
         />

--- a/apps/storybook/src/patterns/LayoutPatterns.stories.tsx
+++ b/apps/storybook/src/patterns/LayoutPatterns.stories.tsx
@@ -451,11 +451,15 @@ function DapValidationPanel({ onClose }: { onClose: () => void }) {
               />
               <div className="space-y-1.5">
                 <Label htmlFor="dap-validation-body" className="text-xs">
-                  Body <span className="text-foreground">*</span>
+                  Body{' '}
+                  <span aria-hidden="true" className="text-foreground">
+                    *
+                  </span>
                 </Label>
                 <Textarea
                   id="dap-validation-body"
                   value={body}
+                  required
                   onChange={(event) => setBody(event.target.value)}
                   className="min-h-24 resize-none bg-surface-overlay text-xs"
                 />

--- a/apps/storybook/src/patterns/LayoutPatterns.stories.tsx
+++ b/apps/storybook/src/patterns/LayoutPatterns.stories.tsx
@@ -346,7 +346,7 @@ function DapValueField({
     <div className="space-y-1.5">
       <Label htmlFor={id} className="text-xs">
         {label}
-        {required && <span className="text-error"> *</span>}
+        {required && <span className="text-foreground"> *</span>}
       </Label>
       <InputGroup className="h-9 bg-surface-overlay" error={error}>
         <InputGroupInput
@@ -451,7 +451,7 @@ function DapValidationPanel({ onClose }: { onClose: () => void }) {
               />
               <div className="space-y-1.5">
                 <Label htmlFor="dap-validation-body" className="text-xs">
-                  Body <span className="text-error">*</span>
+                  Body <span className="text-foreground">*</span>
                 </Label>
                 <Textarea
                   id="dap-validation-body"


### PR DESCRIPTION
## Summary

- Update the required asterisks in the Layout Patterns error and validation story to use the label foreground token.
- Ensure all three pattern labels render white and match the requested standard.
<img width="981" height="994" alt="Screenshot 2026-08-28 at 2 46 03 PM" src="https://github.com/user-attachments/assets/20163694-b370-476b-84eb-55a3ae0fbd83" />

## Verification

- Storybook preview verified at http://localhost:6007/?path=/story/apollo-wind-patterns-layout-patterns--error-and-validation
- `pnpm --filter storybook-app format:check`
- `git diff --check`