### PR TITLE
feat(apollo-react): swap start point adornment to a lightning bolt [MST-11943]

### DIFF
--- a/packages/apollo-react/src/canvas/components/BaseNode/BaseNode.stories.tsx
+++ b/packages/apollo-react/src/canvas/components/BaseNode/BaseNode.stories.tsx
@@ -31,6 +31,7 @@ import {
 } from '../../storybook-utils';
 import { DefaultCanvasTranslations } from '../../types';
 import type { ValidationErrorSeverity } from '../../types/validation';
+import { ExecutionStartPointIndicator } from '../../utils/adornment-resolver';
 import { CanvasIcon } from '../../utils/icon-registry';
 import { BaseCanvas } from '../BaseCanvas';
 import { CanvasPositionControls } from '../CanvasPositionControls';
@@ -1500,7 +1501,8 @@ const ADORNMENT_ROWS = [
   { key: 'status-completed', label: 'Status: Completed (top-right)' },
   { key: 'status-inprogress', label: 'Status: InProgress (top-right)' },
   { key: 'status-failed', label: 'Status: Failed (top-right)' },
-  { key: 'start-point', label: 'Start Point (bottom-left)' },
+  { key: 'start-point', label: 'Default trigger (filled)' },
+  { key: 'start-point-secondary', label: 'Secondary trigger (outline)' },
   { key: 'mock-static', label: 'Custom: static mock (bottom-right)' },
   { key: 'mock-generated', label: 'Custom: generated mock (bottom-right)' },
   { key: 'all', label: 'All Adornments' },
@@ -1543,6 +1545,7 @@ function MockOutputIndicator({ variant }: { variant: keyof typeof MOCK_OUTPUT_VA
  * own this slot and decide what it renders.
  */
 const ADORNMENT_OVERRIDES: Record<string, NodeAdornments> = {
+  'start-point-secondary': { bottomLeft: <ExecutionStartPointIndicator filled={false} /> },
   'mock-static': { bottomRight: <MockOutputIndicator variant="static" /> },
   'mock-generated': { bottomRight: <MockOutputIndicator variant="generated" /> },
 };
@@ -1616,6 +1619,7 @@ function getAdornmentExecutionState(key: string) {
     case 'status-failed':
       return { status: 'Failed' as const };
     case 'start-point':
+    case 'start-point-secondary':
       return { status: 'None' as const, isExecutionStartPoint: true };
     case 'mock-static':
     case 'mock-generated':

--- a/packages/apollo-react/src/canvas/utils/adornment-resolver.tsx
+++ b/packages/apollo-react/src/canvas/utils/adornment-resolver.tsx
@@ -24,20 +24,29 @@ export function BreakpointIndicator({ isActive = true }: BreakpointIndicatorProp
 
 interface ExecutionStartPointIndicatorProps {
   isActive?: boolean;
+  /** Default entry point renders solid; a secondary trigger renders as an outline. */
+  filled?: boolean;
 }
 
 export function ExecutionStartPointIndicator({
   isActive = true,
+  filled = true,
 }: ExecutionStartPointIndicatorProps) {
   if (!isActive) {
     return null;
   }
 
   return (
-    <div
-      className="w-4 h-4 rounded-full bg-blue-500 border border-blue-600 shadow-sm"
-      title="Execution Start Point"
-    />
+    <CanvasTooltip content={filled ? 'Default trigger' : 'Secondary trigger'} placement="bottom">
+      <span style={{ display: 'inline-flex' }}>
+        <CanvasIcon
+          icon="zap"
+          size={16}
+          color="var(--color-foreground-emp)"
+          fill={filled ? 'currentColor' : undefined}
+        />
+      </span>
+    </CanvasTooltip>
   );
 }
 


### PR DESCRIPTION
## What

Replaces the blue-dot start point adornment on `BaseNode` with a lightning bolt, per the design reference on MST-11943.

- Filled bolt = default trigger
- Outline bolt = secondary trigger

Both use lucide `zap` via the existing `CanvasIcon` registry, so the two variants share identical geometry. Apollo's own icon set only ships filled bolts (`Flash`, `Trigger1`), with no outline twin.

## Before

Both rows render the same blue dot. There is no filled/outline distinction to make.

![Before: blue dot adornment](https://gist.githubusercontent.com/bryan-uipath/02604d402b4abc92664b9ef5de631547/raw/05022f6f13ea7887a492e2bd228c72c694dc350c/before.png)

## After

Top row filled, bottom row outline, across all three node shapes.

![After: lightning bolt adornment, filled and outline](https://gist.githubusercontent.com/bryan-uipath/02604d402b4abc92664b9ef5de631547/raw/05022f6f13ea7887a492e2bd228c72c694dc350c/after.png)

## Not in this PR

- **Positioning.** The bolt stays in the existing bottom-left badge slot. The reference puts it at bottom-center, which needs a new `BaseBadgeSlot` position; splitting that out so the icon can be evaluated on its own first.
- **Data model.** `filled` is a component prop with a `true` default. The execution API only carries the `isExecutionStartPoint` boolean, so distinguishing default from secondary needs a schema addition. The story drives the outline variant through `BaseNodeOverrideConfigProvider`.
- **Single-trigger suppression.** MST-11943 asks that the mark be omitted when a flow has only one trigger. That is a canvas-level decision, since the resolver cannot see sibling nodes.

## Verify

Storybook: `Apollo React Canvas / Components / Nodes / BaseNode / Adornments`. Rows "Default trigger (filled)" and "Secondary trigger (outline)".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
