### PR TITLE
fix(apollo-wind): stop FormField overflowing on truncating controls

### DIFF
--- a/packages/apollo-wind/src/components/ui/form-field.test.tsx
+++ b/packages/apollo-wind/src/components/ui/form-field.test.tsx
@@ -19,6 +19,18 @@ describe('FormField', () => {
     expect(screen.getByText('The URL to call.')).toBeInTheDocument();
     expect(screen.getByText('Endpoint is required.')).toBeInTheDocument();
   });
+
+  it('pins the column so a truncating control cannot widen the field', () => {
+    render(<FormField data-testid="field" />);
+    expect(screen.getByTestId('field')).toHaveClass('grid', 'grid-cols-[minmax(0,1fr)]');
+  });
+
+  it('lets a consumer override the column template', () => {
+    render(<FormField data-testid="field" className="grid-cols-2" />);
+    const field = screen.getByTestId('field');
+    expect(field).toHaveClass('grid-cols-2');
+    expect(field).not.toHaveClass('grid-cols-[minmax(0,1fr)]');
+  });
 });
 
 describe('FormFieldLabel', () => {

--- a/packages/apollo-wind/src/components/ui/form-field.tsx
+++ b/packages/apollo-wind/src/components/ui/form-field.tsx
@@ -10,10 +10,23 @@ export type FormFieldProps = React.ComponentPropsWithoutRef<'div'>;
  *
  * These parts are presentational and hold no form state, so they compose the
  * same way inside a metadata-driven form as they do in hand-built panels.
+ *
+ * The single column is pinned to `minmax(0, 1fr)` rather than left implicit.
+ * An implicit `auto` track floors at its widest child's min-content, and a
+ * control that ellipsizes is `white-space: nowrap`, so its min-content is the
+ * whole string: the field would push past a width-constrained host instead of
+ * truncating. A `1fr` track still resolves to max-content when the host width
+ * is indefinite, so shrink-to-fit hosts are unaffected. `className` is merged
+ * last, so a consumer can still override with `grid-cols-2` or similar.
  */
 const FormField = React.forwardRef<HTMLDivElement, FormFieldProps>(
   ({ children, className, ...props }, ref) => (
-    <div ref={ref} data-slot="form-field" className={cn('grid gap-1.5', className)} {...props}>
+    <div
+      ref={ref}
+      data-slot="form-field"
+      className={cn('grid grid-cols-[minmax(0,1fr)] gap-1.5', className)}
+      {...props}
+    >
       {children}
     </div>
   )

--- a/packages/apollo-wind/src/components/ui/label.test.tsx
+++ b/packages/apollo-wind/src/components/ui/label.test.tsx
@@ -24,6 +24,18 @@ describe('Label', () => {
     expect(results).toHaveNoViolations();
   });
 
+  it('is inline-block so a vertical margin from a space-y-* wrapper lands', () => {
+    render(<Label>Email</Label>);
+    expect(screen.getByText('Email')).toHaveClass('inline-block');
+  });
+
+  it('lets a consumer swap the display', () => {
+    render(<Label className="flex items-center gap-2">Email</Label>);
+    const label = screen.getByText('Email');
+    expect(label).toHaveClass('flex');
+    expect(label).not.toHaveClass('inline-block');
+  });
+
   it('applies the default treatment', () => {
     render(<Label>Email</Label>);
     expect(screen.getByText('Email')).toHaveClass('text-xs', 'font-medium', 'text-foreground');

--- a/packages/apollo-wind/src/components/ui/label.tsx
+++ b/packages/apollo-wind/src/components/ui/label.tsx
@@ -4,19 +4,22 @@ import * as React from 'react';
 
 import { cn } from '@/lib/index';
 
-const labelVariants = cva('text-xs peer-disabled:cursor-not-allowed peer-disabled:opacity-70', {
-  variants: {
-    variant: {
-      /** Names a field: the header above an input, select, or editor. */
-      default: 'font-medium text-foreground',
-      /** De-emphasized, for a label that names one option inside a field. */
-      muted: 'font-normal text-foreground-muted',
+const labelVariants = cva(
+  'inline-block text-xs peer-disabled:cursor-not-allowed peer-disabled:opacity-70',
+  {
+    variants: {
+      variant: {
+        /** Names a field: the header above an input, select, or editor. */
+        default: 'font-medium text-foreground',
+        /** De-emphasized, for a label that names one option inside a field. */
+        muted: 'font-normal text-foreground-muted',
+      },
     },
-  },
-  defaultVariants: {
-    variant: 'default',
-  },
-});
+    defaultVariants: {
+      variant: 'default',
+    },
+  }
+);
 
 /** Variant props, for consumers that forward a variant through to `Label`. */
 export type LabelVariants = VariantProps<typeof labelVariants>;
@@ -29,6 +32,15 @@ export type LabelProps = React.ComponentPropsWithoutRef<typeof LabelPrimitive.Ro
  * Long labels wrap. Do not ellipsize one with `truncate`: the indicator shares
  * the label's inline run, so the ellipsis swallows it, and a clipped field name
  * is unreadable anyway.
+ *
+ * Renders `inline-block` rather than the `<label>` default of `inline`.
+ * Vertical margins do nothing on an inline box, so under Tailwind v4, where
+ * `space-y-*` puts `margin-block-end` on every child but the last, the gap a
+ * `space-y-1.5` wrapper means to put under the label was silently dropped.
+ * `inline-block` keeps the label usable in inline flow, which `block` would
+ * not. As a grid or flex item the label is blockified anyway, so this changes
+ * nothing inside `FormField`, and a consumer needing another display passes
+ * one: `cn` merges `className` last.
  *
  * `data-variant` exposes the variant so a container can restyle every label of
  * one kind at once rather than reaching for each slot by name. Target it as


### PR DESCRIPTION
Two related layout fixes in `apollo-wind`, reported against 2.43.1.

## 1. `FormField`'s grid floors at min-content

`FormField` rendered `grid gap-1.5`. Its implicit column track is `auto`, whose *minimum* is the item's automatic minimum size, and grid items get `min-width: auto`. So the track could never be narrower than its widest child's min-content.

A control containing a `truncate` span is `white-space: nowrap`, which makes its min-content the **entire string**. Any such control forced the track wider than the form and overflowed its container instead of ellipsizing.

This was not limited to custom fields: `field-renderer` wraps every standard-typed field in `FormField`, so `MetadataForm` carried it too. It showed up wherever a form lives in a width-constrained surface, such as a properties panel, sidebar, or narrow dialog.

**Fix:** pin the single column to `minmax(0, 1fr)`.

### Measured, against the compiled Tailwind build

Same markup, same text, in a 320px host (304px content box):

| host | `grid` (before) | `grid-cols-[minmax(0,1fr)]` (after) |
| --- | --- | --- |
| definite 320px | control **712.8px**, no ellipsis | **304px**, ellipsizes |
| `inline-block` (shrink-to-fit) | 712.8px | 712.8px |
| flex item, `flex: 0 1 auto` | 712.8px | 712.8px |
| block, 1000px | 1000px | 1000px |

An `fr` track resolves against the max-content constraint when the container's width is indefinite, so shrink-to-fit hosts are byte-identical. The two behaviours diverge **only** when the width is definite, which is exactly the broken case, so no consumer depends on today's behaviour who isn't already looking at an overflowing control.

The escape hatch survives, since `className` is merged last:

```
cn('grid grid-cols-[minmax(0,1fr)] gap-1.5', 'grid-cols-2')
  -> 'grid gap-1.5 grid-cols-2'
```

`flex flex-col` would also have fixed this, and arguably more honestly, since the automatic-minimum-size rule applies only to the flex main axis. It was rejected because it silently breaks any consumer passing `grid-cols-2` / `grid-cols-[auto_1fr]`, as those utilities do not restore `display: grid`. One extra class is the cheaper trade.

## 2. `Label` had no display, so `space-y-*` silently did nothing

`Label` rendered a bare Radix `<label>` with typography classes and no display utility, so it was `display: inline`. Tailwind v4 changed `space-y-*` to emit `margin-block-end` on every child but the last (v3 emitted `margin-top` on every child but the first). Vertical margins have no effect on non-replaced inline boxes, so the margin landed on the `Label` and was discarded.

Confirmed in the browser: the `space-y-1.5` rule does emit `margin-block-end`, the `Label` computed to `display: inline`, `margin-block-end` computed to `6px`, and the measured gap was `3.5px` (pure line-box leading).

**Fix:** `inline-block`. It preserves inline-flow use, such as checkbox rows and inline hints, in a way `block` would not.

### ⚠️ Expected visual change

Anywhere a consumer wrapped a bare `Label` in `space-y-*`, the previously swallowed gap now appears. One instance exists in our own stories (`Basic Contact Form`, the "Urgent Request" toggle under a `space-y-0.5` wrapper).

Inside `FormField` nothing changes: grid items are blockified, so the label already computed to `block`. Verified in the DOM. The `datetime-picker` label that passes `flex items-center gap-2` stays `flex` via tailwind-merge. No consumer puts `truncate` on a `Label`.

## Verification

- Full `apollo-wind` suite: **1437 tests / 93 files passing**. Four new regression tests covering the pinned column, the consumer column override, the label display, and the label display override.
- `biome check` clean on all four files; `tsc --noEmit` clean.
- Rendered in Storybook at desktop and 375px, no breakage.
- `test:visual` is declared in `turbo.json` but no package implements it, so there is no visual suite to run. The pixel diff noted above is worth a manual look if snapshots exist elsewhere.

## Notes for the reporter

The local `@layer base` workaround can be deleted once this lands:

```css
@layer base {
  :where([data-slot='form-field']) {
    grid-template-columns: minmax(0, 1fr);
  }
}
```

It composes with this fix rather than fighting it, so there is no version gate on removing it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
