### PR TITLE
fix(apollo-vertex): namespace the registry's own item references

### DIFF
--- a/apps/apollo-vertex/registry.json
+++ b/apps/apollo-vertex/registry.json
@@ -9,7 +9,7 @@
       "title": "Apollo Vertex Theme",
       "description": "Apollo Vertex design system tokens — colors, typography, spacing, shadows, and easing functions with light and dark mode support.",
       "dependencies": ["tw-animate-css"],
-      "registryDependencies": ["font-inter"],
+      "registryDependencies": ["@uipath/font-inter"],
       "cssVars": {
         "theme": {
           "radius-sm": "calc(var(--radius) - 4px)",
@@ -1658,7 +1658,7 @@
       "title": "Button Group",
       "description": "Groups multiple buttons together.",
       "dependencies": ["@radix-ui/react-slot"],
-      "registryDependencies": ["separator"],
+      "registryDependencies": ["@uipath/separator"],
       "files": [
         {
           "path": "registry/button-group/button-group.tsx",
@@ -1746,7 +1746,12 @@
       "type": "registry:ui",
       "title": "Combobox",
       "description": "An autocomplete input with a filterable list, supporting single and multi-select with badges.",
-      "registryDependencies": ["badge", "button", "command", "popover"],
+      "registryDependencies": [
+        "@uipath/badge",
+        "@uipath/button",
+        "@uipath/command",
+        "@uipath/popover"
+      ],
       "dependencies": ["react-i18next"],
       "files": [
         {
@@ -1761,7 +1766,7 @@
       "title": "Command",
       "description": "A command menu for searching and executing commands.",
       "dependencies": ["cmdk"],
-      "registryDependencies": ["dialog"],
+      "registryDependencies": ["@uipath/dialog"],
       "files": [
         {
           "path": "registry/command/command.tsx",
@@ -1775,7 +1780,11 @@
       "title": "Confidence Signal",
       "description": "A signal-bar chip that communicates AI confidence (high/medium/low/unknown) without a raw score, with an optional popover for factor breakdowns and required next steps.",
       "dependencies": ["framer-motion", "lucide-react", "react-i18next"],
-      "registryDependencies": ["button", "popover", "tooltip"],
+      "registryDependencies": [
+        "@uipath/button",
+        "@uipath/popover",
+        "@uipath/tooltip"
+      ],
       "cssVars": {
         "theme": {
           "color-success": "var(--success)",
@@ -1994,7 +2003,7 @@
       "type": "registry:ui",
       "title": "Field",
       "description": "A form field component with label, input, and description.",
-      "registryDependencies": ["label", "separator"],
+      "registryDependencies": ["@uipath/label", "@uipath/separator"],
       "files": [{ "path": "registry/field/field.tsx", "type": "registry:ui" }]
     },
     {
@@ -2046,7 +2055,11 @@
       "type": "registry:ui",
       "title": "Input Group",
       "description": "Groups input elements with addons and buttons.",
-      "registryDependencies": ["button", "input", "textarea"],
+      "registryDependencies": [
+        "@uipath/button",
+        "@uipath/input",
+        "@uipath/textarea"
+      ],
       "files": [
         {
           "path": "registry/input-group/input-group.tsx",
@@ -2073,7 +2086,7 @@
       "title": "Item",
       "description": "A list item component for displaying content in lists.",
       "dependencies": ["@radix-ui/react-slot"],
-      "registryDependencies": ["separator"],
+      "registryDependencies": ["@uipath/separator"],
       "files": [{ "path": "registry/item/item.tsx", "type": "registry:ui" }]
     },
     {
@@ -2109,7 +2122,11 @@
       "type": "registry:ui",
       "title": "Metric Card",
       "description": "Displays a labeled metric with value, optional trend indicator, and percentage change badge.",
-      "registryDependencies": ["@uipath/card", "@uipath/badge", "skeleton"],
+      "registryDependencies": [
+        "@uipath/card",
+        "@uipath/badge",
+        "@uipath/skeleton"
+      ],
       "files": [
         {
           "path": "registry/metric-card/metric-card.tsx",
@@ -2127,7 +2144,7 @@
         "lucide-react",
         "@radix-ui/react-dialog"
       ],
-      "registryDependencies": ["button"],
+      "registryDependencies": ["@uipath/button"],
       "files": [
         {
           "path": "registry/onboarding-tour-joyride/index.ts",
@@ -2306,14 +2323,14 @@
         "@uipath/vs-core@^4.2.0"
       ],
       "registryDependencies": [
-        "button",
-        "tooltip",
-        "avatar",
-        "dropdown-menu",
-        "skeleton",
-        "sidebar",
-        "spinner",
-        "collapsible"
+        "@uipath/button",
+        "@uipath/tooltip",
+        "@uipath/avatar",
+        "@uipath/dropdown-menu",
+        "@uipath/skeleton",
+        "@uipath/sidebar",
+        "@uipath/spinner",
+        "@uipath/collapsible"
       ],
       "cssVars": {
         "theme": {
@@ -2530,13 +2547,13 @@
         "react-i18next"
       ],
       "registryDependencies": [
-        "button",
-        "input",
-        "separator",
-        "sheet",
-        "skeleton",
-        "tooltip",
-        "use-mobile"
+        "@uipath/button",
+        "@uipath/input",
+        "@uipath/separator",
+        "@uipath/sheet",
+        "@uipath/skeleton",
+        "@uipath/tooltip",
+        "@uipath/use-mobile"
       ],
       "files": [
         {
@@ -2703,14 +2720,14 @@
       "description": "A composition-first form built on TanStack Form and Zod with Apollo-bound field components and translatable validation errors.",
       "dependencies": ["@tanstack/react-form", "zod", "react-i18next"],
       "registryDependencies": [
-        "button",
-        "checkbox",
-        "field",
-        "input",
-        "radio-group",
-        "select",
-        "switch",
-        "textarea"
+        "@uipath/button",
+        "@uipath/checkbox",
+        "@uipath/field",
+        "@uipath/input",
+        "@uipath/radio-group",
+        "@uipath/select",
+        "@uipath/switch",
+        "@uipath/textarea"
       ],
       "files": [
         {
@@ -2901,7 +2918,7 @@
       "title": "Toggle Group",
       "description": "A set of two-state buttons that can be toggled on or off.",
       "dependencies": ["@radix-ui/react-toggle-group"],
-      "registryDependencies": ["toggle"],
+      "registryDependencies": ["@uipath/toggle"],
       "files": [
         {
           "path": "registry/toggle-group/toggle-group.tsx",
@@ -2933,7 +2950,11 @@
         "lucide-react",
         "react-i18next"
       ],
-      "registryDependencies": ["button", "popover", "@uipath/calendar"],
+      "registryDependencies": [
+        "@uipath/button",
+        "@uipath/popover",
+        "@uipath/calendar"
+      ],
       "files": [
         {
           "path": "registry/date-picker/date-picker.tsx",


### PR DESCRIPTION
## Summary

44 `registryDependencies` across 15 items were bare names (`"button"`, `"sheet"`, `"skeleton"`…). The shadcn CLI resolves a bare name against its **default registry**, so installing an Apollo item silently pulls shadcn's component instead of this one's.

Prefixes all 44 with `@uipath/`, matching the 82 references that already were.

## How it surfaced

A consumer ran `shadcn add @uipath/sidebar @uipath/collapsible`. The sidebar files arrived correctly, but the CLI also resolved `sidebar`'s bare dependencies from shadcn and overwrote five files the app already had:

| File | What the consumer got |
| --- | --- |
| `button.tsx` | shadcn's button — lost the `ai`, `success`, `info`, `warning` and `destructive-outline` variants. Their app renders `variant="ai"` |
| `separator.tsx`, `sheet.tsx`, `skeleton.tsx` | shadcn versions, plus `skeleton` restyled from `bg-muted` to `bg-accent` |
| `use-mobile.ts` | shadcn's, which passes a redundant `undefined` their linter rejects |

All five imported `cn` from a `cn` **npm package** rather than `@/lib/utils`, and pulled `cn` and `radix-ui` into `package.json`. Without `twMerge`, a caller's `className` stops overriding — and their whole app failed to render, taking every E2E test with it.

## Why this is drift, not intent

- **82 of 126 references were already prefixed** — `charts-core → @uipath/spinner`, `line-chart → @uipath/card`, and so on.
- The docs tell consumers to configure this registry as `@uipath` (`app/mcp/page.mdx`, `app/patterns/*/page.mdx`).
- `metric-card` had it both ways inside a single array: `["@uipath/card", "@uipath/badge", "skeleton"]`.

## Items changed

`apollo-vertex-theme` · `button-group` · `combobox` · `command` · `confidence-signal` · `date-picker` · `field` · `form` · `input-group` · `item` · `metric-card` · `onboarding-tour-joyride` · `shell` · `sidebar` · `toggle-group`

Every bare name resolved to an item that exists in this registry — verified before rewriting — so nothing changes which component is intended, only which registry it comes from.

## Impact on consumers

Nothing here breaks a build, but two consequences are worth naming before this merges.

**1. A one-time overwrite in every consumer repo.** Anyone who previously installed an affected item received shadcn's version of its dependencies. Their next install, or an automated registry refresh, now writes Apollo's over it. That is the bug being fixed, but it arrives as an unexpected diff rather than a no-op — the 25 names involved are `avatar`, `badge`, `button`, `checkbox`, `collapsible`, `command`, `dialog`, `dropdown-menu`, `field`, `font-inter`, `input`, `label`, `popover`, `radio-group`, `select`, `separator`, `sheet`, `sidebar`, `skeleton`, `spinner`, `switch`, `textarea`, `toggle`, `tooltip`, `use-mobile`.

**2. Apollo's `dialog` and `sheet` require i18n.** Both declare `react-i18next` and call `t()`; shadcn's equivalents have no such dependency. So a consumer installing `@uipath/command` now transitively acquires an i18n-dependent dialog. `Apollo Vertex Registry Check` copies `locales/` into its test app, so this is the registry's existing consumer contract — but the bare names were understating it.

The `@uipath` namespace must be configured in the consumer's `components.json` for the nested references to resolve. Every documented install command already uses `@uipath/<name>`, so this is not a new requirement.

## Testing

| Check | Result |
| --- | --- |
| All 126 `registryDependencies` resolve to a real item in this registry | 0 dangling |
| Bare or raw-URL references remaining | 0 |
| New private-registry (GHP-only) transitive dependencies | none; all public npm |
| `registry:build` + `check-css-vars` | pass |
| Typecheck / Build / Lint / Lint Deps / Format | pass |
| Files touched under `registry/` | none |

`biome ci` is clean; the prefix pushed some arrays past the line width, so Biome re-wrapped them, which accounts for the insertions beyond the 35 changed reference lines.

`Apollo Vertex Registry Check` exercises this directly: it installs each item into a fresh shadcn app with the `@uipath` registry configured, which is the path that was resolving to the wrong registry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SnmiT3edq81s2qTDqoE8zP

---
_Generated by [Claude Code](https://claude.ai/code/session_01SnmiT3edq81s2qTDqoE8zP)_