### PR TITLE
Consolidate tree components: Tree View Files + Tree View Code

### DIFF
--- a/packages/apollo-react/src/canvas/components/JsonTree/JsonTree.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/JsonTree/JsonTree.stories.tsx
@@ -1,16 +1,37 @@
 import type { Meta, StoryFn } from '@storybook/react';
 import { useMemo, useState } from 'react';
 import { Column, Row } from '../../layouts';
-import { buildJsonTree } from './buildJsonTree';
-import type { JsonTreeNode } from './JsonTree.types';
+import { buildJsonTree, removeValueAtPath, setValueAtPath } from './buildJsonTree';
+import type { JsonObject, JsonTreeNode } from './JsonTree.types';
 import { JsonTree } from './JsonTree';
 
 export default {
-  title: 'Components/JsonTree',
+  title: 'Components/Tree View Code',
+  tags: ['autodocs'],
   parameters: {
     layout: 'fullscreen',
+    docs: {
+      description: {
+        component: `
+An interactive tree for structured data: a JSON value merged with its schema, rendered as expandable objects and arrays with typed, editable leaves.
+
+## Features
+
+- **Search** – Matches keys and scalar values; matching containers auto-expand
+- **Inline editing** – Every JSON type edits in place; objects and arrays open a code editor
+- **Copy** – Copy a field's path or its value from the row actions
+- **Custom rendering** – Override value cells, type icons, and per-node decorations (labels, chips, badge colors)
+- **Virtualization** – Mount only the rows in view for trees with thousands of fields, opt in with \`virtualized\`
+
+## Where this is used
+
+- **Node Property Panel**: the Input / Output 3 Column story renders request and response shapes with this component, via \`NodeIOView\`
+- **Templates, Flow Standalone**: node inspector panels throughout the canvas flow demo
+        `,
+      },
+    },
   },
-} satisfies Meta;
+} satisfies Meta<typeof JsonTree>;
 
 const RECORD_COUNT = 20_000;
 
@@ -44,6 +65,43 @@ function useCollapsed() {
 }
 
 const frame = { background: 'var(--canvas-background)', color: 'var(--canvas-foreground)' };
+
+/**
+ * The tree on its own, with no panel chrome around it: a small, realistic response shape,
+ * editable inline. This is the same component the Node Property Panel's Input / Output view
+ * renders, via `NodeIOView`.
+ */
+export const Default: StoryFn = () => {
+  const [value, setValue] = useState<JsonObject>({
+    code: 200,
+    headers: { 'content-type': 'application/json' },
+    body: {
+      id: '9e415fe5-0001',
+      name: 'Record 1',
+      isActive: true,
+      tags: ['alpha', 'beta'],
+    },
+  });
+  const { collapsed, toggle } = useCollapsed();
+  const nodes = useMemo(() => buildJsonTree({ value }), [value]);
+
+  return (
+    <Column p={24} gap={12} style={frame}>
+      <JsonTree
+        nodes={nodes}
+        collapsed={collapsed}
+        onToggleCollapsed={toggle}
+        onEdit={(node, nodeValue) => {
+          const next =
+            nodeValue === undefined
+              ? removeValueAtPath(value, node.segments)
+              : setValueAtPath(value, node.segments, nodeValue);
+          if (next !== undefined) setValue(next as JsonObject);
+        }}
+      />
+    </Column>
+  );
+};
 
 /** Only the rows in view mount; the tree scrolls inside its own box, capped at the viewport height. */
 export const VirtualizedOwnScrollBox: StoryFn = () => {

--- a/packages/apollo-react/src/canvas/components/JsonTree/buildJsonTree.ts
+++ b/packages/apollo-react/src/canvas/components/JsonTree/buildJsonTree.ts
@@ -340,7 +340,11 @@ export function flattenJsonTree(
               filterPredicate: selfPredicateMatch ? undefined : filterPredicate,
             }
           : options;
-      rows.push(...flattenJsonTree(node.children, childOptions, depth + 1));
+      // Not `rows.push(...childRows)`: spreading tens of thousands of arguments
+      // into `push` overflows the engine's call-stack argument limit.
+      for (const row of flattenJsonTree(node.children, childOptions, depth + 1)) {
+        rows.push(row);
+      }
     }
   }
   return rows;


### PR DESCRIPTION
## Summary

First pass toward a two-component naming convention for this design system's tree views, per design discussion:

- **Tree View Files**: apollo-wind's existing `TreeView` (file/folder navigation). Not yet renamed in this PR.
- **Tree View Code**: apollo-react's `JsonTree` (nested object/array/value tree). This PR surfaces it as its own discoverable Storybook entry.

## Changes

- **Bug fix**: `flattenJsonTree` threw `RangeError: Maximum call stack size exceeded` on large trees (e.g. the 20k-record demo). `rows.push(...childRows)` overflowed the JS engine's call-stack argument limit once a subtree flattened past roughly 65k rows. Switched to an explicit loop.
- **Storybook**: renamed the `JsonTree` story group to `Components/Tree View Code` and added a small, editable `Default` story so the component can be evaluated on its own, without loading the full Node Property Panel. Added a component description documenting where it's already used (Node Property Panel Input/Output, Templates/Flow Standalone).
- Skipped auto-generated Controls/props table (no `component:` reference in the story meta): `JsonTree`'s recursive node type and several function-valued props crash Storybook's docgen renderer. Confirmed this is specific to `JsonTree`'s prop shape, not a general docgen issue (other components with `tags: ['autodocs']` render fine).

## Open question for engineering review

`JsonTree` currently lives in `apollo-react/src/canvas/components/JsonTree/`, a completely different package from apollo-wind's `TreeView`. Storybook's top-level "Apollo Wind" vs "Apollo React/Canvas" grouping is derived from which package a story physically lives in (see `apps/storybook/.storybook/main.ts`), not from the story title, so **Tree View Files and Tree View Code cannot appear as siblings under Apollo Wind > Components > Data Display without physically relocating `JsonTree` into the `apollo-wind` package.**

That relocation is not a small mechanical move:
- `apollo-wind` currently has zero dependency on `apollo-react` (confirmed via `package.json`), and the intended architecture keeps them siblings under `apollo-core`. Moving `JsonTree` in place would need to happen without pulling `apollo-react` in as a dependency.
- `JsonTree` and its subcomponents pull in three apollo-react-internal pieces:
  - `useIsomorphicLayoutEffect` — trivial, copy as-is.
  - `useSafeLingui` (Lingui i18n) — apollo-wind has no i18n setup today; would need `@lingui/core`/`@lingui/react` added, or the hook stripped to a no-op translator.
  - `CanvasTooltip` / `CanvasTooltipProviderMarker` (used by 5+ files, itself pulling in `useTruncationDetection` from apollo-react's Material tooltip) — the tooltip-dedup marker is droppable for standalone use, but the truncation-aware tooltip wrapper itself needs a real decision: port it into apollo-wind, or rewrite those call sites against apollo-wind's plain `Tooltip`.

Needs a decision before proceeding: relocate `JsonTree` into `apollo-wind` (bigger refactor, but matches the requested nav structure), or keep it in `apollo-react` and accept that "Tree View Files" and "Tree View Code" live under different top-level Storybook sections.

## Test plan

- [ ] `Components/Tree View Code/Default` renders and edits correctly in Storybook
- [ ] `Components/Tree View Code/Virtualized Own Scroll Box`, `Virtualized Inside Panel`, `Virtualized Editable`, `Not Virtualized` no longer crash
- [ ] Existing Node Property Panel Input/Output stories unaffected
- [ ] Engineering sign-off on the apollo-wind relocation question above

🤖 Generated with [Claude Code](https://claude.com/claude-code)