### PR TITLE
fix(apollo-wind): removes sr-only default text for required indicator

### DIFF
--- a/packages/apollo-wind/src/components/custom/flow-properties-simple.test.tsx
+++ b/packages/apollo-wind/src/components/custom/flow-properties-simple.test.tsx
@@ -46,7 +46,7 @@ describe('PropertiesSimple', () => {
   it('renders a custom title and top-level field labels', () => {
     render(<PropertiesSimple title="Webhook trigger" fields={fields} />);
     expect(screen.getByText('Webhook trigger')).toBeInTheDocument();
-    expect(screen.getByRole('combobox', { name: /Method.*required/i })).toBeInTheDocument();
+    expect(screen.getByRole('combobox', { name: /Method.*/i })).toBeInTheDocument();
     expect(screen.getByText('Endpoint')).toBeInTheDocument();
   });
 

--- a/packages/apollo-wind/src/components/ui/label.test.tsx
+++ b/packages/apollo-wind/src/components/ui/label.test.tsx
@@ -106,7 +106,7 @@ describe('RequiredIndicator', () => {
     expect(indicator).not.toHaveClass('text-error');
   });
 
-  it('hides the asterisk glyph from assistive tech but announces it via sr-only text', () => {
+  it('hides the asterisk glyph from assistive tech and has no sr label by default', () => {
     render(
       <Label htmlFor="name">
         Name
@@ -114,7 +114,7 @@ describe('RequiredIndicator', () => {
       </Label>
     );
     expect(screen.getByText('*')).toHaveAttribute('aria-hidden', 'true');
-    expect(screen.getByText('(required)')).toHaveClass('sr-only');
+    expect(screen.queryByText('(required)')).not.toBeInTheDocument();
   });
 
   it('lets a localized surface supply its own announced text', () => {
@@ -133,7 +133,7 @@ describe('RequiredIndicator', () => {
       <div>
         <Label htmlFor="name">
           Name
-          <RequiredIndicator />
+          <RequiredIndicator srLabel="(required)" />
         </Label>
         <Input id="name" />
       </div>

--- a/packages/apollo-wind/src/components/ui/label.tsx
+++ b/packages/apollo-wind/src/components/ui/label.tsx
@@ -64,16 +64,16 @@ export interface RequiredIndicatorProps
  * required field isn't in an error state, so coloring the asterisk red reads
  * as a validation failure before the person has done anything. The asterisk
  * glyph is `aria-hidden` since it's a visual affordance, not the thing that
- * makes the field required to assistive tech; a `sr-only` "(required)" is
- * included alongside it so the label still announces the requirement even if
- * the field's own control is missing `required`/`aria-required`. That text is
- * English by default; pass `srLabel` to localize it.
+ * makes the field required to assistive tech;
+ * Use `required` or `aria-required` on the field's control for that.
+ * Or pass `srLabel` to provide assistive announcements if the field's own control
+ * is missing `required`/`aria-required`.
  */
 const RequiredIndicator = React.forwardRef<HTMLSpanElement, RequiredIndicatorProps>(
-  ({ className, srLabel = ' (required)', ...props }, ref) => (
+  ({ className, srLabel, ...props }, ref) => (
     <span ref={ref} {...props} className={cn('ml-0.5', className, 'text-foreground')}>
       <span aria-hidden="true">*</span>
-      <span className="sr-only">{srLabel}</span>
+      {srLabel && <span className="sr-only">{srLabel}</span>}
     </span>
   )
 );


### PR DESCRIPTION
Supplying default screen reader text was overkill for majority of cases. It leads to a duplicated required announcement for assistive tech when labelled fields correctly use `required`/`aria-required`. The props remains as an escape hatch for consumers to provide alternative assistive labels or label controls that do not support `required`/`aria-required`.