### PR TITLE
fix(apollo-vertex): make useIsMobile correct on first render, harden sidebar cookie

### DIFF
--- a/apps/apollo-vertex/registry/sidebar/sidebar-provider.tsx
+++ b/apps/apollo-vertex/registry/sidebar/sidebar-provider.tsx
@@ -52,6 +52,12 @@ export function useSidebar() {
   return context;
 }
 
+/**
+ * This provider only *writes* `sidebar_state`. Reading it back is the consumer's
+ * job: a server component passes the cookie in as `defaultOpen`, and an app with
+ * no server render has to read it on the client and do the same. Without that,
+ * `defaultOpen` always wins and the collapsed state does not survive a reload.
+ */
 export function SidebarProvider({
   defaultOpen = true,
   open: openProp,
@@ -81,7 +87,7 @@ export function SidebarProvider({
     }
 
     // eslint-disable-next-line unicorn/no-document-cookie -- Standard shadcn pattern for persisting sidebar state
-    document.cookie = `${SIDEBAR_COOKIE_NAME}=${openState}; path=/; max-age=${SIDEBAR_COOKIE_MAX_AGE}`;
+    document.cookie = `${SIDEBAR_COOKIE_NAME}=${openState}; path=/; max-age=${SIDEBAR_COOKIE_MAX_AGE}; samesite=lax`;
   }
 
   // Resolve CSS width values to pixels, accounting for style overrides from consumers

--- a/apps/apollo-vertex/registry/use-mobile/use-mobile.ts
+++ b/apps/apollo-vertex/registry/use-mobile/use-mobile.ts
@@ -1,19 +1,32 @@
 import * as React from "react";
 
 const MOBILE_BREAKPOINT = 768;
+const MOBILE_QUERY = `(max-width: ${MOBILE_BREAKPOINT - 1}px)`;
+
+// Resolved lazily: the module is importable on the server, where there is no
+// `window`, and only `subscribe`/`getSnapshot` ever run in the browser.
+let mediaQuery: MediaQueryList | undefined;
+function mobileQuery() {
+  mediaQuery ??= window.matchMedia(MOBILE_QUERY);
+  return mediaQuery;
+}
+
+function subscribe(onStoreChange: () => void) {
+  const mql = mobileQuery();
+  mql.addEventListener("change", onStoreChange);
+  return () => mql.removeEventListener("change", onStoreChange);
+}
+
+function getSnapshot() {
+  return mobileQuery().matches;
+}
+
+// A server render has no viewport, so it commits to desktop and the client
+// corrects on hydration.
+function getServerSnapshot() {
+  return false;
+}
 
 export function useIsMobile() {
-  const [isMobile, setIsMobile] = React.useState<boolean | undefined>();
-
-  React.useEffect(() => {
-    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`);
-    const onChange = () => {
-      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT);
-    };
-    mql.addEventListener("change", onChange);
-    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT);
-    return () => mql.removeEventListener("change", onChange);
-  }, []);
-
-  return !!isMobile;
+  return React.useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
 }


### PR DESCRIPTION
## Summary

Two findings from consuming `@uipath/sidebar` in a Vite SPA. Both are in registry source, so they cannot be fixed downstream — `components/ui/` is verbatim vendored output there.

## 1. `useIsMobile()` reports desktop on the first render

```ts
const [isMobile, setIsMobile] = React.useState<boolean | undefined>();
// …effect sets the real value…
return !!isMobile;
```

State starts `undefined` and is coerced with `!!`, so the first render always says desktop and the effect corrects it after paint. `Sidebar` branches on exactly that value, so on a phone it renders the desktop variant once and then swaps to the `Sheet`. A tap landing in that window toggles the desktop collapse state instead of opening the sheet.

Replaced with `useSyncExternalStore`, which reads the media query directly:

```ts
export function useIsMobile() {
  return React.useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
}
```

**Why not just initialise from `matchMedia().matches`** — the obvious one-line fix. This file has no `"use client"`, so it is importable from a server render, and a `useState` initialiser would run there and throw on `window`. `getServerSnapshot` returns `false`, which keeps the module server-safe and preserves the current server-side behaviour exactly; the client then corrects on hydration. The `MediaQueryList` is resolved lazily for the same reason, and cached so `getSnapshot` does not allocate on every render.

## 2. `SidebarProvider` and the `sidebar_state` cookie

- Now written with `SameSite=Lax`.
- Documented that the provider **only writes** it.

That second half is the substantive part. The provider writes the cookie but never reads it — by design, since a Next.js consumer reads it in a server component and passes it back as `defaultOpen`. That contract was implicit, and an app with no server render gets no persistence at all: `defaultOpen` always wins and the collapsed state does not survive a reload. It looks like it works, because the cookie is visibly being written.

**Deliberately not changed: the initial state.** Reading the cookie inside `useState` here would desynchronise any SSR consumer that does not also pass `defaultOpen` — the server would render one value and the client hydrate with another. Documenting the contract fixes the surprise without putting a hydration mismatch into every Next.js app. Happy to revisit if you would rather the provider read it and SSR consumers opt out.

## Testing

| Check | Result |
| --- | --- |
| Lines over the 100-char width | none added (`sidebar-provider.tsx` keeps the 4 it already had, all templates/comments Biome cannot break) |
| Files touched outside `registry/` | none |
| `registry.json` | unchanged — no new files, no new dependencies |

I could not run `pnpm build` / `lint` / `format` in this session, so those are for CI to confirm. `Apollo Vertex Registry Check` installs both items into a fresh app, which exercises the changed files directly.

## Related

- [UiPath/apollo-ui#1144](https://github.com/UiPath/apollo-ui/pull/1144) — the `registryDependencies` namespace fix, from the same downstream install. Independent of this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SnmiT3edq81s2qTDqoE8zP

---
_Generated by [Claude Code](https://claude.ai/code/session_01SnmiT3edq81s2qTDqoE8zP)_