### PR TITLE
feat(apollo-react): add `EditableText` primitive [MST-14012]

### DIFF
--- a/packages/apollo-react/src/canvas/components/BaseNode/BaseNode.tsx
+++ b/packages/apollo-react/src/canvas/components/BaseNode/BaseNode.tsx
@@ -106,6 +106,8 @@ const BaseNodeComponent = (props: NodeProps<Node<BaseNodeData>>) => {
     executionStatusOverride,
     labelTooltip,
     labelBackgroundColor,
+    labelPlaceholder,
+    subLabelPlaceholder,
     footerVariant,
     footerComponent,
     subLabelComponent,
@@ -696,6 +698,8 @@ const BaseNodeComponent = (props: NodeProps<Node<BaseNodeData>>) => {
           subLabel={displaySubLabel}
           labelTooltip={displayLabelTooltip}
           labelBackgroundColor={displayLabelBackgroundColor}
+          labelPlaceholder={labelPlaceholder}
+          subLabelPlaceholder={subLabelPlaceholder}
           shape={displayShape}
           hasBottomHandles={hasVisibleBottomHandles}
           selected={selected}

--- a/packages/apollo-react/src/canvas/components/BaseNode/BaseNodeConfigContext.tsx
+++ b/packages/apollo-react/src/canvas/components/BaseNode/BaseNodeConfigContext.tsx
@@ -45,6 +45,10 @@ export interface BaseNodeOverrideConfig {
   // Display Customization
   labelTooltip?: string;
   labelBackgroundColor?: string;
+  /** Hint shown in the inline name editor while empty. Defaults to `"Name"`. */
+  labelPlaceholder?: string;
+  /** Hint shown in the inline description editor while empty. Defaults to `"Description"`. */
+  subLabelPlaceholder?: string;
   /** When providing a `footerComponent`, also set `footerVariant` to a sized variant (`button` | `single` | `double`). */
   footerVariant?: FooterVariant;
   footerComponent?: React.ReactNode;

--- a/packages/apollo-react/src/canvas/components/BaseNode/NodeLabel.test.tsx
+++ b/packages/apollo-react/src/canvas/components/BaseNode/NodeLabel.test.tsx
@@ -598,6 +598,44 @@ describe('NodeLabel', () => {
       expect(screen.getByText('Test Node')).toBeInTheDocument();
     });
 
+    it('should default the edit placeholders to Name and Description', async () => {
+      const user = userEvent.setup();
+      render(<NodeLabel {...defaultProps} />);
+
+      await user.dblClick(screen.getByText('Test Node'));
+
+      expect(screen.getByRole('textbox', { name: 'Edit node name' })).toHaveAttribute(
+        'placeholder',
+        'Name'
+      );
+      expect(screen.getByRole('textbox', { name: 'Edit node description' })).toHaveAttribute(
+        'placeholder',
+        'Description'
+      );
+    });
+
+    it('should use the caller placeholders when provided', async () => {
+      const user = userEvent.setup();
+      render(
+        <NodeLabel
+          {...defaultProps}
+          labelPlaceholder="HTTP Request"
+          subLabelPlaceholder="HTTP Request"
+        />
+      );
+
+      await user.dblClick(screen.getByText('Test Node'));
+
+      expect(screen.getByRole('textbox', { name: 'Edit node name' })).toHaveAttribute(
+        'placeholder',
+        'HTTP Request'
+      );
+      expect(screen.getByRole('textbox', { name: 'Edit node description' })).toHaveAttribute(
+        'placeholder',
+        'HTTP Request'
+      );
+    });
+
     it('should apply horizontal padding to the edit inputs regardless of background color', async () => {
       const user = userEvent.setup();
       render(<NodeLabel {...defaultProps} />);

--- a/packages/apollo-react/src/canvas/components/BaseNode/NodeLabel.tsx
+++ b/packages/apollo-react/src/canvas/components/BaseNode/NodeLabel.tsx
@@ -205,6 +205,10 @@ const EmptyLabelPlaceholder = ({ disabled, onDoubleClick }: EmptyLabelPlaceholde
 export interface NodeLabelProps {
   label?: string;
   subLabel?: string;
+  /** Hint shown in the name editor while empty. Defaults to `"Name"`. */
+  labelPlaceholder?: string;
+  /** Hint shown in the description editor while empty. Defaults to `"Description"`. */
+  subLabelPlaceholder?: string;
   labelTooltip?: string;
   labelBackgroundColor?: string;
   shape?: NodeShape;
@@ -221,6 +225,8 @@ export interface NodeLabelProps {
 const NodeLabelInternal = ({
   label = '',
   subLabel = '',
+  labelPlaceholder = 'Name',
+  subLabelPlaceholder = 'Description',
   labelTooltip,
   labelBackgroundColor,
   shape,
@@ -245,11 +251,11 @@ const NodeLabelInternal = ({
     setIsEditing(false);
     setFocusTarget(null);
 
-    // Only call onChange if values have changed
-    if (localLabel !== label || localSubLabel !== subLabel) {
+    const [nextLabel, nextSubLabel] = [localLabel.trim(), localSubLabel.trim()];
+    if (nextLabel !== label || nextSubLabel !== subLabel) {
       onChange?.({
-        label: localLabel,
-        subLabel: localSubLabel,
+        label: nextLabel,
+        subLabel: nextSubLabel,
       });
     }
   }, [localLabel, localSubLabel, label, subLabel, onChange]);
@@ -363,7 +369,7 @@ const NodeLabelInternal = ({
             shape={shape}
             variant="normal"
             backgroundColor={labelBackgroundColor}
-            placeholder="Name"
+            placeholder={labelPlaceholder}
             rows={shape === 'rectangle' ? 1 : undefined}
             aria-label="Edit node name"
           />
@@ -375,7 +381,7 @@ const NodeLabelInternal = ({
             onBlur={handleBlur}
             shape={shape}
             variant="subtext"
-            placeholder="Description"
+            placeholder={subLabelPlaceholder}
             rows={shape === 'rectangle' ? 2 : undefined}
             aria-label="Edit node description"
           />

--- a/packages/apollo-react/src/canvas/components/NodePropertyPanel/EditableText.test.tsx
+++ b/packages/apollo-react/src/canvas/components/NodePropertyPanel/EditableText.test.tsx
@@ -1,0 +1,370 @@
+import type { HTMLAttributes, ReactNode } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen, userEvent } from '../../utils/testing';
+import { EditableText } from './EditableText';
+
+// Stand in for the real overflow detection, which needs layout jsdom does not do.
+vi.mock('../CanvasTooltip', async () => {
+  const React = await import('react');
+
+  return {
+    CanvasTooltip: ({ content, children }: { content: ReactNode; children: ReactNode }) =>
+      React.isValidElement(children)
+        ? React.cloneElement(children, {
+            'data-tooltip-trigger': typeof content === 'string' ? content : 'true',
+          } as HTMLAttributes<HTMLElement>)
+        : children,
+  };
+});
+
+describe('EditableText', () => {
+  it('renders static text with no interactive affordance when onChange is omitted', () => {
+    render(<EditableText value="End" />);
+    expect(screen.getByText('End')).toBeInTheDocument();
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+
+  it('shows the placeholder in place of an empty value', () => {
+    render(<EditableText value="" placeholder="Control" onChange={vi.fn()} />);
+    expect(screen.getByRole('button', { name: 'Control' })).toBeInTheDocument();
+  });
+
+  it('enters edit mode on a single click and selects the current value', async () => {
+    const user = userEvent.setup();
+    render(<EditableText value="End" onChange={vi.fn()} aria-label="Node name" />);
+
+    await user.click(screen.getByRole('button', { name: /^Node name/ }));
+
+    const input = screen.getByRole('textbox', { name: /^Node name/ });
+    expect(input).toHaveFocus();
+    expect(input).toHaveValue('End');
+    expect((input as HTMLInputElement).selectionStart).toBe(0);
+    expect((input as HTMLInputElement).selectionEnd).toBe(3);
+  });
+
+  it('commits the new value on Enter', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<EditableText value="End" onChange={onChange} aria-label="Node name" />);
+
+    await user.click(screen.getByRole('button', { name: /^Node name/ }));
+    await user.keyboard('Wrap up{Enter}');
+
+    expect(onChange).toHaveBeenCalledExactlyOnceWith('Wrap up');
+    expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
+  });
+
+  it('commits on blur', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <>
+        <EditableText value="End" onChange={onChange} aria-label="Node name" />
+        <button type="button">elsewhere</button>
+      </>
+    );
+
+    await user.click(screen.getByRole('button', { name: /^Node name/ }));
+    await user.keyboard('Wrap up');
+    await user.click(screen.getByRole('button', { name: 'elsewhere' }));
+
+    expect(onChange).toHaveBeenCalledExactlyOnceWith('Wrap up');
+  });
+
+  it('reverts on Escape without committing', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<EditableText value="End" onChange={onChange} aria-label="Node name" />);
+
+    await user.click(screen.getByRole('button', { name: /^Node name/ }));
+    await user.keyboard('Wrap up{Escape}');
+
+    expect(onChange).not.toHaveBeenCalled();
+    expect(screen.getByRole('button', { name: /^Node name/ })).toHaveTextContent('End');
+  });
+
+  it('trims the committed value', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<EditableText value="End" onChange={onChange} aria-label="Node name" />);
+
+    await user.click(screen.getByRole('button', { name: /^Node name/ }));
+    await user.keyboard('  Wrap up  {Enter}');
+
+    expect(onChange).toHaveBeenCalledExactlyOnceWith('Wrap up');
+  });
+
+  it('commits an empty string when the value is cleared, so the caller can delete it', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<EditableText value="End" onChange={onChange} aria-label="Node name" />);
+
+    await user.click(screen.getByRole('button', { name: /^Node name/ }));
+    await user.keyboard('{Backspace}{Enter}');
+
+    expect(onChange).toHaveBeenCalledExactlyOnceWith('');
+  });
+
+  it('does not fire onChange when the value is unchanged', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<EditableText value="End" onChange={onChange} aria-label="Node name" />);
+
+    await user.click(screen.getByRole('button', { name: /^Node name/ }));
+    await user.keyboard('{Enter}');
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('keeps keystrokes from reaching an ancestor while editing', async () => {
+    const user = userEvent.setup();
+    const onAncestorKeyDown = vi.fn();
+    render(
+      <div onKeyDown={onAncestorKeyDown}>
+        <EditableText value="End" onChange={vi.fn()} aria-label="Node name" />
+      </div>
+    );
+
+    await user.click(screen.getByRole('button', { name: /^Node name/ }));
+    await user.keyboard('x{Escape}');
+
+    expect(onAncestorKeyDown).not.toHaveBeenCalled();
+  });
+
+  it('picks up an external value change while not editing', () => {
+    const { rerender } = render(
+      <EditableText value="End" onChange={vi.fn()} aria-label="Node name" />
+    );
+    rerender(<EditableText value="Finish" onChange={vi.fn()} aria-label="Node name" />);
+    expect(screen.getByRole('button', { name: /^Node name/ })).toHaveTextContent('Finish');
+  });
+  it('announces the value through the trigger, not only the field name', () => {
+    render(<EditableText value="End" onChange={vi.fn()} aria-label="Node name" />);
+    expect(screen.getByRole('button', { name: 'Node name: End' })).toBeInTheDocument();
+  });
+
+  it('keeps the draft when the parent re-renders with a new value mid-edit', async () => {
+    const user = userEvent.setup();
+    const { rerender } = render(
+      <EditableText value="End" onChange={vi.fn()} aria-label="Node name" />
+    );
+
+    await user.click(screen.getByRole('button', { name: /^Node name/ }));
+    await user.keyboard('Wrap up');
+    rerender(<EditableText value="Finish" onChange={vi.fn()} aria-label="Node name" />);
+
+    expect(screen.getByRole('textbox', { name: 'Node name' })).toHaveValue('Wrap up');
+  });
+
+  it('reopens the editor on the current value after a commit the caller ignores', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<EditableText value="End" onChange={onChange} aria-label="Node name" />);
+
+    await user.click(screen.getByRole('button', { name: /^Node name/ }));
+    await user.keyboard('Wrap up{Enter}');
+    await user.click(screen.getByRole('button', { name: /^Node name/ }));
+
+    expect(screen.getByRole('textbox', { name: 'Node name' })).toHaveValue('End');
+  });
+
+  it('commits an empty string for whitespace-only input', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<EditableText value="End" onChange={onChange} aria-label="Node name" />);
+
+    await user.click(screen.getByRole('button', { name: /^Node name/ }));
+    await user.keyboard('   {Enter}');
+
+    expect(onChange).toHaveBeenCalledExactlyOnceWith('');
+  });
+
+  it('does not commit after Escape when focus moves elsewhere', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <>
+        <EditableText value="End" onChange={onChange} aria-label="Node name" />
+        <button type="button">elsewhere</button>
+      </>
+    );
+
+    await user.click(screen.getByRole('button', { name: /^Node name/ }));
+    await user.keyboard('Wrap up{Escape}');
+    await user.click(screen.getByRole('button', { name: 'elsewhere' }));
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  describe('overflow tooltip', () => {
+    it('offers the full value as a tooltip on the read trigger', () => {
+      render(<EditableText value="A very long description" onChange={vi.fn()} />);
+
+      expect(screen.getByRole('button')).toHaveAttribute(
+        'data-tooltip-trigger',
+        'A very long description'
+      );
+    });
+
+    it('offers the tooltip on static text too', () => {
+      render(<EditableText value="Client-side tool" />);
+
+      expect(screen.getByText('Client-side tool')).toHaveAttribute(
+        'data-tooltip-trigger',
+        'Client-side tool'
+      );
+    });
+
+    it('falls back to the placeholder, which is what a value-less field renders', () => {
+      render(<EditableText value="" placeholder="A very long placeholder" onChange={vi.fn()} />);
+
+      expect(screen.getByRole('button')).toHaveAttribute(
+        'data-tooltip-trigger',
+        'A very long placeholder'
+      );
+    });
+
+    it('drops the tooltip while editing, where the text is not truncated', async () => {
+      const user = userEvent.setup();
+      render(<EditableText value="A very long description" onChange={vi.fn()} />);
+
+      await user.click(screen.getByRole('button'));
+
+      expect(screen.getByRole('textbox')).not.toHaveAttribute('data-tooltip-trigger');
+    });
+  });
+
+  describe('multiline', () => {
+    it('inserts a newline on Shift+Enter without committing', async () => {
+      const user = userEvent.setup();
+      const onChange = vi.fn();
+      render(<EditableText value="First" multiline onChange={onChange} aria-label="Description" />);
+
+      await user.click(screen.getByRole('button', { name: /^Description/ }));
+      await user.keyboard('{End}{Shift>}{Enter}{/Shift}Second');
+
+      expect(screen.getByRole('textbox', { name: /^Description/ })).toHaveValue('First\nSecond');
+      expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it('commits the multi-line value on a plain Enter', async () => {
+      const user = userEvent.setup();
+      const onChange = vi.fn();
+      render(<EditableText value="First" multiline onChange={onChange} aria-label="Description" />);
+
+      await user.click(screen.getByRole('button', { name: /^Description/ }));
+      await user.keyboard('{End}{Shift>}{Enter}{/Shift}Second{Enter}');
+
+      expect(onChange).toHaveBeenCalledExactlyOnceWith('First\nSecond');
+      expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
+    });
+
+    it('caps the editor at maxLines and leaves it scrollable', async () => {
+      const user = userEvent.setup();
+      render(
+        <EditableText
+          value="First"
+          multiline
+          maxLines={2}
+          size="sm"
+          onChange={vi.fn()}
+          aria-label="Description"
+        />
+      );
+
+      await user.click(screen.getByRole('button', { name: /^Description/ }));
+
+      // 2 lines * 16px (`leading-4`) + 4px of `py-0.5`.
+      expect(screen.getByRole('textbox', { name: /^Description/ })).toHaveStyle({
+        maxHeight: '36px',
+      });
+    });
+
+    it('keeps Enter single-line when multiline is off', async () => {
+      const user = userEvent.setup();
+      const onChange = vi.fn();
+      render(<EditableText value="First" onChange={onChange} aria-label="Node name" />);
+
+      await user.click(screen.getByRole('button', { name: /^Node name/ }));
+      await user.keyboard('{Shift>}{Enter}{/Shift}');
+
+      expect(onChange).not.toHaveBeenCalled();
+      expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('error state', () => {
+    it('renders no error message when no error is passed', () => {
+      render(<EditableText value="End" onChange={vi.fn()} aria-label="Node name" />);
+      expect(document.querySelector('[data-slot="editable-text-error"]')).toBeNull();
+    });
+
+    it('shows the message and marks the trigger invalid while collapsed', () => {
+      render(
+        <EditableText
+          value="1 bad"
+          onChange={vi.fn()}
+          aria-label="Node name"
+          error="Tool name must begin with a letter."
+        />
+      );
+
+      const trigger = screen.getByRole('button', { name: /^Node name/ });
+      expect(trigger).toHaveAttribute('aria-invalid', 'true');
+      expect(screen.getByText('Tool name must begin with a letter.')).toBeInTheDocument();
+      expect(trigger).toHaveAccessibleDescription('Tool name must begin with a letter.');
+    });
+
+    it('keeps the error visible after the editor closes, so a rejected commit still explains itself', async () => {
+      const user = userEvent.setup();
+      render(
+        <EditableText
+          value="1 bad"
+          onChange={vi.fn()}
+          aria-label="Node name"
+          error="Tool name must begin with a letter."
+        />
+      );
+
+      await user.click(screen.getByRole('button', { name: /^Node name/ }));
+      const input = screen.getByRole('textbox', { name: 'Node name' });
+      expect(input).toHaveAttribute('aria-invalid', 'true');
+      expect(input).toHaveAccessibleDescription('Tool name must begin with a letter.');
+
+      await user.keyboard('{Escape}');
+
+      expect(screen.getByRole('button', { name: /^Node name/ })).toHaveAttribute(
+        'aria-invalid',
+        'true'
+      );
+      expect(screen.getByText('Tool name must begin with a letter.')).toBeInTheDocument();
+    });
+
+    it('describes static text without claiming an unsupported invalid state on a generic role', () => {
+      render(<EditableText value="End" error="Something is off." />);
+
+      const text = document.querySelector('[data-slot="editable-text"]')!;
+      expect(text).not.toHaveAttribute('aria-invalid');
+      expect(screen.getByText('Something is off.')).toBeInTheDocument();
+      expect(text).toHaveAccessibleDescription('Something is off.');
+    });
+
+    it('still commits while in error, so the user can type their way out', async () => {
+      const user = userEvent.setup();
+      const onChange = vi.fn();
+      render(
+        <EditableText
+          value="1 bad"
+          onChange={onChange}
+          aria-label="Node name"
+          error="Tool name must begin with a letter."
+        />
+      );
+
+      await user.click(screen.getByRole('button', { name: /^Node name/ }));
+      await user.keyboard('Analyze files{Enter}');
+
+      expect(onChange).toHaveBeenCalledExactlyOnceWith('Analyze files');
+    });
+  });
+});

--- a/packages/apollo-react/src/canvas/components/NodePropertyPanel/EditableText.tsx
+++ b/packages/apollo-react/src/canvas/components/NodePropertyPanel/EditableText.tsx
@@ -1,0 +1,227 @@
+import { cn, FormFieldError } from '@uipath/apollo-wind';
+import { type ReactNode, useCallback, useId, useRef, useState } from 'react';
+import { useIsomorphicLayoutEffect } from '../../hooks/useIsomorphicLayoutEffect';
+import { CanvasTooltip } from '../CanvasTooltip';
+
+export interface EditableTextProps {
+  value: string;
+  placeholder?: string;
+  size?: 'sm' | 'lg';
+  /** Accept newlines (Shift+Enter). Enter still commits. */
+  multiline?: boolean;
+  /** Visible-line ceiling when `multiline`. The editor scrolls past it. Defaults to 3. */
+  maxLines?: number;
+  onChange?: (next: string) => void;
+  /** Field-specific feedback rendered immediately below the text. */
+  error?: ReactNode;
+  /** Names the editor and its click target. Unused for static text (no `onChange`). */
+  'aria-label'?: string;
+  className?: string;
+  'data-testid'?: string;
+}
+
+const READ_CLASS = {
+  lg: 'text-base font-semibold leading-5 tracking-[-0.3px] text-foreground',
+  sm: 'text-xs leading-4 text-foreground-muted',
+} as const;
+
+const EDIT_CLASS = {
+  lg: 'text-base font-semibold leading-5 tracking-[-0.3px]',
+  sm: 'text-xs leading-4',
+} as const;
+
+/** Per-size line box, matching the `leading-*` above, so a line cap needs no measuring. */
+const LINE_HEIGHT = { lg: 20, sm: 16 } as const;
+
+/** Vertical padding of `INTERACTIVE_CLASS` (`py-0.5`), added to the editor's line cap. */
+const VERTICAL_PADDING = 4;
+
+/**
+ * Multi-line truncation, the same `line-clamp` idiom the canvas node label uses, with the count
+ * fed through a CSS variable so the class stays static. `wrap-break-word` is load-bearing: an
+ * unbroken token would otherwise run past the box and be cut mid-glyph, since the clamp can only
+ * ellipsize at a line boundary. `line-clamp` sets its own `display`, so no `block` alongside it.
+ */
+const CLAMP_CLASS = 'line-clamp-[var(--editable-text-lines)] whitespace-pre-line wrap-break-word';
+
+/** Padding the ring needs to sit off the glyphs; the negative margin keeps text aligned across modes. */
+const INTERACTIVE_CLASS = 'rounded px-1.5 py-0.5 -mx-1.5';
+
+const ERROR_RING_CLASS = 'ring-1 ring-error';
+
+/** Click-to-edit text for the node identity row: enters on click, commits on Enter or blur, reverts on Escape. Static text without `onChange`. */
+export function EditableText({
+  value,
+  placeholder,
+  size = 'lg',
+  multiline,
+  maxLines = 3,
+  onChange,
+  error,
+  'aria-label': ariaLabel,
+  className,
+  'data-testid': dataTestId,
+}: EditableTextProps) {
+  const [isEditing, setIsEditing] = useState(false);
+  const [draft, setDraft] = useState(value);
+  const inputRef = useRef<HTMLInputElement | HTMLTextAreaElement>(null);
+  const errorId = `editable-text-${useId().replace(/:/g, '')}-error`;
+
+  const hasError = !!error;
+  // `aria-invalid` is only valid on the widget renders; a static span takes the
+  // description alone (role=generic does not support the state).
+  const describedBy = hasError ? errorId : undefined;
+
+  useIsomorphicLayoutEffect(() => {
+    if (!isEditing) return;
+    inputRef.current?.focus();
+    inputRef.current?.select();
+  }, [isEditing]);
+
+  const commit = useCallback(() => {
+    setIsEditing(false);
+    const next = draft.trim();
+    if (next !== value) onChange?.(next);
+  }, [draft, value, onChange]);
+
+  const cancel = useCallback(() => {
+    setIsEditing(false);
+  }, []);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+      // Shift+Enter falls through to insert a newline; every other Enter commits.
+      if (e.key === 'Enter' && !(multiline && e.shiftKey)) {
+        e.preventDefault();
+        commit();
+      } else if (e.key === 'Escape') {
+        e.preventDefault();
+        cancel();
+      }
+      e.stopPropagation();
+    },
+    [commit, cancel, multiline]
+  );
+
+  // Read mode caps the rendered lines through the clamp; edit mode grows with
+  // content up to the same height, then scrolls.
+  const editorMaxHeight = multiline
+    ? { maxHeight: maxLines * LINE_HEIGHT[size] + VERTICAL_PADDING }
+    : undefined;
+  const readClampStyle = multiline
+    ? ({ '--editable-text-lines': maxLines } as React.CSSProperties)
+    : undefined;
+  const readClampClass = multiline ? CLAMP_CLASS : 'block truncate';
+
+  const message = (
+    <FormFieldError id={errorId} data-slot="editable-text-error" className="-ml-1 mt-1">
+      {error}
+    </FormFieldError>
+  );
+
+  if (!onChange) {
+    return (
+      <>
+        <CanvasTooltip content={value || placeholder} smartTooltip delay>
+          <span
+            data-slot="editable-text"
+            data-testid={dataTestId}
+            aria-describedby={describedBy}
+            style={readClampStyle}
+            className={cn(
+              readClampClass,
+              READ_CLASS[size],
+              !value && 'text-foreground-subtle',
+              hasError && cn(INTERACTIVE_CLASS, ERROR_RING_CLASS),
+              className
+            )}
+          >
+            {value || placeholder}
+          </span>
+        </CanvasTooltip>
+        {message}
+      </>
+    );
+  }
+
+  if (isEditing) {
+    const sharedProps = {
+      'data-slot': 'editable-text-input',
+      'data-testid': dataTestId ? `${dataTestId}-input` : undefined,
+      value: draft,
+      placeholder,
+      'aria-label': ariaLabel,
+      'aria-describedby': describedBy,
+      'aria-errormessage': hasError ? errorId : undefined,
+      'aria-invalid': hasError || undefined,
+      onKeyDown: handleKeyDown,
+      onBlur: commit,
+      className: cn(
+        'nodrag nowheel w-full min-w-0 border-none bg-surface-overlay text-foreground outline-none ring-1',
+        hasError ? 'ring-error' : 'ring-brand',
+        INTERACTIVE_CLASS,
+        EDIT_CLASS[size],
+        className
+      ),
+    } as const;
+
+    return (
+      <>
+        {multiline ? (
+          <textarea
+            {...sharedProps}
+            ref={inputRef as React.RefObject<HTMLTextAreaElement>}
+            rows={1}
+            style={editorMaxHeight}
+            className={cn(
+              sharedProps.className,
+              'field-sizing-content max-w-full resize-none overflow-y-auto wrap-break-word'
+            )}
+            onChange={(e) => setDraft(e.target.value)}
+          />
+        ) : (
+          <input
+            {...sharedProps}
+            ref={inputRef as React.RefObject<HTMLInputElement>}
+            autoComplete="off"
+            onChange={(e) => setDraft(e.target.value)}
+          />
+        )}
+        {message}
+      </>
+    );
+  }
+
+  return (
+    <>
+      <CanvasTooltip content={value || placeholder} smartTooltip delay>
+        <button
+          type="button"
+          data-slot="editable-text"
+          data-testid={dataTestId}
+          aria-label={ariaLabel && `${ariaLabel}: ${value || placeholder || ''}`}
+          aria-describedby={describedBy}
+          aria-errormessage={hasError ? errorId : undefined}
+          aria-invalid={hasError || undefined}
+          onClick={() => {
+            setDraft(value);
+            setIsEditing(true);
+          }}
+          style={readClampStyle}
+          className={cn(
+            'nodrag max-w-full cursor-text border-none bg-transparent text-left transition hover:bg-surface-overlay',
+            readClampClass,
+            INTERACTIVE_CLASS,
+            READ_CLASS[size],
+            !value && 'text-foreground-subtle',
+            hasError && ERROR_RING_CLASS,
+            className
+          )}
+        >
+          {value || placeholder}
+        </button>
+      </CanvasTooltip>
+      {message}
+    </>
+  );
+}

--- a/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.stories.tsx
@@ -272,7 +272,7 @@ function getMonacoThemeName(): string {
   if (typeof document === 'undefined') return 'apollo-future-dark';
   const classes = Array.from(document.body.classList);
   const match = classes.find((c) => c in THEME_CLASS_MAP);
-  return match ? THEME_CLASS_MAP[match] : 'apollo-future-dark';
+  return (match ? THEME_CLASS_MAP[match] : undefined) ?? 'apollo-future-dark';
 }
 
 function useMonacoTheme(): string {
@@ -385,7 +385,6 @@ const httpRequestForm: FormSchema = {
               name: 'node_id',
               label: 'ID',
               defaultValue: 'httpRequest1',
-              disabled: true,
             },
             { type: 'text', name: 'label', label: 'Label', defaultValue: 'Fetch invoice details' },
             { type: 'textarea', name: 'description', label: 'Description' },
@@ -432,7 +431,6 @@ const manualTriggerForm: FormSchema = {
               name: 'node_id',
               label: 'ID',
               defaultValue: 'manualTrigger1',
-              disabled: true,
             },
             { type: 'text', name: 'label', label: 'Label', defaultValue: 'Manual trigger' },
             { type: 'textarea', name: 'description', label: 'Description' },
@@ -534,6 +532,54 @@ export const Default: Story = {
 export const QuickForm: Story = {
   name: 'Form HITL',
   render: () => <QuickFormPanel />,
+};
+
+function IdentityValidationStory() {
+  const [label, setLabel] = useState('Analyze files');
+  const [description, setDescription] = useState('');
+
+  // Stand-in for a host rule (here: an agent tool name). The caller owns both
+  // the message and when it clears, so the ring persists after the editor
+  // closes on a value the host would reject.
+  const labelError = !label
+    ? 'Tool name is required.'
+    : /^[A-Z_a-z][\w ]*$/.test(label)
+      ? undefined
+      : 'Tool name must begin with a letter or underscore and contain only letters, digits, spaces, and underscores.';
+
+  return (
+    <PanelFrame>
+      <NodePropertyPanel
+        panelTitle="Properties"
+        nodeIcon={<Globe />}
+        nodeLabel={label}
+        nodeLabelPlaceholder="Name"
+        nodeDescription={description}
+        nodeDescriptionPlaceholder="Client-side tool"
+        onNodeLabelChange={setLabel}
+        onNodeDescriptionChange={setDescription}
+        nodeLabelError={labelError}
+        action={<RunButton />}
+        schema={httpRequestForm}
+        contentInset="0.875rem"
+        onClose={() => {}}
+        className="h-[640px]"
+      />
+    </PanelFrame>
+  );
+}
+
+export const IdentityValidation: Story = {
+  name: 'Identity Validation',
+  render: () => <IdentityValidationStory />,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Rename the node to something starting with a digit to see the error state. `nodeLabelError` / `nodeDescriptionError` render below the line with a persistent error ring, matching `Input`: the control gets `aria-invalid` plus `aria-errormessage`, and the message renders through `FormFieldError` so it announces politely. The ring stays after the editor closes, so a commit the host rejects still explains itself.',
+      },
+    },
+  },
 };
 
 export const EmbeddedNoTitleBar: Story = {
@@ -1392,11 +1438,7 @@ function InputEditorStory() {
   const nextIdRef = useRef(2);
   const [defaultBranch, setDefaultBranch] = useState(false);
   const [label, setLabel] = useState('End');
-  const [category, setCategory] = useState('Control');
-  const [editingLabel, setEditingLabel] = useState(false);
-  const [editingCategory, setEditingCategory] = useState(false);
-  const labelRef = useRef<HTMLInputElement>(null);
-  const categoryRef = useRef<HTMLInputElement>(null);
+  const [description, setDescription] = useState('');
 
   const addCase = () => {
     const id = nextIdRef.current++;
@@ -1412,70 +1454,16 @@ function InputEditorStory() {
         onClose={() => {}}
         contentInset="0.875rem"
         className="h-[640px]"
+        nodeIcon={<CircleCheck />}
+        nodeLabel={label}
+        nodeLabelPlaceholder="Control"
+        nodeDescription={description}
+        nodeDescriptionPlaceholder="Control"
+        onNodeLabelChange={setLabel}
+        onNodeDescriptionChange={setDescription}
+        action={<DebugButton />}
       >
         <div className="flex h-full flex-col">
-          {/* Inline-editable identity row */}
-          <div className="flex shrink-0 items-center justify-between gap-4 py-4 [padding-inline:var(--mf-content-inset,0.875rem)]">
-            <div className="flex min-w-0 flex-1 items-center gap-3.5">
-              <div className="grid size-11 shrink-0 place-items-center rounded-xl bg-surface-overlay text-foreground-subtle [&>svg]:size-5">
-                <CircleCheck />
-              </div>
-              <div className="flex min-w-0 flex-1 flex-col justify-center">
-                {editingLabel ? (
-                  <input
-                    ref={labelRef}
-                    value={label}
-                    onChange={(e) => setLabel(e.target.value)}
-                    onBlur={() => setEditingLabel(false)}
-                    onKeyDown={(e) => {
-                      if (e.key === 'Enter' || e.key === 'Escape') setEditingLabel(false);
-                    }}
-                    className="w-full rounded bg-surface-overlay px-1.5 py-0.5 text-base font-semibold leading-5 tracking-[-0.3px] text-foreground outline-none ring-1 ring-brand"
-                    autoFocus
-                  />
-                ) : (
-                  <button
-                    type="button"
-                    onClick={() => {
-                      setEditingLabel(true);
-                      setTimeout(() => labelRef.current?.select(), 0);
-                    }}
-                    className="truncate rounded px-1.5 py-0.5 text-left text-base font-semibold leading-5 tracking-[-0.3px] text-foreground transition hover:bg-surface-overlay"
-                  >
-                    {label}
-                  </button>
-                )}
-                {editingCategory ? (
-                  <input
-                    ref={categoryRef}
-                    value={category}
-                    onChange={(e) => setCategory(e.target.value)}
-                    onBlur={() => setEditingCategory(false)}
-                    onKeyDown={(e) => {
-                      if (e.key === 'Enter' || e.key === 'Escape') setEditingCategory(false);
-                    }}
-                    className="w-full rounded bg-surface-overlay px-1.5 py-0.5 text-xs leading-4 text-foreground outline-none ring-1 ring-brand"
-                    autoFocus
-                  />
-                ) : (
-                  <button
-                    type="button"
-                    onClick={() => {
-                      setEditingCategory(true);
-                      setTimeout(() => categoryRef.current?.select(), 0);
-                    }}
-                    className="truncate rounded px-1.5 py-0.5 text-left text-xs leading-4 text-foreground-muted transition hover:bg-surface-overlay"
-                  >
-                    {category}
-                  </button>
-                )}
-              </div>
-            </div>
-            <div className="shrink-0">
-              <DebugButton />
-            </div>
-          </div>
-
           {/* Tabs */}
           <Tabs defaultValue="parameters" className="flex min-h-0 flex-1 flex-col">
             <div className="shrink-0 pt-3 [padding-inline:var(--mf-content-inset,0.875rem)]">
@@ -3505,7 +3493,7 @@ function InventoryField({
 }: {
   label: string;
   description?: string;
-  children: ReactElement;
+  children: ReactElement<{ id?: string; 'aria-describedby'?: string }>;
 }) {
   const generatedId = useId();
   const controlId = children.props.id ?? generatedId;
@@ -3876,7 +3864,7 @@ function PanelUIInventoryStory() {
       if (!match) return;
 
       const [, tab, section] = match;
-      if (!['layout', 'states', 'actions', 'composition'].includes(tab)) return;
+      if (!tab || !['layout', 'states', 'actions', 'composition'].includes(tab)) return;
       setInventoryTab(tab);
       setInventorySection(section ?? null);
       if (tab === 'layout' && section && ['text-fields', 'choices', 'advanced'].includes(section)) {

--- a/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.test.tsx
+++ b/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.test.tsx
@@ -1,6 +1,6 @@
 import type { FormSchema } from '@uipath/apollo-wind';
 import { describe, expect, it, vi } from 'vitest';
-import { render, screen } from '../../utils/testing';
+import { render, screen, userEvent } from '../../utils/testing';
 import { NodePropertyPanel } from './NodePropertyPanel';
 
 const MULTI_STEP: FormSchema = {
@@ -10,12 +10,12 @@ const MULTI_STEP: FormSchema = {
     {
       id: 'parameters',
       title: 'Parameters',
-      sections: [{ id: 'p', fields: [{ id: 'url', name: 'url', type: 'text', label: 'URL' }] }],
+      sections: [{ id: 'p', fields: [{ name: 'url', type: 'text', label: 'URL' }] }],
     },
     {
       id: 'advanced',
       title: 'Advanced',
-      sections: [{ id: 'a', fields: [{ id: 'nid', name: 'nid', type: 'text', label: 'ID' }] }],
+      sections: [{ id: 'a', fields: [{ name: 'nid', type: 'text', label: 'ID' }] }],
     },
   ],
 };
@@ -68,6 +68,83 @@ describe('NodePropertyPanel', () => {
     expect(screen.getByText('HTTP Request')).toBeInTheDocument();
   });
 
+  it('renders the description instead of the category when a description is given', () => {
+    render(
+      <NodePropertyPanel
+        nodeLabel="Fetch invoice details"
+        nodeCategory="HTTP Request"
+        nodeDescription="Pulls the line items for one invoice"
+        schema={MULTI_STEP}
+      />
+    );
+    expect(screen.getByText('Pulls the line items for one invoice')).toBeInTheDocument();
+    expect(screen.queryByText('HTTP Request')).not.toBeInTheDocument();
+  });
+
+  it('keeps the identity row read-only when no change handlers are given', () => {
+    render(<NodePropertyPanel nodeLabel="Fetch invoice details" schema={MULTI_STEP} />);
+    expect(screen.queryByRole('button', { name: /^Node name/ })).not.toBeInTheDocument();
+  });
+
+  it('makes the label editable and reports the committed value', async () => {
+    const user = userEvent.setup();
+    const onNodeLabelChange = vi.fn();
+    render(
+      <NodePropertyPanel
+        nodeLabel="Fetch invoice details"
+        onNodeLabelChange={onNodeLabelChange}
+        schema={MULTI_STEP}
+      />
+    );
+
+    await user.click(screen.getByRole('button', { name: /^Node name/ }));
+    await user.keyboard('Fetch invoice{Enter}');
+
+    expect(onNodeLabelChange).toHaveBeenCalledExactlyOnceWith('Fetch invoice');
+  });
+
+  it('makes the description editable and reports the committed value', async () => {
+    const user = userEvent.setup();
+    const onNodeDescriptionChange = vi.fn();
+    render(
+      <NodePropertyPanel
+        nodeLabel="Fetch invoice details"
+        nodeDescription=""
+        onNodeDescriptionChange={onNodeDescriptionChange}
+        schema={MULTI_STEP}
+      />
+    );
+
+    await user.click(screen.getByRole('button', { name: /^Node description/ }));
+    await user.keyboard('One invoice{Enter}');
+
+    expect(onNodeDescriptionChange).toHaveBeenCalledExactlyOnceWith('One invoice');
+  });
+
+  it('keeps the category when the description is defined but empty', () => {
+    render(
+      <NodePropertyPanel
+        nodeLabel="Fetch invoice details"
+        nodeCategory="HTTP Request"
+        nodeDescription=""
+        schema={MULTI_STEP}
+      />
+    );
+    expect(screen.getByText('HTTP Request')).toBeInTheDocument();
+  });
+
+  it('renders the identity row for an editable-but-empty label, so the affordance survives a cleared name', () => {
+    render(
+      <NodePropertyPanel
+        nodeLabel=""
+        nodeLabelPlaceholder="HTTP Request"
+        onNodeLabelChange={vi.fn()}
+        schema={MULTI_STEP}
+      />
+    );
+    expect(screen.getByRole('button', { name: /^Node name/ })).toHaveTextContent('HTTP Request');
+  });
+
   it('renders a tab per step for a multi-step schema', () => {
     render(<NodePropertyPanel schema={MULTI_STEP} />);
     expect(screen.getByRole('tab', { name: 'Parameters' })).toBeInTheDocument();
@@ -113,7 +190,7 @@ describe('NodePropertyPanel', () => {
     const SINGLE_PAGE: FormSchema = {
       id: 'http',
       title: 'HTTP',
-      sections: [{ id: 'p', fields: [{ id: 'url', name: 'url', type: 'text', label: 'URL' }] }],
+      sections: [{ id: 'p', fields: [{ name: 'url', type: 'text', label: 'URL' }] }],
     };
     const { container } = render(<NodePropertyPanel schema={SINGLE_PAGE} autoComplete="off" />);
     expect(container.querySelector('form')).toHaveAttribute('autocomplete', 'off');

--- a/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.tsx
+++ b/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.tsx
@@ -1,6 +1,8 @@
 import { cn, MetadataForm } from '@uipath/apollo-wind';
 import { GripVertical, X } from 'lucide-react';
 import { type CSSProperties, useMemo } from 'react';
+import { useSafeLingui } from '../../../i18n';
+import { EditableText } from './EditableText';
 import type { NodePropertyPanelProps } from './NodePropertyPanel.types';
 
 // Future themes raise the panel surface, so inputs remap surface-raised ->
@@ -12,10 +14,13 @@ const SURFACE_REMAP = 'future:[--surface-raised:var(--surface-overlay)]';
  * NodePropertyPanel — a presentational, docked properties panel for canvas nodes.
  *
  * The panel owns only the *chrome*: an optional title bar (drag handle + close),
- * a node identity row (icon / label / category + an action slot), and the form
- * frame. The form itself is a single `MetadataForm` rendered from the `schema`
- * you pass in, with multi-step schemas presented as tabs (Parameters, Error
- * handling, Advanced, ...).
+ * a node identity row (icon / label / description-or-category + an action slot),
+ * and the form frame. The label and description lines become click-to-edit when
+ * the matching `onNode*Change` callback is passed.
+ *
+ * The form itself is a single `MetadataForm` rendered from the `schema` you pass
+ * in, with multi-step schemas presented as tabs (Parameters, Error handling,
+ * Advanced, ...).
  *
  * The caller owns everything domain-specific: schema assembly, real-time change
  * handling, custom field components, and validation are all supplied through
@@ -27,7 +32,8 @@ const SURFACE_REMAP = 'future:[--surface-raised:var(--surface-overlay)]';
  * <NodePropertyPanel
  *   panelTitle="Properties"               // omit when dockview owns the title bar
  *   nodeLabel="Fetch invoice details"
- *   nodeCategory="HTTP Request"
+ *   nodeCategory="HTTP Request"         // fallback second line; a description wins
+ *   onNodeLabelChange={renameNode}      // omit for a read-only label
  *   action={<RunButton />}
  *   schema={assembledSchema}              // caller-built FormSchema (steps = tabs)
  *   plugins={formPlugins}                 // real-time onChange, custom fields
@@ -43,6 +49,13 @@ export function NodePropertyPanel({
   nodeIcon,
   nodeLabel,
   nodeCategory,
+  nodeDescription,
+  nodeLabelPlaceholder,
+  nodeDescriptionPlaceholder,
+  onNodeLabelChange,
+  onNodeDescriptionChange,
+  nodeLabelError,
+  nodeDescriptionError,
   action,
   schema,
   plugins,
@@ -58,7 +71,12 @@ export function NodePropertyPanel({
   activeStepId,
   onActiveStepChange,
 }: NodePropertyPanelProps) {
-  const hasNodeHeader = !!(nodeLabel || nodeCategory || nodeIcon || action);
+  const { _ } = useSafeLingui();
+  const isLabelEditable = !!onNodeLabelChange;
+  const isDescriptionEditable = !!onNodeDescriptionChange;
+  const showsDescription = !!nodeDescription || isDescriptionEditable || !!nodeDescriptionError;
+  const showsLabel = !!nodeLabel || isLabelEditable || !!nodeLabelError;
+  const hasNodeHeader = !!(showsLabel || nodeCategory || nodeIcon || action || showsDescription);
 
   // This panel is a live-edit surface: changes persist via plugins/onChange, so
   // there is no Submit button by default. Callers can still opt in by setting
@@ -95,8 +113,8 @@ export function NodePropertyPanel({
               <button
                 type="button"
                 onClick={onClose}
-                title="Close"
-                aria-label="Close"
+                title={_({ id: 'canvas.node_property_panel.close', message: 'Close' })}
+                aria-label={_({ id: 'canvas.node_property_panel.close', message: 'Close' })}
                 className="grid size-6 place-items-center rounded text-foreground-muted transition hover:bg-surface-overlay hover:text-foreground"
               >
                 <X size={14} />
@@ -116,17 +134,52 @@ export function NodePropertyPanel({
               </div>
             )}
             <div className="flex min-w-0 flex-1 flex-col justify-center">
-              {nodeLabel && (
-                // <span>, not <p>: host apps (e.g. Angular Material's `.mat-typography p`)
-                // inject a bottom margin on <p> that breaks the header alignment.
-                <span className="block truncate text-base font-semibold leading-5 tracking-[-0.3px] text-foreground">
-                  {nodeLabel}
-                </span>
+              {showsLabel && (
+                <EditableText
+                  value={nodeLabel ?? ''}
+                  placeholder={
+                    nodeLabelPlaceholder ??
+                    _({ id: 'canvas.node_property_panel.name_placeholder', message: 'Name' })
+                  }
+                  size="lg"
+                  onChange={onNodeLabelChange}
+                  error={nodeLabelError}
+                  aria-label={_({
+                    id: 'canvas.node_property_panel.node_name',
+                    message: 'Node name',
+                  })}
+                  data-testid="node-property-panel-label"
+                />
               )}
-              {nodeCategory && (
-                <span className="block truncate text-xs leading-4 text-foreground-muted">
-                  {nodeCategory}
-                </span>
+              {showsDescription ? (
+                <EditableText
+                  value={nodeDescription ?? ''}
+                  placeholder={
+                    nodeDescriptionPlaceholder ??
+                    _({
+                      id: 'canvas.node_property_panel.description_placeholder',
+                      message: 'Description',
+                    })
+                  }
+                  size="sm"
+                  multiline
+                  maxLines={3}
+                  onChange={onNodeDescriptionChange}
+                  error={nodeDescriptionError}
+                  aria-label={_({
+                    id: 'canvas.node_property_panel.node_description',
+                    message: 'Node description',
+                  })}
+                  data-testid="node-property-panel-description"
+                />
+              ) : (
+                nodeCategory && (
+                  <EditableText
+                    value={nodeCategory}
+                    size="sm"
+                    data-testid="node-property-panel-category"
+                  />
+                )
               )}
             </div>
           </div>

--- a/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.types.ts
+++ b/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.types.ts
@@ -15,8 +15,25 @@ export interface NodePropertyPanelProps {
   nodeIcon?: ReactNode;
   /** The node's display label shown in the node identity row. */
   nodeLabel?: string;
-  /** Category/subtitle text shown below `nodeLabel` (e.g. "HTTP Request"). */
+  /** Category/subtitle text shown below `nodeLabel` (e.g. "HTTP Request"). Fallback: a description, a description callback, or a description error takes the line instead. */
   nodeCategory?: string;
+  /** User-authored description on the identity row's second line. Takes the line from `nodeCategory` whenever it is non-empty, as does `onNodeDescriptionChange` on its own. */
+  nodeDescription?: string;
+  /** Hint shown in place of an empty `nodeLabel`. Defaults to a localized `"Name"`. Never committed. */
+  nodeLabelPlaceholder?: string;
+  /** Hint shown in place of an empty `nodeDescription`. Defaults to a localized `"Description"`. Never committed. */
+  nodeDescriptionPlaceholder?: string;
+  /** Makes `nodeLabel` click-to-edit: commits the trimmed value on Enter or blur, Escape reverts. Omit for read-only. */
+  onNodeLabelChange?: (label: string) => void;
+  /** Makes `nodeDescription` click-to-edit. Same contract as `onNodeLabelChange`. */
+  onNodeDescriptionChange?: (description: string) => void;
+  /**
+   * Validation message for the node name, rendered below it with a persistent
+   * error ring.
+   */
+  nodeLabelError?: ReactNode;
+  /** Validation message for the description. Same contract as `nodeLabelError`; takes the second line even with no description or edit callback. */
+  nodeDescriptionError?: ReactNode;
   /** Action slot rendered on the right of the identity row (e.g. a Run button). */
   action?: ReactNode;
   /**

--- a/packages/apollo-react/src/canvas/components/NodePropertyPanel/index.ts
+++ b/packages/apollo-react/src/canvas/components/NodePropertyPanel/index.ts
@@ -1,10 +1,12 @@
+export type { EditableTextProps } from './EditableText';
+export { EditableText } from './EditableText';
 export type { ExpressionFieldProps, ExpressionMode } from './ExpressionField';
 export { ExpressionField } from './ExpressionField';
 export { NodePropertyPanel } from './NodePropertyPanel';
+export type { NodePropertyPanelProps } from './NodePropertyPanel.types';
 export {
   NodePropertyPanelLayout,
   type NodePropertyPanelLayoutProps,
 } from './NodePropertyPanelLayout';
-export type { NodePropertyPanelProps } from './NodePropertyPanel.types';
 export type { PanelFieldLabelProps, PanelFieldProps } from './PanelField';
 export { PanelField, PanelFieldLabel } from './PanelField';

--- a/packages/apollo-react/src/canvas/locales/en.json
+++ b/packages/apollo-react/src/canvas/locales/en.json
@@ -150,5 +150,10 @@
   "canvas.node_mode_select.simulated_description": "Generate a response dynamically using an LLM",
   "canvas.node_mode_select.simulated_label": "Simulated",
   "canvas.node_mode_select.static_description": "Always return a value you define",
-  "canvas.node_mode_select.static_label": "Static mock"
+  "canvas.node_mode_select.static_label": "Static mock",
+  "canvas.node_property_panel.close": "Close",
+  "canvas.node_property_panel.name_placeholder": "Name",
+  "canvas.node_property_panel.description_placeholder": "Description",
+  "canvas.node_property_panel.node_name": "Node name",
+  "canvas.node_property_panel.node_description": "Node description"
 }


### PR DESCRIPTION
Adds an `EditableText` component that supports inline text editing. This could be useful for the HITL node.

## Demo

### Interaction
<img width="405" height="669" alt="2026-09-03 16 09 47" src="https://github.com/user-attachments/assets/912f0591-17c6-4315-811a-b65af188eab9" />

### Error
Synced w/ @dbacomputer on error UX.

<img width="405" height="669" alt="2026-09-03 16 14 36" src="https://github.com/user-attachments/assets/9af784b5-5cdb-4233-921c-b09a36a85bb7" />

### Long content
<img width="405" height="669" alt="2026-09-03 17 08 46" src="https://github.com/user-attachments/assets/794dc758-7bd9-4fb3-8537-c08b18e3b958" />

[MST-14012]: https://uipath.atlassian.net/browse/MST-14012?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ