### PR TITLE
feat(apollo-wind): align panel controls and field states

### DIFF
--- a/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.stories.tsx
@@ -4233,15 +4233,23 @@ function PanelUIInventoryStory() {
                   </section>
 
                   <section className="grid gap-3 border-t border-border-subtle pt-5">
-                    <PatternNote title="Manage and add" eyebrow="Action pattern">
-                      Manage opens a separate configuration surface, so it is a secondary action
-                      beside the field or section it affects. Use the lightweight plus link for
-                      adding another item to a repeatable list.
+                    <PatternNote title="Manage" eyebrow="Action pattern">
+                      Use a secondary button when the action opens a separate configuration surface
+                      for the field or section it affects.
                     </PatternNote>
-                    <div className="flex flex-wrap items-center gap-2">
+                    <div className="flex flex-wrap items-center">
                       <Button variant="secondary" size="sm">
                         Manage
                       </Button>
+                    </div>
+                  </section>
+
+                  <section className="grid gap-3 border-t border-border-subtle pt-5">
+                    <PatternNote title="Add" eyebrow="Action pattern">
+                      Use the lightweight plus link when adding another item to a repeatable list.
+                      Keep it separate from manage actions so the two intents are easy to scan.
+                    </PatternNote>
+                    <div className="flex flex-wrap items-center">
                       <PanelAddButton>Add field</PanelAddButton>
                     </div>
                   </section>

--- a/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.stories.tsx
@@ -234,7 +234,7 @@ function PanelAddButton({ children = 'Add field' }: { children?: ReactNode }) {
   return (
     <button
       type="button"
-      className="flex w-fit cursor-pointer items-center gap-1.5 text-xs text-brand transition hover:text-brand-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+      className="flex w-fit cursor-pointer items-center gap-1.5 text-xs text-brand transition hover:text-brand-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
     >
       <Plus size={12} />
       {children}

--- a/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.stories.tsx
@@ -230,6 +230,18 @@ function DebugButton() {
   );
 }
 
+function PanelAddButton({ children = 'Add field' }: { children?: ReactNode }) {
+  return (
+    <button
+      type="button"
+      className="flex w-fit cursor-pointer items-center gap-1.5 text-xs text-brand transition hover:text-brand-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+    >
+      <Plus size={12} />
+      {children}
+    </button>
+  );
+}
+
 // ── Monaco ──────────────────────────────────────────────────────────────────
 
 let _monacoThemesRegistered = false;
@@ -3220,7 +3232,7 @@ export function QuickFormPanel({
                       placeholder="e.g. An invoice approval form with amount and due date"
                       className="resize-none text-sm"
                     />
-                    <Button size="sm" className="w-full">
+                    <Button size="sm" className="w-fit">
                       Generate
                     </Button>
                   </PopoverContent>
@@ -4200,6 +4212,16 @@ function PanelUIInventoryStory() {
                   </section>
 
                   <section className="grid gap-3 border-t border-border-subtle pt-5">
+                    <PatternNote title="Inline links" eyebrow="Action pattern">
+                      Use a compact link when the action is related to nearby content and should not
+                      compete with the panel's primary controls.
+                    </PatternNote>
+                    <Button variant="link" size="2xs" className="w-fit px-0">
+                      View documentation
+                    </Button>
+                  </section>
+
+                  <section className="grid gap-3 border-t border-border-subtle pt-5">
                     <PatternNote title="Footer actions" eyebrow="Action pattern">
                       Place panel-level actions at the end of the content, with the primary action
                       last and the cancel action immediately before it.
@@ -4207,6 +4229,20 @@ function PanelUIInventoryStory() {
                     <div className="flex justify-end gap-2 border-t border-border-subtle pt-4">
                       <Button variant="ghost">Cancel</Button>
                       <Button>Save changes</Button>
+                    </div>
+                  </section>
+
+                  <section className="grid gap-3 border-t border-border-subtle pt-5">
+                    <PatternNote title="Manage and add" eyebrow="Action pattern">
+                      Manage opens a separate configuration surface, so it is a secondary action
+                      beside the field or section it affects. Use the lightweight plus link for
+                      adding another item to a repeatable list.
+                    </PatternNote>
+                    <div className="flex flex-wrap items-center gap-2">
+                      <Button variant="secondary" size="sm">
+                        Manage
+                      </Button>
+                      <PanelAddButton>Add field</PanelAddButton>
                     </div>
                   </section>
 

--- a/packages/apollo-wind/src/components/ui/button.stories.tsx
+++ b/packages/apollo-wind/src/components/ui/button.stories.tsx
@@ -34,6 +34,18 @@ export const Default: Story = {
   },
 };
 
+export const IntrinsicWidth: Story = {
+  name: 'Intrinsic width',
+  parameters: {
+    layout: 'padded',
+  },
+  render: () => (
+    <div className="w-full max-w-lg rounded-lg border border-border-subtle p-4">
+      <Button>Content-sized action</Button>
+    </div>
+  ),
+};
+
 export const Destructive: Story = {
   args: {
     children: 'Delete',
@@ -67,6 +79,38 @@ export const Link: Story = {
     children: 'Link',
     variant: 'link',
   },
+};
+
+export const LinkSizes: Story = {
+  name: 'Link sizes',
+  parameters: {
+    layout: 'padded',
+  },
+  render: () => (
+    <div className="flex flex-wrap items-center gap-4">
+      <Button variant="link" size="sm">
+        Add another
+      </Button>
+      <Button variant="link" size="xs">
+        Learn more
+      </Button>
+      <Button variant="link" size="2xs">
+        Manage
+      </Button>
+      <Button variant="link" size="3xs">
+        View details
+      </Button>
+    </div>
+  ),
+};
+
+export const LinkAsAnchor: Story = {
+  name: 'Link as anchor',
+  render: () => (
+    <Button asChild variant="link" size="2xs">
+      <a href="/documentation">View documentation</a>
+    </Button>
+  ),
 };
 
 export const Disabled: Story = {

--- a/packages/apollo-wind/src/components/ui/button.test.tsx
+++ b/packages/apollo-wind/src/components/ui/button.test.tsx
@@ -18,7 +18,7 @@ describe('Button', () => {
   it('applies default variant classes', () => {
     render(<Button>Default</Button>);
     const button = screen.getByRole('button');
-    expect(button).toHaveClass('bg-primary');
+    expect(button).toHaveClass('bg-primary', 'w-fit');
   });
 
   it('applies destructive variant classes', () => {

--- a/packages/apollo-wind/src/components/ui/button.test.tsx
+++ b/packages/apollo-wind/src/components/ui/button.test.tsx
@@ -18,7 +18,8 @@ describe('Button', () => {
   it('applies default variant classes', () => {
     render(<Button>Default</Button>);
     const button = screen.getByRole('button');
-    expect(button).toHaveClass('bg-primary', 'w-fit');
+    expect(button).toHaveClass('bg-primary');
+    expect(button).not.toHaveClass('w-full');
   });
 
   it('applies destructive variant classes', () => {

--- a/packages/apollo-wind/src/components/ui/button.tsx
+++ b/packages/apollo-wind/src/components/ui/button.tsx
@@ -5,7 +5,7 @@ import * as React from 'react';
 import { cn } from '@/lib/index';
 
 const buttonVariants = cva(
-  'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-lg text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 cursor-pointer',
+  'inline-flex w-fit items-center justify-center gap-2 whitespace-nowrap rounded-lg text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 cursor-pointer',
   {
     variants: {
       variant: {

--- a/packages/apollo-wind/src/components/ui/button.tsx
+++ b/packages/apollo-wind/src/components/ui/button.tsx
@@ -5,7 +5,7 @@ import * as React from 'react';
 import { cn } from '@/lib/index';
 
 const buttonVariants = cva(
-  'inline-flex w-fit items-center justify-center gap-2 whitespace-nowrap rounded-lg text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 cursor-pointer',
+  'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-lg text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 cursor-pointer',
   {
     variants: {
       variant: {

--- a/packages/apollo-wind/src/components/ui/combobox.stories.tsx
+++ b/packages/apollo-wind/src/components/ui/combobox.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta } from '@storybook/react-vite';
 import { Check, ChevronsUpDown, Loader2, X } from 'lucide-react';
 import * as React from 'react';
+import { cn } from '../../lib';
 import { Badge } from './badge';
 import { Button } from './button';
 import { Combobox, ComboboxItem } from './combobox';
@@ -14,7 +15,6 @@ import {
 } from './command';
 import { Label } from './label';
 import { Popover, PopoverContent, PopoverTrigger } from './popover';
-import { cn } from '../../lib';
 
 const meta: Meta<typeof Combobox> = {
   title: 'Components/Core/Combobox',
@@ -95,7 +95,7 @@ function MultiSelectCombobox() {
             variant="outline"
             role="combobox"
             aria-expanded={open}
-            className="w-[320px] justify-between future:rounded-xl future:border-0 future:bg-surface-raised future:hover:bg-surface-overlay future:font-normal future:text-muted-foreground"
+            className="w-[320px] justify-between future:rounded-xl future:border-0 future:font-normal future:text-muted-foreground"
           >
             {selected.length > 0 ? `${selected.length} selected` : 'Select frameworks...'}
             <ChevronsUpDown className="opacity-50" />
@@ -182,7 +182,7 @@ function CustomDisplayCombobox() {
           variant="outline"
           role="combobox"
           aria-expanded={open}
-          className="w-[320px] justify-between future:rounded-xl future:border-0 future:bg-surface-raised future:hover:bg-surface-overlay future:font-normal future:text-muted-foreground"
+          className="w-[320px] justify-between future:rounded-xl future:border-0 future:font-normal future:text-muted-foreground"
         >
           {selected ? (
             <span className="flex items-center gap-2">
@@ -284,7 +284,7 @@ function AsyncCombobox() {
             variant="outline"
             role="combobox"
             aria-expanded={open}
-            className="w-[280px] justify-between future:rounded-xl future:border-0 future:bg-surface-raised future:hover:bg-surface-overlay future:font-normal future:text-muted-foreground"
+            className="w-[280px] justify-between future:rounded-xl future:border-0 future:font-normal future:text-muted-foreground"
           >
             {selected ? selected.label : 'Search libraries...'}
             <ChevronsUpDown className="opacity-50" />

--- a/packages/apollo-wind/src/components/ui/combobox.stories.tsx
+++ b/packages/apollo-wind/src/components/ui/combobox.stories.tsx
@@ -95,7 +95,7 @@ function MultiSelectCombobox() {
             variant="outline"
             role="combobox"
             aria-expanded={open}
-            className="w-[320px] justify-between future:rounded-xl future:border-0 future:font-normal future:text-muted-foreground"
+            className="w-[320px] justify-between future:rounded-xl future:border-0 future:bg-surface-overlay future:font-normal future:text-muted-foreground future:hover:bg-surface-hover"
           >
             {selected.length > 0 ? `${selected.length} selected` : 'Select frameworks...'}
             <ChevronsUpDown className="opacity-50" />
@@ -182,7 +182,7 @@ function CustomDisplayCombobox() {
           variant="outline"
           role="combobox"
           aria-expanded={open}
-          className="w-[320px] justify-between future:rounded-xl future:border-0 future:font-normal future:text-muted-foreground"
+          className="w-[320px] justify-between future:rounded-xl future:border-0 future:bg-surface-overlay future:font-normal future:text-muted-foreground future:hover:bg-surface-hover"
         >
           {selected ? (
             <span className="flex items-center gap-2">
@@ -284,7 +284,7 @@ function AsyncCombobox() {
             variant="outline"
             role="combobox"
             aria-expanded={open}
-            className="w-[280px] justify-between future:rounded-xl future:border-0 future:font-normal future:text-muted-foreground"
+            className="w-[280px] justify-between future:rounded-xl future:border-0 future:bg-surface-overlay future:font-normal future:text-muted-foreground future:hover:bg-surface-hover"
           >
             {selected ? selected.label : 'Search libraries...'}
             <ChevronsUpDown className="opacity-50" />

--- a/packages/apollo-wind/src/components/ui/combobox.stories.tsx
+++ b/packages/apollo-wind/src/components/ui/combobox.stories.tsx
@@ -95,7 +95,7 @@ function MultiSelectCombobox() {
             variant="outline"
             role="combobox"
             aria-expanded={open}
-            className="w-[320px] justify-between future:rounded-xl future:border-0 future:bg-surface-overlay future:font-normal future:text-muted-foreground future:hover:bg-surface-hover"
+            className="w-[320px] justify-between future:gap-4 future:rounded-xl future:border-0 future:bg-surface-overlay future:font-normal future:text-muted-foreground future:hover:bg-surface-hover future:focus-visible:ring-offset-2 future:focus-visible:ring-offset-background"
           >
             {selected.length > 0 ? `${selected.length} selected` : 'Select frameworks...'}
             <ChevronsUpDown className="opacity-50" />
@@ -182,7 +182,7 @@ function CustomDisplayCombobox() {
           variant="outline"
           role="combobox"
           aria-expanded={open}
-          className="w-[320px] justify-between future:rounded-xl future:border-0 future:bg-surface-overlay future:font-normal future:text-muted-foreground future:hover:bg-surface-hover"
+          className="w-[320px] justify-between future:gap-4 future:rounded-xl future:border-0 future:bg-surface-overlay future:font-normal future:text-muted-foreground future:hover:bg-surface-hover future:focus-visible:ring-offset-2 future:focus-visible:ring-offset-background"
         >
           {selected ? (
             <span className="flex items-center gap-2">
@@ -284,7 +284,7 @@ function AsyncCombobox() {
             variant="outline"
             role="combobox"
             aria-expanded={open}
-            className="w-[280px] justify-between future:rounded-xl future:border-0 future:bg-surface-overlay future:font-normal future:text-muted-foreground future:hover:bg-surface-hover"
+            className="w-[280px] justify-between future:gap-4 future:rounded-xl future:border-0 future:bg-surface-overlay future:font-normal future:text-muted-foreground future:hover:bg-surface-hover future:focus-visible:ring-offset-2 future:focus-visible:ring-offset-background"
           >
             {selected ? selected.label : 'Search libraries...'}
             <ChevronsUpDown className="opacity-50" />

--- a/packages/apollo-wind/src/components/ui/combobox.tsx
+++ b/packages/apollo-wind/src/components/ui/combobox.tsx
@@ -57,7 +57,7 @@ export const Combobox = React.forwardRef<HTMLButtonElement, ComboboxProps>(funct
           aria-expanded={open}
           aria-label={selectedItem ? selectedItem.label : placeholder}
           className={cn(
-            'w-[280px] justify-between future:rounded-xl future:border-0 future:bg-surface-overlay future:hover:bg-surface-hover future:font-normal future:text-muted-foreground',
+            'w-[280px] justify-between future:h-10 future:rounded-xl future:border-0 future:bg-surface-overlay future:px-4 future:gap-4 future:hover:bg-surface-hover future:font-normal future:text-muted-foreground future:focus-visible:ring-offset-2 future:focus-visible:ring-offset-background',
             className
           )}
           disabled={disabled}

--- a/packages/apollo-wind/src/components/ui/dropdown-menu.stories.tsx
+++ b/packages/apollo-wind/src/components/ui/dropdown-menu.stories.tsx
@@ -1,26 +1,26 @@
-import { useState } from 'react';
 import type { Meta } from '@storybook/react-vite';
 import {
   ChevronDown,
   Copy,
+  CreditCard,
   Download,
   Edit,
   ExternalLink,
   FileText,
+  HelpCircle,
   LogOut,
+  Moon,
   MoreHorizontal,
   Pencil,
   Settings,
   Share2,
   Star,
+  Sun,
   Trash2,
   User,
-  CreditCard,
   Users,
-  HelpCircle,
-  Moon,
-  Sun,
 } from 'lucide-react';
+import { useState } from 'react';
 import { Button } from './button';
 import {
   DropdownMenu,
@@ -36,6 +36,7 @@ import {
   DropdownMenuSubTrigger,
   DropdownMenuTrigger,
 } from './dropdown-menu';
+import { FormField, FormFieldError, FormFieldLabel } from './form-field';
 
 const meta: Meta<typeof DropdownMenu> = {
   title: 'Components/Overlays/Dropdown',
@@ -53,7 +54,7 @@ export const BasicDropdown = {
   name: 'Basic Dropdown',
   render: () => (
     <DropdownMenu>
-      <DropdownMenuTrigger asChild>
+      <DropdownMenuTrigger asChild field>
         <Button variant="outline">
           Options
           <ChevronDown className="ml-2 h-4 w-4" />
@@ -67,6 +68,35 @@ export const BasicDropdown = {
         <DropdownMenuItem>Export</DropdownMenuItem>
         <DropdownMenuSeparator />
         <DropdownMenuItem>Preferences</DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  ),
+};
+
+export const WithInlineValidation = {
+  name: 'With inline validation',
+  render: () => (
+    <DropdownMenu>
+      <FormField>
+        <FormFieldLabel htmlFor="connection-dropdown">Connection</FormFieldLabel>
+        <DropdownMenuTrigger
+          asChild
+          field
+          error="Select a connection before continuing."
+          errorId="connection-dropdown-error"
+        >
+          <Button id="connection-dropdown" variant="outline">
+            Choose a connection
+            <ChevronDown className="ml-2 h-4 w-4" />
+          </Button>
+        </DropdownMenuTrigger>
+        <FormFieldError id="connection-dropdown-error">
+          Select a connection before continuing.
+        </FormFieldError>
+      </FormField>
+      <DropdownMenuContent className="w-48">
+        <DropdownMenuItem>Production</DropdownMenuItem>
+        <DropdownMenuItem>Staging</DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>
   ),

--- a/packages/apollo-wind/src/components/ui/dropdown-menu.test.tsx
+++ b/packages/apollo-wind/src/components/ui/dropdown-menu.test.tsx
@@ -31,6 +31,47 @@ describe('DropdownMenu', () => {
       expect(screen.getByText('Open Menu')).toBeInTheDocument();
     });
 
+    it('associates validation feedback with a field trigger', () => {
+      render(
+        <DropdownMenu>
+          <DropdownMenuTrigger
+            field
+            error="Choose a connection"
+            errorId="connection-error"
+            aria-describedby="field-help"
+          >
+            Open Menu
+          </DropdownMenuTrigger>
+          <DropdownMenuContent>
+            <DropdownMenuItem>Action</DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      );
+      const trigger = screen.getByRole('button', { name: 'Open Menu' });
+      expect(trigger).toHaveAttribute('aria-invalid', 'true');
+      expect(trigger).toHaveAttribute('aria-errormessage', 'connection-error');
+      expect(trigger).toHaveAttribute('aria-describedby', 'field-help connection-error');
+      expect(trigger.className).toContain('future:h-10');
+      expect(trigger.className).toContain('ring-1');
+    });
+
+    it('preserves an existing error message reference without an error id', () => {
+      render(
+        <DropdownMenu>
+          <DropdownMenuTrigger error="Choose a connection" aria-errormessage="existing-error">
+            Open Menu
+          </DropdownMenuTrigger>
+          <DropdownMenuContent>
+            <DropdownMenuItem>Action</DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      );
+      expect(screen.getByRole('button', { name: 'Open Menu' })).toHaveAttribute(
+        'aria-errormessage',
+        'existing-error'
+      );
+    });
+
     it('shows menu on click', async () => {
       const user = userEvent.setup();
       render(

--- a/packages/apollo-wind/src/components/ui/dropdown-menu.tsx
+++ b/packages/apollo-wind/src/components/ui/dropdown-menu.tsx
@@ -24,26 +24,40 @@ const DropdownMenuTrigger = React.forwardRef<
     /** Optional id for the validation message referenced by aria-describedby. */
     errorId?: string;
   }
->(({ className, field, error, errorId, 'aria-describedby': ariaDescribedBy, ...props }, ref) => {
-  const describedBy = [ariaDescribedBy, error ? errorId : undefined].filter(Boolean).join(' ');
+>(
+  (
+    {
+      className,
+      field,
+      error,
+      errorId,
+      'aria-describedby': ariaDescribedBy,
+      'aria-invalid': ariaInvalid,
+      'aria-errormessage': ariaErrorMessage,
+      ...props
+    },
+    ref
+  ) => {
+    const describedBy = [ariaDescribedBy, error ? errorId : undefined].filter(Boolean).join(' ');
 
-  return (
-    <DropdownMenuPrimitive.Trigger
-      ref={ref}
-      data-slot="dropdown-menu-trigger"
-      className={cn(
-        field &&
-          'future:h-10 future:rounded-xl future:border-0 future:bg-surface-overlay future:px-4 future:gap-4 future:font-normal future:text-muted-foreground future:hover:bg-surface-hover',
-        error && 'border-error ring-error/20 future:ring-1 future:ring-error/40',
-        className
-      )}
-      aria-describedby={describedBy || undefined}
-      aria-errormessage={error ? errorId : undefined}
-      aria-invalid={error ? true : props['aria-invalid']}
-      {...props}
-    />
-  );
-});
+    return (
+      <DropdownMenuPrimitive.Trigger
+        ref={ref}
+        data-slot="dropdown-menu-trigger"
+        className={cn(
+          field &&
+            'future:h-10 future:rounded-xl future:border-0 future:bg-surface-overlay future:px-4 future:gap-4 future:font-normal future:text-muted-foreground future:hover:bg-surface-hover',
+          error && 'border-error ring-1 ring-error/20 future:ring-error/40',
+          className
+        )}
+        aria-describedby={describedBy || undefined}
+        aria-errormessage={error ? errorId : ariaErrorMessage}
+        aria-invalid={error ? true : ariaInvalid}
+        {...props}
+      />
+    );
+  }
+);
 DropdownMenuTrigger.displayName = DropdownMenuPrimitive.Trigger.displayName;
 
 const DropdownMenuGroup = React.forwardRef<

--- a/packages/apollo-wind/src/components/ui/dropdown-menu.tsx
+++ b/packages/apollo-wind/src/components/ui/dropdown-menu.tsx
@@ -16,10 +16,34 @@ DropdownMenu.displayName = 'DropdownMenu';
 
 const DropdownMenuTrigger = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.Trigger>,
-  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Trigger>
->((props, ref) => (
-  <DropdownMenuPrimitive.Trigger ref={ref} data-slot="dropdown-menu-trigger" {...props} />
-));
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Trigger> & {
+    /** Apply the Future theme field treatment when the trigger is used as a form control. */
+    field?: boolean;
+    /** Field-specific validation feedback rendered below the trigger by the consumer. */
+    error?: React.ReactNode;
+    /** Optional id for the validation message referenced by aria-describedby. */
+    errorId?: string;
+  }
+>(({ className, field, error, errorId, 'aria-describedby': ariaDescribedBy, ...props }, ref) => {
+  const describedBy = [ariaDescribedBy, error ? errorId : undefined].filter(Boolean).join(' ');
+
+  return (
+    <DropdownMenuPrimitive.Trigger
+      ref={ref}
+      data-slot="dropdown-menu-trigger"
+      className={cn(
+        field &&
+          'future:h-10 future:rounded-xl future:border-0 future:bg-surface-overlay future:px-4 future:gap-4 future:font-normal future:text-muted-foreground future:hover:bg-surface-hover',
+        error && 'border-error ring-error/20 future:ring-1 future:ring-error/40',
+        className
+      )}
+      aria-describedby={describedBy || undefined}
+      aria-errormessage={error ? errorId : undefined}
+      aria-invalid={error ? true : props['aria-invalid']}
+      {...props}
+    />
+  );
+});
 DropdownMenuTrigger.displayName = DropdownMenuPrimitive.Trigger.displayName;
 
 const DropdownMenuGroup = React.forwardRef<

--- a/packages/apollo-wind/src/components/ui/dropdown-menu.tsx
+++ b/packages/apollo-wind/src/components/ui/dropdown-menu.tsx
@@ -51,7 +51,7 @@ const DropdownMenuTrigger = React.forwardRef<
           className
         )}
         aria-describedby={describedBy || undefined}
-        aria-errormessage={error ? errorId : ariaErrorMessage}
+        aria-errormessage={error ? (errorId ?? ariaErrorMessage) : ariaErrorMessage}
         aria-invalid={error ? true : ariaInvalid}
         {...props}
       />

--- a/packages/apollo-wind/src/components/ui/multi-select.tsx
+++ b/packages/apollo-wind/src/components/ui/multi-select.tsx
@@ -106,14 +106,16 @@ const MultiSelect = React.forwardRef<HTMLDivElement, MultiSelectProps>(
                     : placeholder
               }
               className={cn(
-                'w-full justify-between future:rounded-xl future:border-0 future:bg-surface-overlay future:hover:bg-surface-hover future:font-normal future:text-muted-foreground',
+                'w-full justify-between future:rounded-xl future:border-0 future:bg-surface-overlay future:px-4 future:gap-4 future:hover:bg-surface-hover future:font-normal future:text-muted-foreground future:focus-visible:ring-offset-2 future:focus-visible:ring-offset-background',
                 selected.length > 0 ? 'h-auto min-h-10' : 'h-10'
               )}
               disabled={disabled}
             >
               <div className="flex flex-wrap gap-1 flex-1">
                 {selected.length === 0 ? (
-                  <span className="text-muted-foreground">{placeholder}</span>
+                  <span className="text-muted-foreground future:text-foreground-muted">
+                    {placeholder}
+                  </span>
                 ) : (
                   selected.map((value) => {
                     const option = options.find((opt) => opt.value === value);

--- a/packages/apollo-wind/src/components/ui/prompt-editor/components/EditorToolbar.tsx
+++ b/packages/apollo-wind/src/components/ui/prompt-editor/components/EditorToolbar.tsx
@@ -70,7 +70,7 @@ export const EditorToolbar = ({
       // No bottom border on the toolbar itself — the separator is drawn by the absolute hairline
       // `<span>` below at full width so the L/R outlines stay continuous with the editor body's
       // `border-t-0` border underneath.
-      className="relative flex items-center justify-between gap-1 overflow-hidden rounded-t-md border border-b-0 bg-background px-2 py-1"
+      className="relative flex items-center justify-between gap-1 overflow-hidden rounded-t-md border border-b-0 bg-background px-2 py-1 future:rounded-t-xl future:border-0 future:bg-surface-overlay"
       data-testid="editor-toolbar"
     >
       <span

--- a/packages/apollo-wind/src/components/ui/prompt-editor/components/EditorToolbar.tsx
+++ b/packages/apollo-wind/src/components/ui/prompt-editor/components/EditorToolbar.tsx
@@ -1,12 +1,13 @@
 import { Bold, Italic, List, ListOrdered, Maximize2, Strikethrough } from 'lucide-react';
-import { cn } from '@/lib';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { cn } from '@/lib';
 import type { PromptEditorMode, PromptEditorToolbarActionsRef } from '../types';
 
 export interface EditorToolbarProps {
   mode: PromptEditorMode;
   onModeChange: (mode: PromptEditorMode) => void;
   disabled?: boolean;
+  error?: boolean;
   actionsRef?: React.RefObject<PromptEditorToolbarActionsRef | null>;
   onFullscreen?: () => void;
 }
@@ -53,6 +54,7 @@ export const EditorToolbar = ({
   mode,
   onModeChange,
   disabled,
+  error,
   actionsRef,
   onFullscreen,
 }: EditorToolbarProps) => {
@@ -70,7 +72,10 @@ export const EditorToolbar = ({
       // No bottom border on the toolbar itself — the separator is drawn by the absolute hairline
       // `<span>` below at full width so the L/R outlines stay continuous with the editor body's
       // `border-t-0` border underneath.
-      className="relative flex items-center justify-between gap-1 overflow-hidden rounded-t-md border border-b-0 bg-background px-2 py-1 future:rounded-t-xl future:border-0 future:bg-surface-overlay"
+      className={cn(
+        'relative flex items-center justify-between gap-1 overflow-hidden rounded-t-md border border-b-0 bg-background px-2 py-1 future:rounded-t-xl future:border-0 future:bg-surface-overlay',
+        error && 'border-error ring-1 ring-error/20 future:ring-error/40'
+      )}
       data-testid="editor-toolbar"
     >
       <span

--- a/packages/apollo-wind/src/components/ui/prompt-editor/prompt-editor.stories.tsx
+++ b/packages/apollo-wind/src/components/ui/prompt-editor/prompt-editor.stories.tsx
@@ -57,6 +57,15 @@ export const Default: Story = {
   },
 };
 
+export const WithInlineValidation: Story = {
+  name: 'With inline validation',
+  args: {
+    placeholder: 'Write your prompt…',
+    ariaLabel: 'Prompt',
+    error: 'Enter a prompt before continuing.',
+  },
+};
+
 export const SingleLine: Story = {
   args: {
     multiline: false,

--- a/packages/apollo-wind/src/components/ui/prompt-editor/prompt-editor.test.tsx
+++ b/packages/apollo-wind/src/components/ui/prompt-editor/prompt-editor.test.tsx
@@ -47,6 +47,17 @@ describe('PromptEditor', () => {
       expect(screen.getByText('Type your prompt…')).toBeInTheDocument();
     });
 
+    it('associates inline validation feedback with the textbox', () => {
+      render(
+        <PromptEditor ariaLabel="Prompt" error="A prompt is required" errorId="prompt-error" />
+      );
+      const editor = screen.getByRole('textbox', { name: 'Prompt' });
+      expect(editor).toHaveAttribute('aria-invalid', 'true');
+      expect(editor).toHaveAttribute('aria-describedby', 'prompt-error');
+      expect(editor).toHaveAttribute('aria-errormessage', 'prompt-error');
+      expect(screen.getByText('A prompt is required')).toHaveAttribute('id', 'prompt-error');
+    });
+
     it('marks the editor non-editable when disabled', async () => {
       render(<PromptEditor ariaLabel="Prompt" disabled />);
       await waitFor(() =>

--- a/packages/apollo-wind/src/components/ui/prompt-editor/prompt-editor.test.tsx
+++ b/packages/apollo-wind/src/components/ui/prompt-editor/prompt-editor.test.tsx
@@ -148,6 +148,18 @@ describe('PromptEditor', () => {
       expect(invalidPreview).toHaveClass('border-error', 'ring-1');
       expect(screen.getByText('A prompt is required')).toBeInTheDocument();
     });
+
+    it('applies validation styling to the toolbar', () => {
+      render(
+        <PromptEditor
+          mode="preview"
+          showToolbar
+          error="A prompt is required"
+          errorId="prompt-error"
+        />
+      );
+      expect(screen.getByTestId('editor-toolbar')).toHaveClass('border-error', 'ring-1');
+    });
   });
 
   describe('tokens', () => {

--- a/packages/apollo-wind/src/components/ui/prompt-editor/prompt-editor.test.tsx
+++ b/packages/apollo-wind/src/components/ui/prompt-editor/prompt-editor.test.tsx
@@ -134,6 +134,15 @@ describe('PromptEditor', () => {
       render(<PromptEditor value={[]} mode="preview" />);
       expect(screen.getByText('Nothing to preview')).toBeInTheDocument();
     });
+
+    it('keeps validation styling visible in preview mode', () => {
+      const { container } = render(
+        <PromptEditor mode="preview" error="A prompt is required" errorId="prompt-error" />
+      );
+      const invalidPreview = container.querySelector('[data-invalid="true"]');
+      expect(invalidPreview).toHaveClass('border-error', 'ring-1');
+      expect(screen.getByText('A prompt is required')).toBeInTheDocument();
+    });
   });
 
   describe('tokens', () => {

--- a/packages/apollo-wind/src/components/ui/prompt-editor/prompt-editor.test.tsx
+++ b/packages/apollo-wind/src/components/ui/prompt-editor/prompt-editor.test.tsx
@@ -49,11 +49,16 @@ describe('PromptEditor', () => {
 
     it('associates inline validation feedback with the textbox', () => {
       render(
-        <PromptEditor ariaLabel="Prompt" error="A prompt is required" errorId="prompt-error" />
+        <PromptEditor
+          ariaLabel="Prompt"
+          error="A prompt is required"
+          errorId="prompt-error"
+          aria-describedby="prompt-help"
+        />
       );
       const editor = screen.getByRole('textbox', { name: 'Prompt' });
       expect(editor).toHaveAttribute('aria-invalid', 'true');
-      expect(editor).toHaveAttribute('aria-describedby', 'prompt-error');
+      expect(editor).toHaveAttribute('aria-describedby', 'prompt-help prompt-error');
       expect(editor).toHaveAttribute('aria-errormessage', 'prompt-error');
       expect(screen.getByText('A prompt is required')).toHaveAttribute('id', 'prompt-error');
     });

--- a/packages/apollo-wind/src/components/ui/prompt-editor/prompt-editor.tsx
+++ b/packages/apollo-wind/src/components/ui/prompt-editor/prompt-editor.tsx
@@ -376,7 +376,7 @@ const EditorInner = forwardRef(
                       textOverflow: 'ellipsis' as const,
                     }),
               }}
-              className="text-muted-foreground/60"
+              className="text-muted-foreground future:text-foreground-muted future:font-normal"
             >
               {placeholder}
             </div>

--- a/packages/apollo-wind/src/components/ui/prompt-editor/prompt-editor.tsx
+++ b/packages/apollo-wind/src/components/ui/prompt-editor/prompt-editor.tsx
@@ -321,6 +321,7 @@ const EditorInner = forwardRef(
     return (
       <div
         className={wrapperClassName}
+        data-invalid={error ? 'true' : undefined}
         style={{
           fontFamily: "'Noto Sans', sans-serif",
           fontSize: '14px',
@@ -330,7 +331,7 @@ const EditorInner = forwardRef(
       >
         <style>{`
           .prompt-editor-paragraph { padding: 0; margin: 0; }
-          ${borderless ? '' : '.prompt-editor-shell:focus-within { border-color: var(--color-ring); box-shadow: 0 0 0 1px var(--color-ring); } .future .prompt-editor-shell:focus-within { box-shadow: 0 0 0 2px color-mix(in srgb, var(--color-ring) 35%, transparent); }'}
+          ${borderless ? '' : '.prompt-editor-shell:not([data-invalid="true"]):focus-within { border-color: var(--color-ring); box-shadow: 0 0 0 1px var(--color-ring); } .future .prompt-editor-shell:not([data-invalid="true"]):focus-within { box-shadow: 0 0 0 2px color-mix(in srgb, var(--color-ring) 35%, transparent); }'}
           .prompt-editor-root *::selection { background-color: color-mix(in srgb, var(--color-primary) 30%, transparent); }
         `}</style>
         <div

--- a/packages/apollo-wind/src/components/ui/prompt-editor/prompt-editor.tsx
+++ b/packages/apollo-wind/src/components/ui/prompt-editor/prompt-editor.tsx
@@ -496,6 +496,7 @@ export const PromptEditor = ({
           <EditorToolbar
             mode={mode}
             disabled={disabled}
+            error={Boolean(error)}
             actionsRef={toolbarActionsRef}
             onModeChange={handleModeChange}
             onFullscreen={onFullscreen}

--- a/packages/apollo-wind/src/components/ui/prompt-editor/prompt-editor.tsx
+++ b/packages/apollo-wind/src/components/ui/prompt-editor/prompt-editor.tsx
@@ -9,11 +9,13 @@ import {
   forwardRef,
   useCallback,
   useEffect,
+  useId,
   useImperativeHandle,
   useMemo,
   useRef,
   useState,
 } from 'react';
+import { FormFieldError } from '@/components/ui/form-field';
 import { TooltipProvider } from '@/components/ui/tooltip';
 import { EditorToolbar } from './components/EditorToolbar';
 import { MarkdownPreview } from './components/MarkdownPreview';
@@ -72,6 +74,12 @@ export interface PromptEditorProps {
   fillHeight?: boolean;
   /** Drop the editor's own border/background/rounding so a parent can provide the field chrome. */
   borderless?: boolean;
+  /** Field-specific validation feedback rendered below the editor. */
+  error?: React.ReactNode;
+  /** Optional id for the inline validation message. */
+  errorId?: string;
+  /** Additional description id(s) associated with the editor. */
+  ariaDescribedBy?: string;
   /**
    * Enable variable drag-drop: map a path dropped onto the editor (see `VARIABLE_DRAG_MIME`) to the
    * token to insert at the drop point. The drag *source* is the consumer's (it sets the path on
@@ -111,6 +119,9 @@ const EditorInner = forwardRef(
       ariaLabel,
       fillHeight,
       borderless,
+      error,
+      errorId,
+      ariaDescribedBy,
       mapVarDropToToken,
       toolbarActionsRef,
       showToolbar,
@@ -305,7 +316,7 @@ const EditorInner = forwardRef(
 
     const wrapperClassName = borderless
       ? 'flex flex-col w-full relative'
-      : `prompt-editor-shell flex flex-col w-full relative border bg-background ${showToolbar ? 'border-t-0 rounded-b-md' : 'rounded-md'}`;
+      : `prompt-editor-shell flex flex-col w-full relative border bg-background future:border-0 future:bg-surface-overlay ${showToolbar ? 'border-t-0 rounded-b-md future:rounded-b-xl' : 'rounded-md future:rounded-xl'} ${error ? 'border-error ring-1 ring-error/20 future:ring-error/40' : ''}`;
 
     return (
       <div
@@ -319,7 +330,7 @@ const EditorInner = forwardRef(
       >
         <style>{`
           .prompt-editor-paragraph { padding: 0; margin: 0; }
-          ${borderless ? '' : '.prompt-editor-shell:focus-within { border-color: var(--color-ring); box-shadow: 0 0 0 1px var(--color-ring); }'}
+          ${borderless ? '' : '.prompt-editor-shell:focus-within { border-color: var(--color-ring); box-shadow: 0 0 0 1px var(--color-ring); } .future .prompt-editor-shell:focus-within { box-shadow: 0 0 0 2px color-mix(in srgb, var(--color-ring) 35%, transparent); }'}
           .prompt-editor-root *::selection { background-color: color-mix(in srgb, var(--color-primary) 30%, transparent); }
         `}</style>
         <div
@@ -332,7 +343,15 @@ const EditorInner = forwardRef(
           }}
         >
           <PlainTextPlugin
-            contentEditable={<ContentEditable style={contentEditableStyle} ariaLabel={ariaLabel} />}
+            contentEditable={
+              <ContentEditable
+                style={contentEditableStyle}
+                ariaLabel={ariaLabel}
+                aria-invalid={error ? true : undefined}
+                aria-describedby={ariaDescribedBy}
+                aria-errormessage={error ? errorId : undefined}
+              />
+            }
             placeholder={null}
             ErrorBoundary={LexicalErrorBoundary}
           />
@@ -406,6 +425,9 @@ export const PromptEditor = ({
   editorRef,
   fillHeight,
   borderless,
+  error,
+  errorId: providedErrorId,
+  ariaDescribedBy,
   mapVarDropToToken,
 }: PromptEditorProps) => {
   // Normalize the token-array props once so malformed input (e.g. `{}` from a Storybook object
@@ -440,6 +462,9 @@ export const PromptEditor = ({
 
   const isControlled = value !== undefined;
   const previewTokens = isControlled ? value : uncontrolledPreviewTokens;
+  const generatedErrorId = useId();
+  const errorId = providedErrorId ?? `prompt-editor-${generatedErrorId.replace(/:/g, '')}-error`;
+  const describedBy = [ariaDescribedBy, error ? errorId : undefined].filter(Boolean).join(' ');
 
   const handleEditorChange = useCallback(
     (tokens: PromptEditorToken[]) => {
@@ -476,7 +501,7 @@ export const PromptEditor = ({
             className={
               borderless
                 ? undefined
-                : `border bg-background ${showToolbar ? 'border-t-0 rounded-b-md' : 'rounded-md'}`
+                : `border bg-background future:border-0 future:bg-surface-overlay ${showToolbar ? 'border-t-0 rounded-b-md future:rounded-b-xl' : 'rounded-md future:rounded-xl'}`
             }
           >
             <MarkdownPreview tokens={previewTokens} minRows={minRows} />
@@ -497,6 +522,9 @@ export const PromptEditor = ({
               autoCompleteOptions={autoCompleteOptions}
               disabled={disabled}
               ariaLabel={ariaLabel}
+              error={error}
+              errorId={error ? errorId : undefined}
+              ariaDescribedBy={describedBy || undefined}
               initialValue={initialValue}
               maxRows={maxRows}
               minRows={minRows}
@@ -512,6 +540,9 @@ export const PromptEditor = ({
             />
           </LexicalComposer>
         </div>
+        <FormFieldError id={errorId} data-slot="prompt-editor-error" className="mt-1">
+          {error}
+        </FormFieldError>
       </div>
     </TooltipProvider>
   );

--- a/packages/apollo-wind/src/components/ui/prompt-editor/prompt-editor.tsx
+++ b/packages/apollo-wind/src/components/ui/prompt-editor/prompt-editor.tsx
@@ -499,10 +499,11 @@ export const PromptEditor = ({
             the editor's own border/background here too (keeps edit/preview consistent). */}
         {mode === 'preview' && (
           <div
+            data-invalid={error ? 'true' : undefined}
             className={
               borderless
                 ? undefined
-                : `border bg-background future:border-0 future:bg-surface-overlay ${showToolbar ? 'border-t-0 rounded-b-md future:rounded-b-xl' : 'rounded-md future:rounded-xl'}`
+                : `border bg-background future:border-0 future:bg-surface-overlay ${showToolbar ? 'border-t-0 rounded-b-md future:rounded-b-xl' : 'rounded-md future:rounded-xl'} ${error ? 'border-error ring-1 ring-error/20 future:ring-error/40' : ''}`
             }
           >
             <MarkdownPreview tokens={previewTokens} minRows={minRows} />

--- a/packages/apollo-wind/src/components/ui/prompt-editor/prompt-editor.tsx
+++ b/packages/apollo-wind/src/components/ui/prompt-editor/prompt-editor.tsx
@@ -79,6 +79,8 @@ export interface PromptEditorProps {
   /** Optional id for the inline validation message. */
   errorId?: string;
   /** Additional description id(s) associated with the editor. */
+  'aria-describedby'?: string;
+  /** @deprecated Use the native `aria-describedby` prop instead. */
   ariaDescribedBy?: string;
   /**
    * Enable variable drag-drop: map a path dropped onto the editor (see `VARIABLE_DRAG_MIME`) to the
@@ -428,7 +430,8 @@ export const PromptEditor = ({
   borderless,
   error,
   errorId: providedErrorId,
-  ariaDescribedBy,
+  'aria-describedby': nativeAriaDescribedBy,
+  ariaDescribedBy: legacyAriaDescribedBy,
   mapVarDropToToken,
 }: PromptEditorProps) => {
   // Normalize the token-array props once so malformed input (e.g. `{}` from a Storybook object
@@ -465,7 +468,11 @@ export const PromptEditor = ({
   const previewTokens = isControlled ? value : uncontrolledPreviewTokens;
   const generatedErrorId = useId();
   const errorId = providedErrorId ?? `prompt-editor-${generatedErrorId.replace(/:/g, '')}-error`;
-  const describedBy = [ariaDescribedBy, error ? errorId : undefined].filter(Boolean).join(' ');
+  // Prefer the native prop while accepting the legacy camelCase alias for compatibility.
+  const additionalDescribedBy = nativeAriaDescribedBy ?? legacyAriaDescribedBy;
+  const describedBy = [additionalDescribedBy, error ? errorId : undefined]
+    .filter(Boolean)
+    .join(' ');
 
   const handleEditorChange = useCallback(
     (tokens: PromptEditorToken[]) => {


### PR DESCRIPTION
## Summary

- Add panel UI inventory references for inline links, secondary Manage actions, footer actions, and lightweight + Add actions.
- Add Button intrinsic-width documentation, regression coverage, and semantic anchor link examples.
- Align dropdown, Combobox, Multi-select, and Prompt Editor controls with Future field styling.
- Add inline validation states and accessible error attributes for dropdown triggers and Prompt Editor.
- Keep the interactive Manage surface deferred for a follow-up PR.
<img width="1227" height="987" alt="Screenshot 2026-08-31 at 3 03 01 PM" src="https://github.com/user-attachments/assets/4d1fa2f8-58a8-461d-b63a-02a31e87333e" />
<img width="1229" height="990" alt="Screenshot 2026-08-31 at 3 03 26 PM" src="https://github.com/user-attachments/assets/bf4d6117-8466-42d9-a5b1-faadccf7f597" />
<img width="1230" height="993" alt="Screenshot 2026-08-31 at 3 03 58 PM" src="https://github.com/user-attachments/assets/b2b3a21f-9ee3-479d-93d8-38229a481b5f" />
<img width="1229" height="989" alt="Screenshot 2026-08-31 at 3 04 36 PM" src="https://github.com/user-attachments/assets/85810034-ff38-4c03-9c0f-db328b9ed77f" />


## Verification

- `pnpm --filter @uipath/apollo-wind test -- --run src/components/ui/button.test.tsx`
- 1,428 Apollo Wind tests passing
- Apollo Wind TypeScript check passing
- Biome checks and `git diff --check` passing
- Storybook references verified at `http://localhost:6009/`

## Review notes

Full-width Button usages that remain are intentional form, picker, menu, or submit layouts. Standard action buttons default to intrinsic content width.