### PR TITLE
fix(apollo-react): restore focus when EditableText leaves edit mode

### DIFF
--- a/packages/apollo-react/src/canvas/components/NodePropertyPanel/EditableText.test.tsx
+++ b/packages/apollo-react/src/canvas/components/NodePropertyPanel/EditableText.test.tsx
@@ -196,6 +196,41 @@ describe('EditableText', () => {
     expect(onChange).not.toHaveBeenCalled();
   });
 
+  it('returns focus to the read trigger after Enter, so the tab sequence continues', async () => {
+    const user = userEvent.setup();
+    render(<EditableText value="End" onChange={vi.fn()} aria-label="Node name" />);
+
+    await user.click(screen.getByRole('button', { name: /^Node name/ }));
+    await user.keyboard('Wrap up{Enter}');
+
+    expect(screen.getByRole('button', { name: /^Node name/ })).toHaveFocus();
+  });
+
+  it('returns focus to the read trigger after Escape', async () => {
+    const user = userEvent.setup();
+    render(<EditableText value="End" onChange={vi.fn()} aria-label="Node name" />);
+
+    await user.click(screen.getByRole('button', { name: /^Node name/ }));
+    await user.keyboard('{Escape}');
+
+    expect(screen.getByRole('button', { name: /^Node name/ })).toHaveFocus();
+  });
+
+  it('lands focus on the next field when tabbing out of the editor', async () => {
+    const user = userEvent.setup();
+    render(
+      <>
+        <EditableText value="End" onChange={vi.fn()} aria-label="Node name" />
+        <button type="button">next</button>
+      </>
+    );
+
+    await user.click(screen.getByRole('button', { name: /^Node name/ }));
+    await user.tab();
+
+    expect(screen.getByRole('button', { name: 'next' })).toHaveFocus();
+  });
+
   describe('overflow tooltip', () => {
     it('offers the full value as a tooltip on the read trigger', () => {
       render(<EditableText value="A very long description" onChange={vi.fn()} />);

--- a/packages/apollo-react/src/canvas/components/NodePropertyPanel/EditableText.tsx
+++ b/packages/apollo-react/src/canvas/components/NodePropertyPanel/EditableText.tsx
@@ -65,6 +65,13 @@ export function EditableText({
   const [isEditing, setIsEditing] = useState(false);
   const [draft, setDraft] = useState(value);
   const inputRef = useRef<HTMLInputElement | HTMLTextAreaElement>(null);
+  const readRef = useRef<HTMLButtonElement>(null);
+  /**
+   * Where focus goes once the editor unmounts: the read trigger for Enter/Escape, the element the
+   * user tabbed to otherwise. Without this the focused editor unmounts mid-blur and focus falls to
+   * `document.body`, so the next Tab restarts from the top of the document.
+   */
+  const pendingFocus = useRef<HTMLElement | 'read' | null>(null);
   const errorId = `editable-text-${useId().replace(/:/g, '')}-error`;
 
   const hasError = !!error;
@@ -73,18 +80,29 @@ export function EditableText({
   const describedBy = hasError ? errorId : undefined;
 
   useIsomorphicLayoutEffect(() => {
-    if (!isEditing) return;
-    inputRef.current?.focus();
-    inputRef.current?.select();
+    if (isEditing) {
+      inputRef.current?.focus();
+      inputRef.current?.select();
+      return;
+    }
+    const target = pendingFocus.current;
+    pendingFocus.current = null;
+    if (target === 'read') readRef.current?.focus();
+    else target?.focus();
   }, [isEditing]);
 
-  const commit = useCallback(() => {
-    setIsEditing(false);
-    const next = draft.trim();
-    if (next !== value) onChange?.(next);
-  }, [draft, value, onChange]);
+  const commit = useCallback(
+    (nextFocus: HTMLElement | 'read' | null) => {
+      pendingFocus.current = nextFocus;
+      setIsEditing(false);
+      const next = draft.trim();
+      if (next !== value) onChange?.(next);
+    },
+    [draft, value, onChange]
+  );
 
   const cancel = useCallback(() => {
+    pendingFocus.current = 'read';
     setIsEditing(false);
   }, []);
 
@@ -93,7 +111,7 @@ export function EditableText({
       // Shift+Enter falls through to insert a newline; every other Enter commits.
       if (e.key === 'Enter' && !(multiline && e.shiftKey)) {
         e.preventDefault();
-        commit();
+        commit('read');
       } else if (e.key === 'Escape') {
         e.preventDefault();
         cancel();
@@ -155,7 +173,9 @@ export function EditableText({
       'aria-errormessage': hasError ? errorId : undefined,
       'aria-invalid': hasError || undefined,
       onKeyDown: handleKeyDown,
-      onBlur: commit,
+      // A click outside leaves `relatedTarget` null: commit, but do not yank focus back.
+      onBlur: (e: React.FocusEvent<HTMLInputElement | HTMLTextAreaElement>) =>
+        commit((e.relatedTarget as HTMLElement | null) ?? null),
       className: cn(
         'nodrag nowheel w-full min-w-0 border-none bg-surface-overlay text-foreground outline-none ring-1',
         hasError ? 'ring-error' : 'ring-brand',
@@ -197,6 +217,7 @@ export function EditableText({
       <CanvasTooltip content={value || placeholder} smartTooltip delay>
         <button
           type="button"
+          ref={readRef}
           data-slot="editable-text"
           data-testid={dataTestId}
           aria-label={ariaLabel && `${ariaLabel}: ${value || placeholder || ''}`}

--- a/packages/apollo-react/src/canvas/components/NodePropertyPanel/EditableText.tsx
+++ b/packages/apollo-react/src/canvas/components/NodePropertyPanel/EditableText.tsx
@@ -66,11 +66,6 @@ export function EditableText({
   const [draft, setDraft] = useState(value);
   const inputRef = useRef<HTMLInputElement | HTMLTextAreaElement>(null);
   const readRef = useRef<HTMLButtonElement>(null);
-  /**
-   * Where focus goes once the editor unmounts: the read trigger for Enter/Escape, the element the
-   * user tabbed to otherwise. Without this the focused editor unmounts mid-blur and focus falls to
-   * `document.body`, so the next Tab restarts from the top of the document.
-   */
   const pendingFocus = useRef<HTMLElement | 'read' | null>(null);
   const errorId = `editable-text-${useId().replace(/:/g, '')}-error`;
 
@@ -175,7 +170,7 @@ export function EditableText({
       onKeyDown: handleKeyDown,
       // A click outside leaves `relatedTarget` null: commit, but do not yank focus back.
       onBlur: (e: React.FocusEvent<HTMLInputElement | HTMLTextAreaElement>) =>
-        commit((e.relatedTarget as HTMLElement | null) ?? null),
+        commit(e.relatedTarget instanceof HTMLElement ? e.relatedTarget : null),
       className: cn(
         'nodrag nowheel w-full min-w-0 border-none bg-surface-overlay text-foreground outline-none ring-1',
         hasError ? 'ring-error' : 'ring-brand',

--- a/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.stories.tsx
@@ -160,6 +160,7 @@ import type {
 } from '../JsonTree';
 import { isJsonObject } from '../JsonTree';
 import { NodeIOView, type NodeIOViewTab } from '../NodeIOView';
+import { EditableText } from './EditableText';
 import { NodePropertyPanel } from './NodePropertyPanel';
 import { NodePropertyPanelLayout } from './NodePropertyPanelLayout';
 
@@ -624,10 +625,6 @@ function FullEditorStory() {
   const editorRef = useRef<Parameters<NonNullable<EditorProps['onMount']>>[0] | null>(null);
   const [label, setLabel] = useState('Script');
   const [category, setCategory] = useState('HTTP Request');
-  const [editingLabel, setEditingLabel] = useState(false);
-  const [editingCategory, setEditingCategory] = useState(false);
-  const labelRef = useRef<HTMLInputElement>(null);
-  const categoryRef = useRef<HTMLInputElement>(null);
   const variables = useMemo<VariablePickerItem[]>(
     () => [
       {
@@ -691,72 +688,16 @@ function FullEditorStory() {
       <NodePropertyPanel
         panelTitle="Properties"
         onClose={() => {}}
+        nodeIcon={<Code2 />}
+        nodeLabel={label}
+        onNodeLabelChange={setLabel}
+        nodeDescription={category}
+        onNodeDescriptionChange={setCategory}
+        action={<DebugButton />}
         contentInset="0.875rem"
         className="h-[560px]"
       >
         <div className="flex h-full flex-col">
-          {/* Inline-editable identity row */}
-          <div className="flex shrink-0 items-center justify-between gap-4 py-4 [padding-inline:var(--mf-content-inset,0.875rem)]">
-            <div className="flex min-w-0 flex-1 items-center gap-3.5">
-              <div className="grid size-11 shrink-0 place-items-center rounded-xl bg-surface-overlay text-foreground-subtle [&>svg]:size-5">
-                <Code2 />
-              </div>
-              <div className="flex min-w-0 flex-1 flex-col justify-center">
-                {editingLabel ? (
-                  <input
-                    ref={labelRef}
-                    value={label}
-                    onChange={(e) => setLabel(e.target.value)}
-                    onBlur={() => setEditingLabel(false)}
-                    onKeyDown={(e) => {
-                      if (e.key === 'Enter' || e.key === 'Escape') setEditingLabel(false);
-                    }}
-                    className="w-full rounded bg-surface-overlay px-1.5 py-0.5 text-base font-semibold leading-5 tracking-[-0.3px] text-foreground outline-none ring-1 ring-brand"
-                    autoFocus
-                  />
-                ) : (
-                  <button
-                    type="button"
-                    onClick={() => {
-                      setEditingLabel(true);
-                      setTimeout(() => labelRef.current?.select(), 0);
-                    }}
-                    className="truncate rounded px-1.5 py-0.5 text-left text-base font-semibold leading-5 tracking-[-0.3px] text-foreground transition hover:bg-surface-overlay"
-                  >
-                    {label}
-                  </button>
-                )}
-                {editingCategory ? (
-                  <input
-                    ref={categoryRef}
-                    value={category}
-                    onChange={(e) => setCategory(e.target.value)}
-                    onBlur={() => setEditingCategory(false)}
-                    onKeyDown={(e) => {
-                      if (e.key === 'Enter' || e.key === 'Escape') setEditingCategory(false);
-                    }}
-                    className="w-full rounded bg-surface-overlay px-1.5 py-0.5 text-xs leading-4 text-foreground outline-none ring-1 ring-brand"
-                    autoFocus
-                  />
-                ) : (
-                  <button
-                    type="button"
-                    onClick={() => {
-                      setEditingCategory(true);
-                      setTimeout(() => categoryRef.current?.select(), 0);
-                    }}
-                    className="truncate rounded px-1.5 py-0.5 text-left text-xs leading-4 text-foreground-muted transition hover:bg-surface-overlay"
-                  >
-                    {category}
-                  </button>
-                )}
-              </div>
-            </div>
-            <div className="shrink-0">
-              <DebugButton />
-            </div>
-          </div>
-
           {/* Tabs + editor */}
           <Tabs defaultValue="parameters" className="flex min-h-0 flex-1 flex-col">
             <div className="shrink-0 pt-3 [padding-inline:var(--mf-content-inset,0.875rem)]">
@@ -953,8 +894,6 @@ function CasePanel({
   errorAction?: string;
 }) {
   const [expanded, setExpanded] = useState(defaultExpanded);
-  const [editingTitle, setEditingTitle] = useState(false);
-  const titleRef = useRef<HTMLInputElement>(null);
   const editorRef = useRef<Parameters<NonNullable<EditorProps['onMount']>>[0] | null>(null);
   const hasError = Boolean(errorMessage);
 
@@ -988,30 +927,12 @@ function CasePanel({
             className={cn('transition-transform duration-150', !expanded && '-rotate-90')}
           />
         </Button>
-        {editingTitle ? (
-          <input
-            ref={titleRef}
-            value={caseTitle}
-            onChange={(e) => onTitleChange(e.target.value)}
-            onBlur={() => setEditingTitle(false)}
-            onKeyDown={(e) => {
-              if (e.key === 'Enter' || e.key === 'Escape') setEditingTitle(false);
-            }}
-            className="flex-1 rounded bg-surface-overlay px-1 py-0.5 text-xs font-medium text-foreground outline-none ring-1 ring-brand"
-            autoFocus
-          />
-        ) : (
-          <button
-            type="button"
-            onClick={() => {
-              setEditingTitle(true);
-              setTimeout(() => titleRef.current?.select(), 0);
-            }}
-            className="flex min-w-0 flex-1 items-center rounded px-1 py-0.5 text-left text-xs font-medium text-foreground transition hover:bg-surface-overlay"
-          >
-            {caseTitle}
-          </button>
-        )}
+        <EditableText
+          value={caseTitle}
+          onChange={onTitleChange}
+          size="sm"
+          className="min-w-0 flex-1 font-medium text-foreground"
+        />
         {hasError && (
           <Badge variant="error" className="h-5 gap-1 px-1.5 text-[10px] font-medium">
             <CircleAlert size={10} />1
@@ -1222,82 +1143,22 @@ function CompactEditorStory() {
     setCases((prev) => prev.map((c) => (c.id === id ? { ...c, title } : c)));
   const [label, setLabel] = useState('Switch');
   const [category, setCategory] = useState('Control');
-  const [editingLabel, setEditingLabel] = useState(false);
-  const [editingCategory, setEditingCategory] = useState(false);
-  const labelRef = useRef<HTMLInputElement>(null);
-  const categoryRef = useRef<HTMLInputElement>(null);
 
   return (
     <PanelFrame>
       <NodePropertyPanel
         panelTitle="Properties"
         onClose={() => {}}
+        nodeIcon={<GitFork />}
+        nodeLabel={label}
+        onNodeLabelChange={setLabel}
+        nodeDescription={category}
+        onNodeDescriptionChange={setCategory}
+        action={<DebugButton />}
         contentInset="0.875rem"
         className="h-[640px]"
       >
         <div className="flex h-full flex-col">
-          {/* Inline-editable identity row */}
-          <div className="flex shrink-0 items-center justify-between gap-4 py-4 [padding-inline:var(--mf-content-inset,0.875rem)]">
-            <div className="flex min-w-0 flex-1 items-center gap-3.5">
-              <div className="grid size-11 shrink-0 place-items-center rounded-xl bg-surface-overlay text-foreground-subtle [&>svg]:size-5">
-                <GitFork />
-              </div>
-              <div className="flex min-w-0 flex-1 flex-col justify-center">
-                {editingLabel ? (
-                  <input
-                    ref={labelRef}
-                    value={label}
-                    onChange={(e) => setLabel(e.target.value)}
-                    onBlur={() => setEditingLabel(false)}
-                    onKeyDown={(e) => {
-                      if (e.key === 'Enter' || e.key === 'Escape') setEditingLabel(false);
-                    }}
-                    className="w-full rounded bg-surface-overlay px-1.5 py-0.5 text-base font-semibold leading-5 tracking-[-0.3px] text-foreground outline-none ring-1 ring-brand"
-                    autoFocus
-                  />
-                ) : (
-                  <button
-                    type="button"
-                    onClick={() => {
-                      setEditingLabel(true);
-                      setTimeout(() => labelRef.current?.select(), 0);
-                    }}
-                    className="truncate rounded px-1.5 py-0.5 text-left text-base font-semibold leading-5 tracking-[-0.3px] text-foreground transition hover:bg-surface-overlay"
-                  >
-                    {label}
-                  </button>
-                )}
-                {editingCategory ? (
-                  <input
-                    ref={categoryRef}
-                    value={category}
-                    onChange={(e) => setCategory(e.target.value)}
-                    onBlur={() => setEditingCategory(false)}
-                    onKeyDown={(e) => {
-                      if (e.key === 'Enter' || e.key === 'Escape') setEditingCategory(false);
-                    }}
-                    className="w-full rounded bg-surface-overlay px-1.5 py-0.5 text-xs leading-4 text-foreground outline-none ring-1 ring-brand"
-                    autoFocus
-                  />
-                ) : (
-                  <button
-                    type="button"
-                    onClick={() => {
-                      setEditingCategory(true);
-                      setTimeout(() => categoryRef.current?.select(), 0);
-                    }}
-                    className="truncate rounded px-1.5 py-0.5 text-left text-xs leading-4 text-foreground-muted transition hover:bg-surface-overlay"
-                  >
-                    {category}
-                  </button>
-                )}
-              </div>
-            </div>
-            <div className="shrink-0">
-              <DebugButton />
-            </div>
-          </div>
-
           <Tabs defaultValue="parameters" className="flex min-h-0 flex-1 flex-col">
             <div className="shrink-0 pt-3 [padding-inline:var(--mf-content-inset,0.875rem)]">
               <TabsList className={TAB_LIST_CLASS}>
@@ -1380,8 +1241,6 @@ function InlineCaseRow({
   defaultValue?: string;
 }) {
   const fieldId = useId();
-  const [editingTitle, setEditingTitle] = useState(false);
-  const titleRef = useRef<HTMLInputElement>(null);
   const [value, setValue] = useState(defaultValue);
   const [locked, setLocked] = useState(false);
   const [mode, setMode] = useState<LockableValueFieldMode>('fixed');
@@ -1390,32 +1249,12 @@ function InlineCaseRow({
     <LockableValueField
       id={fieldId}
       label={
-        <div className="flex min-w-0 flex-1 items-center">
-          {editingTitle ? (
-            <input
-              ref={titleRef}
-              value={caseTitle}
-              onChange={(event) => onTitleChange(event.target.value)}
-              onBlur={() => setEditingTitle(false)}
-              onKeyDown={(event) => {
-                if (event.key === 'Enter' || event.key === 'Escape') setEditingTitle(false);
-              }}
-              className="min-w-0 flex-1 rounded bg-surface-overlay px-1 py-0.5 text-xs font-medium leading-4 text-foreground outline-none ring-1 ring-brand"
-              autoFocus
-            />
-          ) : (
-            <button
-              type="button"
-              onClick={() => {
-                setEditingTitle(true);
-                setTimeout(() => titleRef.current?.select(), 0);
-              }}
-              className="min-w-0 flex-1 truncate rounded px-1 py-0.5 text-left text-xs font-medium leading-4 text-foreground transition hover:bg-surface-overlay"
-            >
-              {caseTitle}
-            </button>
-          )}
-        </div>
+        <EditableText
+          value={caseTitle}
+          onChange={onTitleChange}
+          size="sm"
+          className="min-w-0 flex-1 font-medium text-foreground"
+        />
       }
       value={value}
       onValueChange={setValue}
@@ -2604,8 +2443,6 @@ function LockableCaseRow({
   /** Shows the insertion line below this row (the dragged item would land here). */
   insertAfter?: boolean;
 }) {
-  const [editingTitle, setEditingTitle] = useState(false);
-  const titleRef = useRef<HTMLInputElement>(null);
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
     id,
   });
@@ -2642,35 +2479,13 @@ function LockableCaseRow({
               >
                 <GripVertical size={12} />
               </button>
-              {editingTitle ? (
-                <input
-                  ref={titleRef}
-                  value={caseTitle}
-                  onChange={(e) => onTitleChange(e.target.value)}
-                  onBlur={() => setEditingTitle(false)}
-                  onKeyDown={(e) => {
-                    if (e.key === 'Enter' || e.key === 'Escape') setEditingTitle(false);
-                  }}
-                  className="min-w-0 flex-1 rounded bg-surface-overlay px-1 py-0.5 text-xs font-medium text-foreground outline-none ring-1 ring-brand"
-                  autoFocus
-                />
-              ) : (
-                <button
-                  type="button"
-                  onClick={() => {
-                    setEditingTitle(true);
-                    setTimeout(() => titleRef.current?.select(), 0);
-                  }}
-                  title={caseTitle}
-                  className="flex min-w-0 items-center rounded px-1 py-0.5 text-left text-xs font-medium text-foreground transition hover:bg-surface-overlay"
-                >
-                  {/* Single-line header row, so the title ellipsizes. The
-                      indicator sits outside the truncated run so the ellipsis
-                      cannot swallow it. */}
-                  <span className="truncate">{caseTitle}</span>
-                  {required && <RequiredIndicator className="shrink-0" />}
-                </button>
-              )}
+              <EditableText
+                value={caseTitle}
+                onChange={onTitleChange}
+                size="sm"
+                className="min-w-0 flex-1 font-medium text-foreground"
+              />
+              {required && <RequiredIndicator className="shrink-0" />}
             </div>
           }
           headerActions={
@@ -3034,10 +2849,6 @@ export function QuickFormPanel({
   const [formView, setFormView] = useState<'edit' | 'json'>('edit');
   const [formTitle, setFormTitle] = useState('Quick Approve');
   const [formDescription, setFormDescription] = useState('Add a description');
-  const [editingFormTitle, setEditingFormTitle] = useState(false);
-  const [editingFormDescription, setEditingFormDescription] = useState(false);
-  const formTitleRef = useRef<HTMLInputElement>(null);
-  const formDescriptionRef = useRef<HTMLInputElement>(null);
   const [jsonDraft, setJsonDraft] = useState(() => JSON.stringify(DEFAULT_LOCKABLE_CASES, null, 2));
   const [jsonError, setJsonError] = useState<string | null>(null);
   const [jsonCopied, setJsonCopied] = useState(false);
@@ -3273,55 +3084,8 @@ export function QuickFormPanel({
                     </HoverCardContent>
                   </HoverCard>
                   <div className="flex min-w-0 flex-1 flex-col justify-center">
-                    {editingFormTitle ? (
-                      <input
-                        ref={formTitleRef}
-                        value={formTitle}
-                        onChange={(e) => setFormTitle(e.target.value)}
-                        onBlur={() => setEditingFormTitle(false)}
-                        onKeyDown={(e) => {
-                          if (e.key === 'Enter' || e.key === 'Escape') setEditingFormTitle(false);
-                        }}
-                        className="rounded bg-surface-overlay px-1 text-base font-semibold leading-5 tracking-[-0.3px] text-foreground outline-none ring-1 ring-brand"
-                        autoFocus
-                      />
-                    ) : (
-                      <button
-                        type="button"
-                        onClick={() => {
-                          setEditingFormTitle(true);
-                          setTimeout(() => formTitleRef.current?.select(), 0);
-                        }}
-                        className="truncate rounded px-1 text-left text-base font-semibold leading-5 tracking-[-0.3px] text-foreground transition hover:bg-surface-overlay"
-                      >
-                        {formTitle}
-                      </button>
-                    )}
-                    {editingFormDescription ? (
-                      <input
-                        ref={formDescriptionRef}
-                        value={formDescription}
-                        onChange={(e) => setFormDescription(e.target.value)}
-                        onBlur={() => setEditingFormDescription(false)}
-                        onKeyDown={(e) => {
-                          if (e.key === 'Enter' || e.key === 'Escape')
-                            setEditingFormDescription(false);
-                        }}
-                        className="rounded bg-surface-overlay px-1 text-xs leading-4 text-foreground outline-none ring-1 ring-brand"
-                        autoFocus
-                      />
-                    ) : (
-                      <button
-                        type="button"
-                        onClick={() => {
-                          setEditingFormDescription(true);
-                          setTimeout(() => formDescriptionRef.current?.select(), 0);
-                        }}
-                        className="truncate rounded px-1 text-left text-xs leading-4 text-foreground-muted transition hover:bg-surface-overlay hover:text-foreground"
-                      >
-                        {formDescription}
-                      </button>
-                    )}
+                    <EditableText value={formTitle} onChange={setFormTitle} size="lg" />
+                    <EditableText value={formDescription} onChange={setFormDescription} size="sm" />
                   </div>
                 </div>
                 {formView === 'edit' && (


### PR DESCRIPTION
## Demo

### Before

**Storybook**
<img width="858" height="1148" alt="2026-09-04 16 35 05" src="https://github.com/user-attachments/assets/1d99882f-055a-475d-bd9a-26b14fc6d1fb" />

**Flow**
<img width="2744" height="1816" alt="2026-09-04 16 36 50" src="https://github.com/user-attachments/assets/4b571287-7882-4d77-bc15-fc954ab0835e" />

### After

**Storybook**
<img width="970" height="1124" alt="2026-09-04 16 29 00" src="https://github.com/user-attachments/assets/c533c91b-cdb2-4d17-967b-cf1cced140ab" />

**Flow**