### PR TITLE
fix(apollo-react): render virtualized JsonTree rows on mount and at scale [MST-15023]

### DIFF
--- a/packages/apollo-react/src/canvas/components/JsonTree/JsonTree.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/JsonTree/JsonTree.stories.tsx
@@ -2,8 +2,8 @@ import type { Meta, StoryFn } from '@storybook/react';
 import { useMemo, useState } from 'react';
 import { Column, Row } from '../../layouts';
 import { buildJsonTree } from './buildJsonTree';
-import type { JsonTreeNode } from './JsonTree.types';
 import { JsonTree } from './JsonTree';
+import type { JsonTreeNode } from './JsonTree.types';
 
 export default {
   title: 'Components/JsonTree',
@@ -12,11 +12,14 @@ export default {
   },
 } satisfies Meta;
 
-const RECORD_COUNT = 20_000;
+const RECORD_COUNT = 10_000;
+
+/** The unvirtualized baseline mounts every row, so it gets a page it can actually paint. */
+const SMALL_RECORD_COUNT = 50;
 
 /**
  * A connector-style response: a status, headers, and a page of records. Built on first
- * render and cached, so opening any other story does not pay for 20k records.
+ * render and cached, so opening any other story does not pay to rebuild it.
  */
 let cachedNodes: JsonTreeNode[] | undefined;
 function useLargeTree(): JsonTreeNode[] {
@@ -35,6 +38,23 @@ function useLargeTree(): JsonTreeNode[] {
     });
     return cachedNodes;
   }, []);
+}
+
+/**
+ * The same tree with `body` cut to the first `recordCount` records — the nodes are
+ * reused as built, so no second tree is constructed and the paths still line up.
+ */
+function useTruncatedTree(recordCount: number): JsonTreeNode[] {
+  const nodes = useLargeTree();
+  return useMemo(
+    () =>
+      nodes.map((node) =>
+        node.key === 'body' && node.children
+          ? { ...node, children: node.children.slice(0, recordCount) }
+          : node
+      ),
+    [nodes, recordCount]
+  );
 }
 
 function useCollapsed() {
@@ -124,13 +144,15 @@ export const VirtualizedEditable: StoryFn = () => {
   );
 };
 
-/** Baseline: every row mounts. Kept for comparison; expect a long first paint at this size. */
+/** Baseline: every row mounts, on a page small enough that mounting them all is fine. */
 export const NotVirtualized: StoryFn = () => {
-  const nodes = useLargeTree();
+  const nodes = useTruncatedTree(SMALL_RECORD_COUNT);
   const { collapsed, toggle } = useCollapsed();
   return (
     <Column p={24} gap={12} minH="100vh" style={frame}>
-      <span style={{ fontSize: 14 }}>Same value without virtualization.</span>
+      <span style={{ fontSize: 14 }}>
+        The same shape without virtualization, at {SMALL_RECORD_COUNT} records.
+      </span>
       <JsonTree nodes={nodes} collapsed={collapsed} onToggleCollapsed={toggle} readOnly />
     </Column>
   );

--- a/packages/apollo-react/src/canvas/components/JsonTree/JsonTree.test.tsx
+++ b/packages/apollo-react/src/canvas/components/JsonTree/JsonTree.test.tsx
@@ -1,3 +1,4 @@
+import { render as bareRender } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { render, screen } from '../../utils/testing';
@@ -9,10 +10,14 @@ interface VirtualizerOptions {
   count: number;
   getItemKey?: (index: number) => string | number;
   scrollMargin?: number;
+  getScrollElement: () => Element | null;
 }
 
 const WINDOW_SIZE = 3;
 const virtualizerCalls: VirtualizerOptions[] = [];
+// What `getScrollElement` resolved to each time the virtualizer would have
+// subscribed. See the mock below.
+const attachedScrollElements: (Element | null)[] = [];
 // Driven per test: where the window sits, and whether a scroll is in flight.
 let windowStart = 0;
 let isScrolling = false;
@@ -20,33 +25,42 @@ let isScrolling = false;
 // The virtualizer needs a laid-out scroll element, which happy-dom has none of.
 // Standing in for it with a movable window exercises the tree's side of the
 // contract: what it hands the virtualizer and what it does with the items back.
-vi.mock('@tanstack/react-virtual', () => ({
-  useVirtualizer: (options: VirtualizerOptions) => {
-    virtualizerCalls.push(options);
-    const scrollMargin = options.scrollMargin ?? 0;
-    const measure = (index: number) => ({
-      index,
-      key: options.getItemKey?.(index) ?? index,
-      start: scrollMargin + index * ROW_MIN_HEIGHT_PX,
-      end: scrollMargin + (index + 1) * ROW_MIN_HEIGHT_PX,
-      size: ROW_MIN_HEIGHT_PX,
-      lane: 0,
-    });
-    const windowed = Array.from(
-      { length: Math.max(0, Math.min(WINDOW_SIZE, options.count - windowStart)) },
-      (_, offset) => measure(windowStart + offset)
-    );
-    return {
-      getVirtualItems: () => windowed,
-      getTotalSize: () => options.count * ROW_MIN_HEIGHT_PX,
-      measureElement: () => {},
-      measurementsCache: Array.from({ length: options.count }, (_, index) => measure(index)),
-      options: { scrollMargin },
-      scrollElement: null,
-      isScrolling,
-    };
-  },
-}));
+vi.mock('@tanstack/react-virtual', async () => {
+  const { useLayoutEffect } = await import('react');
+  return {
+    useVirtualizer: (options: VirtualizerOptions) => {
+      virtualizerCalls.push(options);
+      // The real adapter resolves the scroll element in a layout effect after
+      // every render and subscribes only when it changed, so an element that is
+      // still null on the mount pass is never observed and no row is ever placed.
+      useLayoutEffect(() => {
+        attachedScrollElements.push(options.getScrollElement());
+      });
+      const scrollMargin = options.scrollMargin ?? 0;
+      const measure = (index: number) => ({
+        index,
+        key: options.getItemKey?.(index) ?? index,
+        start: scrollMargin + index * ROW_MIN_HEIGHT_PX,
+        end: scrollMargin + (index + 1) * ROW_MIN_HEIGHT_PX,
+        size: ROW_MIN_HEIGHT_PX,
+        lane: 0,
+      });
+      const windowed = Array.from(
+        { length: Math.max(0, Math.min(WINDOW_SIZE, options.count - windowStart)) },
+        (_, offset) => measure(windowStart + offset)
+      );
+      return {
+        getVirtualItems: () => windowed,
+        getTotalSize: () => options.count * ROW_MIN_HEIGHT_PX,
+        measureElement: () => {},
+        measurementsCache: Array.from({ length: options.count }, (_, index) => measure(index)),
+        options: { scrollMargin },
+        scrollElement: null,
+        isScrolling,
+      };
+    },
+  };
+});
 
 /** happy-dom reports every rect as zero, so the offsets the effect reads are stubbed in. */
 function stubOffsets(
@@ -70,6 +84,7 @@ const nodes = buildJsonTree({ value });
 describe('JsonTree', () => {
   beforeEach(() => {
     virtualizerCalls.length = 0;
+    attachedScrollElements.length = 0;
     windowStart = 0;
     isScrolling = false;
   });
@@ -98,6 +113,21 @@ describe('JsonTree', () => {
     expect((rowHost.parentElement as HTMLElement).style.height).toBe(
       `${FIELD_COUNT * ROW_MIN_HEIGHT_PX}px`
     );
+  });
+
+  // Rendered without the shared i18n provider: activating it re-renders the tree
+  // a second time, which resolves the box by chance and hides the defect below.
+  it('re-renders to hand the virtualizer its own scroll box on mount', () => {
+    const { container } = bareRender(<JsonTree nodes={nodes} readOnly virtualized />);
+
+    // A parent's ref is assigned only after its children's layout effects have
+    // run, so reading the box through a ref leaves it null for the whole mount
+    // and the sequence below stops at the first entry. The virtualizer
+    // subscribes only when the element changed, so it would then never observe
+    // anything, keep a zero viewport, and window no rows at all — until some
+    // unrelated re-render happened to come along. Remounting the tree (switching
+    // a tab away and back) lands in exactly that state.
+    expect(attachedScrollElements).toEqual([null, container.firstElementChild]);
   });
 
   it('caps its own scroll box at the viewport so rows out of view never mount', () => {

--- a/packages/apollo-react/src/canvas/components/JsonTree/JsonTree.tsx
+++ b/packages/apollo-react/src/canvas/components/JsonTree/JsonTree.tsx
@@ -1,7 +1,7 @@
 import { useVirtualizer, type VirtualItem } from '@tanstack/react-virtual';
 import { cn } from '@uipath/apollo-wind';
 import { TooltipProvider } from '@uipath/apollo-wind/components/ui/tooltip';
-import { type RefObject, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useSafeLingui } from '../../../i18n';
 import { useIsomorphicLayoutEffect } from '../../hooks/useIsomorphicLayoutEffect';
 import { CanvasTooltipProviderMarker } from '../CanvasTooltip';
@@ -113,12 +113,19 @@ function scrollMarginOf(element: HTMLElement, scrollElement: HTMLElement): numbe
  */
 function VirtualRows({
   rows,
-  containerRef,
+  container,
   scrollElement,
   pinnedPaths,
 }: {
   rows: FlatRows;
-  containerRef: RefObject<HTMLDivElement | null>;
+  /**
+   * The tree's own scroll box, held as state rather than read from a ref: the
+   * virtualizer resolves its scroll element in a layout effect, and a parent's
+   * ref is assigned only after its children's effects have run, so a ref would
+   * still be null on the mount pass. Subscribing only happens when the element
+   * changed, so it would then never observe anything and window no rows.
+   */
+  container: HTMLDivElement | null;
   scrollElement?: HTMLElement | null;
   /** Rows that must stay mounted wherever the window is (see `pinnedItems`). */
   pinnedPaths: readonly string[];
@@ -127,7 +134,7 @@ function VirtualRows({
   const getItemKey = useCallback((index: number) => rows[index]?.node.path ?? index, [rows]);
   const virtualizer = useVirtualizer({
     count: rows.length,
-    getScrollElement: () => scrollElement ?? containerRef.current,
+    getScrollElement: () => scrollElement ?? container,
     estimateSize: () => ROW_MIN_HEIGHT_PX,
     getItemKey,
     overscan: VIRTUAL_OVERSCAN,
@@ -139,7 +146,6 @@ function VirtualRows({
   // rect reads would force layout on each tick, and the offset cannot change while scrolling
   // anyway (the tree's top moves up by exactly the scroll delta).
   useIsomorphicLayoutEffect(() => {
-    const container = containerRef.current;
     // The scroller can go away while this stays mounted (a panel collapsing, a tab switching).
     // A margin left over from it would shift every measurement while the offset restarts at 0,
     // and the row transform and total size both subtract it, so only scrolling would look wrong.
@@ -255,7 +261,8 @@ export function JsonTree({
   className,
 }: JsonTreeProps) {
   const { _ } = useSafeLingui();
-  const containerRef = useRef<HTMLDivElement | null>(null);
+  // State, not a ref — see `VirtualRows`' `container` prop.
+  const [container, setContainer] = useState<HTMLDivElement | null>(null);
   const usesAncestorScroller = virtualized && !!scrollElement;
   const RowWrapper = rowWrapper ?? DefaultRowWrapper;
   const [editingPath, setEditingPath] = useState<string | null>(null);
@@ -373,7 +380,7 @@ export function JsonTree({
       <CanvasTooltipProviderMarker>
         <JsonTreeRowContextProvider value={rowContext}>
           <div
-            ref={containerRef}
+            ref={setContainer}
             className={cn(
               // Scrolled by an ancestor: grow to content and scroll nothing here. `clip`, not
               // `hidden`: per CSS Overflow 3, `hidden` on one axis makes a `visible` other axis
@@ -390,7 +397,7 @@ export function JsonTree({
             {virtualized ? (
               <VirtualRows
                 rows={rows}
-                containerRef={containerRef}
+                container={container}
                 scrollElement={scrollElement}
                 pinnedPaths={pinnedPaths}
               />

--- a/packages/apollo-react/src/canvas/components/JsonTree/buildJsonTree.test.ts
+++ b/packages/apollo-react/src/canvas/components/JsonTree/buildJsonTree.test.ts
@@ -299,6 +299,31 @@ describe('flattenJsonTree', () => {
   });
 });
 
+// A subtree bigger than the engine's argument limit: spreading its rows into the
+// parent's `push` (`push(...rows)`) throws RangeError once a container holds more
+// descendants than a call can take arguments — a real run output reaches this.
+describe('large trees', () => {
+  const tree = buildJsonTree({
+    value: {
+      body: Array.from({ length: 20_000 }, (_, index) => ({
+        id: index,
+        name: `Record ${index}`,
+        tags: ['alpha', 'beta'],
+      })),
+    },
+  });
+
+  it('flattens without exceeding the call-stack argument limit', () => {
+    // 20k records x (record + id + name + tags + 2 tag items), plus the body array.
+    expect(flattenJsonTree(tree)).toHaveLength(120_001);
+  });
+
+  it('collects container paths without exceeding it either', () => {
+    // The body array, each record, and each record's tags array.
+    expect(collectContainerPaths(tree)).toHaveLength(40_001);
+  });
+});
+
 describe('value path helpers', () => {
   it('collects container paths with depth', () => {
     const tree = buildJsonTree({ value: { a: { b: { c: 1 } } } });

--- a/packages/apollo-react/src/canvas/components/JsonTree/buildJsonTree.ts
+++ b/packages/apollo-react/src/canvas/components/JsonTree/buildJsonTree.ts
@@ -340,7 +340,12 @@ export function flattenJsonTree(
               filterPredicate: selfPredicateMatch ? undefined : filterPredicate,
             }
           : options;
-      rows.push(...flattenJsonTree(node.children, childOptions, depth + 1));
+      // Appended one by one, not spread: a spread passes every descendant row as
+      // its own argument, and a large tree (a run output with tens of thousands
+      // of records) exceeds the engine's argument limit and throws RangeError.
+      for (const row of flattenJsonTree(node.children, childOptions, depth + 1)) {
+        rows.push(row);
+      }
     }
   }
   return rows;
@@ -357,7 +362,10 @@ export function collectContainerPaths(nodes: JsonTreeNode[], depth = 0): Contain
   for (const node of nodes) {
     if (node.children) {
       paths.push({ path: node.path, depth });
-      paths.push(...collectContainerPaths(node.children, depth + 1));
+      // Appended, not spread — same argument-limit ceiling as flattenJsonTree above.
+      for (const child of collectContainerPaths(node.children, depth + 1)) {
+        paths.push(child);
+      }
     }
   }
   return paths;


### PR DESCRIPTION
## Why

Two independent defects made the virtualized `JsonTree` render nothing.

**1. It never subscribed to its own scroll box.** The virtualizer resolves its scroll element in a layout effect and subscribes *only when that element changed*. `JsonTree` read the box through a ref owned by an **ancestor** of the component that calls `useVirtualizer`, and React assigns a parent's ref only after its children's layout effects have run. So on the mount pass `getScrollElement()` returned `null`, the `null !== null` guard skipped the subscription, and nothing observed the element afterwards. The viewport stayed `0`, `calculateRange` bailed on `outerSize === 0`, and `getVirtualItems()` returned an empty window — indefinitely.

A first open was usually rescued by some unrelated re-render. Remounting into a quiet subtree was not, which is how this surfaced downstream: in Maestro Flow's node input/output panels, switching the Schema/JSON tab away and back left the tree permanently empty.

Traced in a real browser against the published build:

```
MOUNT (Schema)   boxHeight=566 rows=0   _willUpdate got=null    willAttach=false
→ JSON tab       _willUpdate got=ELEMENT willAttach=true  rect 418x566   ← too late
→ back to Schema boxHeight=566 rows=0   _willUpdate got=null    willAttach=false
```

**2. `flattenJsonTree` threw on large values.** It and `collectContainerPaths` merged each subtree into the parent with `push(...children)`. A spread passes every element as its own argument, so a container with more descendants than a call can take arguments throws `RangeError: Maximum call stack size exceeded` — argument count, not recursion depth. A 20k-record page crossed the ceiling; 10k did not, so it only appeared once the data got big enough.

## What changed

- `JsonTree` holds its scroll box in **state** rather than a ref, so attaching it is a render and the layout effect always runs again with the element in hand.
- `flattenJsonTree` / `collectContainerPaths` **append** rows instead of spreading them.
- `NotVirtualized` story slices the cached tree to 50 records instead of mounting every row of the full page; the virtualized stories drop to 10k.

## Verification

Both fixes have regression tests that fail without the change:

- `re-renders to hand the virtualizer its own scroll box on mount` — `[null]` before, `[null, box]` after. It renders without the shared i18n provider on purpose: that provider's activation re-render resolves the box by chance and hides the defect.
- `large trees` — `RangeError` before, passes after. Flattening 140k rows takes ~20ms.

End-to-end in headless Chromium, driving the real Schema→JSON→Schema round trip through `NodeIOView`: **0 rows before, 31 rows after**, on mount and after the round trip.

`pnpm --filter @uipath/apollo-react test src/canvas/components` → **1642 passed**. The single failure, `formatDuration > keeps the cap in other locales (de, ja)`, fails identically on a clean `main` and is unrelated.

Also verified against a consumer: linked into Maestro Flow's `flow-workbench`, its full canvas suite (714 files / 11,350 tests) and monorepo-wide `typecheck` both pass.

## Note for reviewers

`NodeIOView` does not forward a `scrollElement` prop to the `JsonTree` it renders. Consumers that pass one — e.g. a tree inside a host panel's scroller — were never affected by defect 1, because `getScrollElement()` was non-null from the first call. That gap is worth closing separately: without it, these panels open a second scrollbar in their own box rather than scrolling with the host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
