### PR TITLE
fix(apollo-wind): tag the PromptEditor placeholder with a data-slot

### DIFF
--- a/packages/apollo-wind/src/components/ui/prompt-editor/prompt-editor.test.tsx
+++ b/packages/apollo-wind/src/components/ui/prompt-editor/prompt-editor.test.tsx
@@ -35,6 +35,14 @@ describe('PromptEditor', () => {
   });
 
   describe('rendering', () => {
+    it('tags the placeholder with a stable slot for host styling', () => {
+      render(<PromptEditor placeholder="Type here…" ariaLabel="Prompt" />);
+      const slot = document.querySelector('[data-slot="prompt-editor-placeholder"]');
+      expect(slot).not.toBeNull();
+      expect(slot?.textContent).toBe('Type here…');
+    });
+
+
     it('renders an editable textbox with the given aria-label', () => {
       render(<PromptEditor ariaLabel="Prompt" />);
       const editor = screen.getByRole('textbox', { name: 'Prompt' });

--- a/packages/apollo-wind/src/components/ui/prompt-editor/prompt-editor.test.tsx
+++ b/packages/apollo-wind/src/components/ui/prompt-editor/prompt-editor.test.tsx
@@ -37,11 +37,11 @@ describe('PromptEditor', () => {
   describe('rendering', () => {
     it('tags the placeholder with a stable slot for host styling', () => {
       render(<PromptEditor placeholder="Type here…" ariaLabel="Prompt" />);
-      const slot = document.querySelector('[data-slot="prompt-editor-placeholder"]');
-      expect(slot).not.toBeNull();
-      expect(slot?.textContent).toBe('Type here…');
+      expect(screen.getByText('Type here…')).toHaveAttribute(
+        'data-slot',
+        'prompt-editor-placeholder'
+      );
     });
-
 
     it('renders an editable textbox with the given aria-label', () => {
       render(<PromptEditor ariaLabel="Prompt" />);

--- a/packages/apollo-wind/src/components/ui/prompt-editor/prompt-editor.tsx
+++ b/packages/apollo-wind/src/components/ui/prompt-editor/prompt-editor.tsx
@@ -472,6 +472,7 @@ const EditorInner = forwardRef(
           )}
           {placeholder && isEmpty && (
             <div
+              data-slot="prompt-editor-placeholder"
               style={{
                 position: 'absolute',
                 top: '8px',


### PR DESCRIPTION
## Summary

Adds `data-slot="prompt-editor-placeholder"` to the PromptEditor's placeholder div. The apollo default placeholder color (`text-muted-foreground`, matching apollo's `Input`) stays unchanged — this only gives hosts a stable selector: flow's DAP properties panel dims every text-input placeholder to `text-muted-foreground/60`, and the editor's absolutely-positioned placeholder was the one element it couldn't reach (review feedback on UiPath/flow-workbench#3650).

## Changes

- `prompt-editor.tsx`: `data-slot="prompt-editor-placeholder"` on the placeholder div (follows the existing `data-slot="prompt-editor-error"` convention).
- Test asserting the slot renders with the placeholder text.

## Testing

- [x] `vitest run src/components/ui/prompt-editor` — 45 passed
- [x] biome + tsc clean

Refs: MST-13998
