### PR TITLE
feat(apollo-react): let consumers title the replace-task toolbox

### DIFF
--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.stories.tsx
@@ -1425,7 +1425,11 @@ const availableTaskOptions: ListItem[] = [
   },
 ];
 
-const AddAndReplaceTasksStory = () => {
+const AddAndReplaceTasksStory = ({
+  replaceTaskToolboxTitle,
+}: {
+  replaceTaskToolboxTitle?: string;
+}) => {
   const nodeTypes = useMemo(() => ({ stage: StageNodeWrapper }), []);
   const edgeTypes = useMemo(() => ({ stage: StageEdge }), []);
 
@@ -1673,6 +1677,7 @@ const AddAndReplaceTasksStory = () => {
                 },
                 onAddTaskFromToolbox: handleAddTask,
                 onReplaceTaskFromToolbox: handleReplaceTask,
+                replaceTaskToolboxTitle,
                 onTaskGroupModification: handleTaskGroupModification,
                 onTaskReorder: handleTaskReorder,
                 onTaskClick: handleTaskClick,
@@ -1694,6 +1699,7 @@ const AddAndReplaceTasksStory = () => {
       nodesState,
       pendingReplaceTask,
       selectedTaskId,
+      replaceTaskToolboxTitle,
       handleAddTask,
       handleReplaceTask,
       handleTaskGroupModification,
@@ -1767,6 +1773,14 @@ export const AddAndReplaceTasks: Story = {
     useCustomRender: true,
   },
   render: () => <AddAndReplaceTasksStory />,
+};
+
+export const ReplaceTaskToolboxCustomTitle: Story = {
+  name: 'Replace Task Toolbox with a Consumer Title',
+  parameters: {
+    useCustomRender: true,
+  },
+  render: () => <AddAndReplaceTasksStory replaceTaskToolboxTitle="Select activity" />,
 };
 
 const InlineTitleEditStory = () => {

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.test.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.test.tsx
@@ -348,6 +348,22 @@ describe('StageNode - Replace Task Functionality', () => {
       expect(screen.getByTestId('toolbox-title')).toHaveTextContent('Select activity');
     });
 
+    it('should keep the default title when the consumer supplies an empty one', async () => {
+      const user = userEvent.setup();
+      const onReplaceTaskFromToolbox = vi.fn();
+      renderStageNode({ onReplaceTaskFromToolbox, replaceTaskToolboxTitle: '' });
+
+      const taskMenuButton = screen.getByTestId('task-menu-button-task-1');
+      await user.click(taskMenuButton);
+      await user.click(screen.getByTestId('menu-item-task-1-replace-task'));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('toolbox')).toBeInTheDocument();
+      });
+
+      expect(screen.getByTestId('toolbox-title')).toHaveTextContent('Replace task');
+    });
+
     it('should display task options in replace task toolbox', async () => {
       const user = userEvent.setup();
       const onReplaceTaskFromToolbox = vi.fn();

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.test.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.test.tsx
@@ -330,6 +330,24 @@ describe('StageNode - Replace Task Functionality', () => {
       expect(toolboxTitle).toHaveTextContent('Replace task');
     });
 
+    it('should title the replace task toolbox from the consumer when one is supplied', async () => {
+      // Consumers can open this toolbox to answer a question of their own, where "Replace task"
+      // describes the wrong thing.
+      const user = userEvent.setup();
+      const onReplaceTaskFromToolbox = vi.fn();
+      renderStageNode({ onReplaceTaskFromToolbox, replaceTaskToolboxTitle: 'Select activity' });
+
+      const taskMenuButton = screen.getByTestId('task-menu-button-task-1');
+      await user.click(taskMenuButton);
+      await user.click(screen.getByTestId('menu-item-task-1-replace-task'));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('toolbox')).toBeInTheDocument();
+      });
+
+      expect(screen.getByTestId('toolbox-title')).toHaveTextContent('Select activity');
+    });
+
     it('should display task options in replace task toolbox', async () => {
       const user = userEvent.setup();
       const onReplaceTaskFromToolbox = vi.fn();

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.tsx
@@ -32,6 +32,7 @@ const StageNodeInner = (props: StageNodeProps) => {
     execution,
     stageDetails,
     taskOptions = [],
+    replaceTaskToolboxTitle,
     menuItems,
     pendingReplaceTask,
     onStageClick,
@@ -201,7 +202,7 @@ const StageNodeInner = (props: StageNodeProps) => {
       {onReplaceTaskFromToolbox && isReplacingTask && !isReadOnly && (
         <FloatingCanvasPanel nodeId={id} offset={15}>
           <Toolbox
-            title={labels.replaceTask}
+            title={replaceTaskToolboxTitle ?? labels.replaceTask}
             initialItems={taskOptions}
             onClose={handleReplaceTaskToolboxClose}
             onItemSelect={handleReplaceTaskToolboxItemSelected}

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.tsx
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.tsx
@@ -202,7 +202,7 @@ const StageNodeInner = (props: StageNodeProps) => {
       {onReplaceTaskFromToolbox && isReplacingTask && !isReadOnly && (
         <FloatingCanvasPanel nodeId={id} offset={15}>
           <Toolbox
-            title={replaceTaskToolboxTitle ?? labels.replaceTask}
+            title={replaceTaskToolboxTitle || labels.replaceTask}
             initialItems={taskOptions}
             onClose={handleReplaceTaskToolboxClose}
             onItemSelect={handleReplaceTaskToolboxItemSelected}

--- a/packages/apollo-react/src/canvas/components/StageNode/StageNode.types.ts
+++ b/packages/apollo-react/src/canvas/components/StageNode/StageNode.types.ts
@@ -82,6 +82,12 @@ export interface StageNodeBaseProps {
     completionRules?: StageRule[];
   };
   taskOptions?: ListItem[];
+  /**
+   * Overrides the title of the replace-task toolbox, for consumers that open it to answer a
+   * question of their own rather than to replace a task. Supply it already translated: Apollo only
+   * places it, since the wording belongs to the consumer's catalogues. Defaults to "Replace task".
+   */
+  replaceTaskToolboxTitle?: string;
   execution?: {
     stageStatus: {
       status?: StageStatus;


### PR DESCRIPTION
## What

Adds an optional `replaceTaskToolboxTitle` prop to `StageNode`. When supplied, it replaces the hardcoded "Replace task" heading on the toolbox that `StageNode` opens; when omitted or empty, the title is unchanged.

```ts
/**
 * Overrides the title of the replace-task toolbox, for consumers that open it to answer a
 * question of their own rather than to replace a task. Supply it already translated: Apollo only
 * places it, since the wording belongs to the consumer's catalogues. Defaults to "Replace task".
 */
replaceTaskToolboxTitle?: string;
```

## Why

`StageNode` titles its toolbox "Replace task" unconditionally, which is right for the gesture it was built for: picking a replacement from the node itself.

Maestro (PO.Frontend) now opens that same toolbox from a different entry point, the properties panel's *Select activity* field. In the VS Code extension host there is no command palette, so that field has to open the canvas toolbox to let the user choose an activity. The toolbox is doing the picking, not a replacement, and "Replace task" reads wrong there. The replace-task gesture on the node itself still exists and still wants the default title, so this has to be per-open, not a global relabel.

Following the `durationLabel` precedent on the same component, the prop takes an already-translated string: Apollo places it, the consumer owns the wording and its catalogues.

## Compatibility

Additive and optional. Every existing consumer keeps the current heading with no change. An empty string falls back to the default rather than rendering a blank heading, so a consumer computing the title from a catalogue lookup cannot accidentally blank it.

## Storybook

`StageNode`'s meta carries no `autodocs` tag, so a prop with no story is undiscoverable. The existing `AddAndReplaceTasks` story is parameterised and a second thin story, **Replace Task Toolbox with a Consumer Title**, renders it with an override. The original story still renders with no argument, so the two sit side by side as default vs. overridden. This adds one new visual-regression snapshot.

## Testing

`StageNode.test.tsx` covers all three paths: the existing default-title assertion, a consumer-supplied title, and an empty override falling back to the default. The empty-string test was checked against the previous `??` implementation to confirm it actually catches the regression it guards. Full file run locally: 90 tests pass. Typecheck and Biome lint/format clean on the changed files.

<img width="573" height="584" alt="image" src="https://github.com/user-attachments/assets/7f487fdb-3152-4555-a26e-3c1ef3237b19" />
