### PR TITLE
fix: add portal toggle to Popover and i18n for Combobox remove

### DIFF
--- a/apps/apollo-vertex/locales/en.json
+++ b/apps/apollo-vertex/locales/en.json
@@ -217,6 +217,7 @@
   "projects": "Projects",
   "recent_activity": "Recent Activity",
   "recent_invoices": "Recent Invoices",
+  "remove": "Remove",
   "remove_file": "Remove {{name}}",
   "remove_from_expected_result": "Remove from baseline",
   "remove_quoted_text": "Remove quoted text",

--- a/apps/apollo-vertex/registry/combobox/combobox.tsx
+++ b/apps/apollo-vertex/registry/combobox/combobox.tsx
@@ -7,6 +7,7 @@ import {
   XIcon,
 } from "lucide-react";
 import * as React from "react";
+import { useTranslation } from "react-i18next";
 import { Badge } from "@/components/ui/badge";
 import { buttonVariants } from "@/components/ui/button";
 import {
@@ -261,6 +262,7 @@ function ComboboxBadge({
   children,
   ...props
 }: ComboboxBadgeProps) {
+  const { t } = useTranslation();
   const { value: selectedValues, onValueChange } = useComboboxContext();
 
   function handleRemove(e: React.MouseEvent | React.KeyboardEvent) {
@@ -290,7 +292,7 @@ function ComboboxBadge({
         }
       >
         <XIcon className="size-3" />
-        <span className="sr-only">{"Remove"}</span>
+        <span className="sr-only">{t("remove")}</span>
       </button>
     </Badge>
   );

--- a/apps/apollo-vertex/registry/popover/popover.tsx
+++ b/apps/apollo-vertex/registry/popover/popover.tsx
@@ -21,10 +21,17 @@ function PopoverContent({
   className,
   align = "center",
   sideOffset = 4,
+  // Portaled content sits outside an enclosing dialog's focus scope, which then reclaims
+  // focus from it; `portal={false}` keeps it inside so nested inputs stay usable.
+  portal = true,
   ...props
-}: React.ComponentProps<typeof PopoverPrimitive.Content>) {
+}: React.ComponentProps<typeof PopoverPrimitive.Content> & {
+  portal?: boolean;
+}) {
+  const Wrapper = portal ? PopoverPrimitive.Portal : React.Fragment;
+
   return (
-    <PopoverPrimitive.Portal>
+    <Wrapper>
       <PopoverPrimitive.Content
         data-slot="popover-content"
         align={align}
@@ -35,7 +42,7 @@ function PopoverContent({
         )}
         {...props}
       />
-    </PopoverPrimitive.Portal>
+    </Wrapper>
   );
 }
 


### PR DESCRIPTION
## Summary

This PR makes two targeted improvements to the component library:

1. **Popover**: Adds optional control over portal behavior to support nested inputs within dialogs
2. **Combobox**: Internationalizes the "Remove" button label using i18n

## Changes

- **Popover (`popover.tsx`)**
  - Added `portal` prop (defaults to `true`) to `PopoverContent` to conditionally wrap content in `PopoverPrimitive.Portal`
  - Includes explanatory comment: portaled content sits outside an enclosing dialog's focus scope, which can reclaim focus; `portal={false}` keeps it inside so nested inputs remain usable
  - Uses `React.Fragment` as wrapper when `portal={false}`

- **Combobox (`combobox.tsx`)**
  - Imported `useTranslation` from `react-i18next`
  - Updated `ComboboxBadge` to use `t("remove")` instead of hardcoded "Remove" string
  - Maintains `sr-only` class for screen reader accessibility

- **Localization (`en.json`)**
  - Added `"remove": "Remove"` entry to English locale file

## Implementation Details

The Popover change is backward-compatible—the default `portal={true}` preserves existing behavior. The conditional wrapper pattern allows consumers to opt into keeping popover content within a dialog's focus scope when needed.

The Combobox i18n change follows the existing translation pattern in the codebase and enables multi-language support for the remove button label.

https://claude.ai/code/session_01SnmiT3edq81s2qTDqoE8zP