### PR TITLE
fix(apollo-wind): use foreground text for populated field triggers

### DIFF
--- a/packages/apollo-wind/src/components/ui/combobox.stories.tsx
+++ b/packages/apollo-wind/src/components/ui/combobox.stories.tsx
@@ -95,9 +95,13 @@ function MultiSelectCombobox() {
             variant="outline"
             role="combobox"
             aria-expanded={open}
-            className="w-[320px] justify-between future:gap-4 future:rounded-xl future:border-0 future:bg-surface-overlay future:font-normal future:text-muted-foreground future:hover:bg-surface-hover future:focus-visible:ring-offset-2 future:focus-visible:ring-offset-background"
+            className="w-[320px] justify-between future:gap-4 future:rounded-xl future:border-0 future:bg-surface-overlay future:font-normal future:text-foreground future:hover:bg-surface-hover future:focus-visible:ring-offset-2 future:focus-visible:ring-offset-background"
           >
-            {selected.length > 0 ? `${selected.length} selected` : 'Select frameworks...'}
+            {selected.length > 0 ? (
+              `${selected.length} selected`
+            ) : (
+              <span className="text-foreground-muted">Select frameworks...</span>
+            )}
             <ChevronDown className="opacity-50" />
           </Button>
         </PopoverTrigger>
@@ -182,7 +186,7 @@ function CustomDisplayCombobox() {
           variant="outline"
           role="combobox"
           aria-expanded={open}
-          className="w-[320px] justify-between future:gap-4 future:rounded-xl future:border-0 future:bg-surface-overlay future:font-normal future:text-muted-foreground future:hover:bg-surface-hover future:focus-visible:ring-offset-2 future:focus-visible:ring-offset-background"
+          className="w-[320px] justify-between future:gap-4 future:rounded-xl future:border-0 future:bg-surface-overlay future:font-normal future:text-foreground future:hover:bg-surface-hover future:focus-visible:ring-offset-2 future:focus-visible:ring-offset-background"
         >
           {selected ? (
             <span className="flex items-center gap-2">
@@ -190,7 +194,7 @@ function CustomDisplayCombobox() {
               <span>{selected.label}</span>
             </span>
           ) : (
-            'Select issue type...'
+            <span className="text-foreground-muted">Select issue type...</span>
           )}
           <ChevronDown className="opacity-50" />
         </Button>
@@ -284,9 +288,13 @@ function AsyncCombobox() {
             variant="outline"
             role="combobox"
             aria-expanded={open}
-            className="w-[280px] justify-between future:gap-4 future:rounded-xl future:border-0 future:bg-surface-overlay future:font-normal future:text-muted-foreground future:hover:bg-surface-hover future:focus-visible:ring-offset-2 future:focus-visible:ring-offset-background"
+            className="w-[280px] justify-between future:gap-4 future:rounded-xl future:border-0 future:bg-surface-overlay future:font-normal future:text-foreground future:hover:bg-surface-hover future:focus-visible:ring-offset-2 future:focus-visible:ring-offset-background"
           >
-            {selected ? selected.label : 'Search libraries...'}
+            {selected ? (
+              selected.label
+            ) : (
+              <span className="text-foreground-muted">Search libraries...</span>
+            )}
             <ChevronDown className="opacity-50" />
           </Button>
         </PopoverTrigger>

--- a/packages/apollo-wind/src/components/ui/combobox.test.tsx
+++ b/packages/apollo-wind/src/components/ui/combobox.test.tsx
@@ -126,4 +126,29 @@ describe('Combobox', () => {
       });
     });
   });
+
+  describe('Value vs placeholder color', () => {
+    it('mutes the placeholder via its own span', () => {
+      render(<Combobox items={mockItems} placeholder="Select an option..." />);
+      const placeholder = screen.getByText('Select an option...');
+      expect(placeholder.tagName).toBe('SPAN');
+      expect(placeholder).toHaveClass('text-foreground-muted');
+    });
+
+    it('renders a selected value at full strength', () => {
+      render(<Combobox items={mockItems} value="apple" />);
+      const trigger = screen.getByRole('combobox');
+      expect(trigger).toHaveTextContent('Apple');
+      expect(trigger.querySelector('.text-foreground-muted')).toBeNull();
+    });
+
+    // The outline Button variant mutes its own text in Future themes, so the
+    // trigger has to override it rather than rely on removing the class.
+    it('overrides the outline variant so the trigger is not globally muted', () => {
+      render(<Combobox items={mockItems} />);
+      const trigger = screen.getByRole('combobox');
+      expect(trigger).toHaveClass('future:text-foreground');
+      expect(trigger).not.toHaveClass('future:text-muted-foreground');
+    });
+  });
 });

--- a/packages/apollo-wind/src/components/ui/combobox.tsx
+++ b/packages/apollo-wind/src/components/ui/combobox.tsx
@@ -57,12 +57,16 @@ export const Combobox = React.forwardRef<HTMLButtonElement, ComboboxProps>(funct
           aria-expanded={open}
           aria-label={selectedItem ? selectedItem.label : placeholder}
           className={cn(
-            'w-[280px] justify-between future:h-10 future:rounded-xl future:border-0 future:bg-surface-overlay future:px-4 future:gap-4 future:hover:bg-surface-hover future:font-normal future:text-muted-foreground future:focus-visible:ring-offset-2 future:focus-visible:ring-offset-background',
+            'w-[280px] justify-between future:h-10 future:rounded-xl future:border-0 future:bg-surface-overlay future:px-4 future:gap-4 future:hover:bg-surface-hover future:font-normal future:text-foreground future:focus-visible:ring-offset-2 future:focus-visible:ring-offset-background',
             className
           )}
           disabled={disabled}
         >
-          {selectedItem ? selectedItem.label : placeholder}
+          {selectedItem ? (
+            selectedItem.label
+          ) : (
+            <span className="text-foreground-muted">{placeholder}</span>
+          )}
           <ChevronDown className="opacity-50" />
         </Button>
       </PopoverTrigger>

--- a/packages/apollo-wind/src/components/ui/date-picker.test.tsx
+++ b/packages/apollo-wind/src/components/ui/date-picker.test.tsx
@@ -179,3 +179,70 @@ describe('DateRangePicker', () => {
     });
   });
 });
+
+describe('value vs placeholder color', () => {
+  it('mutes the DatePicker placeholder via its own span', () => {
+    render(<DatePicker placeholder="Pick a date" />);
+    const placeholder = screen.getByText('Pick a date');
+    expect(placeholder.tagName).toBe('SPAN');
+    expect(placeholder).toHaveClass('text-foreground-muted');
+  });
+
+  it('mutes the DateRangePicker placeholder via its own span', () => {
+    render(<DateRangePicker placeholder="Pick a date range" />);
+    const placeholder = screen.getByText('Pick a date range');
+    expect(placeholder.tagName).toBe('SPAN');
+    expect(placeholder).toHaveClass('text-foreground-muted');
+  });
+
+  it('renders a selected date at full strength', () => {
+    render(<DatePicker value={new Date(2024, 5, 15)} />);
+    const trigger = screen.getByRole('button');
+    expect(trigger).toHaveTextContent(/June 15/);
+    expect(trigger.querySelector('.text-foreground-muted')).toBeNull();
+  });
+
+  // A range with only `from` set still renders a value, so the trigger must not
+  // fall back to the placeholder colour.
+  it('renders a partial range at full strength', () => {
+    render(<DateRangePicker value={{ from: new Date(2024, 5, 15), to: undefined }} />);
+    const trigger = screen.getByRole('button');
+    expect(trigger).toHaveTextContent(/Jun 15/);
+    expect(trigger.querySelector('.text-foreground-muted')).toBeNull();
+  });
+
+  // The outline Button variant mutes its own text in Future themes, so each
+  // trigger has to override it rather than rely on removing the class.
+  it.each([
+    ['DatePicker', <DatePicker key="d" />],
+    ['DateRangePicker', <DateRangePicker key="r" />],
+  ])('overrides the outline variant on %s', (_name, element) => {
+    render(element);
+    const trigger = screen.getByRole('button');
+    expect(trigger).toHaveClass('future:text-foreground');
+    expect(trigger).not.toHaveClass('future:text-muted-foreground');
+  });
+});
+
+describe('trigger icon color', () => {
+  it.each([
+    ['DatePicker', <DatePicker key="d" />],
+    ['DateRangePicker', <DateRangePicker key="r" />],
+  ])('mutes the %s icon and brightens it on hover', (_name, element) => {
+    render(element);
+    const trigger = screen.getByRole('button');
+    expect(trigger).toHaveClass('[&>svg]:text-foreground-muted');
+    expect(trigger).toHaveClass('hover:[&>svg]:text-accent-foreground');
+  });
+
+  // The [&>svg] selector only matches a direct child, so wrapping the icon
+  // would silently drop both rules.
+  it.each([
+    ['DatePicker', <DatePicker key="d" />],
+    ['DateRangePicker', <DateRangePicker key="r" />],
+  ])('keeps the %s icon a direct child of the trigger', (_name, element) => {
+    render(element);
+    const trigger = screen.getByRole('button');
+    expect(trigger.querySelector(':scope > svg')).not.toBeNull();
+  });
+});

--- a/packages/apollo-wind/src/components/ui/date-picker.tsx
+++ b/packages/apollo-wind/src/components/ui/date-picker.tsx
@@ -33,15 +33,18 @@ export const DatePicker = React.forwardRef<HTMLButtonElement, DatePickerProps>(f
           variant="outline"
           aria-label={value ? `Selected date: ${format(value, 'PPP')}` : placeholder}
           className={cn(
-            'w-full justify-start text-left font-normal',
-            'future:h-10 future:rounded-xl future:border-0 future:bg-surface-overlay future:px-4 future:gap-4 future:text-muted-foreground future:hover:bg-surface-hover future:focus-visible:ring-offset-2 future:focus-visible:ring-offset-background',
-            !value && 'text-muted-foreground',
+            'w-full justify-start text-left font-normal [&>svg]:text-foreground-muted hover:[&>svg]:text-accent-foreground',
+            'future:h-10 future:rounded-xl future:border-0 future:bg-surface-overlay future:px-4 future:gap-4 future:text-foreground future:hover:bg-surface-hover future:focus-visible:ring-offset-2 future:focus-visible:ring-offset-background',
             className
           )}
           disabled={disabled}
         >
           <CalendarIcon />
-          {value ? format(value, 'PPP') : <span>{placeholder}</span>}
+          {value ? (
+            format(value, 'PPP')
+          ) : (
+            <span className="text-foreground-muted">{placeholder}</span>
+          )}
         </Button>
       </PopoverTrigger>
       <PopoverContent className="w-auto p-0">
@@ -94,9 +97,8 @@ export const DateRangePicker = React.forwardRef<HTMLButtonElement, DateRangePick
                 : placeholder
             }
             className={cn(
-              'w-[300px] justify-start text-left font-normal',
-              'future:h-10 future:rounded-xl future:border-0 future:bg-surface-overlay future:px-4 future:gap-4 future:text-muted-foreground future:hover:bg-surface-hover future:focus-visible:ring-offset-2 future:focus-visible:ring-offset-background',
-              !value && 'text-muted-foreground',
+              'w-[300px] justify-start text-left font-normal [&>svg]:text-foreground-muted hover:[&>svg]:text-accent-foreground',
+              'future:h-10 future:rounded-xl future:border-0 future:bg-surface-overlay future:px-4 future:gap-4 future:text-foreground future:hover:bg-surface-hover future:focus-visible:ring-offset-2 future:focus-visible:ring-offset-background',
               className
             )}
             disabled={disabled}
@@ -111,7 +113,7 @@ export const DateRangePicker = React.forwardRef<HTMLButtonElement, DateRangePick
                 format(value.from, 'LLL dd, y')
               )
             ) : (
-              <span>{placeholder}</span>
+              <span className="text-foreground-muted">{placeholder}</span>
             )}
           </Button>
         </PopoverTrigger>

--- a/packages/apollo-wind/src/components/ui/datetime-picker.test.tsx
+++ b/packages/apollo-wind/src/components/ui/datetime-picker.test.tsx
@@ -163,4 +163,43 @@ describe('DateTimePicker', () => {
       expect(screen.getByRole('button', { name: 'Done' })).toBeDisabled();
     });
   });
+
+  describe('value vs placeholder color', () => {
+    it('mutes the placeholder via its own span', () => {
+      render(<DateTimePicker placeholder="Pick a date and time" />);
+      const placeholder = screen.getByText('Pick a date and time');
+      expect(placeholder.tagName).toBe('SPAN');
+      expect(placeholder).toHaveClass('text-foreground-muted');
+    });
+
+    it('renders a selected value at full strength', () => {
+      const { container } = render(<DateTimePicker value={new Date(2024, 5, 15, 14, 30)} />);
+      expect(screen.getByRole('button')).toHaveTextContent(/June 15/);
+      expect(container.querySelector('.text-foreground-muted')).toBeNull();
+    });
+
+    it('overrides the outline variant so the trigger is not globally muted', () => {
+      render(<DateTimePicker />);
+      const trigger = screen.getByRole('button');
+      expect(trigger).toHaveClass('future:text-foreground');
+      expect(trigger).not.toHaveClass('future:text-muted-foreground');
+    });
+  });
+
+  describe('trigger icon color', () => {
+    it('mutes the icon and brightens it on hover', () => {
+      render(<DateTimePicker />);
+      const trigger = screen.getByRole('button');
+      expect(trigger).toHaveClass('[&>svg]:text-foreground-muted');
+      expect(trigger).toHaveClass('hover:[&>svg]:text-accent-foreground');
+    });
+
+    // The [&>svg] selector only matches a direct child, so wrapping the icon
+    // would silently drop both rules.
+    it('keeps the icon a direct child of the trigger', () => {
+      render(<DateTimePicker />);
+      const trigger = screen.getByRole('button');
+      expect(trigger.querySelector(':scope > svg')).not.toBeNull();
+    });
+  });
 });

--- a/packages/apollo-wind/src/components/ui/datetime-picker.tsx
+++ b/packages/apollo-wind/src/components/ui/datetime-picker.tsx
@@ -65,7 +65,8 @@ export const DateTimePicker = React.forwardRef<HTMLButtonElement, DateTimePicker
     };
 
     const formatDisplayValue = () => {
-      if (!selectedDate) return placeholder;
+      // Placeholder is rendered by the caller; this only narrows for format().
+      if (!selectedDate) return null;
       const datePart = format(selectedDate, 'PPP');
       const timePart = format(selectedDate, use12Hour ? 'hh:mm a' : 'HH:mm');
       return `${datePart} at ${timePart}`;
@@ -78,15 +79,18 @@ export const DateTimePicker = React.forwardRef<HTMLButtonElement, DateTimePicker
             ref={ref}
             variant="outline"
             className={cn(
-              'w-full justify-start text-left font-normal',
-              'future:h-10 future:rounded-xl future:border-0 future:bg-surface-overlay future:px-4 future:gap-4 future:text-muted-foreground future:hover:bg-surface-hover future:focus-visible:ring-offset-2 future:focus-visible:ring-offset-background',
-              !selectedDate && 'text-muted-foreground',
+              'w-full justify-start text-left font-normal [&>svg]:text-foreground-muted hover:[&>svg]:text-accent-foreground',
+              'future:h-10 future:rounded-xl future:border-0 future:bg-surface-overlay future:px-4 future:gap-4 future:text-foreground future:hover:bg-surface-hover future:focus-visible:ring-offset-2 future:focus-visible:ring-offset-background',
               className
             )}
             disabled={disabled}
           >
             <CalendarIcon className="mr-2 h-4 w-4" />
-            {formatDisplayValue()}
+            {selectedDate ? (
+              formatDisplayValue()
+            ) : (
+              <span className="text-foreground-muted">{placeholder}</span>
+            )}
           </Button>
         </PopoverTrigger>
         <PopoverContent className="w-auto p-0" align="start">

--- a/packages/apollo-wind/src/components/ui/multi-select.test.tsx
+++ b/packages/apollo-wind/src/components/ui/multi-select.test.tsx
@@ -236,4 +236,27 @@ describe('MultiSelect', () => {
     render(<MultiSelect ref={ref} options={mockOptions} selected={[]} onChange={onChange} />);
     expect(ref.current).toBeInstanceOf(HTMLDivElement);
   });
+
+  describe('value vs placeholder color', () => {
+    it('mutes the placeholder via its own span', () => {
+      render(
+        <MultiSelect
+          options={mockOptions}
+          selected={[]}
+          onChange={vi.fn()}
+          placeholder="Select frameworks..."
+        />
+      );
+      const placeholder = screen.getByText('Select frameworks...');
+      expect(placeholder.tagName).toBe('SPAN');
+      expect(placeholder).toHaveClass('text-foreground-muted');
+    });
+
+    it('overrides the outline variant so the trigger is not globally muted', () => {
+      render(<MultiSelect options={mockOptions} selected={[]} onChange={vi.fn()} />);
+      const trigger = screen.getByRole('combobox');
+      expect(trigger).toHaveClass('future:text-foreground');
+      expect(trigger).not.toHaveClass('future:text-muted-foreground');
+    });
+  });
 });

--- a/packages/apollo-wind/src/components/ui/multi-select.tsx
+++ b/packages/apollo-wind/src/components/ui/multi-select.tsx
@@ -106,16 +106,14 @@ const MultiSelect = React.forwardRef<HTMLDivElement, MultiSelectProps>(
                     : placeholder
               }
               className={cn(
-                'w-full justify-between future:rounded-xl future:border-0 future:bg-surface-overlay future:px-4 future:gap-4 future:hover:bg-surface-hover future:font-normal future:text-muted-foreground future:focus-visible:ring-offset-2 future:focus-visible:ring-offset-background',
+                'w-full justify-between future:rounded-xl future:border-0 future:bg-surface-overlay future:px-4 future:gap-4 future:hover:bg-surface-hover future:font-normal future:text-foreground future:focus-visible:ring-offset-2 future:focus-visible:ring-offset-background',
                 selected.length > 0 ? 'h-auto min-h-10' : 'h-10'
               )}
               disabled={disabled}
             >
               <div className="flex flex-wrap gap-1 flex-1">
                 {selected.length === 0 ? (
-                  <span className="text-muted-foreground future:text-foreground-muted">
-                    {placeholder}
-                  </span>
+                  <span className="text-foreground-muted">{placeholder}</span>
                 ) : (
                   selected.map((value) => {
                     const option = options.find((opt) => opt.value === value);

--- a/packages/apollo-wind/src/components/ui/select.test.tsx
+++ b/packages/apollo-wind/src/components/ui/select.test.tsx
@@ -313,4 +313,26 @@ describe('Select', () => {
       });
     });
   });
+
+  // SelectTrigger is not Button-based: Radix's data-placeholder already mutes the
+  // empty state in every theme. A future:text-foreground here would outrank it.
+  describe('value vs placeholder color', () => {
+    it('mutes the empty state through data-placeholder, not a blanket class', () => {
+      render(<SelectExample />);
+      const trigger = screen.getByRole('combobox');
+      expect(trigger).toHaveAttribute('data-placeholder');
+      expect(trigger).toHaveClass('data-[placeholder]:text-muted-foreground');
+      expect(trigger).not.toHaveClass('future:text-muted-foreground');
+      expect(trigger).not.toHaveClass('future:text-foreground');
+    });
+
+    it('drops data-placeholder once a value is selected', async () => {
+      const user = userEvent.setup();
+      render(<SelectExample />);
+      const trigger = screen.getByRole('combobox');
+      await user.click(trigger);
+      await user.click(await screen.findByRole('option', { name: 'Apple' }));
+      await waitFor(() => expect(trigger).not.toHaveAttribute('data-placeholder'));
+    });
+  });
 });

--- a/packages/apollo-wind/src/components/ui/select.tsx
+++ b/packages/apollo-wind/src/components/ui/select.tsx
@@ -34,7 +34,7 @@ const SelectTrigger = React.forwardRef<
     ref={ref}
     data-slot="select-trigger"
     className={cn(
-      'flex h-9 w-full cursor-pointer items-center justify-between rounded-md border border-input bg-transparent px-3 py-1 text-base transition-colors data-[placeholder]:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 md:text-sm [&>span]:line-clamp-1 future:h-10 future:rounded-xl future:border-0 future:bg-surface-overlay future:hover:bg-surface-hover future:px-4 future:gap-4 future:font-normal future:text-muted-foreground',
+      'flex h-9 w-full cursor-pointer items-center justify-between rounded-md border border-input bg-transparent px-3 py-1 text-base transition-colors data-[placeholder]:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 md:text-sm [&>span]:line-clamp-1 future:h-10 future:rounded-xl future:border-0 future:bg-surface-overlay future:hover:bg-surface-hover future:px-4 future:gap-4 future:font-normal',
       className
     )}
     {...props}


### PR DESCRIPTION
## Summary

Field triggers rendered their text at `text-muted-foreground` in the Future themes even when a value was selected, so a populated Select or date picker looked de-emphasised. The root cause is `buttonVariants`: the `outline` / `ghost` / `secondary` / `link` variants all carry `future:text-muted-foreground`, which every Button-based trigger inherited. This makes populated triggers use `text-foreground` in all themes and moves the muted colour onto the placeholder itself. MST-14567.

## Demo

https://github.com/user-attachments/assets/68067d65-b493-4d33-8847-b94792488bad


## Changes

- **Button-based triggers** (`combobox`, `multi-select`, `date-picker` x2, `datetime-picker`): added `future:text-foreground` to override `buttonVariants`, and moved the empty state into its own `<span className="text-foreground-muted">`. Removed the `!value && 'text-muted-foreground'` conditionals, which the span now replaces.
- **`select.tsx`**: removed the blanket `future:text-muted-foreground` and added nothing. `SelectTrigger` is not Button-based, and Radix's `data-[placeholder]:text-muted-foreground` already covers every theme.
- **Picker icons**: the calendar icon now sits at `[&>svg]:text-foreground-muted` and brightens to `text-accent-foreground` on hover, matching the token the outline variant pairs with `hover:bg-accent`. In Future themes `--accent-foreground` is overridden to `var(--foreground)`, so it resolves to plain foreground there.
- **Tests**: 22 new assertions across the five components. 14 of them fail against the pre-fix source.
- `combobox.stories.tsx`: same treatment for the three inline story triggers.

## Flow

```mermaid
flowchart TD
    A[Field trigger] --> B{Button-based?}
    B -->|"combobox, multi-select,<br/>date + datetime pickers"| C["buttonVariants outline forces<br/>future:text-muted-foreground"]
    C --> D["add future:text-foreground<br/>(wins via twMerge, last in cn)"]
    D --> E["placeholder in its own span:<br/>text-foreground-muted"]
    E --> F["immune to future:hover:text-foreground<br/>(0,3,0) on the parent"]
    B -->|"select"| G["Radix sets data-placeholder"]
    G --> H["data-[placeholder]:text-muted-foreground<br/>(0,2,0) covers all six themes"]
    H --> I["add nothing: future:text-foreground<br/>is also (0,2,0) and emitted later"]
```

## Why the two paths differ

Worth knowing before "fixing" `select.tsx` for consistency. Tailwind emits same-variant utilities alphabetically, so `future:text-foreground` (L6342) lands after `data-[placeholder]:text-muted-foreground` (L5660) at equal `(0,2,0)` specificity. Adding it to `SelectTrigger` would silently break placeholder muting. `select.test.tsx` asserts the absence of both classes with a comment explaining why.

The placeholder also moved into a child span rather than staying a conditional class on the trigger because `buttonVariants` carries `hover:text-accent-foreground` and `future:hover:text-foreground`. Those are separate `twMerge` keys and higher specificity, so hovering an empty trigger used to flip the placeholder to full-strength text in every theme. A child with its own colour does not inherit it.

`text-foreground-muted` needs no `future:` counterpart: `--muted-foreground` aliases `--foreground-muted` in the block covering all six core themes.

## Testing

- [x] `pnpm lint` passes (JS, CSS, deps)
- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes (93 suites, 1473 tests)
- [x] `pnpm test:visual` — no visual-regression suite exists in this repo yet (no package defines `test:visual`, no Playwright config), so the root script runs zero tasks
- [x] **Manual Storybook check on the Future themes still needed.** The new tests assert class plumbing, which is all jsdom can see; nothing here verifies the actual rendered colour
- [x] Type-safe (no `as any` or type suppressions added)

## Reviewer notes

- Unaddressed on purpose: the chevrons in `combobox.tsx` and `select.tsx` use `opacity-50` rather than a muted token, so they will not match the pickers' new icon treatment. Separate change if we want them unified.
- Keyboard users never see the brightened icon, since `:focus-visible` is not `:hover`. Adding `focus-visible:[&>svg]:text-foreground` would give parity if we want it.
- Tailwind wraps `hover:` in `@media (hover: hover)`, so the icon stays muted on touch devices.
- `DropdownMenuTrigger`'s `field` prop has the same inherited-muted issue, but was left alone since it is not intended as a form control.



