### PR TITLE
fix(apollo-react): add aria-label to suggestion navigator chevrons

### DIFF
--- a/packages/apollo-react/src/canvas/components/AgentCanvas/components/SuggestionGroupPanel.test.tsx
+++ b/packages/apollo-react/src/canvas/components/AgentCanvas/components/SuggestionGroupPanel.test.tsx
@@ -1,0 +1,67 @@
+import { render, screen } from '@testing-library/react';
+import { ReactFlowProvider } from '@uipath/apollo-react/canvas/xyflow/react';
+import { describe, expect, it, vi } from 'vitest';
+import type { AgentFlowSuggestionGroup } from '../../../types';
+import { SuggestionGroupPanel } from './SuggestionGroupPanel';
+
+const suggestionGroup: AgentFlowSuggestionGroup = {
+  id: 'group-1',
+  suggestions: [
+    { id: 'suggestion-1', type: 'add' },
+    { id: 'suggestion-2', type: 'add' },
+  ],
+};
+
+const renderWithProvider = (ui: React.ReactElement) =>
+  render(<ReactFlowProvider>{ui}</ReactFlowProvider>);
+
+describe('SuggestionGroupPanel', () => {
+  it('renders nothing when there is no suggestion group', () => {
+    renderWithProvider(<SuggestionGroupPanel suggestionGroup={null} />);
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+
+  it('exposes accessible names for the previous/next navigator buttons', () => {
+    renderWithProvider(
+      <SuggestionGroupPanel
+        suggestionGroup={suggestionGroup}
+        currentIndex={0}
+        onNavigateNext={vi.fn()}
+        onNavigatePrevious={vi.fn()}
+      />
+    );
+
+    expect(screen.getByRole('button', { name: 'Previous suggestion' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Next suggestion' })).toBeInTheDocument();
+  });
+
+  it('calls onNavigatePrevious/onNavigateNext when the navigator buttons are clicked', async () => {
+    const onNavigatePrevious = vi.fn();
+    const onNavigateNext = vi.fn();
+
+    renderWithProvider(
+      <SuggestionGroupPanel
+        suggestionGroup={suggestionGroup}
+        currentIndex={0}
+        onNavigateNext={onNavigateNext}
+        onNavigatePrevious={onNavigatePrevious}
+      />
+    );
+
+    screen.getByRole('button', { name: 'Previous suggestion' }).click();
+    expect(onNavigatePrevious).toHaveBeenCalledTimes(1);
+
+    screen.getByRole('button', { name: 'Next suggestion' }).click();
+    expect(onNavigateNext).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows the current position among the suggestions', () => {
+    renderWithProvider(<SuggestionGroupPanel suggestionGroup={suggestionGroup} currentIndex={0} />);
+
+    expect(
+      screen.getByText(
+        (_, element) => element?.tagName === 'SPAN' && element.textContent === '1 of 2'
+      )
+    ).toBeInTheDocument();
+  });
+});

--- a/packages/apollo-react/src/canvas/components/AgentCanvas/components/SuggestionGroupPanel.tsx
+++ b/packages/apollo-react/src/canvas/components/AgentCanvas/components/SuggestionGroupPanel.tsx
@@ -88,6 +88,7 @@ const SuggestionGroupNavigator = ({
         variant="ghost"
         size="icon"
         className="h-8 w-8"
+        aria-label="Previous suggestion"
         onMouseEnter={() => setIsHoveringUp(true)}
         onMouseLeave={() => setIsHoveringUp(false)}
         onClick={onNavigatePrevious}
@@ -105,6 +106,7 @@ const SuggestionGroupNavigator = ({
         variant="ghost"
         size="icon"
         className="h-8 w-8"
+        aria-label="Next suggestion"
         onMouseEnter={() => setIsHoveringDown(true)}
         onMouseLeave={() => setIsHoveringDown(false)}
         onClick={onNavigateNext}


### PR DESCRIPTION
## Summary
- The chevron-up/chevron-down icon buttons in `SuggestionGroupNavigator` (`packages/apollo-react/src/canvas/components/AgentCanvas/components/SuggestionGroupPanel.tsx`) had no accessible name at all — their only content is a decorative Lucide icon (`chevron-up`/`chevron-down`), which contributes nothing to the accessible name.
- Screen reader users focusing these controls got no indication of what "previous suggestion" / "next suggestion" navigation they performed.
- Confirmed this is unfixed as of `main` (not just the pinned `6.20.1` a downstream consumer had) before filing.

## Changes
- Added `aria-label="Previous suggestion"` / `aria-label="Next suggestion"` to the two navigator `Button`s.
- Added `SuggestionGroupPanel.test.tsx` (new file — none existed for this component) covering: empty-state renders nothing, both buttons expose accessible names, both buttons invoke their respective callbacks, and the position counter renders correctly.

## Test plan
- [x] `vitest run` on the new test file — 4/4 passing
- [x] `biome check` — clean
- [x] `tsc --noEmit` — no new errors

## Source
Found while investigating a WCAG 2.4.6 report (PC-4063) filed against a downstream product consuming this package — the bug turned out to be upstream here, not in the consumer.