### PR TITLE
fix(apollo-react): keep tool call expanded while a response streams [JAR-9940]

### DIFF
--- a/packages/apollo-react/src/material/components/ap-chat/components/message/chat-message-content.test.tsx
+++ b/packages/apollo-react/src/material/components/ap-chat/components/message/chat-message-content.test.tsx
@@ -1,0 +1,89 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type React from 'react';
+import { describe, expect, it } from 'vitest';
+
+import { ApI18nProvider } from '../../../../../i18n';
+import { AutopilotChatServiceProvider } from '../../providers/chat-service.provider';
+import { AutopilotChatStateProvider } from '../../providers/chat-state-provider';
+import { LocaleProvider } from '../../providers/locale-provider';
+import {
+  AGENTS_TOOL_CALL_RENDERER,
+  type AutopilotChatMessage,
+  AutopilotChatRole,
+  AutopilotChatService,
+} from '../../service';
+import { AutopilotChatMessageContent } from './chat-message-content';
+
+const START_TIME = '2026-01-01T00:00:00.000Z';
+const END_TIME = '2026-01-01T00:00:02.000Z';
+
+const chatService = AutopilotChatService.Instantiate({
+  instanceName: 'chat-message-content-test',
+});
+
+const toolCallMessage = (meta: Record<string, unknown> = {}): AutopilotChatMessage => ({
+  id: 'tool-call-1',
+  groupId: 'group-1',
+  content: "Performing 'get_weather'",
+  created_at: START_TIME,
+  role: AutopilotChatRole.Assistant,
+  widget: AGENTS_TOOL_CALL_RENDERER,
+  meta: {
+    toolName: 'get_weather',
+    input: { city: 'Bucharest' },
+    startTime: START_TIME,
+    ...meta,
+  },
+});
+
+const tree = (message: AutopilotChatMessage, isLastInGroup: boolean): React.ReactElement => (
+  <AutopilotChatServiceProvider chatServiceInstance={chatService}>
+    <LocaleProvider>
+      <ApI18nProvider component="material/components/ap-chat">
+        <AutopilotChatStateProvider>
+          <AutopilotChatMessageContent
+            message={message}
+            isLastInGroup={isLastInGroup}
+            disableActions
+            containerRef={null}
+          />
+        </AutopilotChatStateProvider>
+      </ApI18nProvider>
+    </LocaleProvider>
+  </AutopilotChatServiceProvider>
+);
+
+// Re-query rather than hold a reference: a remount replaces the node.
+const toolCallHeader = () => screen.getByRole('button', { name: /get weather/i });
+
+describe('<AutopilotChatMessageContent> tool call renderer', () => {
+  it('stays expanded when the streamed reply lands after it in the same group', async () => {
+    const user = userEvent.setup();
+    const message = toolCallMessage();
+    const { rerender } = render(tree(message, true));
+
+    await user.click(toolCallHeader());
+    expect(toolCallHeader()).toHaveAttribute('aria-expanded', 'true');
+
+    // The streamed reply shares this group, so the tool call stops being last.
+    rerender(tree(message, false));
+
+    expect(toolCallHeader()).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  it('stays expanded when the tool result replaces the message', async () => {
+    const user = userEvent.setup();
+    const { rerender } = render(tree(toolCallMessage(), false));
+
+    await user.click(toolCallHeader());
+    expect(toolCallHeader()).toHaveAttribute('aria-expanded', 'true');
+
+    // A finished tool call is re-sent under the same id, as a new message object.
+    rerender(
+      tree(toolCallMessage({ output: { tempC: 21 }, endTime: END_TIME, isError: false }), false)
+    );
+
+    expect(toolCallHeader()).toHaveAttribute('aria-expanded', 'true');
+  });
+});

--- a/packages/apollo-react/src/material/components/ap-chat/components/message/chat-message-content.tsx
+++ b/packages/apollo-react/src/material/components/ap-chat/components/message/chat-message-content.tsx
@@ -2,7 +2,6 @@ import { styled } from '@mui/material';
 import token from '@uipath/apollo-core';
 import React from 'react';
 
-import type { SupportedLocale } from '../../../../../i18n';
 import { ApToolCall } from '../../../ap-tool-call';
 import { useChatService } from '../../providers/chat-service.provider';
 import { useChatState } from '../../providers/chat-state-provider';
@@ -28,40 +27,49 @@ import { AutopilotChatMarkdownRenderer } from './markdown/markdown';
 import { AutopilotChatSources } from './sources/chat-sources';
 import { ApolloChatTreeRenderer } from './tree/tree-renderer';
 
-const getApolloMessageRenderers = (locale: SupportedLocale) => [
+const ToolCallMessageRenderer = ({ message }: { message: AutopilotChatMessage }) => {
+  const { locale } = useLocale();
+
+  if (!message.meta.span && !message.meta.input && !message.meta.toolName) {
+    return null;
+  }
+  return (
+    <ApToolCall
+      span={message.meta.span}
+      toolName={message.meta.toolName}
+      input={message.meta.input}
+      output={message.meta.output}
+      isError={message.meta.isError}
+      startTime={message.meta.startTime}
+      endTime={message.meta.endTime}
+      displayMode={message.meta.displayMode}
+      locale={locale}
+    />
+  );
+};
+
+const ChatTreeMessageRenderer = ({ message }: { message: AutopilotChatMessage }) => {
+  if (!message.meta?.span) {
+    return null;
+  }
+  return <ApolloChatTreeRenderer span={message.meta.span} />;
+};
+
+// Must stay at module scope: `component` is used as an element type, and React reconciles those
+// by reference, so rebuilding this list per render remounts the subtree and wipes ApToolCall's
+// expanded state.
+const APOLLO_MESSAGE_RENDERERS = [
   {
     name: DEFAULT_MESSAGE_RENDERER,
     component: AutopilotChatMarkdownRenderer,
   },
   {
     name: AGENTS_TOOL_CALL_RENDERER,
-    component: ({ message }: { message: AutopilotChatMessage }) => {
-      if (!message.meta.span && !message.meta.input && !message.meta.toolName) {
-        return null;
-      }
-      return (
-        <ApToolCall
-          span={message.meta.span}
-          toolName={message.meta.toolName}
-          input={message.meta.input}
-          output={message.meta.output}
-          isError={message.meta.isError}
-          startTime={message.meta.startTime}
-          endTime={message.meta.endTime}
-          displayMode={message.meta.displayMode}
-          locale={locale}
-        />
-      );
-    },
+    component: ToolCallMessageRenderer,
   },
   {
     name: APOLLO_CHAT_TREE_RENDERER,
-    component: ({ message }: { message: AutopilotChatMessage }) => {
-      if (!message.meta?.span) {
-        return null;
-      }
-      return <ApolloChatTreeRenderer span={message.meta.span} />;
-    },
+    component: ChatTreeMessageRenderer,
   },
 ];
 
@@ -200,14 +208,12 @@ function AutopilotChatMessageContentComponent({
   containerRef: HTMLDivElement | null;
 }) {
   const chatService = useChatService();
-  const { locale } = useLocale();
 
   if (!message.content && !message.contentParts && !message.attachments) {
     return null;
   }
 
   if (!chatService.getMessageRenderer(message.widget)) {
-    const APOLLO_MESSAGE_RENDERERS = getApolloMessageRenderers(locale);
     const ApolloMessageRenderer = APOLLO_MESSAGE_RENDERERS.find(
       (renderer) => renderer.name === message.widget
     )?.component;


### PR DESCRIPTION
## Problem

An expanded tool call in `ApChat` collapses by itself while the agent is still responding. Expand it to inspect input/output, and it snaps shut as the reply streams in.

## Cause

`getApolloMessageRenderers(locale)` was called **inside the render body**:

```ts
const APOLLO_MESSAGE_RENDERERS = getApolloMessageRenderers(locale);
const ApolloMessageRenderer = APOLLO_MESSAGE_RENDERERS.find(...)?.component;
return <ApolloMessageRenderer message={message} />;
```

The resolved `component` is used as a JSX **element type**, and React reconciles element types by reference. Rebuilding the list per render produced a new function identity every time, so React unmounted and remounted the subtree. `ApToolCall` keeps `toolCallExpanded` in local `useState(false)`, so every remount silently reset it.

`AutopilotChatMessageContent` is memoised, so this only bites when its props actually change — which happens twice per tool-using turn:

1. **`isLastInGroup` flips.** `sendRequest` assigns one `groupId` per turn, so the streamed reply joins the tool call's group and the tool call stops being last.
2. **The message object is replaced** when the completed tool call is re-sent under the same id with its output.

Regression introduced in 23d6df82, which turned a module-scope constant into a per-render factory purely to thread `locale` into `<ApToolCall>`.

## Fix

Hoist the renderers back to module scope as named components, and read `locale` with a hook inside the tool call renderer instead of closing over it — that closure was the only reason the list was built per render.

## Scope

`apollo-markdown-renderer` was already a module-scope reference, so the renderer used by nearly every message was unaffected. `apollo-chat-tree-renderer` did remount but holds no internal state, so it showed no symptom. Only `apollo-agents-tool-call` was visibly broken.

Any consumer rendering `widget: 'apollo-agents-tool-call'` is affected, not one product.

## Testing

- Two regression tests covering both triggers. Both **fail on `main`** with `aria-expanded="false"` and pass with the fix.
- Full `apollo-react` suite green: 169 files, 2638 tests.
- Verified in studio/flow

https://github.com/user-attachments/assets/0d381d15-0f64-4cc9-95d5-daac357307b2



## Risk

Low. Same renderers, same props, same guards — only the definition site and one hook call moved. `LocaleProvider` was already required on this path (the old code called `useLocale()` one level up), so there is no new provider requirement. Locale behaviour is unchanged, and a locale change now re-renders only the tool call rather than the whole message content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
