### PR TITLE
feat(apollo-react): controlled EditableText, plus disabled and wrap modes

### DIFF
--- a/packages/apollo-react/src/canvas/components/NodePropertyPanel/EditableText.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/NodePropertyPanel/EditableText.stories.tsx
@@ -1,0 +1,184 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useState } from 'react';
+import { EditableText, type EditableTextProps } from './EditableText';
+
+const meta: Meta<typeof EditableText> = {
+  title: 'Components/Panels/Editable Text',
+  component: EditableText,
+  parameters: {
+    docs: {
+      description: {
+        component: `
+**EditableText** is the click-to-edit text used by the node identity row. It reads as plain
+text, turns into a field on click, submits on Enter or blur, and reverts on Escape. It is a
+controlled field: \`onChange\` fires per keystroke and \`value\` has to follow it, which is what
+lets the owner validate what is being typed and answer through \`error\`. Omit either callback and
+it renders static text with no interactive affordance.
+
+These props shape how the text behaves:
+
+- \`multiline\`: \`false\` (default) keeps a single-line input that truncates when collapsed.
+  \`true\` renders a textarea that accepts newlines on Shift+Enter. \`'wrap'\` renders the same
+  textarea layout but keeps the value single-line: every Enter commits and pasted newlines
+  collapse to spaces.
+- \`disabled\`: locks the text as-is. The read trigger stops responding to clicks, and disabling
+  during an edit closes the editor without submitting.
+- \`error\`: any feedback, rendered below the text with a ring. Since the owner holds the text, it
+  can derive this from what is being typed (see *Identity validation* on NodePropertyPanel) or
+  from an async check on the persisted value.
+        `,
+      },
+    },
+  },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** Owns the text, as any consumer of a controlled field must. */
+function Live({
+  initial,
+  ...props
+}: { initial: string } & Omit<EditableTextProps, 'value' | 'onChange'>) {
+  const [value, setValue] = useState(initial);
+  return <EditableText onSubmit={() => {}} {...props} value={value} onChange={setValue} />;
+}
+
+const Case = ({
+  label,
+  hint,
+  children,
+}: {
+  label: string;
+  hint: string;
+  children: React.ReactNode;
+}) => (
+  <div className="flex flex-col gap-1.5">
+    <div className="text-xs font-semibold uppercase tracking-wide text-foreground-muted">
+      {label}
+    </div>
+    <div className="text-xs text-foreground-subtle">{hint}</div>
+    <div className="rounded-lg border border-border-subtle bg-surface px-4 py-3">{children}</div>
+  </div>
+);
+
+const Frame = ({ children }: { children: React.ReactNode }) => (
+  <div className="flex w-[420px] flex-col gap-6 p-6">{children}</div>
+);
+
+const LONG_TEXT =
+  'Fetch the customer record, enrich it with the latest invoice totals, then hand it to the approval step';
+
+export const Playground: Story = {
+  args: {
+    placeholder: 'Untitled node',
+    size: 'lg',
+    multiline: false,
+    maxLines: 3,
+    disabled: false,
+    'aria-label': 'Node name',
+  },
+  argTypes: {
+    multiline: { control: 'inline-radio', options: [false, true, 'wrap'] },
+    size: { control: 'inline-radio', options: ['lg', 'sm'] },
+    maxLines: { control: { type: 'number', min: 1, max: 6 } },
+  },
+  render: (args) => (
+    <Frame>
+      <Live {...args} initial={LONG_TEXT} />
+    </Frame>
+  ),
+};
+
+export const MultilineModes: Story = {
+  name: 'Multiline settings',
+  render: () => (
+    <Frame>
+      <Case
+        label="Single line (default)"
+        hint="Renders an input. The collapsed text truncates with an ellipsis, and Enter commits."
+      >
+        <Live initial={LONG_TEXT} aria-label="Single line name" />
+      </Case>
+
+      <Case
+        label="multiline"
+        hint="Renders a textarea. Shift+Enter inserts a newline, a plain Enter commits."
+      >
+        <Live
+          initial={'Validate the payload\nthen branch on the result'}
+          multiline
+          aria-label="Multiline description"
+        />
+      </Case>
+
+      <Case
+        label='multiline="wrap"'
+        hint="Same wrapping layout, single-line value. Every Enter commits, including Shift+Enter, and pasted newlines collapse to spaces."
+      >
+        <Live initial={LONG_TEXT} multiline="wrap" aria-label="Wrapped name" />
+      </Case>
+
+      <Case
+        label="maxLines"
+        hint="Caps the visible lines in both modes. The collapsed text clamps, the editor scrolls past the cap."
+      >
+        <Live
+          initial={`${LONG_TEXT}. ${LONG_TEXT}`}
+          multiline
+          maxLines={2}
+          size="sm"
+          aria-label="Capped description"
+        />
+      </Case>
+    </Frame>
+  ),
+};
+
+export const DisabledStates: Story = {
+  name: 'Disabled settings',
+  render: () => (
+    <Frame>
+      <Case label="Enabled" hint="Click the text to edit it.">
+        <Live initial="Enrich customer record" aria-label="Enabled name" />
+      </Case>
+
+      <Case
+        label="disabled"
+        hint="Dimmed, with a not-allowed cursor. Clicks open no editor and the value cannot change."
+      >
+        <Live initial="Enrich customer record" disabled aria-label="Disabled name" />
+      </Case>
+
+      <Case label="disabled, small" hint="The same lock on the secondary description line.">
+        <Live
+          initial="Runs after the approval step"
+          size="sm"
+          disabled
+          aria-label="Disabled description"
+        />
+      </Case>
+
+      <Case
+        label="disabled with an error"
+        hint="A rejected value stays visible and explained while the field is locked."
+      >
+        <Live
+          initial=""
+          placeholder="Untitled node"
+          disabled
+          error="A node name is required."
+          aria-label="Disabled invalid name"
+        />
+      </Case>
+
+      <Case
+        label="Static text (no callbacks)"
+        hint="Not the same as disabled. There is no trigger at all, so nothing is dimmed."
+      >
+        <EditableText value="Read-only label" />
+      </Case>
+    </Frame>
+  ),
+};

--- a/packages/apollo-react/src/canvas/components/NodePropertyPanel/EditableText.test.tsx
+++ b/packages/apollo-react/src/canvas/components/NodePropertyPanel/EditableText.test.tsx
@@ -1,6 +1,7 @@
-import type { HTMLAttributes, ReactNode } from 'react';
+import { type HTMLAttributes, type ReactNode, useState } from 'react';
 import { describe, expect, it, vi } from 'vitest';
 import { render, screen, userEvent } from '../../utils/testing';
+import type { EditableTextProps } from './EditableText';
 import { EditableText } from './EditableText';
 
 // Stand in for the real overflow detection, which needs layout jsdom does not do.
@@ -17,21 +18,90 @@ vi.mock('../CanvasTooltip', async () => {
   };
 });
 
+/** Owns the text, as a real consumer must: the field only shows what comes back through `value`. */
+function Controlled({
+  initial,
+  validate,
+  onChangeSpy,
+  ...props
+}: {
+  initial: string;
+  validate?: (text: string) => string | undefined;
+  onChangeSpy?: (next: string) => void;
+} & Omit<EditableTextProps, 'value' | 'onChange'>) {
+  const [text, setText] = useState(initial);
+
+  return (
+    <EditableText
+      {...props}
+      value={text}
+      onChange={(next) => {
+        onChangeSpy?.(next);
+        setText(next);
+      }}
+      error={props.error ?? validate?.(text)}
+    />
+  );
+}
+
 describe('EditableText', () => {
-  it('renders static text with no interactive affordance when onChange is omitted', () => {
+  it('renders static text with no interactive affordance when the callbacks are omitted', () => {
     render(<EditableText value="End" />);
     expect(screen.getByText('End')).toBeInTheDocument();
     expect(screen.queryByRole('button')).not.toBeInTheDocument();
   });
 
+  it('stays static without onSubmit, since it would have nowhere to commit', () => {
+    render(<EditableText value="End" onChange={vi.fn()} />);
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+
+  it('does not enter edit mode when disabled', async () => {
+    const user = userEvent.setup();
+    render(<Controlled initial="End" onSubmit={vi.fn()} aria-label="Node name" disabled />);
+
+    const trigger = screen.getByRole('button', { name: /^Node name/ });
+    await user.click(trigger);
+
+    expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
+    // The trigger stays a focusable button (aria-disabled, not disabled), so a
+    // truncated value keeps its overflow tooltip.
+    expect(trigger).toHaveAttribute('data-tooltip-trigger', 'End');
+    expect(trigger).not.toBeDisabled();
+  });
+
+  it('leaves edit mode without submitting when disabled mid-edit', async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    const { rerender } = render(
+      <EditableText value="End" onChange={vi.fn()} onSubmit={onSubmit} aria-label="Node name" />
+    );
+
+    await user.click(screen.getByRole('button', { name: /^Node name/ }));
+    rerender(
+      <EditableText
+        value="Ending"
+        onChange={vi.fn()}
+        onSubmit={onSubmit}
+        aria-label="Node name"
+        disabled
+      />
+    );
+
+    expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
+    expect(onSubmit).not.toHaveBeenCalled();
+    // The text belongs to the owner, so it survives the editor closing.
+    expect(screen.getByRole('button', { name: /^Node name/ })).toHaveTextContent('Ending');
+  });
+
   it('shows the placeholder in place of an empty value', () => {
-    render(<EditableText value="" placeholder="Control" onChange={vi.fn()} />);
+    render(<Controlled initial="" placeholder="Control" onSubmit={vi.fn()} />);
     expect(screen.getByRole('button', { name: 'Control' })).toBeInTheDocument();
   });
 
   it('enters edit mode on a single click and selects the current value', async () => {
     const user = userEvent.setup();
-    render(<EditableText value="End" onChange={vi.fn()} aria-label="Node name" />);
+    render(<Controlled initial="End" onSubmit={vi.fn()} aria-label="Node name" />);
 
     await user.click(screen.getByRole('button', { name: /^Node name/ }));
 
@@ -42,24 +112,40 @@ describe('EditableText', () => {
     expect((input as HTMLInputElement).selectionEnd).toBe(3);
   });
 
-  it('commits the new value on Enter', async () => {
+  it('reports every keystroke through onChange', async () => {
     const user = userEvent.setup();
-    const onChange = vi.fn();
-    render(<EditableText value="End" onChange={onChange} aria-label="Node name" />);
+    const onChangeSpy = vi.fn();
+    render(
+      <Controlled initial="" onChangeSpy={onChangeSpy} onSubmit={vi.fn()} aria-label="Node name" />
+    );
 
     await user.click(screen.getByRole('button', { name: /^Node name/ }));
-    await user.keyboard('Wrap up{Enter}');
+    await user.keyboard('End');
 
-    expect(onChange).toHaveBeenCalledExactlyOnceWith('Wrap up');
-    expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
+    expect(onChangeSpy.mock.calls.map(([next]) => next)).toEqual(['E', 'En', 'End']);
+    expect(screen.getByRole('textbox', { name: 'Node name' })).toHaveValue('End');
   });
 
-  it('commits on blur', async () => {
+  it('submits the trimmed value on Enter and closes', async () => {
     const user = userEvent.setup();
-    const onChange = vi.fn();
+    const onSubmit = vi.fn();
+    render(<Controlled initial="End" onSubmit={onSubmit} aria-label="Node name" />);
+
+    await user.click(screen.getByRole('button', { name: /^Node name/ }));
+    await user.keyboard('  Wrap up  {Enter}');
+
+    expect(onSubmit).toHaveBeenCalledExactlyOnceWith('Wrap up');
+    expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
+    // The trim reaches the owner too, so read mode shows what was submitted.
+    expect(screen.getByRole('button', { name: /^Node name/ })).toHaveTextContent('Wrap up');
+  });
+
+  it('submits on blur', async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
     render(
       <>
-        <EditableText value="End" onChange={onChange} aria-label="Node name" />
+        <Controlled initial="End" onSubmit={onSubmit} aria-label="Node name" />
         <button type="button">elsewhere</button>
       </>
     );
@@ -68,52 +154,73 @@ describe('EditableText', () => {
     await user.keyboard('Wrap up');
     await user.click(screen.getByRole('button', { name: 'elsewhere' }));
 
-    expect(onChange).toHaveBeenCalledExactlyOnceWith('Wrap up');
+    expect(onSubmit).toHaveBeenCalledExactlyOnceWith('Wrap up');
   });
 
-  it('reverts on Escape without committing', async () => {
+  it('reverts to the text it opened with on Escape, without submitting', async () => {
     const user = userEvent.setup();
-    const onChange = vi.fn();
-    render(<EditableText value="End" onChange={onChange} aria-label="Node name" />);
+    const onSubmit = vi.fn();
+    render(<Controlled initial="End" onSubmit={onSubmit} aria-label="Node name" />);
 
     await user.click(screen.getByRole('button', { name: /^Node name/ }));
     await user.keyboard('Wrap up{Escape}');
 
-    expect(onChange).not.toHaveBeenCalled();
+    expect(onSubmit).not.toHaveBeenCalled();
     expect(screen.getByRole('button', { name: /^Node name/ })).toHaveTextContent('End');
   });
 
-  it('trims the committed value', async () => {
+  it('does not submit when the editor closes on the text it opened with', async () => {
     const user = userEvent.setup();
-    const onChange = vi.fn();
-    render(<EditableText value="End" onChange={onChange} aria-label="Node name" />);
+    const onSubmit = vi.fn();
+    render(
+      <>
+        <Controlled initial="End" onSubmit={onSubmit} aria-label="Node name" />
+        <button type="button">elsewhere</button>
+      </>
+    );
 
     await user.click(screen.getByRole('button', { name: /^Node name/ }));
-    await user.keyboard('  Wrap up  {Enter}');
+    await user.click(screen.getByRole('button', { name: 'elsewhere' }));
 
-    expect(onChange).toHaveBeenCalledExactlyOnceWith('Wrap up');
+    expect(onSubmit).not.toHaveBeenCalled();
   });
 
-  it('commits an empty string when the value is cleared, so the caller can delete it', async () => {
+  it('submits an empty string when the value is cleared, so the caller can delete it', async () => {
     const user = userEvent.setup();
-    const onChange = vi.fn();
-    render(<EditableText value="End" onChange={onChange} aria-label="Node name" />);
+    const onSubmit = vi.fn();
+    render(<Controlled initial="End" onSubmit={onSubmit} aria-label="Node name" />);
 
     await user.click(screen.getByRole('button', { name: /^Node name/ }));
     await user.keyboard('{Backspace}{Enter}');
 
-    expect(onChange).toHaveBeenCalledExactlyOnceWith('');
+    expect(onSubmit).toHaveBeenCalledExactlyOnceWith('');
   });
 
-  it('does not fire onChange when the value is unchanged', async () => {
+  it('renders owner feedback about the text being typed', async () => {
     const user = userEvent.setup();
-    const onChange = vi.fn();
-    render(<EditableText value="End" onChange={onChange} aria-label="Node name" />);
+    render(
+      <Controlled
+        initial="End"
+        validate={(text) => (/^\d/.test(text) ? 'Must begin with a letter' : undefined)}
+        onSubmit={vi.fn()}
+        aria-label="Node name"
+      />
+    );
 
     await user.click(screen.getByRole('button', { name: /^Node name/ }));
-    await user.keyboard('{Enter}');
+    await user.clear(screen.getByRole('textbox', { name: 'Node name' }));
+    await user.keyboard('2fa');
 
-    expect(onChange).not.toHaveBeenCalled();
+    expect(screen.getByText('Must begin with a letter')).toBeInTheDocument();
+    expect(screen.getByRole('textbox', { name: 'Node name' })).toHaveAttribute(
+      'aria-invalid',
+      'true'
+    );
+
+    await user.keyboard('{Escape}');
+
+    // Escape reverts the text, so the owner's message goes with it.
+    expect(screen.queryByText('Must begin with a letter')).not.toBeInTheDocument();
   });
 
   it('keeps keystrokes from reaching an ancestor while editing', async () => {
@@ -121,7 +228,7 @@ describe('EditableText', () => {
     const onAncestorKeyDown = vi.fn();
     render(
       <div onKeyDown={onAncestorKeyDown}>
-        <EditableText value="End" onChange={vi.fn()} aria-label="Node name" />
+        <Controlled initial="End" onSubmit={vi.fn()} aria-label="Node name" />
       </div>
     );
 
@@ -131,240 +238,85 @@ describe('EditableText', () => {
     expect(onAncestorKeyDown).not.toHaveBeenCalled();
   });
 
-  it('picks up an external value change while not editing', () => {
-    const { rerender } = render(
-      <EditableText value="End" onChange={vi.fn()} aria-label="Node name" />
-    );
-    rerender(<EditableText value="Finish" onChange={vi.fn()} aria-label="Node name" />);
-    expect(screen.getByRole('button', { name: /^Node name/ })).toHaveTextContent('Finish');
-  });
-  it('announces the value through the trigger, not only the field name', () => {
-    render(<EditableText value="End" onChange={vi.fn()} aria-label="Node name" />);
-    expect(screen.getByRole('button', { name: 'Node name: End' })).toBeInTheDocument();
-  });
-
-  it('keeps the draft when the parent re-renders with a new value mid-edit', async () => {
+  it('follows an external value change, editing or not', async () => {
     const user = userEvent.setup();
     const { rerender } = render(
-      <EditableText value="End" onChange={vi.fn()} aria-label="Node name" />
+      <EditableText value="End" onChange={vi.fn()} onSubmit={vi.fn()} aria-label="Node name" />
     );
+    rerender(
+      <EditableText value="Finish" onChange={vi.fn()} onSubmit={vi.fn()} aria-label="Node name" />
+    );
+    expect(screen.getByRole('button', { name: /^Node name/ })).toHaveTextContent('Finish');
 
     await user.click(screen.getByRole('button', { name: /^Node name/ }));
-    await user.keyboard('Wrap up');
-    rerender(<EditableText value="Finish" onChange={vi.fn()} aria-label="Node name" />);
-
+    rerender(
+      <EditableText value="Wrap up" onChange={vi.fn()} onSubmit={vi.fn()} aria-label="Node name" />
+    );
     expect(screen.getByRole('textbox', { name: 'Node name' })).toHaveValue('Wrap up');
   });
 
-  it('reopens the editor on the current value after a commit the caller ignores', async () => {
-    const user = userEvent.setup();
-    const onChange = vi.fn();
-    render(<EditableText value="End" onChange={onChange} aria-label="Node name" />);
-
-    await user.click(screen.getByRole('button', { name: /^Node name/ }));
-    await user.keyboard('Wrap up{Enter}');
-    await user.click(screen.getByRole('button', { name: /^Node name/ }));
-
-    expect(screen.getByRole('textbox', { name: 'Node name' })).toHaveValue('End');
-  });
-
-  it('commits an empty string for whitespace-only input', async () => {
-    const user = userEvent.setup();
-    const onChange = vi.fn();
-    render(<EditableText value="End" onChange={onChange} aria-label="Node name" />);
-
-    await user.click(screen.getByRole('button', { name: /^Node name/ }));
-    await user.keyboard('   {Enter}');
-
-    expect(onChange).toHaveBeenCalledExactlyOnceWith('');
-  });
-
-  it('does not commit after Escape when focus moves elsewhere', async () => {
-    const user = userEvent.setup();
-    const onChange = vi.fn();
-    render(
-      <>
-        <EditableText value="End" onChange={onChange} aria-label="Node name" />
-        <button type="button">elsewhere</button>
-      </>
-    );
-
-    await user.click(screen.getByRole('button', { name: /^Node name/ }));
-    await user.keyboard('Wrap up{Escape}');
-    await user.click(screen.getByRole('button', { name: 'elsewhere' }));
-
-    expect(onChange).not.toHaveBeenCalled();
-  });
-
-  describe('overflow tooltip', () => {
-    it('offers the full value as a tooltip on the read trigger', () => {
-      render(<EditableText value="A very long description" onChange={vi.fn()} />);
-
-      expect(screen.getByRole('button')).toHaveAttribute(
-        'data-tooltip-trigger',
-        'A very long description'
-      );
-    });
-
-    it('offers the tooltip on static text too', () => {
-      render(<EditableText value="Client-side tool" />);
-
-      expect(screen.getByText('Client-side tool')).toHaveAttribute(
-        'data-tooltip-trigger',
-        'Client-side tool'
-      );
-    });
-
-    it('falls back to the placeholder, which is what a value-less field renders', () => {
-      render(<EditableText value="" placeholder="A very long placeholder" onChange={vi.fn()} />);
-
-      expect(screen.getByRole('button')).toHaveAttribute(
-        'data-tooltip-trigger',
-        'A very long placeholder'
-      );
-    });
-
-    it('drops the tooltip while editing, where the text is not truncated', async () => {
-      const user = userEvent.setup();
-      render(<EditableText value="A very long description" onChange={vi.fn()} />);
-
-      await user.click(screen.getByRole('button'));
-
-      expect(screen.getByRole('textbox')).not.toHaveAttribute('data-tooltip-trigger');
-    });
+  it('announces the value through the trigger, not only the field name', () => {
+    render(<Controlled initial="End" onSubmit={vi.fn()} aria-label="Node name" />);
+    expect(screen.getByRole('button', { name: 'Node name: End' })).toBeInTheDocument();
   });
 
   describe('multiline', () => {
-    it('inserts a newline on Shift+Enter without committing', async () => {
+    it('inserts a newline on Shift+Enter, submits the multi-line value on a plain Enter', async () => {
       const user = userEvent.setup();
-      const onChange = vi.fn();
-      render(<EditableText value="First" multiline onChange={onChange} aria-label="Description" />);
+      const onSubmit = vi.fn();
+      render(<Controlled initial="First" multiline onSubmit={onSubmit} aria-label="Description" />);
 
       await user.click(screen.getByRole('button', { name: /^Description/ }));
       await user.keyboard('{End}{Shift>}{Enter}{/Shift}Second');
+      expect(screen.getByRole('textbox', { name: 'Description' })).toHaveValue('First\nSecond');
+      expect(onSubmit).not.toHaveBeenCalled();
 
-      expect(screen.getByRole('textbox', { name: /^Description/ })).toHaveValue('First\nSecond');
-      expect(onChange).not.toHaveBeenCalled();
+      await user.keyboard('{Enter}');
+      expect(onSubmit).toHaveBeenCalledExactlyOnceWith('First\nSecond');
     });
 
-    it('commits the multi-line value on a plain Enter', async () => {
+    it('collapses newlines and submits on Enter in wrap mode', async () => {
       const user = userEvent.setup();
-      const onChange = vi.fn();
-      render(<EditableText value="First" multiline onChange={onChange} aria-label="Description" />);
+      const onSubmit = vi.fn();
+      render(
+        <Controlled initial="First" multiline="wrap" onSubmit={onSubmit} aria-label="Description" />
+      );
 
       await user.click(screen.getByRole('button', { name: /^Description/ }));
-      await user.keyboard('{End}{Shift>}{Enter}{/Shift}Second{Enter}');
+      await user.keyboard('{End} draft{Shift>}{Enter}{/Shift}');
+      expect(onSubmit).toHaveBeenCalledWith('First draft');
 
-      expect(onChange).toHaveBeenCalledExactlyOnceWith('First\nSecond');
-      expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
+      await user.click(screen.getByRole('button', { name: /^Description/ }));
+      await user.keyboard('{End}');
+      await user.paste('\nSecond');
+      expect(screen.getByRole('textbox', { name: 'Description' })).toHaveValue(
+        'First draft Second'
+      );
     });
 
-    it('caps the editor at maxLines and leaves it scrollable', async () => {
+    it.each([
+      [true],
+      ['wrap'] as const,
+    ])('caps the read clamp and the editor height at maxLines (multiline=%s)', async (multiline) => {
       const user = userEvent.setup();
       render(
-        <EditableText
-          value="First"
-          multiline
+        <Controlled
+          initial="First"
+          multiline={multiline}
           maxLines={2}
-          size="sm"
-          onChange={vi.fn()}
+          onSubmit={vi.fn()}
           aria-label="Description"
         />
       );
 
-      await user.click(screen.getByRole('button', { name: /^Description/ }));
+      const trigger = screen.getByRole('button', { name: /^Description/ });
+      expect(trigger).toHaveStyle({ '--editable-text-lines': '2' });
 
-      // 2 lines * 16px (`leading-4`) + 4px of `py-0.5`.
-      expect(screen.getByRole('textbox', { name: /^Description/ })).toHaveStyle({
-        maxHeight: '36px',
+      await user.click(trigger);
+      // 2 lines at the `lg` line box (20px) plus the editor's vertical padding.
+      expect(screen.getByRole('textbox', { name: 'Description' })).toHaveStyle({
+        maxHeight: '44px',
       });
-    });
-
-    it('keeps Enter single-line when multiline is off', async () => {
-      const user = userEvent.setup();
-      const onChange = vi.fn();
-      render(<EditableText value="First" onChange={onChange} aria-label="Node name" />);
-
-      await user.click(screen.getByRole('button', { name: /^Node name/ }));
-      await user.keyboard('{Shift>}{Enter}{/Shift}');
-
-      expect(onChange).not.toHaveBeenCalled();
-      expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
-    });
-  });
-
-  describe('error state', () => {
-    it('renders no error message when no error is passed', () => {
-      render(<EditableText value="End" onChange={vi.fn()} aria-label="Node name" />);
-      expect(document.querySelector('[data-slot="editable-text-error"]')).toBeNull();
-    });
-
-    it('shows the message and marks the trigger invalid while collapsed', () => {
-      render(
-        <EditableText
-          value="1 bad"
-          onChange={vi.fn()}
-          aria-label="Node name"
-          error="Tool name must begin with a letter."
-        />
-      );
-
-      const trigger = screen.getByRole('button', { name: /^Node name/ });
-      expect(trigger).toHaveAttribute('aria-invalid', 'true');
-      expect(screen.getByText('Tool name must begin with a letter.')).toBeInTheDocument();
-      expect(trigger).toHaveAccessibleDescription('Tool name must begin with a letter.');
-    });
-
-    it('keeps the error visible after the editor closes, so a rejected commit still explains itself', async () => {
-      const user = userEvent.setup();
-      render(
-        <EditableText
-          value="1 bad"
-          onChange={vi.fn()}
-          aria-label="Node name"
-          error="Tool name must begin with a letter."
-        />
-      );
-
-      await user.click(screen.getByRole('button', { name: /^Node name/ }));
-      const input = screen.getByRole('textbox', { name: 'Node name' });
-      expect(input).toHaveAttribute('aria-invalid', 'true');
-      expect(input).toHaveAccessibleDescription('Tool name must begin with a letter.');
-
-      await user.keyboard('{Escape}');
-
-      expect(screen.getByRole('button', { name: /^Node name/ })).toHaveAttribute(
-        'aria-invalid',
-        'true'
-      );
-      expect(screen.getByText('Tool name must begin with a letter.')).toBeInTheDocument();
-    });
-
-    it('describes static text without claiming an unsupported invalid state on a generic role', () => {
-      render(<EditableText value="End" error="Something is off." />);
-
-      const text = document.querySelector('[data-slot="editable-text"]')!;
-      expect(text).not.toHaveAttribute('aria-invalid');
-      expect(screen.getByText('Something is off.')).toBeInTheDocument();
-      expect(text).toHaveAccessibleDescription('Something is off.');
-    });
-
-    it('still commits while in error, so the user can type their way out', async () => {
-      const user = userEvent.setup();
-      const onChange = vi.fn();
-      render(
-        <EditableText
-          value="1 bad"
-          onChange={onChange}
-          aria-label="Node name"
-          error="Tool name must begin with a letter."
-        />
-      );
-
-      await user.click(screen.getByRole('button', { name: /^Node name/ }));
-      await user.keyboard('Analyze files{Enter}');
-
-      expect(onChange).toHaveBeenCalledExactlyOnceWith('Analyze files');
     });
   });
 });

--- a/packages/apollo-react/src/canvas/components/NodePropertyPanel/EditableText.tsx
+++ b/packages/apollo-react/src/canvas/components/NodePropertyPanel/EditableText.tsx
@@ -4,21 +4,32 @@ import { useIsomorphicLayoutEffect } from '../../hooks/useIsomorphicLayoutEffect
 import { CanvasTooltip } from '../CanvasTooltip';
 
 export interface EditableTextProps {
+  /** The text on screen, in both modes: this is a controlled field, so an edit shows up only once `onChange` has been applied here. */
   value: string;
   placeholder?: string;
   size?: 'sm' | 'lg';
-  /** Accept newlines (Shift+Enter). Enter still commits. */
-  multiline?: boolean;
+  /**
+   * Text layout. `true` accepts newlines (Shift+Enter); `'wrap'` wraps across lines but keeps the
+   * value single-line, so every Enter commits and pasted newlines collapse. Enter always commits.
+   */
+  multiline?: boolean | 'wrap';
   /** Visible-line ceiling when `multiline`. The editor scrolls past it. Defaults to 3. */
   maxLines?: number;
+  /** Fires on every keystroke with the text as typed, like any controlled input. Pair with `onSubmit`: both are required to make the text editable, and `value` has to follow this callback or the field won't accept input. Escape reports the text held when the editor opened, so the owner reverts through this same path. */
   onChange?: (next: string) => void;
+  /** Fires on Enter or blur with the trimmed `value`, and only when it differs from the text the editor opened with, so a click in and straight back out is silent. The owner decides whether to persist it. */
+  onSubmit?: (next: string) => void;
+  /** Locks the text as-is: no edit mode, no commit. Ignored for static text. */
+  disabled?: boolean;
   /** Field-specific feedback rendered immediately below the text. */
   error?: ReactNode;
-  /** Names the editor and its click target. Unused for static text (no `onChange`). */
+  /** Names the editor and its click target. Unused for static text. */
   'aria-label'?: string;
   className?: string;
   'data-testid'?: string;
 }
+
+const stripNewlines = (text: string) => text.replace(/\n+/g, ' ');
 
 const READ_CLASS = {
   lg: 'text-base font-semibold leading-5 tracking-[-0.3px] text-foreground',
@@ -49,7 +60,12 @@ const INTERACTIVE_CLASS = 'rounded px-1.5 py-0.5 -mx-1.5';
 
 const ERROR_RING_CLASS = 'ring-1 ring-error';
 
-/** Click-to-edit text for the node identity row: enters on click, commits on Enter or blur, reverts on Escape. Static text without `onChange`. */
+/**
+ * Click-to-edit text for the node identity row: enters on click, submits on Enter or blur, reverts
+ * on Escape. Controlled — the owner holds the text and feeds it back through `value`, which lets it
+ * validate what is being typed and render the message through `error`. Renders static text unless
+ * both `onChange` and `onSubmit` are given.
+ */
 export function EditableText({
   value,
   placeholder,
@@ -57,14 +73,20 @@ export function EditableText({
   multiline,
   maxLines = 3,
   onChange,
+  onSubmit,
+  disabled,
   error,
   'aria-label': ariaLabel,
   className,
   'data-testid': dataTestId,
 }: EditableTextProps) {
+  const allowNewlines = multiline === true;
+  const editable = !!onChange && !!onSubmit;
   const [isEditing, setIsEditing] = useState(false);
-  const [draft, setDraft] = useState(value);
   const inputRef = useRef<HTMLInputElement | HTMLTextAreaElement>(null);
+  // What Escape reverts to. Taken when the editor opens, since by then `value`
+  // is the owner's live state and no longer remembers where the edit started.
+  const openedWith = useRef(value);
   const errorId = `editable-text-${useId().replace(/:/g, '')}-error`;
 
   const hasError = !!error;
@@ -73,25 +95,33 @@ export function EditableText({
   const describedBy = hasError ? errorId : undefined;
 
   useIsomorphicLayoutEffect(() => {
+    // Going disabled mid-edit closes the editor (below) without submitting. The
+    // text itself is the owner's, so re-enabling shows whatever it kept.
+    if (disabled) return setIsEditing(false);
     if (!isEditing) return;
     inputRef.current?.focus();
     inputRef.current?.select();
-  }, [isEditing]);
+  }, [isEditing, disabled]);
 
   const commit = useCallback(() => {
     setIsEditing(false);
-    const next = draft.trim();
+    const next = value.trim();
     if (next !== value) onChange?.(next);
-  }, [draft, value, onChange]);
+    // Opening and closing without touching the text is not an edit: staying
+    // silent keeps the owner from persisting a value it already has.
+    if (next !== openedWith.current) onSubmit?.(next);
+  }, [value, onChange, onSubmit]);
 
   const cancel = useCallback(() => {
     setIsEditing(false);
-  }, []);
+    if (openedWith.current !== value) onChange?.(openedWith.current);
+  }, [value, onChange]);
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLInputElement | HTMLTextAreaElement>) => {
-      // Shift+Enter falls through to insert a newline; every other Enter commits.
-      if (e.key === 'Enter' && !(multiline && e.shiftKey)) {
+      // Only `multiline` (not `'wrap'`) lets Shift+Enter fall through to a newline;
+      // every other Enter commits.
+      if (e.key === 'Enter' && !(allowNewlines && e.shiftKey)) {
         e.preventDefault();
         commit();
       } else if (e.key === 'Escape') {
@@ -100,7 +130,7 @@ export function EditableText({
       }
       e.stopPropagation();
     },
-    [commit, cancel, multiline]
+    [commit, cancel, allowNewlines]
   );
 
   // Read mode caps the rendered lines through the clamp; edit mode grows with
@@ -119,7 +149,7 @@ export function EditableText({
     </FormFieldError>
   );
 
-  if (!onChange) {
+  if (!editable) {
     return (
       <>
         <CanvasTooltip content={value || placeholder} smartTooltip delay>
@@ -144,11 +174,11 @@ export function EditableText({
     );
   }
 
-  if (isEditing) {
+  if (isEditing && !disabled) {
     const sharedProps = {
       'data-slot': 'editable-text-input',
       'data-testid': dataTestId ? `${dataTestId}-input` : undefined,
-      value: draft,
+      value,
       placeholder,
       'aria-label': ariaLabel,
       'aria-describedby': describedBy,
@@ -177,14 +207,16 @@ export function EditableText({
               sharedProps.className,
               'field-sizing-content max-w-full resize-none overflow-y-auto wrap-break-word'
             )}
-            onChange={(e) => setDraft(e.target.value)}
+            onChange={(e) =>
+              onChange?.(allowNewlines ? e.target.value : stripNewlines(e.target.value))
+            }
           />
         ) : (
           <input
             {...sharedProps}
             ref={inputRef as React.RefObject<HTMLInputElement>}
             autoComplete="off"
-            onChange={(e) => setDraft(e.target.value)}
+            onChange={(e) => onChange?.(e.target.value)}
           />
         )}
         {message}
@@ -203,13 +235,16 @@ export function EditableText({
           aria-describedby={describedBy}
           aria-errormessage={hasError ? errorId : undefined}
           aria-invalid={hasError || undefined}
+          aria-disabled={disabled || undefined}
           onClick={() => {
-            setDraft(value);
+            if (disabled) return;
+            openedWith.current = value;
             setIsEditing(true);
           }}
           style={readClampStyle}
           className={cn(
             'nodrag max-w-full cursor-text border-none bg-transparent text-left transition hover:bg-surface-overlay',
+            'aria-disabled:cursor-not-allowed aria-disabled:opacity-50 aria-disabled:hover:bg-transparent',
             readClampClass,
             INTERACTIVE_CLASS,
             READ_CLASS[size],

--- a/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.stories.tsx
@@ -519,6 +519,56 @@ export const QuickForm: Story = {
   render: () => <QuickFormPanel />,
 };
 
+function IdentityValidationStory() {
+  const [label, setLabel] = useState('Analyze files');
+  const [description, setDescription] = useState('');
+
+  // Stand-in for a host rule (here: an agent tool name). The editor is
+  // controlled, so this runs on every keystroke and the message tracks the text
+  // on screen — including after the editor closes on a value the host rejects.
+  const labelError = !label
+    ? 'Tool name is required.'
+    : /^[A-Z_a-z][\w ]*$/.test(label)
+      ? undefined
+      : 'Tool name must begin with a letter or underscore and contain only letters, digits, spaces, and underscores.';
+
+  return (
+    <PanelFrame>
+      <NodePropertyPanel
+        panelTitle="Properties"
+        nodeIcon={<Globe />}
+        nodeLabel={label}
+        nodeLabelPlaceholder="Name"
+        nodeDescription={description}
+        nodeDescriptionPlaceholder="Client-side tool"
+        onNodeLabelChange={setLabel}
+        onNodeLabelSubmit={setLabel}
+        onNodeDescriptionChange={setDescription}
+        onNodeDescriptionSubmit={setDescription}
+        nodeLabelError={labelError}
+        action={<RunButton />}
+        schema={httpRequestForm}
+        contentInset="0.875rem"
+        onClose={() => {}}
+        className="h-[640px]"
+      />
+    </PanelFrame>
+  );
+}
+
+export const IdentityValidation: Story = {
+  name: 'Identity Validation',
+  render: () => <IdentityValidationStory />,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Rename the node to something starting with a digit to see the error state. `nodeLabelError` / `nodeDescriptionError` render below the line with a persistent error ring, matching `Input`: the control gets `aria-invalid` plus `aria-errormessage`, and the message renders through `FormFieldError` so it announces politely. The ring stays after the editor closes, so a commit the host rejects still explains itself.',
+      },
+    },
+  },
+};
+
 export const EmbeddedNoTitleBar: Story = {
   name: 'Form Embedded',
   render: () => (
@@ -1397,7 +1447,9 @@ function InputEditorStory() {
         nodeDescription={description}
         nodeDescriptionPlaceholder="Control"
         onNodeLabelChange={setLabel}
+        onNodeLabelSubmit={setLabel}
         onNodeDescriptionChange={setDescription}
+        onNodeDescriptionSubmit={setDescription}
         action={<RunButton />}
       >
         <div className="flex h-full flex-col">

--- a/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.test.tsx
+++ b/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.test.tsx
@@ -56,6 +56,28 @@ describe('NodePropertyPanel', () => {
     expect(onPointerDown).toHaveBeenCalledOnce();
   });
 
+  it('locks the identity row when the panel is disabled', async () => {
+    const user = userEvent.setup();
+    render(
+      <NodePropertyPanel
+        nodeLabel="Fetch invoice"
+        nodeDescription="Calls the billing API"
+        onNodeLabelChange={vi.fn()}
+        onNodeLabelSubmit={vi.fn()}
+        onNodeDescriptionChange={vi.fn()}
+        onNodeDescriptionSubmit={vi.fn()}
+        schema={MULTI_STEP}
+        disabled
+      />
+    );
+
+    await user.click(screen.getByTestId('node-property-panel-label'));
+    await user.click(screen.getByTestId('node-property-panel-description'));
+
+    expect(screen.queryByTestId('node-property-panel-label-input')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('node-property-panel-description-input')).not.toBeInTheDocument();
+  });
+
   it('renders the node label and category in the identity row', () => {
     render(
       <NodePropertyPanel
@@ -86,39 +108,77 @@ describe('NodePropertyPanel', () => {
     expect(screen.queryByRole('button', { name: /^Node name/ })).not.toBeInTheDocument();
   });
 
-  it('makes the label editable and reports the committed value', async () => {
+  it('makes the label editable, reporting keystrokes and the submitted value', async () => {
     const user = userEvent.setup();
     const onNodeLabelChange = vi.fn();
-    render(
+    const onNodeLabelSubmit = vi.fn();
+    const { rerender } = render(
       <NodePropertyPanel
-        nodeLabel="Fetch invoice details"
+        nodeLabel="Fetch"
         onNodeLabelChange={onNodeLabelChange}
+        onNodeLabelSubmit={onNodeLabelSubmit}
         schema={MULTI_STEP}
       />
     );
 
     await user.click(screen.getByRole('button', { name: /^Node name/ }));
-    await user.keyboard('Fetch invoice{Enter}');
+    await user.keyboard('{End}!');
 
-    expect(onNodeLabelChange).toHaveBeenCalledExactlyOnceWith('Fetch invoice');
+    // Controlled: the panel reports the keystroke, the owner decides what `nodeLabel` becomes.
+    expect(onNodeLabelChange).toHaveBeenCalledExactlyOnceWith('Fetch!');
+
+    rerender(
+      <NodePropertyPanel
+        nodeLabel="Fetch!"
+        onNodeLabelChange={onNodeLabelChange}
+        onNodeLabelSubmit={onNodeLabelSubmit}
+        schema={MULTI_STEP}
+      />
+    );
+    await user.keyboard('{Enter}');
+    expect(onNodeLabelSubmit).toHaveBeenCalledExactlyOnceWith('Fetch!');
   });
 
-  it('makes the description editable and reports the committed value', async () => {
-    const user = userEvent.setup();
-    const onNodeDescriptionChange = vi.fn();
+  it('renders owner feedback under the label', () => {
     render(
       <NodePropertyPanel
         nodeLabel="Fetch invoice details"
-        nodeDescription=""
-        onNodeDescriptionChange={onNodeDescriptionChange}
+        onNodeLabelChange={vi.fn()}
+        onNodeLabelSubmit={vi.fn()}
+        nodeLabelError="Name is required"
+        schema={MULTI_STEP}
+      />
+    );
+
+    expect(screen.getByText('Name is required')).toBeInTheDocument();
+  });
+
+  it('makes the description editable and reports the submitted value', async () => {
+    const user = userEvent.setup();
+    const onNodeDescriptionSubmit = vi.fn();
+    const { rerender } = render(
+      <NodePropertyPanel
+        nodeLabel="Fetch invoice details"
+        nodeDescription="One invoice"
+        onNodeDescriptionChange={vi.fn()}
+        onNodeDescriptionSubmit={onNodeDescriptionSubmit}
         schema={MULTI_STEP}
       />
     );
 
     await user.click(screen.getByRole('button', { name: /^Node description/ }));
-    await user.keyboard('One invoice{Enter}');
+    rerender(
+      <NodePropertyPanel
+        nodeLabel="Fetch invoice details"
+        nodeDescription="Two invoices"
+        onNodeDescriptionChange={vi.fn()}
+        onNodeDescriptionSubmit={onNodeDescriptionSubmit}
+        schema={MULTI_STEP}
+      />
+    );
+    await user.keyboard('{Enter}');
 
-    expect(onNodeDescriptionChange).toHaveBeenCalledExactlyOnceWith('One invoice');
+    expect(onNodeDescriptionSubmit).toHaveBeenCalledExactlyOnceWith('Two invoices');
   });
 
   it('keeps the category when the description is defined but empty', () => {
@@ -139,6 +199,7 @@ describe('NodePropertyPanel', () => {
         nodeLabel=""
         nodeLabelPlaceholder="HTTP Request"
         onNodeLabelChange={vi.fn()}
+        onNodeLabelSubmit={vi.fn()}
         schema={MULTI_STEP}
       />
     );

--- a/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.tsx
+++ b/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.tsx
@@ -16,7 +16,7 @@ const SURFACE_REMAP = 'future:[--surface-raised:var(--surface-overlay)]';
  * The panel owns only the *chrome*: an optional title bar (drag handle + close),
  * a node identity row (icon / label / description-or-category + an action slot),
  * and the form frame. The label and description lines become click-to-edit when
- * the matching `onNode*Change` callback is passed.
+ * both matching callbacks are passed (`onNode*Change` and `onNode*Submit`).
  *
  * The form itself is a single `MetadataForm` rendered from the `schema` you pass
  * in, with multi-step schemas presented as tabs (Parameters, Error handling,
@@ -29,11 +29,15 @@ const SURFACE_REMAP = 'future:[--surface-raised:var(--surface-overlay)]';
  *
  * @example
  * ```tsx
+ * // The label is controlled: the draft has to flow back through `nodeLabel`.
+ * const [draftLabel, setDraftLabel] = useState(node.label);
+ *
  * <NodePropertyPanel
  *   panelTitle="Properties"               // omit when dockview owns the title bar
- *   nodeLabel="Fetch invoice details"
+ *   nodeLabel={draftLabel}
  *   nodeCategory="HTTP Request"         // fallback second line; a description wins
- *   onNodeLabelChange={renameNode}      // omit for a read-only label
+ *   onNodeLabelChange={setDraftLabel}   // per keystroke; omit either for a read-only label
+ *   onNodeLabelSubmit={renameNode}      // on Enter or blur, trimmed
  *   action={<RunButton />}
  *   schema={assembledSchema}              // caller-built FormSchema (steps = tabs)
  *   plugins={formPlugins}                 // real-time onChange, custom fields
@@ -53,7 +57,9 @@ export function NodePropertyPanel({
   nodeLabelPlaceholder,
   nodeDescriptionPlaceholder,
   onNodeLabelChange,
+  onNodeLabelSubmit,
   onNodeDescriptionChange,
+  onNodeDescriptionSubmit,
   nodeLabelError,
   nodeDescriptionError,
   action,
@@ -72,8 +78,8 @@ export function NodePropertyPanel({
   onActiveStepChange,
 }: NodePropertyPanelProps) {
   const { _ } = useSafeLingui();
-  const isLabelEditable = !!onNodeLabelChange;
-  const isDescriptionEditable = !!onNodeDescriptionChange;
+  const isLabelEditable = !!onNodeLabelChange && !!onNodeLabelSubmit;
+  const isDescriptionEditable = !!onNodeDescriptionChange && !!onNodeDescriptionSubmit;
   const showsDescription = !!nodeDescription || isDescriptionEditable || !!nodeDescriptionError;
   const showsLabel = !!nodeLabel || isLabelEditable || !!nodeLabelError;
   const hasNodeHeader = !!(showsLabel || nodeCategory || nodeIcon || action || showsDescription);
@@ -143,6 +149,8 @@ export function NodePropertyPanel({
                   }
                   size="lg"
                   onChange={onNodeLabelChange}
+                  onSubmit={onNodeLabelSubmit}
+                  disabled={disabled}
                   error={nodeLabelError}
                   aria-label={_({
                     id: 'canvas.node_property_panel.node_name',
@@ -165,6 +173,8 @@ export function NodePropertyPanel({
                   multiline
                   maxLines={3}
                   onChange={onNodeDescriptionChange}
+                  onSubmit={onNodeDescriptionSubmit}
+                  disabled={disabled}
                   error={nodeDescriptionError}
                   aria-label={_({
                     id: 'canvas.node_property_panel.node_description',

--- a/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.types.ts
+++ b/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.types.ts
@@ -15,18 +15,22 @@ export interface NodePropertyPanelProps {
   nodeIcon?: ReactNode;
   /** The node's display label shown in the node identity row. */
   nodeLabel?: string;
-  /** Category/subtitle text shown below `nodeLabel` (e.g. "HTTP Request"). Fallback: a description, a description callback, or a description error takes the line instead. */
+  /** Category/subtitle text shown below `nodeLabel` (e.g. "HTTP Request"). Fallback: a description, an editable description, or a description error takes the line instead. */
   nodeCategory?: string;
-  /** User-authored description on the identity row's second line. Takes the line from `nodeCategory` whenever it is non-empty, as does `onNodeDescriptionChange` on its own. */
+  /** User-authored description on the identity row's second line. Takes the line from `nodeCategory` whenever it is non-empty, as does an editable description (`onNodeDescriptionChange` and `onNodeDescriptionSubmit` together). */
   nodeDescription?: string;
   /** Hint shown in place of an empty `nodeLabel`. Defaults to a localized `"Name"`. Never committed. */
   nodeLabelPlaceholder?: string;
   /** Hint shown in place of an empty `nodeDescription`. Defaults to a localized `"Description"`. Never committed. */
   nodeDescriptionPlaceholder?: string;
-  /** Makes `nodeLabel` click-to-edit: commits the trimmed value on Enter or blur, Escape reverts. Omit for read-only. */
+  /** Fires on every keystroke in `nodeLabel`; required with `onNodeLabelSubmit` to make it editable, since the editor is controlled. */
   onNodeLabelChange?: (label: string) => void;
-  /** Makes `nodeDescription` click-to-edit. Same contract as `onNodeLabelChange`. */
+  /** Fires on Enter or blur with the trimmed `nodeLabel`, for the owner to persist. */
+  onNodeLabelSubmit?: (label: string) => void;
+  /** Fires on every keystroke in `nodeDescription`. Same contract as `onNodeLabelChange`. */
   onNodeDescriptionChange?: (description: string) => void;
+  /** Fires on Enter or blur with the trimmed `nodeDescription`. Same contract as `onNodeLabelSubmit`. */
+  onNodeDescriptionSubmit?: (description: string) => void;
   /**
    * Validation message for the node name, rendered below it with a persistent
    * error ring.


### PR DESCRIPTION
## What

`EditableText` is now a **controlled** field, plus two new props (`disabled`, a `'wrap'` option for `multiline`) and a dedicated story for the component.

### `multiline: 'wrap'`

Lays out across lines exactly as `true` does, but keeps the value single-line:

- every Enter commits, with no Shift+Enter escape hatch
- pasted newlines collapse to spaces, since paste is the only way one can reach the editor

## New `EditableText` Story

### Playground
<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/603aada3-cb29-4e0a-93bd-1dc5d3a333bd" />

### Multiline settings
<img width="431" height="635" alt="image" src="https://github.com/user-attachments/assets/f9803b06-9da8-4689-b335-d047acb4aebc" />

### Disabled settings
<img width="417" height="682" alt="image" src="https://github.com/user-attachments/assets/58f9ff5e-b404-460c-9068-bd5fcee35e54" />

## API change

`onChange` changed shape. It used to keep the draft internally and fire once, on commit, with the trimmed value. The field is controlled now: `onChange` fires on every keystroke and the commit moved to the new `onSubmit`, so editing takes both callbacks. Passing only `onChange` renders static text. Same for `NodePropertyPanel`: `onNodeLabelChange` / `onNodeDescriptionChange` need their matching `onNodeLabelSubmit` / `onNodeDescriptionSubmit` for the line to be editable.

```diff
- <EditableText value={label} onChange={renameNode} />
+ <EditableText value={draftLabel} onChange={setDraftLabel} onSubmit={renameNode} />
```

Released as a minor, not a major: the component landed a week ago in 6.43.0 and its only consumers are the ones we update ourselves in the same pass. No compatibility shim, and no uncontrolled mode for now. If an external consumer ever needs the old shape, a `defaultValue` mode is the way to add it.
