### PR TITLE
perf(apollo-wind): re-render only the edited field in MetadataForm

### DIFF
--- a/packages/apollo-wind/src/components/forms/field-renderer.tsx
+++ b/packages/apollo-wind/src/components/forms/field-renderer.tsx
@@ -211,22 +211,26 @@ export function FormFieldRenderer({
     });
   }, [field.rules, field.validation?.required, getValues, watchedRuleDependentValues]);
 
+  // Tracked apart from inlineOptions so a field whose options go away clears to [].
+  const isOptionsField = hasOptions(field);
+  const inlineOptions = isOptionsField ? field.options : undefined;
+
   // Sync inline options when field.options changes (for fields without dataSource)
   useEffect(() => {
     if (field.dataSource) return; // Skip if using dataSource
-    if (!hasOptions(field)) return;
+    if (!isOptionsField) return;
 
-    const inlineOptions = field.options || [];
+    const nextOptions = inlineOptions || [];
     setFieldState((prev) => {
-      if (deepEqual(prev.options, inlineOptions)) {
+      if (deepEqual(prev.options, nextOptions)) {
         return prev;
       }
       return {
         ...prev,
-        options: inlineOptions,
+        options: nextOptions,
       };
     });
-  }, [field]);
+  }, [field.dataSource, isOptionsField, inlineOptions]);
 
   // Fetch data source options (re-fetches when dependent fields change)
   // biome-ignore lint/correctness/useExhaustiveDependencies: watchedDataSourceValues triggers re-fetch when dependent field values change (cascading dropdowns)

--- a/packages/apollo-wind/src/components/forms/form-state-viewer.test.tsx
+++ b/packages/apollo-wind/src/components/forms/form-state-viewer.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { axe } from 'jest-axe';
-import type { FieldValues, UseFormReturn } from 'react-hook-form';
+import { createFormControl, type FieldValues, type UseFormReturn } from 'react-hook-form';
 import { describe, expect, it } from 'vitest';
 import { FormStateViewer } from './form-state-viewer';
 
@@ -24,11 +24,13 @@ interface MockFormStateOptions {
 }
 
 /**
- * FormStateViewer only reads `form.formState` and `form.watch()`, so a plain
- * stub gives deterministic state without racing react-hook-form validation.
+ * Built on a real form control so `useWatch` has something to subscribe to,
+ * with only `formState` stubbed to keep the flags deterministic.
  */
 function createMockForm(options: MockFormStateOptions = {}): UseFormReturn<FieldValues> {
+  const formControl = createFormControl<FieldValues>({ defaultValues: options.values ?? {} });
   return {
+    ...formControl,
     formState: {
       isValid: options.isValid ?? true,
       isDirty: options.isDirty ?? false,
@@ -41,7 +43,6 @@ function createMockForm(options: MockFormStateOptions = {}): UseFormReturn<Field
       dirtyFields: options.dirtyFields ?? {},
       touchedFields: options.touchedFields ?? {},
     },
-    watch: () => options.values ?? {},
   } as unknown as UseFormReturn<FieldValues>;
 }
 

--- a/packages/apollo-wind/src/components/forms/form-state-viewer.tsx
+++ b/packages/apollo-wind/src/components/forms/form-state-viewer.tsx
@@ -1,10 +1,10 @@
+import { AlertCircle, CheckCircle2, Database, Eye, FileEdit, XCircle } from 'lucide-react';
 import { useState } from 'react';
-import type { UseFormReturn, FieldValues } from 'react-hook-form';
+import { type FieldValues, type UseFormReturn, useWatch } from 'react-hook-form';
 import { Badge } from '@/components/ui/badge';
 import { Card } from '@/components/ui/card';
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { ScrollArea } from '@/components/ui/scroll-area';
-import { CheckCircle2, XCircle, AlertCircle, FileEdit, Eye, Database } from 'lucide-react';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 
 /**
  * FormStateViewer Component
@@ -27,8 +27,14 @@ export function FormStateViewer({
   compact = false,
 }: FormStateViewerProps) {
   const [activeTab, setActiveTab] = useState('values');
-  const { formState, watch } = form;
-  const values = watch();
+  const { formState, control, getValues } = form;
+
+  // useWatch re-renders only this component. A bare watch() would instead set
+  // watchAll on the shared control, re-rendering the useForm owner (e.g.
+  // MetadataForm) once per keystroke. Values are read fresh on every render so
+  // fields that register after mount are included.
+  useWatch({ control });
+  const values = getValues() as Record<string, unknown>;
 
   const stats = {
     isValid: formState.isValid,

--- a/packages/apollo-wind/src/components/forms/metadata-form.test.tsx
+++ b/packages/apollo-wind/src/components/forms/metadata-form.test.tsx
@@ -332,6 +332,371 @@ describe('MetadataForm', () => {
         expect(screen.getByText('Step 1')).toBeInTheDocument();
       });
     });
+
+    it('skips a single hidden step and lands on the next visible one', async () => {
+      const user = userEvent.setup();
+      const schema: FormSchema = {
+        id: 'skip-single',
+        title: 'Skip Single',
+        steps: [
+          {
+            id: 'step-1',
+            title: 'Visible Step 1',
+            sections: [
+              { id: 's1', fields: [{ name: 'f1', type: 'text', label: 'F1', defaultValue: '' }] },
+            ],
+          },
+          {
+            id: 'step-2',
+            title: 'Hidden Step',
+            // Condition that never matches — "ghost" field will always be undefined
+            conditions: [{ when: 'ghost', is: 'never' }],
+            sections: [
+              { id: 's2', fields: [{ name: 'f2', type: 'text', label: 'F2', defaultValue: '' }] },
+            ],
+          },
+          {
+            id: 'step-3',
+            title: 'Visible Step 3',
+            sections: [
+              { id: 's3', fields: [{ name: 'f3', type: 'text', label: 'F3', defaultValue: '' }] },
+            ],
+          },
+        ],
+      };
+
+      render(<MetadataForm schema={schema} />);
+      expect(screen.getByText('Visible Step 1')).toBeInTheDocument();
+
+      await user.click(screen.getByRole('button', { name: /next/i }));
+
+      await waitFor(() => {
+        expect(screen.getByText('Visible Step 3')).toBeInTheDocument();
+      });
+      expect(screen.queryByText('Hidden Step')).not.toBeInTheDocument();
+    });
+
+    it('skips multiple consecutive hidden steps in one jump', async () => {
+      const user = userEvent.setup();
+      const schema: FormSchema = {
+        id: 'skip-multi',
+        title: 'Skip Multi',
+        steps: [
+          {
+            id: 'step-1',
+            title: 'Start',
+            sections: [
+              { id: 's1', fields: [{ name: 'f1', type: 'text', label: 'F1', defaultValue: '' }] },
+            ],
+          },
+          {
+            id: 'step-2',
+            title: 'Hidden A',
+            conditions: [{ when: 'ghost', is: 'never' }],
+            sections: [
+              { id: 's2', fields: [{ name: 'f2', type: 'text', label: 'F2', defaultValue: '' }] },
+            ],
+          },
+          {
+            id: 'step-3',
+            title: 'Hidden B',
+            conditions: [{ when: 'ghost', is: 'never' }],
+            sections: [
+              { id: 's3', fields: [{ name: 'f3', type: 'text', label: 'F3', defaultValue: '' }] },
+            ],
+          },
+          {
+            id: 'step-4',
+            title: 'End',
+            sections: [
+              { id: 's4', fields: [{ name: 'f4', type: 'text', label: 'F4', defaultValue: '' }] },
+            ],
+          },
+        ],
+      };
+
+      render(<MetadataForm schema={schema} />);
+      expect(screen.getByText('Start')).toBeInTheDocument();
+
+      await user.click(screen.getByRole('button', { name: /next/i }));
+
+      await waitFor(() => {
+        expect(screen.getByText('End')).toBeInTheDocument();
+      });
+      expect(screen.queryByText('Hidden A')).not.toBeInTheDocument();
+      expect(screen.queryByText('Hidden B')).not.toBeInTheDocument();
+    });
+
+    it('renders nothing when all remaining steps are hidden (no way back)', async () => {
+      const user = userEvent.setup();
+      const schema: FormSchema = {
+        id: 'all-hidden',
+        title: 'All Hidden',
+        steps: [
+          {
+            id: 'step-1',
+            title: 'Only Visible',
+            sections: [
+              { id: 's1', fields: [{ name: 'f1', type: 'text', label: 'F1', defaultValue: '' }] },
+            ],
+          },
+          {
+            id: 'step-2',
+            title: 'Hidden Last',
+            conditions: [{ when: 'ghost', is: 'never' }],
+            sections: [
+              { id: 's2', fields: [{ name: 'f2', type: 'text', label: 'F2', defaultValue: '' }] },
+            ],
+          },
+        ],
+      };
+
+      render(<MetadataForm schema={schema} />);
+      expect(screen.getByText('Only Visible')).toBeInTheDocument();
+
+      await user.click(screen.getByRole('button', { name: /next/i }));
+
+      await waitFor(() => {
+        // The hidden step's title should never appear
+        expect(screen.queryByText('Hidden Last')).not.toBeInTheDocument();
+      });
+
+      expect(screen.queryByText('Only Visible')).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /previous/i })).not.toBeInTheDocument();
+    });
+  });
+
+  describe('plugin hooks', () => {
+    // Written before plugins run, not after: otherwise a plugin lifting state to
+    // a parent persists the previous keystroke.
+    it('sees the just-changed value in context.values, not the previous one', async () => {
+      const user = userEvent.setup();
+      const seen: Array<Record<string, unknown>> = [];
+      const observer: FormPlugin = {
+        name: 'observer',
+        onValueChange: (_fieldName, _value, context) => {
+          seen.push({ ...context.values });
+        },
+      };
+      const schema: FormSchema = {
+        id: 'plugin-values',
+        title: 'Plugin Values',
+        sections: [
+          {
+            id: 's',
+            fields: [
+              {
+                name: 'letters',
+                type: 'text',
+                label: 'Letters',
+                placeholder: 'Letters',
+                defaultValue: '',
+              },
+            ],
+          },
+        ],
+      };
+
+      render(<MetadataForm schema={schema} plugins={[observer]} />);
+      await user.type(screen.getByPlaceholderText('Letters'), 'abc');
+
+      await waitFor(() => {
+        expect(seen.length).toBe(3);
+      });
+
+      expect(seen.map((values) => values.letters)).toEqual(['a', 'ab', 'abc']);
+    });
+
+    it('passes the changed value for a dot-path field name', async () => {
+      const user = userEvent.setup();
+      const seen: Array<[string, unknown]> = [];
+      const observer: FormPlugin = {
+        name: 'observer',
+        onValueChange: (fieldName, value) => {
+          seen.push([fieldName, value]);
+        },
+      };
+      const schema: FormSchema = {
+        id: 'nested-plugin',
+        title: 'Nested Plugin',
+        sections: [
+          {
+            id: 's',
+            fields: [
+              {
+                name: 'inputs.url',
+                type: 'text',
+                label: 'URL',
+                placeholder: 'URL',
+                defaultValue: '',
+              },
+            ],
+          },
+        ],
+      };
+
+      render(<MetadataForm schema={schema} plugins={[observer]} />);
+      await user.type(screen.getByPlaceholderText('URL'), 'ab');
+
+      await waitFor(() => {
+        expect(seen.length).toBe(2);
+      });
+      expect(seen).toEqual([
+        ['inputs.url', 'a'],
+        ['inputs.url', 'ab'],
+      ]);
+    });
+  });
+
+  describe('form actions', () => {
+    it('disables the submit action and shows its loading label while submitting', async () => {
+      const user = userEvent.setup();
+      let release: () => void = () => {};
+      const onSubmit = () =>
+        new Promise<void>((resolve) => {
+          release = resolve;
+        });
+      const schema: FormSchema = {
+        id: 'submitting',
+        title: 'Submitting',
+        sections: [
+          { id: 's', fields: [{ name: 'a', type: 'text', label: 'A', defaultValue: 'x' }] },
+        ],
+        actions: [{ id: 'submit', type: 'submit', label: 'Save', loading: true }],
+      };
+
+      render(<MetadataForm schema={schema} onSubmit={onSubmit} />);
+      await user.click(screen.getByRole('button', { name: 'Save' }));
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: 'Loading...' })).toBeDisabled();
+      });
+
+      release();
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: 'Save' })).toBeEnabled();
+      });
+    });
+
+    it('re-evaluates action conditions as values change', async () => {
+      const user = userEvent.setup();
+      const schema: FormSchema = {
+        id: 'action-conditions',
+        title: 'Action Conditions',
+        sections: [
+          { id: 's', fields: [{ name: 'showExtra', type: 'checkbox', label: 'Show extra' }] },
+        ],
+        actions: [
+          { id: 'submit', type: 'submit', label: 'Submit' },
+          {
+            id: 'extra',
+            type: 'custom',
+            label: 'Extra',
+            conditions: [{ when: 'showExtra', is: true }],
+          },
+        ],
+      };
+
+      render(<MetadataForm schema={schema} />);
+      expect(screen.queryByRole('button', { name: 'Extra' })).not.toBeInTheDocument();
+
+      await user.click(screen.getByRole('checkbox'));
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: 'Extra' })).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('reactive conditions', () => {
+    // One click = one change, and SinglePageForm has no other subscription to
+    // ride on, so a missing values subscription fails here.
+    it('re-evaluates section conditions as values change', async () => {
+      const user = userEvent.setup();
+      const schema: FormSchema = {
+        id: 'reactive-sections',
+        title: 'Reactive Sections',
+        sections: [
+          {
+            id: 'trigger',
+            fields: [{ name: 'showMore', type: 'checkbox', label: 'Show more' }],
+          },
+          {
+            id: 'more',
+            title: 'More Details',
+            conditions: [{ when: 'showMore', is: true }],
+            fields: [{ name: 'notes', type: 'text', label: 'Notes', defaultValue: '' }],
+          },
+        ],
+      };
+
+      render(<MetadataForm schema={schema} />);
+      expect(screen.queryByText('More Details')).not.toBeInTheDocument();
+
+      await user.click(screen.getByRole('checkbox'));
+
+      await waitFor(() => {
+        expect(screen.getByText('More Details')).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole('checkbox'));
+
+      await waitFor(() => {
+        expect(screen.queryByText('More Details')).not.toBeInTheDocument();
+      });
+    });
+
+    // Multi-character on purpose: TabbedStepForm's useFormState re-renders when
+    // isDirty first flips, so a single change passes even without a subscription.
+    it('re-evaluates step conditions as values change (tabs)', async () => {
+      const user = userEvent.setup();
+      const schema: FormSchema = {
+        id: 'reactive-tabs',
+        title: 'Reactive Tabs',
+        steps: [
+          {
+            id: 'general',
+            title: 'General',
+            sections: [
+              {
+                id: 'g',
+                fields: [
+                  {
+                    name: 'mode',
+                    type: 'text',
+                    label: 'Mode',
+                    placeholder: 'Enter mode',
+                    defaultValue: '',
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            id: 'advanced',
+            title: 'Advanced',
+            conditions: [{ when: 'mode', is: 'expert' }],
+            sections: [{ id: 'a', fields: [{ name: 'tuning', type: 'text', label: 'Tuning' }] }],
+          },
+        ],
+      };
+
+      render(<MetadataForm schema={schema} stepVariant="tabs" />);
+      expect(screen.queryByRole('tab', { name: 'Advanced' })).not.toBeInTheDocument();
+
+      await user.type(screen.getByPlaceholderText('Enter mode'), 'expert');
+
+      await waitFor(() => {
+        expect(screen.getByRole('tab', { name: 'Advanced' })).toBeInTheDocument();
+      });
+
+      // Already dirty, so no formState flag moves on this edit either.
+      await user.type(screen.getByPlaceholderText('Enter mode'), '!');
+
+      await waitFor(() => {
+        expect(screen.queryByRole('tab', { name: 'Advanced' })).not.toBeInTheDocument();
+      });
+    });
   });
 
   describe('tabbed multi-step form (stepVariant="tabs")', () => {

--- a/packages/apollo-wind/src/components/forms/metadata-form.tsx
+++ b/packages/apollo-wind/src/components/forms/metadata-form.tsx
@@ -1,6 +1,6 @@
 import { standardSchemaResolver } from '@hookform/resolvers/standard-schema';
-import React, { useEffect, useMemo, useRef, useState } from 'react';
-import { type FieldValues, FormProvider, useForm, useFormState } from 'react-hook-form';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { type FieldValues, FormProvider, useForm, useFormState, useWatch } from 'react-hook-form';
 import { z } from 'zod/v4';
 import {
   Accordion,
@@ -10,6 +10,7 @@ import {
 } from '@/components/ui/accordion';
 import { Button } from '@/components/ui/button';
 import { ScrollableTabsList, Tabs, TabsContent, TabsTrigger } from '@/components/ui/tabs';
+import { deepEqual, get } from '@/lib';
 
 import { DataFetcher } from './data-fetcher';
 import { FormFieldRenderer } from './field-renderer';
@@ -93,28 +94,42 @@ export function MetadataForm({
   >({});
   const [isInitialized, setIsInitialized] = useState(false);
 
+  // Stabilize schema reference using deep equality
+  const schemaRef = useRef(schema);
+  const stableSchema = useMemo(() => {
+    if (deepEqual(schemaRef.current, schema)) {
+      return schemaRef.current;
+    }
+    schemaRef.current = schema;
+    return schema;
+  }, [schema]);
+
   // Build Zod schema from metadata
-  const zodSchema = useMemo(() => buildZodSchema(schema), [schema]);
+  const zodSchema = useMemo(() => buildZodSchema(stableSchema), [stableSchema]);
 
   // Initialize React Hook Form
   const form = useForm<FieldValues>({
     resolver: standardSchemaResolver(zodSchema),
-    mode: schema.mode || 'onSubmit',
-    reValidateMode: schema.reValidateMode || 'onChange',
+    defaultValues: stableSchema.initialData || {},
+    mode: stableSchema.mode || 'onSubmit',
+    reValidateMode: stableSchema.reValidateMode || 'onChange',
   });
 
   const { watch, handleSubmit, reset } = form;
 
   // Use ref to store values - prevents context recreation on every render
-  const valuesRef = useRef<Record<string, unknown>>({});
-  // This watch() triggers re-renders but we store in ref for stable context access
-  const watchedValues = watch();
-  valuesRef.current = watchedValues;
+  const valuesRef = useRef<Record<string, unknown>>(form.getValues());
+
+  // Stable refs for plugins and onSubmit to use in memoized callbacks
+  const pluginsRef = useRef(plugins);
+  pluginsRef.current = plugins;
+  const onSubmitRef = useRef(onSubmit);
+  onSubmitRef.current = onSubmit;
 
   // Build form context - STABLE reference (values accessed via ref/getters)
   const context: FormContext = useMemo(
     () => ({
-      schema,
+      schema: stableSchema,
       form,
       // Use getter to always return latest values without recreating context
       get values() {
@@ -129,7 +144,7 @@ export function MetadataForm({
       get isDirty() {
         return form.formState.isDirty;
       },
-      currentStep: schema.steps ? currentStep : undefined,
+      currentStep: stableSchema.steps ? currentStep : undefined,
 
       evaluateConditions: (conditions: FieldCondition[]) =>
         RulesEngine.evaluateConditions(conditions, valuesRef.current, 'AND'),
@@ -146,12 +161,30 @@ export function MetadataForm({
         setCustomComponents((prev) => ({ ...prev, [name]: component }));
       },
     }),
-    [schema, form, currentStep]
+    [stableSchema, form, currentStep]
   );
 
   // Ref for context to use in useEffects without causing dependency loops
   const contextRef = useRef(context);
   contextRef.current = context;
+
+  const isInitializedRef = useRef(isInitialized);
+  isInitializedRef.current = isInitialized;
+
+  // valuesRef is written before the plugin fan-out: context.values must be current.
+  useEffect(() => {
+    const subscription = watch((value, { name }) => {
+      valuesRef.current = value as Record<string, unknown>;
+
+      if (!name || !isInitializedRef.current) return;
+
+      pluginsRef.current.forEach((plugin) => {
+        plugin.onValueChange?.(name, get(value, name), contextRef.current);
+      });
+    });
+
+    return () => subscription.unsubscribe();
+  }, [watch]);
 
   // Initialize form - runs once on mount only
   // biome-ignore lint/correctness/useExhaustiveDependencies: intentionally runs once on mount - use key prop to reinitialize with new schema
@@ -161,8 +194,8 @@ export function MetadataForm({
 
     const initializeForm = async () => {
       // Load initial data
-      if (schema.initialData) {
-        const data = await loadInitialData(schema.initialData, contextRef.current);
+      if (stableSchema.initialData) {
+        const data = await loadInitialData(stableSchema.initialData, contextRef.current);
         reset(data);
       }
 
@@ -177,62 +210,49 @@ export function MetadataForm({
     initializeForm();
   }, [isInitialized]);
 
-  // Watch for field changes and execute plugin hooks
-  useEffect(() => {
-    if (!isInitialized) return;
+  // Built once, so plugins/onSubmit/context are read from refs at call time.
+  const handleFormSubmit = useMemo(
+    () =>
+      handleSubmit(async (data) => {
+        // Plugin submit hooks
+        let finalData = data;
+        for (const plugin of pluginsRef.current) {
+          if (plugin.onSubmit) {
+            finalData = (await plugin.onSubmit(finalData, contextRef.current)) || finalData;
+          }
+        }
 
-    const subscription = watch((value, { name }) => {
-      if (name) {
-        // Update valuesRef with the latest values BEFORE calling plugins
-        // This ensures context.values returns current data, not stale data
-        valuesRef.current = value as Record<string, unknown>;
+        // Execute submit
+        if (onSubmitRef.current) {
+          await onSubmitRef.current(finalData);
+        }
+      }),
+    [handleSubmit]
+  );
 
-        // Plugin field change hooks
-        plugins.forEach((plugin) => {
-          plugin.onValueChange?.(name, value[name], contextRef.current);
-        });
-      }
-    });
-
-    return () => subscription.unsubscribe();
-  }, [watch, isInitialized, plugins]);
-
-  // Handle form submission
-  const handleFormSubmit = handleSubmit(async (data) => {
-    // Plugin submit hooks
-    let finalData = data;
-    for (const plugin of plugins) {
-      if (plugin.onSubmit) {
-        finalData = (await plugin.onSubmit(finalData, context)) || finalData;
-      }
-    }
-
-    // Execute submit
-    if (onSubmit) {
-      await onSubmit(finalData);
-    }
-  });
+  // Stable reset callback
+  const handleReset = useCallback(() => reset(), [reset]);
 
   // Render based on form structure
   const renderContent = () => {
-    if (schema.steps) {
+    if (stableSchema.steps) {
       if (stepVariant === 'tabs') {
         return (
           <TabbedStepForm
-            schema={schema}
+            schema={stableSchema}
             context={context}
             customComponents={customComponents}
             disabled={disabled}
             sectionVariant={sectionVariant}
             activeStepId={activeStepId}
             onActiveStepChange={onActiveStepChange}
-            onReset={() => reset()}
+            onReset={handleReset}
           />
         );
       }
       return (
         <MultiStepForm
-          schema={schema}
+          schema={stableSchema}
           context={context}
           currentStep={currentStep}
           setCurrentStep={setCurrentStep}
@@ -245,7 +265,7 @@ export function MetadataForm({
 
     return (
       <SinglePageForm
-        schema={schema}
+        schema={stableSchema}
         context={context}
         customComponents={customComponents}
         disabled={disabled}
@@ -262,7 +282,9 @@ export function MetadataForm({
         {/* Wizard forms own their navigation/Submit, and tabbed forms render
             FormActions inside TabbedStepForm so it's suppressed when no tab is
             visible. Only single-page forms render FormActions here. */}
-        {!schema.steps && <FormActions schema={schema} context={context} onReset={() => reset()} />}
+        {!stableSchema.steps && (
+          <FormActions schema={stableSchema} context={context} onReset={handleReset} />
+        )}
       </form>
     </FormProvider>
   );
@@ -272,6 +294,26 @@ export function MetadataForm({
 // Supporting Components
 // ============================================================================
 
+// Field names a set of `conditions` reads. As in FormFieldRenderer, fields used
+// only inside a `custom` expression aren't traced.
+function conditionDependencies(conditionGroups: Array<FieldCondition[] | undefined>): string[] {
+  const fields = new Set<string>();
+  for (const conditions of conditionGroups) {
+    for (const condition of conditions || []) {
+      if (condition.when) {
+        fields.add(condition.when);
+      }
+    }
+  }
+  return Array.from(fields);
+}
+
+// Conditions are evaluated during render from context.values, and these
+// components are memo'd behind stable props, so the subscription must live here.
+function useConditionDependencies(context: FormContext, conditionFields: string[]) {
+  useWatch({ control: context.form.control, name: conditionFields });
+}
+
 interface SinglePageFormProps {
   schema: FormSchema;
   context: FormContext;
@@ -280,7 +322,7 @@ interface SinglePageFormProps {
   sectionVariant?: 'card' | 'plain';
 }
 
-function SinglePageForm({
+const SinglePageForm = React.memo(function SinglePageForm({
   schema,
   context,
   customComponents,
@@ -288,6 +330,12 @@ function SinglePageForm({
   sectionVariant,
 }: SinglePageFormProps) {
   const sections = schema.sections || [];
+
+  const conditionFields = useMemo(
+    () => conditionDependencies(schema.sections?.map((section) => section.conditions) ?? []),
+    [schema]
+  );
+  useConditionDependencies(context, conditionFields);
 
   // Filter visible sections
   const visibleSections = sections.filter(
@@ -310,14 +358,14 @@ function SinglePageForm({
       ))}
     </div>
   );
-}
+});
 
 interface MultiStepFormProps extends SinglePageFormProps {
   currentStep: number;
   setCurrentStep: (step: number) => void;
 }
 
-function MultiStepForm({
+const MultiStepForm = React.memo(function MultiStepForm({
   schema,
   context,
   currentStep,
@@ -327,18 +375,35 @@ function MultiStepForm({
   sectionVariant,
 }: MultiStepFormProps) {
   const steps = schema.steps || [];
-  const step = steps[currentStep];
 
-  if (!step) return null;
+  const conditionFields = useMemo(
+    () => conditionDependencies(schema.steps?.map((step) => step.conditions) ?? []),
+    [schema]
+  );
+  useConditionDependencies(context, conditionFields);
 
-  // Evaluate step conditions
-  if (step.conditions && !context.evaluateConditions(step.conditions)) {
-    // Auto-skip hidden steps
-    if (currentStep < steps.length - 1) {
-      setCurrentStep(currentStep + 1);
+  // Find the next visible step starting from currentStep, skipping all hidden
+  // steps in one pass to avoid intermediate renders / flicker.
+  // Not memoized: the walk reads context.values via a ref no dep list can track.
+  let visibleStepIndex = -1;
+  for (let i = currentStep; i < steps.length; i++) {
+    const candidate = steps[i];
+    if (!candidate.conditions || context.evaluateConditions(candidate.conditions)) {
+      visibleStepIndex = i;
+      break;
     }
-    return null;
   }
+
+  // Jump to the first visible step if it differs from the current one
+  useEffect(() => {
+    if (visibleStepIndex !== -1 && visibleStepIndex !== currentStep) {
+      setCurrentStep(visibleStepIndex);
+    }
+  }, [visibleStepIndex, currentStep, setCurrentStep]);
+
+  const step = visibleStepIndex !== -1 ? steps[visibleStepIndex] : undefined;
+
+  if (!step || visibleStepIndex !== currentStep) return null;
 
   return (
     <div className="space-y-6">
@@ -390,7 +455,7 @@ function MultiStepForm({
       </div>
     </div>
   );
-}
+});
 
 interface TabbedStepFormProps extends SinglePageFormProps {
   onReset: () => void;
@@ -409,6 +474,18 @@ function TabbedStepForm({
   onActiveStepChange,
 }: TabbedStepFormProps) {
   const steps = schema.steps || [];
+
+  const conditionFields = useMemo(
+    () =>
+      conditionDependencies(
+        schema.steps?.flatMap((step) => [
+          step.conditions,
+          ...step.sections.map((section) => section.conditions),
+        ]) ?? []
+      ),
+    [schema]
+  );
+  useConditionDependencies(context, conditionFields);
 
   // Hide steps whose conditions evaluate to false, or that would render nothing:
   // a step needs at least one *currently visible* section (sections hidden by
@@ -590,7 +667,7 @@ interface FormSectionProps {
   sectionVariant?: 'card' | 'plain';
 }
 
-function FormSection({
+const FormSection = React.memo(function FormSection({
   section,
   context,
   customComponents,
@@ -712,7 +789,7 @@ function FormSection({
       </div>
     </div>
   );
-}
+});
 
 interface FormActionsProps {
   schema: FormSchema;
@@ -720,7 +797,21 @@ interface FormActionsProps {
   onReset: () => void;
 }
 
-function FormActions({ schema, context, onReset }: FormActionsProps) {
+const FormActions = React.memo(function FormActions({
+  schema,
+  context,
+  onReset,
+}: FormActionsProps) {
+  // context is a stable reference and this component is memoized, so it has to
+  // subscribe to the submit state and condition fields it reads itself.
+  const { isSubmitting } = useFormState({ control: context.form.control });
+
+  const conditionFields = useMemo(
+    () => conditionDependencies(schema.actions?.map((action) => action.conditions) ?? []),
+    [schema]
+  );
+  useConditionDependencies(context, conditionFields);
+
   const actions = schema.actions || [
     {
       id: 'submit',
@@ -762,15 +853,15 @@ function FormActions({ schema, context, onReset }: FormActionsProps) {
             key={action.id}
             type={action.type === 'submit' ? 'submit' : 'button'}
             variant={action.variant || 'default'}
-            disabled={action.disabled || (action.type === 'submit' && context.isSubmitting)}
+            disabled={action.disabled || (action.type === 'submit' && isSubmitting)}
           >
-            {action.loading && context.isSubmitting ? 'Loading...' : action.label}
+            {action.loading && isSubmitting ? 'Loading...' : action.label}
           </Button>
         );
       })}
     </div>
   );
-}
+});
 
 // ============================================================================
 // Utility Functions


### PR DESCRIPTION
`MetadataForm`'s top-level `watch()` re-rendered the entire form on every keystroke, rebuilding the Zod schema and form context and re-rendering every section and field. Values now flow through a ref fed by one subscription, the schema reference is stabilized by deep equality, and the sub-components are memoized.

Measured on a 10-field, 2-section form, one keystroke:

| | before | after |
|---|---|---|
| `MetadataForm` | 1 | 0 |
| `SinglePageForm` | 1 | 0 |
| `FormSection` | 2 | 0 |
| `FormFieldRenderer` | 10 | 0 |

Only the edited field's `Controller` re-renders.


https://github.com/user-attachments/assets/b18778c5-0c11-43c5-adba-15adeb1445da


### Keeping conditions reactive

Section and step `conditions` are evaluated during render from `context.values`. With the form no longer re-rendering on input, and the sub-components memoized behind stable props, they would have silently stopped reacting. Each layout now subscribes with `useWatch` to only the fields its own conditions reference, so typing in an unrelated field still costs nothing.

Without this the `Forms/Examples > Conditional Sections` story breaks: selecting a mid/senior experience level never reveals the "Work Experience" section. Nothing in the existing suite covered it, so two regression tests were added and confirmed to fail with the fix reverted.

### Also included

- `defaultValues` seeded from `initialData`, so fields paint with their values on first render
- a select whose `options` go away now clears instead of keeping a stale list
- `FormStateViewer` subscribes instead of calling `watch()`, which set `watchAll` on the shared control and re-rendered the `useForm` owner once per keystroke (measured: 3 keystrokes → 3 parent renders, now 0). Its test mock gained `getValues` to match.
- a test pinning the ordering guarantee that plugins see the current value in `context.values`, not the previous one

### Verification

1457 tests, typecheck, and build pass. Biome reports the same three pre-existing findings as `main`, none new. `Conditional Sections`, `Tabbed Steps`, `Multi Step Wizard`, `Cascading Dropdowns`, `With State Viewer`, and `Section Variants` verified in the browser.

### Known gaps, unchanged by this PR

- Wizard mode still ignores section-level `conditions` entirely, unlike the single-page and tabbed layouts
- A wizard whose remaining steps are all hidden renders nothing, with no navigation back. A test now documents it rather than leaving it implicit.
- Consumers that round-trip every value into `schema.initialData` (the Form Builder's field inspector) invalidate the deep-equality check each keystroke and so see none of this benefit

🤖 Generated with [Claude Code](https://claude.com/claude-code)