### PR TITLE
fix(apollo-react): use MUI CSS classes for color variants [MST-14544]

### DIFF
--- a/packages/apollo-react/src/material/theme/overrides/MuiChip.ts
+++ b/packages/apollo-react/src/material/theme/overrides/MuiChip.ts
@@ -96,7 +96,27 @@ export const MuiChip = (palette: Palette): ComponentsOverrides['MuiChip'] => ({
       height: 'auto',
     },
     '& .MuiChip-deleteIcon:hover': { color: palette.semantic.colorForeground },
-    '&.warning': {
+    // MUI color-prop slots (filled variant). Outlined + colored is left to MUI's
+    // built-in `MuiChip-outlinedXxx` styling (border/text only, transparent fill).
+    '&.MuiChip-filled.MuiChip-colorPrimary': {
+      color: palette.semantic.colorForegroundOnAccent,
+      background: palette.semantic.colorPrimary,
+      fontWeight: token.FontFamily.FontWeightSemibold,
+      '&:hover': {
+        color: palette.semantic.colorForegroundOnAccent,
+        background: palette.semantic.colorPrimaryHover,
+      },
+    },
+    '&.MuiChip-filled.MuiChip-colorSecondary': {
+      color: palette.secondary.contrastText,
+      background: palette.secondary.main,
+      fontWeight: token.FontFamily.FontWeightSemibold,
+      '&:hover': {
+        color: palette.secondary.contrastText,
+        background: palette.secondary.dark,
+      },
+    },
+    '&.MuiChip-filled.MuiChip-colorWarning': {
       color: palette.semantic.colorWarningText,
       background: palette.semantic.colorWarningBackground,
       fontWeight: token.FontFamily.FontWeightSemibold,
@@ -105,7 +125,7 @@ export const MuiChip = (palette: Palette): ComponentsOverrides['MuiChip'] => ({
         background: palette.semantic.colorWarningBackground,
       },
     },
-    '&.success': {
+    '&.MuiChip-filled.MuiChip-colorSuccess': {
       color: palette.semantic.colorSuccessText,
       background: palette.semantic.colorSuccessBackground,
       fontWeight: token.FontFamily.FontWeightSemibold,
@@ -114,7 +134,7 @@ export const MuiChip = (palette: Palette): ComponentsOverrides['MuiChip'] => ({
         background: palette.semantic.colorSuccessBackground,
       },
     },
-    '&.info': {
+    '&.MuiChip-filled.MuiChip-colorInfo': {
       color: palette.semantic.colorInfoForeground,
       background: palette.semantic.colorInfoBackground,
       fontWeight: token.FontFamily.FontWeightSemibold,
@@ -123,7 +143,7 @@ export const MuiChip = (palette: Palette): ComponentsOverrides['MuiChip'] => ({
         background: palette.semantic.colorInfoBackground,
       },
     },
-    '&.error': {
+    '&.MuiChip-filled.MuiChip-colorError': {
       color: palette.semantic.colorErrorText,
       background: palette.semantic.colorErrorBackground,
       fontWeight: token.FontFamily.FontWeightSemibold,


### PR DESCRIPTION
## Description
Update CSS styles to use MUI Chip's CSS classes to display the different color variants:
* Primary
* Secondary
* Success
* Info
* Warning
* Error

## Demo
Before:
<img width="688" height="452" alt="Screenshot 2026-09-01 at 3 20 05 PM" src="https://github.com/user-attachments/assets/9343f588-6594-4390-bd84-f9043de5148f" />

After:
<img width="724" height="471" alt="Screenshot 2026-09-01 at 3 19 58 PM" src="https://github.com/user-attachments/assets/5b50e745-8a52-4c96-afa8-b386f1307081" />
