### PR TITLE
fix(apollo-react): node property panel - wrap node description input

### DIFF
--- a/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.tsx
+++ b/packages/apollo-react/src/canvas/components/NodePropertyPanel/NodePropertyPanel.tsx
@@ -170,7 +170,7 @@ export function NodePropertyPanel({
                     })
                   }
                   size="sm"
-                  multiline
+                  multiline="wrap"
                   maxLines={3}
                   onChange={onNodeDescriptionChange}
                   onSubmit={onNodeDescriptionSubmit}


### PR DESCRIPTION
Removes the ability to add newlines the node property panel description field.

### Before
<img width="406" height="663" alt="2026-09-10 17 31 51" src="https://github.com/user-attachments/assets/0ac32c58-b1b6-4269-89ee-129e9d5bc15b" />

### After
<img width="406" height="663" alt="2026-09-10 17 34 46" src="https://github.com/user-attachments/assets/8a68a2f5-9e1f-4c6e-a9df-fcd6a71ef943" />

<img width="406" height="663" alt="2026-09-10 17 36 46" src="https://github.com/user-attachments/assets/e36b253f-2cad-4223-b0f1-a2619fb26b30" />