### PR TITLE
docs(apollo-wind): add Field Types reference page

### DIFF
--- a/apps/storybook/src/patterns/FieldTypes.stories.tsx
+++ b/apps/storybook/src/patterns/FieldTypes.stories.tsx
@@ -38,7 +38,7 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 type Status = 'supported' | 'needs-type' | 'needs-component';
-type VisualExample = LockableFieldType | 'mode-fixed' | 'mode-expression';
+type VisualExample = LockableFieldType | 'mode-fixed' | 'mode-expression' | 'insert-variable';
 
 interface TypeRow {
   type: string;
@@ -331,7 +331,7 @@ const CATEGORIES: Category[] = [
         flowWorkbenchConfirmed: false,
       },
       {
-        type: 'autoComplete / connectorAutocomplete / autoCompleteForExpression',
+        type: 'autoComplete / connectorAutocomplete',
         source: 'integration-service WidgetType',
         support: 'Not modeled.',
         status: 'needs-component',
@@ -452,6 +452,22 @@ const BINDING_STATE_ROWS: TypeRow[] = [
     action:
       'Add a read-only bound state to LockableValueFieldMode, rendered like the locked display but indicating an upstream binding rather than a static value.',
   },
+  {
+    type: 'Insert variable (click to append)',
+    source: 'n/a, this is the Apollo Wind mechanism, not a flow-workbench type',
+    support: 'VariablePicker in field-header.tsx, wired via the variables prop',
+    status: 'supported',
+    visual: 'insert-variable',
+  },
+  {
+    type: 'Inline reference autocomplete while typing',
+    source: 'integration-service WidgetType.autoCompleteForExpression',
+    support:
+      'Not modeled. The expression input is a plain monospace field (or a consumer-supplied renderExpressionEditor) with no built-in suggestion behavior.',
+    status: 'needs-component',
+    action:
+      'Different from the Insert variable button above: this is IntelliSense-style, suggest a reference as the user types "$" inside an expression. Needs an editor with suggestion support (e.g. Monaco), not a fieldType addition.',
+  },
 ];
 
 // Every collapsible section on the page, category tables plus the binding-state
@@ -567,6 +583,24 @@ function ModeExample({ mode }: { mode: LockableValueFieldMode }) {
   );
 }
 
+// showFieldActions stays at its true default here (every other example turns it
+// off) since the Insert variable button only renders when it's on.
+function InsertVariableExample() {
+  const [value, setValue] = useState('');
+  return (
+    <div className="w-56">
+      <LockableValueField
+        fieldType="string"
+        value={value}
+        onValueChange={setValue}
+        locked={false}
+        showAiAssist={false}
+        variables={[{ label: 'Customer name', value: '$vars.customerName' }]}
+      />
+    </div>
+  );
+}
+
 // Rendered instead of a fake mockup for gap rows: there is no real control to show,
 // and a hand-drawn one would look like it already exists.
 function GapPlaceholder() {
@@ -581,6 +615,7 @@ function VisualExampleCell({ visual }: { visual?: VisualExample }) {
   if (!visual) return <GapPlaceholder />;
   if (visual === 'mode-fixed') return <ModeExample mode="fixed" />;
   if (visual === 'mode-expression') return <ModeExample mode="expression" />;
+  if (visual === 'insert-variable') return <InsertVariableExample />;
 
   if (!FIELD_TYPE_META[visual].supportsExpression) {
     return <FieldTypeExample fieldType={visual} />;

--- a/apps/storybook/src/patterns/FieldTypes.stories.tsx
+++ b/apps/storybook/src/patterns/FieldTypes.stories.tsx
@@ -793,6 +793,18 @@ function FieldTypesPage({ globalTheme }: { globalTheme: string }) {
         <Divider />
 
         <section>
+          <SectionTitle>What each type looks like</SectionTitle>
+          <SectionDescription>
+            A side-by-side comparison, each type in its default fixed-value state. The tables below
+            drill into one type at a time: its gaps, its status, and (where it applies) its
+            expression variant.
+          </SectionDescription>
+          <VisualReferenceGrid />
+        </section>
+
+        <Divider />
+
+        <section>
           <SectionTitle>Supported today</SectionTitle>
           <SectionDescription>
             The fieldType values LockableValueField already implements, read live from{' '}
@@ -802,18 +814,6 @@ function FieldTypesPage({ globalTheme }: { globalTheme: string }) {
             .
           </SectionDescription>
           <SupportedTodayStrip />
-        </section>
-
-        <Divider />
-
-        <section>
-          <SectionTitle>What each type looks like</SectionTitle>
-          <SectionDescription>
-            A side-by-side comparison, each type in its default fixed-value state. The tables below
-            drill into one type at a time: its gaps, its status, and (where it applies) its
-            expression variant.
-          </SectionDescription>
-          <VisualReferenceGrid />
         </section>
 
         <Divider />

--- a/apps/storybook/src/patterns/FieldTypes.stories.tsx
+++ b/apps/storybook/src/patterns/FieldTypes.stories.tsx
@@ -9,6 +9,7 @@ import {
 } from '@/components/ui/accordion';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
+import { Label } from '@/components/ui/label';
 import {
   FIELD_TYPE_META,
   FIELD_TYPE_ORDER,
@@ -16,6 +17,7 @@ import {
   LockableValueField,
   type LockableValueFieldMode,
 } from '@/components/ui/lockable-value-field';
+import { Switch } from '@/components/ui/switch';
 import {
   Table,
   TableBody,
@@ -706,6 +708,18 @@ const ALL_SECTION_TITLES = ALL_SECTIONS.map((section) => section.title);
 
 function FieldTypesPage({ globalTheme }: { globalTheme: string }) {
   const [openSections, setOpenSections] = useState<string[]>(ALL_SECTION_TITLES);
+  const [onlySupported, setOnlySupported] = useState(false);
+
+  // Sections with nothing supported (e.g. Security, Resource reference) drop out
+  // entirely under the filter, rather than sticking around empty.
+  const visibleSections = onlySupported
+    ? ALL_SECTIONS.map((section) => ({
+        ...section,
+        rows: section.rows.filter((row) => row.status === 'supported'),
+      })).filter((section) => section.rows.length > 0)
+    : ALL_SECTIONS;
+  const visibleSectionTitles = visibleSections.map((section) => section.title);
+
   return (
     <div
       className={cn(globalTheme, 'min-h-screen w-full bg-background text-foreground')}
@@ -817,17 +831,34 @@ function FieldTypesPage({ globalTheme }: { globalTheme: string }) {
 
         <Divider />
 
-        <div className="mb-4 flex items-center justify-end gap-2">
-          <Button variant="outline" size="2xs" onClick={() => setOpenSections(ALL_SECTION_TITLES)}>
-            Expand all
-          </Button>
-          <Button variant="outline" size="2xs" onClick={() => setOpenSections([])}>
-            Collapse all
-          </Button>
+        <div className="mb-4 flex items-center justify-between gap-2">
+          <div className="flex items-center gap-2">
+            <Switch
+              id="only-supported"
+              size="sm"
+              checked={onlySupported}
+              onCheckedChange={setOnlySupported}
+            />
+            <Label htmlFor="only-supported" className="text-sm font-medium text-foreground">
+              Only show supported
+            </Label>
+          </div>
+          <div className="flex items-center gap-2">
+            <Button
+              variant="outline"
+              size="2xs"
+              onClick={() => setOpenSections(visibleSectionTitles)}
+            >
+              Expand all
+            </Button>
+            <Button variant="outline" size="2xs" onClick={() => setOpenSections([])}>
+              Collapse all
+            </Button>
+          </div>
         </div>
 
         <Accordion type="multiple" value={openSections} onValueChange={setOpenSections}>
-          {ALL_SECTIONS.map((section) => (
+          {visibleSections.map((section) => (
             <AccordionItem key={section.title} value={section.title} className="border-border">
               <AccordionTrigger className="text-lg font-semibold text-foreground hover:no-underline">
                 <span>

--- a/apps/storybook/src/patterns/FieldTypes.stories.tsx
+++ b/apps/storybook/src/patterns/FieldTypes.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Lock, Search } from 'lucide-react';
 import type * as React from 'react';
 import { useState } from 'react';
 import {
@@ -9,6 +10,13 @@ import {
 } from '@/components/ui/accordion';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupButton,
+  InputGroupInput,
+} from '@/components/ui/input-group';
 import { Label } from '@/components/ui/label';
 import {
   FIELD_TYPE_META,
@@ -811,11 +819,13 @@ function AssignmentBindingExample() {
   );
 }
 
-const LOCKABLE_STATES: {
+interface StateRow {
   label: string;
   description: string;
   Example: React.ComponentType;
-}[] = [
+}
+
+const LOCKABLE_STATES: StateRow[] = [
   {
     label: 'Locked',
     description: 'Read-only display, not a disabled control. The default.',
@@ -838,16 +848,160 @@ const LOCKABLE_STATES: {
   },
 ];
 
-function LockableStatesGrid() {
+function InputDefaultExample() {
+  const [value, setValue] = useState('');
   return (
-    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
-      {LOCKABLE_STATES.map(({ label, description, Example }) => (
-        <div key={label} className="rounded-lg border border-border bg-card p-4">
-          <span className="text-xs font-medium text-foreground">{label}</span>
-          <p className="mb-3 mt-1 text-xs text-muted-foreground">{description}</p>
-          <Example />
-        </div>
-      ))}
+    <Input
+      className="w-56"
+      placeholder="Enter a value"
+      value={value}
+      onChange={(e) => setValue(e.target.value)}
+    />
+  );
+}
+
+function InputDisabledExample() {
+  return <Input className="w-56" placeholder="Enter a value" disabled />;
+}
+
+function InputReadOnlyExample() {
+  return <Input className="w-56" value="Read-only value" readOnly />;
+}
+
+function InputInvalidExample() {
+  const [value, setValue] = useState('Invalid value');
+  return (
+    <Input
+      className="w-56"
+      value={value}
+      onChange={(e) => setValue(e.target.value)}
+      error="This field is required."
+    />
+  );
+}
+
+const INPUT_STATES: StateRow[] = [
+  {
+    label: 'Default',
+    description: 'The bare control most fields are built on top of.',
+    Example: InputDefaultExample,
+  },
+  {
+    label: 'Disabled',
+    description:
+      'disabled. Not the same as locked: a locked field uses LockableValueField’s read-only display instead, not a disabled Input.',
+    Example: InputDisabledExample,
+  },
+  {
+    label: 'Read-only',
+    description: 'readOnly.',
+    Example: InputReadOnlyExample,
+  },
+  {
+    label: 'Invalid',
+    description: 'error sets aria-invalid and renders the message below the input.',
+    Example: InputInvalidExample,
+  },
+];
+
+function InputGroupDefaultExample() {
+  const [value, setValue] = useState('');
+  return (
+    <InputGroup className="w-56">
+      <InputGroupAddon align="inline-start">
+        <Search size={14} />
+      </InputGroupAddon>
+      <InputGroupInput
+        placeholder="Search..."
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+      />
+    </InputGroup>
+  );
+}
+
+function InputGroupDisabledExample() {
+  return (
+    <InputGroup className="w-56">
+      <InputGroupAddon align="inline-start">
+        <Search size={14} />
+      </InputGroupAddon>
+      <InputGroupInput placeholder="Search..." disabled />
+    </InputGroup>
+  );
+}
+
+function InputGroupInvalidExample() {
+  const [value, setValue] = useState('Invalid value');
+  return (
+    <InputGroup className="w-56" error="This field is required.">
+      <InputGroupInput value={value} onChange={(e) => setValue(e.target.value)} />
+    </InputGroup>
+  );
+}
+
+function InputGroupLockedExample() {
+  return (
+    <InputGroup className="w-56">
+      <InputGroupAddon align="inline-start">
+        <InputGroupButton icon size="3xs" aria-label="Locked">
+          <Lock size={12} />
+        </InputGroupButton>
+      </InputGroupAddon>
+      <InputGroupInput readOnly value="Locked value" />
+    </InputGroup>
+  );
+}
+
+const INPUT_GROUP_STATES: StateRow[] = [
+  {
+    label: 'Default',
+    description: 'InputGroupAddon + InputGroupInput, e.g. a leading icon.',
+    Example: InputGroupDefaultExample,
+  },
+  {
+    label: 'Disabled',
+    description: 'disabled on InputGroupInput.',
+    Example: InputGroupDisabledExample,
+  },
+  {
+    label: 'Invalid',
+    description: 'error on InputGroup itself, shared across every input inside it.',
+    Example: InputGroupInvalidExample,
+  },
+  {
+    label: 'Locked (read-only)',
+    description:
+      'The lighter-weight recipe referenced in LockableValueField’s own docs: a lock icon addon plus a readOnly InputGroupInput, without pulling in the full component.',
+    Example: InputGroupLockedExample,
+  },
+];
+
+function StatesTable({ rows }: { rows: StateRow[] }) {
+  return (
+    <div className="overflow-hidden rounded-lg border border-border">
+      <Table>
+        <TableHeader>
+          <TableRow className="hover:bg-transparent">
+            <TableHead className={cn(HEADER_CELL_CLASS, 'w-[16%]')}>State</TableHead>
+            <TableHead className={cn(HEADER_CELL_CLASS, 'w-[28%]')}>Example</TableHead>
+            <TableHead className={HEADER_CELL_CLASS}>Notes</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {rows.map(({ label, description, Example }) => (
+            <TableRow key={label}>
+              <TableCell className={cn(BODY_CELL_CLASS, 'font-mono text-xs')}>{label}</TableCell>
+              <TableCell className={BODY_CELL_CLASS}>
+                <Example />
+              </TableCell>
+              <TableCell className={cn(BODY_CELL_CLASS, 'text-xs text-muted-foreground')}>
+                {description}
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
     </div>
   );
 }
@@ -906,6 +1060,30 @@ function FieldTypesPage({ globalTheme }: { globalTheme: string }) {
         <Divider />
 
         <section>
+          <SectionTitle>Input</SectionTitle>
+          <SectionDescription>
+            The bare control underneath everything else on this page. Reach for it directly when a
+            field needs nothing beyond a value and native HTML validation, no lock, no mode, no
+            addons.
+          </SectionDescription>
+          <StatesTable rows={INPUT_STATES} />
+        </section>
+
+        <Divider />
+
+        <section>
+          <SectionTitle>Input Group</SectionTitle>
+          <SectionDescription>
+            Input plus addon slots (icons, buttons, prefixes) sharing one bordered container and one
+            validation message. Reach for it when a field needs a leading or trailing affordance but
+            not the full lock/mode/fieldType model LockableValueField adds on top.
+          </SectionDescription>
+          <StatesTable rows={INPUT_GROUP_STATES} />
+        </section>
+
+        <Divider />
+
+        <section>
           <SectionTitle>What each type looks like</SectionTitle>
           <SectionDescription>
             A side-by-side comparison, each type in its default fixed-value state. The tables below
@@ -924,16 +1102,7 @@ function FieldTypesPage({ globalTheme }: { globalTheme: string }) {
             the lock affordance itself is shown, and the assignment-binding pattern used for
             node-property fields.
           </SectionDescription>
-          <InfoCallout>
-            LockableValueField composes Input and Input Group, which each have their own dedicated
-            Storybook page (<span className="font-mono text-foreground">Components/Core/Input</span>
-            , <span className="font-mono text-foreground">Components/Core/Input Group</span>)
-            documenting their full set of states. Not duplicated here, this page stays focused on
-            LockableValueField and type coverage.
-          </InfoCallout>
-          <div className="mt-4">
-            <LockableStatesGrid />
-          </div>
+          <StatesTable rows={LOCKABLE_STATES} />
         </section>
 
         <Divider />

--- a/apps/storybook/src/patterns/FieldTypes.stories.tsx
+++ b/apps/storybook/src/patterns/FieldTypes.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { Lock, Search } from 'lucide-react';
+import { Code2, Lock, Search } from 'lucide-react';
 import type * as React from 'react';
 import { useState } from 'react';
 import {
@@ -890,17 +890,16 @@ function EqualsAddon() {
   );
 }
 
+// The real "Assignment & Binding" reference story renders this as a bordered,
+// divider-set button (a literal "ƒ" glyph in a box). That reads as a stray
+// outlier next to every other trailing icon on this page (mode-switch,
+// Insert variable, lock toggle), all plain ghost icon buttons with no
+// divider, so it's restyled to match those here instead of copied verbatim.
 function FunctionAddon() {
   return (
-    <button
-      type="button"
-      aria-label="Open expression editor"
-      className="grid size-7 place-items-center border-l border-border text-foreground-subtle transition hover:bg-surface-overlay hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-    >
-      <span className="rounded border border-current px-0.5 font-mono text-[10px] leading-3">
-        ƒ
-      </span>
-    </button>
+    <InputGroupButton icon size="3xs" aria-label="Open expression editor">
+      <Code2 />
+    </InputGroupButton>
   );
 }
 
@@ -996,6 +995,97 @@ const LVF_BINDING_STATES: StateRow[] = [
     description:
       'trailingAddon replaces the built-in Fixed/Expression toggle with a dedicated "Open expression editor" button.',
     Example: BindingFunctionAddonExample,
+  },
+];
+
+const DEMO_VARIABLES = [
+  { label: 'Customer name', value: '$input.customerName' },
+  { label: 'Invoice number', value: '$input.invoiceNumber' },
+];
+
+function InsertVariableDefaultExample() {
+  const [value, setValue] = useState('');
+  return (
+    <div className="w-full">
+      <LockableValueField
+        fieldType="string"
+        value={value}
+        onValueChange={setValue}
+        locked={false}
+        variables={DEMO_VARIABLES}
+      />
+    </div>
+  );
+}
+
+function InsertVariableLockedExample() {
+  return (
+    <div className="w-full">
+      <LockableValueField
+        fieldType="string"
+        value="Invoice processor"
+        locked
+        variables={DEMO_VARIABLES}
+      />
+    </div>
+  );
+}
+
+function InsertVariableEmptyExample() {
+  const [value, setValue] = useState('');
+  return (
+    <div className="w-full">
+      <LockableValueField
+        fieldType="string"
+        value={value}
+        onValueChange={setValue}
+        locked={false}
+        variables={[]}
+      />
+    </div>
+  );
+}
+
+function InsertVariableOnlyExample() {
+  const [value, setValue] = useState('');
+  return (
+    <div className="w-full">
+      <LockableValueField
+        fieldType="string"
+        value={value}
+        onValueChange={setValue}
+        locked={false}
+        showAiAssist={false}
+        variables={DEMO_VARIABLES}
+      />
+    </div>
+  );
+}
+
+const LVF_INSERT_VARIABLE_STATES: StateRow[] = [
+  {
+    label: 'Default',
+    description:
+      'showFieldActions defaults to true. Insert variable opens a popover listing variables; selecting one appends its value.',
+    Example: InsertVariableDefaultExample,
+  },
+  {
+    label: 'Locked',
+    description:
+      'onValueChange becomes undefined when locked, so Insert variable disables automatically, not because variables is empty.',
+    Example: InsertVariableLockedExample,
+  },
+  {
+    label: 'No variables',
+    description:
+      'variables={[]} (the default). Renders but stays disabled until variables are provided.',
+    Example: InsertVariableEmptyExample,
+  },
+  {
+    label: 'Insert variable only',
+    description:
+      'showAiAssist={false} hides just the AI-assist button; Insert variable is independent of it.',
+    Example: InsertVariableOnlyExample,
   },
 ];
 
@@ -1164,6 +1254,12 @@ const TYPES_SECTIONS: TypesSection[] = [
     description:
       'Mirrors the “Assignment & Binding” reference example in lockable-value-field.stories.tsx: the pattern node-property assignment fields use, leadingAddon replaces the lock icon with a semantic “=”, and mode is always expression.',
     rows: LVF_BINDING_STATES,
+  },
+  {
+    title: 'LockableValueField, insert variable',
+    description:
+      'The variables prop and its built-in Insert variable popover, gated separately from the AI-assist button by showAiAssist and showFieldActions. Every other table on this page sets showFieldActions={false} to keep it out of the way; this is the one place it is shown.',
+    rows: LVF_INSERT_VARIABLE_STATES,
   },
 ];
 

--- a/apps/storybook/src/patterns/FieldTypes.stories.tsx
+++ b/apps/storybook/src/patterns/FieldTypes.stories.tsx
@@ -1,6 +1,12 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import type * as React from 'react';
 import { useState } from 'react';
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from '@/components/ui/accordion';
 import { Badge } from '@/components/ui/badge';
 import {
   FIELD_TYPE_META,
@@ -38,6 +44,9 @@ interface TypeRow {
   status: Status;
   action?: string;
   visual?: VisualExample;
+  // False when it is unconfirmed that flow-workbench itself renders this as a
+  // distinct control, not just declares it in a schema. Defaults to true.
+  flowWorkbenchConfirmed?: boolean;
 }
 
 interface Category {
@@ -107,6 +116,7 @@ const CATEGORIES: Category[] = [
         status: 'needs-type',
         action:
           'Confirm whether the 32 vs. 64 bit distinction matters at the UI layer. If it is a backend validation constraint only, no UI change is needed.',
+        flowWorkbenchConfirmed: false,
       },
     ],
   },
@@ -165,6 +175,7 @@ const CATEGORIES: Category[] = [
         status: 'needs-type',
         action:
           'Clarify what verbatim means at the UI layer. Likely no visual difference from string. Confirm with the flow-workbench team.',
+        flowWorkbenchConfirmed: false,
       },
     ],
   },
@@ -232,6 +243,7 @@ const CATEGORIES: Category[] = [
         status: 'needs-component',
         action:
           'Clarify against the generic array row above. May be the same concept under a different name.',
+        flowWorkbenchConfirmed: false,
       },
       {
         type: 'stringArray / rawStringArray / stringArrayWithExpression',
@@ -239,6 +251,7 @@ const CATEGORIES: Category[] = [
         support: 'Overlaps with multi-select and generic array.',
         status: 'needs-type',
         action: 'De-duplicate with flow-workbench before adding a new fieldType.',
+        flowWorkbenchConfirmed: false,
       },
     ],
   },
@@ -303,6 +316,7 @@ const CATEGORIES: Category[] = [
         status: 'needs-type',
         action:
           'Confirm whether an all-options-visible checkbox group is a real visual distinction worth its own fieldType, versus multi-select’s dropdown and chips.',
+        flowWorkbenchConfirmed: false,
       },
       {
         type: 'radioGroup',
@@ -311,6 +325,7 @@ const CATEGORIES: Category[] = [
         status: 'needs-type',
         action:
           'Confirm whether a radio group is a real visual distinction worth its own fieldType, versus a single-select dropdown.',
+        flowWorkbenchConfirmed: false,
       },
       {
         type: 'autoComplete / connectorAutocomplete / autoCompleteForExpression',
@@ -389,6 +404,7 @@ const CATEGORIES: Category[] = [
         status: 'needs-type',
         action:
           'Usually paired with another type in a union, such as a nullable string. Confirm whether an explicit null or empty state is needed per type, or whether an empty value already covers it.',
+        flowWorkbenchConfirmed: false,
       },
       {
         type: 'ref',
@@ -396,6 +412,7 @@ const CATEGORIES: Category[] = [
         support: 'Overlaps with the resource reference family above.',
         status: 'needs-component',
         action: 'De-duplicate with the resource reference family before adding.',
+        flowWorkbenchConfirmed: false,
       },
     ],
   },
@@ -434,11 +451,32 @@ const BINDING_STATE_ROWS: TypeRow[] = [
   },
 ];
 
+// Every collapsible section on the page, category tables plus the binding-state
+// table, in the order they render.
+const ALL_SECTIONS: Category[] = [
+  ...CATEGORIES,
+  {
+    title: 'Binding state',
+    description:
+      'Separate from field type: how a value relates to fixed input versus an upstream binding. LockableValueField only distinguishes fixed and expression. The integration-service widget catalog has a richer set.',
+    rows: BINDING_STATE_ROWS,
+    rowLabel: 'State',
+  },
+];
+
 const STATUS_META: Record<Status, { label: string; variant: 'success' | 'warning' | 'info' }> = {
   supported: { label: 'Supported', variant: 'success' },
   'needs-type': { label: 'Needs fieldType', variant: 'warning' },
   'needs-component': { label: 'Needs component', variant: 'info' },
 };
+
+// Smaller and denser than the Table primitive's default h-12/text-sm header,
+// so a 6-column reference table reads as a table, not a lighter block of prose.
+const HEADER_CELL_CLASS =
+  'h-9 whitespace-nowrap bg-muted/40 text-[11px] font-semibold uppercase tracking-wide';
+// Tighter than the Table primitive's default p-4, since most cells here are one
+// short line or a badge, not a paragraph.
+const BODY_CELL_CLASS = 'align-top px-4 py-3';
 
 function SectionTitle({ children }: { children: React.ReactNode }) {
   return <h2 className="mb-2 text-2xl font-bold tracking-tight text-foreground">{children}</h2>;
@@ -548,40 +586,55 @@ function VisualExampleCell({ visual }: { visual?: VisualExample }) {
   );
 }
 
-function CategoryTable({ title, description, rows, rowLabel = 'Type' }: Category) {
+function gapCount(rows: TypeRow[]) {
+  return rows.filter((row) => row.status !== 'supported').length;
+}
+
+function CategoryTable({ description, rows, rowLabel = 'Type' }: Category) {
   return (
-    <section className="mb-10">
-      <h3 className="mb-1.5 text-lg font-semibold text-foreground">{title}</h3>
+    <div>
       <p className="mb-4 text-sm leading-6 text-muted-foreground">{description}</p>
       <div className="overflow-hidden rounded-lg border border-border">
         <Table>
           <TableHeader>
-            <TableRow>
-              <TableHead className="w-[16%]">{rowLabel}</TableHead>
-              <TableHead className="w-[18%]">Visual example</TableHead>
-              <TableHead className="w-[15%]">Apollo Wind support</TableHead>
-              <TableHead className="w-[11%]">Status</TableHead>
-              <TableHead className="w-[24%]">Recommended action</TableHead>
-              <TableHead>Source in flow-workbench</TableHead>
+            <TableRow className="hover:bg-transparent">
+              <TableHead className={cn(HEADER_CELL_CLASS, 'w-[16%]')}>{rowLabel}</TableHead>
+              <TableHead className={cn(HEADER_CELL_CLASS, 'w-[18%]')}>Visual example</TableHead>
+              <TableHead className={cn(HEADER_CELL_CLASS, 'w-[15%]')}>
+                Apollo Wind support
+              </TableHead>
+              <TableHead className={cn(HEADER_CELL_CLASS, 'w-[11%]')}>Status</TableHead>
+              <TableHead className={cn(HEADER_CELL_CLASS, 'w-[24%]')}>Recommended action</TableHead>
+              <TableHead className={HEADER_CELL_CLASS}>Source in flow-workbench</TableHead>
             </TableRow>
           </TableHeader>
           <TableBody>
             {rows.map((row) => (
               <TableRow key={row.type}>
-                <TableCell className="align-top font-mono text-xs">{row.type}</TableCell>
-                <TableCell className="align-top">
+                <TableCell className={cn(BODY_CELL_CLASS, 'font-mono text-xs')}>
+                  {row.type}
+                  {row.flowWorkbenchConfirmed === false && (
+                    <sup
+                      className="ml-0.5 cursor-help text-muted-foreground"
+                      title="Not confirmed as a distinct, separately-rendered type in flow-workbench either, only a schema-level type name. See Recommended action."
+                    >
+                      †
+                    </sup>
+                  )}
+                </TableCell>
+                <TableCell className={BODY_CELL_CLASS}>
                   <VisualExampleCell visual={row.visual} />
                 </TableCell>
-                <TableCell className="align-top text-xs text-muted-foreground">
+                <TableCell className={cn(BODY_CELL_CLASS, 'text-xs text-muted-foreground')}>
                   {row.support}
                 </TableCell>
-                <TableCell className="align-top">
+                <TableCell className={BODY_CELL_CLASS}>
                   <StatusBadge status={row.status} />
                 </TableCell>
-                <TableCell className="align-top text-xs text-muted-foreground">
+                <TableCell className={cn(BODY_CELL_CLASS, 'text-xs text-muted-foreground')}>
                   {row.action ?? '—'}
                 </TableCell>
-                <TableCell className="align-top text-xs text-muted-foreground">
+                <TableCell className={cn(BODY_CELL_CLASS, 'text-xs text-muted-foreground')}>
                   {row.source}
                 </TableCell>
               </TableRow>
@@ -589,7 +642,7 @@ function CategoryTable({ title, description, rows, rowLabel = 'Type' }: Category
           </TableBody>
         </Table>
       </div>
-    </section>
+    </div>
   );
 }
 
@@ -697,20 +750,40 @@ function FieldTypesPage({ globalTheme }: { globalTheme: string }) {
               </p>
             </div>
           </div>
+          <InfoCallout>
+            Status describes the gap on the Apollo Wind side only. It assumes flow-workbench already
+            renders the type distinctly, which is true for most rows (backed by a real renderer: the
+            integration-service widget catalog, JSON Schema, entity fields). A type marked{' '}
+            <span className="font-mono text-foreground">†</span> is different: it is only a
+            schema-level type name, and it is not confirmed that flow-workbench itself treats it as
+            a separately-rendered control. For those rows the gap may not be &ldquo;Apollo Wind is
+            missing this,&rdquo; it may be &ldquo;no one has decided this is a real distinction yet,
+            in either place.&rdquo; See that row&rsquo;s recommended action before treating it as a
+            straightforward addition.
+          </InfoCallout>
         </section>
 
         <Divider />
 
-        {CATEGORIES.map((category) => (
-          <CategoryTable key={category.title} {...category} />
-        ))}
-
-        <CategoryTable
-          title="Binding state"
-          description="Separate from field type: how a value relates to fixed input versus an upstream binding. LockableValueField only distinguishes fixed and expression. The integration-service widget catalog has a richer set."
-          rows={BINDING_STATE_ROWS}
-          rowLabel="State"
-        />
+        <Accordion type="multiple" defaultValue={ALL_SECTIONS.map((section) => section.title)}>
+          {ALL_SECTIONS.map((section) => (
+            <AccordionItem key={section.title} value={section.title} className="border-border">
+              <AccordionTrigger className="text-lg font-semibold text-foreground hover:no-underline">
+                <span>
+                  {section.title}
+                  <span className="ml-2 text-sm font-normal text-muted-foreground">
+                    {gapCount(section.rows) === 0
+                      ? 'all supported'
+                      : `${gapCount(section.rows)} gap${gapCount(section.rows) === 1 ? '' : 's'}`}
+                  </span>
+                </span>
+              </AccordionTrigger>
+              <AccordionContent>
+                <CategoryTable {...section} />
+              </AccordionContent>
+            </AccordionItem>
+          ))}
+        </Accordion>
 
         <Divider />
 

--- a/apps/storybook/src/patterns/FieldTypes.stories.tsx
+++ b/apps/storybook/src/patterns/FieldTypes.stories.tsx
@@ -466,10 +466,17 @@ function StatusBadge({ status }: { status: Status }) {
 }
 
 // Live, interactive demo of a real fieldType, not a screenshot, so it can never drift
-// out of sync with the component it documents.
-function FieldTypeExample({ fieldType }: { fieldType: LockableFieldType }) {
-  const [value, setValue] = useState('');
-  const [mode, setMode] = useState<LockableValueFieldMode>('fixed');
+// out of sync with the component it documents. Seeded into fixed or expression mode
+// so both variants are visible without anyone having to click the mode switch.
+function FieldTypeExample({
+  fieldType,
+  initialMode = 'fixed',
+}: {
+  fieldType: LockableFieldType;
+  initialMode?: LockableValueFieldMode;
+}) {
+  const [value, setValue] = useState(initialMode === 'expression' ? '$vars.example' : '');
+  const [mode, setMode] = useState<LockableValueFieldMode>(initialMode);
   return (
     <div className="w-44">
       <LockableValueField
@@ -482,6 +489,14 @@ function FieldTypeExample({ fieldType }: { fieldType: LockableFieldType }) {
         showFieldActions={false}
       />
     </div>
+  );
+}
+
+function ExampleLabel({ children }: { children: React.ReactNode }) {
+  return (
+    <span className="text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+      {children}
+    </span>
   );
 }
 
@@ -515,7 +530,22 @@ function VisualExampleCell({ visual }: { visual?: VisualExample }) {
   if (!visual) return <GapPlaceholder />;
   if (visual === 'mode-fixed') return <ModeExample mode="fixed" />;
   if (visual === 'mode-expression') return <ModeExample mode="expression" />;
-  return <FieldTypeExample fieldType={visual} />;
+
+  if (!FIELD_TYPE_META[visual].supportsExpression) {
+    return <FieldTypeExample fieldType={visual} />;
+  }
+
+  // Expression-capable types get both variants stacked, since the fixed vs.
+  // expression toggle changes the control's placeholder, styling, and (for a
+  // custom renderExpressionEditor) the editor itself, not just its value.
+  return (
+    <div className="flex flex-col gap-2">
+      <ExampleLabel>Fixed</ExampleLabel>
+      <FieldTypeExample fieldType={visual} initialMode="fixed" />
+      <ExampleLabel>Expression</ExampleLabel>
+      <FieldTypeExample fieldType={visual} initialMode="expression" />
+    </div>
+  );
 }
 
 function CategoryTable({ title, description, rows, rowLabel = 'Type' }: Category) {

--- a/apps/storybook/src/patterns/FieldTypes.stories.tsx
+++ b/apps/storybook/src/patterns/FieldTypes.stories.tsx
@@ -559,10 +559,10 @@ function CategoryTable({ title, description, rows, rowLabel = 'Type' }: Category
             <TableRow>
               <TableHead className="w-[16%]">{rowLabel}</TableHead>
               <TableHead className="w-[18%]">Visual example</TableHead>
-              <TableHead className="w-[16%]">Source in flow-workbench</TableHead>
               <TableHead className="w-[15%]">Apollo Wind support</TableHead>
               <TableHead className="w-[11%]">Status</TableHead>
-              <TableHead>Recommended action</TableHead>
+              <TableHead className="w-[24%]">Recommended action</TableHead>
+              <TableHead>Source in flow-workbench</TableHead>
             </TableRow>
           </TableHeader>
           <TableBody>
@@ -573,9 +573,6 @@ function CategoryTable({ title, description, rows, rowLabel = 'Type' }: Category
                   <VisualExampleCell visual={row.visual} />
                 </TableCell>
                 <TableCell className="align-top text-xs text-muted-foreground">
-                  {row.source}
-                </TableCell>
-                <TableCell className="align-top text-xs text-muted-foreground">
                   {row.support}
                 </TableCell>
                 <TableCell className="align-top">
@@ -583,6 +580,9 @@ function CategoryTable({ title, description, rows, rowLabel = 'Type' }: Category
                 </TableCell>
                 <TableCell className="align-top text-xs text-muted-foreground">
                   {row.action ?? '—'}
+                </TableCell>
+                <TableCell className="align-top text-xs text-muted-foreground">
+                  {row.source}
                 </TableCell>
               </TableRow>
             ))}

--- a/apps/storybook/src/patterns/FieldTypes.stories.tsx
+++ b/apps/storybook/src/patterns/FieldTypes.stories.tsx
@@ -505,8 +505,25 @@ const HEADER_CELL_CLASS =
 // short line or a badge, not a paragraph.
 const BODY_CELL_CLASS = 'align-top px-4 py-3';
 
+// One level below the page's own h1: Overview, Types, LockableValueField
+// status. SectionTitle (h3) nests underneath each of these.
+function PartTitle({
+  children,
+  actions,
+}: {
+  children: React.ReactNode;
+  actions?: React.ReactNode;
+}) {
+  return (
+    <div className="mb-6 flex items-center justify-between gap-4">
+      <h2 className="text-[1.75rem] font-bold tracking-tight text-foreground">{children}</h2>
+      {actions}
+    </div>
+  );
+}
+
 function SectionTitle({ children }: { children: React.ReactNode }) {
-  return <h2 className="mb-2 text-2xl font-bold tracking-tight text-foreground">{children}</h2>;
+  return <h3 className="mb-2 text-2xl font-bold tracking-tight text-foreground">{children}</h3>;
 }
 
 function SectionDescription({ children }: { children: React.ReactNode }) {
@@ -536,16 +553,14 @@ function StatusBadge({ status }: { status: Status }) {
 function FieldTypeExample({
   fieldType,
   initialMode = 'fixed',
-  className,
 }: {
   fieldType: LockableFieldType;
   initialMode?: LockableValueFieldMode;
-  className?: string;
 }) {
   const [value, setValue] = useState(initialMode === 'expression' ? '$vars.example' : '');
   const [mode, setMode] = useState<LockableValueFieldMode>(initialMode);
   return (
-    <div className={cn('w-56', className)}>
+    <div className="w-56">
       <LockableValueField
         fieldType={fieldType}
         value={value}
@@ -558,14 +573,6 @@ function FieldTypeExample({
     </div>
   );
 }
-
-// FileUpload's dropzone is a fixed h-32 with its own "Click to upload or drag
-// and drop" copy, both sized for a full-width form field, not a compact
-// side-by-side comparison cell. Collapses it to a single icon-only row here;
-// the accessible name (aria-label="File upload area") is unaffected, it does
-// not depend on this visible text.
-const COMPACT_FILE_UPLOAD_CLASS =
-  '[&_[role="button"]]:h-9 [&_[role="button"]]:flex-row [&_[role="button"]]:justify-start [&_[role="button"]]:gap-2 [&_[role="button"]]:px-3 [&_[role="button"]]:py-0 [&_[role="button"]_svg]:mb-0 [&_[role="button"]_svg]:size-4 [&_[role="button"]_p]:hidden';
 
 function ExampleLabel({ children }: { children: React.ReactNode }) {
   return (
@@ -726,35 +733,155 @@ function SupportedTodayStrip() {
   );
 }
 
-// A side-by-side visual comparison across types, each in its default fixed
-// state. Distinct from the per-category tables below: this answers "what does
-// a date field look like next to a select," those answer "what's the gap for
-// this one type."
-function VisualReferenceGrid() {
+interface StateRow {
+  label: string;
+  description: string;
+  Example: React.ComponentType;
+}
+
+// Four states, shown twice: once with showLock={false}, once with the
+// default showLock={true}, so the two tables are directly comparable column
+// by column, the icon toggle is the only thing that differs between them.
+function LvfDefaultExample({ showLock }: { showLock: boolean }) {
+  const [value, setValue] = useState('Editable value');
   return (
-    <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
-      {FIELD_TYPE_ORDER.map((type) => {
-        const typeMeta = FIELD_TYPE_META[type];
-        return (
-          <div key={type} className="flex flex-col gap-2">
-            <span className="flex items-center gap-1.5 text-xs font-medium text-foreground">
-              <typeMeta.icon size={12} />
-              {typeMeta.label}
-            </span>
-            <FieldTypeExample
-              fieldType={type}
-              className={type === 'file' ? COMPACT_FILE_UPLOAD_CLASS : undefined}
-            />
-          </div>
-        );
-      })}
+    <div className="w-full">
+      <LockableValueField
+        fieldType="string"
+        value={value}
+        onValueChange={setValue}
+        locked={false}
+        showLock={showLock}
+        showFieldActions={false}
+      />
     </div>
   );
 }
 
-// Mirrors EqualsAddon in lockable-value-field.stories.tsx's "Assignment &
-// Binding" reference example: a leadingAddon that replaces the lock icon with
-// a semantic "=" prefix, the pattern node-property assignment fields use.
+function LvfLockedExample({ showLock }: { showLock: boolean }) {
+  return (
+    <div className="w-full">
+      <LockableValueField
+        fieldType="string"
+        value="Invoice processor"
+        locked
+        showLock={showLock}
+        showFieldActions={false}
+      />
+    </div>
+  );
+}
+
+function LvfInvalidExample({ showLock }: { showLock: boolean }) {
+  const [value, setValue] = useState('Invalid value');
+  return (
+    <div className="w-full">
+      <LockableValueField
+        fieldType="string"
+        value={value}
+        onValueChange={setValue}
+        locked={false}
+        showLock={showLock}
+        showFieldActions={false}
+        error="This field is required."
+      />
+    </div>
+  );
+}
+
+function LvfExpressionExample({ showLock }: { showLock: boolean }) {
+  const [value, setValue] = useState('$vars.example');
+  return (
+    <div className="w-full">
+      <LockableValueField
+        fieldType="string"
+        value={value}
+        onValueChange={setValue}
+        locked={false}
+        showLock={showLock}
+        mode="expression"
+        showFieldActions={false}
+      />
+    </div>
+  );
+}
+
+function LvfNoIconDefaultExample() {
+  return <LvfDefaultExample showLock={false} />;
+}
+function LvfNoIconLockedExample() {
+  return <LvfLockedExample showLock={false} />;
+}
+function LvfNoIconInvalidExample() {
+  return <LvfInvalidExample showLock={false} />;
+}
+function LvfNoIconExpressionExample() {
+  return <LvfExpressionExample showLock={false} />;
+}
+
+function LvfWithIconDefaultExample() {
+  return <LvfDefaultExample showLock={true} />;
+}
+function LvfWithIconLockedExample() {
+  return <LvfLockedExample showLock={true} />;
+}
+function LvfWithIconInvalidExample() {
+  return <LvfInvalidExample showLock={true} />;
+}
+function LvfWithIconExpressionExample() {
+  return <LvfExpressionExample showLock={true} />;
+}
+
+const LVF_NO_ICON_STATES: StateRow[] = [
+  {
+    label: 'Default',
+    description: 'showLock={false}, locked={false}. No lock affordance at all.',
+    Example: LvfNoIconDefaultExample,
+  },
+  {
+    label: 'Locked',
+    description: 'showLock={false}, locked={true}. Read-only display, but nothing signals why.',
+    Example: LvfNoIconLockedExample,
+  },
+  {
+    label: 'Invalid',
+    description: 'error, same as Input and Input Group.',
+    Example: LvfNoIconInvalidExample,
+  },
+  {
+    label: 'Expression',
+    description: 'mode="expression". Still no lock icon, for consumers supplying their own.',
+    Example: LvfNoIconExpressionExample,
+  },
+];
+
+const LVF_WITH_ICON_STATES: StateRow[] = [
+  {
+    label: 'Default',
+    description: 'showLock defaults to true. The lock toggle is the built-in affordance.',
+    Example: LvfWithIconDefaultExample,
+  },
+  {
+    label: 'Locked',
+    description: 'Read-only display, not a disabled control. The default state.',
+    Example: LvfWithIconLockedExample,
+  },
+  {
+    label: 'Invalid',
+    description: 'error, same as Input and Input Group.',
+    Example: LvfWithIconInvalidExample,
+  },
+  {
+    label: 'Expression',
+    description: 'mode="expression". The lock toggle stays available alongside it.',
+    Example: LvfWithIconExpressionExample,
+  },
+];
+
+// Mirrors the "Assignment & Binding" reference example in
+// lockable-value-field.stories.tsx: leadingAddon replaces the lock icon with
+// a semantic "=" prefix, and mode is always expression, the pattern used for
+// node-property assignment fields in flow-workbench.
 function EqualsAddon() {
   return (
     <span className="font-mono text-sm font-semibold text-foreground-accent" aria-hidden="true">
@@ -763,54 +890,24 @@ function EqualsAddon() {
   );
 }
 
-function LockedStateExample() {
+function FunctionAddon() {
   return (
-    <div className="w-56">
-      <LockableValueField
-        fieldType="string"
-        value="Invoice processor"
-        locked
-        showFieldActions={false}
-      />
-    </div>
+    <button
+      type="button"
+      aria-label="Open expression editor"
+      className="grid size-7 place-items-center border-l border-border text-foreground-subtle transition hover:bg-surface-overlay hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+    >
+      <span className="rounded border border-current px-0.5 font-mono text-[10px] leading-3">
+        ƒ
+      </span>
+    </button>
   );
 }
 
-function UnlockedLockShownExample() {
-  const [value, setValue] = useState('Editable value');
-  return (
-    <div className="w-56">
-      <LockableValueField
-        fieldType="string"
-        value={value}
-        onValueChange={setValue}
-        locked={false}
-        showFieldActions={false}
-      />
-    </div>
-  );
-}
-
-function UnlockedLockHiddenExample() {
-  const [value, setValue] = useState('Editable value');
-  return (
-    <div className="w-56">
-      <LockableValueField
-        fieldType="string"
-        value={value}
-        onValueChange={setValue}
-        locked={false}
-        showLock={false}
-        showFieldActions={false}
-      />
-    </div>
-  );
-}
-
-function AssignmentBindingExample() {
+function BindingObjectExample() {
   const [value, setValue] = useState('$vars.flowArray');
   return (
-    <div className="w-56">
+    <div className="w-full">
       <LockableValueField
         fieldType="object"
         value={value}
@@ -824,32 +921,81 @@ function AssignmentBindingExample() {
   );
 }
 
-interface StateRow {
-  label: string;
-  description: string;
-  Example: React.ComponentType;
+function BindingFileExample() {
+  const [value, setValue] = useState('$vars.flowTest');
+  return (
+    <div className="w-full">
+      <LockableValueField
+        fieldType="file"
+        value={value}
+        onValueChange={setValue}
+        locked={false}
+        leadingAddon={<EqualsAddon />}
+        mode="expression"
+        showFieldActions={false}
+      />
+    </div>
+  );
 }
 
-const LOCKABLE_STATES: StateRow[] = [
+function BindingWithHelperTextExample() {
+  const [value, setValue] = useState('$vars.flowTest');
+  return (
+    <div className="w-full">
+      <LockableValueField
+        fieldType="file"
+        value={value}
+        onValueChange={setValue}
+        locked={false}
+        leadingAddon={<EqualsAddon />}
+        mode="expression"
+        showFieldActions={false}
+        belowValue={<p className="text-xs text-foreground-muted">File to extract data from</p>}
+      />
+    </div>
+  );
+}
+
+function BindingFunctionAddonExample() {
+  const [value, setValue] = useState('$vars.flowTest');
+  return (
+    <div className="w-full">
+      <LockableValueField
+        fieldType="string"
+        value={value}
+        onValueChange={setValue}
+        locked={false}
+        leadingAddon={<EqualsAddon />}
+        mode="expression"
+        showFieldActions={false}
+        trailingAddon={<FunctionAddon />}
+      />
+    </div>
+  );
+}
+
+const LVF_BINDING_STATES: StateRow[] = [
   {
-    label: 'Locked',
-    description: 'Read-only display, not a disabled control. The default.',
-    Example: LockedStateExample,
+    label: 'Object',
+    description:
+      'fieldType="object". leadingAddon="=" replaces the lock icon; mode is always expression.',
+    Example: BindingObjectExample,
   },
   {
-    label: 'Unlocked, lock shown',
-    description: 'locked={false}. showLock defaults to true.',
-    Example: UnlockedLockShownExample,
+    label: 'File',
+    description: 'fieldType="file" with the same = leadingAddon and expression mode.',
+    Example: BindingFileExample,
   },
   {
-    label: 'Unlocked, lock hidden',
-    description: 'showLock={false}, for consumers supplying their own lock affordance elsewhere.',
-    Example: UnlockedLockHiddenExample,
+    label: 'With helper text',
+    description: 'belowValue adds context below the field, same prop the plain Input uses.',
+    Example: BindingWithHelperTextExample,
   },
   {
-    label: 'Assignment binding',
-    description: 'leadingAddon replaces the lock icon with a semantic prefix, e.g. "=".',
-    Example: AssignmentBindingExample,
+    label: 'Custom expression editor',
+    description:
+      'trailingAddon replaces the built-in Fixed/Expression toggle with a dedicated "Open expression editor" button.',
+    Example: BindingFunctionAddonExample,
   },
 ];
 
@@ -857,7 +1003,7 @@ function InputDefaultExample() {
   const [value, setValue] = useState('');
   return (
     <Input
-      className="w-56"
+      className="w-full"
       placeholder="Enter a value"
       value={value}
       onChange={(e) => setValue(e.target.value)}
@@ -866,18 +1012,18 @@ function InputDefaultExample() {
 }
 
 function InputDisabledExample() {
-  return <Input className="w-56" placeholder="Enter a value" disabled />;
+  return <Input className="w-full" placeholder="Enter a value" disabled />;
 }
 
 function InputReadOnlyExample() {
-  return <Input className="w-56" value="Read-only value" readOnly />;
+  return <Input className="w-full" value="Read-only value" readOnly />;
 }
 
 function InputInvalidExample() {
   const [value, setValue] = useState('Invalid value');
   return (
     <Input
-      className="w-56"
+      className="w-full"
       value={value}
       onChange={(e) => setValue(e.target.value)}
       error="This field is required."
@@ -912,7 +1058,7 @@ const INPUT_STATES: StateRow[] = [
 function InputGroupDefaultExample() {
   const [value, setValue] = useState('');
   return (
-    <InputGroup className="w-56">
+    <InputGroup className="w-full">
       <InputGroupAddon align="inline-start">
         <Search size={14} />
       </InputGroupAddon>
@@ -927,7 +1073,7 @@ function InputGroupDefaultExample() {
 
 function InputGroupDisabledExample() {
   return (
-    <InputGroup className="w-56">
+    <InputGroup className="w-full">
       <InputGroupAddon align="inline-start">
         <Search size={14} />
       </InputGroupAddon>
@@ -939,7 +1085,7 @@ function InputGroupDisabledExample() {
 function InputGroupInvalidExample() {
   const [value, setValue] = useState('Invalid value');
   return (
-    <InputGroup className="w-56" error="This field is required.">
+    <InputGroup className="w-full" error="This field is required.">
       <InputGroupInput value={value} onChange={(e) => setValue(e.target.value)} />
     </InputGroup>
   );
@@ -947,7 +1093,7 @@ function InputGroupInvalidExample() {
 
 function InputGroupLockedExample() {
   return (
-    <InputGroup className="w-56">
+    <InputGroup className="w-full">
       <InputGroupAddon align="inline-start">
         <InputGroupButton icon size="3xs" aria-label="Locked">
           <Lock size={12} />
@@ -982,6 +1128,47 @@ const INPUT_GROUP_STATES: StateRow[] = [
   },
 ];
 
+interface TypesSection {
+  title: string;
+  description: string;
+  rows: StateRow[];
+}
+
+const TYPES_SECTIONS: TypesSection[] = [
+  {
+    title: 'Input',
+    description:
+      'The bare control underneath everything else on this page. Reach for it directly when a field needs nothing beyond a value and native HTML validation, no lock, no mode, no addons.',
+    rows: INPUT_STATES,
+  },
+  {
+    title: 'Input Group',
+    description:
+      'Input plus addon slots (icons, buttons, prefixes) sharing one bordered container and one validation message. Reach for it when a field needs a leading or trailing affordance but not the full lock/mode/fieldType model LockableValueField adds on top.',
+    rows: INPUT_GROUP_STATES,
+  },
+  {
+    title: 'LockableValueField, no left icon',
+    description:
+      'The showLock prop set to false: no built-in lock affordance. For consumers supplying their own, or embedding the field somewhere the lock toggle doesn’t make sense.',
+    rows: LVF_NO_ICON_STATES,
+  },
+  {
+    title: 'LockableValueField, with left icon',
+    description:
+      'showLock defaults to true: the built-in lock toggle. Same four states as above, so the two tables are directly comparable, the icon is the only thing that differs.',
+    rows: LVF_WITH_ICON_STATES,
+  },
+  {
+    title: 'LockableValueField, assignment & binding',
+    description:
+      'Mirrors the “Assignment & Binding” reference example in lockable-value-field.stories.tsx: the pattern node-property assignment fields use, leadingAddon replaces the lock icon with a semantic “=”, and mode is always expression.',
+    rows: LVF_BINDING_STATES,
+  },
+];
+
+const ALL_TYPES_SECTION_TITLES = TYPES_SECTIONS.map((section) => section.title);
+
 // States run across as columns, not down as rows: with every table on this
 // page so far having exactly 4 states, 4 stacked rows (each a label + a live
 // example + a paragraph) took much more vertical room than laying them out
@@ -989,13 +1176,12 @@ const INPUT_GROUP_STATES: StateRow[] = [
 function StatesTable({ rows }: { rows: StateRow[] }) {
   const columnClass = rows.length === 4 ? 'w-1/4' : undefined;
   return (
-    // No overflow-hidden here: 4 columns of w-56 examples plus padding (~1024px)
-    // routinely exceeds the ~960px content width, and overflow-hidden would
-    // silently clip the last column instead of letting it scroll into view.
-    // Table's own scroll container (overflow-auto) handles that; rounded-lg
-    // still applies, just without the corner-clipping that also hid content.
+    // table-fixed forces every column to its declared w-1/4, an even quarter
+    // of the container, rather than sizing to content. Each Example fills
+    // that with w-full instead of a fixed pixel width, so all 4 columns show
+    // at once with nothing pushed past the edge and clipped or scrolled.
     <div className="rounded-lg border border-border">
-      <Table>
+      <Table className="table-fixed">
         <TableHeader>
           <TableRow className="hover:bg-transparent">
             {rows.map(({ label }) => (
@@ -1032,6 +1218,7 @@ function StatesTable({ rows }: { rows: StateRow[] }) {
 const ALL_SECTION_TITLES = ALL_SECTIONS.map((section) => section.title);
 
 function FieldTypesPage({ globalTheme }: { globalTheme: string }) {
+  const [openTypesSections, setOpenTypesSections] = useState<string[]>(ALL_TYPES_SECTION_TITLES);
   const [openSections, setOpenSections] = useState<string[]>(ALL_SECTION_TITLES);
   const [onlySupported, setOnlySupported] = useState(false);
 
@@ -1064,6 +1251,8 @@ function FieldTypesPage({ globalTheme }: { globalTheme: string }) {
 
         <Divider />
 
+        <PartTitle>Overview</PartTitle>
+
         <section>
           <SectionTitle>Why this exists</SectionTitle>
           <SectionDescription>
@@ -1082,53 +1271,44 @@ function FieldTypesPage({ globalTheme }: { globalTheme: string }) {
 
         <Divider />
 
-        <section>
-          <SectionTitle>Input</SectionTitle>
-          <SectionDescription>
-            The bare control underneath everything else on this page. Reach for it directly when a
-            field needs nothing beyond a value and native HTML validation, no lock, no mode, no
-            addons.
-          </SectionDescription>
-          <StatesTable rows={INPUT_STATES} />
-        </section>
+        <PartTitle
+          actions={
+            <div className="flex items-center gap-2">
+              <Button
+                variant="outline"
+                size="2xs"
+                onClick={() => setOpenTypesSections(ALL_TYPES_SECTION_TITLES)}
+              >
+                Expand all
+              </Button>
+              <Button variant="outline" size="2xs" onClick={() => setOpenTypesSections([])}>
+                Collapse all
+              </Button>
+            </div>
+          }
+        >
+          Types
+        </PartTitle>
+
+        <Accordion type="multiple" value={openTypesSections} onValueChange={setOpenTypesSections}>
+          {TYPES_SECTIONS.map((section) => (
+            <AccordionItem key={section.title} value={section.title} className="border-border">
+              <AccordionTrigger className="text-lg font-semibold text-foreground hover:no-underline">
+                {section.title}
+              </AccordionTrigger>
+              <AccordionContent>
+                <p className="mb-4 text-sm leading-6 text-muted-foreground">
+                  {section.description}
+                </p>
+                <StatesTable rows={section.rows} />
+              </AccordionContent>
+            </AccordionItem>
+          ))}
+        </Accordion>
 
         <Divider />
 
-        <section>
-          <SectionTitle>Input Group</SectionTitle>
-          <SectionDescription>
-            Input plus addon slots (icons, buttons, prefixes) sharing one bordered container and one
-            validation message. Reach for it when a field needs a leading or trailing affordance but
-            not the full lock/mode/fieldType model LockableValueField adds on top.
-          </SectionDescription>
-          <StatesTable rows={INPUT_GROUP_STATES} />
-        </section>
-
-        <Divider />
-
-        <section>
-          <SectionTitle>What each type looks like</SectionTitle>
-          <SectionDescription>
-            A side-by-side comparison, each type in its default fixed-value state. The tables below
-            drill into one type at a time: its gaps, its status, and (where it applies) its
-            expression variant.
-          </SectionDescription>
-          <VisualReferenceGrid />
-        </section>
-
-        <Divider />
-
-        <section>
-          <SectionTitle>LockableValueField states</SectionTitle>
-          <SectionDescription>
-            Cross-cutting states layered on top of fieldType: whether the field is locked, whether
-            the lock affordance itself is shown, and the assignment-binding pattern used for
-            node-property fields.
-          </SectionDescription>
-          <StatesTable rows={LOCKABLE_STATES} />
-        </section>
-
-        <Divider />
+        <PartTitle>LockableValueField status</PartTitle>
 
         <section>
           <SectionTitle>Supported today</SectionTitle>
@@ -1142,9 +1322,7 @@ function FieldTypesPage({ globalTheme }: { globalTheme: string }) {
           <SupportedTodayStrip />
         </section>
 
-        <Divider />
-
-        <section>
+        <section className="mt-10">
           <SectionTitle>How to read the status column</SectionTitle>
           <div className="grid gap-4 sm:grid-cols-3">
             <div className="rounded-lg border border-border bg-card p-4">

--- a/apps/storybook/src/patterns/FieldTypes.stories.tsx
+++ b/apps/storybook/src/patterns/FieldTypes.stories.tsx
@@ -510,14 +510,16 @@ function StatusBadge({ status }: { status: Status }) {
 function FieldTypeExample({
   fieldType,
   initialMode = 'fixed',
+  className,
 }: {
   fieldType: LockableFieldType;
   initialMode?: LockableValueFieldMode;
+  className?: string;
 }) {
   const [value, setValue] = useState(initialMode === 'expression' ? '$vars.example' : '');
   const [mode, setMode] = useState<LockableValueFieldMode>(initialMode);
   return (
-    <div className="w-56">
+    <div className={cn('w-56', className)}>
       <LockableValueField
         fieldType={fieldType}
         value={value}
@@ -530,6 +532,14 @@ function FieldTypeExample({
     </div>
   );
 }
+
+// FileUpload's dropzone is a fixed h-32 with its own "Click to upload or drag
+// and drop" copy, both sized for a full-width form field, not a compact
+// side-by-side comparison cell. Collapses it to a single icon-only row here;
+// the accessible name (aria-label="File upload area") is unaffected, it does
+// not depend on this visible text.
+const COMPACT_FILE_UPLOAD_CLASS =
+  '[&_[role="button"]]:h-9 [&_[role="button"]]:flex-row [&_[role="button"]]:justify-start [&_[role="button"]]:gap-2 [&_[role="button"]]:px-3 [&_[role="button"]]:py-0 [&_[role="button"]_svg]:mb-0 [&_[role="button"]_svg]:size-4 [&_[role="button"]_p]:hidden';
 
 function ExampleLabel({ children }: { children: React.ReactNode }) {
   return (
@@ -666,6 +676,32 @@ function SupportedTodayStrip() {
   );
 }
 
+// A side-by-side visual comparison across types, each in its default fixed
+// state. Distinct from the per-category tables below: this answers "what does
+// a date field look like next to a select," those answer "what's the gap for
+// this one type."
+function VisualReferenceGrid() {
+  return (
+    <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+      {FIELD_TYPE_ORDER.map((type) => {
+        const typeMeta = FIELD_TYPE_META[type];
+        return (
+          <div key={type} className="flex flex-col gap-2">
+            <span className="flex items-center gap-1.5 text-xs font-medium text-foreground">
+              <typeMeta.icon size={12} />
+              {typeMeta.label}
+            </span>
+            <FieldTypeExample
+              fieldType={type}
+              className={type === 'file' ? COMPACT_FILE_UPLOAD_CLASS : undefined}
+            />
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
 const ALL_SECTION_TITLES = ALL_SECTIONS.map((section) => section.title);
 
 function FieldTypesPage({ globalTheme }: { globalTheme: string }) {
@@ -717,6 +753,18 @@ function FieldTypesPage({ globalTheme }: { globalTheme: string }) {
             .
           </SectionDescription>
           <SupportedTodayStrip />
+        </section>
+
+        <Divider />
+
+        <section>
+          <SectionTitle>What each type looks like</SectionTitle>
+          <SectionDescription>
+            A side-by-side comparison, each type in its default fixed-value state. The tables below
+            drill into one type at a time: its gaps, its status, and (where it applies) its
+            expression variant.
+          </SectionDescription>
+          <VisualReferenceGrid />
         </section>
 
         <Divider />

--- a/apps/storybook/src/patterns/FieldTypes.stories.tsx
+++ b/apps/storybook/src/patterns/FieldTypes.stories.tsx
@@ -739,6 +739,119 @@ function VisualReferenceGrid() {
   );
 }
 
+// Mirrors EqualsAddon in lockable-value-field.stories.tsx's "Assignment &
+// Binding" reference example: a leadingAddon that replaces the lock icon with
+// a semantic "=" prefix, the pattern node-property assignment fields use.
+function EqualsAddon() {
+  return (
+    <span className="font-mono text-sm font-semibold text-foreground-accent" aria-hidden="true">
+      =
+    </span>
+  );
+}
+
+function LockedStateExample() {
+  return (
+    <div className="w-56">
+      <LockableValueField
+        fieldType="string"
+        value="Invoice processor"
+        locked
+        showFieldActions={false}
+      />
+    </div>
+  );
+}
+
+function UnlockedLockShownExample() {
+  const [value, setValue] = useState('Editable value');
+  return (
+    <div className="w-56">
+      <LockableValueField
+        fieldType="string"
+        value={value}
+        onValueChange={setValue}
+        locked={false}
+        showFieldActions={false}
+      />
+    </div>
+  );
+}
+
+function UnlockedLockHiddenExample() {
+  const [value, setValue] = useState('Editable value');
+  return (
+    <div className="w-56">
+      <LockableValueField
+        fieldType="string"
+        value={value}
+        onValueChange={setValue}
+        locked={false}
+        showLock={false}
+        showFieldActions={false}
+      />
+    </div>
+  );
+}
+
+function AssignmentBindingExample() {
+  const [value, setValue] = useState('$vars.flowArray');
+  return (
+    <div className="w-56">
+      <LockableValueField
+        fieldType="object"
+        value={value}
+        onValueChange={setValue}
+        locked={false}
+        leadingAddon={<EqualsAddon />}
+        mode="expression"
+        showFieldActions={false}
+      />
+    </div>
+  );
+}
+
+const LOCKABLE_STATES: {
+  label: string;
+  description: string;
+  Example: React.ComponentType;
+}[] = [
+  {
+    label: 'Locked',
+    description: 'Read-only display, not a disabled control. The default.',
+    Example: LockedStateExample,
+  },
+  {
+    label: 'Unlocked, lock shown',
+    description: 'locked={false}. showLock defaults to true.',
+    Example: UnlockedLockShownExample,
+  },
+  {
+    label: 'Unlocked, lock hidden',
+    description: 'showLock={false}, for consumers supplying their own lock affordance elsewhere.',
+    Example: UnlockedLockHiddenExample,
+  },
+  {
+    label: 'Assignment binding',
+    description: 'leadingAddon replaces the lock icon with a semantic prefix, e.g. "=".',
+    Example: AssignmentBindingExample,
+  },
+];
+
+function LockableStatesGrid() {
+  return (
+    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+      {LOCKABLE_STATES.map(({ label, description, Example }) => (
+        <div key={label} className="rounded-lg border border-border bg-card p-4">
+          <span className="text-xs font-medium text-foreground">{label}</span>
+          <p className="mb-3 mt-1 text-xs text-muted-foreground">{description}</p>
+          <Example />
+        </div>
+      ))}
+    </div>
+  );
+}
+
 const ALL_SECTION_TITLES = ALL_SECTIONS.map((section) => section.title);
 
 function FieldTypesPage({ globalTheme }: { globalTheme: string }) {
@@ -800,6 +913,27 @@ function FieldTypesPage({ globalTheme }: { globalTheme: string }) {
             expression variant.
           </SectionDescription>
           <VisualReferenceGrid />
+        </section>
+
+        <Divider />
+
+        <section>
+          <SectionTitle>LockableValueField states</SectionTitle>
+          <SectionDescription>
+            Cross-cutting states layered on top of fieldType: whether the field is locked, whether
+            the lock affordance itself is shown, and the assignment-binding pattern used for
+            node-property fields.
+          </SectionDescription>
+          <InfoCallout>
+            LockableValueField composes Input and Input Group, which each have their own dedicated
+            Storybook page (<span className="font-mono text-foreground">Components/Core/Input</span>
+            , <span className="font-mono text-foreground">Components/Core/Input Group</span>)
+            documenting their full set of states. Not duplicated here, this page stays focused on
+            LockableValueField and type coverage.
+          </InfoCallout>
+          <div className="mt-4">
+            <LockableStatesGrid />
+          </div>
         </section>
 
         <Divider />

--- a/apps/storybook/src/patterns/FieldTypes.stories.tsx
+++ b/apps/storybook/src/patterns/FieldTypes.stories.tsx
@@ -606,7 +606,7 @@ function CategoryTable({ description, rows, rowLabel = 'Type' }: Category) {
               </TableHead>
               <TableHead className={cn(HEADER_CELL_CLASS, 'w-[10%]')}>Status</TableHead>
               <TableHead className={cn(HEADER_CELL_CLASS, 'w-[21%]')}>Recommended action</TableHead>
-              <TableHead className={HEADER_CELL_CLASS}>Source in flow-workbench</TableHead>
+              <TableHead className={HEADER_CELL_CLASS}>Source</TableHead>
             </TableRow>
           </TableHeader>
           <TableBody>
@@ -754,7 +754,7 @@ function FieldTypesPage({ globalTheme }: { globalTheme: string }) {
               </p>
             </div>
           </div>
-          <InfoCallout>
+          <p className="mt-4 text-sm leading-6 text-muted-foreground">
             Status describes the gap on the Apollo Wind side only. It assumes flow-workbench already
             renders the type distinctly, which is true for most rows (backed by a real renderer: the
             integration-service widget catalog, JSON Schema, entity fields). A type marked{' '}
@@ -764,7 +764,7 @@ function FieldTypesPage({ globalTheme }: { globalTheme: string }) {
             missing this,&rdquo; it may be &ldquo;no one has decided this is a real distinction yet,
             in either place.&rdquo; See that row&rsquo;s recommended action before treating it as a
             straightforward addition.
-          </InfoCallout>
+          </p>
         </section>
 
         <Divider />

--- a/apps/storybook/src/patterns/FieldTypes.stories.tsx
+++ b/apps/storybook/src/patterns/FieldTypes.stories.tsx
@@ -977,29 +977,42 @@ const INPUT_GROUP_STATES: StateRow[] = [
   },
 ];
 
+// States run across as columns, not down as rows: with every table on this
+// page so far having exactly 4 states, 4 stacked rows (each a label + a live
+// example + a paragraph) took much more vertical room than laying them out
+// side by side and reading the example/notes pair down each column instead.
 function StatesTable({ rows }: { rows: StateRow[] }) {
+  const columnClass = rows.length === 4 ? 'w-1/4' : undefined;
   return (
     <div className="overflow-hidden rounded-lg border border-border">
       <Table>
         <TableHeader>
           <TableRow className="hover:bg-transparent">
-            <TableHead className={cn(HEADER_CELL_CLASS, 'w-[16%]')}>State</TableHead>
-            <TableHead className={cn(HEADER_CELL_CLASS, 'w-[28%]')}>Example</TableHead>
-            <TableHead className={HEADER_CELL_CLASS}>Notes</TableHead>
+            {rows.map(({ label }) => (
+              <TableHead key={label} className={cn(HEADER_CELL_CLASS, columnClass)}>
+                {label}
+              </TableHead>
+            ))}
           </TableRow>
         </TableHeader>
         <TableBody>
-          {rows.map(({ label, description, Example }) => (
-            <TableRow key={label}>
-              <TableCell className={cn(BODY_CELL_CLASS, 'font-mono text-xs')}>{label}</TableCell>
-              <TableCell className={BODY_CELL_CLASS}>
+          <TableRow>
+            {rows.map(({ label, Example }) => (
+              <TableCell key={label} className={cn(BODY_CELL_CLASS, columnClass)}>
                 <Example />
               </TableCell>
-              <TableCell className={cn(BODY_CELL_CLASS, 'text-xs text-muted-foreground')}>
+            ))}
+          </TableRow>
+          <TableRow>
+            {rows.map(({ label, description }) => (
+              <TableCell
+                key={label}
+                className={cn(BODY_CELL_CLASS, columnClass, 'text-xs text-muted-foreground')}
+              >
                 {description}
               </TableCell>
-            </TableRow>
-          ))}
+            ))}
+          </TableRow>
         </TableBody>
       </Table>
     </div>

--- a/apps/storybook/src/patterns/FieldTypes.stories.tsx
+++ b/apps/storybook/src/patterns/FieldTypes.stories.tsx
@@ -650,7 +650,12 @@ function CategoryTable({ description, rows, rowLabel = 'Type' }: Category) {
   return (
     <div>
       <p className="mb-4 text-sm leading-6 text-muted-foreground">{description}</p>
-      <div className="overflow-hidden rounded-lg border border-border">
+      {/* No overflow-hidden: the Visual example column's w-56 demos (doubled to
+          two stacked for expression-capable types) routinely make the table
+          wider than its container. overflow-hidden would silently clip
+          whatever's in the last column instead of letting it scroll into
+          view via the Table primitive's own overflow-auto container. */}
+      <div className="rounded-lg border border-border">
         <Table>
           <TableHeader>
             <TableRow className="hover:bg-transparent">
@@ -984,7 +989,12 @@ const INPUT_GROUP_STATES: StateRow[] = [
 function StatesTable({ rows }: { rows: StateRow[] }) {
   const columnClass = rows.length === 4 ? 'w-1/4' : undefined;
   return (
-    <div className="overflow-hidden rounded-lg border border-border">
+    // No overflow-hidden here: 4 columns of w-56 examples plus padding (~1024px)
+    // routinely exceeds the ~960px content width, and overflow-hidden would
+    // silently clip the last column instead of letting it scroll into view.
+    // Table's own scroll container (overflow-auto) handles that; rounded-lg
+    // still applies, just without the corner-clipping that also hid content.
+    <div className="rounded-lg border border-border">
       <Table>
         <TableHeader>
           <TableRow className="hover:bg-transparent">

--- a/apps/storybook/src/patterns/FieldTypes.stories.tsx
+++ b/apps/storybook/src/patterns/FieldTypes.stories.tsx
@@ -1,0 +1,719 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import type * as React from 'react';
+import { useState } from 'react';
+import { Badge } from '@/components/ui/badge';
+import {
+  FIELD_TYPE_META,
+  FIELD_TYPE_ORDER,
+  type LockableFieldType,
+  LockableValueField,
+  type LockableValueFieldMode,
+} from '@/components/ui/lockable-value-field';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { fontFamily } from '@/foundation/Future/typography';
+import { cn } from '@/lib';
+
+const meta = {
+  title: 'Apollo Wind/Forms/Field Types',
+  parameters: { layout: 'fullscreen' },
+} satisfies Meta;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+type Status = 'supported' | 'needs-type' | 'needs-component';
+type VisualExample = LockableFieldType | 'mode-fixed' | 'mode-expression';
+
+interface TypeRow {
+  type: string;
+  source: string;
+  support: string;
+  status: Status;
+  action?: string;
+  visual?: VisualExample;
+}
+
+interface Category {
+  title: string;
+  description: string;
+  rows: TypeRow[];
+  rowLabel?: string;
+}
+
+const CATEGORIES: Category[] = [
+  {
+    title: 'Temporal',
+    description: 'Date and time values. Only bare dates are modeled today.',
+    rows: [
+      {
+        type: 'date',
+        source: 'JSON Schema, entity fields, hitl-schema-types',
+        support: 'fieldType="date"',
+        status: 'supported',
+        visual: 'date',
+      },
+      {
+        type: 'datetime / date-time',
+        source: 'hitl-schema-types, integration-service WidgetType.Datetime, entity field dateTime',
+        support: 'Not modeled. Distinct from date today.',
+        status: 'needs-type',
+        action: 'Add a datetime fieldType with a combined date and time control.',
+      },
+      {
+        type: 'time',
+        source: 'integration-service WidgetType.Time, entity field time',
+        support: 'Not modeled.',
+        status: 'needs-type',
+        action: 'Add a time fieldType with a time-of-day control.',
+      },
+      {
+        type: 'duration / timeSpan',
+        source: 'integration-service WidgetType.Timespan',
+        support: 'Not modeled.',
+        status: 'needs-type',
+        action: 'Add a duration fieldType. Likely a segmented number plus unit control.',
+      },
+    ],
+  },
+  {
+    title: 'Numeric',
+    description: 'Only integer is modeled today, without a decimal counterpart.',
+    rows: [
+      {
+        type: 'integer',
+        source: 'JSON Schema, hitl-schema-types',
+        support: 'fieldType="integer"',
+        status: 'supported',
+        visual: 'integer',
+      },
+      {
+        type: 'number / float / double',
+        source: 'hitl-schema-types (float, double), JSON Schema number',
+        support: 'Renders via integer today, but the control does not allow decimals.',
+        status: 'needs-type',
+        action: 'Add a number fieldType for decimal values, separate from integer.',
+      },
+      {
+        type: 'int32 / int64',
+        source: 'hitl-schema-types schema definitions',
+        support: 'Renders via integer.',
+        status: 'needs-type',
+        action:
+          'Confirm whether the 32 vs. 64 bit distinction matters at the UI layer. If it is a backend validation constraint only, no UI change is needed.',
+      },
+    ],
+  },
+  {
+    title: 'Boolean',
+    description: 'A single true or false value.',
+    rows: [
+      {
+        type: 'boolean',
+        source: 'JSON Schema, hitl-schema-types',
+        support: 'fieldType="boolean"',
+        status: 'supported',
+        visual: 'boolean',
+      },
+    ],
+  },
+  {
+    title: 'Text and string formats',
+    description:
+      'string covers the base case. JSON Schema format extensions and loose fallbacks currently render the same as a plain string, with no format-specific behavior.',
+    rows: [
+      {
+        type: 'string',
+        source: 'JSON Schema',
+        support: 'fieldType="string"',
+        status: 'supported',
+        visual: 'string',
+      },
+      {
+        type: 'text / any / json',
+        source: 'argument-utils.ts, expression-model getEffectiveType fallback',
+        support: 'Renders via string.',
+        status: 'needs-type',
+        action:
+          'Decide whether any and json need a distinct, code-aware control, or should resolve to string with a monospace hint.',
+      },
+      {
+        type: 'email / uri / uuid',
+        source: 'JSON Schema format extensions',
+        support: 'Renders via string. No format validation.',
+        status: 'needs-type',
+        action:
+          'Add format-level validation and masking. Likely a format prop on string rather than a new fieldType.',
+      },
+      {
+        type: 'monetary / currency',
+        source: 'JSON Schema format extensions',
+        support: 'Renders via string.',
+        status: 'needs-type',
+        action: 'Needs a currency-aware control with symbol and locale formatting.',
+      },
+      {
+        type: 'verbatim',
+        source: 'JSON Schema format extension',
+        support: 'Renders via string.',
+        status: 'needs-type',
+        action:
+          'Clarify what verbatim means at the UI layer. Likely no visual difference from string. Confirm with the flow-workbench team.',
+      },
+    ],
+  },
+  {
+    title: 'Security',
+    description: 'No masked or credential-aware control exists today.',
+    rows: [
+      {
+        type: 'Secret',
+        source: 'asset-binding.ts, schemaTypeDisplay.tsx',
+        support: 'Not modeled.',
+        status: 'needs-type',
+        action: 'Add a secret fieldType: masked input, no plaintext reveal even when unlocked.',
+      },
+      {
+        type: 'Credential',
+        source: 'asset-binding.ts',
+        support: 'Not modeled.',
+        status: 'needs-type',
+        action:
+          'Add a credential fieldType. Likely a connection-style picker rather than free text.',
+      },
+      {
+        type: 'secretAsset / credentialAsset',
+        source: 'asset-binding.ts',
+        support: 'Not modeled.',
+        status: 'needs-type',
+        action:
+          'Likely the same secret and credential fieldTypes bound through the asset system. Confirm with flow-schema owners before adding separate variants.',
+      },
+    ],
+  },
+  {
+    title: 'Object and collection',
+    description:
+      'object is modeled. Nothing today handles an arbitrary list, a key-value map, or a heterogeneous collection.',
+    rows: [
+      {
+        type: 'object',
+        source: 'JSON Schema',
+        support: 'fieldType="object"',
+        status: 'supported',
+        visual: 'object',
+      },
+      {
+        type: 'array (generic)',
+        source: 'Workflow variables dropdown, JSON Schema',
+        support:
+          'No generic array editor. Only multi-select, which is a fixed list of string options.',
+        status: 'needs-type',
+        action:
+          'Add a generic array fieldType: add, remove, and reorder rows of an arbitrary sub-type.',
+      },
+      {
+        type: 'dictionary',
+        source: 'integration-service WidgetType.dictionary',
+        support: 'Not modeled.',
+        status: 'needs-component',
+        action: 'Build a dedicated key-value map editor. Does not fit the single-value model.',
+      },
+      {
+        type: 'collection',
+        source: 'integration-service WidgetType.collection',
+        support: 'Not modeled.',
+        status: 'needs-component',
+        action:
+          'Clarify against the generic array row above. May be the same concept under a different name.',
+      },
+      {
+        type: 'stringArray / rawStringArray / stringArrayWithExpression',
+        source: 'integration-service WidgetType',
+        support: 'Overlaps with multi-select and generic array.',
+        status: 'needs-type',
+        action: 'De-duplicate with flow-workbench before adding a new fieldType.',
+      },
+    ],
+  },
+  {
+    title: 'File and media',
+    description: 'file covers upload only. There is no picker for existing resources or images.',
+    rows: [
+      {
+        type: 'file',
+        source: 'JSON Schema resource-kind extension, hitl-schema-types',
+        support: 'fieldType="file"',
+        status: 'supported',
+        visual: 'file',
+      },
+      {
+        type: 'browser / localResource',
+        source: 'integration-service WidgetType',
+        support: 'Not modeled.',
+        status: 'needs-component',
+        action:
+          'Build a file system or folder picker. Different from the existing upload-only file control.',
+      },
+      {
+        type: 'image / icon',
+        source: 'integration-service WidgetType',
+        support: 'Not modeled.',
+        status: 'needs-component',
+        action: 'Build an image or icon picker with a preview.',
+      },
+    ],
+  },
+  {
+    title: 'Choice controls',
+    description:
+      'single-select and multi-select cover the base cases. Some flow-workbench choice controls may be visual variants of these rather than genuinely new types.',
+    rows: [
+      {
+        type: 'single-select',
+        source: 'JSON Schema enum, integration-service dropdown',
+        support: 'fieldType="single-select"',
+        status: 'supported',
+        visual: 'single-select',
+      },
+      {
+        type: 'multi-select',
+        source: 'JSON Schema, integration-service',
+        support: 'fieldType="multi-select"',
+        status: 'supported',
+        visual: 'multi-select',
+      },
+      {
+        type: 'dropdown',
+        source: 'integration-service WidgetType.dropdown',
+        support: 'Renders via single-select. Naming alias only.',
+        status: 'supported',
+        visual: 'single-select',
+      },
+      {
+        type: 'checkboxGroup',
+        source: 'integration-service WidgetType.checkboxGroup',
+        support: 'Closest existing analog is multi-select.',
+        status: 'needs-type',
+        action:
+          'Confirm whether an all-options-visible checkbox group is a real visual distinction worth its own fieldType, versus multi-select’s dropdown and chips.',
+      },
+      {
+        type: 'radioGroup',
+        source: 'integration-service WidgetType.radioGroup',
+        support: 'Closest existing analog is single-select.',
+        status: 'needs-type',
+        action:
+          'Confirm whether a radio group is a real visual distinction worth its own fieldType, versus a single-select dropdown.',
+      },
+      {
+        type: 'autoComplete / connectorAutocomplete / autoCompleteForExpression',
+        source: 'integration-service WidgetType',
+        support: 'Not modeled.',
+        status: 'needs-component',
+        action:
+          'Build an async-search autocomplete control. The existing single-select assumes a static option list.',
+      },
+    ],
+  },
+  {
+    title: 'Resource reference',
+    description: 'A whole family with no equivalent today.',
+    rows: [
+      {
+        type: 'connection / entity / process / app / portal / definition / solutionResource',
+        source: 'solution-resource-picker/kinds',
+        support: 'Not modeled.',
+        status: 'needs-component',
+        action:
+          'Build one resource-reference picker component parameterized by kind, rather than seven separate fieldTypes.',
+      },
+    ],
+  },
+  {
+    title: 'Rich and composite controls',
+    description:
+      'Controls whose interaction model is fundamentally different from a single value field.',
+    rows: [
+      {
+        type: 'richText / richTextComposer',
+        source: 'integration-service WidgetType',
+        support: 'Not modeled.',
+        status: 'needs-component',
+        action: 'Build a rich text editor control.',
+      },
+      {
+        type: 'promptComposer / promptSingleValue',
+        source: 'integration-service WidgetType',
+        support: 'Not modeled.',
+        status: 'needs-component',
+        action: 'Build an AI prompt composer control.',
+      },
+      {
+        type: 'filter / conditionBuilder',
+        source: 'integration-service WidgetType',
+        support: 'Not modeled.',
+        status: 'needs-component',
+        action: 'Build a condition or query builder control.',
+      },
+      {
+        type: 'outputMapping / dataMapping',
+        source: 'integration-service WidgetType',
+        support: 'Not modeled.',
+        status: 'needs-component',
+        action: 'Build a field-mapping control for source to target pairs.',
+      },
+      {
+        type: 'typePicker',
+        source: 'integration-service WidgetType',
+        support: 'Not modeled.',
+        status: 'needs-component',
+        action: 'Build a schema or type picker control.',
+      },
+    ],
+  },
+  {
+    title: 'Loose and fallback types',
+    description: 'Edge cases that usually resolve to another row in this table.',
+    rows: [
+      {
+        type: 'null',
+        source: 'JSON Schema, flow-schema expression.ts',
+        support: 'No explicit null state.',
+        status: 'needs-type',
+        action:
+          'Usually paired with another type in a union, such as a nullable string. Confirm whether an explicit null or empty state is needed per type, or whether an empty value already covers it.',
+      },
+      {
+        type: 'ref',
+        source: 'generate-variable-declarations.ts',
+        support: 'Overlaps with the resource reference family above.',
+        status: 'needs-component',
+        action: 'De-duplicate with the resource reference family before adding.',
+      },
+    ],
+  },
+];
+
+const BINDING_STATE_ROWS: TypeRow[] = [
+  {
+    type: 'fixed  (LockableValueFieldMode)  ↔  Widget  (integration-service ValueType)',
+    source: 'lockable-value-field/types.ts, integration-service ValueType',
+    support: 'mode="fixed"',
+    status: 'supported',
+    visual: 'mode-fixed',
+  },
+  {
+    type: 'expression  (LockableValueFieldMode)  ↔  Expression  (integration-service ValueType)',
+    source: 'lockable-value-field/types.ts, integration-service ValueType',
+    support: 'mode="expression"',
+    status: 'supported',
+    visual: 'mode-expression',
+  },
+  {
+    type: 'Variable',
+    source: 'integration-service ValueType.Variable',
+    support: 'Not modeled as a distinct mode.',
+    status: 'needs-type',
+    action:
+      'Clarify whether a bound-to-variable state needs its own visual treatment, or is already covered by inserting a variable into an expression.',
+  },
+  {
+    type: 'Mapping / Dynamic',
+    source: 'integration-service ValueType',
+    support: 'Not modeled.',
+    status: 'needs-type',
+    action:
+      'Add a read-only bound state to LockableValueFieldMode, rendered like the locked display but indicating an upstream binding rather than a static value.',
+  },
+];
+
+const STATUS_META: Record<Status, { label: string; variant: 'success' | 'warning' | 'info' }> = {
+  supported: { label: 'Supported', variant: 'success' },
+  'needs-type': { label: 'Needs fieldType', variant: 'warning' },
+  'needs-component': { label: 'Needs component', variant: 'info' },
+};
+
+function SectionTitle({ children }: { children: React.ReactNode }) {
+  return <h2 className="mb-2 text-2xl font-bold tracking-tight text-foreground">{children}</h2>;
+}
+
+function SectionDescription({ children }: { children: React.ReactNode }) {
+  return <p className="mb-6 text-base leading-7 text-muted-foreground">{children}</p>;
+}
+
+function Divider() {
+  return <div className="my-10 h-px bg-border" />;
+}
+
+function InfoCallout({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="rounded-lg border border-border bg-muted/50 p-4 text-sm leading-6 text-muted-foreground">
+      {children}
+    </div>
+  );
+}
+
+function StatusBadge({ status }: { status: Status }) {
+  const meta = STATUS_META[status];
+  return <Badge variant={meta.variant}>{meta.label}</Badge>;
+}
+
+// Live, interactive demo of a real fieldType, not a screenshot, so it can never drift
+// out of sync with the component it documents.
+function FieldTypeExample({ fieldType }: { fieldType: LockableFieldType }) {
+  const [value, setValue] = useState('');
+  const [mode, setMode] = useState<LockableValueFieldMode>('fixed');
+  return (
+    <div className="w-44">
+      <LockableValueField
+        fieldType={fieldType}
+        value={value}
+        onValueChange={setValue}
+        locked={false}
+        mode={mode}
+        onModeChange={setMode}
+        showFieldActions={false}
+      />
+    </div>
+  );
+}
+
+function ModeExample({ mode }: { mode: LockableValueFieldMode }) {
+  const [value, setValue] = useState(mode === 'expression' ? '$vars.example' : 'Example value');
+  return (
+    <div className="w-44">
+      <LockableValueField
+        fieldType="string"
+        value={value}
+        onValueChange={setValue}
+        locked={false}
+        mode={mode}
+        showFieldActions={false}
+      />
+    </div>
+  );
+}
+
+// Rendered instead of a fake mockup for gap rows: there is no real control to show,
+// and a hand-drawn one would look like it already exists.
+function GapPlaceholder() {
+  return (
+    <div className="flex h-9 w-44 items-center justify-center rounded-lg border border-dashed border-border px-2 text-center text-[11px] text-muted-foreground">
+      No control yet
+    </div>
+  );
+}
+
+function VisualExampleCell({ visual }: { visual?: VisualExample }) {
+  if (!visual) return <GapPlaceholder />;
+  if (visual === 'mode-fixed') return <ModeExample mode="fixed" />;
+  if (visual === 'mode-expression') return <ModeExample mode="expression" />;
+  return <FieldTypeExample fieldType={visual} />;
+}
+
+function CategoryTable({ title, description, rows, rowLabel = 'Type' }: Category) {
+  return (
+    <section className="mb-10">
+      <h3 className="mb-1.5 text-lg font-semibold text-foreground">{title}</h3>
+      <p className="mb-4 text-sm leading-6 text-muted-foreground">{description}</p>
+      <div className="overflow-hidden rounded-lg border border-border">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead className="w-[16%]">{rowLabel}</TableHead>
+              <TableHead className="w-[18%]">Visual example</TableHead>
+              <TableHead className="w-[16%]">Source in flow-workbench</TableHead>
+              <TableHead className="w-[15%]">Apollo Wind support</TableHead>
+              <TableHead className="w-[11%]">Status</TableHead>
+              <TableHead>Recommended action</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {rows.map((row) => (
+              <TableRow key={row.type}>
+                <TableCell className="align-top font-mono text-xs">{row.type}</TableCell>
+                <TableCell className="align-top">
+                  <VisualExampleCell visual={row.visual} />
+                </TableCell>
+                <TableCell className="align-top text-xs text-muted-foreground">
+                  {row.source}
+                </TableCell>
+                <TableCell className="align-top text-xs text-muted-foreground">
+                  {row.support}
+                </TableCell>
+                <TableCell className="align-top">
+                  <StatusBadge status={row.status} />
+                </TableCell>
+                <TableCell className="align-top text-xs text-muted-foreground">
+                  {row.action ?? '—'}
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+    </section>
+  );
+}
+
+function SupportedTodayStrip() {
+  return (
+    <div className="flex flex-wrap gap-2">
+      {FIELD_TYPE_ORDER.map((type) => {
+        const typeMeta = FIELD_TYPE_META[type];
+        return (
+          <span
+            key={type}
+            className="inline-flex items-center gap-1.5 rounded-full border border-border bg-card px-3 py-1 text-xs font-medium text-foreground"
+          >
+            <typeMeta.icon size={12} />
+            {typeMeta.label}
+          </span>
+        );
+      })}
+    </div>
+  );
+}
+
+function FieldTypesPage({ globalTheme }: { globalTheme: string }) {
+  return (
+    <div
+      className={cn(globalTheme, 'min-h-screen w-full bg-background text-foreground')}
+      style={{ fontFamily: fontFamily.base }}
+    >
+      <main className="mx-auto max-w-5xl p-8">
+        <header>
+          <h1 className="text-[2rem] font-bold tracking-tight text-foreground">Field types</h1>
+          <p className="mt-2 text-base leading-7 text-muted-foreground">
+            A single reference for every field, property, and parameter type flow-workbench needs to
+            support, cross-referenced against what LockableValueField and the rest of Apollo Wind
+            implement today. Use this before adding a new type case: check whether it already has a
+            home, and if not, follow the recommended action instead of improvising a one-off
+            control.
+          </p>
+        </header>
+
+        <Divider />
+
+        <section>
+          <SectionTitle>Why this exists</SectionTitle>
+          <SectionDescription>
+            flow-workbench does not have one canonical type enum. At least six separate, partially
+            overlapping type systems define field types across workflow variables, JSON Schema
+            manifests, entity fields, HITL forms, and the integration-service widget catalog. Apollo
+            Wind&rsquo;s LockableFieldType was designed against a narrower slice of that list, which
+            is why some flow-workbench types have nowhere to go yet.
+          </SectionDescription>
+          <InfoCallout>
+            This table is a point-in-time audit, not a live sync. It was last checked against
+            flow-workbench on 2026-09-09. If a type here looks stale, re-check the cited source file
+            before trusting the row.
+          </InfoCallout>
+        </section>
+
+        <Divider />
+
+        <section>
+          <SectionTitle>Supported today</SectionTitle>
+          <SectionDescription>
+            The fieldType values LockableValueField already implements, read live from{' '}
+            <code className="rounded bg-muted px-1.5 py-0.5 text-sm font-medium text-foreground">
+              FIELD_TYPE_META
+            </code>
+            .
+          </SectionDescription>
+          <SupportedTodayStrip />
+        </section>
+
+        <Divider />
+
+        <section>
+          <SectionTitle>How to read the status column</SectionTitle>
+          <div className="grid gap-4 sm:grid-cols-3">
+            <div className="rounded-lg border border-border bg-card p-4">
+              <div className="mb-2">
+                <StatusBadge status="supported" />
+              </div>
+              <p className="text-sm leading-6 text-muted-foreground">
+                Already implemented. Use the existing fieldType, no contribution needed.
+              </p>
+            </div>
+            <div className="rounded-lg border border-border bg-card p-4">
+              <div className="mb-2">
+                <StatusBadge status="needs-type" />
+              </div>
+              <p className="text-sm leading-6 text-muted-foreground">
+                Fits LockableValueField&rsquo;s existing lock, mode, and value model. Needs a new{' '}
+                <code className="rounded bg-muted px-1 py-0.5 text-xs font-medium text-foreground">
+                  fieldType
+                </code>{' '}
+                (or format) added to that component.
+              </p>
+            </div>
+            <div className="rounded-lg border border-border bg-card p-4">
+              <div className="mb-2">
+                <StatusBadge status="needs-component" />
+              </div>
+              <p className="text-sm leading-6 text-muted-foreground">
+                Does not fit the single-value model at all. Needs a dedicated component, not another
+                fieldType case.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        <Divider />
+
+        {CATEGORIES.map((category) => (
+          <CategoryTable key={category.title} {...category} />
+        ))}
+
+        <CategoryTable
+          title="Binding state"
+          description="Separate from field type: how a value relates to fixed input versus an upstream binding. LockableValueField only distinguishes fixed and expression. The integration-service widget catalog has a richer set."
+          rows={BINDING_STATE_ROWS}
+          rowLabel="State"
+        />
+
+        <Divider />
+
+        <section>
+          <SectionTitle>Out of scope</SectionTitle>
+          <SectionDescription>
+            Left out of the table above on purpose, so the list stays focused on value fields.
+          </SectionDescription>
+          <GuidanceOutOfScope />
+        </section>
+      </main>
+    </div>
+  );
+}
+
+function GuidanceOutOfScope() {
+  return (
+    <ul className="space-y-2 text-sm leading-6 text-muted-foreground">
+      <li>
+        <span className="font-medium text-foreground">textBlock, button, addActivityWidget:</span>{' '}
+        display-only or action-triggering widgets from the integration-service catalog. They do not
+        bind to a value, so they are not a LockableValueField concern.
+      </li>
+      <li>
+        <span className="font-medium text-foreground">Evals FieldType:</span> a separate, narrower
+        type list used for eval scoring (llmModel, toolCallArgs, and similar). Unrelated to node or
+        form rendering.
+      </li>
+    </ul>
+  );
+}
+
+export const Documentation: Story = {
+  name: 'Documentation',
+  render: (_args, { globals }) => <FieldTypesPage globalTheme={globals.theme || 'future-dark'} />,
+};

--- a/apps/storybook/src/patterns/FieldTypes.stories.tsx
+++ b/apps/storybook/src/patterns/FieldTypes.stories.tsx
@@ -8,6 +8,7 @@ import {
   AccordionTrigger,
 } from '@/components/ui/accordion';
 import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
 import {
   FIELD_TYPE_META,
   FIELD_TYPE_ORDER,
@@ -516,7 +517,7 @@ function FieldTypeExample({
   const [value, setValue] = useState(initialMode === 'expression' ? '$vars.example' : '');
   const [mode, setMode] = useState<LockableValueFieldMode>(initialMode);
   return (
-    <div className="w-44">
+    <div className="w-56">
       <LockableValueField
         fieldType={fieldType}
         value={value}
@@ -541,7 +542,7 @@ function ExampleLabel({ children }: { children: React.ReactNode }) {
 function ModeExample({ mode }: { mode: LockableValueFieldMode }) {
   const [value, setValue] = useState(mode === 'expression' ? '$vars.example' : 'Example value');
   return (
-    <div className="w-44">
+    <div className="w-56">
       <LockableValueField
         fieldType="string"
         value={value}
@@ -558,7 +559,7 @@ function ModeExample({ mode }: { mode: LockableValueFieldMode }) {
 // and a hand-drawn one would look like it already exists.
 function GapPlaceholder() {
   return (
-    <div className="flex h-9 w-44 items-center justify-center rounded-lg border border-dashed border-border px-2 text-center text-[11px] text-muted-foreground">
+    <div className="flex h-9 w-56 items-center justify-center rounded-lg border border-dashed border-border px-2 text-center text-[11px] text-muted-foreground">
       No control yet
     </div>
   );
@@ -598,13 +599,13 @@ function CategoryTable({ description, rows, rowLabel = 'Type' }: Category) {
         <Table>
           <TableHeader>
             <TableRow className="hover:bg-transparent">
-              <TableHead className={cn(HEADER_CELL_CLASS, 'w-[16%]')}>{rowLabel}</TableHead>
-              <TableHead className={cn(HEADER_CELL_CLASS, 'w-[18%]')}>Visual example</TableHead>
-              <TableHead className={cn(HEADER_CELL_CLASS, 'w-[15%]')}>
+              <TableHead className={cn(HEADER_CELL_CLASS, 'w-[13%]')}>{rowLabel}</TableHead>
+              <TableHead className={cn(HEADER_CELL_CLASS, 'w-[23%]')}>Visual example</TableHead>
+              <TableHead className={cn(HEADER_CELL_CLASS, 'w-[13%]')}>
                 Apollo Wind support
               </TableHead>
-              <TableHead className={cn(HEADER_CELL_CLASS, 'w-[11%]')}>Status</TableHead>
-              <TableHead className={cn(HEADER_CELL_CLASS, 'w-[24%]')}>Recommended action</TableHead>
+              <TableHead className={cn(HEADER_CELL_CLASS, 'w-[10%]')}>Status</TableHead>
+              <TableHead className={cn(HEADER_CELL_CLASS, 'w-[21%]')}>Recommended action</TableHead>
               <TableHead className={HEADER_CELL_CLASS}>Source in flow-workbench</TableHead>
             </TableRow>
           </TableHeader>
@@ -665,7 +666,10 @@ function SupportedTodayStrip() {
   );
 }
 
+const ALL_SECTION_TITLES = ALL_SECTIONS.map((section) => section.title);
+
 function FieldTypesPage({ globalTheme }: { globalTheme: string }) {
+  const [openSections, setOpenSections] = useState<string[]>(ALL_SECTION_TITLES);
   return (
     <div
       className={cn(globalTheme, 'min-h-screen w-full bg-background text-foreground')}
@@ -765,7 +769,16 @@ function FieldTypesPage({ globalTheme }: { globalTheme: string }) {
 
         <Divider />
 
-        <Accordion type="multiple" defaultValue={ALL_SECTIONS.map((section) => section.title)}>
+        <div className="mb-4 flex items-center justify-end gap-2">
+          <Button variant="outline" size="2xs" onClick={() => setOpenSections(ALL_SECTION_TITLES)}>
+            Expand all
+          </Button>
+          <Button variant="outline" size="2xs" onClick={() => setOpenSections([])}>
+            Collapse all
+          </Button>
+        </div>
+
+        <Accordion type="multiple" value={openSections} onValueChange={setOpenSections}>
           {ALL_SECTIONS.map((section) => (
             <AccordionItem key={section.title} value={section.title} className="border-border">
               <AccordionTrigger className="text-lg font-semibold text-foreground hover:no-underline">


### PR DESCRIPTION
## Summary

New Storybook page at `Apollo Wind/Forms/Field Types`, sitting next to `Field guidance`. Documents every field-level building block used on a form and cross-references every value type flow-workbench needs against what LockableValueField supports today, so engineers have one place to check before adding a new type case instead of improvising.

**Page structure, three top-level parts, each independently collapsible with Expand all / Collapse all:**

- **Overview** — Why this exists: flow-workbench has no single canonical type enum, at least 6 overlapping type systems define types across its own subsystems. Dated audit caveat: point-in-time snapshot, not a live sync.
- **Types** — the actual form-building blocks:
  - **Input** and **Input Group**: Default, Disabled, Invalid, plus Read-only (Input) and a Locked (read-only) recipe (Input Group).
  - **LockableValueField, no left icon** / **with left icon**: the same 4 states (Default, Locked, Invalid, Expression) shown both ways, so the icon toggle is the only variable.
  - **LockableValueField, assignment & binding**: mirrors the real "Assignment & Binding" reference example in `lockable-value-field.stories.tsx`, leadingAddon `=` instead of the lock icon, mode always expression, including the custom-expression-editor trailing-addon variant.
  - **LockableValueField, insert variable**: the `variables` prop and its Insert-variable popover (normally suppressed everywhere else on the page via `showFieldActions={false}`), across Default / Locked / No variables / Insert-variable-only, confirming locked and empty-variables disable the button for two different real reasons.
- **LockableValueField status** — Supported today (live from `FIELD_TYPE_META`), the status legend (`Supported` / `Needs fieldType` / `Needs component`, plus a `†` flag for rows where it's not confirmed flow-workbench itself treats the type as distinct), an "Only show supported" filter, and the gap-tracking category accordion (Temporal, Numeric, Boolean, Text/string formats, Security, Object/collection, File/media, Choice controls, Resource reference, Rich/composite, Loose/fallback, Binding state — now including Insert-variable's supported status and a companion gap row for inline reference autocomplete-while-typing, which is not modeled).

All live examples are real, interactive `LockableValueField`/`Input`/`Input Group` instances, never fabricated mockups; gap rows show a "No control yet" placeholder instead.

Posting as a draft to get design/eng feedback on the three-part structure, the icon/binding/insert-variable split, the `†` confidence flag, and whether the recommended actions per gap type are right before this becomes the thing people are pointed to.

## Test plan

- [ ] Storybook renders the page with no console errors (`Apollo Wind/Forms/Field Types` → `Documentation`)
- [ ] Live examples throughout (Types tables + status tables) are interactive and match component behavior, including Fixed/Expression toggles, the assignment-binding `=` addon, and Insert-variable's popover
- [ ] Every states table shows all 4 columns evenly with nothing clipped or requiring horizontal scroll
- [ ] Both accordions (Types, LockableValueField status) expand/collapse independently, bulk buttons and per-section toggling all agree
- [ ] Gap rows show the "No control yet" placeholder, not a fake control
- [ ] The rows marked `†` read correctly against the legend callout
- [ ] `pnpm biome check` passes on the new file

🤖 Generated with [Claude Code](https://claude.com/claude-code)