### PR TITLE
feat(apollo-wind): unify field label styling

### DIFF
--- a/apps/storybook/src/patterns/LayoutPatterns.stories.tsx
+++ b/apps/storybook/src/patterns/LayoutPatterns.stories.tsx
@@ -420,10 +420,15 @@ function DapValidationPanel({ onClose }: { onClose: () => void }) {
               </AlertDescription>
             </Alert>
 
-            <section className="space-y-3">
-              <p className="text-xs font-semibold text-foreground">Connection</p>
+            <section className="space-y-1.5">
+              <Label htmlFor="dap-validation-connection" className="text-xs text-foreground">
+                Connection
+              </Label>
               <Select defaultValue="gmail-finance">
-                <SelectTrigger className="h-9 w-full bg-surface-overlay text-xs">
+                <SelectTrigger
+                  id="dap-validation-connection"
+                  className="h-9 w-full bg-surface-overlay text-xs"
+                >
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>

--- a/packages/apollo-react/src/canvas/components/NodePropertiesPanel/fields/CheckboxField.tsx
+++ b/packages/apollo-react/src/canvas/components/NodePropertiesPanel/fields/CheckboxField.tsx
@@ -32,7 +32,7 @@ export const CheckboxField = memo(function CheckboxField({
       >
         <Label
           className={cn(
-            'flex items-center text-[13px] text-(--canvas-foreground) select-none',
+            'flex items-center select-none',
             field.disabled ? 'cursor-not-allowed' : 'cursor-pointer'
           )}
         >

--- a/packages/apollo-react/src/canvas/components/NodePropertiesPanel/fields/CheckboxField.tsx
+++ b/packages/apollo-react/src/canvas/components/NodePropertiesPanel/fields/CheckboxField.tsx
@@ -1,4 +1,4 @@
-import { cn } from '@uipath/apollo-wind';
+import { cn, Label } from '@uipath/apollo-wind';
 import { memo, useCallback } from 'react';
 import type { ConfigField } from '../NodePropertiesPanel.types';
 
@@ -30,7 +30,7 @@ export const CheckboxField = memo(function CheckboxField({
           field.disabled ? 'opacity-50 cursor-not-allowed' : 'hover:bg-(--canvas-background-hover)'
         )}
       >
-        <label
+        <Label
           className={cn(
             'flex items-center text-[13px] text-(--canvas-foreground) select-none',
             field.disabled ? 'cursor-not-allowed' : 'cursor-pointer'
@@ -45,7 +45,7 @@ export const CheckboxField = memo(function CheckboxField({
           />
           <span>{field.label}</span>
           {field.icon && <span className="ml-2">{field.icon}</span>}
-        </label>
+        </Label>
       </div>
       {field.helpText && (
         <span className="text-[12px] text-(--canvas-foreground-de-emp) block ml-[26px]">

--- a/packages/apollo-react/src/canvas/components/NodePropertiesPanel/fields/NumberField.tsx
+++ b/packages/apollo-react/src/canvas/components/NodePropertiesPanel/fields/NumberField.tsx
@@ -60,9 +60,7 @@ export const NumberField = memo(function NumberField({
 
   return (
     <div className="flex flex-col gap-1">
-      <Label htmlFor={`field-${field.key}`} className="text-xs text-(--canvas-foreground-de-emp)">
-        {field.label}
-      </Label>
+      <Label htmlFor={`field-${field.key}`}>{field.label}</Label>
       <div className="flex items-center gap-2">
         <input
           id={`field-${field.key}`}

--- a/packages/apollo-react/src/canvas/components/NodePropertiesPanel/fields/NumberField.tsx
+++ b/packages/apollo-react/src/canvas/components/NodePropertiesPanel/fields/NumberField.tsx
@@ -1,4 +1,4 @@
-import { cn } from '@uipath/apollo-wind';
+import { cn, Label } from '@uipath/apollo-wind';
 import { memo, useCallback, useEffect, useRef, useState } from 'react';
 import type { ConfigField } from '../NodePropertiesPanel.types';
 
@@ -60,12 +60,9 @@ export const NumberField = memo(function NumberField({
 
   return (
     <div className="flex flex-col gap-1">
-      <label
-        htmlFor={`field-${field.key}`}
-        className="text-[13px] text-(--canvas-foreground-de-emp)"
-      >
+      <Label htmlFor={`field-${field.key}`} className="text-xs text-(--canvas-foreground-de-emp)">
         {field.label}
-      </label>
+      </Label>
       <div className="flex items-center gap-2">
         <input
           id={`field-${field.key}`}

--- a/packages/apollo-react/src/canvas/components/NodePropertiesPanel/fields/SelectField.tsx
+++ b/packages/apollo-react/src/canvas/components/NodePropertiesPanel/fields/SelectField.tsx
@@ -1,4 +1,4 @@
-import { cn } from '@uipath/apollo-wind';
+import { cn, Label } from '@uipath/apollo-wind';
 import { ChevronDown } from 'lucide-react';
 import { memo, useCallback } from 'react';
 import type { ConfigField } from '../NodePropertiesPanel.types';
@@ -31,9 +31,9 @@ export const SelectField = memo(function SelectField({
 
   return (
     <div className="flex flex-col gap-1">
-      <label htmlFor={selectId} className="text-[13px] text-(--canvas-foreground-de-emp)">
+      <Label htmlFor={selectId} className="text-xs text-(--canvas-foreground-de-emp)">
         {field.label}
-      </label>
+      </Label>
       <div className="relative">
         <select
           id={selectId}

--- a/packages/apollo-react/src/canvas/components/NodePropertiesPanel/fields/SelectField.tsx
+++ b/packages/apollo-react/src/canvas/components/NodePropertiesPanel/fields/SelectField.tsx
@@ -31,9 +31,7 @@ export const SelectField = memo(function SelectField({
 
   return (
     <div className="flex flex-col gap-1">
-      <Label htmlFor={selectId} className="text-xs text-(--canvas-foreground-de-emp)">
-        {field.label}
-      </Label>
+      <Label htmlFor={selectId}>{field.label}</Label>
       <div className="relative">
         <select
           id={selectId}

--- a/packages/apollo-react/src/canvas/components/NodePropertiesPanel/fields/TextField.tsx
+++ b/packages/apollo-react/src/canvas/components/NodePropertiesPanel/fields/TextField.tsx
@@ -61,9 +61,7 @@ export const TextField = memo(function TextField({
 
   return (
     <div className="flex flex-col gap-1">
-      <Label htmlFor={inputId} className="text-xs text-(--canvas-foreground-de-emp)">
-        {field.label}
-      </Label>
+      <Label htmlFor={inputId}>{field.label}</Label>
       {field.type === 'textarea' ? (
         <textarea
           id={inputId}

--- a/packages/apollo-react/src/canvas/components/NodePropertiesPanel/fields/TextField.tsx
+++ b/packages/apollo-react/src/canvas/components/NodePropertiesPanel/fields/TextField.tsx
@@ -1,4 +1,4 @@
-import { cn } from '@uipath/apollo-wind';
+import { cn, Label } from '@uipath/apollo-wind';
 import { memo, useCallback, useEffect, useRef, useState } from 'react';
 import type { ConfigField } from '../NodePropertiesPanel.types';
 
@@ -61,9 +61,9 @@ export const TextField = memo(function TextField({
 
   return (
     <div className="flex flex-col gap-1">
-      <label htmlFor={inputId} className="text-[13px] text-(--canvas-foreground-de-emp)">
+      <Label htmlFor={inputId} className="text-xs text-(--canvas-foreground-de-emp)">
         {field.label}
-      </label>
+      </Label>
       {field.type === 'textarea' ? (
         <textarea
           id={inputId}

--- a/packages/apollo-react/src/canvas/components/NodePropertyPanel/PanelField.test.tsx
+++ b/packages/apollo-react/src/canvas/components/NodePropertyPanel/PanelField.test.tsx
@@ -24,7 +24,7 @@ describe('PanelField', () => {
       </PanelField>
     );
 
-    expect(screen.getByText('*').parentElement).toHaveClass('text-current');
+    expect(screen.getByText('*').parentElement).toHaveClass('text-foreground');
     expect(screen.getByText('*')).toHaveAttribute('aria-hidden', 'true');
     expect(screen.getByLabelText(/Name/)).toHaveAttribute('aria-invalid', 'true');
     expect(screen.getByText('Name is required.')).toHaveAttribute('id', 'name-error');
@@ -49,7 +49,7 @@ describe('PanelField', () => {
     );
 
     expect(screen.getByText('Expression')).toHaveAttribute('for', 'expression');
-    expect(screen.getByText('*').parentElement).toHaveClass('text-current');
+    expect(screen.getByText('*').parentElement).toHaveClass('text-foreground');
     expect(screen.getByText('*')).toHaveAttribute('aria-hidden', 'true');
   });
 });

--- a/packages/apollo-react/src/canvas/components/NodePropertyPanel/PanelField.test.tsx
+++ b/packages/apollo-react/src/canvas/components/NodePropertyPanel/PanelField.test.tsx
@@ -24,7 +24,8 @@ describe('PanelField', () => {
       </PanelField>
     );
 
-    expect(screen.getByText('*')).toBeInTheDocument();
+    expect(screen.getByText('*').parentElement).toHaveClass('text-current');
+    expect(screen.getByText('*')).toHaveAttribute('aria-hidden', 'true');
     expect(screen.getByLabelText(/Name/)).toHaveAttribute('aria-invalid', 'true');
     expect(screen.getByText('Name is required.')).toHaveAttribute('id', 'name-error');
   });
@@ -48,6 +49,7 @@ describe('PanelField', () => {
     );
 
     expect(screen.getByText('Expression')).toHaveAttribute('for', 'expression');
-    expect(screen.getByText('*')).toBeInTheDocument();
+    expect(screen.getByText('*').parentElement).toHaveClass('text-current');
+    expect(screen.getByText('*')).toHaveAttribute('aria-hidden', 'true');
   });
 });

--- a/packages/apollo-react/src/canvas/stories/templates/Flow.stories.tsx
+++ b/packages/apollo-react/src/canvas/stories/templates/Flow.stories.tsx
@@ -1151,7 +1151,7 @@ function ExpressionField({ value, placeholder }: { value?: string; placeholder?:
 function BooleanField({ label }: { label: string }) {
   return (
     <div>
-      <Label className="mb-2 text-xs">{label}</Label>
+      <p className="mb-2 text-xs font-medium">{label}</p>
       <div className="flex items-center gap-5 text-xs text-foreground-muted">
         <span className="flex items-center gap-2">
           <span className="size-4 rounded-full border-2 border-border" /> True
@@ -1188,7 +1188,7 @@ function SendEmailForm({ spacious = false }: { spacious?: boolean }) {
       <div className={spacious ? 'space-y-5' : 'space-y-4'}>
         <div>
           <div className="mb-2 flex items-center justify-between gap-3">
-            <Label className="text-xs">Microsoft Outlook 365 connection *</Label>
+            <p className="text-xs font-medium">Microsoft Outlook 365 connection *</p>
             <button type="button" className="shrink-0 text-xs text-brand">
               Refresh Schema
             </button>
@@ -1202,15 +1202,15 @@ function SendEmailForm({ spacious = false }: { spacious?: boolean }) {
         </div>
         <BooleanField label="Save as draft" />
         <div>
-          <Label className="mb-2 text-xs">To *</Label>
+          <p className="mb-2 text-xs font-medium">To *</p>
           <ExpressionField value="$vars.executeQuerySynchronously1.output[0].assignee_email" />
         </div>
         <div>
-          <Label className="mb-2 text-xs">Subject</Label>
+          <p className="mb-2 text-xs font-medium">Subject</p>
           <ExpressionField value="$vars.recordUpdated1.output.Subject" />
         </div>
         <div>
-          <Label className="mb-2 text-xs">Body</Label>
+          <p className="mb-2 text-xs font-medium">Body</p>
           <div className="rounded-lg border border-border-subtle bg-surface-overlay">
             <div className="flex h-9 items-center gap-1 border-b border-border-subtle px-2 text-foreground-muted">
               {[
@@ -1238,7 +1238,7 @@ function SendEmailForm({ spacious = false }: { spacious?: boolean }) {
           </div>
         </div>
         <div>
-          <Label className="mb-2 text-xs">Attachment</Label>
+          <p className="mb-2 text-xs font-medium">Attachment</p>
           <ExpressionField placeholder="The file to attach to the email" />
         </div>
         <BooleanField label="Include message details" />
@@ -1250,7 +1250,7 @@ function SendEmailForm({ spacious = false }: { spacious?: boolean }) {
         </button>
         <div className="rounded-lg bg-surface-overlay px-3 py-2 text-xs font-semibold">Options</div>
         <div>
-          <Label className="mb-2 text-xs">Reply to</Label>
+          <p className="mb-2 text-xs font-medium">Reply to</p>
           <ExpressionField placeholder="Email addresses to use when replying" />
         </div>
       </div>

--- a/packages/apollo-react/src/canvas/stories/templates/Flow.stories.tsx
+++ b/packages/apollo-react/src/canvas/stories/templates/Flow.stories.tsx
@@ -1151,7 +1151,7 @@ function ExpressionField({ value, placeholder }: { value?: string; placeholder?:
 function BooleanField({ label }: { label: string }) {
   return (
     <div>
-      <p className="mb-2 text-xs font-medium">{label}</p>
+      <Label className="mb-2 text-xs">{label}</Label>
       <div className="flex items-center gap-5 text-xs text-foreground-muted">
         <span className="flex items-center gap-2">
           <span className="size-4 rounded-full border-2 border-border" /> True
@@ -1188,7 +1188,7 @@ function SendEmailForm({ spacious = false }: { spacious?: boolean }) {
       <div className={spacious ? 'space-y-5' : 'space-y-4'}>
         <div>
           <div className="mb-2 flex items-center justify-between gap-3">
-            <p className="text-xs font-medium">Microsoft Outlook 365 connection *</p>
+            <Label className="text-xs">Microsoft Outlook 365 connection *</Label>
             <button type="button" className="shrink-0 text-xs text-brand">
               Refresh Schema
             </button>
@@ -1202,15 +1202,15 @@ function SendEmailForm({ spacious = false }: { spacious?: boolean }) {
         </div>
         <BooleanField label="Save as draft" />
         <div>
-          <p className="mb-2 text-xs font-medium">To *</p>
+          <Label className="mb-2 text-xs">To *</Label>
           <ExpressionField value="$vars.executeQuerySynchronously1.output[0].assignee_email" />
         </div>
         <div>
-          <p className="mb-2 text-xs font-medium">Subject</p>
+          <Label className="mb-2 text-xs">Subject</Label>
           <ExpressionField value="$vars.recordUpdated1.output.Subject" />
         </div>
         <div>
-          <p className="mb-2 text-xs font-medium">Body</p>
+          <Label className="mb-2 text-xs">Body</Label>
           <div className="rounded-lg border border-border-subtle bg-surface-overlay">
             <div className="flex h-9 items-center gap-1 border-b border-border-subtle px-2 text-foreground-muted">
               {[
@@ -1238,7 +1238,7 @@ function SendEmailForm({ spacious = false }: { spacious?: boolean }) {
           </div>
         </div>
         <div>
-          <p className="mb-2 text-xs font-medium">Attachment</p>
+          <Label className="mb-2 text-xs">Attachment</Label>
           <ExpressionField placeholder="The file to attach to the email" />
         </div>
         <BooleanField label="Include message details" />
@@ -1250,7 +1250,7 @@ function SendEmailForm({ spacious = false }: { spacious?: boolean }) {
         </button>
         <div className="rounded-lg bg-surface-overlay px-3 py-2 text-xs font-semibold">Options</div>
         <div>
-          <p className="mb-2 text-xs font-medium">Reply to</p>
+          <Label className="mb-2 text-xs">Reply to</Label>
           <ExpressionField placeholder="Email addresses to use when replying" />
         </div>
       </div>

--- a/packages/apollo-react/src/canvas/stories/templates/Flow.stories.tsx
+++ b/packages/apollo-react/src/canvas/stories/templates/Flow.stories.tsx
@@ -15,6 +15,7 @@ import {
   InputGroupInput,
   Label,
   type PanelImperativeHandle,
+  RequiredIndicator,
   ResizableHandle,
   ResizablePanel,
   ResizablePanelGroup,
@@ -2770,8 +2771,7 @@ function FieldHelpPanel({ onClose }: { onClose: () => void }) {
 
           <div className="space-y-1.5">
             <Label htmlFor="field-help-url" className="text-xs">
-              Webhook URL <span aria-hidden="true">*</span>
-              <span className="sr-only"> (required)</span>
+              Webhook URL <RequiredIndicator />
             </Label>
             <InputGroup className="h-9 bg-surface-overlay">
               <InputGroupInput
@@ -2825,8 +2825,7 @@ function FieldHelpPanel({ onClose }: { onClose: () => void }) {
           <div className="space-y-1.5">
             <div className="flex items-center gap-1">
               <Label htmlFor="field-help-secret" className="text-xs">
-                Signing secret <span aria-hidden="true">*</span>
-                <span className="sr-only"> (required)</span>
+                Signing secret <RequiredIndicator />
               </Label>
               <Tooltip>
                 <TooltipTrigger asChild>

--- a/packages/apollo-wind/src/components/custom/flow-properties-simple.test.tsx
+++ b/packages/apollo-wind/src/components/custom/flow-properties-simple.test.tsx
@@ -46,7 +46,7 @@ describe('PropertiesSimple', () => {
   it('renders a custom title and top-level field labels', () => {
     render(<PropertiesSimple title="Webhook trigger" fields={fields} />);
     expect(screen.getByText('Webhook trigger')).toBeInTheDocument();
-    expect(screen.getByText('Method*')).toBeInTheDocument();
+    expect(screen.getByText('Method', { exact: true }).parentElement).toHaveTextContent('*');
     expect(screen.getByText('Endpoint')).toBeInTheDocument();
   });
 

--- a/packages/apollo-wind/src/components/custom/flow-properties-simple.test.tsx
+++ b/packages/apollo-wind/src/components/custom/flow-properties-simple.test.tsx
@@ -46,7 +46,7 @@ describe('PropertiesSimple', () => {
   it('renders a custom title and top-level field labels', () => {
     render(<PropertiesSimple title="Webhook trigger" fields={fields} />);
     expect(screen.getByText('Webhook trigger')).toBeInTheDocument();
-    expect(screen.getByText('Method', { exact: true }).parentElement).toHaveTextContent('*');
+    expect(screen.getByRole('combobox', { name: /Method.*required/i })).toBeInTheDocument();
     expect(screen.getByText('Endpoint')).toBeInTheDocument();
   });
 

--- a/packages/apollo-wind/src/components/custom/flow-properties-simple.tsx
+++ b/packages/apollo-wind/src/components/custom/flow-properties-simple.tsx
@@ -122,7 +122,6 @@ function FieldItem({
       {field.type === 'select' ? (
         <Select value={value || undefined} onValueChange={setValue}>
           <SelectTrigger
-            aria-label={field.label}
             aria-required={field.required}
             id={inputId}
             className="h-10 rounded-xl border-0 bg-surface-overlay text-foreground shadow-sm placeholder:text-foreground-muted"

--- a/packages/apollo-wind/src/components/custom/flow-properties-simple.tsx
+++ b/packages/apollo-wind/src/components/custom/flow-properties-simple.tsx
@@ -102,7 +102,7 @@ function FieldItem({
       <div className="flex items-center justify-between">
         <span className="text-sm font-medium leading-5 text-foreground-muted">
           {field.label}
-          {field.required && '*'}
+          {field.required && <span className="text-foreground" aria-hidden="true">*</span>}
         </span>
         {field.showGraphControl && (
           <button

--- a/packages/apollo-wind/src/components/custom/flow-properties-simple.tsx
+++ b/packages/apollo-wind/src/components/custom/flow-properties-simple.tsx
@@ -102,7 +102,11 @@ function FieldItem({
       <div className="flex items-center justify-between">
         <span className="text-sm font-medium leading-5 text-foreground-muted">
           {field.label}
-          {field.required && <span className="text-foreground" aria-hidden="true">*</span>}
+          {field.required && (
+            <span className="text-foreground" aria-hidden="true">
+              *
+            </span>
+          )}
         </span>
         {field.showGraphControl && (
           <button

--- a/packages/apollo-wind/src/components/custom/flow-properties-simple.tsx
+++ b/packages/apollo-wind/src/components/custom/flow-properties-simple.tsx
@@ -18,6 +18,7 @@ import {
   AccordionTrigger,
 } from '@/components/ui/accordion';
 import { Input } from '@/components/ui/input';
+import { Label, RequiredIndicator } from '@/components/ui/label';
 import {
   Select,
   SelectContent,
@@ -95,19 +96,16 @@ function FieldItem({
   onGraphControl?: (label: string) => void;
 }) {
   const [value, setValue] = React.useState(field.value ?? '');
+  const inputId = React.useId();
 
   return (
     <div className="flex flex-col gap-1 pt-4">
       {/* Label row */}
       <div className="flex items-center justify-between">
-        <span className="text-sm font-medium leading-5 text-foreground-muted">
+        <Label htmlFor={inputId} className="text-sm font-medium leading-5 text-foreground-muted">
           {field.label}
-          {field.required && (
-            <span className="text-foreground" aria-hidden="true">
-              *
-            </span>
-          )}
-        </span>
+          {field.required && <RequiredIndicator />}
+        </Label>
         {field.showGraphControl && (
           <button
             type="button"
@@ -125,6 +123,8 @@ function FieldItem({
         <Select value={value || undefined} onValueChange={setValue}>
           <SelectTrigger
             aria-label={field.label}
+            aria-required={field.required}
+            id={inputId}
             className="h-10 rounded-xl border-0 bg-surface-overlay text-foreground shadow-sm placeholder:text-foreground-muted"
           >
             <SelectValue placeholder={field.placeholder ?? 'Select...'} />
@@ -144,6 +144,8 @@ function FieldItem({
       ) : field.type === 'url' ? (
         <div className="flex h-10 w-full items-center overflow-hidden rounded-xl bg-surface-overlay shadow-[0px_1px_2px_0px_rgba(0,0,0,0.05)] transition-colors focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2 focus-within:ring-offset-background">
           <Input
+            aria-required={field.required}
+            id={inputId}
             value={value}
             onChange={(e) => setValue(e.target.value)}
             placeholder={field.placeholder}
@@ -159,6 +161,8 @@ function FieldItem({
         </div>
       ) : (
         <Input
+          aria-required={field.required}
+          id={inputId}
           value={value}
           onChange={(e) => setValue(e.target.value)}
           placeholder={field.placeholder}

--- a/packages/apollo-wind/src/components/forms/field-renderer.test.tsx
+++ b/packages/apollo-wind/src/components/forms/field-renderer.test.tsx
@@ -81,7 +81,8 @@ describe('FormFieldRenderer', () => {
         </FormWrapper>
       );
 
-      expect(screen.getByText('*')).toBeInTheDocument();
+      expect(screen.getByText('*').parentElement).toHaveClass('text-current');
+      expect(screen.getByText('*')).toHaveAttribute('aria-hidden', 'true');
     });
 
     it('handles disabled state', () => {

--- a/packages/apollo-wind/src/components/forms/field-renderer.test.tsx
+++ b/packages/apollo-wind/src/components/forms/field-renderer.test.tsx
@@ -1,10 +1,10 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import { axe } from 'jest-axe';
 import { useEffect } from 'react';
-import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
-import { useForm, FormProvider } from 'react-hook-form';
-import { FormFieldRenderer } from './field-renderer';
+import { FormProvider, useForm } from 'react-hook-form';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { DataFetcher } from './data-fetcher';
+import { FormFieldRenderer } from './field-renderer';
 import type { FieldMetadata, FormContext } from './form-schema';
 
 // Wrapper component to provide form context
@@ -81,7 +81,7 @@ describe('FormFieldRenderer', () => {
         </FormWrapper>
       );
 
-      expect(screen.getByText('*').parentElement).toHaveClass('text-current');
+      expect(screen.getByText('*').parentElement).toHaveClass('text-foreground');
       expect(screen.getByText('*')).toHaveAttribute('aria-hidden', 'true');
     });
 

--- a/packages/apollo-wind/src/components/ui/dap-components.stories.tsx
+++ b/packages/apollo-wind/src/components/ui/dap-components.stories.tsx
@@ -778,7 +778,7 @@ function AccountFieldsExample() {
                 className={`text-base font-semibold ${invalid ? 'text-destructive' : ''}`}
                 htmlFor={`dap-${field.id}`}
               >
-                {field.label} {field.required && <span aria-hidden="true">*</span>}
+                {field.label} {field.required && <span className="text-foreground" aria-hidden="true">*</span>}
               </Label>
               <InputGroup className="future:rounded-lg">
                 <InputGroupInput

--- a/packages/apollo-wind/src/components/ui/dap-components.stories.tsx
+++ b/packages/apollo-wind/src/components/ui/dap-components.stories.tsx
@@ -848,7 +848,7 @@ function AccountObjectEditorExample() {
     <div className="rounded-xl border bg-background p-6 shadow-sm sm:p-10">
       <div className="mb-2 flex items-center justify-between gap-4">
         <Label className="text-base font-semibold">
-          Account <span aria-hidden="true">*</span>
+          Account <RequiredIndicator />
         </Label>
         <Button variant="link">Switch to fields view</Button>
       </div>
@@ -1008,7 +1008,7 @@ function GmailConnectionPickerExample() {
     <div className="rounded-xl border bg-background p-6 shadow-sm sm:p-10">
       <div className="mb-2 flex items-center justify-between gap-4">
         <Label className="text-base font-semibold" htmlFor="gmail-connection-picker">
-          Gmail connection <span aria-hidden="true">*</span>
+          Gmail connection <RequiredIndicator />
         </Label>
         <Button variant="link">Refresh schema</Button>
       </div>

--- a/packages/apollo-wind/src/components/ui/dap-components.stories.tsx
+++ b/packages/apollo-wind/src/components/ui/dap-components.stories.tsx
@@ -41,7 +41,7 @@ import {
   DropdownMenuTrigger,
 } from './dropdown-menu';
 import { InputGroup, InputGroupAddon, InputGroupButton, InputGroupInput } from './input-group';
-import { Label } from './label';
+import { Label, RequiredIndicator } from './label';
 import { Popover, PopoverContent, PopoverTrigger } from './popover';
 import { PromptEditor } from './prompt-editor';
 import type { PromptEditorAutoCompleteOption, PromptEditorToken } from './prompt-editor/types';
@@ -778,12 +778,7 @@ function AccountFieldsExample() {
                 className={`text-base font-semibold ${invalid ? 'text-destructive' : ''}`}
                 htmlFor={`dap-${field.id}`}
               >
-                {field.label}{' '}
-                {field.required && (
-                  <span className="text-foreground" aria-hidden="true">
-                    *
-                  </span>
-                )}
+                {field.label} {field.required && <RequiredIndicator />}
               </Label>
               <InputGroup className="future:rounded-lg">
                 <InputGroupInput

--- a/packages/apollo-wind/src/components/ui/dap-components.stories.tsx
+++ b/packages/apollo-wind/src/components/ui/dap-components.stories.tsx
@@ -778,7 +778,12 @@ function AccountFieldsExample() {
                 className={`text-base font-semibold ${invalid ? 'text-destructive' : ''}`}
                 htmlFor={`dap-${field.id}`}
               >
-                {field.label} {field.required && <span className="text-foreground" aria-hidden="true">*</span>}
+                {field.label}{' '}
+                {field.required && (
+                  <span className="text-foreground" aria-hidden="true">
+                    *
+                  </span>
+                )}
               </Label>
               <InputGroup className="future:rounded-lg">
                 <InputGroupInput

--- a/packages/apollo-wind/src/components/ui/label.test.tsx
+++ b/packages/apollo-wind/src/components/ui/label.test.tsx
@@ -24,7 +24,7 @@ describe('Label', () => {
   it('applies base classes', () => {
     render(<Label>Email</Label>);
     const label = screen.getByText('Email');
-    expect(label).toHaveClass('text-sm', 'font-medium');
+    expect(label).toHaveClass('text-xs', 'font-medium');
   });
 
   it('accepts htmlFor attribute', () => {

--- a/packages/apollo-wind/src/components/ui/label.tsx
+++ b/packages/apollo-wind/src/components/ui/label.tsx
@@ -29,7 +29,7 @@ export interface RequiredIndicatorProps
 /**
  * Marks a field as required. Place it right after the label text.
  *
- * Uses `text-current` rather than an error/destructive color: an untouched
+ * Uses the foreground color rather than an error/destructive color: an untouched
  * required field isn't in an error state, so coloring the asterisk red reads
  * as a validation failure before the person has done anything. The asterisk
  * glyph is `aria-hidden` since it's a visual affordance, not the thing that
@@ -39,7 +39,7 @@ export interface RequiredIndicatorProps
  */
 const RequiredIndicator = React.forwardRef<HTMLSpanElement, RequiredIndicatorProps>(
   ({ className, ...props }, ref) => (
-    <span ref={ref} {...props} className={cn('ml-0.5 text-current', className)}>
+    <span ref={ref} {...props} className={cn(className, 'ml-0.5 text-foreground')}>
       <span aria-hidden="true">*</span>
       <span className="sr-only"> (required)</span>
     </span>

--- a/packages/apollo-wind/src/components/ui/label.tsx
+++ b/packages/apollo-wind/src/components/ui/label.tsx
@@ -39,7 +39,7 @@ export interface RequiredIndicatorProps
  */
 const RequiredIndicator = React.forwardRef<HTMLSpanElement, RequiredIndicatorProps>(
   ({ className, ...props }, ref) => (
-    <span ref={ref} {...props} className={cn(className, 'ml-0.5 text-foreground')}>
+    <span ref={ref} {...props} className={cn('ml-0.5', className, 'text-foreground')}>
       <span aria-hidden="true">*</span>
       <span className="sr-only"> (required)</span>
     </span>

--- a/packages/apollo-wind/src/components/ui/label.tsx
+++ b/packages/apollo-wind/src/components/ui/label.tsx
@@ -5,7 +5,7 @@ import * as React from 'react';
 import { cn } from '@/lib/index';
 
 const labelVariants = cva(
-  'text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70'
+  'text-xs font-medium peer-disabled:cursor-not-allowed peer-disabled:opacity-70'
 );
 
 export type LabelProps = React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root> &

--- a/packages/apollo-wind/src/components/ui/tooltip.stories.tsx
+++ b/packages/apollo-wind/src/components/ui/tooltip.stories.tsx
@@ -21,6 +21,7 @@ import {
 } from 'lucide-react';
 import { Button } from './button';
 import { Input } from './input';
+import { Label } from './label';
 import { Separator } from './separator';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from './tooltip';
 
@@ -279,9 +280,9 @@ export const TooltipWithFormElements = {
       <div className="flex flex-col gap-4 max-w-sm">
         <div className="space-y-2">
           <div className="flex items-center gap-1.5">
-            <label htmlFor="api-key" className="text-sm font-medium">
+            <Label htmlFor="api-key" className="text-xs">
               API Key
-            </label>
+            </Label>
             <Tooltip>
               <TooltipTrigger asChild>
                 <Info className="h-3.5 w-3.5 text-muted-foreground cursor-help" />
@@ -296,9 +297,9 @@ export const TooltipWithFormElements = {
 
         <div className="space-y-2">
           <div className="flex items-center gap-1.5">
-            <label htmlFor="webhook" className="text-sm font-medium">
+            <Label htmlFor="webhook" className="text-xs">
               Webhook URL
-            </label>
+            </Label>
             <Tooltip>
               <TooltipTrigger asChild>
                 <Info className="h-3.5 w-3.5 text-muted-foreground cursor-help" />

--- a/packages/apollo-wind/src/templates/Delegate/delegate.stories.tsx
+++ b/packages/apollo-wind/src/templates/Delegate/delegate.stories.tsx
@@ -21,6 +21,7 @@ import { ChatComposer } from '@/components/custom/chat-composer';
 import { ChatFirstExperience } from '@/components/custom/chat-first-experience';
 import { StepsView } from '@/components/custom/chat-steps-view';
 import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
 import type { NavItem } from './template-delegate';
 import { DelegateTemplate } from './template-delegate';
 
@@ -333,9 +334,9 @@ function SettingsContent() {
 
               {/* Your Name */}
               <div className="flex flex-col gap-2">
-                <label htmlFor="profile-name" className="text-sm font-medium text-foreground">
+                <Label htmlFor="profile-name" className="text-xs text-foreground">
                   Your name
-                </label>
+                </Label>
                 <Input
                   id="profile-name"
                   placeholder="Enter your name"
@@ -345,9 +346,9 @@ function SettingsContent() {
 
               {/* Your Email */}
               <div className="flex flex-col gap-2">
-                <label htmlFor="profile-email" className="text-sm font-medium text-foreground">
+                <Label htmlFor="profile-email" className="text-xs text-foreground">
                   Your email
-                </label>
+                </Label>
                 <Input
                   id="profile-email"
                   placeholder="Enter your email"
@@ -361,9 +362,9 @@ function SettingsContent() {
 
               {/* Language */}
               <div className="flex flex-col gap-2">
-                <label htmlFor="profile-language" className="text-sm font-medium text-foreground">
+                <Label htmlFor="profile-language" className="text-xs text-foreground">
                   Language
-                </label>
+                </Label>
                 <p className="text-sm text-foreground-muted">
                   Select your preferred language for the interface.
                 </p>


### PR DESCRIPTION
## Summary

- Standardize field labels on the shared Apollo Wind Label primitive.
- Set the shared label size to 12px / 16px to match UI Inventory.
- Keep required indicators white and add shared RequiredIndicator coverage.
- Align field spacing and label/control associations in the Storybook patterns.
<img width="1414" height="1205" alt="Screenshot 2026-08-31 at 7 56 53 AM" src="https://github.com/user-attachments/assets/d31bc497-0146-4f59-b264-9f417727fb48" />
<img width="1418" height="1203" alt="Screenshot 2026-08-31 at 7 57 08 AM" src="https://github.com/user-attachments/assets/57bc9152-7125-4d01-ad56-4379af2b04e7" />


## Verification

- Apollo Wind focused tests: 33 passed
- Apollo React focused tests: 17 passed
- git diff --check passed
- Storybook preview verified at http://localhost:6007/