### PR TITLE
feat(apollo-react): virtualize JsonTree rows behind an opt-in prop

### DIFF
--- a/packages/apollo-react/src/canvas/components/JsonTree/JsonTree.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/JsonTree/JsonTree.stories.tsx
@@ -1,0 +1,137 @@
+import type { Meta, StoryFn } from '@storybook/react';
+import { useMemo, useState } from 'react';
+import { Column, Row } from '../../layouts';
+import { buildJsonTree } from './buildJsonTree';
+import type { JsonTreeNode } from './JsonTree.types';
+import { JsonTree } from './JsonTree';
+
+export default {
+  title: 'Components/JsonTree',
+  parameters: {
+    layout: 'fullscreen',
+  },
+} satisfies Meta;
+
+const RECORD_COUNT = 20_000;
+
+/**
+ * A connector-style response: a status, headers, and a page of records. Built on first
+ * render and cached, so opening any other story does not pay for 20k records.
+ */
+let cachedNodes: JsonTreeNode[] | undefined;
+function useLargeTree(): JsonTreeNode[] {
+  return useMemo(() => {
+    cachedNodes ??= buildJsonTree({
+      value: {
+        code: 200,
+        headers: { 'content-type': 'application/json', 'x-request-id': 'b2c4a9e0' },
+        body: Array.from({ length: RECORD_COUNT }, (_, index) => ({
+          id: `9e415fe5-${index.toString(16).padStart(8, '0')}`,
+          name: `Record ${index}`,
+          isActive: index % 3 !== 0,
+          tags: ['alpha', 'beta'],
+        })),
+      },
+    });
+    return cachedNodes;
+  }, []);
+}
+
+function useCollapsed() {
+  const [collapsed, setCollapsed] = useState<Record<string, boolean>>({});
+  const toggle = (path: string) => setCollapsed((prev) => ({ ...prev, [path]: !prev[path] }));
+  return { collapsed, toggle };
+}
+
+const frame = { background: 'var(--canvas-background)', color: 'var(--canvas-foreground)' };
+
+/** Only the rows in view mount; the tree scrolls inside its own box, capped at the viewport height. */
+export const VirtualizedOwnScrollBox: StoryFn = () => {
+  const nodes = useLargeTree();
+  const { collapsed, toggle } = useCollapsed();
+  return (
+    <Column p={24} gap={12} minH="100vh" style={frame}>
+      <span style={{ fontSize: 14 }}>
+        {RECORD_COUNT.toLocaleString()} records, every container expanded. Scroll the tree.
+      </span>
+      <JsonTree
+        nodes={nodes}
+        collapsed={collapsed}
+        onToggleCollapsed={toggle}
+        readOnly
+        virtualized
+      />
+    </Column>
+  );
+};
+
+/** The tree grows to its content and windows rows by the panel's scroll position: one scrollbar. */
+export const VirtualizedInsidePanel: StoryFn = () => {
+  const nodes = useLargeTree();
+  const { collapsed, toggle } = useCollapsed();
+  const [panel, setPanel] = useState<HTMLDivElement | null>(null);
+  return (
+    <Column p={24} gap={12} h="100vh" style={frame}>
+      <span style={{ fontSize: 14 }}>A panel with content above the tree. Scroll the panel.</span>
+      <div
+        ref={setPanel}
+        style={{
+          flex: 1,
+          minHeight: 0,
+          overflowY: 'auto',
+          border: '1px solid var(--canvas-border)',
+        }}
+      >
+        <Row p={16} style={{ borderBottom: '1px solid var(--canvas-border)' }}>
+          <span style={{ fontSize: 14, fontWeight: 500 }}>Input</span>
+        </Row>
+        <Row p={16} style={{ borderBottom: '1px solid var(--canvas-border)' }}>
+          <span style={{ fontSize: 14, fontWeight: 500 }}>Output</span>
+        </Row>
+        <JsonTree
+          nodes={nodes}
+          collapsed={collapsed}
+          onToggleCollapsed={toggle}
+          readOnly
+          virtualized
+          scrollElement={panel}
+        />
+      </div>
+    </Column>
+  );
+};
+
+/**
+ * Editing survives the window moving: start editing a value, scroll it out of view, scroll back,
+ * and the draft is still there. The row being edited stays mounted wherever the window goes.
+ */
+export const VirtualizedEditable: StoryFn = () => {
+  const nodes = useLargeTree();
+  const { collapsed, toggle } = useCollapsed();
+  const [lastEdit, setLastEdit] = useState<string>('nothing committed yet');
+  return (
+    <Column p={24} gap={12} minH="100vh" style={frame}>
+      <span style={{ fontSize: 14 }}>Click a value to edit it, scroll away, then scroll back.</span>
+      <span style={{ fontSize: 14 }}>Last commit: {lastEdit}</span>
+      <JsonTree
+        nodes={nodes}
+        collapsed={collapsed}
+        onToggleCollapsed={toggle}
+        onEdit={(node, value) => setLastEdit(`${node.path} = ${JSON.stringify(value)}`)}
+        virtualized
+      />
+    </Column>
+  );
+};
+
+/** Baseline: every row mounts. Kept for comparison; expect a long first paint at this size. */
+export const NotVirtualized: StoryFn = () => {
+  const nodes = useLargeTree();
+  const { collapsed, toggle } = useCollapsed();
+  return (
+    <Column p={24} gap={12} minH="100vh" style={frame}>
+      <span style={{ fontSize: 14 }}>Same value without virtualization.</span>
+      <JsonTree nodes={nodes} collapsed={collapsed} onToggleCollapsed={toggle} readOnly />
+    </Column>
+  );
+};

--- a/packages/apollo-react/src/canvas/components/JsonTree/JsonTree.test.tsx
+++ b/packages/apollo-react/src/canvas/components/JsonTree/JsonTree.test.tsx
@@ -1,0 +1,265 @@
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen } from '../../utils/testing';
+import { buildJsonTree } from './buildJsonTree';
+import { JsonTree } from './JsonTree';
+import { ROW_MIN_HEIGHT_PX } from './JsonTreeRow';
+
+interface VirtualizerOptions {
+  count: number;
+  getItemKey?: (index: number) => string | number;
+  scrollMargin?: number;
+}
+
+const WINDOW_SIZE = 3;
+const virtualizerCalls: VirtualizerOptions[] = [];
+// Driven per test: where the window sits, and whether a scroll is in flight.
+let windowStart = 0;
+let isScrolling = false;
+
+// The virtualizer needs a laid-out scroll element, which happy-dom has none of.
+// Standing in for it with a movable window exercises the tree's side of the
+// contract: what it hands the virtualizer and what it does with the items back.
+vi.mock('@tanstack/react-virtual', () => ({
+  useVirtualizer: (options: VirtualizerOptions) => {
+    virtualizerCalls.push(options);
+    const scrollMargin = options.scrollMargin ?? 0;
+    const measure = (index: number) => ({
+      index,
+      key: options.getItemKey?.(index) ?? index,
+      start: scrollMargin + index * ROW_MIN_HEIGHT_PX,
+      end: scrollMargin + (index + 1) * ROW_MIN_HEIGHT_PX,
+      size: ROW_MIN_HEIGHT_PX,
+      lane: 0,
+    });
+    const windowed = Array.from(
+      { length: Math.max(0, Math.min(WINDOW_SIZE, options.count - windowStart)) },
+      (_, offset) => measure(windowStart + offset)
+    );
+    return {
+      getVirtualItems: () => windowed,
+      getTotalSize: () => options.count * ROW_MIN_HEIGHT_PX,
+      measureElement: () => {},
+      measurementsCache: Array.from({ length: options.count }, (_, index) => measure(index)),
+      options: { scrollMargin },
+      scrollElement: null,
+      isScrolling,
+    };
+  },
+}));
+
+/** happy-dom reports every rect as zero, so the offsets the effect reads are stubbed in. */
+function stubOffsets(
+  container: HTMLElement,
+  scroller: HTMLElement,
+  tops: { container: number; scroller: number; scrollTop: number }
+) {
+  container.getBoundingClientRect = () => ({ top: tops.container }) as DOMRect;
+  scroller.getBoundingClientRect = () => ({ top: tops.scroller }) as DOMRect;
+  Object.defineProperty(scroller, 'scrollTop', { value: tops.scrollTop, configurable: true });
+}
+
+const lastScrollMargin = () => virtualizerCalls.at(-1)?.scrollMargin;
+
+const FIELD_COUNT = 40;
+const value = Object.fromEntries(
+  Array.from({ length: FIELD_COUNT }, (_, index) => [`field${index}`, `value${index}`])
+);
+const nodes = buildJsonTree({ value });
+
+describe('JsonTree', () => {
+  beforeEach(() => {
+    virtualizerCalls.length = 0;
+    windowStart = 0;
+    isScrolling = false;
+  });
+
+  it('mounts every row by default', () => {
+    render(<JsonTree nodes={nodes} readOnly />);
+
+    expect(screen.getByText('field0')).toBeInTheDocument();
+    expect(screen.getByText(`field${FIELD_COUNT - 1}`)).toBeInTheDocument();
+  });
+
+  it('mounts only the rows the virtualizer reports when virtualized', () => {
+    render(<JsonTree nodes={nodes} readOnly virtualized />);
+
+    expect(screen.getByText('field0')).toBeInTheDocument();
+    expect(screen.getByText(`field${WINDOW_SIZE - 1}`)).toBeInTheDocument();
+    expect(screen.queryByText(`field${WINDOW_SIZE}`)).not.toBeInTheDocument();
+  });
+
+  it('reserves the full height and positions each row at its offset', () => {
+    render(<JsonTree nodes={nodes} readOnly virtualized />);
+
+    const rowHost = screen.getByText('field1').closest('[data-index]') as HTMLElement;
+    expect(rowHost.dataset.index).toBe('1');
+    expect(rowHost.style.transform).toBe(`translateY(${ROW_MIN_HEIGHT_PX}px)`);
+    expect((rowHost.parentElement as HTMLElement).style.height).toBe(
+      `${FIELD_COUNT * ROW_MIN_HEIGHT_PX}px`
+    );
+  });
+
+  it('caps its own scroll box at the viewport so rows out of view never mount', () => {
+    const { container: plain } = render(<JsonTree nodes={nodes} readOnly />);
+    const { container: virtual } = render(<JsonTree nodes={nodes} readOnly virtualized />);
+
+    expect((plain.querySelector('.overflow-y-auto') as HTMLElement).className).not.toContain(
+      'max-h-screen'
+    );
+    const scrollBox = virtual.querySelector('.overflow-y-auto') as HTMLElement;
+    expect(scrollBox.className).toContain('max-h-screen');
+    expect(scrollBox.className).toContain('[overflow-anchor:none]');
+  });
+
+  it('grows to its content and scrolls with the given ancestor instead of its own box', () => {
+    const scroller = document.createElement('div');
+    const { container } = render(
+      <JsonTree nodes={nodes} readOnly virtualized scrollElement={scroller} />
+    );
+
+    // Nothing here may scroll or be capped, or the ancestor's scrollbar would be the second one
+    // and the virtualizer would listen to an element the user is not scrolling.
+    const treeBox = container.firstElementChild as HTMLElement;
+    expect(treeBox.className).not.toContain('overflow-y-auto');
+    expect(treeBox.className).not.toContain('h-full');
+    expect(treeBox.className).not.toContain('max-h-screen');
+    // Offsets stay relative to the tree: the virtualizer's start includes the scroll margin, the row subtracts it.
+    const rowHost = screen.getByText('field1').closest('[data-index]') as HTMLElement;
+    expect(rowHost.style.transform).toBe(`translateY(${ROW_MIN_HEIGHT_PX}px)`);
+  });
+
+  it('measures how far it sits down the ancestor scroller and passes that as the margin', () => {
+    const scroller = document.createElement('div');
+    // A fresh element each time: React skips re-rendering a referentially identical one.
+    const view = () => <JsonTree nodes={nodes} readOnly virtualized scrollElement={scroller} />;
+    const { container, rerender } = render(view());
+    expect(lastScrollMargin()).toBe(0);
+
+    stubOffsets(container.firstElementChild as HTMLElement, scroller, {
+      container: 200,
+      scroller: 50,
+      scrollTop: 10,
+    });
+    rerender(view());
+
+    // 200 - 50 + 10: the tree's top within the scroller's content.
+    expect(lastScrollMargin()).toBe(160);
+  });
+
+  it('drops the margin when the ancestor scroller goes away', () => {
+    const scroller = document.createElement('div');
+    const { container, rerender } = render(
+      <JsonTree nodes={nodes} readOnly virtualized scrollElement={scroller} />
+    );
+    stubOffsets(container.firstElementChild as HTMLElement, scroller, {
+      container: 200,
+      scroller: 50,
+      scrollTop: 10,
+    });
+    rerender(<JsonTree nodes={nodes} readOnly virtualized scrollElement={scroller} />);
+    expect(lastScrollMargin()).toBe(160);
+
+    // A stale margin here would shift every measurement while the offset restarts at 0.
+    rerender(<JsonTree nodes={nodes} readOnly virtualized scrollElement={null} />);
+
+    expect(lastScrollMargin()).toBe(0);
+  });
+
+  it('does not re-measure mid-scroll', () => {
+    const scroller = document.createElement('div');
+    const view = () => <JsonTree nodes={nodes} readOnly virtualized scrollElement={scroller} />;
+    const { container, rerender } = render(view());
+    stubOffsets(container.firstElementChild as HTMLElement, scroller, {
+      container: 200,
+      scroller: 50,
+      scrollTop: 10,
+    });
+    isScrolling = true;
+    rerender(view());
+
+    // Reading rects on every tick would force layout, and the offset cannot change while scrolling.
+    expect(lastScrollMargin()).toBe(0);
+  });
+
+  it('keeps the row being edited mounted after the window moves past it', async () => {
+    const onEdit = vi.fn();
+    const view = () => <JsonTree nodes={nodes} virtualized onEdit={onEdit} />;
+    const { rerender } = render(view());
+
+    await userEvent.click(screen.getByRole('button', { name: 'Edit value of field0' }));
+    expect(screen.getByDisplayValue('value0')).toBeInTheDocument();
+
+    windowStart = 20;
+    rerender(view());
+
+    // The window really moved: field0's neighbours are gone and the new range is mounted.
+    expect(screen.getByText('field20')).toBeInTheDocument();
+    expect(screen.queryByText('field1')).not.toBeInTheDocument();
+    // An editor commits on blur, and React fires no focusout for a removed node, so unmounting
+    // the row would silently drop what was typed.
+    expect(screen.getByDisplayValue('value0')).toBeInTheDocument();
+
+    // Pinned, it still sits at its own offset rather than inside the window, and stays ahead of
+    // the window in the DOM so it tabs and reads in list order.
+    const hosts = [...document.querySelectorAll('[data-index]')] as HTMLElement[];
+    const indices = hosts.map((host) => Number(host.dataset.index));
+    expect(indices).toEqual([...indices].sort((a, b) => a - b));
+    const pinned = hosts.find((host) => host.dataset.index === '0') as HTMLElement;
+    expect(pinned.style.transform).toBe('translateY(0px)');
+  });
+
+  it('renders the pinned row once, with its draft intact, when the window returns to it', async () => {
+    const onEdit = vi.fn();
+    const view = () => <JsonTree nodes={nodes} virtualized onEdit={onEdit} />;
+    const { rerender } = render(view());
+
+    await userEvent.click(screen.getByRole('button', { name: 'Edit value of field0' }));
+    await userEvent.clear(screen.getByDisplayValue('value0'));
+    await userEvent.type(screen.getByRole('textbox'), 'typed while scrolling');
+
+    windowStart = 20;
+    rerender(view());
+    windowStart = 0;
+    rerender(view());
+
+    // Back in the window it is an ordinary row again, not a second copy of itself, and the
+    // draft survived both transitions because the row is keyed by path.
+    expect(screen.getAllByText('field0')).toHaveLength(1);
+    expect(screen.getByDisplayValue('typed while scrolling')).toBeInTheDocument();
+    expect(onEdit).not.toHaveBeenCalled();
+  });
+
+  it('renders each row once when a value is refreshed under an open editor', async () => {
+    const onEdit = vi.fn();
+    const view = (tree: typeof nodes) => <JsonTree nodes={tree} virtualized onEdit={onEdit} />;
+    const { rerender } = render(view(nodes));
+    await userEvent.click(screen.getByRole('button', { name: 'Edit value of field0' }));
+    windowStart = 20;
+    rerender(view(nodes));
+
+    // A poll rebuilds the nodes while the row stays pinned: same paths, new objects.
+    rerender(view(buildJsonTree({ value })));
+
+    expect(screen.getAllByText('field0')).toHaveLength(1);
+    expect(screen.getByDisplayValue('value0')).toBeInTheDocument();
+  });
+
+  it('keys rows by their new path after the rows reorder', () => {
+    const reordered = buildJsonTree({ value: { later: 'x', ...value } });
+    const { rerender } = render(<JsonTree nodes={nodes} readOnly virtualized />);
+    expect(virtualizerCalls.at(-1)?.getItemKey?.(0)).toBe('field0');
+
+    rerender(<JsonTree nodes={reordered} readOnly virtualized />);
+
+    expect(virtualizerCalls.at(-1)?.getItemKey?.(0)).toBe('later');
+  });
+
+  it('keys rows by path so row state survives the window moving', () => {
+    render(<JsonTree nodes={nodes} readOnly virtualized />);
+
+    const options = virtualizerCalls.at(-1);
+    expect(options?.count).toBe(FIELD_COUNT);
+    expect(options?.getItemKey?.(1)).toBe('field1');
+  });
+});

--- a/packages/apollo-react/src/canvas/components/JsonTree/JsonTree.tsx
+++ b/packages/apollo-react/src/canvas/components/JsonTree/JsonTree.tsx
@@ -1,7 +1,9 @@
+import { useVirtualizer, type VirtualItem } from '@tanstack/react-virtual';
 import { cn } from '@uipath/apollo-wind';
 import { TooltipProvider } from '@uipath/apollo-wind/components/ui/tooltip';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { type RefObject, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useSafeLingui } from '../../../i18n';
+import { useIsomorphicLayoutEffect } from '../../hooks/useIsomorphicLayoutEffect';
 import { CanvasTooltipProviderMarker } from '../CanvasTooltip';
 import { flattenJsonTree } from './buildJsonTree';
 import { copyTextToClipboard } from './clipboard';
@@ -20,6 +22,7 @@ import {
   JsonTreeRow,
   JsonTreeRowContextProvider,
   type JsonTreeRowContextValue,
+  ROW_MIN_HEIGHT_PX,
 } from './JsonTreeRow';
 
 export interface JsonTreeProps {
@@ -68,8 +71,147 @@ export interface JsonTreeProps {
   pathForCopy?: (path: string) => string;
   /** Called after something is copied to the clipboard. */
   onCopy?: (event: CopyEvent) => void;
+  /**
+   * Mounts only the rows in view (plus a small overscan) instead of every row,
+   * for values with thousands of fields. Rows are measured, so wrapped values
+   * and inline editors keep their height. The tree scrolls inside its own box,
+   * capped at the viewport height, unless `scrollElement` names the scroller.
+   * Off by default.
+   */
+  virtualized?: boolean;
+  /**
+   * With `virtualized`, the ancestor that scrolls the tree. The tree then grows
+   * to its content and windows its rows by that element's scroll position, so
+   * the panel keeps its single scrollbar. The element must be height-bound: one
+   * that grows with its content never scrolls, and every row would count as in
+   * view.
+   */
+  scrollElement?: HTMLElement | null;
   emptyMessage?: string;
   className?: string;
+}
+
+type FlatRows = ReturnType<typeof flattenJsonTree>;
+
+const VIRTUAL_OVERSCAN = 10;
+
+/** Where the tree's top sits in the scroll element's content, so row offsets stay relative to the tree. */
+function scrollMarginOf(element: HTMLElement, scrollElement: HTMLElement): number {
+  // Whole pixels: sub-pixel drift between renders would otherwise update state every frame.
+  return Math.round(
+    element.getBoundingClientRect().top -
+      scrollElement.getBoundingClientRect().top +
+      scrollElement.scrollTop
+  );
+}
+
+/**
+ * Scrolls against the consumer's `scrollElement` when given, else the tree's own
+ * container. Either must be height-bound: an overflow box that grows with its
+ * content never scrolls, so every row would count as "in view" and mount —
+ * which is why the own container is capped at the viewport height.
+ */
+function VirtualRows({
+  rows,
+  containerRef,
+  scrollElement,
+  pinnedPaths,
+}: {
+  rows: FlatRows;
+  containerRef: RefObject<HTMLDivElement | null>;
+  scrollElement?: HTMLElement | null;
+  /** Rows that must stay mounted wherever the window is (see `pinnedItems`). */
+  pinnedPaths: readonly string[];
+}) {
+  const [scrollMargin, setScrollMargin] = useState(0);
+  const getItemKey = useCallback((index: number) => rows[index]?.node.path ?? index, [rows]);
+  const virtualizer = useVirtualizer({
+    count: rows.length,
+    getScrollElement: () => scrollElement ?? containerRef.current,
+    estimateSize: () => ROW_MIN_HEIGHT_PX,
+    getItemKey,
+    overscan: VIRTUAL_OVERSCAN,
+    scrollMargin,
+  });
+
+  // Content above the tree in a shared scroller can grow or shrink (a sibling section
+  // collapsing), so the offset is re-read after every render but never mid-scroll: the two
+  // rect reads would force layout on each tick, and the offset cannot change while scrolling
+  // anyway (the tree's top moves up by exactly the scroll delta).
+  useIsomorphicLayoutEffect(() => {
+    const container = containerRef.current;
+    // The scroller can go away while this stays mounted (a panel collapsing, a tab switching).
+    // A margin left over from it would shift every measurement while the offset restarts at 0,
+    // and the row transform and total size both subtract it, so only scrolling would look wrong.
+    if (!container || !scrollElement) {
+      if (scrollMargin !== 0) setScrollMargin(0);
+      return;
+    }
+    if (virtualizer.isScrolling) return;
+    const next = scrollMarginOf(container, scrollElement);
+    if (next !== scrollMargin) setScrollMargin(next);
+  });
+
+  const isPinning = pinnedPaths.length > 0;
+  // Built only while a row is pinned, so a scroll frame never scans every row to place it.
+  const indexByPath = useMemo(() => {
+    if (!isPinning) return undefined;
+    const byPath = new Map<string, number>();
+    rows.forEach((row, index) => byPath.set(row.node.path, index));
+    return byPath;
+  }, [isPinning, rows]);
+
+  const items = virtualizer.getVirtualItems();
+  // The window is one ascending, contiguous range, so "is this row already rendered" is a bounds
+  // check rather than a lookup table rebuilt on every scroll frame. Empty window: nothing is in it.
+  const firstWindowed = items[0]?.index ?? -1;
+  const lastWindowed = items[items.length - 1]?.index ?? -2;
+
+  // An open editor holds its draft in local state and commits on blur, but React dispatches no
+  // focusout for a focused node that is removed, so unmounting the row being edited would throw
+  // away what was typed. Keep those rows mounted even when the window has moved past them.
+  const pinnedItems: VirtualItem[] = [];
+  if (indexByPath) {
+    for (const path of pinnedPaths) {
+      const index = indexByPath.get(path);
+      if (index === undefined || (index >= firstWindowed && index <= lastWindowed)) continue;
+      // Measured offsets for every index, so a row outside the window still lands where it belongs.
+      const measurement = virtualizer.measurementsCache[index];
+      if (measurement) pinnedItems.push(measurement);
+    }
+  }
+
+  // A pinned row lies outside the window, so it slots in before or after it and no sort is
+  // needed. Order matters: appended last, it would tab and read out of sequence, and would move
+  // in the DOM once the window reached it.
+  const rendered =
+    pinnedItems.length === 0
+      ? items
+      : [
+          ...pinnedItems.filter((item) => item.index < firstWindowed),
+          ...items,
+          ...pinnedItems.filter((item) => item.index > lastWindowed),
+        ];
+
+  return (
+    <div className="relative" style={{ height: virtualizer.getTotalSize() }}>
+      {rendered.map((item) => {
+        const row = rows[item.index];
+        if (!row) return null;
+        return (
+          <div
+            key={item.key}
+            data-index={item.index}
+            ref={virtualizer.measureElement}
+            className="absolute top-0 left-0 w-full"
+            style={{ transform: `translateY(${item.start - virtualizer.options.scrollMargin}px)` }}
+          >
+            <JsonTreeRow node={row.node} depth={row.depth} />
+          </div>
+        );
+      })}
+    </div>
+  );
 }
 
 function valueAsText(node: JsonTreeNode): string {
@@ -107,14 +249,25 @@ export function JsonTree({
   renderCodeEditor,
   pathForCopy,
   onCopy,
+  virtualized = false,
+  scrollElement,
   emptyMessage,
   className,
 }: JsonTreeProps) {
   const { _ } = useSafeLingui();
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const usesAncestorScroller = virtualized && !!scrollElement;
   const RowWrapper = rowWrapper ?? DefaultRowWrapper;
   const [editingPath, setEditingPath] = useState<string | null>(null);
   const [jsonEditingPath, setJsonEditingPath] = useState<string | null>(null);
   const [wrappedPaths, setWrappedPaths] = useState<Record<string, boolean>>({});
+  // Unmounting a row mid-edit loses the draft, so a virtualized tree keeps these mounted.
+  const pinnedPaths = useMemo(
+    () => [
+      ...new Set([editingPath, jsonEditingPath].filter((path): path is string => path !== null)),
+    ],
+    [editingPath, jsonEditingPath]
+  );
   const [copied, setCopied] = useState<{
     path: string;
     kind: CopyEvent['kind'];
@@ -219,10 +372,33 @@ export function JsonTree({
     <TooltipProvider delayDuration={300} skipDelayDuration={100}>
       <CanvasTooltipProviderMarker>
         <JsonTreeRowContextProvider value={rowContext}>
-          <div className={cn('h-full overflow-y-auto overflow-x-hidden', className)}>
-            {rows.map(({ node, depth }) => (
-              <JsonTreeRow key={node.path} node={node} depth={depth} />
-            ))}
+          <div
+            ref={containerRef}
+            className={cn(
+              // Scrolled by an ancestor: grow to content and scroll nothing here. `clip`, not
+              // `hidden`: per CSS Overflow 3, `hidden` on one axis makes a `visible` other axis
+              // compute to `auto`, which would silently make this a scroll container again.
+              usesAncestorScroller ? 'overflow-x-clip' : 'h-full overflow-y-auto overflow-x-hidden',
+              // Nothing taller than the viewport is on screen at once, and an unbounded scroll box
+              // would put every row "in view" and mount all of them.
+              virtualized && !usesAncestorScroller && 'max-h-screen',
+              // Rows mounting and unmounting as the window moves would otherwise read as content shifting.
+              virtualized && '[overflow-anchor:none]',
+              className
+            )}
+          >
+            {virtualized ? (
+              <VirtualRows
+                rows={rows}
+                containerRef={containerRef}
+                scrollElement={scrollElement}
+                pinnedPaths={pinnedPaths}
+              />
+            ) : (
+              rows.map(({ node, depth }) => (
+                <JsonTreeRow key={node.path} node={node} depth={depth} />
+              ))
+            )}
             {rows.length === 0 && (
               <span className="p-4 text-center text-xs text-foreground-subtle">
                 {resolvedEmptyMessage}

--- a/packages/apollo-react/src/canvas/components/JsonTree/JsonTreeRow.tsx
+++ b/packages/apollo-react/src/canvas/components/JsonTree/JsonTreeRow.tsx
@@ -28,6 +28,9 @@ import { ScalarValueCell, valueColorClass } from './ScalarValueCell';
 // editing, which would otherwise let the row collapse to the badge height.
 const ROW_CLASS =
   'group flex min-h-7 cursor-default items-center gap-1.5 py-1 pr-1 transition hover:bg-surface-overlay';
+/** `min-h-7` above (1.75rem) in px at the default root size: the virtualizer's estimate
+ *  until each row is measured, so a different root size costs accuracy but not correctness. */
+export const ROW_MIN_HEIGHT_PX = 28;
 
 // Wrapper for a value cell. `flex-1` lets it fill the space between the key
 // and the row actions, `min-w-8` keeps a sliver of it legible when squeezed.

--- a/packages/apollo-react/src/canvas/components/NodeIOView/NodeIOView.tsx
+++ b/packages/apollo-react/src/canvas/components/NodeIOView/NodeIOView.tsx
@@ -93,6 +93,7 @@ export function NodeIOView({
   renderCodeEditor,
   pathForCopy,
   onCopy,
+  virtualized = false,
   defaultCollapsedDepth = 2,
   className,
 }: NodeIOViewProps) {
@@ -267,6 +268,7 @@ export function NodeIOView({
               renderCodeEditor={renderCodeEditor}
               pathForCopy={pathForCopy}
               onCopy={onCopy}
+              virtualized={virtualized}
               // JsonTree shows its own "no match" text while a search or
               // filter is active; this only covers the genuinely-empty case.
               emptyMessage={emptyMessage}

--- a/packages/apollo-react/src/canvas/components/NodeIOView/NodeIOView.types.ts
+++ b/packages/apollo-react/src/canvas/components/NodeIOView/NodeIOView.types.ts
@@ -99,6 +99,8 @@ export interface NodeIOViewProps {
   pathForCopy?: (path: string) => string;
   /** Called after something is copied to the clipboard. */
   onCopy?: (event: CopyEvent) => void;
+  /** Windows the schema tree's rows so only those in view mount. See `JsonTreeProps.virtualized`. */
+  virtualized?: boolean;
   /** Containers at depth >= this start collapsed. Default 2 (top two levels open). */
   defaultCollapsedDepth?: number;
   className?: string;


### PR DESCRIPTION
## Problem

`JsonTree` mounts one row per field with every container expanded. A JSON value with thousands of fields (a connector response, a large node output) therefore commits the whole tree in a single pass and blocks the main thread long enough for the host to look hung. In a host that shares a renderer with other UI, a large enough value can exhaust it outright.

## Change

Two new props on `JsonTree`, both off by default, so every existing consumer renders exactly as before.

**`virtualized`** windows the rows through `@tanstack/react-virtual` (already a dependency, used by `ap-model-picker`'s `OptionList`):

- only the rows in view plus a small overscan mount
- each row is measured via `measureElement`, so wrapped values and open inline editors keep their real height
- rows are keyed by node path, so edit, wrap and copy state survives the window moving
- `estimateSize` uses `ROW_MIN_HEIGHT_PX`, now exported next to `ROW_CLASS` in `JsonTreeRow` so the estimate and the row's `min-h-7` cannot drift apart

**`scrollElement`** names the ancestor that scrolls the tree, for consumers whose panel already has a scrollbar.

A virtualizer needs a bounded scroll box: an overflow container that grows with its content never scrolls, so every row counts as "in view" and all of them mount regardless. Two shapes are supported:

| | Scroller | Tree height |
|---|---|---|
| `virtualized` alone | the tree's own container | capped at `100vh` so it is always bounded |
| `virtualized` + `scrollElement` | the consumer's panel | grows to content; rows are offset by `scrollMargin` |

The second is what keeps a panel's single scrollbar instead of nesting a second one. The cap is set inline rather than as a utility class so it cannot depend on a consumer's CSS build emitting it, and the virtualized container sets `overflow-anchor: none` (as TanStack's own dynamic example does) so mounting and unmounting rows is not read as content shifting.

`NodeIOView` forwards `virtualized` to the schema tree it hosts.

## Verification

- `pnpm exec tsc --noEmit` clean, `biome lint` and `biome format` clean
- `vitest` 98 passing across `JsonTree` and `NodeIOView`, including 6 new tests: default mounts every row, virtualized mounts only the reported window, the spacer reserves full height and rows carry their offset, rows are keyed by path, the own scroll box is capped, and `scrollElement` grows to content instead
- 3 new stories (`Components/JsonTree`) covering the own-scroll-box, inside-a-panel and non-virtualized cases at 20k records

Exercised against a 4.9 MB / 112k-field connector response in a downstream consumer: the tree renders and scrolls with roughly 40 rows mounted.

## Notes for review

- `getScrollElement` is called on every virtualizer update and re-initialises when the element changes, so a `scrollElement` that resolves after mount (a wrapper that owns its own scroll viewport, for instance) is handled without extra plumbing.
- `scrollMargin` is derived from bounding rects rather than `offsetTop`, since the scroller may be any ancestor rather than the offset parent, and is rounded to whole pixels so sub-pixel drift cannot re-set state each frame.
