### PR TITLE
feat(apollo-wind): guardrail list section with reorder and status chips [AL-575]

### DIFF
--- a/packages/apollo-wind/src/components/custom/guardrails/README.md
+++ b/packages/apollo-wind/src/components/custom/guardrails/README.md
@@ -2,8 +2,9 @@
 
 Shared UI for the UiPath Guardrails experience, consumed by Flow (flow-workbench) and, in a
 later stage, Agents (`frontend-sw`). Members: `GuardrailBuilder` (the whole Add/Edit screen),
-`GuardrailFormLayout` (the screen shell), and `GuardrailValidatorForm` (the validator
-parameter section, also rendered inside the builder).
+`GuardrailFormLayout` (the screen shell), `GuardrailValidatorForm` (the validator parameter
+section, also rendered inside the builder), and `GuardrailList` (the list section that shows,
+reorders and annotates the guardrails already applied).
 
 ## GuardrailBuilder
 
@@ -157,6 +158,139 @@ Radix overlays (the enum select, the enum-list popover, tooltips) portal to `doc
 by default and escape shadow roots; wrap the form's subtree with `PortalContainerProvider`
 and inject the package CSS into the shadow root (see `HitlSchemaCanvas` in `frontend-sw` for
 the `?inline` injection precedent).
+
+## GuardrailList
+
+The guardrails list section: the guardrails applied to an agent or tool, with drag and
+keyboard reorder, status and origin chips, per-row edit and remove intents, the BYO provider
+line and its two failure notices, and the mixed-scopes banner.
+
+```tsx
+import { GuardrailList } from '@uipath/apollo-wind';
+
+<GuardrailList
+  guardrails={visibleGuardrails}   // pre-filtered by the host
+  definitions={definitions}        // pre-filtered by the host
+  disabled={isReadOnly}
+  onReorder={(next) => save(next)}
+  onEdit={openBuilder}
+  onRemove={confirmRemoval}
+  onAdd={openPalette}
+  locale={i18n.language}
+/>;
+```
+
+### Contract
+
+- **The host filters, the component renders.** `GuardrailList` never drops a row. Every
+  product gate stays on the host side of the boundary: Agents' `enableOutOfTheBoxGuardrails`,
+  `enableGuardrailPII`, `enableGuardrailPromptInjection`, `enableGuardrailHarmfulContent`,
+  `enableGuardrailIntellectualProperty` and `enableGuardrailUserPromptAttacks`, and Flow's
+  `canvas.guardrails` entitlement plus its allowed-scope filter. Pass the survivors. There is
+  deliberately no flag prop, and adding one would put a product's release process inside a
+  design-system release.
+- **Callbacks are intents, not mutations.** `onRemove` fires when the user asks to remove a
+  guardrail; the confirmation dialog and the write stay host-side, because the two products
+  confirm with different copy and unwind tool-scoped guardrails differently. Same for
+  `onAdd` / `onEdit`: the palette and the builder are the host's.
+- **No telemetry.** Both products instrument add, reorder and delete. Wrap the callbacks.
+- **Row identity** defaults to `id`, falling back to `name` for hosts that persist no id.
+  Override with `getItemId`.
+- **Origin is host-supplied.** Governance-managed guardrails come from a different endpoint in
+  both products and are not inferable from the record, so tag them with `getItemOrigin`.
+- **New UI is opt-in.** `statusChips` and `previewChip` are both off by default, so an
+  adopting host gets a swap that renders what it renders today and turns the additions on
+  deliberately. The two BYO row notices are not gated, because both products already show them.
+- **`disabled` governs the row actions, `reorderDisabled` governs the handle.** The latter
+  defaults to `disabled` (Agents), and Flow passes `false` to keep its read-only list
+  reorderable, which is what it does today.
+- Requires no provider of its own, unless `renderRowTooltip` is supplied, which needs an
+  ancestor `TooltipProvider`.
+
+### Matching a host's existing chrome
+
+`GuardrailList` ships Flow's layout, because that is the shape the extraction converges on.
+Agents wraps its list in a `SectionAccordion`, puts the add affordance below the rows, and
+hovers a combined description/provider/scopes tooltip. Those are props, not forks:
+
+```tsx
+<GuardrailList
+  unstyled                        // no card border, rounding or padding
+  hideHeader                      // the accordion supplies the title
+  emptyState={null}               // no empty-state line, just the add button
+  footer={addButton}              // add affordance below the rows
+  rowActivatesEdit                // the whole row opens the builder
+  formatAction={() => null}       // no action badge
+  formatScopes={localizedScopes}
+  renderItemActions={overflowMenu}
+  renderRowTooltip={combinedHover}
+/>
+```
+
+### Reordering a filtered view
+
+`onReorder` receives the reordered *visible* array plus the move that produced it, so a host
+rendering a tool-level view over an agent-level list can splice the change back:
+
+```tsx
+<GuardrailList
+  guardrails={toolGuardrails}
+  onReorder={(_next, { from, to }) => {
+    const indices = allGuardrails.flatMap((g, i) => (isVisible(g) ? [i] : []));
+    setAllGuardrails(moveWithin(allGuardrails, indices[from], indices[to]));
+  }}
+/>
+```
+
+The pure helpers behind the rows are exported for hosts that need the same derivations
+elsewhere: `resolveGuardrailListItemState`, `findGuardrailDefinition`,
+`matchGuardrailDefinition`, `defaultGuardrailItemId` and `moveGuardrail`.
+
+### Chips and notices
+
+| Row state | Rendering |
+| --- | --- |
+| any, with `statusChips` off (the default) | no chip at all |
+| `Available`, origin `local` | no chip; the common row stays quiet |
+| `FeatureDisabled`, `Unauthorised` | warning chip |
+| `Disabled` | error chip, plus an inline notice when the guardrail is BYO |
+| `Unavailable` (BYO definition missing from a loaded catalog) | error chip and an inline notice |
+| origin `governance` | accent chip |
+| built-in validator, with `previewChip` | accent "Preview" chip |
+
+A BYO row reports nothing while the catalog is still empty. That guard is load-order
+protection, not defensiveness: without it every BYO row flashes "no longer available" during
+the definitions request, and both products already carry it.
+
+Chips are `Badge`-based (`GuardrailStatusChip`), not `GuardrailChip`. `GuardrailChip` wraps a
+Radix Toggle, so it is a focusable button with pressed state; these are read-only labels and
+would otherwise put fake buttons in the tab order. The geometry matches, so the two chip
+families still read as one system.
+
+### Slots
+
+| Slot | Fallback |
+| --- | --- |
+| `renderItemActions` | inline Edit and Delete icon buttons. The slot receives `edit` and `remove`, so an overflow menu still routes through the list's callbacks |
+| `addSlot` | the header Add button, when `onAdd` is set |
+| `footer` | nothing. Rendered below the rows, for hosts whose add affordance lives there |
+| `emptyState` | "No guardrails configured". Pass `null` for nothing at all |
+| `renderRowTooltip` | no tooltip. Wraps the row body; needs a `TooltipProvider` |
+| `title` | the localized header title |
+| `formatScopes` | the raw `selector.scopes`, comma-joined |
+| `formatAction` | the raw `action.$actionType` |
+
+Scope names and action types are domain strings and print as stored. Hosts that localize them
+(Agents renders `Llm` as "LLM calls") pass `formatScopes` / `formatAction` rather than the
+package growing a scope-label map.
+
+### Localization
+
+Chrome strings follow the family mechanism: English defaults < packaged catalog (`locale`) <
+`labels` overrides. Ten of the list's strings are translated in all 13 non-English catalogs,
+harvested from Flow's canvas catalog. The status and origin chip labels and the row
+aria-label are English-only for now and fall back per key, so a host that needs them
+translated today supplies them through `labels`.
 
 ## Definitions layer
 

--- a/packages/apollo-wind/src/components/custom/guardrails/__fixtures__/list-items.ts
+++ b/packages/apollo-wind/src/components/custom/guardrails/__fixtures__/list-items.ts
@@ -1,0 +1,77 @@
+import type { GuardrailListItem } from '../list-types';
+
+/**
+ * Guardrail records as the two products persist them, for the list section's tests and
+ * stories. Field-for-field what `GuardrailsListingSection` (Agents) and `GuardrailsEditor`
+ * (Flow) hand their rows, so a fixture drifting from the hosts is a review signal.
+ *
+ * The validators line up with `GOLDEN_ENRICHED_DEFINITIONS`, so the two fixtures can be used
+ * together to exercise definition matching.
+ */
+
+export const CUSTOM_GUARDRAIL: GuardrailListItem = {
+  id: 'gr-custom',
+  $guardrailType: 'custom',
+  name: 'Block refunds over 500',
+  description: 'Deterministic rule set for refund limits',
+  selector: { scopes: ['Tool'], matchNames: ['issue_refund'] },
+  action: { $actionType: 'block' },
+};
+
+export const BUILT_IN_GUARDRAIL: GuardrailListItem = {
+  id: 'gr-pii',
+  $guardrailType: 'builtInValidator',
+  name: 'PII detection',
+  description: 'Detect personally identifiable information',
+  validatorType: 'pii_detection',
+  selector: { scopes: ['Agent', 'Llm'] },
+  action: { $actionType: 'log' },
+};
+
+/** Matches the enriched `acme_toxicity` definition: Available, provider "Acme Security". */
+export const BYO_GUARDRAIL: GuardrailListItem = {
+  id: 'gr-byo',
+  $guardrailType: 'builtInValidator',
+  name: 'Acme toxicity',
+  validatorType: 'acme_toxicity',
+  byoValidatorName: 'acme-toxicity-v2',
+  selector: { scopes: ['Llm'] },
+  action: { $actionType: 'escalate' },
+};
+
+/** Matches the enriched `acme_pii` definition, whose configuration is Disabled. */
+export const BYO_DISABLED_GUARDRAIL: GuardrailListItem = {
+  id: 'gr-byo-disabled',
+  $guardrailType: 'builtInValidator',
+  name: 'Acme PII detector',
+  validatorType: 'acme_pii',
+  byoValidatorName: 'acme-pii-detector',
+  selector: { scopes: ['Agent'] },
+  action: { $actionType: 'log' },
+};
+
+/** No definition carries this validator name, so the catalog resolves it as unavailable. */
+export const BYO_UNAVAILABLE_GUARDRAIL: GuardrailListItem = {
+  id: 'gr-byo-gone',
+  $guardrailType: 'builtInValidator',
+  name: 'Retired scanner',
+  validatorType: 'acme_retired',
+  byoValidatorName: 'acme-retired-v0',
+  selector: { scopes: ['Tool'], matchNames: ['send_email'] },
+  action: { $actionType: 'block' },
+};
+
+/** Agents persists no id; the list falls back to the (unique) name. */
+export const UNIDENTIFIED_GUARDRAIL: GuardrailListItem = {
+  $guardrailType: 'builtInValidator',
+  name: 'Prompt injection',
+  validatorType: 'prompt_injection',
+  selector: { scopes: ['Llm'] },
+  action: { $actionType: 'block' },
+};
+
+export const GUARDRAIL_LIST_ITEMS: GuardrailListItem[] = [
+  BUILT_IN_GUARDRAIL,
+  CUSTOM_GUARDRAIL,
+  BYO_GUARDRAIL,
+];

--- a/packages/apollo-wind/src/components/custom/guardrails/components/guardrail-list-row.test.tsx
+++ b/packages/apollo-wind/src/components/custom/guardrails/components/guardrail-list-row.test.tsx
@@ -1,0 +1,241 @@
+import { DndContext } from '@dnd-kit/core';
+import { SortableContext } from '@dnd-kit/sortable';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { axe } from 'jest-axe';
+import type { ReactNode } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { TooltipProvider } from '@/components/ui/tooltip';
+import { BUILT_IN_GUARDRAIL, CUSTOM_GUARDRAIL } from '../__fixtures__/list-items';
+import { GUARDRAIL_LIST_EN_LABELS } from '../i18n';
+import type { GuardrailListItem, GuardrailListItemState } from '../list-types';
+import { GuardrailListRow, type GuardrailListRowProps } from './guardrail-list-row';
+
+const labels = GUARDRAIL_LIST_EN_LABELS;
+
+function renderRow(
+  overrides: Partial<GuardrailListRowProps> = {},
+  wrapper?: (n: ReactNode) => ReactNode
+) {
+  const guardrail = overrides.guardrail ?? BUILT_IN_GUARDRAIL;
+  const state: GuardrailListItemState = overrides.state ?? { status: 'Available', origin: 'local' };
+  const row = (
+    <GuardrailListRow
+      guardrail={guardrail}
+      id={guardrail.id ?? guardrail.name}
+      state={state}
+      labels={labels}
+      disabled={false}
+      sortable
+      statusChips
+      previewChip={false}
+      activatesEdit={false}
+      formatScopes={(item) => item.selector?.scopes?.join(', ')}
+      formatAction={(item) => item.action?.$actionType}
+      {...overrides}
+    />
+  );
+  return render(
+    <DndContext>
+      <SortableContext items={[guardrail.id ?? guardrail.name]}>
+        <ul>{wrapper ? wrapper(row) : row}</ul>
+      </SortableContext>
+    </DndContext>
+  );
+}
+
+describe('GuardrailListRow', () => {
+  it('renders the name, description, action and scopes', () => {
+    renderRow();
+
+    expect(screen.getByText('PII detection')).toBeInTheDocument();
+    expect(screen.getByText('Detect personally identifiable information')).toBeInTheDocument();
+    expect(screen.getByText('log')).toBeInTheDocument();
+    expect(screen.getByText('Agent, Llm')).toBeInTheDocument();
+  });
+
+  it('names the drag handle after the guardrail', () => {
+    renderRow();
+    expect(screen.getByRole('button', { name: 'Reorder guardrail PII detection' })).toBeEnabled();
+  });
+
+  it('renders no drag handle when the list is not sortable', () => {
+    renderRow({ sortable: false });
+    expect(screen.queryByRole('button', { name: /Reorder guardrail/ })).not.toBeInTheDocument();
+  });
+
+  it('renders no chips when statusChips is off, which is both products today', () => {
+    renderRow({
+      statusChips: false,
+      previewChip: true,
+      state: { status: 'Disabled', origin: 'governance' },
+    });
+
+    expect(screen.queryByText('Disabled')).not.toBeInTheDocument();
+    expect(screen.queryByText('Governance')).not.toBeInTheDocument();
+    // The preview chip has its own flag, and the BYO notices are never gated.
+    expect(screen.getByText('Preview')).toBeInTheDocument();
+  });
+
+  it('renders no chips for a healthy local row', () => {
+    renderRow();
+
+    expect(screen.queryByText('Preview')).not.toBeInTheDocument();
+    expect(screen.queryByText('Governance')).not.toBeInTheDocument();
+    expect(screen.queryByText('Disabled')).not.toBeInTheDocument();
+  });
+
+  it.each([
+    ['Disabled', 'Disabled'],
+    ['Unavailable', 'Unavailable'],
+    ['Unauthorised', 'Not entitled'],
+    ['FeatureDisabled', 'Feature disabled'],
+  ] as const)('chips the %s status', (status, expectedLabel) => {
+    renderRow({ state: { status, origin: 'local' } });
+    expect(screen.getByText(expectedLabel)).toBeInTheDocument();
+  });
+
+  it('chips a governance-managed row', () => {
+    renderRow({ state: { status: 'Available', origin: 'governance' } });
+    expect(screen.getByText('Governance')).toBeInTheDocument();
+  });
+
+  it('chips built-in rows as preview only when the host asks for it', () => {
+    const { unmount } = renderRow({ previewChip: true });
+    expect(screen.getByText('Preview')).toBeInTheDocument();
+    unmount();
+
+    renderRow({ previewChip: true, guardrail: CUSTOM_GUARDRAIL });
+    expect(screen.queryByText('Preview')).not.toBeInTheDocument();
+  });
+
+  it('announces the BYO disabled notice as an alert', () => {
+    renderRow({ state: { status: 'Disabled', origin: 'local', notice: 'byoDisabled' } });
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      "This guardrail's configuration has been disabled"
+    );
+  });
+
+  it('announces the BYO unavailable notice as an alert', () => {
+    renderRow({ state: { status: 'Unavailable', origin: 'local', notice: 'byoUnavailable' } });
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      "This guardrail's configuration is no longer available"
+    );
+  });
+
+  it('renders the provider line for a BYO row', () => {
+    renderRow({ state: { status: 'Available', origin: 'local', byoConnectorName: 'Acme' } });
+
+    const provider = screen.getByText('Provider: Acme');
+    expect(provider).toHaveAttribute('title', 'Provider: Acme');
+  });
+
+  it('reports edit and remove with the original guardrail object', async () => {
+    const user = userEvent.setup();
+    const onEdit = vi.fn();
+    const onRemove = vi.fn();
+    renderRow({ onEdit, onRemove });
+
+    await user.click(screen.getByRole('button', { name: 'Edit guardrail' }));
+    await user.click(screen.getByRole('button', { name: 'Delete guardrail' }));
+
+    expect(onEdit).toHaveBeenCalledWith(BUILT_IN_GUARDRAIL);
+    expect(onEdit.mock.calls[0][0]).toBe(BUILT_IN_GUARDRAIL);
+    expect(onRemove.mock.calls[0][0]).toBe(BUILT_IN_GUARDRAIL);
+  });
+
+  it('renders only the affordances the host wired up', () => {
+    renderRow({ onEdit: vi.fn() });
+
+    expect(screen.getByRole('button', { name: 'Edit guardrail' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Delete guardrail' })).not.toBeInTheDocument();
+  });
+
+  it('disables the row actions in read-only mode', () => {
+    renderRow({ disabled: true, onEdit: vi.fn(), onRemove: vi.fn() });
+
+    expect(screen.getByRole('button', { name: 'Edit guardrail' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Delete guardrail' })).toBeDisabled();
+  });
+
+  it('leaves the drag handle live in a read-only row, which is Flow behaviour', () => {
+    // The list decides whether a row is sortable; `disabled` only governs the actions, so a
+    // host can keep reordering while editing is off.
+    renderRow({ disabled: true });
+    expect(screen.getByRole('button', { name: /Reorder guardrail/ })).toBeEnabled();
+  });
+
+  it('is not a control unless rowActivatesEdit is set', () => {
+    renderRow({ onEdit: vi.fn() });
+    expect(screen.queryByRole('button', { name: /Edit guardrail PII/ })).not.toBeInTheDocument();
+  });
+
+  it('activates edit from the row body on click and on Enter', async () => {
+    const user = userEvent.setup();
+    const onEdit = vi.fn();
+    renderRow({ activatesEdit: true, onEdit });
+
+    const body = screen.getByRole('button', { name: 'Edit guardrail PII detection' });
+    await user.click(body);
+    body.focus();
+    await user.keyboard('{Enter}');
+    await user.keyboard(' ');
+
+    expect(onEdit).toHaveBeenCalledTimes(3);
+  });
+
+  it('does not activate a read-only row body', () => {
+    renderRow({ activatesEdit: true, disabled: true, onEdit: vi.fn() });
+    expect(
+      screen.queryByRole('button', { name: 'Edit guardrail PII detection' })
+    ).not.toBeInTheDocument();
+  });
+
+  it('replaces the built-in actions with the host slot', () => {
+    renderRow({
+      onEdit: vi.fn(),
+      onRemove: vi.fn(),
+      renderActions: () => <button type="button">More options</button>,
+    });
+
+    expect(screen.getByRole('button', { name: 'More options' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Edit guardrail' })).not.toBeInTheDocument();
+  });
+
+  it('wraps the row body in a tooltip when the host supplies one', async () => {
+    const user = userEvent.setup();
+    renderRow(
+      { renderTooltip: (item) => `Scopes: ${item.selector?.scopes?.join(', ')}` },
+      (row) => <TooltipProvider>{row}</TooltipProvider>
+    );
+
+    await user.hover(screen.getByText('PII detection'));
+    expect(await screen.findAllByText('Scopes: Agent, Llm')).not.toHaveLength(0);
+  });
+
+  it('omits the footer when the guardrail carries neither an action nor scopes', () => {
+    const bare: GuardrailListItem = { $guardrailType: 'custom', name: 'Bare' };
+    renderRow({ guardrail: bare });
+
+    expect(screen.getByText('Bare')).toBeInTheDocument();
+    expect(screen.queryByText('log')).not.toBeInTheDocument();
+  });
+
+  it('has no accessibility violations when every element renders', async () => {
+    const { container } = renderRow({
+      previewChip: true,
+      activatesEdit: true,
+      state: {
+        status: 'Disabled',
+        origin: 'governance',
+        notice: 'byoDisabled',
+        byoConnectorName: 'Acme',
+      },
+      onEdit: vi.fn(),
+      onRemove: vi.fn(),
+    });
+
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/packages/apollo-wind/src/components/custom/guardrails/components/guardrail-list-row.tsx
+++ b/packages/apollo-wind/src/components/custom/guardrails/components/guardrail-list-row.tsx
@@ -1,0 +1,237 @@
+import { useSortable } from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import { GripVertical, Pencil, Trash2 } from 'lucide-react';
+import type { KeyboardEvent, ReactNode } from 'react';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { cn } from '@/lib';
+import { formatGuardrailFormMessage, type GuardrailListLabels } from '../i18n';
+import type {
+  GuardrailListItem,
+  GuardrailListItemState,
+  GuardrailListItemStatus,
+} from '../list-types';
+import { GuardrailStatusChip, type GuardrailStatusChipTone } from './guardrail-status-chip';
+
+/** Chip tone and label key per non-quiet status. `Available` renders no chip at all. */
+const STATUS_CHIP: Record<
+  Exclude<GuardrailListItemStatus, 'Available'>,
+  { tone: GuardrailStatusChipTone; label: keyof GuardrailListLabels }
+> = {
+  Disabled: { tone: 'error', label: 'statusDisabledChip' },
+  Unavailable: { tone: 'error', label: 'statusUnavailableChip' },
+  Unauthorised: { tone: 'warning', label: 'statusUnauthorizedChip' },
+  FeatureDisabled: { tone: 'warning', label: 'statusFeatureDisabledChip' },
+};
+
+const NOTICE_LABEL = {
+  byoDisabled: 'byoDisabledNotice',
+  byoUnavailable: 'byoUnavailableNotice',
+} as const satisfies Record<
+  NonNullable<GuardrailListItemState['notice']>,
+  keyof GuardrailListLabels
+>;
+
+export interface GuardrailListRowProps<T extends GuardrailListItem = GuardrailListItem> {
+  guardrail: T;
+  /** Sortable id, resolved by the list through its `getItemId`. */
+  id: string;
+  state: GuardrailListItemState;
+  labels: GuardrailListLabels;
+  /** Read-only: actions rendered disabled. Reordering is governed by `sortable`. */
+  disabled: boolean;
+  /** Whether the drag handle renders and works. False renders no handle at all. */
+  sortable: boolean;
+  /** Whether the status and origin chips render. The BYO notices are not gated by this. */
+  statusChips: boolean;
+  /** Whether built-in-validator rows carry the preview chip. Host-controlled lifecycle flag. */
+  previewChip: boolean;
+  /** Whether the row body itself activates edit (Agents) on click and Enter/Space. */
+  activatesEdit: boolean;
+  formatScopes: (guardrail: T) => string | undefined;
+  formatAction: (guardrail: T) => ReactNode;
+  /** Tooltip content for this row. Requires an ancestor `TooltipProvider` when supplied. */
+  renderTooltip?: (guardrail: T) => ReactNode;
+  onEdit?: (guardrail: T) => void;
+  onRemove?: (guardrail: T) => void;
+  renderActions?: () => ReactNode;
+}
+
+/**
+ * One guardrail in the list: drag handle, title with its chips, any status notice,
+ * description, BYO provider, and the action/scope footer.
+ */
+export function GuardrailListRow<T extends GuardrailListItem = GuardrailListItem>({
+  guardrail,
+  id,
+  state,
+  labels,
+  disabled,
+  sortable,
+  statusChips,
+  previewChip,
+  activatesEdit,
+  formatScopes,
+  formatAction,
+  renderTooltip,
+  onEdit,
+  onRemove,
+  renderActions,
+}: GuardrailListRowProps<T>) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id,
+    disabled: !sortable,
+  });
+
+  const statusChip =
+    statusChips && state.status !== 'Available' ? STATUS_CHIP[state.status] : undefined;
+  const scopes = formatScopes(guardrail);
+  const action = formatAction(guardrail);
+  const isBuiltIn = guardrail.$guardrailType === 'builtInValidator';
+  const canActivate = activatesEdit && !disabled && onEdit !== undefined;
+
+  const handleActivate = () => {
+    if (canActivate) onEdit?.(guardrail);
+  };
+  const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (event.key !== 'Enter' && event.key !== ' ') return;
+    event.preventDefault();
+    handleActivate();
+  };
+
+  const activation = canActivate
+    ? ({
+        role: 'button',
+        tabIndex: 0,
+        'aria-label': formatGuardrailFormMessage(labels.editRowAriaLabel, {
+          name: guardrail.name,
+        }),
+        onClick: handleActivate,
+        onKeyDown: handleKeyDown,
+      } as const)
+    : undefined;
+
+  const tooltip = renderTooltip?.(guardrail);
+  const rowBody = (
+    <div className={cn('min-w-0 flex-1', canActivate && 'cursor-pointer')} {...activation}>
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="truncate text-sm font-medium">{guardrail.name}</span>
+        {previewChip && isBuiltIn && (
+          <GuardrailStatusChip tone="accent">{labels.previewChip}</GuardrailStatusChip>
+        )}
+        {statusChip && (
+          <GuardrailStatusChip tone={statusChip.tone}>
+            {labels[statusChip.label]}
+          </GuardrailStatusChip>
+        )}
+        {statusChips && state.origin === 'governance' && (
+          <GuardrailStatusChip tone="accent">{labels.originGovernanceChip}</GuardrailStatusChip>
+        )}
+      </div>
+
+      {state.notice && (
+        <p className="whitespace-normal break-words text-xs text-error" role="alert">
+          {labels[NOTICE_LABEL[state.notice]]}
+        </p>
+      )}
+
+      {guardrail.description && (
+        <p className="truncate text-xs text-foreground-muted">{guardrail.description}</p>
+      )}
+
+      {state.byoConnectorName !== undefined && (
+        <p
+          className="truncate text-xs text-foreground-muted"
+          title={`${labels.providerLabel}: ${state.byoConnectorName}`}
+        >
+          {labels.providerLabel}: {state.byoConnectorName}
+        </p>
+      )}
+
+      {(action || scopes) && (
+        <div className="mt-1 flex flex-wrap items-center gap-1.5">
+          {action && (
+            <Badge variant="secondary" className="border-border bg-muted/60 text-[11px] capitalize">
+              {action}
+            </Badge>
+          )}
+          {scopes && <span className="text-[11px] text-foreground-muted">{scopes}</span>}
+        </div>
+      )}
+    </div>
+  );
+
+  // Radix clones the trigger onto the row body, so the tooltip covers the same region Agents
+  // hovers today (title, description, provider, scopes) without adding another focus stop.
+  const body = tooltip ? (
+    <Tooltip>
+      <TooltipTrigger asChild>{rowBody}</TooltipTrigger>
+      <TooltipContent side="bottom" className="max-w-[300px]">
+        {tooltip}
+      </TooltipContent>
+    </Tooltip>
+  ) : (
+    rowBody
+  );
+
+  return (
+    <li
+      ref={setNodeRef}
+      data-slot="guardrail-list-row"
+      style={{ transform: CSS.Transform.toString(transform), transition }}
+      className={cn('flex items-center gap-2', isDragging && 'opacity-50')}
+    >
+      {sortable && (
+        <Button
+          variant="ghost"
+          size="2xs"
+          icon
+          className="-ml-2 -mr-2 shrink-0 cursor-grab touch-none"
+          aria-label={formatGuardrailFormMessage(labels.reorderHandleAriaLabel, {
+            name: guardrail.name,
+          })}
+          {...attributes}
+          {...listeners}
+        >
+          <GripVertical />
+        </Button>
+      )}
+
+      {body}
+
+      <div className="flex shrink-0 items-center">
+        {renderActions ? (
+          renderActions()
+        ) : (
+          <>
+            {onEdit && (
+              <Button
+                variant="ghost"
+                size="3xs"
+                icon
+                disabled={disabled}
+                aria-label={labels.editButtonAriaLabel}
+                onClick={() => onEdit(guardrail)}
+              >
+                <Pencil />
+              </Button>
+            )}
+            {onRemove && (
+              <Button
+                variant="ghost"
+                size="3xs"
+                icon
+                disabled={disabled}
+                aria-label={labels.deleteButtonAriaLabel}
+                onClick={() => onRemove(guardrail)}
+              >
+                <Trash2 />
+              </Button>
+            )}
+          </>
+        )}
+      </div>
+    </li>
+  );
+}

--- a/packages/apollo-wind/src/components/custom/guardrails/components/guardrail-status-chip.test.tsx
+++ b/packages/apollo-wind/src/components/custom/guardrails/components/guardrail-status-chip.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen } from '@testing-library/react';
+import { axe } from 'jest-axe';
+import { describe, expect, it } from 'vitest';
+import { GuardrailStatusChip } from './guardrail-status-chip';
+
+describe('GuardrailStatusChip', () => {
+  it('renders its label as static text, not as a control', () => {
+    render(<GuardrailStatusChip>Disabled</GuardrailStatusChip>);
+
+    expect(screen.getByText('Disabled')).toBeInTheDocument();
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+
+  it.each([
+    ['neutral', 'bg-secondary'],
+    ['accent', 'bg-info-background'],
+    ['warning', 'bg-warning-background'],
+    ['error', 'bg-error-background'],
+  ] as const)('paints the %s tone', (tone, expectedClass) => {
+    render(<GuardrailStatusChip tone={tone}>Status</GuardrailStatusChip>);
+    expect(screen.getByText('Status')).toHaveClass(expectedClass);
+  });
+
+  it('defaults to the neutral tone', () => {
+    render(<GuardrailStatusChip>Status</GuardrailStatusChip>);
+    expect(screen.getByText('Status')).toHaveClass('bg-secondary');
+  });
+
+  it('keeps caller classes alongside the chip geometry', () => {
+    render(<GuardrailStatusChip className="ml-4">Status</GuardrailStatusChip>);
+
+    const chip = screen.getByText('Status');
+    expect(chip).toHaveClass('ml-4');
+    expect(chip).toHaveClass('h-6');
+  });
+
+  it('has no accessibility violations', async () => {
+    const { container } = render(
+      <>
+        <GuardrailStatusChip>Preview</GuardrailStatusChip>
+        <GuardrailStatusChip tone="warning">Not entitled</GuardrailStatusChip>
+        <GuardrailStatusChip tone="error">Unavailable</GuardrailStatusChip>
+      </>
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/packages/apollo-wind/src/components/custom/guardrails/components/guardrail-status-chip.tsx
+++ b/packages/apollo-wind/src/components/custom/guardrails/components/guardrail-status-chip.tsx
@@ -1,0 +1,43 @@
+import type * as React from 'react';
+import { Badge } from '@/components/ui/badge';
+import { cn } from '@/lib';
+
+/**
+ * Tone of a guardrail list chip. `accent` marks provenance (governance-managed, preview),
+ * `warning` and `error` mark a definition the tenant cannot currently use.
+ */
+export type GuardrailStatusChipTone = 'neutral' | 'accent' | 'warning' | 'error';
+
+const TONE_VARIANT = {
+  neutral: 'secondary',
+  accent: 'info',
+  warning: 'warning',
+  error: 'error',
+} as const satisfies Record<GuardrailStatusChipTone, React.ComponentProps<typeof Badge>['variant']>;
+
+export interface GuardrailStatusChipProps extends React.ComponentPropsWithoutRef<typeof Badge> {
+  tone?: GuardrailStatusChipTone;
+}
+
+/**
+ * Static label pill for a guardrail row: status, origin, preview.
+ *
+ * Built on `Badge` rather than `GuardrailChip` on purpose. `GuardrailChip` wraps a Radix
+ * Toggle, so it is a focusable button with pressed state; these chips are read-only text and
+ * would put fake buttons in the tab order. The geometry matches `guardrailChipVariants` so the
+ * two chip families still read as one system.
+ */
+export function GuardrailStatusChip({
+  tone = 'neutral',
+  className,
+  ...props
+}: GuardrailStatusChipProps) {
+  return (
+    <Badge
+      data-slot="guardrail-status-chip"
+      variant={TONE_VARIANT[tone]}
+      className={cn('h-6 gap-1 whitespace-nowrap px-2.5 font-medium [&_svg]:size-3', className)}
+      {...props}
+    />
+  );
+}

--- a/packages/apollo-wind/src/components/custom/guardrails/guardrail-list-utils.test.ts
+++ b/packages/apollo-wind/src/components/custom/guardrails/guardrail-list-utils.test.ts
@@ -1,0 +1,200 @@
+import { describe, expect, it } from 'vitest';
+import { GOLDEN_ENRICHED_DEFINITIONS } from './__fixtures__/golden-enriched';
+import {
+  BUILT_IN_GUARDRAIL,
+  BYO_DISABLED_GUARDRAIL,
+  BYO_GUARDRAIL,
+  BYO_UNAVAILABLE_GUARDRAIL,
+  CUSTOM_GUARDRAIL,
+  UNIDENTIFIED_GUARDRAIL,
+} from './__fixtures__/list-items';
+import {
+  defaultGuardrailItemId,
+  findGuardrailDefinition,
+  type GuardrailListDefinition,
+  matchGuardrailDefinition,
+  moveGuardrail,
+  resolveGuardrailListItemState,
+} from './guardrail-list-utils';
+import type { GuardrailListItem } from './list-types';
+
+const definitions = GOLDEN_ENRICHED_DEFINITIONS;
+
+function definition(overrides: Partial<GuardrailListDefinition>): GuardrailListDefinition {
+  return {
+    validator: 'pii_detection',
+    displayName: 'PII detection',
+    allowedScopes: ['Agent'],
+    parameters: [],
+    status: 'Available',
+    ...overrides,
+  };
+}
+
+describe('defaultGuardrailItemId', () => {
+  it('prefers the persisted id', () => {
+    expect(defaultGuardrailItemId(BUILT_IN_GUARDRAIL)).toBe('gr-pii');
+  });
+
+  it('falls back to the name for hosts that persist no id', () => {
+    expect(defaultGuardrailItemId(UNIDENTIFIED_GUARDRAIL)).toBe('Prompt injection');
+  });
+});
+
+describe('matchGuardrailDefinition', () => {
+  it('matches a built-in on its validator id', () => {
+    expect(matchGuardrailDefinition(definition({}), BUILT_IN_GUARDRAIL)).toBe(true);
+  });
+
+  it('does not match a built-in against a BYO definition sharing the validator id', () => {
+    const byoDefinition = definition({ byoValidatorName: 'acme-pii-v1' });
+    expect(matchGuardrailDefinition(byoDefinition, BUILT_IN_GUARDRAIL)).toBe(false);
+  });
+
+  it('matches a BYO guardrail on the validator name alone, ignoring the validator id', () => {
+    const rebound = definition({ validator: 'something_else', byoValidatorName: 'acme-pii-v1' });
+    const guardrail: GuardrailListItem = {
+      $guardrailType: 'builtInValidator',
+      name: 'Acme PII',
+      validatorType: 'pii_detection',
+      byoValidatorName: 'acme-pii-v1',
+    };
+    expect(matchGuardrailDefinition(rebound, guardrail)).toBe(true);
+  });
+});
+
+describe('findGuardrailDefinition', () => {
+  it('resolves a built-in guardrail to the non-BYO definition of the same validator', () => {
+    const found = findGuardrailDefinition(BUILT_IN_GUARDRAIL, definitions);
+    expect(found?.validator).toBe('pii_detection');
+    expect(found?.byoValidatorName).toBeUndefined();
+  });
+
+  it('never resolves a custom guardrail', () => {
+    expect(findGuardrailDefinition(CUSTOM_GUARDRAIL, definitions)).toBeUndefined();
+  });
+
+  it('tolerates a missing catalog', () => {
+    expect(findGuardrailDefinition(BUILT_IN_GUARDRAIL, undefined)).toBeUndefined();
+  });
+});
+
+describe('resolveGuardrailListItemState', () => {
+  it('reports a custom guardrail as quiet, with no definition lookup', () => {
+    expect(resolveGuardrailListItemState(CUSTOM_GUARDRAIL, definitions)).toEqual({
+      status: 'Available',
+      origin: 'local',
+    });
+  });
+
+  it('reports a healthy built-in as quiet', () => {
+    expect(resolveGuardrailListItemState(BUILT_IN_GUARDRAIL, definitions)).toEqual({
+      status: 'Available',
+      origin: 'local',
+    });
+  });
+
+  it('carries the connector name of a BYO definition', () => {
+    expect(resolveGuardrailListItemState(BYO_GUARDRAIL, definitions)).toEqual({
+      status: 'Available',
+      origin: 'local',
+      byoConnectorName: 'Acme Security',
+    });
+  });
+
+  it('notices a BYO configuration that was disabled', () => {
+    expect(resolveGuardrailListItemState(BYO_DISABLED_GUARDRAIL, definitions)).toEqual({
+      status: 'Disabled',
+      origin: 'local',
+      notice: 'byoDisabled',
+    });
+  });
+
+  it('notices a BYO configuration that no longer exists', () => {
+    expect(resolveGuardrailListItemState(BYO_UNAVAILABLE_GUARDRAIL, definitions)).toEqual({
+      status: 'Unavailable',
+      origin: 'local',
+      notice: 'byoUnavailable',
+    });
+  });
+
+  it('stays quiet about an unmatched BYO guardrail while the catalog is still empty', () => {
+    expect(resolveGuardrailListItemState(BYO_UNAVAILABLE_GUARDRAIL, [])).toEqual({
+      status: 'Available',
+      origin: 'local',
+    });
+    expect(resolveGuardrailListItemState(BYO_UNAVAILABLE_GUARDRAIL)).toEqual({
+      status: 'Available',
+      origin: 'local',
+    });
+  });
+
+  it('stays quiet about an unmatched built-in, which is a filtered catalog and not a fault', () => {
+    const guardrail: GuardrailListItem = {
+      $guardrailType: 'builtInValidator',
+      name: 'Unknown',
+      validatorType: 'not_in_catalog',
+    };
+    expect(resolveGuardrailListItemState(guardrail, definitions)).toEqual({
+      status: 'Available',
+      origin: 'local',
+    });
+  });
+
+  it.each([
+    'FeatureDisabled',
+    'Unauthorised',
+  ] as const)('passes the %s status through without a notice', (status) => {
+    expect(resolveGuardrailListItemState(BUILT_IN_GUARDRAIL, [definition({ status })])).toEqual({
+      status,
+      origin: 'local',
+    });
+  });
+
+  it('reports a disabled built-in with a chip but no inline notice', () => {
+    expect(
+      resolveGuardrailListItemState(BUILT_IN_GUARDRAIL, [definition({ status: 'Disabled' })])
+    ).toEqual({ status: 'Disabled', origin: 'local' });
+  });
+
+  it('carries the host-supplied origin', () => {
+    expect(resolveGuardrailListItemState(CUSTOM_GUARDRAIL, definitions, 'governance')).toEqual({
+      status: 'Available',
+      origin: 'governance',
+    });
+    expect(resolveGuardrailListItemState(BYO_GUARDRAIL, definitions, 'governance').origin).toBe(
+      'governance'
+    );
+  });
+});
+
+describe('moveGuardrail', () => {
+  const items = [{ id: 'a' }, { id: 'b' }, { id: 'c' }];
+  const getId = (item: { id: string }) => item.id;
+
+  it('moves the active item to the position of the item it was dropped on', () => {
+    const result = moveGuardrail(items, 'a', 'c', getId);
+    expect(result?.guardrails.map(getId)).toEqual(['b', 'c', 'a']);
+    expect(result?.move).toEqual({ from: 0, to: 2, id: 'a' });
+  });
+
+  it('moves upwards too', () => {
+    const result = moveGuardrail(items, 'c', 'a', getId);
+    expect(result?.guardrails.map(getId)).toEqual(['c', 'a', 'b']);
+    expect(result?.move).toEqual({ from: 2, to: 0, id: 'c' });
+  });
+
+  it('leaves the input array untouched', () => {
+    moveGuardrail(items, 'a', 'c', getId);
+    expect(items.map(getId)).toEqual(['a', 'b', 'c']);
+  });
+
+  it('reports a no-op when the item was dropped on itself', () => {
+    expect(moveGuardrail(items, 'b', 'b', getId)).toBeNull();
+  });
+
+  it('reports a no-op for ids the list does not hold', () => {
+    expect(moveGuardrail(items, 'zzz', 'b', getId)).toBeNull();
+    expect(moveGuardrail(items, 'a', 'zzz', getId)).toBeNull();
+  });
+});

--- a/packages/apollo-wind/src/components/custom/guardrails/guardrail-list-utils.ts
+++ b/packages/apollo-wind/src/components/custom/guardrails/guardrail-list-utils.ts
@@ -1,0 +1,112 @@
+import { arrayMove } from '@dnd-kit/sortable';
+import type { GuardrailDefinition } from './builder-types';
+import type {
+  GuardrailListItem,
+  GuardrailListItemState,
+  GuardrailListMove,
+  GuardrailListOrigin,
+} from './list-types';
+
+/**
+ * Pure derivations behind the guardrail list section. Everything here used to live twice: the
+ * definition lookup and the BYO broken/disabled predicates are byte-for-byte equivalent in
+ * Agents (`ToolGuardrailPolicyBuilder.utils.tsx`) and Flow (`guardrail-utils.ts`), which is
+ * why they can be lifted without picking a winner.
+ */
+
+/**
+ * A definition as the list reads it: the display-ready shape plus the connector name that
+ * only enrichment supplies. Written as an intersection rather than
+ * `EnrichedGuardrailDefinition` so a host holding plain `GuardrailDefinition`s still fits.
+ */
+export type GuardrailListDefinition = GuardrailDefinition & { byoConnectorName?: string };
+
+/** `$guardrailType` of the records that resolve against the definitions catalog. */
+const BUILT_IN_VALIDATOR_TYPE = 'builtInValidator';
+
+/**
+ * Whether a definition describes a guardrail. BYO validator names are unique per tenant, so
+ * the name alone identifies the configuration and an admin rebinding it to another connection
+ * still resolves; built-ins match on `validator` and must not match a BYO definition that
+ * happens to declare the same validator id.
+ */
+export function matchGuardrailDefinition(
+  definition: GuardrailListDefinition,
+  guardrail: GuardrailListItem
+): boolean {
+  return guardrail.byoValidatorName === undefined
+    ? definition.byoValidatorName === undefined && definition.validator === guardrail.validatorType
+    : definition.byoValidatorName === guardrail.byoValidatorName;
+}
+
+/**
+ * Non-throwing lookup: `undefined` when the definition is missing (a removed BYO
+ * configuration, or a validator the tenant cannot see) so callers can render a broken state.
+ */
+export function findGuardrailDefinition<T extends GuardrailListDefinition>(
+  guardrail: GuardrailListItem,
+  definitions: readonly T[] | undefined
+): T | undefined {
+  if (guardrail.$guardrailType !== BUILT_IN_VALIDATOR_TYPE) return undefined;
+  return definitions?.find((definition) => matchGuardrailDefinition(definition, guardrail));
+}
+
+/**
+ * Row identity. Flow persists an `id`; Agents does not and keys by the (unique) `name`.
+ * Falling back rather than requiring one lets both hosts pass their records unmapped.
+ */
+export function defaultGuardrailItemId(guardrail: GuardrailListItem): string {
+  return guardrail.id ?? guardrail.name;
+}
+
+/**
+ * Everything a row renders about a guardrail's health and provenance.
+ *
+ * The `definitions.length > 0` guard on the unavailable case is load-order protection, not
+ * defensiveness: without it every BYO row flashes "no longer available" while the catalog is
+ * still in flight. Both products already carry it.
+ */
+export function resolveGuardrailListItemState(
+  guardrail: GuardrailListItem,
+  definitions: readonly GuardrailListDefinition[] = [],
+  origin: GuardrailListOrigin = 'local'
+): GuardrailListItemState {
+  if (guardrail.$guardrailType !== BUILT_IN_VALIDATOR_TYPE) {
+    return { status: 'Available', origin };
+  }
+
+  const definition = findGuardrailDefinition(guardrail, definitions);
+  const isByo = guardrail.byoValidatorName !== undefined;
+
+  if (!definition) {
+    return isByo && definitions.length > 0
+      ? { status: 'Unavailable', origin, notice: 'byoUnavailable' }
+      : { status: 'Available', origin };
+  }
+
+  const state: GuardrailListItemState = { status: definition.status, origin };
+  if (definition.byoConnectorName !== undefined) {
+    state.byoConnectorName = definition.byoConnectorName;
+  }
+  // Only BYO rows explain a disabled definition inline: a disabled built-in is a tenant-wide
+  // condition the row cannot act on, so it gets the chip and nothing more.
+  if (isByo && definition.status === 'Disabled') state.notice = 'byoDisabled';
+  return state;
+}
+
+/**
+ * Apply a drag or keyboard reorder. Returns `null` for a no-op (same position, or an id the
+ * list does not hold) so callers can skip the write entirely rather than persist an identical
+ * array.
+ */
+export function moveGuardrail<T>(
+  guardrails: readonly T[],
+  activeId: string,
+  overId: string,
+  getItemId: (guardrail: T) => string
+): { guardrails: T[]; move: GuardrailListMove } | null {
+  const from = guardrails.findIndex((guardrail) => getItemId(guardrail) === activeId);
+  const to = guardrails.findIndex((guardrail) => getItemId(guardrail) === overId);
+  if (from === -1 || to === -1 || from === to) return null;
+  return { guardrails: arrayMove([...guardrails], from, to), move: { from, to, id: activeId } };
+}

--- a/packages/apollo-wind/src/components/custom/guardrails/guardrail-list.stories.tsx
+++ b/packages/apollo-wind/src/components/custom/guardrails/guardrail-list.stories.tsx
@@ -1,0 +1,226 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { MoreVertical, Plus } from 'lucide-react';
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { TooltipProvider } from '@/components/ui/tooltip';
+import { GOLDEN_ENRICHED_DEFINITIONS } from './__fixtures__/golden-enriched';
+import {
+  BUILT_IN_GUARDRAIL,
+  BYO_DISABLED_GUARDRAIL,
+  BYO_GUARDRAIL,
+  BYO_UNAVAILABLE_GUARDRAIL,
+  CUSTOM_GUARDRAIL,
+  GUARDRAIL_LIST_ITEMS,
+} from './__fixtures__/list-items';
+import { GuardrailList } from './guardrail-list';
+import type { GuardrailListItem } from './list-types';
+
+const meta = {
+  title: 'Components/UiPath/Guardrail List',
+  component: GuardrailList,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component: `
+The guardrails applied to an agent or tool: drag or keyboard reorder, status and origin chips,
+per-row edit and remove intents, and the mixed-scopes banner.
+
+Rendering only. The host filters the rows and the definitions before passing them, owns the
+add and edit flows and the remove confirmation, and fires its own telemetry around the
+callbacks. Feature flags never cross this boundary: pass the guardrails that survived them.
+        `,
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    guardrails: GUARDRAIL_LIST_ITEMS,
+    definitions: GOLDEN_ENRICHED_DEFINITIONS,
+    onAdd: () => {},
+    onEdit: () => {},
+    onRemove: () => {},
+    onReorder: () => {},
+  },
+  decorators: [
+    (Story) => (
+      <div className="w-[480px]">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof GuardrailList>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Empty: Story = {
+  args: { guardrails: [] },
+};
+
+/**
+ * Reordering writes back through `onReorder`, which also reports the move so a host rendering
+ * a filtered view can splice the change into its full list.
+ */
+export const Reorderable: Story = {
+  render: (args) => {
+    const [guardrails, setGuardrails] = useState<GuardrailListItem[]>(args.guardrails);
+    return <GuardrailList {...args} guardrails={guardrails} onReorder={setGuardrails} />;
+  },
+};
+
+/**
+ * One row per status the definitions catalog can report, plus a governance-managed row.
+ * Chips are opt-in: neither product renders them today, so an adopting host gets a
+ * behaviour-identical swap first and turns them on deliberately.
+ */
+export const StatusAndOriginChips: Story = {
+  args: {
+    guardrails: [
+      BUILT_IN_GUARDRAIL,
+      BYO_DISABLED_GUARDRAIL,
+      BYO_UNAVAILABLE_GUARDRAIL,
+      CUSTOM_GUARDRAIL,
+    ],
+    statusChips: true,
+    previewChip: true,
+    getItemOrigin: (guardrail) =>
+      guardrail.name === 'Block refunds over 500' ? 'governance' : 'local',
+  },
+};
+
+/** A bring-your-own guardrail resolves its provider from the matching definition. */
+export const ByoProvider: Story = {
+  args: { guardrails: [BYO_GUARDRAIL] },
+};
+
+/**
+ * Read-only, with reordering kept live. Flow's list behaves this way today: `disabled` governs
+ * the row actions, and `reorderDisabled` governs the drag handle.
+ */
+export const ReadOnlyButReorderable: Story = {
+  args: { disabled: true, reorderDisabled: false },
+};
+
+/**
+ * Agents' shape: its own container, no header, the add affordance below the rows, an overflow
+ * menu per row, no action badge, and a hover carrying the description, provider and scopes.
+ */
+export const HostSuppliedChrome: Story = {
+  args: {
+    unstyled: true,
+    hideHeader: true,
+    rowActivatesEdit: true,
+    previewChip: true,
+    emptyState: null,
+    formatAction: () => null,
+    formatScopes: (guardrail) => `Scopes: ${guardrail.selector?.scopes?.join(', ') ?? ''}`,
+    renderRowTooltip: (guardrail) => guardrail.description,
+    footer: (
+      <Button variant="ghost" size="2xs">
+        <Plus />
+        Add another guardrail
+      </Button>
+    ),
+    renderItemActions: ({ guardrail, disabled }) => (
+      <Button
+        variant="ghost"
+        size="3xs"
+        icon
+        disabled={disabled}
+        aria-label={`More options for ${guardrail.name}`}
+      >
+        <MoreVertical />
+      </Button>
+    ),
+  },
+  decorators: [
+    (Story) => (
+      <TooltipProvider>
+        <div className="w-[480px] rounded-md border border-dashed p-2">
+          <Story />
+        </div>
+      </TooltipProvider>
+    ),
+  ],
+};
+
+export const MixedScopes: Story = {
+  args: {
+    guardrails: [BUILT_IN_GUARDRAIL],
+    mixedScopes: { scopes: ['Agent'], tools: ['send_email', 'issue_refund'] },
+  },
+};
+
+/** Section-level notice, e.g. the definitions request failed. */
+export const WithStatusBanner: Story = {
+  args: {
+    statusBanner: { tone: 'error', message: 'Guardrail definitions could not be loaded.' },
+  },
+};
+
+export const ReadOnly: Story = {
+  args: { disabled: true },
+};
+
+/**
+ * Hosts that show an overflow menu instead of inline buttons replace the row actions.
+ * The slot receives `edit` and `remove` so the menu still routes through the list's callbacks.
+ */
+export const CustomRowActions: Story = {
+  args: {
+    rowActivatesEdit: true,
+    renderItemActions: ({ guardrail, disabled, remove }) => (
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            variant="ghost"
+            size="3xs"
+            icon
+            disabled={disabled}
+            aria-label={`More options for ${guardrail.name}`}
+          >
+            <MoreVertical />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          <DropdownMenuItem onSelect={remove}>Remove</DropdownMenuItem>
+          <DropdownMenuItem>Help</DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    ),
+  },
+};
+
+/** The add affordance is a slot, so an entitlement lock replaces it without a product branch. */
+export const EntitlementLocked: Story = {
+  args: {
+    guardrails: [],
+    addSlot: <span className="text-xs text-foreground-muted">Requires entitlement</span>,
+  },
+};
+
+/**
+ * Scope names and action types are domain strings and print as stored. Hosts that localize
+ * them pass `formatScopes` and `formatAction`.
+ */
+export const HostFormattedSummaries: Story = {
+  args: {
+    guardrails: [BUILT_IN_GUARDRAIL],
+    formatScopes: () => 'Scopes: Agent, LLM calls',
+    formatAction: () => 'Log',
+  },
+};
+
+/** Chrome strings come from the packaged catalog; domain strings stay host-resolved. */
+export const Localized: Story = {
+  args: { locale: 'de' },
+};

--- a/packages/apollo-wind/src/components/custom/guardrails/guardrail-list.test.tsx
+++ b/packages/apollo-wind/src/components/custom/guardrails/guardrail-list.test.tsx
@@ -1,0 +1,392 @@
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { axe } from 'jest-axe';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { GOLDEN_ENRICHED_DEFINITIONS } from './__fixtures__/golden-enriched';
+import {
+  BUILT_IN_GUARDRAIL,
+  BYO_DISABLED_GUARDRAIL,
+  BYO_GUARDRAIL,
+  BYO_UNAVAILABLE_GUARDRAIL,
+  CUSTOM_GUARDRAIL,
+  GUARDRAIL_LIST_ITEMS,
+  UNIDENTIFIED_GUARDRAIL,
+} from './__fixtures__/list-items';
+import { GuardrailList } from './guardrail-list';
+import type { GuardrailListItem } from './list-types';
+
+const definitions = GOLDEN_ENRICHED_DEFINITIONS;
+
+function rowNames() {
+  return screen
+    .getAllByRole('listitem')
+    .map((row) => within(row).getAllByText(/.+/)[0].textContent);
+}
+
+const ROW_HEIGHT = 56;
+const ROW_PITCH = 64;
+
+function domRect(top: number, height: number): DOMRect {
+  return {
+    x: 0,
+    y: top,
+    top,
+    bottom: top + height,
+    left: 0,
+    right: 320,
+    width: 320,
+    height,
+    toJSON: () => ({}),
+  } as DOMRect;
+}
+
+/**
+ * jsdom reports a zero rect for everything, which leaves dnd-kit's collision detection unable
+ * to tell two rows apart, so a keyboard drag resolves onto the row it started from. Laying the
+ * rows out on a synthetic vertical grid is the minimum geometry needed to exercise the real
+ * sensor rather than mock the drag away.
+ */
+function stubRowGeometry() {
+  vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(function (
+    this: HTMLElement
+  ) {
+    const row = this.closest('li');
+    if (row?.parentElement) {
+      const index = Array.prototype.indexOf.call(row.parentElement.children, row);
+      return domRect(index * ROW_PITCH, ROW_HEIGHT);
+    }
+    const list = this.tagName === 'UL' ? this : this.querySelector('ul');
+    if (list) return domRect(0, list.children.length * ROW_PITCH);
+    return domRect(0, 0);
+  });
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('GuardrailList', () => {
+  it('renders the rows in the given order', () => {
+    render(<GuardrailList guardrails={GUARDRAIL_LIST_ITEMS} definitions={definitions} />);
+
+    expect(rowNames()).toEqual(['PII detection', 'Block refunds over 500', 'Acme toxicity']);
+  });
+
+  it('renders the header with the add affordance', async () => {
+    const user = userEvent.setup();
+    const onAdd = vi.fn();
+    render(<GuardrailList guardrails={GUARDRAIL_LIST_ITEMS} onAdd={onAdd} />);
+
+    expect(screen.getByText('Guardrails')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Add' }));
+    expect(onAdd).toHaveBeenCalledOnce();
+  });
+
+  it('hides the header and the add button when asked', () => {
+    render(<GuardrailList guardrails={GUARDRAIL_LIST_ITEMS} onAdd={vi.fn()} hideHeader />);
+
+    expect(screen.queryByText('Guardrails')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Add' })).not.toBeInTheDocument();
+  });
+
+  it('accepts a custom header title', () => {
+    render(<GuardrailList guardrails={[]} title="Tool guardrails" />);
+    expect(screen.getByText('Tool guardrails')).toBeInTheDocument();
+  });
+
+  it('replaces the add button with the host slot', () => {
+    render(
+      <GuardrailList guardrails={[]} onAdd={vi.fn()} addSlot={<span>Requires entitlement</span>} />
+    );
+
+    expect(screen.getByText('Requires entitlement')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Add' })).not.toBeInTheDocument();
+  });
+
+  it('renders the empty state, and lets the host replace it', () => {
+    const { unmount } = render(<GuardrailList guardrails={[]} />);
+    expect(screen.getByText('No guardrails configured')).toBeInTheDocument();
+    unmount();
+
+    render(<GuardrailList guardrails={[]} emptyState={<span>Nothing here yet</span>} />);
+    expect(screen.getByText('Nothing here yet')).toBeInTheDocument();
+    expect(screen.queryByText('No guardrails configured')).not.toBeInTheDocument();
+  });
+
+  it('resolves each row against the definitions catalog', () => {
+    render(
+      <GuardrailList
+        guardrails={[BYO_GUARDRAIL, BYO_DISABLED_GUARDRAIL, BYO_UNAVAILABLE_GUARDRAIL]}
+        definitions={definitions}
+        statusChips
+      />
+    );
+
+    expect(screen.getByText('Provider: Acme Security')).toBeInTheDocument();
+    expect(screen.getByText('Disabled')).toBeInTheDocument();
+    expect(screen.getByText('Unavailable')).toBeInTheDocument();
+    expect(screen.getAllByRole('alert')).toHaveLength(2);
+  });
+
+  it('tags rows with the host-supplied origin', () => {
+    render(
+      <GuardrailList
+        guardrails={GUARDRAIL_LIST_ITEMS}
+        definitions={definitions}
+        statusChips
+        getItemOrigin={(guardrail) =>
+          guardrail.name === 'Block refunds over 500' ? 'governance' : 'local'
+        }
+      />
+    );
+
+    expect(screen.getAllByText('Governance')).toHaveLength(1);
+  });
+
+  it('keys rows by name when the host persists no id', () => {
+    render(<GuardrailList guardrails={[UNIDENTIFIED_GUARDRAIL]} onReorder={vi.fn()} />);
+
+    expect(
+      screen.getByRole('button', { name: 'Reorder guardrail Prompt injection' })
+    ).toBeInTheDocument();
+  });
+
+  it('accepts a custom id resolver', () => {
+    const getItemId = vi.fn((guardrail: GuardrailListItem) => `custom-${guardrail.name}`);
+    render(
+      <GuardrailList guardrails={GUARDRAIL_LIST_ITEMS} getItemId={getItemId} onReorder={vi.fn()} />
+    );
+
+    expect(getItemId).toHaveBeenCalled();
+    expect(screen.getAllByRole('listitem')).toHaveLength(3);
+  });
+
+  it('reports edit and remove with the original guardrail object', async () => {
+    const user = userEvent.setup();
+    const onEdit = vi.fn();
+    const onRemove = vi.fn();
+    render(<GuardrailList guardrails={[CUSTOM_GUARDRAIL]} onEdit={onEdit} onRemove={onRemove} />);
+
+    await user.click(screen.getByRole('button', { name: 'Edit guardrail' }));
+    await user.click(screen.getByRole('button', { name: 'Delete guardrail' }));
+
+    expect(onEdit.mock.calls[0][0]).toBe(CUSTOM_GUARDRAIL);
+    expect(onRemove.mock.calls[0][0]).toBe(CUSTOM_GUARDRAIL);
+  });
+
+  it('routes the host action slot back through onEdit and onRemove', async () => {
+    const user = userEvent.setup();
+    const onEdit = vi.fn();
+    const onRemove = vi.fn();
+    render(
+      <GuardrailList
+        guardrails={[CUSTOM_GUARDRAIL]}
+        onEdit={onEdit}
+        onRemove={onRemove}
+        renderItemActions={({ guardrail, state, disabled, edit, remove }) => (
+          <>
+            <span>{`${guardrail.name}:${state.status}:${String(disabled)}`}</span>
+            <button type="button" onClick={edit}>
+              Menu edit
+            </button>
+            <button type="button" onClick={remove}>
+              Menu remove
+            </button>
+          </>
+        )}
+      />
+    );
+
+    expect(screen.getByText('Block refunds over 500:Available:false')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Edit guardrail' })).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Menu edit' }));
+    await user.click(screen.getByRole('button', { name: 'Menu remove' }));
+
+    expect(onEdit.mock.calls[0][0]).toBe(CUSTOM_GUARDRAIL);
+    expect(onRemove.mock.calls[0][0]).toBe(CUSTOM_GUARDRAIL);
+  });
+
+  it('renders no drag handles without an onReorder callback', () => {
+    render(<GuardrailList guardrails={GUARDRAIL_LIST_ITEMS} />);
+    expect(screen.queryByRole('button', { name: /Reorder guardrail/ })).not.toBeInTheDocument();
+  });
+
+  it('renders no drag handles in read-only mode', () => {
+    render(<GuardrailList guardrails={GUARDRAIL_LIST_ITEMS} onReorder={vi.fn()} disabled />);
+    expect(screen.queryByRole('button', { name: /Reorder guardrail/ })).not.toBeInTheDocument();
+  });
+
+  it('keeps reordering when the host separates it from read-only', () => {
+    render(
+      <GuardrailList
+        guardrails={GUARDRAIL_LIST_ITEMS}
+        onReorder={vi.fn()}
+        disabled
+        reorderDisabled={false}
+      />
+    );
+
+    expect(screen.getAllByRole('button', { name: /Reorder guardrail/ })).toHaveLength(3);
+  });
+
+  it('renders nothing for an empty list when the host passes null', () => {
+    render(<GuardrailList guardrails={[]} emptyState={null} />);
+    expect(screen.queryByText('No guardrails configured')).not.toBeInTheDocument();
+  });
+
+  it('renders the footer slot below the rows', () => {
+    render(
+      <GuardrailList
+        guardrails={GUARDRAIL_LIST_ITEMS}
+        footer={<button type="button">Add another guardrail</button>}
+      />
+    );
+
+    expect(screen.getByRole('button', { name: 'Add another guardrail' })).toBeInTheDocument();
+  });
+
+  it('drops the card chrome when unstyled', () => {
+    const { container } = render(<GuardrailList guardrails={[]} unstyled />);
+
+    const root = container.querySelector('[data-slot="guardrail-list"]');
+    expect(root).not.toHaveClass('border');
+    expect(root).not.toHaveClass('rounded-md');
+  });
+
+  it('chips nothing by default, which keeps an adopting host behaviour-identical', () => {
+    render(
+      <GuardrailList
+        guardrails={[BYO_DISABLED_GUARDRAIL]}
+        definitions={definitions}
+        getItemOrigin={() => 'governance'}
+      />
+    );
+
+    expect(screen.queryByText('Disabled')).not.toBeInTheDocument();
+    expect(screen.queryByText('Governance')).not.toBeInTheDocument();
+    // The notice is not a chip and stays on: both products render it today.
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+  });
+
+  it('disables the add and row actions in read-only mode', () => {
+    render(
+      <GuardrailList
+        guardrails={[CUSTOM_GUARDRAIL]}
+        onAdd={vi.fn()}
+        onEdit={vi.fn()}
+        onRemove={vi.fn()}
+        disabled
+      />
+    );
+
+    expect(screen.getByRole('button', { name: 'Add' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Edit guardrail' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Delete guardrail' })).toBeDisabled();
+  });
+
+  it('reorders with the keyboard and reports the move', async () => {
+    const user = userEvent.setup();
+    const onReorder = vi.fn();
+    stubRowGeometry();
+    render(<GuardrailList guardrails={GUARDRAIL_LIST_ITEMS} onReorder={onReorder} />);
+
+    screen.getByRole('button', { name: 'Reorder guardrail PII detection' }).focus();
+    await user.keyboard(' ');
+    await user.keyboard('{ArrowDown}');
+    await user.keyboard(' ');
+
+    await waitFor(() => expect(onReorder).toHaveBeenCalledOnce());
+    const [reordered, move] = onReorder.mock.calls[0];
+    expect(reordered.map((guardrail: GuardrailListItem) => guardrail.name)).toEqual([
+      'Block refunds over 500',
+      'PII detection',
+      'Acme toxicity',
+    ]);
+    expect(move).toEqual({ from: 0, to: 1, id: 'gr-pii' });
+    expect(reordered[1]).toBe(BUILT_IN_GUARDRAIL);
+  });
+
+  it('renders the section banners, and hides them when the host passes null', () => {
+    const { unmount } = render(
+      <GuardrailList
+        guardrails={[]}
+        statusBanner={{ tone: 'error', message: 'Could not load definitions.' }}
+        mixedScopes={{ scopes: ['Agent'], tools: ['send_email'] }}
+      />
+    );
+
+    expect(screen.getByText('Could not load definitions.')).toBeInTheDocument();
+    expect(screen.getByText('This guardrail is also applied to:')).toBeInTheDocument();
+    expect(screen.getByText('send_email')).toBeInTheDocument();
+    unmount();
+
+    render(<GuardrailList guardrails={[]} statusBanner={null} mixedScopes={null} />);
+    expect(screen.queryByText('This guardrail is also applied to:')).not.toBeInTheDocument();
+  });
+
+  it('reshapes the scope and action summaries through the host slots', () => {
+    render(
+      <GuardrailList
+        guardrails={[BUILT_IN_GUARDRAIL]}
+        formatScopes={() => 'Scopes: Agent, LLM calls'}
+        formatAction={() => 'Log'}
+      />
+    );
+
+    expect(screen.getByText('Scopes: Agent, LLM calls')).toBeInTheDocument();
+    expect(screen.getByText('Log')).toBeInTheDocument();
+  });
+
+  it('overrides chrome strings per key', () => {
+    render(<GuardrailList guardrails={[]} labels={{ emptyState: 'No guardrails yet' }} />);
+
+    expect(screen.getByText('No guardrails yet')).toBeInTheDocument();
+    expect(screen.getByText('Guardrails')).toBeInTheDocument();
+  });
+
+  it('loads the packaged catalog for a host locale', async () => {
+    render(<GuardrailList guardrails={[]} locale="de" />);
+
+    await waitFor(() =>
+      expect(screen.getByText('Keine Leitplanken konfiguriert')).toBeInTheDocument()
+    );
+  });
+
+  it('has no accessibility violations', async () => {
+    const { container } = render(
+      <GuardrailList
+        guardrails={GUARDRAIL_LIST_ITEMS}
+        definitions={definitions}
+        onAdd={vi.fn()}
+        onEdit={vi.fn()}
+        onRemove={vi.fn()}
+        onReorder={vi.fn()}
+      />
+    );
+
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('has no accessibility violations with every chip, notice and banner rendered', async () => {
+    const { container } = render(
+      <GuardrailList
+        guardrails={[BYO_DISABLED_GUARDRAIL, BYO_UNAVAILABLE_GUARDRAIL, CUSTOM_GUARDRAIL]}
+        definitions={definitions}
+        getItemOrigin={() => 'governance'}
+        statusChips
+        previewChip
+        rowActivatesEdit
+        statusBanner={{ tone: 'warning', message: 'Read-only.' }}
+        mixedScopes={{ scopes: ['Agent'], tools: ['send_email'] }}
+        onEdit={vi.fn()}
+        onRemove={vi.fn()}
+        onReorder={vi.fn()}
+      />
+    );
+
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/packages/apollo-wind/src/components/custom/guardrails/guardrail-list.tsx
+++ b/packages/apollo-wind/src/components/custom/guardrails/guardrail-list.tsx
@@ -1,0 +1,311 @@
+import {
+  closestCenter,
+  DndContext,
+  type DragEndEvent,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+} from '@dnd-kit/core';
+import { restrictToParentElement, restrictToVerticalAxis } from '@dnd-kit/modifiers';
+import {
+  SortableContext,
+  sortableKeyboardCoordinates,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable';
+import { Plus, Shield } from 'lucide-react';
+import { type ReactNode, useEffect, useMemo, useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib';
+import { GuardrailListRow } from './components/guardrail-list-row';
+import { GuardrailStatusBanner } from './components/guardrail-status-banner';
+import { MixedScopesBanner } from './components/mixed-scopes-banner';
+import {
+  defaultGuardrailItemId,
+  type GuardrailListDefinition,
+  moveGuardrail,
+  resolveGuardrailListItemState,
+} from './guardrail-list-utils';
+import { type GuardrailListLabels, resolveGuardrailListLabels } from './i18n';
+import type {
+  GuardrailListItem,
+  GuardrailListItemActionsContext,
+  GuardrailListMove,
+  GuardrailListOrigin,
+} from './list-types';
+import { type GuardrailMessages, loadGuardrailMessages } from './load-messages';
+
+const DND_MODIFIERS = [restrictToVerticalAxis, restrictToParentElement];
+// A small activation distance keeps a click on the handle from starting a drag, which is what
+// makes the handle usable as a button (and keyboard-focusable) at the same time.
+const POINTER_SENSOR_OPTIONS = { activationConstraint: { distance: 8 } };
+
+export interface GuardrailListProps<T extends GuardrailListItem = GuardrailListItem> {
+  /**
+   * The rows to render, in order.
+   *
+   * Pre-filtered by the host: this component never drops a row. Every product-side gate lives
+   * on the other side of the boundary, including Agents' six `enableGuardrail*` feature flags
+   * and Flow's `canvas.guardrails` entitlement plus its allowed-scope filter. Pass the
+   * survivors.
+   */
+  guardrails: T[];
+  /**
+   * Definitions catalog used to resolve each row's status, provider and notices. Also
+   * host-filtered. Omit it for lists that hold only custom guardrails.
+   */
+  definitions?: readonly GuardrailListDefinition[];
+  /** Read-only mode: no reordering, actions rendered disabled. */
+  disabled?: boolean;
+  /**
+   * Whether reordering is off, independent of `disabled`. Defaults to `disabled`, which is
+   * what Agents does. Flow's read-only list stays reorderable, so it passes `false`.
+   */
+  reorderDisabled?: boolean;
+  /**
+   * Called with the reordered visible array and the move that produced it. Hosts rendering a
+   * filtered view (Flow's tool view over an agent-level list) use `move` to splice the change
+   * back into the full list. Omit to render no drag handles.
+   */
+  onReorder?: (guardrails: T[], move: GuardrailListMove) => void;
+  /** Edit intent. The host owns the builder; omit to render no edit affordance. */
+  onEdit?: (guardrail: T) => void;
+  /**
+   * Remove intent, not the removal. Both products confirm first, with different copy and
+   * different scoped-removal rules, so the dialog and the mutation stay host-side.
+   */
+  onRemove?: (guardrail: T) => void;
+  /** Add intent. Omit (or replace with `addSlot`) to render no add affordance. */
+  onAdd?: () => void;
+  /** Pre-localized scope and tool names this guardrail also applies to; null hides the banner. */
+  mixedScopes?: { scopes: string[]; tools: string[] } | null;
+  /** Section-level notice, e.g. a definitions load failure. */
+  statusBanner?: { tone: 'error' | 'warning'; message: string } | null;
+  /** Row identity. Defaults to `id`, falling back to `name` for hosts that persist no id. */
+  getItemId?: (guardrail: T) => string;
+  /** Where a row is administered from. Defaults to `'local'` for every row. */
+  getItemOrigin?: (guardrail: T) => GuardrailListOrigin;
+  /** Replace a row's Edit/Delete buttons wholesale, e.g. with an overflow menu. */
+  renderItemActions?: (context: GuardrailListItemActionsContext<T>) => ReactNode;
+  /** Replace the header's Add button, e.g. with an entitlement lock. */
+  addSlot?: ReactNode;
+  /**
+   * Rendered below the rows. Agents puts its add affordance here rather than in the header,
+   * and swaps it for an entitlement line, so `addSlot` alone cannot express that layout.
+   */
+  footer?: ReactNode;
+  /**
+   * Show the status and origin chips. Off by default: neither product renders them today, so
+   * an adopting host gets a behaviour-identical swap and turns them on deliberately. The two
+   * BYO row notices are not gated by this, because both products already show those.
+   */
+  statusChips?: boolean;
+  /**
+   * Mark built-in-validator rows as preview. Off by default: whether the feature is in
+   * preview is product lifecycle, and baking it in would need a package release to undo.
+   */
+  previewChip?: boolean;
+  /**
+   * Drop the card chrome (border, rounding, content padding) for hosts that supply their own
+   * container, e.g. Agents' `SectionAccordion`.
+   */
+  unstyled?: boolean;
+  /** Let the row body activate edit on click and Enter/Space, in addition to any Edit button. */
+  rowActivatesEdit?: boolean;
+  hideHeader?: boolean;
+  /** Overrides the header title text. */
+  title?: ReactNode;
+  /** Replaces the default "No guardrails configured" line. */
+  emptyState?: ReactNode;
+  /** Renders the row's scope summary. Defaults to the raw scopes, comma-joined. */
+  formatScopes?: (guardrail: T) => string | undefined;
+  /** Renders the row's action badge. Defaults to the raw `$actionType`. */
+  formatAction?: (guardrail: T) => ReactNode;
+  /**
+   * Tooltip content for a row, e.g. Agents' combined description, provider and scopes hover.
+   * Return nothing to leave a row untooltipped. Requires an ancestor `TooltipProvider`, and
+   * only when the slot is supplied.
+   */
+  renderRowTooltip?: (guardrail: T) => ReactNode;
+  /** Host locale; loads the packaged catalog. Omit for synchronous English. */
+  locale?: string;
+  labels?: Partial<GuardrailListLabels>;
+  className?: string;
+}
+
+/** Resolve chrome strings: English defaults < packaged catalog < `labels` overrides. */
+function useGuardrailListLabels(
+  locale?: string,
+  overrides?: Partial<GuardrailListLabels>
+): GuardrailListLabels {
+  const [catalog, setCatalog] = useState<GuardrailMessages>({});
+
+  useEffect(() => {
+    if (!locale) {
+      setCatalog({});
+      return;
+    }
+    let cancelled = false;
+    loadGuardrailMessages(locale).then((messages) => {
+      if (!cancelled) setCatalog(messages);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [locale]);
+
+  return useMemo(() => resolveGuardrailListLabels(catalog, overrides), [catalog, overrides]);
+}
+
+function defaultFormatScopes(guardrail: GuardrailListItem): string | undefined {
+  const scopes = guardrail.selector?.scopes;
+  return scopes && scopes.length > 0 ? scopes.join(', ') : undefined;
+}
+
+function defaultFormatAction(guardrail: GuardrailListItem): ReactNode {
+  return guardrail.action?.$actionType;
+}
+
+/**
+ * The guardrails list section: the guardrails applied to an agent or tool, with reorder,
+ * status and origin chips, per-row edit/remove intents, and the mixed-scopes banner.
+ *
+ * Rendering only. The host filters the rows, owns the add/edit flows and the remove
+ * confirmation, and fires its own telemetry around the callbacks. Feature flags never cross
+ * this boundary.
+ */
+export function GuardrailList<T extends GuardrailListItem = GuardrailListItem>({
+  guardrails,
+  definitions,
+  disabled = false,
+  reorderDisabled = disabled,
+  onReorder,
+  onEdit,
+  onRemove,
+  onAdd,
+  mixedScopes = null,
+  statusBanner = null,
+  getItemId = defaultGuardrailItemId,
+  getItemOrigin,
+  renderItemActions,
+  addSlot,
+  footer,
+  statusChips = false,
+  previewChip = false,
+  unstyled = false,
+  rowActivatesEdit = false,
+  hideHeader = false,
+  title,
+  emptyState,
+  formatScopes = defaultFormatScopes,
+  formatAction = defaultFormatAction,
+  renderRowTooltip,
+  locale,
+  labels: labelOverrides,
+  className,
+}: GuardrailListProps<T>) {
+  const labels = useGuardrailListLabels(locale, labelOverrides);
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, POINTER_SENSOR_OPTIONS),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
+  );
+
+  const sortableIds = useMemo(() => guardrails.map(getItemId), [guardrails, getItemId]);
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+    if (!over || !onReorder) return;
+    const result = moveGuardrail(guardrails, String(active.id), String(over.id), getItemId);
+    if (result) onReorder(result.guardrails, result.move);
+  };
+
+  const sortable = onReorder !== undefined && !reorderDisabled;
+
+  const header = hideHeader ? null : (
+    <div className="flex items-center justify-between px-3 py-2">
+      <div className="flex items-center gap-2">
+        <Shield className="size-4 text-foreground-muted" aria-hidden="true" />
+        <span className="text-sm font-medium">{title ?? labels.headerTitle}</span>
+      </div>
+      {addSlot ??
+        (onAdd && (
+          <Button variant="ghost" size="2xs" disabled={disabled} onClick={onAdd}>
+            <Plus />
+            {labels.addButton}
+          </Button>
+        ))}
+    </div>
+  );
+
+  return (
+    <div data-slot="guardrail-list" className={cn(!unstyled && 'rounded-md border', className)}>
+      {header}
+      <div className={cn('space-y-2', !unstyled && 'p-3')}>
+        {statusBanner && (
+          <GuardrailStatusBanner tone={statusBanner.tone} message={statusBanner.message} />
+        )}
+        <MixedScopesBanner otherAppliedScopes={mixedScopes} labels={labels} />
+        {guardrails.length === 0 ? (
+          // `??` would swallow an explicit `null`, which is how a host says "render nothing
+          // when empty" (Agents shows only its add button).
+          emptyState !== undefined ? (
+            emptyState
+          ) : (
+            <p className="text-sm text-foreground-muted">{labels.emptyState}</p>
+          )
+        ) : (
+          <DndContext
+            sensors={sensors}
+            collisionDetection={closestCenter}
+            modifiers={DND_MODIFIERS}
+            onDragEnd={handleDragEnd}
+          >
+            <SortableContext items={sortableIds} strategy={verticalListSortingStrategy}>
+              <ul className="space-y-2">
+                {guardrails.map((guardrail, index) => {
+                  const state = resolveGuardrailListItemState(
+                    guardrail,
+                    definitions,
+                    getItemOrigin?.(guardrail)
+                  );
+                  return (
+                    <GuardrailListRow
+                      key={sortableIds[index]}
+                      id={sortableIds[index]}
+                      guardrail={guardrail}
+                      state={state}
+                      labels={labels}
+                      disabled={disabled}
+                      sortable={sortable}
+                      statusChips={statusChips}
+                      previewChip={previewChip}
+                      activatesEdit={rowActivatesEdit}
+                      formatScopes={formatScopes}
+                      formatAction={formatAction}
+                      renderTooltip={renderRowTooltip}
+                      onEdit={onEdit}
+                      onRemove={onRemove}
+                      renderActions={
+                        renderItemActions &&
+                        (() =>
+                          renderItemActions({
+                            guardrail,
+                            state,
+                            disabled,
+                            edit: () => onEdit?.(guardrail),
+                            remove: () => onRemove?.(guardrail),
+                          }))
+                      }
+                    />
+                  );
+                })}
+              </ul>
+            </SortableContext>
+          </DndContext>
+        )}
+        {footer}
+      </div>
+    </div>
+  );
+}

--- a/packages/apollo-wind/src/components/custom/guardrails/i18n.ts
+++ b/packages/apollo-wind/src/components/custom/guardrails/i18n.ts
@@ -159,20 +159,29 @@ export const GUARDRAIL_BUILDER_EN_LABELS: GuardrailBuilderLabels = {
   actionAppRequiredError: 'Action app is required',
 };
 
-/** Merge English defaults, a loaded catalog, and per-string overrides (undefined skipped). */
-export function resolveGuardrailBuilderLabels(
-  catalog?: Partial<GuardrailBuilderLabels>,
-  overrides?: Partial<GuardrailBuilderLabels>
-): GuardrailBuilderLabels {
-  const merged: GuardrailBuilderLabels = { ...GUARDRAIL_BUILDER_EN_LABELS };
-  for (const source of [catalog, overrides]) {
+/**
+ * Layer sparse sources over a complete English default set, later source wins per key.
+ * Only keys the defaults declare are copied, so a catalog carrying stale keys cannot inject
+ * them, and an explicit `undefined` override falls through to the layer below.
+ */
+function mergeLabels<T extends object>(defaults: T, sources: Array<Partial<T> | undefined>): T {
+  const merged: T = { ...defaults };
+  for (const source of sources) {
     if (!source) continue;
-    for (const key of Object.keys(merged) as Array<keyof GuardrailBuilderLabels>) {
+    for (const key of Object.keys(merged) as Array<keyof T>) {
       const value = source[key];
       if (value !== undefined) merged[key] = value;
     }
   }
   return merged;
+}
+
+/** Merge English defaults, a loaded catalog, and per-string overrides (undefined skipped). */
+export function resolveGuardrailBuilderLabels(
+  catalog?: Partial<GuardrailBuilderLabels>,
+  overrides?: Partial<GuardrailBuilderLabels>
+): GuardrailBuilderLabels {
+  return mergeLabels(GUARDRAIL_BUILDER_EN_LABELS, [catalog, overrides]);
 }
 
 /** Interpolate `{{token}}` placeholders in a catalog message. Unknown tokens are left as-is. */
@@ -190,13 +199,69 @@ export function resolveGuardrailFormLabels(
   catalog?: Partial<GuardrailValidatorFormLabels>,
   overrides?: Partial<GuardrailValidatorFormLabels>
 ): GuardrailValidatorFormLabels {
-  const merged: GuardrailValidatorFormLabels = { ...GUARDRAIL_FORM_EN_LABELS };
-  for (const source of [catalog, overrides]) {
-    if (!source) continue;
-    for (const key of Object.keys(merged) as Array<keyof GuardrailValidatorFormLabels>) {
-      const value = source[key];
-      if (value !== undefined) merged[key] = value;
-    }
-  }
-  return merged;
+  return mergeLabels(GUARDRAIL_FORM_EN_LABELS, [catalog, overrides]);
+}
+
+/**
+ * Chrome strings of the guardrail list section (header, row affordances, status chips, and
+ * the two BYO row notices). Domain strings stay host-resolved: scope names and action types
+ * are printed as given, or reshaped through the list's `formatScopes` / `formatAction` slots.
+ *
+ * Strings shared with the builder are referenced from `GUARDRAIL_BUILDER_EN_LABELS` rather
+ * than retyped, so the two label sets cannot drift apart the way the two products' tables did.
+ */
+export interface GuardrailListLabels {
+  headerTitle: string;
+  addButton: string;
+  emptyState: string;
+  /** Aria-label template of a row's drag handle: `{{name}}`. */
+  reorderHandleAriaLabel: string;
+  /** Aria-label template of the whole row when `rowActivatesEdit` is set: `{{name}}`. */
+  editRowAriaLabel: string;
+  editButtonAriaLabel: string;
+  deleteButtonAriaLabel: string;
+  providerLabel: string;
+  previewChip: string;
+  originGovernanceChip: string;
+  statusDisabledChip: string;
+  statusUnauthorizedChip: string;
+  statusFeatureDisabledChip: string;
+  statusUnavailableChip: string;
+  /** Row notice for a BYO guardrail whose configuration was disabled. */
+  byoDisabledNotice: string;
+  /** Row notice for a BYO guardrail whose configuration no longer exists. */
+  byoUnavailableNotice: string;
+  // Mixed scopes banner (shared with the builder)
+  mixedScopesAlsoApplied: string;
+  mixedScopesSaveAsNewHint: string;
+}
+
+export const GUARDRAIL_LIST_EN_LABELS: GuardrailListLabels = {
+  headerTitle: 'Guardrails',
+  addButton: 'Add',
+  emptyState: 'No guardrails configured',
+  reorderHandleAriaLabel: 'Reorder guardrail {{name}}',
+  editRowAriaLabel: 'Edit guardrail {{name}}',
+  editButtonAriaLabel: 'Edit guardrail',
+  deleteButtonAriaLabel: 'Delete guardrail',
+  providerLabel: 'Provider',
+  previewChip: 'Preview',
+  originGovernanceChip: 'Governance',
+  statusDisabledChip: 'Disabled',
+  statusUnauthorizedChip: 'Not entitled',
+  statusFeatureDisabledChip: 'Feature disabled',
+  statusUnavailableChip: 'Unavailable',
+  byoDisabledNotice: GUARDRAIL_BUILDER_EN_LABELS.byoDisabledMessage,
+  byoUnavailableNotice:
+    "This guardrail's configuration is no longer available. Replace it before running the agent.",
+  mixedScopesAlsoApplied: GUARDRAIL_BUILDER_EN_LABELS.mixedScopesAlsoApplied,
+  mixedScopesSaveAsNewHint: GUARDRAIL_BUILDER_EN_LABELS.mixedScopesSaveAsNewHint,
+};
+
+/** Merge English defaults, a loaded catalog, and per-string overrides (undefined skipped). */
+export function resolveGuardrailListLabels(
+  catalog?: Partial<GuardrailListLabels>,
+  overrides?: Partial<GuardrailListLabels>
+): GuardrailListLabels {
+  return mergeLabels(GUARDRAIL_LIST_EN_LABELS, [catalog, overrides]);
 }

--- a/packages/apollo-wind/src/components/custom/guardrails/index.ts
+++ b/packages/apollo-wind/src/components/custom/guardrails/index.ts
@@ -33,6 +33,15 @@ export {
 } from './builder-utils';
 export type { GuardrailChipProps } from './components/guardrail-chip';
 export { GuardrailChip, guardrailChipVariants } from './components/guardrail-chip';
+export type { GuardrailStatusBannerProps } from './components/guardrail-status-banner';
+export { GuardrailStatusBanner } from './components/guardrail-status-banner';
+export type {
+  GuardrailStatusChipProps,
+  GuardrailStatusChipTone,
+} from './components/guardrail-status-chip';
+export { GuardrailStatusChip } from './components/guardrail-status-chip';
+export type { MixedScopesBannerProps } from './components/mixed-scopes-banner';
+export { MixedScopesBanner } from './components/mixed-scopes-banner';
 export type { GuardrailCopyKey, GuardrailCopyTranslator } from './definitions-copy';
 export {
   GUARDRAIL_COPY_EN,
@@ -62,15 +71,40 @@ export type { GuardrailBuilderProps } from './guardrail-builder';
 export { GuardrailBuilder } from './guardrail-builder';
 export type { GuardrailFormLayoutProps } from './guardrail-form-layout';
 export { GuardrailFormLayout } from './guardrail-form-layout';
+export type { GuardrailListProps } from './guardrail-list';
+export { GuardrailList } from './guardrail-list';
+export type { GuardrailListDefinition } from './guardrail-list-utils';
+export {
+  defaultGuardrailItemId,
+  findGuardrailDefinition,
+  matchGuardrailDefinition,
+  moveGuardrail,
+  resolveGuardrailListItemState,
+} from './guardrail-list-utils';
 export { GuardrailValidatorForm } from './guardrail-validator-form';
-export type { GuardrailBuilderLabels, GuardrailValidatorFormLabels } from './i18n';
+export type {
+  GuardrailBuilderLabels,
+  GuardrailListLabels,
+  GuardrailValidatorFormLabels,
+} from './i18n';
 export {
   formatGuardrailFormMessage,
   GUARDRAIL_BUILDER_EN_LABELS,
   GUARDRAIL_FORM_EN_LABELS,
+  GUARDRAIL_LIST_EN_LABELS,
   resolveGuardrailBuilderLabels,
   resolveGuardrailFormLabels,
+  resolveGuardrailListLabels,
 } from './i18n';
+export type {
+  GuardrailListItem,
+  GuardrailListItemActionsContext,
+  GuardrailListItemNotice,
+  GuardrailListItemState,
+  GuardrailListItemStatus,
+  GuardrailListMove,
+  GuardrailListOrigin,
+} from './list-types';
 export type { GuardrailFormLocale } from './load-messages';
 export {
   GUARDRAIL_FORM_LOCALES,

--- a/packages/apollo-wind/src/components/custom/guardrails/list-types.ts
+++ b/packages/apollo-wind/src/components/custom/guardrails/list-types.ts
@@ -1,0 +1,70 @@
+import type { GuardrailDefinitionStatus, GuardrailSelector } from './builder-types';
+
+/**
+ * Structural mirror of the persisted guardrail record, narrowed to what the list section
+ * reads. Hosts pass their own richer union unmapped: the list is generic over `T`, so every
+ * callback hands back the exact object that went in.
+ *
+ * Deliberately not `GuardrailBuilderValue`: the list renders custom (rule-based) guardrails
+ * next to built-in-validator ones, and custom records carry no `validatorType`.
+ */
+export interface GuardrailListItem {
+  /** Flow keys rows by `id`; Agents has no id and keys by `name`. See `defaultGuardrailItemId`. */
+  id?: string;
+  name: string;
+  description?: string;
+  /** `'builtInValidator'` rows resolve against the definitions; every other value does not. */
+  $guardrailType: string;
+  validatorType?: string;
+  byoValidatorName?: string;
+  selector?: GuardrailSelector;
+  action?: { $actionType: string };
+}
+
+/**
+ * Where the guardrail is administered from. Not inferable from the record: both products
+ * fetch governance-managed guardrails from a different endpoint, so the host tags them.
+ */
+export type GuardrailListOrigin = 'local' | 'governance';
+
+/**
+ * Row status. `'Unavailable'` extends the wire statuses with the client-side case both
+ * products already detect: a BYO guardrail whose definition is gone from the catalog.
+ */
+export type GuardrailListItemStatus = GuardrailDefinitionStatus | 'Unavailable';
+
+/** Which explanatory sentence, if any, the row prints under its title. */
+export type GuardrailListItemNotice = 'byoDisabled' | 'byoUnavailable';
+
+/** Everything the row derives from a guardrail plus the definitions catalog. */
+export interface GuardrailListItemState {
+  /**
+   * `'Available'` is the quiet state and renders no chip. It also covers rows there is
+   * nothing to report on: custom guardrails, and built-ins whose definition has not loaded.
+   */
+  status: GuardrailListItemStatus;
+  origin: GuardrailListOrigin;
+  /** Connector that supplies a BYO guardrail, shown as the row's provider line. */
+  byoConnectorName?: string;
+  notice?: GuardrailListItemNotice;
+}
+
+/** Context handed to the `renderItemActions` slot (e.g. an overflow menu instead of buttons). */
+export interface GuardrailListItemActionsContext<T extends GuardrailListItem = GuardrailListItem> {
+  guardrail: T;
+  state: GuardrailListItemState;
+  /** True when the whole list is read-only; render your actions disabled. */
+  disabled: boolean;
+  /** Routes through the list's `onEdit`; a no-op when the host passed none. */
+  edit: () => void;
+  /** Routes through the list's `onRemove`; a no-op when the host passed none. */
+  remove: () => void;
+}
+
+/** The move a drag or keyboard reorder produced, reported alongside the reordered array. */
+export interface GuardrailListMove {
+  from: number;
+  to: number;
+  /** Id of the guardrail that moved, per the list's `getItemId`. */
+  id: string;
+}

--- a/packages/apollo-wind/src/components/custom/guardrails/load-messages.ts
+++ b/packages/apollo-wind/src/components/custom/guardrails/load-messages.ts
@@ -1,7 +1,13 @@
-import type { GuardrailBuilderLabels, GuardrailValidatorFormLabels } from './i18n';
+import type {
+  GuardrailBuilderLabels,
+  GuardrailListLabels,
+  GuardrailValidatorFormLabels,
+} from './i18n';
 
 /** Every string the guardrails family localizes; catalogs are sparse subsets of this. */
-export type GuardrailMessages = Partial<GuardrailValidatorFormLabels & GuardrailBuilderLabels>;
+export type GuardrailMessages = Partial<
+  GuardrailValidatorFormLabels & GuardrailBuilderLabels & GuardrailListLabels
+>;
 
 export const GUARDRAIL_FORM_LOCALES = [
   'de',

--- a/packages/apollo-wind/src/components/custom/guardrails/locales/de.ts
+++ b/packages/apollo-wind/src/components/custom/guardrails/locales/de.ts
@@ -1,9 +1,15 @@
 // Translations harvested from Flow Workbench's canvas catalog so the extraction
 // introduces no new translation work. Missing keys fall back to English per key at
 // resolve time (see i18n.ts).
-import type { GuardrailBuilderLabels, GuardrailValidatorFormLabels } from '../i18n';
+import type {
+  GuardrailBuilderLabels,
+  GuardrailListLabels,
+  GuardrailValidatorFormLabels,
+} from '../i18n';
 
-export const messages: Partial<GuardrailValidatorFormLabels & GuardrailBuilderLabels> = {
+export const messages: Partial<
+  GuardrailValidatorFormLabels & GuardrailBuilderLabels & GuardrailListLabels
+> = {
   moreInformation: 'Weitere Informationen',
   enumPlaceholder: 'Auswählen…',
   enumListPlaceholder: 'Optionen auswählen…',
@@ -69,4 +75,17 @@ export const messages: Partial<GuardrailValidatorFormLabels & GuardrailBuilderLa
   filterFieldsRequiredError: 'Eine Feldauswahl ist erforderlich.',
   recipientRequiredError: 'Empfänger ist erforderlich',
   actionAppRequiredError: 'Aktions-App ist erforderlich',
+  // Guardrail list section
+  headerTitle: 'Leitlinien',
+  addButton: 'Hinzufügen',
+  emptyState: 'Keine Leitplanken konfiguriert',
+  reorderHandleAriaLabel: 'Leitplanke {{name}} neu anordnen',
+  editButtonAriaLabel: 'Leitplanke bearbeiten',
+  deleteButtonAriaLabel: 'Leitplanke löschen',
+  providerLabel: 'Provider',
+  previewChip: 'Vorschau',
+  byoDisabledNotice:
+    'Die Konfiguration dieser Leitplanke wurde deaktiviert und kann nicht mehr verwendet werden. Wenden Sie sich an Ihren Administrator, um die Konfiguration wieder zu aktivieren oder diese Leitplanke zu ersetzen, bevor Sie den Agent ausführen.',
+  byoUnavailableNotice:
+    'Die Konfiguration dieser Leitplanke ist nicht mehr verfügbar. Ersetzen Sie sie, bevor Sie den Agent ausführen.',
 };

--- a/packages/apollo-wind/src/components/custom/guardrails/locales/en.ts
+++ b/packages/apollo-wind/src/components/custom/guardrails/locales/en.ts
@@ -1,6 +1,12 @@
-import type { GuardrailBuilderLabels, GuardrailValidatorFormLabels } from '../i18n';
+import type {
+  GuardrailBuilderLabels,
+  GuardrailListLabels,
+  GuardrailValidatorFormLabels,
+} from '../i18n';
 
-export const messages: Partial<GuardrailValidatorFormLabels & GuardrailBuilderLabels> = {
+export const messages: Partial<
+  GuardrailValidatorFormLabels & GuardrailBuilderLabels & GuardrailListLabels
+> = {
   moreInformation: 'More information',
   enumPlaceholder: 'Select...',
   enumListPlaceholder: 'Select options...',
@@ -64,4 +70,17 @@ export const messages: Partial<GuardrailValidatorFormLabels & GuardrailBuilderLa
   filterFieldsRequiredError: 'Fields selection is required',
   recipientRequiredError: 'Recipient is required',
   actionAppRequiredError: 'Action app is required',
+  // Guardrail list section
+  headerTitle: 'Guardrails',
+  addButton: 'Add',
+  emptyState: 'No guardrails configured',
+  reorderHandleAriaLabel: 'Reorder guardrail {{name}}',
+  editButtonAriaLabel: 'Edit guardrail',
+  deleteButtonAriaLabel: 'Delete guardrail',
+  providerLabel: 'Provider',
+  previewChip: 'Preview',
+  byoDisabledNotice:
+    "This guardrail's configuration has been disabled and can no longer be used. Contact your administrator to re-enable the configuration or replace this guardrail before running the agent.",
+  byoUnavailableNotice:
+    "This guardrail's configuration is no longer available. Replace it before running the agent.",
 };

--- a/packages/apollo-wind/src/components/custom/guardrails/locales/es-MX.ts
+++ b/packages/apollo-wind/src/components/custom/guardrails/locales/es-MX.ts
@@ -1,9 +1,15 @@
 // Translations harvested from Flow Workbench's canvas catalog so the extraction
 // introduces no new translation work. Missing keys fall back to English per key at
 // resolve time (see i18n.ts).
-import type { GuardrailBuilderLabels, GuardrailValidatorFormLabels } from '../i18n';
+import type {
+  GuardrailBuilderLabels,
+  GuardrailListLabels,
+  GuardrailValidatorFormLabels,
+} from '../i18n';
 
-export const messages: Partial<GuardrailValidatorFormLabels & GuardrailBuilderLabels> = {
+export const messages: Partial<
+  GuardrailValidatorFormLabels & GuardrailBuilderLabels & GuardrailListLabels
+> = {
   moreInformation: 'Más información',
   enumPlaceholder: 'Seleccionar...',
   enumListPlaceholder: 'Seleccione opciones…',
@@ -70,4 +76,17 @@ export const messages: Partial<GuardrailValidatorFormLabels & GuardrailBuilderLa
   filterFieldsRequiredError: 'Se requiere la selección de campos',
   recipientRequiredError: 'El destinatario es necesario.',
   actionAppRequiredError: 'La aplicación de acción es necesaria.',
+  // Guardrail list section
+  headerTitle: 'Protecciones',
+  addButton: 'Agregar',
+  emptyState: 'No hay medidas de seguridad configuradas',
+  reorderHandleAriaLabel: 'Reordenar la medida de seguridad {{name}}',
+  editButtonAriaLabel: 'Editar protección',
+  deleteButtonAriaLabel: 'Eliminar medida de seguridad',
+  providerLabel: 'Proveedor',
+  previewChip: 'Vista previa',
+  byoDisabledNotice:
+    'La configuración de esta protección se ha deshabilitado y ya no se puede utilizar. Comuníquese con el administrador para volver a habilitar la configuración o reemplazar esta protección antes de ejecutar el agente.',
+  byoUnavailableNotice:
+    'La configuración de esta protección ya no está disponible. Reemplácela antes de ejecutar el agente.',
 };

--- a/packages/apollo-wind/src/components/custom/guardrails/locales/es.ts
+++ b/packages/apollo-wind/src/components/custom/guardrails/locales/es.ts
@@ -1,9 +1,15 @@
 // Translations harvested from Flow Workbench's canvas catalog so the extraction
 // introduces no new translation work. Missing keys fall back to English per key at
 // resolve time (see i18n.ts).
-import type { GuardrailBuilderLabels, GuardrailValidatorFormLabels } from '../i18n';
+import type {
+  GuardrailBuilderLabels,
+  GuardrailListLabels,
+  GuardrailValidatorFormLabels,
+} from '../i18n';
 
-export const messages: Partial<GuardrailValidatorFormLabels & GuardrailBuilderLabels> = {
+export const messages: Partial<
+  GuardrailValidatorFormLabels & GuardrailBuilderLabels & GuardrailListLabels
+> = {
   moreInformation: 'Más información',
   enumPlaceholder: 'Seleccionar...',
   enumListPlaceholder: 'Seleccionar opciones...',
@@ -69,4 +75,17 @@ export const messages: Partial<GuardrailValidatorFormLabels & GuardrailBuilderLa
   filterFieldsRequiredError: 'La selección de campos es obligatoria',
   recipientRequiredError: 'El destinatario es obligatorio',
   actionAppRequiredError: 'La aplicación de acción es obligatoria',
+  // Guardrail list section
+  headerTitle: 'Barandillas',
+  addButton: 'Añadir',
+  emptyState: 'No hay barreras de seguridad configuradas',
+  reorderHandleAriaLabel: 'Reordenar barrera de seguridad {{name}}',
+  editButtonAriaLabel: 'Editar barrera de seguridad',
+  deleteButtonAriaLabel: 'Eliminar barrera de seguridad',
+  providerLabel: 'Proveedor',
+  previewChip: 'Vista previa',
+  byoDisabledNotice:
+    'La configuración de esta barrera de seguridad se ha deshabilitado y ya no se puede utilizar. Póngase en contacto con su administrador para volver a habilitar la configuración o reemplazar esta barrera de seguridad antes de ejecutar el agente.',
+  byoUnavailableNotice:
+    'La configuración de esta barrera de seguridad ya no está disponible. Reemplázalo antes de ejecutar el agente.',
 };

--- a/packages/apollo-wind/src/components/custom/guardrails/locales/fr.ts
+++ b/packages/apollo-wind/src/components/custom/guardrails/locales/fr.ts
@@ -1,9 +1,15 @@
 // Translations harvested from Flow Workbench's canvas catalog so the extraction
 // introduces no new translation work. Missing keys fall back to English per key at
 // resolve time (see i18n.ts).
-import type { GuardrailBuilderLabels, GuardrailValidatorFormLabels } from '../i18n';
+import type {
+  GuardrailBuilderLabels,
+  GuardrailListLabels,
+  GuardrailValidatorFormLabels,
+} from '../i18n';
 
-export const messages: Partial<GuardrailValidatorFormLabels & GuardrailBuilderLabels> = {
+export const messages: Partial<
+  GuardrailValidatorFormLabels & GuardrailBuilderLabels & GuardrailListLabels
+> = {
   moreInformation: 'Plus d’informations',
   enumPlaceholder: 'Sélectionner...',
   enumListPlaceholder: 'Sélectionnez des options…',
@@ -68,4 +74,17 @@ export const messages: Partial<GuardrailValidatorFormLabels & GuardrailBuilderLa
   filterFieldsRequiredError: 'La sélection des champs est requise',
   recipientRequiredError: 'Le destinataire est requis',
   actionAppRequiredError: 'Une application Action est requise',
+  // Guardrail list section
+  headerTitle: 'Garde-fous',
+  addButton: 'Ajouter',
+  emptyState: 'Aucun garde-fou n’est configuré',
+  reorderHandleAriaLabel: 'Réorganiser le garde-fou {{name}}',
+  editButtonAriaLabel: 'Modifier le garde-fou',
+  deleteButtonAriaLabel: 'Supprimer le garde-fou',
+  providerLabel: 'Fournisseur',
+  previewChip: 'Aperçu',
+  byoDisabledNotice:
+    'La configuration de ce garde-fou a été désactivée et ne peut plus être utilisée. Avant d’exécuter l’agent, contactez votre administrateur pour réactiver la configuration ou remplacer ce garde-fou.',
+  byoUnavailableNotice:
+    'La configuration de ce garde-fou n’est plus disponible. Remplacez-la avant d’exécuter l’agent.',
 };

--- a/packages/apollo-wind/src/components/custom/guardrails/locales/ja.ts
+++ b/packages/apollo-wind/src/components/custom/guardrails/locales/ja.ts
@@ -1,9 +1,15 @@
 // Translations harvested from Flow Workbench's canvas catalog so the extraction
 // introduces no new translation work. Missing keys fall back to English per key at
 // resolve time (see i18n.ts).
-import type { GuardrailBuilderLabels, GuardrailValidatorFormLabels } from '../i18n';
+import type {
+  GuardrailBuilderLabels,
+  GuardrailListLabels,
+  GuardrailValidatorFormLabels,
+} from '../i18n';
 
-export const messages: Partial<GuardrailValidatorFormLabels & GuardrailBuilderLabels> = {
+export const messages: Partial<
+  GuardrailValidatorFormLabels & GuardrailBuilderLabels & GuardrailListLabels
+> = {
   moreInformation: '詳細情報',
   enumPlaceholder: '選択...',
   enumListPlaceholder: 'オプションを選択...',
@@ -68,4 +74,17 @@ export const messages: Partial<GuardrailValidatorFormLabels & GuardrailBuilderLa
   filterFieldsRequiredError: 'フィールドの選択は必須です。',
   recipientRequiredError: '受信者は必須です。',
   actionAppRequiredError: 'アクション アプリは必須です。',
+  // Guardrail list section
+  headerTitle: 'ガードレール',
+  addButton: '追加',
+  emptyState: 'ガードレールは設定されていません。',
+  reorderHandleAriaLabel: 'ガードレール {{name}} を並べ替え',
+  editButtonAriaLabel: 'ガードレールを編集',
+  deleteButtonAriaLabel: 'ガードレールを削除',
+  providerLabel: 'プロバイダー',
+  previewChip: 'プレビュー',
+  byoDisabledNotice:
+    'このガードレールの設定は無効化され、使用できなくなりました。エージェントを実行する前に、管理者に問い合わせて設定を再度有効化するか、このガードレールを置換してください。',
+  byoUnavailableNotice:
+    'このガードレールの設定は利用できなくなりました。エージェントを実行する前に、置換してください。',
 };

--- a/packages/apollo-wind/src/components/custom/guardrails/locales/ko.ts
+++ b/packages/apollo-wind/src/components/custom/guardrails/locales/ko.ts
@@ -1,9 +1,15 @@
 // Translations harvested from Flow Workbench's canvas catalog so the extraction
 // introduces no new translation work. Missing keys fall back to English per key at
 // resolve time (see i18n.ts).
-import type { GuardrailBuilderLabels, GuardrailValidatorFormLabels } from '../i18n';
+import type {
+  GuardrailBuilderLabels,
+  GuardrailListLabels,
+  GuardrailValidatorFormLabels,
+} from '../i18n';
 
-export const messages: Partial<GuardrailValidatorFormLabels & GuardrailBuilderLabels> = {
+export const messages: Partial<
+  GuardrailValidatorFormLabels & GuardrailBuilderLabels & GuardrailListLabels
+> = {
   moreInformation: '자세한 정보',
   enumPlaceholder: '선택...',
   enumListPlaceholder: '옵션 선택...',
@@ -68,4 +74,17 @@ export const messages: Partial<GuardrailValidatorFormLabels & GuardrailBuilderLa
   filterFieldsRequiredError: '필드를 선택해야 합니다',
   recipientRequiredError: '수신자는 필수입니다',
   actionAppRequiredError: '액션 앱은 필수입니다',
+  // Guardrail list section
+  headerTitle: '가드레일',
+  addButton: '추가',
+  emptyState: '가드레일이 구성되지 않음',
+  reorderHandleAriaLabel: '가드레일 {{name}} 순서 변경',
+  editButtonAriaLabel: '가드레일 편집',
+  deleteButtonAriaLabel: '가드레일 삭제',
+  providerLabel: '공급자',
+  previewChip: '미리 보기',
+  byoDisabledNotice:
+    '이 가드레일의 구성이 비활성화되어 더 이상 사용할 수 없습니다. 에이전트를 실행하기 전에 관리자에게 문의하여 구성을 다시 활성화하거나 이 가드레일을 교체하십시오.',
+  byoUnavailableNotice:
+    '이 가드레일의 구성은 더 이상 사용할 수 없습니다. 에이전트를 실행하기 전에 바꾸십시오.',
 };

--- a/packages/apollo-wind/src/components/custom/guardrails/locales/pt-BR.ts
+++ b/packages/apollo-wind/src/components/custom/guardrails/locales/pt-BR.ts
@@ -1,9 +1,15 @@
 // Translations harvested from Flow Workbench's canvas catalog so the extraction
 // introduces no new translation work. Missing keys fall back to English per key at
 // resolve time (see i18n.ts).
-import type { GuardrailBuilderLabels, GuardrailValidatorFormLabels } from '../i18n';
+import type {
+  GuardrailBuilderLabels,
+  GuardrailListLabels,
+  GuardrailValidatorFormLabels,
+} from '../i18n';
 
-export const messages: Partial<GuardrailValidatorFormLabels & GuardrailBuilderLabels> = {
+export const messages: Partial<
+  GuardrailValidatorFormLabels & GuardrailBuilderLabels & GuardrailListLabels
+> = {
   moreInformation: 'Mais informações',
   enumPlaceholder: 'Selecionar...',
   enumListPlaceholder: 'Selecionar opções...',
@@ -68,4 +74,17 @@ export const messages: Partial<GuardrailValidatorFormLabels & GuardrailBuilderLa
   filterFieldsRequiredError: 'A seleção dos campos é necessária',
   recipientRequiredError: 'O destinatário é obrigatório',
   actionAppRequiredError: 'O aplicativo de ação é necessário',
+  // Guardrail list section
+  headerTitle: 'Proteções',
+  addButton: 'Adicionar',
+  emptyState: 'Nenhuma proteção configurada',
+  reorderHandleAriaLabel: 'Reordenar proteção {{name}}',
+  editButtonAriaLabel: 'Editar diretriz',
+  deleteButtonAriaLabel: 'Excluir proteção',
+  providerLabel: 'Provedor',
+  previewChip: 'Visualizar',
+  byoDisabledNotice:
+    'A configuração desta proteção foi desabilitada e não pode mais ser usada. Entre em contato com seu administrador para reativar a configuração ou substitua esta proteção antes de executar o agente.',
+  byoUnavailableNotice:
+    'A configuração desta proteção não está mais disponível. Substitua-a antes de executar o agente.',
 };

--- a/packages/apollo-wind/src/components/custom/guardrails/locales/pt.ts
+++ b/packages/apollo-wind/src/components/custom/guardrails/locales/pt.ts
@@ -1,9 +1,15 @@
 // Translations harvested from Flow Workbench's canvas catalog so the extraction
 // introduces no new translation work. Missing keys fall back to English per key at
 // resolve time (see i18n.ts).
-import type { GuardrailBuilderLabels, GuardrailValidatorFormLabels } from '../i18n';
+import type {
+  GuardrailBuilderLabels,
+  GuardrailListLabels,
+  GuardrailValidatorFormLabels,
+} from '../i18n';
 
-export const messages: Partial<GuardrailValidatorFormLabels & GuardrailBuilderLabels> = {
+export const messages: Partial<
+  GuardrailValidatorFormLabels & GuardrailBuilderLabels & GuardrailListLabels
+> = {
   moreInformation: 'Mais informações',
   enumPlaceholder: 'Selecionar...',
   enumListPlaceholder: 'Selecionar opções…',
@@ -69,4 +75,17 @@ export const messages: Partial<GuardrailValidatorFormLabels & GuardrailBuilderLa
   filterFieldsRequiredError: 'A seleção de campos é obrigatória',
   recipientRequiredError: 'O destinatário é obrigatório',
   actionAppRequiredError: 'A aplicação Action é obrigatória',
+  // Guardrail list section
+  headerTitle: 'Barreiras de proteção',
+  addButton: 'Adicionar',
+  emptyState: 'Nenhuma barreira de proteção configurada',
+  reorderHandleAriaLabel: 'Reordenar barreira de proteção {{name}}',
+  editButtonAriaLabel: 'Editar verificador de integridade',
+  deleteButtonAriaLabel: 'Eliminar barreira de proteção',
+  providerLabel: 'Fornecedor',
+  previewChip: 'Pré-visualizar',
+  byoDisabledNotice:
+    'A configuração desta barreira de proteção foi desativada e já não pode ser utilizada. Contacte o seu administrador para reativar a configuração ou substituir esta barreira de proteção antes de executar o agente.',
+  byoUnavailableNotice:
+    'A configuração desta barreira de proteção já não está disponível. Substitua-a antes de executar o agente.',
 };

--- a/packages/apollo-wind/src/components/custom/guardrails/locales/ro.ts
+++ b/packages/apollo-wind/src/components/custom/guardrails/locales/ro.ts
@@ -1,9 +1,15 @@
 // Translations harvested from Flow Workbench's canvas catalog so the extraction
 // introduces no new translation work. Missing keys fall back to English per key at
 // resolve time (see i18n.ts).
-import type { GuardrailBuilderLabels, GuardrailValidatorFormLabels } from '../i18n';
+import type {
+  GuardrailBuilderLabels,
+  GuardrailListLabels,
+  GuardrailValidatorFormLabels,
+} from '../i18n';
 
-export const messages: Partial<GuardrailValidatorFormLabels & GuardrailBuilderLabels> = {
+export const messages: Partial<
+  GuardrailValidatorFormLabels & GuardrailBuilderLabels & GuardrailListLabels
+> = {
   moreInformation: 'Mai multe informații',
   enumPlaceholder: 'Selectează...',
   enumListPlaceholder: 'Selectați opțiuni...',
@@ -69,4 +75,17 @@ export const messages: Partial<GuardrailValidatorFormLabels & GuardrailBuilderLa
   filterFieldsRequiredError: 'Este necesară selectarea câmpurilor',
   recipientRequiredError: 'Este necesar un destinatar',
   actionAppRequiredError: 'Aplicația Action este necesară',
+  // Guardrail list section
+  headerTitle: 'Mecanisme de Control',
+  addButton: 'Adaugă',
+  emptyState: 'Nu sunt configurate măsuri de protecție',
+  reorderHandleAriaLabel: 'Reordonați limita de protecție {{name}}',
+  editButtonAriaLabel: 'Editați limita de protecție',
+  deleteButtonAriaLabel: 'Ștergeți balustrada de protecție',
+  providerLabel: 'Furnizor',
+  previewChip: 'Previzualizare',
+  byoDisabledNotice:
+    'Această configurație a mecanismului de control a fost dezactivată și nu mai poate fi utilizată. Contactați administratorul pentru a reactiva configurația sau pentru a înlocui acest mecanism de control înainte de a executa agentul.',
+  byoUnavailableNotice:
+    'Configurația acestui mecanism de control nu mai este disponibilă. Înlocuiți-l înainte de a executa agentul.',
 };

--- a/packages/apollo-wind/src/components/custom/guardrails/locales/ru.ts
+++ b/packages/apollo-wind/src/components/custom/guardrails/locales/ru.ts
@@ -1,6 +1,12 @@
 // Translations harvested from Flow Workbench's canvas catalog so the extraction
 // introduces no new translation work. Missing keys fall back to English per key at
 // resolve time (see i18n.ts).
-import type { GuardrailBuilderLabels, GuardrailValidatorFormLabels } from '../i18n';
+import type {
+  GuardrailBuilderLabels,
+  GuardrailListLabels,
+  GuardrailValidatorFormLabels,
+} from '../i18n';
 
-export const messages: Partial<GuardrailValidatorFormLabels & GuardrailBuilderLabels> = {};
+export const messages: Partial<
+  GuardrailValidatorFormLabels & GuardrailBuilderLabels & GuardrailListLabels
+> = {};

--- a/packages/apollo-wind/src/components/custom/guardrails/locales/tr.ts
+++ b/packages/apollo-wind/src/components/custom/guardrails/locales/tr.ts
@@ -1,9 +1,15 @@
 // Translations harvested from Flow Workbench's canvas catalog so the extraction
 // introduces no new translation work. Missing keys fall back to English per key at
 // resolve time (see i18n.ts).
-import type { GuardrailBuilderLabels, GuardrailValidatorFormLabels } from '../i18n';
+import type {
+  GuardrailBuilderLabels,
+  GuardrailListLabels,
+  GuardrailValidatorFormLabels,
+} from '../i18n';
 
-export const messages: Partial<GuardrailValidatorFormLabels & GuardrailBuilderLabels> = {
+export const messages: Partial<
+  GuardrailValidatorFormLabels & GuardrailBuilderLabels & GuardrailListLabels
+> = {
   moreInformation: 'Daha fazla bilgi',
   enumPlaceholder: 'Seç...',
   enumListPlaceholder: 'Seçenek belirle...',
@@ -69,4 +75,17 @@ export const messages: Partial<GuardrailValidatorFormLabels & GuardrailBuilderLa
   filterFieldsRequiredError: 'Alan seçimi gereklidir',
   recipientRequiredError: 'Alıcı gereklidir',
   actionAppRequiredError: 'Eylem uygulaması gereklidir',
+  // Guardrail list section
+  headerTitle: 'Tasarım ve uygulama kuralları',
+  addButton: 'Ekle',
+  emptyState: 'Tasarım ve uygulama kuralı yapılandırılmamış',
+  reorderHandleAriaLabel: '{{name}} tasarım ve uygulama kuralını yeniden sırala',
+  editButtonAriaLabel: 'Tasarım ve uygulama kuralını düzenle',
+  deleteButtonAriaLabel: 'Tasarım ve uygulama kuralını sil',
+  providerLabel: 'Sağlayıcı',
+  previewChip: 'Önizleme',
+  byoDisabledNotice:
+    "Bu guardrail'in yapılandırması devre dışı bırakıldı ve artık kullanılamaz. Aracıyı çalıştırmadan önce yapılandırmayı yeniden etkinleştirmek veya bu guardrail'i değiştirmek için yöneticinizle iletişime geçin.",
+  byoUnavailableNotice:
+    'Bu guardrail yapılandırması artık kullanılamıyor. Aracıyı çalıştırmadan önce değiştirin.',
 };

--- a/packages/apollo-wind/src/components/custom/guardrails/locales/zh-CN.ts
+++ b/packages/apollo-wind/src/components/custom/guardrails/locales/zh-CN.ts
@@ -1,9 +1,15 @@
 // Translations harvested from Flow Workbench's canvas catalog so the extraction
 // introduces no new translation work. Missing keys fall back to English per key at
 // resolve time (see i18n.ts).
-import type { GuardrailBuilderLabels, GuardrailValidatorFormLabels } from '../i18n';
+import type {
+  GuardrailBuilderLabels,
+  GuardrailListLabels,
+  GuardrailValidatorFormLabels,
+} from '../i18n';
 
-export const messages: Partial<GuardrailValidatorFormLabels & GuardrailBuilderLabels> = {
+export const messages: Partial<
+  GuardrailValidatorFormLabels & GuardrailBuilderLabels & GuardrailListLabels
+> = {
   moreInformation: '更多信息',
   enumPlaceholder: '选择...',
   enumListPlaceholder: '选择选项...',
@@ -66,4 +72,16 @@ export const messages: Partial<GuardrailValidatorFormLabels & GuardrailBuilderLa
   filterFieldsRequiredError: '“字段选择”为必填项',
   recipientRequiredError: '收件人为必填项',
   actionAppRequiredError: '操作应用程序为必填项',
+  // Guardrail list section
+  headerTitle: '防护机制',
+  addButton: '添加',
+  emptyState: '未配置防护机制',
+  reorderHandleAriaLabel: '重新排序防护机制 {{name}}',
+  editButtonAriaLabel: '编辑防护机制',
+  deleteButtonAriaLabel: '删除防护机制',
+  providerLabel: '提供程序',
+  previewChip: '预览',
+  byoDisabledNotice:
+    '此防护机制配置已禁用，无法再使用。请在运行智能体之前联系您的管理员重新启用配置或替换此防护机制。',
+  byoUnavailableNotice: '此防护机制的配置不再可用。在运行智能体之前进行替换。',
 };

--- a/packages/apollo-wind/src/components/custom/guardrails/locales/zh-TW.ts
+++ b/packages/apollo-wind/src/components/custom/guardrails/locales/zh-TW.ts
@@ -1,9 +1,15 @@
 // Translations harvested from Flow Workbench's canvas catalog so the extraction
 // introduces no new translation work. Missing keys fall back to English per key at
 // resolve time (see i18n.ts).
-import type { GuardrailBuilderLabels, GuardrailValidatorFormLabels } from '../i18n';
+import type {
+  GuardrailBuilderLabels,
+  GuardrailListLabels,
+  GuardrailValidatorFormLabels,
+} from '../i18n';
 
-export const messages: Partial<GuardrailValidatorFormLabels & GuardrailBuilderLabels> = {
+export const messages: Partial<
+  GuardrailValidatorFormLabels & GuardrailBuilderLabels & GuardrailListLabels
+> = {
   moreInformation: '更多資訊',
   enumPlaceholder: '選擇...',
   enumListPlaceholder: '選取選項...',
@@ -66,4 +72,16 @@ export const messages: Partial<GuardrailValidatorFormLabels & GuardrailBuilderLa
   filterFieldsRequiredError: '必須選取欄位',
   recipientRequiredError: '收件者為必填欄位',
   actionAppRequiredError: '動作應用程式為必填欄位',
+  // Guardrail list section
+  headerTitle: '護欄',
+  addButton: '新增',
+  emptyState: '未配置護欄',
+  reorderHandleAriaLabel: '重新排序護欄 {{name}}',
+  editButtonAriaLabel: '編輯護欄',
+  deleteButtonAriaLabel: '刪除護欄',
+  providerLabel: '提供程式',
+  previewChip: '預覽',
+  byoDisabledNotice:
+    '此護欄的組態已停用，無法再使用。請聯絡管理員以重新啟用組態或取代此護欄，然後再執行代理。',
+  byoUnavailableNotice: '此護欄的組態不再可用。在執行代理程式之前取代它。',
 };

--- a/packages/apollo-wind/src/index.ts
+++ b/packages/apollo-wind/src/index.ts
@@ -35,6 +35,10 @@ export {
   getGuardrailSelectorErrorFields,
   initGuardrailBuilderFormData,
 } from './components/custom/guardrails/builder-utils';
+export type { GuardrailStatusBannerProps } from './components/custom/guardrails/components/guardrail-status-banner';
+export { GuardrailStatusBanner } from './components/custom/guardrails/components/guardrail-status-banner';
+export type { MixedScopesBannerProps } from './components/custom/guardrails/components/mixed-scopes-banner';
+export { MixedScopesBanner } from './components/custom/guardrails/components/mixed-scopes-banner';
 export type {
   GuardrailCopyKey,
   GuardrailCopyTranslator,
@@ -67,21 +71,43 @@ export type { GuardrailBuilderProps } from './components/custom/guardrails/guard
 export { GuardrailBuilder } from './components/custom/guardrails/guardrail-builder';
 export type { GuardrailFormLayoutProps } from './components/custom/guardrails/guardrail-form-layout';
 export { GuardrailFormLayout } from './components/custom/guardrails/guardrail-form-layout';
+export type { GuardrailListProps } from './components/custom/guardrails/guardrail-list';
+export { GuardrailList } from './components/custom/guardrails/guardrail-list';
+export type { GuardrailListDefinition } from './components/custom/guardrails/guardrail-list-utils';
+export {
+  defaultGuardrailItemId,
+  findGuardrailDefinition,
+  matchGuardrailDefinition,
+  moveGuardrail,
+  resolveGuardrailListItemState,
+} from './components/custom/guardrails/guardrail-list-utils';
 // -----------------------------------------------------------------------------
 // Guardrails (custom domain components)
 // -----------------------------------------------------------------------------
 export { GuardrailValidatorForm } from './components/custom/guardrails/guardrail-validator-form';
 export type {
   GuardrailBuilderLabels,
+  GuardrailListLabels,
   GuardrailValidatorFormLabels,
 } from './components/custom/guardrails/i18n';
 export {
   formatGuardrailFormMessage,
   GUARDRAIL_BUILDER_EN_LABELS,
   GUARDRAIL_FORM_EN_LABELS,
+  GUARDRAIL_LIST_EN_LABELS,
   resolveGuardrailBuilderLabels,
   resolveGuardrailFormLabels,
+  resolveGuardrailListLabels,
 } from './components/custom/guardrails/i18n';
+export type {
+  GuardrailListItem,
+  GuardrailListItemActionsContext,
+  GuardrailListItemNotice,
+  GuardrailListItemState,
+  GuardrailListItemStatus,
+  GuardrailListMove,
+  GuardrailListOrigin,
+} from './components/custom/guardrails/list-types';
 export type {
   GuardrailFormLocale,
   GuardrailMessages,

--- a/packages/apollo-wind/vitest.config.ts
+++ b/packages/apollo-wind/vitest.config.ts
@@ -46,10 +46,10 @@ export default defineConfig({
       // Vitest only enforces thresholds nested under `coverage.thresholds`;
       // top-level lines/functions/... are silently ignored.
       thresholds: {
-        lines: 60,
-        functions: 63,
-        branches: 54,
-        statements: 58,
+        lines: 69,
+        functions: 72,
+        branches: 63,
+        statements: 67,
       },
     },
   },


### PR DESCRIPTION
Implements [AL-575](https://uipath.atlassian.net/browse/AL-575) (epic AL-526): the guardrails
list section, extracted once into `@uipath/apollo-wind`.

**Draft, and stacked.** Base is [#1132](https://github.com/UiPath/apollo-ui/pull/1132), which is
itself stacked on [#1107](https://github.com/UiPath/apollo-ui/pull/1107). Both are unmerged. A PR
based off those branches runs almost no CI, since `pr-checks`, `preview-deploy` (including the
Storybook visual diff), `dev-publish`, `pr-size`, `security-scan` and `codeql` all filter their
`pull_request` trigger to `main` and `support/**`. This stays draft until #1107 merges and the
chain rebases onto `main`.

## What it replaces

`GuardrailsListingSection.tsx` in Agents (968 LOC), and `GuardrailsEditor.tsx` (743) +
`SortableGuardrailItem.tsx` (126) + `MixedScopesBanner.tsx` (38) in flow-workbench. Prop shape
follows Flow's, per the extraction recipe.

## The contract

The host filters, the component renders. `GuardrailList` never drops a row.

- **No feature flag crosses the boundary.** Agents' `enableOutOfTheBoxGuardrails`,
  `enableGuardrailPII`, `enableGuardrailPromptInjection`, `enableGuardrailHarmfulContent`,
  `enableGuardrailIntellectualProperty` and `enableGuardrailUserPromptAttacks` stay in the
  Agents adapter, as does Flow's `canvas.guardrails` entitlement and its allowed-scope filter.
  Hosts pass the survivors as `guardrails` and `definitions`.
- **Callbacks are intents.** `onRemove` fires the request; the confirmation dialog and the write
  stay host-side, because the two products confirm with different copy and unwind tool-scoped
  guardrails differently. Same for `onAdd` / `onEdit`.
- **No telemetry** in the package. Hosts wrap the callbacks.
- `onReorder` reports the reordered visible array *plus* the move, so a host rendering a
  filtered view (Flow's tool view over an agent-level list) can splice back without the package
  knowing the full list exists.

## Divergences, resolved as one shape plus a seam

| Concern | Agents | Flow | Here |
| --- | --- | --- | --- |
| Row identity | `name` | `id` | `id ?? name`, override with `getItemId` |
| Read-only | `isReadOnly` | `disabled` | `disabled` |
| Row actions | overflow menu | inline buttons | inline buttons; `renderItemActions` swaps in the menu |
| Clickable row | yes | no | no, `rowActivatesEdit` opts in |
| Scope/action copy | localized | raw | raw, `formatScopes` / `formatAction` localize host-side |
| Provider + description | in a MUI tooltip | inline lines | inline lines |

`getItemOrigin` tags governance-managed rows: both products fetch them from a different
endpoint, so nothing on the record identifies them.

## Behaviour parity first

Every addition is opt-in, so an adopting host gets a swap that renders exactly what it renders
today and turns the new UI on deliberately.

| Prop | Default | Why |
| --- | --- | --- |
| `statusChips` | `false` | Neither product renders status or origin chips today. The two BYO row notices are *not* gated, because both already show those. |
| `previewChip` | `false` | Product lifecycle, not a package concern. Both hosts pass it today and drop it at GA without a release. |
| `reorderDisabled` | `disabled` | Flow's read-only list stays reorderable and Agents' does not, so one flag could not express both. Flow passes `false`. |
| `unstyled` | `false` | Agents renders inside a `SectionAccordion`, where the card border is extra chrome. |
| `footer` | none | Agents' add affordance sits *below* the rows and swaps for an entitlement line, which `addSlot` (header-only) cannot express. |
| `emptyState={null}` | shows the default line | Agents shows nothing when empty. An `undefined` check rather than `??`, so an explicit `null` is honoured. |
| `renderRowTooltip` | none | Agents hovers a combined description, provider and scopes tooltip on top of the inline lines. |

So each host passes:

- **Flow:** `previewChip`, `reorderDisabled={false}`, and a `formatAction` carrying its
  "Unknown" fallback. Everything else already matches.
- **Agents:** `previewChip`, `unstyled`, `hideHeader`, `emptyState={null}`, `footer`,
  `rowActivatesEdit`, `formatAction={() => null}`, `formatScopes`, `renderItemActions`,
  `renderRowTooltip`.

One deliberate exception I did not restore: Agents' drag handle is an `aria-hidden` icon with
the listeners on it, so it is unreachable by keyboard. Mine is a real button. That is a bug fix,
not a regression.

## Reuse, and one deliberate non-reuse

`GuardrailStatusBanner` and `MixedScopesBanner` are promoted from internal pieces to exports and
integrated, as the ticket asks. Both additions are additive; nothing existing changed shape, so
there is no breaking-change footer.

The status and origin chips are **not** `GuardrailChip`. That wraps a Radix Toggle, so it is a
focusable button carrying pressed state; these chips are read-only labels and would otherwise
put fake buttons in the tab order and misreport to screen readers. `GuardrailStatusChip` is
`Badge`-based and reuses `guardrailChipVariants`' geometry tokens, so the two chip families
still read as one system. Reviewers who read the ticket line as "reuse the chip UX" should get
what they expected; reviewers who meant the component literally, please push back.

## Chips and notices

`Available` + origin `local` renders nothing, so the common row stays quiet. `FeatureDisabled`
and `Unauthorised` chip as warnings, `Disabled` and `Unavailable` as errors. The two inline
notices (BYO configuration disabled, BYO configuration gone) are the ones both products already
render, and they keep the `definitions.length > 0` guard: without it every BYO row flashes "no
longer available" while the catalog is still in flight.

## i18n

Ten of the list's strings are harvested from Flow's canvas catalog into all 13 non-English
catalogs, so this adds no translation work, matching how #1107 seeded the family. The four
status/origin chip labels and the row aria-label have no Flow equivalent and are English-only
for now; they fall back per key and hosts can supply them through `labels` today. Flagged in the
README.

The three label resolvers now share one merge helper instead of three copies of the same loop.

## Tests

84 new tests. jest-axe on all three rendering suites. The keyboard reorder is exercised through
the real dnd-kit sensor rather than mocked: jsdom reports a zero rect for everything, so the test
lays the rows out on a synthetic vertical grid, which is the minimum geometry collision detection
needs to tell two rows apart.

Coverage floors ratchet **60/63/54/58 to 69/72/63/67** (measured 69.44 / 72.62 / 64.25 / 67.31,
up from 69.03 / 72.11 / 63.49 / 66.87 on the base branch). The five new modules are at 100%
lines and functions, 91 to 100% branches.

## Local gate

`typecheck`, `lint`, `test` and `build` pass for `@uipath/apollo-wind`. Two notes for anyone
reproducing on Windows:

- `packages/apollo-core`'s `build:fonts` and `packages/apollo-ui-icons`' build both fail here for
  pre-existing, unrelated reasons (a single-quoted postcss glob, and a path-join bug in the icon
  rename step), which blocks turbo's dependency step. Neither package is touched by this branch.
- `forms/form-plugins.test.tsx` (26) and `ui/calendar.test.tsx` (1) fail identically on the base
  branch, verified by stashing. `localStorage` is undefined in that environment.

## Open question for review

Both products render governance-managed guardrails in a *separate* `CentralizedGuardrailsSection`
rather than as chip-tagged rows in the main list. The ticket asks for an origin chip, which
implies one mixed list. Two things make that more than a chip:

1. **"Origin chip" is already taken, and means something else.** Agents' `GuardrailOriginChip`
   and Flow's `CentralizedGuardrailOriginBadge` both render **BYO** vs **UiPath managed**, not
   local vs governance. Flow's comment says why: *"A connector may expose a validator id a
   built-in also uses, so origin is otherwise invisible."* So `getItemOrigin` here redefines a
   word the products already use. Renaming it (`getItemAdministration`?) is cheap now and
   breaking later.
2. **Governance rows are a different type.** `CentralizedGuardrail` has no `id`, a nullish
   `name`, `scopes` at the top level rather than under `selector`, and an `ActionType` enum
   instead of `{ $actionType }`, plus `executionStage` and the `appliesTo*` flags. They are also
   read-only, unorderable, and click through to a details panel rather than the builder. A
   merged list would need per-row capabilities and host-side mapping, which is a ticket rather
   than a chip.

This PR ships the chip (behind `statusChips`) and the seam so either layout stays possible, and
leaves the separate sections alone. Worth deciding here whether to rename the prop before it is
public.

## Next

Agents and flow-workbench adoption behind `EnableApolloGuardrailBuilder` /
`canvas.guardrails.apollo-components`, with the existing components kept verbatim as `*Legacy`
twins. Those PRs need a real published version, not a preview pin, so they follow the release.


[AL-575]: https://uipath.atlassian.net/browse/AL-575?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
